### PR TITLE
chore: improve lifecycle_utils_test's readability and stablity

### DIFF
--- a/controllers/dbaas/lifecycle_utils_test.go
+++ b/controllers/dbaas/lifecycle_utils_test.go
@@ -1012,7 +1012,7 @@ spec:
 			Eventually(testdbaas.CheckObj(&testCtx, intctrlutil.GetNamespacedName(vs),
 				func(g Gomega, vs *snapshotv1.VolumeSnapshot) {
 					g.Expect(vs.Status.ReadyToUse).To(BeNil())
-				}), testCtx.DefaultTimeout, testCtx.DefaultInterval).Should(Succeed())
+				})).Should(Succeed())
 			shouldRequeue, err = doBackup(reqCtx, k8sClient, cluster, component, sts, &stsProto, snapshotKey)
 			Expect(shouldRequeue).Should(BeTrue())
 			Expect(err).ShouldNot(HaveOccurred())

--- a/internal/testutil/dbaas/common_util.go
+++ b/internal/testutil/dbaas/common_util.go
@@ -146,7 +146,7 @@ func ClearResources[T intctrlutil.Object, PT intctrlutil.PObject[T],
 	// ginkgo.By("clear resources " + PL(&objList).GetObjectKind().GroupVersionKind().String())
 	gomega.Eventually(func() error {
 		return testCtx.Cli.List(testCtx.Ctx, PL(&objList), listOptions...)
-	}, testCtx.DefaultTimeout, testCtx.DefaultInterval).Should(gomega.Succeed())
+	}).Should(gomega.Succeed())
 	for _, obj := range traits.GetItems(&objList) {
 		// it's possible deletions are initiated in testcases code but cache is not updated
 		gomega.Expect(client.IgnoreNotFound(testCtx.Cli.Delete(testCtx.Ctx, PT(&obj),
@@ -167,7 +167,7 @@ func ClearResources[T intctrlutil.Object, PT intctrlutil.PObject[T],
 			}
 		}
 		g.Expect(len(traits.GetItems(&objList))).Should(gomega.Equal(0))
-	}, testCtx.ClearResourceTimeout, testCtx.ClearResourceInterval).Should(gomega.Succeed())
+	}, testCtx.ClearResourceTimeout, testCtx.ClearResourcePollingInterval).Should(gomega.Succeed())
 }
 
 // ClearClusterResources clears all dependent resources belonging to existing clusters.

--- a/internal/testutil/type.go
+++ b/internal/testutil/type.go
@@ -21,24 +21,28 @@ import (
 	"os"
 	"time"
 
+	"github.com/onsi/gomega"
 	"github.com/sethvargo/go-password/password"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
 type TestContext struct {
-	Ctx                   context.Context
-	Cli                   client.Client
-	TestEnv               *envtest.Environment
-	TestObjLabelKey       string
-	DefaultNamespace      string
-	DefaultTimeout        time.Duration
-	DefaultInterval       time.Duration
-	ClearResourceTimeout  time.Duration
-	ClearResourceInterval time.Duration
-	CreateObj             func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error
-	CheckedCreateObj      func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error
+	Ctx                                context.Context
+	Cli                                client.Client
+	TestEnv                            *envtest.Environment
+	TestObjLabelKey                    string
+	DefaultNamespace                   string
+	DefaultEventuallyTimeout           time.Duration
+	DefaultEventuallyPollingInterval   time.Duration
+	DefaultConsistentlyDuration        time.Duration
+	DefaultConsistentlyPollingInterval time.Duration
+	ClearResourceTimeout               time.Duration
+	ClearResourcePollingInterval       time.Duration
+	CreateObj                          func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error
+	CheckedCreateObj                   func(ctx context.Context, obj client.Object, opts ...client.CreateOption) error
 }
 
 const (
@@ -49,12 +53,14 @@ const (
 
 func NewDefaultTestContext(ctx context.Context, cli client.Client, testEnv *envtest.Environment) TestContext {
 	t := TestContext{
-		TestObjLabelKey:       "kubeblocks.io/test",
-		DefaultNamespace:      "default",
-		DefaultTimeout:        time.Second * 10,
-		DefaultInterval:       time.Second,
-		ClearResourceTimeout:  time.Second * 60,
-		ClearResourceInterval: time.Second,
+		TestObjLabelKey:                    "kubeblocks.io/test",
+		DefaultNamespace:                   "default",
+		DefaultEventuallyTimeout:           time.Second * 10,
+		DefaultEventuallyPollingInterval:   time.Second,
+		DefaultConsistentlyDuration:        time.Second * 3,
+		DefaultConsistentlyPollingInterval: time.Second,
+		ClearResourceTimeout:               time.Second * 60,
+		ClearResourcePollingInterval:       time.Second,
 	}
 	t.Ctx = ctx
 	t.Cli = cli
@@ -75,6 +81,12 @@ func NewDefaultTestContext(ctx context.Context, cli client.Client, testEnv *envt
 		}
 		return nil
 	}
+
+	gomega.SetDefaultEventuallyTimeout(t.DefaultEventuallyTimeout)
+	gomega.SetDefaultEventuallyPollingInterval(t.DefaultEventuallyPollingInterval)
+	gomega.SetDefaultConsistentlyDuration(t.DefaultConsistentlyDuration)
+	gomega.SetDefaultConsistentlyPollingInterval(t.DefaultConsistentlyPollingInterval)
+
 	return t
 }
 


### PR DESCRIPTION
ginkgo is a so-called "Behavior Driven Development" (BDD) framework. we should write description in Context("...") and It("...") to better explain the meaning and intention of a test case.
what's more, ginkgo genenrates a sentence for each  test using the words we embedded in Describe("..."), Context("...") and It("..."), it's better to organize them so that the output reads like normal English.

for example, now the output looks like:

lifecycle_utils has the mergeMonitorConfig function should disable monitor if ClusterComponent.Monitor is false
/Users/wei/ApeCloud/kubeblocks/controllers/dbaas/lifecycle_utils_test.go:118

lifecycle_utils has helper function which builds specific object from cue template builds StatefulSet correctly
/Users/wei/ApeCloud/kubeblocks/controllers/dbaas/lifecycle_utils_test.go:852

lifecycle_utils with HorizontalScalePolicy set to CloneFromSnapshot and VolumeSnapshot exists determines return value of doBackup according to whether VolumeSnapshot is ReadyToUse
/Users/wei/ApeCloud/kubeblocks/controllers/dbaas/lifecycle_utils_test.go:967

they read good.