### PR TITLE
chore: fix and tidy clusterdef controller test

### DIFF
--- a/apis/dbaas/v1alpha1/appversion_types.go
+++ b/apis/dbaas/v1alpha1/appversion_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // AppVersionSpec defines the desired state of AppVersion
@@ -118,4 +119,11 @@ func (r *AppVersion) GetTypeMappingComponents() map[string]*AppVersionComponent 
 		m[c.Type] = &r.Spec.Components[i]
 	}
 	return m
+}
+
+func (r *AppVersion) GetNamespacedName() types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: r.Namespace,
+		Name:      r.Name,
+	}
 }

--- a/apis/dbaas/v1alpha1/cluster_types.go
+++ b/apis/dbaas/v1alpha1/cluster_types.go
@@ -24,6 +24,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // ClusterSpec defines the desired state of Cluster
@@ -369,6 +370,13 @@ func (r *Cluster) GetTypeMappingComponents() map[string][]ClusterComponent {
 		m[c.Type] = v
 	}
 	return m
+}
+
+func (r *Cluster) GetNamespacedName() types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: r.Namespace,
+		Name:      r.Name,
+	}
 }
 
 // GetMessage get message map deep copy object

--- a/apis/dbaas/v1alpha1/clusterdefinition_types.go
+++ b/apis/dbaas/v1alpha1/clusterdefinition_types.go
@@ -19,6 +19,8 @@ package v1alpha1
 import (
 	"strings"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -406,4 +408,11 @@ func (r *ClusterDefinition) ValidateEnabledLogConfigs(typeName string, enabledLo
 		}
 	}
 	return invalidLogNames
+}
+
+func (r *ClusterDefinition) GetNamespacedName() types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: r.Namespace,
+		Name:      r.Name,
+	}
 }

--- a/apis/dbaas/v1alpha1/opsrequest_types.go
+++ b/apis/dbaas/v1alpha1/opsrequest_types.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // OpsRequestSpec defines the desired state of OpsRequest
@@ -181,4 +182,11 @@ type OpsRequestList struct {
 
 func init() {
 	SchemeBuilder.Register(&OpsRequest{}, &OpsRequestList{})
+}
+
+func (r *OpsRequest) GetNamespacedName() types.NamespacedName {
+	return types.NamespacedName{
+		Namespace: r.Namespace,
+		Name:      r.Name,
+	}
 }

--- a/controllers/dbaas/clusterdefinition_controller_test.go
+++ b/controllers/dbaas/clusterdefinition_controller_test.go
@@ -24,7 +24,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -32,6 +31,10 @@ import (
 )
 
 var _ = Describe("ClusterDefinition Controller", func() {
+
+	const timeout = time.Second * 10
+	const interval = time.Second * 1
+	const waitDuration = time.Second * 5
 
 	var ctx = context.Background()
 
@@ -192,68 +195,54 @@ data:
 
 	Context("When updating clusterDefinition", func() {
 		It("Should update status of appVersion at the same time", func() {
-			By("By creating a clusterDefinition")
+			By("creating a clusterDefinition")
 			clusterDefinition := &dbaasv1alpha1.ClusterDefinition{}
 			Expect(yaml.Unmarshal([]byte(clusterDefYaml), clusterDefinition)).Should(Succeed())
 			Expect(testCtx.CreateObj(ctx, clusterDefinition)).Should(Succeed())
-			createdClusterDef := &dbaasv1alpha1.ClusterDefinition{}
 			// check reconciled finalizer and status
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, types.NamespacedName{
-					Namespace: clusterDefinition.Namespace,
-					Name:      clusterDefinition.Name,
-				}, createdClusterDef)
-				if err != nil {
-					return false
-				}
-				return len(createdClusterDef.Finalizers) > 0 &&
-					createdClusterDef.Status.ObservedGeneration == 1
-			}, time.Second*10, time.Second*1).Should(BeTrue())
-			By("By creating an appVersion")
+			Eventually(func(g Gomega) {
+				cd := &dbaasv1alpha1.ClusterDefinition{}
+				g.Expect(k8sClient.Get(ctx, clusterDefinition.GetNamespacedName(), cd)).To(Succeed())
+				g.Expect(len(cd.Finalizers) > 0 &&
+					cd.Status.ObservedGeneration == 1).To(BeTrue())
+			}, timeout, interval).Should(Succeed())
+
+			By("creating an appVersion")
 			appVersion := &dbaasv1alpha1.AppVersion{}
 			Expect(yaml.Unmarshal([]byte(appVerYaml), appVersion)).Should(Succeed())
 			Expect(testCtx.CreateObj(ctx, appVersion)).Should(Succeed())
-			createdAppVersion := &dbaasv1alpha1.AppVersion{}
 			// check reconciled finalizer
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, types.NamespacedName{
-					Namespace: appVersion.Namespace,
-					Name:      appVersion.Name,
-				}, createdAppVersion)
-				if err != nil {
-					return false
-				}
-				return len(createdAppVersion.Finalizers) > 0
-			}, time.Second*10, time.Second*1).Should(BeTrue())
-			By("By updating clusterDefinition's spec")
-			createdClusterDef.Spec.Type = "state.mysql-7"
-			Expect(k8sClient.Update(ctx, createdClusterDef)).Should(Succeed())
-			// check appVersion.Status.ClusterDefSyncStatus to be OutOfSync
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, types.NamespacedName{
-					Namespace: appVersion.Namespace,
-					Name:      appVersion.Name,
-				}, createdAppVersion)
-				if err != nil {
-					return false
-				}
-				return createdAppVersion.Status.ClusterDefSyncStatus == "OutOfSync"
-			}, time.Second*10, time.Second*1).Should(BeTrue())
+			Eventually(func(g Gomega) {
+				av := &dbaasv1alpha1.AppVersion{}
+				g.Expect(k8sClient.Get(ctx, appVersion.GetNamespacedName(), av)).To(Succeed())
+				g.Expect(len(av.Finalizers) > 0 &&
+					av.Status.ObservedGeneration == 1).To(BeTrue())
+			}, timeout, interval).Should(Succeed())
 
