### PR TITLE
chore: add lib to ci

### DIFF
--- a/.github/workflows/cicd-merge.yml
+++ b/.github/workflows/cicd-merge.yml
@@ -13,6 +13,12 @@ jobs:
     name: make test in minikube
     steps:
       - uses: actions/checkout@v3
+      - name: install lib
+        run: |
+          sudo apt-get install -y --no-install-recommends \
+            libbtrfs-dev \
+            libdevmapper-dev
+
       - name: setup Go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -49,6 +49,8 @@ jobs:
           RELEASE_VERSION="latest"
           if [[ ! -z "${{ github.event.inputs.image_tag }}" ]]; then
             RELEASE_VERSION="${{ github.event.inputs.image_tag }}"
+          elif [[ "${{ env.RELEASE_VERSION }}" == "main" ]]; then
+            RELEASE_VERSION="latest"
           elif [[ ! -z "${{ env.RELEASE_VERSION }}" ]]; then
             RELEASE_VERSION=`bash ${{ github.workspace }}/.github/utils/utils.sh ${{ env.RELEASE_VERSION }} 1`
           fi

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -36,6 +36,12 @@ jobs:
         os: [linux-amd64, linux-arm64, darwin-amd64, darwin-arm64, windows-amd64]
     steps:
       - uses: actions/checkout@v3
+      - name: install lib
+        run: |
+          sudo apt-get install -y --no-install-recommends \
+            libbtrfs-dev \
+            libdevmapper-dev
+
       - name: Setup Go
         uses: actions/setup-go@v3
         with:


### PR DESCRIPTION
1. fix #1032 
2. fix release image schedule:  set tag `latest` when branch is `main`.
Error: the release image schedule build tag is branch name
reference: https://github.com/apecloud/kubeblocks/actions/runs/3934848623/jobs/6729965192