### PR TITLE
fix: cli create cluster with new cluster CRD

### DIFF
--- a/docs/user_docs/cli/kbcli_playground_init.md
+++ b/docs/user_docs/cli/kbcli_playground_init.md
@@ -15,9 +15,9 @@ kbcli playground init [flags]
       --cluster-definition string   Cluster definition (default "apecloud-mysql")
       --cluster-version string      Cluster definition
   -h, --help                        help for init
-      --kubeblocks-version string   KubeBlocks version
       --region string               Cloud provider region
       --verbose                     Output more log info
+      --version string              KubeBlocks version
 ```
 
 ### Options inherited from parent commands

--- a/internal/cli/cmd/cluster/create.go
+++ b/internal/cli/cmd/cluster/create.go
@@ -139,7 +139,7 @@ type CreateOptions struct {
 	ClusterDefRef     string                   `json:"clusterDefRef"`
 	ClusterVersionRef string                   `json:"clusterVersionRef"`
 	Tolerations       []interface{}            `json:"tolerations,omitempty"`
-	Components        []map[string]interface{} `json:"components"`
+	ComponentSpecs    []map[string]interface{} `json:"componentSpecs"`
 
 	SetFile string   `json:"-"`
 	Values  []string `json:"-"`
@@ -236,7 +236,7 @@ func (o *CreateOptions) Complete() error {
 	if err := setBackup(o, components); err != nil {
 		return err
 	}
-	o.Components = components
+	o.ComponentSpecs = components
 
 	// TolerationsRaw looks like `["key=engineType,value=mongo,operator=Equal,effect=NoSchedule"]` after parsing by cmd
 	tolerations := buildTolerations(o.TolerationsRaw)
@@ -254,7 +254,7 @@ func (o *CreateOptions) buildComponents() ([]map[string]interface{}, error) {
 	)
 
 	// build components from file
-	components := o.Components
+	components := o.ComponentSpecs
 	if len(o.SetFile) > 0 {
 		if componentByte, err = MultipleSourceComponents(o.SetFile, o.IOStreams.In); err != nil {
 			return nil, err

--- a/internal/cli/cmd/cluster/dataprotection.go
+++ b/internal/cli/cmd/cluster/dataprotection.go
@@ -372,7 +372,7 @@ func (o *CreateRestoreOptions) Complete() error {
 		return err
 	}
 
-	if err = json.Unmarshal(componentByte, &o.Components); err != nil {
+	if err = json.Unmarshal(componentByte, &o.ComponentSpecs); err != nil {
 		return err
 	}
 

--- a/internal/cli/cmd/playground/playground.go
+++ b/internal/cli/cmd/playground/playground.go
@@ -92,7 +92,7 @@ func newInitCmd(streams genericclioptions.IOStreams) *cobra.Command {
 
 	cmd.Flags().StringVar(&o.clusterDef, "cluster-definition", defaultClusterDef, "Cluster definition")
 	cmd.Flags().StringVar(&o.clusterVersion, "cluster-version", "", "Cluster definition")
-	cmd.Flags().StringVar(&o.kbVersion, "kubeblocks-version", version.DefaultKubeBlocksVersion, "KubeBlocks version")
+	cmd.Flags().StringVar(&o.kbVersion, "version", version.DefaultKubeBlocksVersion, "KubeBlocks version")
 	cmd.Flags().StringVar(&o.CloudProvider, "cloud-provider", defaultCloudProvider, "Cloud provider type")
 	cmd.Flags().StringVar(&o.AccessKey, "access-key", "", "Cloud provider access key")
 	cmd.Flags().StringVar(&o.AccessSecret, "access-secret", "", "Cloud provider access secret")
@@ -375,6 +375,7 @@ func newCreateOptions(cd string, version string) (*cmdcluster.CreateOptions, err
 		UpdatableFlags: cmdcluster.UpdatableFlags{
 			TerminationPolicy: "WipeOut",
 			Monitor:           true,
+			PodAntiAffinity:   "Preferred",
 		},
 		ClusterDefRef:     cd,
 		ClusterVersionRef: version,

--- a/internal/cli/create/template/cluster_template.cue
+++ b/internal/cli/create/template/cluster_template.cue
@@ -18,7 +18,7 @@ options: {
 	namespace:         string
 	clusterDefRef:     string
 	clusterVersionRef: string
-	components: [...]
+	componentSpecs: [...]
 	terminationPolicy: string
 	podAntiAffinity:   string
 	topologyKeys: [...]
@@ -43,7 +43,7 @@ content: {
 			nodeLabels:      options.nodeLabels
 		}
 		tolerations:       options.tolerations
-		components:        options.components
+		componentSpecs:    options.componentSpecs
 		terminationPolicy: options.terminationPolicy
 	}
 }

--- a/internal/cli/util/helm/helm.go
+++ b/internal/cli/util/helm/helm.go
@@ -43,6 +43,8 @@ import (
 	"helm.sh/helm/v3/pkg/repo"
 	"helm.sh/helm/v3/pkg/storage"
 	"helm.sh/helm/v3/pkg/storage/driver"
+
+	"github.com/apecloud/kubeblocks/internal/cli/types"
 )
 
 const defaultTimeout = time.Second * 600
@@ -84,15 +86,15 @@ func AddRepo(r *repo.Entry) error {
 
 	// Check if the repo Name is legal
 	if strings.Contains(r.Name, "/") {
-		return errors.Errorf("repository Name (%s) contains '/', please specify a different Name without '/'", r.Name)
+		return errors.Errorf("repository name (%s) contains '/', please specify a different name without '/'", r.Name)
 	}
 
 	if f.Has(r.Name) {
 		existing := f.Get(r.Name)
-		if *r != *existing {
+		if *r != *existing && r.Name != types.KubeBlocksChartName {
 			// The input coming in for the Name is different from what is already
 			// configured. Return an error.
-			return errors.Errorf("repository Name (%s) already exists, please specify a different Name", r.Name)
+			return errors.Errorf("repository name (%s) already exists, please specify a different name", r.Name)
 		}
 	}
 

--- a/internal/controller/component/probe_utils_test.go
+++ b/internal/controller/component/probe_utils_test.go
@@ -17,13 +17,13 @@ limitations under the License.
 package component
 
 import (
-	intctrlutil "github.com/apecloud/kubeblocks/internal/controllerutil"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
 
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
+	intctrlutil "github.com/apecloud/kubeblocks/internal/controllerutil"
 )
 
 var _ = Describe("probe_utils", func() {


### PR DESCRIPTION
fix #1496 

* fix old cluster field `components` to `componentSpecs` when create cluster
* fix `playground` init failed due to empty podAntiAffinity
* rename `playground` --kubeblocks-version to --version
