### PR TITLE
fix: kubeblocks default version of wesql is 8.0.30

### DIFF
--- a/deploy/helm/Chart.lock
+++ b/deploy/helm/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: wesql
   repository: https://apecloud.github.io/helm-charts
-  version: 0.1.1
+  version: 0.1.2
 - name: grafana
   repository: https://grafana.github.io/helm-charts
   version: 6.43.2


### PR DESCRIPTION
fix #551 