-			By("By deleting clusterDefinition")
-			Expect(k8sClient.Delete(ctx, createdAppVersion)).Should(Succeed())
-			Expect(k8sClient.Delete(ctx, createdClusterDef)).Should(Succeed())
+			By("updating clusterDefinition's spec which then mark appVersion's status as OutOfSync")
+			Expect(ChangeClusterDef(clusterDefinition.GetNamespacedName(),
+				func(cd *dbaasv1alpha1.ClusterDefinition) {
+					cd.Spec.Type = "state.mysql-7"
+				})).Should(Succeed())
+			// check appVersion.Status.ClusterDefSyncStatus to be OutOfSync
+			Eventually(func(g Gomega) {
+				av := &dbaasv1alpha1.AppVersion{}
+				g.Expect(k8sClient.Get(ctx, appVersion.GetNamespacedName(), av)).To(Succeed())
+				g.Expect(av.Status.ClusterDefSyncStatus == dbaasv1alpha1.OutOfSyncStatus).To(BeTrue())
+			}, timeout, interval).Should(Succeed())
+
+			By("deleting clusterDefinition")
+			Expect(k8sClient.Delete(ctx, clusterDefinition)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, appVersion)).Should(Succeed())
 		})
 	})
 
-	Context("When configmap template invalid", func() {
-		It("Should invalid status of clusterDefinition", func() {
-			By("By creating a clusterDefinition")
-
+	Context("When configmap template refs in clusterDefinition is invalid", func() {
+		It("Should stop proceeding the status of clusterDefinition", func() {
+			By("creating a clusterDefinition")
 			cmName := "mysql-tree-node-template-8.0-test2"
 			clusterDefinition := &dbaasv1alpha1.ClusterDefinition{}
 			Expect(yaml.Unmarshal([]byte(clusterDefYaml), clusterDefinition)).Should(Succeed())
-
 			clusterDefinition.Name += "-for-test"
 			clusterDefinition.Spec.Components[0].ConfigTemplateRefs = []dbaasv1alpha1.ConfigTemplate{
 				{
@@ -263,75 +252,64 @@ data:
 				},
 			}
 			Expect(testCtx.CreateObj(ctx, clusterDefinition)).Should(Succeed())
-			createdClusterDef := &dbaasv1alpha1.ClusterDefinition{}
-			// check reconciled finalizer and status
 
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, types.NamespacedName{
-					Namespace: clusterDefinition.Namespace,
-					Name:      clusterDefinition.Name,
-				}, createdClusterDef)
-				if err != nil {
-					return false
-				}
-				return len(createdClusterDef.Finalizers) > 0 &&
-					createdClusterDef.Status.ObservedGeneration == 1
-			}, time.Second*10, time.Second*1).Should(BeFalse())
+			By("check the reconciler won't update Status.ObservedGeneration if configmap doesn't exist.")
 
+			// should use Consistently here, since cd.Status.ObservedGeneration is initialized to be zero,
+			// we must watch the value for a while to tell it's not changed by the reconciler.
+			Consistently(func(g Gomega) {
+				cd := &dbaasv1alpha1.ClusterDefinition{}
+				g.Eventually(func() error {
+					return k8sClient.Get(ctx, clusterDefinition.GetNamespacedName(), cd)
+				}, timeout, interval).Should(Succeed())
+				g.Expect(cd.Status.ObservedGeneration == 0).To(BeTrue())
+			}, waitDuration, interval).Should(Succeed())
+
+			By("check the reconciler update Status.ObservedGeneration after configmap is created.")
 			// create configmap
 			assureCfgTplConfigMapObj(cmName, testCtx.DefaultNamespace)
+			Eventually(func(g Gomega) {
+				cd := &dbaasv1alpha1.ClusterDefinition{}
+				g.Expect(k8sClient.Get(ctx, clusterDefinition.GetNamespacedName(), cd)).To(Succeed())
+				g.Expect(cd.Status.ObservedGeneration == 1).To(BeTrue())
+			}, timeout, interval).Should(Succeed())
 
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, types.NamespacedName{
-					Namespace: clusterDefinition.Namespace,
-					Name:      clusterDefinition.Name,
-				}, createdClusterDef)
-				if err != nil {
-					return false
-				}
-				return len(createdClusterDef.Finalizers) > 0 &&
-					createdClusterDef.Status.ObservedGeneration == 1
-			}, time.Second*10, time.Second*1).Should(BeTrue())
-
-			Expect(k8sClient.Delete(ctx, createdClusterDef)).Should(Succeed())
-		})
-	})
-
-	Context("When configmap template invalid parameter", func() {
-		It("Should invalid status of clusterDefinition", func() {
-			By("By creating a clusterDefinition")
-			clusterDefinition := &dbaasv1alpha1.ClusterDefinition{}
-			Expect(yaml.Unmarshal([]byte(clusterDefYaml), clusterDefinition)).Should(Succeed())
-
-			cmName := "mysql-tree-node-template-8.0-test-failed"
-			clusterDefinition.Name += "-for-failed-test"
-			clusterDefinition.Spec.Components[0].ConfigTemplateRefs = []dbaasv1alpha1.ConfigTemplate{
-				{
-					Name:       cmName,
-					VolumeName: testCtx.DefaultNamespace,
-				},
-			}
-
-			// create configmap
-			assureCfgTplConfigMapObj(cmName, testCtx.DefaultNamespace)
-
-			Expect(testCtx.CreateObj(ctx, clusterDefinition)).Should(Succeed())
-			createdClusterDef := &dbaasv1alpha1.ClusterDefinition{}
-			// check reconciled finalizer and status
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, types.NamespacedName{
-					Namespace: clusterDefinition.Namespace,
-					Name:      clusterDefinition.Name,
-				}, createdClusterDef)
-				if err != nil {
-					return false
-				}
-				return len(createdClusterDef.Finalizers) > 0 &&
-					createdClusterDef.Status.ObservedGeneration == 1
-			}, time.Second*10, time.Second*1).Should(BeFalse())
-
+			By("deleting clusterDefinition")
 			Expect(k8sClient.Delete(ctx, clusterDefinition)).Should(Succeed())
 		})
 	})
 
