### PR TITLE
Feature/fix release cicd

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -1,0 +1,35 @@
+name: RELEASE-CHART
+
+on:
+  release:
+    types:
+      - published
+
+env:
+  GO_VERSION: '1.18'
+  HELM_VERSION: 'v3.9.4'
+  HELM_REGISTRY_URL: yimeisun.azurecr.io
+  RELEASE_VERSION: ${{ github.ref_name }}
+
+
+jobs:
+  release-chart:
+    name: Push Helm Chart
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: ${{ env.HELM_VERSION }}
+
+      - name: make helm-push
+        run: |
+          helm registry login -u ${{ secrets.HELM_REGISTRY_USER }} -p ${{ secrets.HELM_REGISTRY_PASSWORD }} \
+            ${{ env.HELM_REGISTRY_URL }}
+          VERSION=${{ env.RELEASE_VERSION }} make helm-push

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,40 @@
+name: RELEASE-IMAGE
+
+on:
+  release:
+    types:
+      - published
+
+env:
+  GO_VERSION: '1.18'
+  DOCKER_REGISTRY_URL: docker.io
+  RELEASE_VERSION: ${{ github.ref_name }}
+
+
+jobs:
+  release-image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: make generate
+        run: make generate
+
+      - uses: docker/setup-qemu-action@v1
+      - uses: docker/setup-buildx-action@v1
+        with:
+          driver-opts: image=moby/buildkit:master
+
+      - name: make push-manager-image
+        run: |
+          docker login --username ${{ secrets.DOCKER_REGISTRY_USER }} \
+            --password ${{ secrets.DOCKER_REGISTRY_PASSWORD }} ${{ env.DOCKER_REGISTRY_URL }}
+          BUILDX_ENABLED=true VERSION=${{ env.RELEASE_VERSION }} make push-manager-image

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -10,105 +10,211 @@ env:
   DARWIN_AMD64: "darwin-amd64"
   LINUX_ARM64: "linux-arm64"
   LINUX_AMD64: "linux-amd64"
+  WINDOWS_AMD64: "windows-amd64"
+  REL_VERSION: ${{ github.ref_name }}
   DARWIN_ARM64_BINARY: "dbctl-darwin-arm64-${{ github.ref_name }}.tar.gz"
   DARWIN_AMD64_BINARY: "dbctl-darwin-amd64-${{ github.ref_name }}.tar.gz"
   LINUX_ARM64_BINARY: "dbctl-linux-arm64-${{ github.ref_name }}.tar.gz"
   LINUX_AMD64_BINARY: "dbctl-linux-amd64-${{ github.ref_name }}.tar.gz"
+  WINDOWS_AMD64_BINARY: "dbctl-windows-amd64-${{ github.ref_name }}.tar.gz"
   INSTALL_SHELL: "install_dbctl.sh"
   INSTALL_DOCKER_SHELL: "install_dbctl_docker.sh"
   GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+  GO_VERSION: '1.18'
+
 
 jobs:
   upload-release:
