### PR TITLE
chore: an example of refactoring ut, to be more concise and better for read

### DIFF
--- a/controllers/dataprotection/backup_controller_test.go
+++ b/controllers/dataprotection/backup_controller_test.go
@@ -17,20 +17,14 @@ limitations under the License.
 package dataprotection
 
 import (
-	"context"
-	"time"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/sethvargo/go-password/password"
 	"github.com/spf13/viper"
-
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/yaml"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
@@ -40,13 +34,7 @@ import (
 	testdbaas "github.com/apecloud/kubeblocks/internal/testutil/dbaas"
 )
 
-var _ = Describe("Backup Controller", func() {
-	type Key = types.NamespacedName
-	const timeout = time.Second * 20
-	const interval = time.Second * 1
-	const TRUE = "true"
-
-	var ctx = context.Background()
+var _ = Describe("Backup for a StatefulSet", func() {
 
 	cleanEnv := func() {
 		// must wait until resources deleted and no longer exist before the testcases start,
@@ -67,511 +55,157 @@ var _ = Describe("Backup Controller", func() {
 		testdbaas.ClearResources(&testCtx, intctrlutil.CronJobSignature, inNS, ml)
 		// non-namespaced
 		testdbaas.ClearResources(&testCtx, intctrlutil.BackupToolSignature, ml)
-		testdbaas.ClearResources(&testCtx, intctrlutil.BackupPolicyTemplateSignature, ml)
 	}
 
-	BeforeEach(cleanEnv)
+	BeforeEach(func() {
+		cleanEnv()
 
-	AfterEach(cleanEnv)
+		By("By creating a statefulset")
+		_ = testdbaas.CreateCustomizedObj(&testCtx, "backup/statefulset.yaml", &appsv1.StatefulSet{},
+			testCtx.UseDefaultNamespace())
+		_ = testdbaas.CreateCustomizedObj(&testCtx, "backup/statefulset_pod.yaml", &corev1.Pod{},
+			testCtx.UseDefaultNamespace())
+	})
 
-	genarateNS := func(prefix string) types.NamespacedName {
-		randomStr, _ := password.Generate(6, 0, 0, true, false)
-		key := types.NamespacedName{
-			Name:      prefix + randomStr,
-			Namespace: testCtx.DefaultNamespace,
-		}
-		return key
-	}
+	AfterEach(func() {
+		cleanEnv()
+	})
 
-	assureBackupObj := func(backupPolicy string) *dataprotectionv1alpha1.Backup {
-		By("By assure an backup obj")
-		backupYaml := `
-apiVersion: dataprotection.kubeblocks.io/v1alpha1
-kind: Backup
-metadata:
-  name: backup-success-demo
+	When("with default settings", func() {
+		var backupPolicyName string
 
-  labels:
-    dataprotection.kubeblocks.io/backup-type: full
-    db.kubeblocks.io/name: mysqlcluster
-    dataprotection.kubeblocks.io/backup-policy-name: backup-policy-demo
-    dataprotection.kubeblocks.io/backup-index: "0"
-
-spec:
-  backupPolicyName: backup-policy-demo
-  backupType: full
-  ttl: 168h0m0s
-`
-		backup := &dataprotectionv1alpha1.Backup{}
-		Expect(yaml.Unmarshal([]byte(backupYaml), backup)).Should(Succeed())
-		ns := genarateNS("backup-job-")
-		backup.Name = ns.Name
-		backup.Namespace = ns.Namespace
-		backup.Spec.BackupPolicyName = backupPolicy
-
-		Expect(testCtx.CreateObj(ctx, backup)).Should(Succeed())
-		return backup
-	}
-
-	assureBackupSnapshotObj := func(backupPolicy string) *dataprotectionv1alpha1.Backup {
-		By("By assure an backup obj")
-		backupYaml := `
-apiVersion: dataprotection.kubeblocks.io/v1alpha1
-kind: Backup
-metadata:
-  name: backup-success-demo
-  namespace: default
-spec:
-  backupPolicyName: backup-policy-demo
-  backupType: snapshot
-  ttl: 168h0m0s
-`
-		backup := &dataprotectionv1alpha1.Backup{}
-		Expect(yaml.Unmarshal([]byte(backupYaml), backup)).Should(Succeed())
-		ns := genarateNS("backup-job-")
-		backup.Name = ns.Name
-		backup.Namespace = ns.Namespace
-		backup.Spec.BackupPolicyName = backupPolicy
-
-		Expect(testCtx.CreateObj(ctx, backup)).Should(Succeed())
-		return backup
-	}
-
-	assureBackupPolicyObj := func(backupTool string) *dataprotectionv1alpha1.BackupPolicy {
-		By("By assure an backupPolicy obj")
-		backupPolicyYaml := `
-apiVersion: dataprotection.kubeblocks.io/v1alpha1
-kind: BackupPolicy
-metadata:
-  name: backup-policy-demo
-spec:
-  schedule: "0 3 * * *"
-  ttl: 168h0m0s
-  backupToolName: xtrabackup-mysql
-  target:
-    databaseEngine: mysql
-    labelsSelector:
-      matchLabels:
-        app.kubernetes.io/instance: wesql-cluster	
-    secret:
-      name: wesql-cluster
-  hooks:
-    preCommands:
-    - touch /data/mysql/.restore;sync
-    postCommands:
-    - rm -f /data/mysql/.restore;sync
-  remoteVolume:
-    name: backup-remote-volume
-    persistentVolumeClaim:
-      claimName: backup-host-path-pvc
-  onFailAttempted: 3
-`
-		backupPolicy := &dataprotectionv1alpha1.BackupPolicy{}
-		Expect(yaml.Unmarshal([]byte(backupPolicyYaml), backupPolicy)).Should(Succeed())
-		ns := genarateNS("backup-policy-")
-		backupPolicy.Name = ns.Name
-		backupPolicy.Namespace = ns.Namespace
-		backupPolicy.Spec.BackupToolName = backupTool
-		Expect(testCtx.CreateObj(ctx, backupPolicy)).Should(Succeed())
-		return backupPolicy
-	}
-
-	assureBackupToolObj := func(withoutResources ...bool) *dataprotectionv1alpha1.BackupTool {
-		By("By assure an backupTool obj")
-		backupToolYaml := `
-apiVersion: dataprotection.kubeblocks.io/v1alpha1
-kind: BackupTool
-metadata:
-  name: xtrabackup-mysql
-spec:
-  image: percona/percona-xtrabackup
-  databaseEngine: mysql
-  deployKind: job
-  resources:
-    limits:
-      cpu: "1"
-      memory: 2Gi
-
-  env:
-    - name: DATA_DIR
-      value: /var/lib/mysql
-  physical:
-    restoreCommands:
-      - |
-        echo "BACKUP_DIR=${BACKUP_DIR} BACKUP_NAME=${BACKUP_NAME} DATA_DIR=${DATA_DIR}" && \
-        mkdir -p /tmp/data/ && cd /tmp/data \
-        && xbstream -x < /${BACKUP_DIR}/${BACKUP_NAME}.xbstream \
-        && xtrabackup --decompress  --target-dir=/tmp/data/ \
-        && find . -name "*.qp"|xargs rm -f \
-        && rm -rf ${DATA_DIR}/* \
-        && rsync -avrP /tmp/data/ ${DATA_DIR}/ \
-        && rm -rf /tmp/data/ \
-        && chmod -R 0777 ${DATA_DIR}
-    incrementalRestoreCommands: []
-  logical:
-    restoreCommands: []
-    incrementalRestoreCommands: []
-  backupCommands:
-    - echo "DB_HOST=${DB_HOST} DB_USER=${DB_USER} DB_PASSWORD=${DB_PASSWORD} DATA_DIR=${DATA_DIR} BACKUP_DIR=${BACKUP_DIR} BACKUP_NAME=${BACKUP_NAME}";
-      mkdir -p /${BACKUP_DIR};
-      xtrabackup --compress --backup  --safe-slave-backup --slave-info --stream=xbstream --host=${DB_HOST} --user=${DB_USER} --password=${DB_PASSWORD} --datadir=${DATA_DIR} > /${BACKUP_DIR}/${BACKUP_NAME}.xbstream
-  incrementalBackupCommands: []
-`
-		backupTool := &dataprotectionv1alpha1.BackupTool{}
-		Expect(yaml.Unmarshal([]byte(backupToolYaml), backupTool)).Should(Succeed())
-		nilResources := false
-		// optional arguments, only use the first one.
-		if len(withoutResources) > 0 {
-			nilResources = withoutResources[0]
-		}
-		if nilResources {
-			backupTool.Spec.Resources = nil
-		}
-		ns := genarateNS("backup-tool-")
-		backupTool.Name = ns.Name
-		backupTool.Namespace = ns.Namespace
-		Expect(testCtx.CreateObj(ctx, backupTool)).Should(Succeed())
-		return backupTool
-	}
-
-	assureStatefulSetObj := func() *appsv1.StatefulSet {
-		By("By assure an stateful obj")
-		statefulYaml := `
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  labels:
-    app.kubernetes.io/instance: wesql-cluster
-  name: wesql-cluster-replicasets-primary
-spec:
-  minReadySeconds: 10
-  podManagementPolicy: Parallel
-  replicas: 1
-  revisionHistoryLimit: 10
-  selector:
-    matchLabels:
-      app.kubernetes.io/component: replicasets-replicasets
-      app.kubernetes.io/instance: wesql-cluster-replicasets-primary
-      app.kubernetes.io/name: state.mysql-wesql-clusterdefinition
-  serviceName: wesql-cluster-replicasets-primary
-  template:
-    metadata:
-      creationTimestamp: null
-      labels:
-        app.kubernetes.io/component: replicasets-replicasets
-        app.kubernetes.io/instance: wesql-cluster-replicasets-primary
-        app.kubernetes.io/name: state.mysql-wesql-clusterdefinition
-    spec:
-      containers:
-      - args: []
-        command:
-        - /bin/bash
-        - -c
-        image: docker.io/apecloud/wesql-server:latest
-        imagePullPolicy: IfNotPresent
-        name: mysql
-        ports:
-        - containerPort: 3306
-          name: mysql
-          protocol: TCP
-        - containerPort: 13306
-          name: paxos
-          protocol: TCP
-        resources: {}
-        terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
-        volumeMounts:
-        - mountPath: /var/lib/mysql
-          name: data
-      dnsPolicy: ClusterFirst
-      restartPolicy: Always
-      schedulerName: default-scheduler
-      securityContext: {}
-      terminationGracePeriodSeconds: 30
-  updateStrategy:
-    rollingUpdate:
-      partition: 0
-    type: RollingUpdate
-  volumeClaimTemplates:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
-      creationTimestamp: null
-      name: data
-    spec:
-      accessModes:
-      - ReadWriteOnce
-      resources:
-        requests:
-          storage: 1Gi
-      volumeMode: Filesystem
-`
-		podYaml := `
-apiVersion: v1
-kind: Pod
-metadata:
-  generateName: wesql-cluster-replicasets-primary-
-  labels:
-    statefulset.kubernetes.io/pod-name: wesql-cluster-replicasets-primary-0
-  name: wesql-cluster-replicasets-primary-0
-  namespace: default
-spec:
-  containers:
-    - args:
-        - docker-entrypoint.sh mysqld
-      command:
-        - /bin/bash
-        - '-c'
-      env:
-        - name: KB_POD_NAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: KB_REPLICASETS_PRIMARY_N
-          value: '1'
-        - name: KB_REPLICASETS_PRIMARY_0_HOSTNAME
-          value: wesql-cluster-replicasets-primary-0
-      image: 'docker.io/apecloud/wesql-server:latest'
-      imagePullPolicy: IfNotPresent
-      name: mysql
-      ports:
-        - containerPort: 3306
-          name: mysql
-          protocol: TCP
-        - containerPort: 13306
-          name: paxos
-          protocol: TCP
-      resources: {}
-      terminationMessagePath: /dev/termination-log
-      terminationMessagePolicy: File
-      volumeMounts:
-        - mountPath: /var/lib/mysql
-          name: data
-  hostname: wesql-cluster-replicasets-primary-0
-  preemptionPolicy: PreemptLowerPriority
-  priority: 0
-  restartPolicy: Always
-  securityContext: {}
-  subdomain: wesql-cluster-replicasets-primary
-  terminationGracePeriodSeconds: 30
-  tolerations:
-    - effect: NoExecute
-      key: node.kubernetes.io/not-ready
-      operator: Exists
-      tolerationSeconds: 300
-    - effect: NoExecute
-      key: node.kubernetes.io/unreachable
-      operator: Exists
-      tolerationSeconds: 300
-  volumes:
-    - name: data
-      persistentVolumeClaim:
-        claimName: data-wesql-cluster-replicasets-primary-0
-  phase: Running
-  qosClass: BestEffort
-`
-		statefulSet := &appsv1.StatefulSet{}
-		Expect(yaml.Unmarshal([]byte(statefulYaml), statefulSet)).Should(Succeed())
-		statefulSet.SetNamespace(testCtx.DefaultNamespace)
-		statefulSet.Spec.Template.GetLabels()[testCtx.TestObjLabelKey] = TRUE
-		Expect(testCtx.CreateObj(ctx, statefulSet)).Should(Succeed())
-
-		if viper.GetBool("USE_EXISTING_CLUSTER") {
-			return statefulSet
-		}
-		pod := &corev1.Pod{}
-		Expect(yaml.Unmarshal([]byte(podYaml), pod)).Should(Succeed())
-		pod.GetLabels()[testCtx.TestObjLabelKey] = TRUE
-		Expect(testCtx.CreateObj(ctx, pod)).Should(Succeed())
-		return statefulSet
-	}
-
-	patchK8sJobStatus := func(jobStatus batchv1.JobConditionType, key types.NamespacedName) {
-		k8sJob := batchv1.Job{}
-		Eventually(func() error {
-			return k8sClient.Get(ctx, key, &k8sJob)
-		}, timeout, interval).Should(Succeed())
-
-		patch := client.MergeFrom(k8sJob.DeepCopy())
-		jobCondition := batchv1.JobCondition{Type: jobStatus}
-		k8sJob.Status.Conditions = append(k8sJob.Status.Conditions, jobCondition)
-		Expect(k8sClient.Status().Patch(ctx, &k8sJob, patch)).Should(Succeed())
-	}
-
-	patchVolumeSnapshotStatus := func(key Key, readyToUse bool) {
-		snap := snapshotv1.VolumeSnapshot{}
-		Eventually(func() error {
-			return k8sClient.Get(ctx, key, &snap)
-		}, timeout, interval).Should(Succeed())
-
-		Expect(k8sClient.Get(ctx, key, &snap)).Should(Succeed())
-
-		patch := client.MergeFrom(snap.DeepCopy())
-		snapStatus := snapshotv1.VolumeSnapshotStatus{ReadyToUse: &readyToUse}
-		snap.Status = &snapStatus
-		Expect(k8sClient.Status().Patch(ctx, &snap, patch)).Should(Succeed())
-	}
-
-	Context("When creating backup", func() {
-		It("Should success with no error", func() {
-
-			By("By creating a statefulset")
-			_ = assureStatefulSetObj()
-
+		BeforeEach(func() {
 			By("By creating a backupTool")
-			backupTool := assureBackupToolObj()
+			backupTool := testdbaas.CreateCustomizedObj(&testCtx, "backup/backuptool.yaml",
+				&dataprotectionv1alpha1.BackupTool{}, testdbaas.RandomizedObjName())
 
 			By("By creating a backupPolicy from backupTool: " + backupTool.Name)
-			backupPolicy := assureBackupPolicyObj(backupTool.Name)
-
-			By("By creating a backup from backupPolicy: " + backupPolicy.Name)
-			toCreate := assureBackupObj(backupPolicy.Name)
-			key := types.NamespacedName{
-				Name:      toCreate.Name,
-				Namespace: toCreate.Namespace,
-			}
-
-			patchK8sJobStatus(batchv1.JobComplete, key)
-
-			result := &dataprotectionv1alpha1.Backup{}
-			Expect(k8sClient.Get(ctx, key, result)).Should(Succeed())
-			Eventually(func() bool {
-				Expect(k8sClient.Get(ctx, key, result)).Should(Succeed())
-				return result.Status.Phase == dataprotectionv1alpha1.BackupFailed ||
-					result.Status.Phase == dataprotectionv1alpha1.BackupCompleted
-			}, timeout, interval).Should(BeTrue())
-			Expect(result.Status.Phase).Should(Equal(dataprotectionv1alpha1.BackupCompleted))
+			backupPolicy := testdbaas.CreateCustomizedObj(&testCtx, "backup/backuppolicy.yaml",
+				&dataprotectionv1alpha1.BackupPolicy{}, testdbaas.RandomizedObjName(), testCtx.UseDefaultNamespace(),
+				func(backupPolicy *dataprotectionv1alpha1.BackupPolicy) {
+					backupPolicy.Spec.BackupToolName = backupTool.Name
+				})
+			backupPolicyName = backupPolicy.Name
 		})
 
-		It("Without backupTool resources should success with no error", func() {
+		Context("creates a full backup", func() {
+			var backupKey types.NamespacedName
 
-			By("By creating a statefulset")
-			_ = assureStatefulSetObj()
+			BeforeEach(func() {
+				By("By creating a backup from backupPolicy: " + backupPolicyName)
+				backup := testdbaas.CreateCustomizedObj(&testCtx, "backup/backup.yaml",
+					&dataprotectionv1alpha1.Backup{}, testdbaas.RandomizedObjName(), testCtx.UseDefaultNamespace(),
+					func(backup *dataprotectionv1alpha1.Backup) {
+						backup.Spec.BackupPolicyName = backupPolicyName
+					})
+				backupKey = client.ObjectKeyFromObject(backup)
+			})
 
-			By("By creating a backupTool")
-			backupTool := assureBackupToolObj(true)
+			It("should succeed after job completes", func() {
+				patchK8sJobStatus(backupKey, batchv1.JobComplete)
 
-			By("By creating a backupPolicy from backupTool: " + backupTool.Name)
-			backupPolicy := assureBackupPolicyObj(backupTool.Name)
+				Eventually(testdbaas.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dataprotectionv1alpha1.Backup) {
+					g.Expect(fetched.Status.Phase).To(Equal(dataprotectionv1alpha1.BackupCompleted))
+				})).Should(Succeed())
+			})
 
-			By("By creating a backup from backupPolicy: " + backupPolicy.Name)
-			toCreate := assureBackupObj(backupPolicy.Name)
-			key := types.NamespacedName{
-				Name:      toCreate.Name,
-				Namespace: toCreate.Namespace,
-			}
+			It("should fail after job fails", func() {
+				patchK8sJobStatus(backupKey, batchv1.JobFailed)
 
-			patchK8sJobStatus(batchv1.JobComplete, key)
+				Eventually(testdbaas.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dataprotectionv1alpha1.Backup) {
+					g.Expect(fetched.Status.Phase).To(Equal(dataprotectionv1alpha1.BackupFailed))
+				})).Should(Succeed())
+			})
+		})
 
-			result := &dataprotectionv1alpha1.Backup{}
-			Expect(k8sClient.Get(ctx, key, result)).Should(Succeed())
-			Eventually(func() bool {
-				Expect(k8sClient.Get(ctx, key, result)).Should(Succeed())
-				return result.Status.Phase == dataprotectionv1alpha1.BackupFailed ||
-					result.Status.Phase == dataprotectionv1alpha1.BackupCompleted
-			}, timeout, interval).Should(BeTrue())
-			Expect(result.Status.Phase).Should(Equal(dataprotectionv1alpha1.BackupCompleted))
+		Context("creates a snapshot backup", func() {
+			var backupKey types.NamespacedName
+
+			BeforeEach(func() {
+				viper.Set("VOLUMESNAPSHOT", "true")
+
+				By("By creating a backup from backupPolicy: " + backupPolicyName)
+				backup := testdbaas.CreateCustomizedObj(&testCtx, "backup/backup_snapshot.yaml",
+					&dataprotectionv1alpha1.Backup{}, testdbaas.RandomizedObjName(), testCtx.UseDefaultNamespace(),
+					func(backup *dataprotectionv1alpha1.Backup) {
+						backup.Spec.BackupPolicyName = backupPolicyName
+					})
+				backupKey = client.ObjectKeyFromObject(backup)
+			})
+
+			AfterEach(func() {
+				viper.Set("VOLUMESNAPSHOT", "false")
+			})
+
+			It("should success after all jobs complete", func() {
+				patchK8sJobStatus(types.NamespacedName{Name: backupKey.Name + "-pre", Namespace: backupKey.Namespace}, batchv1.JobComplete)
+				patchVolumeSnapshotStatus(backupKey, true)
+				patchK8sJobStatus(types.NamespacedName{Name: backupKey.Name + "-post", Namespace: backupKey.Namespace}, batchv1.JobComplete)
+
+				Eventually(testdbaas.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dataprotectionv1alpha1.Backup) {
+					g.Expect(fetched.Status.Phase).To(Equal(dataprotectionv1alpha1.BackupCompleted))
+				})).Should(Succeed())
+			})
+
+			It("should fail after pre-job fails", func() {
+				patchK8sJobStatus(types.NamespacedName{Name: backupKey.Name + "-pre", Namespace: backupKey.Namespace}, batchv1.JobFailed)
+
+				Eventually(testdbaas.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dataprotectionv1alpha1.Backup) {
+					g.Expect(fetched.Status.Phase).To(Equal(dataprotectionv1alpha1.BackupFailed))
+				})).Should(Succeed())
+			})
 		})
 	})
 
-	Context("When failed creating backup", func() {
-		It("Should failed with no error", func() {
+	When("without backupTool resources", func() {
+		Context("creates a full backup", func() {
+			var backupKey types.NamespacedName
 
-			By("By creating a statefulset")
-			_ = assureStatefulSetObj()
+			BeforeEach(func() {
+				By("By creating a backupTool")
+				backupTool := testdbaas.CreateCustomizedObj(&testCtx, "backup/backuptool.yaml",
+					&dataprotectionv1alpha1.BackupTool{}, testdbaas.RandomizedObjName(),
+					func(backupTool *dataprotectionv1alpha1.BackupTool) {
+						backupTool.Spec.Resources = nil
+					})
 
-			By("By creating a backupTool")
-			backupTool := assureBackupToolObj()
+				By("By creating a backupPolicy from backupTool: " + backupTool.Name)
+				backupPolicy := testdbaas.CreateCustomizedObj(&testCtx, "backup/backuppolicy.yaml",
+					&dataprotectionv1alpha1.BackupPolicy{}, testdbaas.RandomizedObjName(), testCtx.UseDefaultNamespace(),
+					func(backupPolicy *dataprotectionv1alpha1.BackupPolicy) {
+						backupPolicy.Spec.BackupToolName = backupTool.Name
+					})
 
-			By("By creating a backupPolicy from backupTool: " + backupTool.Name)
-			backupPolicy := assureBackupPolicyObj(backupTool.Name)
+				By("By creating a backup from backupPolicy: " + backupPolicy.Name)
+				backup := testdbaas.CreateCustomizedObj(&testCtx, "backup/backup.yaml",
+					&dataprotectionv1alpha1.Backup{}, testdbaas.RandomizedObjName(), testCtx.UseDefaultNamespace(),
+					func(backup *dataprotectionv1alpha1.Backup) {
+						backup.Spec.BackupPolicyName = backupPolicy.Name
+					})
+				backupKey = client.ObjectKeyFromObject(backup)
+			})
 
-			By("By creating a backup from backupPolicy: " + backupPolicy.Name)
-			toCreate := assureBackupObj(backupPolicy.Name)
-			key := types.NamespacedName{
-				Name:      toCreate.Name,
-				Namespace: toCreate.Namespace,
-			}
+			It("should succeed after job completes", func() {
+				patchK8sJobStatus(backupKey, batchv1.JobComplete)
 
-			patchK8sJobStatus(batchv1.JobFailed, key)
-
-			result := &dataprotectionv1alpha1.Backup{}
-			Expect(k8sClient.Get(ctx, key, result)).Should(Succeed())
-
-			Eventually(func() bool {
-				Expect(k8sClient.Get(ctx, key, result)).Should(Succeed())
-				return result.Status.Phase == dataprotectionv1alpha1.BackupFailed ||
-					result.Status.Phase == dataprotectionv1alpha1.BackupCompleted
-			}, timeout, interval).Should(BeTrue())
-			Expect(result.Status.Phase).Should(Equal(dataprotectionv1alpha1.BackupFailed))
+				Eventually(testdbaas.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dataprotectionv1alpha1.Backup) {
+					g.Expect(fetched.Status.Phase).To(Equal(dataprotectionv1alpha1.BackupCompleted))
+				})).Should(Succeed())
+			})
 		})
 	})
-
-	Context("When creating backup with snapshot", func() {
-		It("Should success with no error", func() {
-			viper.Set("VOLUMESNAPSHOT", "true")
-			By("By creating a statefulset")
-			_ = assureStatefulSetObj()
-
-			By("By creating a backupTool")
-			backupTool := assureBackupToolObj()
-
-			By("By creating a backupPolicy from backupTool: " + backupTool.Name)
-			backupPolicy := assureBackupPolicyObj(backupTool.Name)
-
-			By("By creating a backup from backupPolicy: " + backupPolicy.Name)
-			toCreate := assureBackupSnapshotObj(backupPolicy.Name)
-			key := types.NamespacedName{
-				Name:      toCreate.Name,
-				Namespace: toCreate.Namespace,
-			}
-
-			patchK8sJobStatus(batchv1.JobComplete, Key{Name: toCreate.Name + "-pre", Namespace: toCreate.Namespace})
-			patchVolumeSnapshotStatus(key, true)
-			patchK8sJobStatus(batchv1.JobComplete, Key{Name: toCreate.Name + "-post", Namespace: toCreate.Namespace})
-
-			result := &dataprotectionv1alpha1.Backup{}
-			Expect(k8sClient.Get(ctx, key, result)).Should(Succeed())
-
-			Eventually(func() bool {
-				Expect(k8sClient.Get(ctx, key, result)).Should(Succeed())
-				return result.Status.Phase == dataprotectionv1alpha1.BackupFailed ||
-					result.Status.Phase == dataprotectionv1alpha1.BackupCompleted
-			}, timeout, interval).Should(BeTrue())
-			Expect(result.Status.Phase).Should(Equal(dataprotectionv1alpha1.BackupCompleted))
-		})
-
-		It("Should failed", func() {
-			viper.Set("VOLUMESNAPSHOT", "true")
-			By("By creating a statefulset")
-			_ = assureStatefulSetObj()
-
-			By("By creating a backupTool")
-			backupTool := assureBackupToolObj()
-
-			By("By creating a backupPolicy from backupTool: " + backupTool.Name)
-			backupPolicy := assureBackupPolicyObj(backupTool.Name)
-
-			By("By creating a backup from backupPolicy: " + backupPolicy.Name)
-			toCreate := assureBackupSnapshotObj(backupPolicy.Name)
-			key := types.NamespacedName{
-				Name:      toCreate.Name,
-				Namespace: toCreate.Namespace,
-			}
-
-			patchK8sJobStatus(batchv1.JobFailed, Key{Name: toCreate.Name + "-pre", Namespace: toCreate.Namespace})
-
-			result := &dataprotectionv1alpha1.Backup{}
-			Expect(k8sClient.Get(ctx, key, result)).Should(Succeed())
-
-			Eventually(func() bool {
-				Expect(k8sClient.Get(ctx, key, result)).Should(Succeed())
-				return result.Status.Phase == dataprotectionv1alpha1.BackupFailed ||
-					result.Status.Phase == dataprotectionv1alpha1.BackupCompleted
-			}, timeout, interval).Should(BeTrue())
-			Expect(result.Status.Phase).Should(Equal(dataprotectionv1alpha1.BackupFailed))
-		})
-	})
-
 })
+
+func patchK8sJobStatus(key types.NamespacedName, jobStatus batchv1.JobConditionType) {
+	Eventually(testdbaas.GetAndChangeObjStatus(&testCtx, key, func(fetched *batchv1.Job) {
+		jobCondition := batchv1.JobCondition{Type: jobStatus}
+		fetched.Status.Conditions = append(fetched.Status.Conditions, jobCondition)
+	})).Should(Succeed())
+}
+
+func patchVolumeSnapshotStatus(key types.NamespacedName, readyToUse bool) {
+	Eventually(testdbaas.GetAndChangeObjStatus(&testCtx, key, func(fetched *snapshotv1.VolumeSnapshot) {
+		snapStatus := snapshotv1.VolumeSnapshotStatus{ReadyToUse: &readyToUse}
+		fetched.Status = &snapStatus
+	})).Should(Succeed())
+}

--- a/controllers/dataprotection/utils.go
+++ b/controllers/dataprotection/utils.go
@@ -18,8 +18,8 @@ package dataprotection
 
 import (
 	"context"
-	"strings"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -33,12 +33,11 @@ func checkResourceExists(
 	obj client.Object) (bool, error) {
 
 	if err := client.Get(ctx, key, obj); err != nil {
-		// if err is NOT "not found", that means unknown error.
-		if !strings.Contains(err.Error(), "not found") {
-			return false, err
+		if apierrors.IsNotFound(err) {
+			return false, nil
 		}
-		// if not found, return false
-		return false, nil
+		// if err is NOT "not found", that means unknown error.
+		return false, err
 	}
 	// if found, return true
 	return true, nil

--- a/internal/testutil/type.go
+++ b/internal/testutil/type.go
@@ -122,3 +122,9 @@ func (testCtx TestContext) GetWebhookHostExternalName() string {
 		return ""
 	}
 }
+
+func (testCtx TestContext) UseDefaultNamespace() func(client.Object) {
+	return func(obj client.Object) {
+		obj.SetNamespace(testCtx.DefaultNamespace)
+	}
+}

--- a/test/testdata/backup/backup.yaml
+++ b/test/testdata/backup/backup.yaml
@@ -1,0 +1,15 @@
+apiVersion: dataprotection.kubeblocks.io/v1alpha1
+kind: Backup
+metadata:
+  name: backup-job-
+
+  labels:
+    dataprotection.kubeblocks.io/backup-type: full
+    db.kubeblocks.io/name: mysqlcluster
+    dataprotection.kubeblocks.io/backup-policy-name: backup-policy-demo
+    dataprotection.kubeblocks.io/backup-index: "0"
+
+spec:
+  backupPolicyName: backup-policy-demo
+  backupType: full
+  ttl: 168h0m0s

--- a/test/testdata/backup/backup_snapshot.yaml
+++ b/test/testdata/backup/backup_snapshot.yaml
@@ -1,0 +1,8 @@
+apiVersion: dataprotection.kubeblocks.io/v1alpha1
+kind: Backup
+metadata:
+  name: backup-job-
+spec:
+  backupPolicyName: backup-policy-
+  backupType: snapshot
+  ttl: 168h0m0s

--- a/test/testdata/backup/backuppolicy.yaml
+++ b/test/testdata/backup/backuppolicy.yaml
@@ -1,0 +1,25 @@
+apiVersion: dataprotection.kubeblocks.io/v1alpha1
+kind: BackupPolicy
+metadata:
+  name: backup-policy-
+spec:
+  schedule: "0 3 * * *"
+  ttl: 168h0m0s
+  backupToolName: xtrabackup-mysql
+  target:
+    databaseEngine: mysql
+    labelsSelector:
+      matchLabels:
+        app.kubernetes.io/instance: wesql-cluster
+    secret:
+      name: wesql-cluster
+  hooks:
+    preCommands:
+      - touch /data/mysql/.restore;sync
+    postCommands:
+      - rm -f /data/mysql/.restore;sync
+  remoteVolume:
+    name: backup-remote-volume
+    persistentVolumeClaim:
+      claimName: backup-host-path-pvc
+  onFailAttempted: 3

--- a/test/testdata/backup/backuptool.yaml
+++ b/test/testdata/backup/backuptool.yaml
@@ -1,0 +1,36 @@
+apiVersion: dataprotection.kubeblocks.io/v1alpha1
+kind: BackupTool
+metadata:
+  name: backup-tool-
+spec:
+  image: percona/percona-xtrabackup
+  databaseEngine: mysql
+  deployKind: job
+  resources:
+    limits:
+      cpu: "1"
+      memory: 2Gi
+  env:
+    - name: DATA_DIR
+      value: /var/lib/mysql
+  physical:
+    restoreCommands:
+      - |
+        echo "BACKUP_DIR=${BACKUP_DIR} BACKUP_NAME=${BACKUP_NAME} DATA_DIR=${DATA_DIR}" && \
+        mkdir -p /tmp/data/ && cd /tmp/data \
+        && xbstream -x < /${BACKUP_DIR}/${BACKUP_NAME}.xbstream \
+        && xtrabackup --decompress  --target-dir=/tmp/data/ \
+        && find . -name "*.qp"|xargs rm -f \
+        && rm -rf ${DATA_DIR}/* \
+        && rsync -avrP /tmp/data/ ${DATA_DIR}/ \
+        && rm -rf /tmp/data/ \
+        && chmod -R 0777 ${DATA_DIR}
+    incrementalRestoreCommands: []
+  logical:
+    restoreCommands: []
+    incrementalRestoreCommands: []
+  backupCommands:
+    - echo "DB_HOST=${DB_HOST} DB_USER=${DB_USER} DB_PASSWORD=${DB_PASSWORD} DATA_DIR=${DATA_DIR} BACKUP_DIR=${BACKUP_DIR} BACKUP_NAME=${BACKUP_NAME}";
+      mkdir -p /${BACKUP_DIR};
+      xtrabackup --compress --backup  --safe-slave-backup --slave-info --stream=xbstream --host=${DB_HOST} --user=${DB_USER} --password=${DB_PASSWORD} --datadir=${DATA_DIR} > /${BACKUP_DIR}/${BACKUP_NAME}.xbstream
+  incrementalBackupCommands: []

--- a/test/testdata/backup/statefulset.yaml
+++ b/test/testdata/backup/statefulset.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.kubernetes.io/instance: wesql-cluster
+  name: wesql-cluster-replicasets-primary
+spec:
+  minReadySeconds: 10
+  podManagementPolicy: Parallel
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: replicasets-replicasets
+      app.kubernetes.io/instance: wesql-cluster-replicasets-primary
+      app.kubernetes.io/name: state.mysql-wesql-clusterdefinition
+  serviceName: wesql-cluster-replicasets-primary
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/component: replicasets-replicasets
+        app.kubernetes.io/instance: wesql-cluster-replicasets-primary
+        app.kubernetes.io/name: state.mysql-wesql-clusterdefinition
+    spec:
+      containers:
+        - args: []
+          command:
+            - /bin/bash
+            - -c
+          image: docker.io/apecloud/wesql-server:latest
+          imagePullPolicy: IfNotPresent
+          name: mysql
+          ports:
+            - containerPort: 3306
+              name: mysql
+              protocol: TCP
+            - containerPort: 13306
+              name: paxos
+              protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /var/lib/mysql
+              name: data
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        creationTimestamp: null
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+        volumeMode: Filesystem

--- a/test/testdata/backup/statefulset_pod.yaml
+++ b/test/testdata/backup/statefulset_pod.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: wesql-cluster-replicasets-primary-
+  labels:
+    statefulset.kubernetes.io/pod-name: wesql-cluster-replicasets-primary-0
+  name: wesql-cluster-replicasets-primary-0
+spec:
+  containers:
+    - args:
+        - docker-entrypoint.sh mysqld
+      command:
+        - /bin/bash
+        - '-c'
+      env:
+        - name: KB_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: KB_REPLICASETS_PRIMARY_N
+          value: '1'
+        - name: KB_REPLICASETS_PRIMARY_0_HOSTNAME
+          value: wesql-cluster-replicasets-primary-0
+      image: 'docker.io/apecloud/wesql-server:latest'
+      imagePullPolicy: IfNotPresent
+      name: mysql
+      ports:
+        - containerPort: 3306
+          name: mysql
+          protocol: TCP
+        - containerPort: 13306
+          name: paxos
+          protocol: TCP
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+        - mountPath: /var/lib/mysql
+          name: data
+  hostname: wesql-cluster-replicasets-primary-0
+  preemptionPolicy: PreemptLowerPriority
+  priority: 0
+  restartPolicy: Always
+  securityContext: {}
+  subdomain: wesql-cluster-replicasets-primary
+  terminationGracePeriodSeconds: 30
+  tolerations:
+    - effect: NoExecute
+      key: node.kubernetes.io/not-ready
+      operator: Exists
+      tolerationSeconds: 300
+    - effect: NoExecute
+      key: node.kubernetes.io/unreachable
+      operator: Exists
+      tolerationSeconds: 300
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: data-wesql-cluster-replicasets-primary-0


### PR DESCRIPTION
Major improvements:
- move configs from code into testdata/
- use ginkgo's Describe/When/Context/It tree structure to organize test cases, subtract common initialization code into each node's BeforeEach()
- use lib functions in internal/dbaas/common_util.go to save LoC