+	Context("When configmap template in clusterDefinition contains invalid parameter(e.g. VolumeName not exist)", func() {
+		It("Should stop proceeding the status of clusterDefinition", func() {
+			By("creating a clusterDefinition and an invalid configmap")
+			clusterDefinition := &dbaasv1alpha1.ClusterDefinition{}
+			Expect(yaml.Unmarshal([]byte(clusterDefYaml), clusterDefinition)).Should(Succeed())
+			cmName := "mysql-tree-node-template-8.0-volumename-not-exist"
+			clusterDefinition.Name += "-volumename-not-exist"
+			// missing VolumeName
+			clusterDefinition.Spec.Components[0].ConfigTemplateRefs = []dbaasv1alpha1.ConfigTemplate{
+				{
+					Name:      cmName,
+					Namespace: testCtx.DefaultNamespace,
+				},
+			}
+			// create configmap
+			assureCfgTplConfigMapObj(cmName, testCtx.DefaultNamespace)
+			Expect(testCtx.CreateObj(ctx, clusterDefinition)).Should(Succeed())
+
+			By("check the reconciler won't update Status.ObservedGeneration")
+			// should use Consistently here, since cd.Status.ObservedGeneration is initialized to be zero,
+			// we must watch the value for a while to tell it's not changed by the reconciler.
+			Consistently(func(g Gomega) {
+				cd := &dbaasv1alpha1.ClusterDefinition{}
+				g.Eventually(func() error {
+					return k8sClient.Get(ctx, clusterDefinition.GetNamespacedName(), cd)
+				}, timeout, interval).Should(Succeed())
+				g.Expect(cd.Status.ObservedGeneration == 0).To(BeTrue())
+			}, waitDuration, interval).Should(Succeed())
+
+			By("By deleting clusterDefinition")
+			Expect(k8sClient.Delete(ctx, clusterDefinition)).Should(Succeed())
+		})
+	})
 })


### PR DESCRIPTION
fix test case logics in ClusterDefinitionControllerTest:
- use Consistently instead of Eventually to ensure checks are meaningful in race conditions.

tidy the code in ClusterDefinitionControllerTest and OpsRequestControllerTest:
- use  "Eventually(func(g Gomega) { " to make tests more compact and readable.


