### PR TITLE
chore: fix ci install setup-envtest fail

### DIFF
--- a/.github/localflows/cicd-local.yml
+++ b/.github/localflows/cicd-local.yml
@@ -10,6 +10,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: make test
         run:  |
+          mkdir -p ./bin
+          cp -r /go/bin/controller-gen ./bin/controller-gen
+          cp -r /go/bin/setup-envtest ./bin/setup-envtest
           make mod-vendor lint test
 
 

--- a/.github/workflows/cicd-merge.yml
+++ b/.github/workflows/cicd-merge.yml
@@ -25,4 +25,4 @@ jobs:
 
       - name: make test
         run: |
-          make test USE_EXISTING_CLUSTER=true
+          make test USE_EXISTING_CLUSTER=true EXISTING_CLUSTER_TYPE=minikube

--- a/.github/workflows/cicd-pull-request.yml
+++ b/.github/workflows/cicd-pull-request.yml
@@ -51,6 +51,7 @@ jobs:
         run: |
           mkdir -p ./bin
           cp -r /go/bin/controller-gen ./bin/controller-gen
+          cp -r /go/bin/setup-envtest ./bin/setup-envtest
           make mod-vendor lint
 
       - name: make test

--- a/.github/workflows/cicd-push.yml
+++ b/.github/workflows/cicd-push.yml
@@ -18,6 +18,7 @@ jobs:
         run: |
           mkdir -p ./bin
           cp -r /go/bin/controller-gen ./bin/controller-gen
+          cp -r /go/bin/setup-envtest ./bin/setup-envtest
           make mod-vendor
           make lint
 


### PR DESCRIPTION
1. cp setup-envtest from runner
2. `make test` run on minikube add parameter EXISTING_CLUSTER_TYPE=minikube