### PR TITLE
fix: the ops cannot be deleted  and webhook message is incorrect 

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -169,7 +169,6 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
-    - DELETE
     resources:
     - opsrequests
   sideEffects: None

--- a/deploy/helm/templates/admission/webhookconfiguration.yaml
+++ b/deploy/helm/templates/admission/webhookconfiguration.yaml
@@ -229,7 +229,6 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
-    - DELETE
     resources:
     - opsrequests
   sideEffects: None


### PR DESCRIPTION
1. the ops cannot be deleted when the cluster has been deleted. 
2. webhook message is incorrect when horizontal scaling with invalid replicas and maxReplicas is zero .