### PR TITLE
fix: udpate helm repo if exists to avoid install fail

### DIFF
--- a/internal/dbctl/cmd/dbaas/installer.go
+++ b/internal/dbctl/cmd/dbaas/installer.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"helm.sh/helm/v3/pkg/action"
-	"helm.sh/helm/v3/pkg/repo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sapitypes "k8s.io/apimachinery/pkg/types"
@@ -41,11 +40,8 @@ type Installer struct {
 }
 
 func (i *Installer) Install() (string, error) {
-	entry := &repo.Entry{
-		Name: types.KubeBlocksChartName,
-		URL:  types.KubeBlocksChartURL,
-	}
-	if err := helm.AddRepo(entry); err != nil {
+	// Add repo, if exits, will update it
+	if err := helm.AddKubeBlocksRepo(); err != nil {
 		return "", err
 	}
 
@@ -81,6 +77,10 @@ func (i *Installer) Uninstall() error {
 	}
 
 	if err := chart.UnInstall(i.HelmCfg); err != nil {
+		return err
+	}
+
+	if err := helm.RemoveKubeBlocksRepo(); err != nil {
 		return err
 	}
 

--- a/internal/dbctl/util/helm/helm.go
+++ b/internal/dbctl/util/helm/helm.go
@@ -42,6 +42,7 @@ import (
 	"helm.sh/helm/v3/pkg/storage"
 	"helm.sh/helm/v3/pkg/storage/driver"
 
+	"github.com/apecloud/kubeblocks/internal/dbctl/types"
 	"github.com/apecloud/kubeblocks/internal/dbctl/util"
 )
 
@@ -321,4 +322,26 @@ func FakeActionConfig() *action.Configuration {
 		Log: func(format string, v ...interface{}) {
 		},
 	}
+}
+
+func AddKubeBlocksRepo() error {
+	entry := &repo.Entry{
+		Name: types.KubeBlocksChartName,
+		URL:  types.KubeBlocksChartURL,
+	}
+	if err := AddRepo(entry); err != nil {
+		return err
+	}
+	return nil
+}
+
+func RemoveKubeBlocksRepo() error {
+	entry := &repo.Entry{
+		Name: types.KubeBlocksChartName,
+		URL:  types.KubeBlocksChartURL,
+	}
+	if err := RemoveRepo(entry); err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
fix #566 

When install KubeBlocks, `dbctl` first add repo, then call helm install. If the repo exists, 
it will return. If KubeBlocks has a new version, we should update the local repo to gets the
latest information about charts from the respective chart repositories, otherwise it will use
local cache that not contains the latest KubeBlocks version.

And remove repo when uninstall KubeBlocks, avoid remain unused repo.