### PR TITLE
fix: stop to install helm chart when last release is not successfully deployed

### DIFF
--- a/internal/cli/util/helm/errors.go
+++ b/internal/cli/util/helm/errors.go
@@ -1,0 +1,5 @@
+package helm
+
+import "fmt"
+
+var ErrorChartNotSuccessDeployed = fmt.Errorf("chart is not in deployed status")

--- a/internal/cli/util/helm/helm.go
+++ b/internal/cli/util/helm/helm.go
@@ -178,6 +178,9 @@ func (i *InstallOpts) Install(cfg *action.Configuration) (string, error) {
 func (i *InstallOpts) tryInstall(cfg *action.Configuration) (string, error) {
 	res, _ := i.getInstalled(cfg)
 	if res != nil {
+		if release.StatusDeployed != res.Info.Status {
+			return "", ErrorChartNotSuccessDeployed
+		}
 		return "", nil
 	}
 


### PR DESCRIPTION

fix #854 

Signed-off-by: Lei Gong <max89@infracreate.com>