-    name: Upload Release Asset
+    name: Upload Install File
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: make build
-        run: |
-          mkdir -p ${{ env.DARWIN_ARM64 }} ${{ env.DARWIN_AMD64 }} ${{ env.LINUX_ARM64 }} ${{ env.LINUX_AMD64 }}
-          
-          make bin/dbctl.darwin.arm64
-          mv bin/dbctl.darwin.arm64 ${{ env.DARWIN_ARM64 }}/dbctl
-          tar -zcvf ${{ env.DARWIN_ARM64_BINARY }} ${{ env.DARWIN_ARM64 }}
-          mv ${{ env.DARWIN_ARM64_BINARY }} bin/
-          
-          make bin/dbctl.darwin.amd64
-          mv bin/dbctl.darwin.amd64 ${{ env.DARWIN_AMD64 }}/dbctl
-          tar -zcvf ${{ env.DARWIN_AMD64_BINARY }} ${{ env.DARWIN_AMD64 }}
-          mv ${{ env.DARWIN_AMD64_BINARY }} bin/
-          
-          make bin/dbctl.linux.arm64
-          mv bin/dbctl.linux.arm64 ${{ env.LINUX_ARM64 }}/dbctl
-          tar -zcvf ${{ env.LINUX_ARM64_BINARY }} ${{ env.LINUX_ARM64 }}
-          mv ${{ env.LINUX_ARM64_BINARY }} bin/
-          
-          make bin/dbctl.linux.amd64
-          mv bin/dbctl.linux.amd64 ${{ env.LINUX_AMD64 }}/dbctl
-          tar -zcvf ${{ env.LINUX_AMD64_BINARY }} ${{ env.LINUX_AMD64 }}
-          mv ${{ env.LINUX_AMD64_BINARY }} bin/
-
-      - name: "get upload_url"
-        id: release
-        run: echo "::set-output name=upload_url::https://uploads.github.com/repos/$GITHUB_REPOSITORY/releases/$(jq --raw-output '.release.id' $GITHUB_EVENT_PATH)/assets{?name,label}"
-
-      - name: upload release asset DARWIN_ARM64
-        uses: actions/upload-release-asset@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-        with:
-          upload_url: ${{ steps.release.outputs.upload_url }}
-          asset_path: ./bin/${{ env.DARWIN_ARM64_BINARY }}
-          asset_name: ${{ env.DARWIN_ARM64_BINARY }}
-          asset_content_type: application/zip
-
-      - name: upload release asset DARWIN_AMD64
-        uses: actions/upload-release-asset@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-        with:
-          upload_url: ${{ steps.release.outputs.upload_url }}
-          asset_path: ./bin/${{ env.DARWIN_AMD64_BINARY }}
-          asset_name: ${{ env.DARWIN_AMD64_BINARY }}
-          asset_content_type: application/zip
-
-      - name: upload release asset LINUX_ARM64
-        uses: actions/upload-release-asset@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-        with:
-          upload_url: ${{ steps.release.outputs.upload_url }}
-          asset_path: ./bin/${{ env.LINUX_ARM64_BINARY }}
-          asset_name: ${{ env.LINUX_ARM64_BINARY }}
-          asset_content_type: application/zip
-
-      - name: upload release asset LINUX_AMD64
-        uses: actions/upload-release-asset@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-        with:
-          upload_url: ${{ steps.release.outputs.upload_url }}
-          asset_path: ./bin/${{ env.LINUX_AMD64_BINARY }}
-          asset_name: ${{ env.LINUX_AMD64_BINARY }}
-          asset_content_type: application/zip
-
+      - name: Get release
+        id: get_release
+        uses: bruceadams/get-release@v1.2.3
+        
       - name: upload release asset
         uses: actions/upload-release-asset@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
-          upload_url: ${{ steps.release.outputs.upload_url }}
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
           asset_path: ./hack/${{ env.INSTALL_SHELL }}
           asset_name: ${{ env.INSTALL_SHELL }}
           asset_content_type: text/plan
-
+          
       - name: upload release asset
         uses: actions/upload-release-asset@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         with:
-          upload_url: ${{ steps.release.outputs.upload_url }}
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
           asset_path: ./hack/${{ env.INSTALL_DOCKER_SHELL }}
           asset_name: ${{ env.INSTALL_DOCKER_SHELL }}
           asset_content_type: text/plan
 
