### PR TITLE
feat: kbcli should support --context when installing charts

### DIFF
--- a/internal/cli/cmd/kubeblocks/kubeblocks.go
+++ b/internal/cli/cmd/kubeblocks/kubeblocks.go
@@ -103,7 +103,12 @@ func (o *Options) complete(f cmdutil.Factory, cmd *cobra.Command) error {
 		return err
 	}
 
-	if o.HelmCfg, err = helm.NewActionConfig(o.Namespace, kubeconfig); err != nil {
+	kubecontext, err := cmd.Flags().GetString("context")
+	if err != nil {
+		return err
+	}
+
+	if o.HelmCfg, err = helm.NewActionConfig(o.Namespace, kubeconfig, helm.WithContext(kubecontext)); err != nil {
 		return err
 	}
 

--- a/internal/cli/cmd/kubeblocks/kubeblocks_test.go
+++ b/internal/cli/cmd/kubeblocks/kubeblocks_test.go
@@ -75,6 +75,7 @@ var _ = Describe("kubeblocks", func() {
 		Expect(o.complete(tf, cmd)).Should(HaveOccurred())
 
 		cmd.Flags().StringVar(&cfg, "kubeconfig", "", "Path to the kubeconfig file to use for CLI requests.")
+		cmd.Flags().StringVar(&cfg, "context", "", "The name of the kubeconfig context to use.")
 		Expect(o.complete(tf, cmd)).To(Succeed())
 		Expect(o.HelmCfg).ShouldNot(BeNil())
 		Expect(o.Namespace).To(Equal("test"))
@@ -107,6 +108,7 @@ var _ = Describe("kubeblocks", func() {
 		Expect(cmd).ShouldNot(BeNil())
 
 		cmd.Flags().StringVar(&cfg, "kubeconfig", "", "Path to the kubeconfig file to use for CLI requests.")
+		cmd.Flags().StringVar(&cfg, "context", "", "The name of the kubeconfig context to use.")
 		Expect(cmd.HasSubCommands()).Should(BeFalse())
 
 		o := &Options{

--- a/internal/cli/util/helm/helm.go
+++ b/internal/cli/util/helm/helm.go
@@ -62,6 +62,14 @@ type LoginOpts struct {
 	URL    string
 }
 
+type Option func(*cli.EnvSettings)
+
+func WithContext(context string) Option {
+	return func(es *cli.EnvSettings) {
+		es.KubeContext = context
+	}
+}
+
 // AddRepo will add a repo
 func AddRepo(r *repo.Entry) error {
 	settings := cli.New()
@@ -282,13 +290,16 @@ func (i *InstallOpts) tryUnInstall(cfg *action.Configuration) error {
 	return nil
 }
 
-func NewActionConfig(ns string, config string) (*action.Configuration, error) {
+func NewActionConfig(ns string, config string, opts ...Option) (*action.Configuration, error) {
 	var err error
 	settings := cli.New()
 	cfg := new(action.Configuration)
 
 	settings.SetNamespace(ns)
 	settings.KubeConfig = config
+	for _, opt := range opts {
+		opt(settings)
+	}
 	if cfg.RegistryClient, err = registry.NewClient(
 		registry.ClientOptDebug(settings.Debug),
 		registry.ClientOptEnableCache(true),

--- a/internal/cli/util/helm/helm_test.go
+++ b/internal/cli/util/helm/helm_test.go
@@ -38,7 +38,7 @@ var _ = Describe("helm util", func() {
 	})
 
 	It("Action Config", func() {
-		cfg, err := NewActionConfig("test", "config")
+		cfg, err := NewActionConfig("test", "config", WithContext("context"))
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(cfg).ShouldNot(BeNil())
 	})


### PR DESCRIPTION
fix: https://github.com/apecloud/kubeblocks/issues/808

Signed-off-by: Lei Gong <max89@infracreate.com>