### PR TITLE
chore: fix a occasional test case fails in stateful_set_controller_test

### DIFF
--- a/controllers/dbaas/components/component.go
+++ b/controllers/dbaas/components/component.go
@@ -130,7 +130,7 @@ func patchClusterComponentStatus(
 		componentName, workloadSpecIsUpdated, componentIsRunning, podsAreReady); err != nil || !ok {
 		return err
 	}
-	compCtx.reqCtx.Log.Info("component status changed", "componentName", componentName, "phase", cluster.Status.Components[componentName].Phase)
+	compCtx.reqCtx.Log.Info("component status changed", "componentName", componentName, "phase", cluster.Status.Components[componentName].Phase, "componentIsRunning", componentIsRunning, "podsAreReady", podsAreReady)
 	return compCtx.cli.Status().Patch(compCtx.reqCtx.Ctx, cluster, patch)
 }
 

--- a/controllers/dbaas/components/stateful_set_controller.go
+++ b/controllers/dbaas/components/stateful_set_controller.go
@@ -92,6 +92,9 @@ func (r *StatefulSetReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 	workloadSpecIsUpdated := util.StatefulSetSpecIsUpdated(sts)
 	compCtx := newComponentContext(reqCtx, r.Client, r.Recorder, component, sts)
+	reqCtx.Log.Info("before handleComponentStatusAndSyncCluster",
+		"generation", sts.Generation, "observed generation", sts.Status.ObservedGeneration,
+		"replicas", sts.Status.Replicas)
 	if requeueAfter, err := handleComponentStatusAndSyncCluster(compCtx, workloadSpecIsUpdated, cluster); err != nil {
 		return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "")
 	} else if requeueAfter != 0 {


### PR DESCRIPTION
code inside consensus_set relies on value of ObservedGeneration to generate the phase of a component.
there is a chance that the test sets component's ObservedGeneration to a staled value, depending on the freshness of client.cache, which will cause the test to fail.