+
+  upload-release-1:
+    name: Upload DARWIN_ARM64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          
+      - name: make generate
+        run: make generate
+        
+      - name: Get release
+        id: get_release
+        uses: bruceadams/get-release@v1.2.3
+        
+      - name: make build
+        run: |
+          mkdir -p ${{ env.DARWIN_ARM64 }} 
+          REL_VERSION=${{ env.REL_VERSION }} make bin/dbctl.darwin.arm64
+          mv bin/dbctl.darwin.arm64 ${{ env.DARWIN_ARM64 }}/dbctl
+          tar -zcvf ${{ env.DARWIN_ARM64_BINARY }} ${{ env.DARWIN_ARM64 }}
+          mv ${{ env.DARWIN_ARM64_BINARY }} bin/
+          
+      - name: upload release asset DARWIN_ARM64
+        uses: actions/upload-release-asset@main
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: ./bin/${{ env.DARWIN_ARM64_BINARY }}
+          asset_name: ${{ env.DARWIN_ARM64_BINARY }}
+          asset_content_type: application/zip
+
+
+  upload-release-2:
+    name: Upload DARWIN_AMD64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          
+      - name: make generate
+        run: make generate
+        
+      - name: Get release
+        id: get_release
+        uses: bruceadams/get-release@v1.2.3
+        
+      - name: make build
+        run: |
+          mkdir -p  ${{ env.DARWIN_AMD64 }}
+          REL_VERSION=${{ env.REL_VERSION }} make bin/dbctl.darwin.amd64
+          mv bin/dbctl.darwin.amd64 ${{ env.DARWIN_AMD64 }}/dbctl
+          tar -zcvf ${{ env.DARWIN_AMD64_BINARY }} ${{ env.DARWIN_AMD64 }}
+          mv ${{ env.DARWIN_AMD64_BINARY }} bin/
+          
+      - name: upload release asset DARWIN_AMD64
+        uses: actions/upload-release-asset@main
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: ./bin/${{ env.DARWIN_AMD64_BINARY }}
+          asset_name: ${{ env.DARWIN_AMD64_BINARY }}
+          asset_content_type: application/zip
+
+
+  upload-release-3:
+    name: Upload LINUX_ARM64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          
+      - name: make generate
+        run: make generate
+        
+      - name: Get release
+        id: get_release
+        uses: bruceadams/get-release@v1.2.3
+        
+      - name: make build
+        run: |
+          mkdir -p ${{ env.LINUX_ARM64 }}
+          REL_VERSION=${{ env.REL_VERSION }} make bin/dbctl.linux.arm64
+          mv bin/dbctl.linux.arm64 ${{ env.LINUX_ARM64 }}/dbctl
+          tar -zcvf ${{ env.LINUX_ARM64_BINARY }} ${{ env.LINUX_ARM64 }}
+          mv ${{ env.LINUX_ARM64_BINARY }} bin/
+          
+      - name: upload release asset LINUX_ARM64
+        uses: actions/upload-release-asset@main
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: ./bin/${{ env.LINUX_ARM64_BINARY }}
+          asset_name: ${{ env.LINUX_ARM64_BINARY }}
+          asset_content_type: application/zip
+
+
+  upload-release-4:
+    name: Upload LINUX_AMD64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          
+      - name: make generate
+        run: make generate
+        
+      - name: Get release
+        id: get_release
+        uses: bruceadams/get-release@v1.2.3
+        
+      - name: make build
+        run: |
+          mkdir -p ${{ env.LINUX_AMD64 }}
+          REL_VERSION=${{ env.REL_VERSION }} make bin/dbctl.linux.amd64
+          mv bin/dbctl.linux.amd64 ${{ env.LINUX_AMD64 }}/dbctl
+          tar -zcvf ${{ env.LINUX_AMD64_BINARY }} ${{ env.LINUX_AMD64 }}
+          mv ${{ env.LINUX_AMD64_BINARY }} bin/
+          
+      - name: upload release asset LINUX_AMD64
+        uses: actions/upload-release-asset@main
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: ./bin/${{ env.LINUX_AMD64_BINARY }}
+          asset_name: ${{ env.LINUX_AMD64_BINARY }}
+          asset_content_type: application/zip
+
+
+  upload-release-5:
+    name: Upload WINDOWS_AMD64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          
+      - name: make generate
+        run: make generate
+        
+      - name: Get release
+        id: get_release
+        uses: bruceadams/get-release@v1.2.3
+        
+      - name: make build
+        run: |
+          mkdir -p ${{ env.WINDOWS_AMD64 }}
+          REL_VERSION=${{ env.REL_VERSION }} make bin/dbctl.windows.amd64
+          mv bin/dbctl.windows.amd64 ${{ env.WINDOWS_AMD64 }}/dbctl
+          tar -zcvf ${{ env.WINDOWS_AMD64_BINARY }} ${{ env.WINDOWS_AMD64 }}
+          mv ${{ env.WINDOWS_AMD64_BINARY }} bin/
+          
+      - name: upload release asset WINDOWS_AMD64
+        uses: actions/upload-release-asset@main
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: ./bin/${{ env.WINDOWS_AMD64_BINARY }}
+          asset_name: ${{ env.WINDOWS_AMD64_BINARY }}
+          asset_content_type: application/zip

--- a/Makefile
+++ b/Makefile
@@ -383,12 +383,18 @@ fix-license-header: ## Run license header fix.
 
 .PHONY: bump-chart-ver
 bump-chart-ver: ## Bump helm chart version.
+ifeq ($(GOOS), darwin)
 	sed -i '' "s/^version:.*/version: $(VERSION)/" $(CHART_PATH)/Chart.yaml
 	sed -i '' "s/^appVersion:.*/appVersion: $(VERSION)/" $(CHART_PATH)/Chart.yaml
+else
+	sed -i "s/^version:.*/version: $(VERSION)/" $(CHART_PATH)/Chart.yaml
+	sed -i "s/^appVersion:.*/appVersion: $(VERSION)/" $(CHART_PATH)/Chart.yaml
+endif
+
 
 .PHONY: helm-package
 helm-package: bump-chart-ver ## Do helm package.
-	$(HELM) package $(CHART_PATH)
+	$(HELM) package $(CHART_PATH) --dependency-update
 
 .PHONY: helm-push
 helm-push: helm-package ## Do helm package and push.


### PR DESCRIPTION
1.  fix #284: make dbctl error
2.  make dbctl changed to trigger in parallel (e.g. [v23.1.0-alpha.1-test](https://github.com/apecloud/kubeblocks/actions/runs/3281342881))
3. add make dbctl.windows.amd64
4. close #263: publish release add push helm chart and build docker image