### PR TITLE
ci: fix helm chart package.

### DIFF
--- a/.github/workflows/release-helm-chart.yml
+++ b/.github/workflows/release-helm-chart.yml
@@ -36,6 +36,8 @@ jobs:
         run: |
           helm repo add grafana https://grafana.github.io/helm-charts
           helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+          helm repo add piraeus-charts https://piraeus.io/helm-charts
+          helm repo add cloudve https://github.com/CloudVE/helm-charts/raw/master
           helm dep update deploy/helm
 
       - name: Package Kubeblocks Helm Chart


### PR DESCRIPTION
Fix helm chart release ci runner failed #635.
ref: https://github.com/apecloud/kubeblocks/actions/runs/3511094638/jobs/5881534085
