### PR TITLE
chore: remove the check of the times of same warning events

### DIFF
--- a/controllers/dbaas/cluster_status_utils.go
+++ b/controllers/dbaas/cluster_status_utils.go
@@ -48,9 +48,6 @@ type clusterStatusHandler func(cluster *dbaasv1alpha1.Cluster) (bool, postHandle
 const (
 	// EventTimeOut timeout of the event
 	EventTimeOut = 30 * time.Second
-
-	// EventOccursTimes occurs times of the event
-	EventOccursTimes int32 = 3
 )
 
 // doChainClusterStatusHandler chain processing clusterStatusHandler.
@@ -355,7 +352,7 @@ func handleEventForClusterStatus(ctx context.Context, cli client.Client, recorde
 		{
 			pred: func() bool {
 				// the error repeated several times, so we can sure it's a real error to the cluster.
-				return !k8score.IsOvertimeAndOccursTimesForEvent(event, EventTimeOut, EventOccursTimes)
+				return !k8score.IsOvertimeEvent(event, EventTimeOut)
 			},
 			processor: nilReturnHandler,
 		},

--- a/controllers/dbaas/operations/volume_expansion_updater.go
+++ b/controllers/dbaas/operations/volume_expansion_updater.go
@@ -39,9 +39,6 @@ const (
 	// PVCEventTimeOut timeout of the pvc event
 	PVCEventTimeOut = 30 * time.Second
 
-	// PVCEventOccursTimes occurs times of the pvc event
-	PVCEventOccursTimes int32 = 5
-
 	// VolumeResizeFailed the event reason of volume resize failed on external-resizer(the csi driver sidecar)
 	VolumeResizeFailed = "VolumeResizeFailed"
 	// FileSystemResizeFailed the event reason of fileSystem resize failed on kubelet volume manager
@@ -110,7 +107,7 @@ func (pvcEventHandler PersistentVolumeClaimEventHandler) Handle(cli client.Clien
 	if !pvcEventHandler.isTargetResizeFailedEvents(event) {
 		return nil
 	}
-	if !k8score.IsOvertimeAndOccursTimesForEvent(event, PVCEventTimeOut, PVCEventOccursTimes) {
+	if !k8score.IsOvertimeEvent(event, PVCEventTimeOut) {
 		return nil
 	}
 	var (

--- a/controllers/k8score/event_controller_test.go
+++ b/controllers/k8score/event_controller_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Event Controller", func() {
 			}, time.Second*60, time.Second).Should(Equal(sndEvent.InvolvedObject.Name))
 
 			By("check whether the duration and number of events reach the threshold")
-			IsOvertimeAndOccursTimesForEvent(sndEvent, 5*time.Second, 1)
+			IsOvertimeEvent(sndEvent, 5*time.Second)
 		})
 	})
 })

--- a/controllers/k8score/event_utils.go
+++ b/controllers/k8score/event_utils.go
@@ -22,8 +22,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// IsOvertimeAndOccursTimesForEvent check whether the duration and number of events reach the threshold
-func IsOvertimeAndOccursTimesForEvent(event *corev1.Event, timeout time.Duration, eventOccursTimes int32) bool {
-	return event.LastTimestamp.After(event.FirstTimestamp.Add(timeout)) &&
-		event.Count >= eventOccursTimes
+// IsOvertimeEvent check whether the duration of warning event reaches the threshold.
+func IsOvertimeEvent(event *corev1.Event, timeout time.Duration) bool {
+	if event.Series != nil {
+		return event.Series.LastObservedTime.After(event.EventTime.Add(timeout))
+	}
+	// Note: LastTimestamp/FirstTimestamp/Count/Source of event are deprecated in k8s v1.25
+	return event.LastTimestamp.After(event.FirstTimestamp.Add(timeout))
 }


### PR DESCRIPTION
1. Warning event is usually triggered when controller error occurs. However, for the controller's delay queue of failed reentry, baseDelay is 5 milliseconds by default. In the same speed limiter, the continuous err will re-enter the queue with a delay of 2 ^ n * 5 milliseconds to trigger controller reconcile. 

2. In k8s scheduling, the backOffQ to ActiveQ is timed for 1s when pod schedules failed. Unless this pod is identified as unscheduled, it will be put into UnscheduleQ. It will enter a 30s timing logic. If the unscheduled pod is more than 60s from the last scheduled time, it will be put into backOffQ. Of course, the complete scheduling logic may take some time, so it may take several minutes to send warning events again. 

So the checks of the times can usually be ignored when the overtime is 30s.
