### PR TITLE
fix: cli hint unknown cluster set key

### DIFF
--- a/internal/cli/cmd/cluster/create.go
+++ b/internal/cli/cmd/cluster/create.go
@@ -485,14 +485,14 @@ func buildCompSetsMap(values []string, cd *appsv1alpha1.ClusterDefinition) (map[
 		for _, set := range sets {
 			kv := strings.Split(set, "=")
 			if len(kv) != 2 {
-				printer.Warning(os.Stdout, "unknown set format \"%s\", ignore it, should be like key1=value1\n", set)
+				printer.Warning(os.Stdout, "unknown set format \"%s\", it will be ignored, should be like key1=value1\n", set)
 				continue
 			}
 
 			// only record the supported key
 			k := parseKey(kv[0])
 			if k == keyUnknown {
-				printer.Warning(os.Stdout, "unknown set key \"%s\", ignore it, should be one of [%s]\n", kv[0], strings.Join(keys, ","))
+				printer.Warning(os.Stdout, "unknown set key \"%s\", it will be ignored, should be one of [%s]\n", kv[0], strings.Join(keys, ","))
 				continue
 			}
 			res[k] = kv[1]


### PR DESCRIPTION
* fix #1460

Example:
```
$ kbcli cluster create --enable-all-logs=true --cluster-definition apecloud-mysql --set=test=v1
Warning: unknown set key "test", ignore it, should be one of [cpu,type,storage,memory,replicas]
Warning: cluster version is not specified, use the recently created ClusterVersion ac-mysql-8.0.30
Cluster clover61 created

$ kbcli cluster create --enable-all-logs=true --cluster-definition apecloud-mysql --set=/Users/ldm/Documents/go/src/github.com/apecloud/kubeblocks/internal/cli/testing/testdata/component.yaml
Warning: unknown set format "/Users/ldm/Documents/go/src/github.com/apecloud/kubeblocks/internal/cli/testing/testdata/component.yaml", ignore it, should be like key1=value1
Warning: cluster version is not specified, use the recently created ClusterVersion ac-mysql-8.0.30
Cluster poplar37 created

```