### PR TITLE
feat: support debug controller and envtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,10 @@ test-current-ctx: manifests generate fmt vet ## Run operator controller tests wi
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" $(GO) test ./$(TEST_MODULE)... -coverprofile cover.out
 
+.PHONY: test-delve
+test-delve: manifests generate fmt vet envtest ## Run tests.
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" dlv --listen=:2346 --headless=true --api-version=2 --accept-multiclient test ./$(TEST_MODULE)
+
 .PHONY: test-webhook-enabled
 test-webhook-enabled: ## Run tests with webhooks enabled.
 	$(MAKE) test ENABLE_WEBHOOKS=true


### PR DESCRIPTION
Start a [delve](https://github.com/go-delve/delve) headless backend server for envtest and connect with an external [frontend client](https://github.com/go-delve/delve/blob/master/Documentation/EditorIntegration.md).

## Usage
### 1. Start a headless server
#### debug controller (port: 2345)
```shell
# port 
make run-delve 
```

#### debug test package `controllers/dbaas` (port: 2346)
```shell
make test-delve TEST_MODULE=controllers/dbaas
```

### 2. Connect the debug server with a frontend client
#### Delve CLI
[terminal interface](https://github.com/go-delve/delve/blob/master/Documentation/cli/README.md)
```
➜  ~ dlv connect 127.0.0.1:2345
Type 'help' for list of commands.
(dlv) break cluster_controller.go:303
(dlv) continue
(dlv) ......
```

#### Goland/IDEA with go plugin
Click Run — Edit configurations, add new debug configuration, select "Go Remote":
<img width="241" alt="image" src="https://user-images.githubusercontent.com/4293867/198922107-6e53f1aa-9f7a-469b-b30e-b90dfb9078a1.png">
<img width="1040" alt="image" src="https://user-images.githubusercontent.com/4293867/198922032-65d70c4c-c0b0-4c31-9349-7ea03d17acb3.png">

Set breakpoints, and debug server will run automatically.

<img width="1932" alt="image" src="https://user-images.githubusercontent.com/4293867/198922872-1700f8b7-1afc-47a4-9fa6-b7fdc1ba1a53.png">


#### vscode 
Create/modify `.vscode/launch.json` file to have following configuration:
```json
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": "debug envtest",
            "type": "go",
            "request": "attach",
            "mode": "remote",
            "remotePath": "",
            "port": 2346,
            "host": "127.0.0.1",
            "showLog": true,
            "trace": "log",
            "logOutput": "rpc"
        }
    ]
}
```
Set breakpoints and run debug:
<img width="1660" alt="image" src="https://user-images.githubusercontent.com/4293867/198923794-7d586780-0b12-4135-9412-401b8948ae3a.png">
 


