### PR TITLE
fix #144 wesql helm chart can support single instance.

### DIFF
--- a/deploy/wesqlcluster/templates/cluster.yaml
+++ b/deploy/wesqlcluster/templates/cluster.yaml
@@ -10,7 +10,10 @@ spec:
   components:
   - name: replicasets # user-defined
     type: replicasets # ref clusterdefinition components.typename
-    replicas: {{ .Values.replicaCount }}
+    roleGroups: 
+    - name: primary
+      type: primary
+      replicas: {{ .Values.replicaCount | default 3 }}
     {{- with  .Values.resources }}
     resources: 
       limits: 


### PR DESCRIPTION
fix #144 WeSQL helm chart suport custom-defined instance replicas.