### PR TITLE
chore: get kbcli release with token

### DIFF
--- a/.github/utils/utils.sh
+++ b/.github/utils/utils.sh
@@ -2,9 +2,11 @@
 PARAM=$1
 TYPE=$2
 UPLOAD_REPO=$3
+GITHUB_TOKEN=$4
 
 gh_curl() {
-  curl -H "Accept: application/vnd.github.v3.raw" \
+  curl -H "Authorization: token $GITHUB_TOKEN" \
+    -H "Accept: application/vnd.github.v3.raw" \
     $@
 }
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -30,6 +30,7 @@ jobs:
   upload-release-assert:
     needs: create-release-kbcli
     name: Upload ${{ matrix.os }}
+    continue-on-error: true
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -83,10 +84,14 @@ jobs:
 
       - name: get release kbcli upload url
         run: |
-          echo 'UPLOAD_URL='`bash ${{ github.workspace }}/.github/utils/utils.sh ${{ env.TAG_NAME }} 2 ${{ env.CLI_REPO }}` >> $GITHUB_ENV
+          echo 'UPLOAD_URL='`bash ${{ github.workspace }}/.github/utils/utils.sh \
+            ${{ env.TAG_NAME }} 2 \
+            ${{ env.CLI_REPO }} \
+            ${{ env.GITHUB_TOKEN }}` >> $GITHUB_ENV
 
       - name: upload release kbcli asset ${{ matrix.os }}
         uses: actions/upload-release-asset@main
+        continue-on-error: true
         env:
           CLI_BINARY: ${{ env.CLI_NAME }}-${{ matrix.os }}-${{ env.TAG_NAME }}.tar.gz
         with:


### PR DESCRIPTION
1. Get kbcli release assets url with token.
2. Add `continue-on-error: true` to prevent other jobs in the matrix from being canceled due to other job errors.