### PR TITLE
chore: replace image repo from quay.io to docker hub

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -157,7 +157,7 @@ prometheus:
     ## alertmanager container image
     ##
     image:
-      repository: apecloud/alertmanager
+      repository: docker.io/apecloud/alertmanager
       tag: v0.24.0
 
     persistentVolume:
@@ -220,7 +220,7 @@ prometheus:
     ## node-exporter container image
     ##
     image:
-      repository: apecloud/node-exporter
+      repository: docker.io/apecloud/node-exporter
       tag: v1.3.1
 
   server:
@@ -231,7 +231,7 @@ prometheus:
     ## Prometheus server container image
     ##
     image:
-      repository: apecloud/prometheus
+      repository: docker.io/apecloud/prometheus
       tag: v2.39.1
 
     global:
@@ -736,7 +736,7 @@ grafana:
 
   sidecar:
     image:
-      repository: apecloud/k8s-sidecar
+      repository: docker.io/apecloud/k8s-sidecar
       tag: 1.19.2
 
     dashboards:


### PR DESCRIPTION
fix #1275

* Copy all dependent image from quay.io to docker hub
```
skopeo copy --all docker://quay.io/prometheus/alertmanager:v0.24.0 docker://docker.io/apecloud/alertmanager:v0.24.0
skopeo copy --all docker://quay.io/prometheus/node-exporter:v1.3.1 docker://docker.io/apecloud/node-exporter:v1.3.1
skopeo copy --all docker://quay.io/prometheus/prometheus:v2.39.1 docker://docker.io/apecloud/prometheus:v2.39.1
skopeo copy --all docker://quay.io/kiwigrid/k8s-sidecar:1.19.2 docker://docker.io/apecloud/k8s-sidecar:1.19.2
```
* Replace all quay.io image to docker hub to speed up the download.
