### PR TITLE
chore: adjust ci checkout

### DIFF
--- a/.github/workflows/cicd-pull-request.yml
+++ b/.github/workflows/cicd-pull-request.yml
@@ -46,7 +46,7 @@ jobs:
     needs: pre-pull-request
     runs-on: [ self-hosted, eks-fargate-runner ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: JashBook/checkout@main
       - name: make mod-vendor and lint
         run: |
           mkdir -p ./bin

--- a/.github/workflows/cicd-push.yml
+++ b/.github/workflows/cicd-push.yml
@@ -13,7 +13,7 @@ jobs:
   make-test:
     runs-on: [self-hosted, eks-fargate-runner ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: JashBook/checkout@main
       - name: make mod-vendor and lint
         run: |
           mkdir -p ./bin


### PR DESCRIPTION
adjust ci checkout action
1. Increase timeout attempts: 3 to 10
2. Reduce timeout waiting times：10～20s to 5s