### PR TITLE
fix: package helm chart

### DIFF
--- a/.github/workflows/release-helm-chart.yml
+++ b/.github/workflows/release-helm-chart.yml
@@ -36,7 +36,6 @@ jobs:
         run: |
           helm repo add grafana https://grafana.github.io/helm-charts
           helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-          helm repo add kubeblocks https://apecloud.github.io/helm-charts
           helm dep update deploy/helm
 
       - name: Package Kubeblocks Helm Chart

--- a/deploy/helm/Chart.lock
+++ b/deploy/helm/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: wesql
-  repository: https://apecloud.github.io/helm-charts
+  repository: file://../wesql
   version: 0.1.3
 - name: grafana
   repository: https://grafana.github.io/helm-charts
@@ -9,7 +9,7 @@ dependencies:
   repository: https://prometheus-community.github.io/helm-charts
   version: 15.16.1
 - name: loadbalancer
-  repository: https://apecloud.github.io/helm-charts
+  repository: file://../loadbalancer
   version: 0.1.0
-digest: sha256:83e80b4f206ff3e36d5a8afd101d94c8fed761a287be03706845da1a344f0077
-generated: "2022-11-14T19:04:44.044539+08:00"
+digest: sha256:fc0b571376e25586d164f0ccdd8decdc44212ecfe5b20806e96dbf4a0e9582e1
+generated: "2022-11-15T21:43:49.288593+08:00"

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -52,7 +52,7 @@ annotations:
 dependencies:
   - condition: wesql.enabled
     name: wesql
-    repository: https://apecloud.github.io/helm-charts
+    repository: file://../wesql
     version: 0.1.*
   - condition: grafana.enabled
     name: grafana
@@ -64,5 +64,5 @@ dependencies:
     version: 15.15 - 15.16
   - condition: loadbalancer.enabled
     name: loadbalancer
-    repository: https://apecloud.github.io/helm-charts
+    repository: file://../loadbalancer
     version: 0.1.*


### PR DESCRIPTION
fix #561 
Package KubeBlocks helm chart dependency wesql/loadbalancer repository change to local path.
Fix when upgrading wesql/loadbalancer, you must upload wesql/loadbalancer before you can package kubeblocks.



