### PR TITLE
chore: add ClusterControllerErrorDuration constant to determine whether the cluster needs to enter the ConditionsError phase

### DIFF
--- a/controllers/dbaas/cluster_status_conditions.go
+++ b/controllers/dbaas/cluster_status_conditions.go
@@ -67,6 +67,12 @@ const (
 	ReasonComponentsNotReady = "ComponentsNotReady"
 	// ReasonClusterReady the components of cluster are ready, the component phase are running
 	ReasonClusterReady = "ClusterReady"
+
+	// ClusterControllerErrorDuration if there is an error in the cluster controller,
+	// it will not be automatically repaired unless there is network jitter.
+	// so if the error lasts more than 5s, the cluster will enter the ConditionsError phase
+	// and prompt the user to repair manually according to the message.
+	ClusterControllerErrorDuration = 5 * time.Second
 )
 
 // updateClusterConditions updates cluster.status condition and records event.
@@ -100,7 +106,7 @@ func (conMgr clusterConditionManager) handleConditionForClusterPhase(condition m
 		return false
 	}
 
-	if time.Now().Before(oldCondition.LastTransitionTime.Add(30 * time.Second)) {
+	if time.Now().Before(oldCondition.LastTransitionTime.Add(ClusterControllerErrorDuration)) {
 		return false
 	}
 	if !util.IsFailedOrAbnormal(conMgr.cluster.Status.Phase) {

--- a/controllers/dbaas/cluster_status_conditions_test.go
+++ b/controllers/dbaas/cluster_status_conditions_test.go
@@ -85,7 +85,7 @@ var _ = Describe("test cluster Failed/Abnormal phase", func() {
 			By("test conditionsError phase")
 			patch := client.MergeFrom(cluster.DeepCopy())
 			condition := meta.FindStatusCondition(cluster.Status.Conditions, ConditionTypeProvisioningStarted)
-			condition.LastTransitionTime = metav1.Time{Time: time.Now().Add(-31 * time.Second)}
+			condition.LastTransitionTime = metav1.Time{Time: time.Now().Add(-(ClusterControllerErrorDuration + time.Second))}
 			cluster.SetStatusCondition(*condition)
 			Expect(k8sClient.Status().Patch(ctx, cluster, patch)).Should(Succeed())
 


### PR DESCRIPTION
if there is an error in the cluster controller,  it will not be automatically repaired unless there is network jitter.
so if the error lasts more than 5s, the cluster will enter the ConditionsError phase and prompt the user to repair manually according to the message. 