### PR TITLE
chore: support/improve get available container ports

### DIFF
--- a/controllers/dbaas/functions.go
+++ b/controllers/dbaas/functions.go
@@ -229,7 +229,7 @@ func getAvailableContainerPorts(containers []corev1.Container, containerPorts []
 	}
 
 	iterAvailPort := func(p int32) (int32, error) {
-		// The TCP/IP port numbers below 1024 are priviliged ports, which are special
+		// The TCP/IP port numbers below 1024 are privileged ports, which are special
 		// in that normal users are not allowed to run servers on them.
 		if p < minAvailPort || p > maxAvailPort {
 			p = minAvailPort

--- a/controllers/dbaas/functions_test.go
+++ b/controllers/dbaas/functions_test.go
@@ -26,21 +26,21 @@ func TestGetAvailableContainerPorts(t *testing.T) {
 	var containers []corev1.Container
 
 	tests := []struct {
-		inputPort int32
+		inputPort  int32
 		outputPort int32
 	}{{
-		inputPort: 80, // 80 is a privileged port
+		inputPort:  80, // 80 is a privileged port
 		outputPort: minAvailPort,
 	}, {
-		inputPort: 65536, // 65536 is an invalid port
+		inputPort:  65536, // 65536 is an invalid port
 		outputPort: minAvailPort,
-	},{
-		inputPort: 3306, // 3306 is a qualified port
+	}, {
+		inputPort:  3306, // 3306 is a qualified port
 		outputPort: 3306,
 	}}
 
 	for _, test := range tests {
-		containerPorts := []int32{int32(test.inputPort)}
+		containerPorts := []int32{test.inputPort}
 		foundPorts, err := getAvailableContainerPorts(containers, containerPorts)
 		if err != nil {
 			t.Error("expect getAvailableContainerPorts success")
@@ -59,7 +59,7 @@ func TestGetAvailableContainerPortsPartlyOccupied(t *testing.T) {
 		containers = append(containers, corev1.Container{Ports: []corev1.ContainerPort{{ContainerPort: int32(p)}}})
 	}
 
-	containerPorts := []int32{minAvailPort+1}
+	containerPorts := []int32{minAvailPort + 1}
 	foundPorts, err := getAvailableContainerPorts(containers, containerPorts)
 	if err != nil {
 		t.Error("expect getAvailableContainerPorts success")


### PR DESCRIPTION
add sanity checks so that if the input ports are invalid,  the output ports are corrected.