### PR TITLE
chore: fix lifecycle_utils_test fails

### DIFF
--- a/controllers/dbaas/lifecycle_utils_test.go
+++ b/controllers/dbaas/lifecycle_utils_test.go
@@ -991,7 +991,7 @@ spec:
 			// ensure cache is up-to-date before calling doBackup
 			Eventually(testdbaas.CheckObj(&testCtx, client.ObjectKeyFromObject(vs),
 				func(g Gomega, fetched *snapshotv1.VolumeSnapshot) {
-					g.Expect(fetched.Status != nil && fetched.Status.ReadyToUse != nil)
+					g.Expect(fetched.Status != nil && fetched.Status.ReadyToUse != nil).To(BeTrue())
 				})).Should(Succeed())
 
 			// prepare doBackup input parameters


### PR DESCRIPTION
client.List reads from cache, which cause test fails when cache is not up-to-date.
wait until cache is updated or replace Expect(...) with Eventually(...), seems the former one is better