### PR TITLE
fix: build kbcli with CGO_ENABLED=0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ CLI_LD_FLAGS ="-s -w \
 
 
 bin/kbcli.%: ## Cross build bin/kbcli.$(OS).$(ARCH).
-	GOOS=$(word 2,$(subst ., ,$@)) GOARCH=$(word 3,$(subst ., ,$@)) $(GO) build -ldflags=${CLI_LD_FLAGS} -o $@ cmd/cli/main.go
+	GOOS=$(word 2,$(subst ., ,$@)) GOARCH=$(word 3,$(subst ., ,$@)) CGO_ENABLED=0 $(GO) build -ldflags=${CLI_LD_FLAGS} -o $@ cmd/cli/main.go
 
 .PHONY: kbcli
 kbcli: OS=$(shell $(GO) env GOOS)


### PR DESCRIPTION
fix #1315 

refer: https://go.dev/blog/cgo

> Cgo lets Go packages call C code. Given a Go source file written with some special features, cgo outputs Go and C files that can be combined into a single Go package.

kbcli **DO NOT** call c code, so disable cgo and fix the dependency to glibc.
