### PR TITLE
chore: fix table printer with more right padding

### DIFF
--- a/internal/cli/cmd/cluster/list.go
+++ b/internal/cli/cmd/cluster/list.go
@@ -162,7 +162,7 @@ func NewListUsersCmd(f cmdutil.Factory, streams genericclioptions.IOStreams) *co
 		Short:             "List cluster users",
 		Example:           listUsersExample,
 		Aliases:           []string{"ls-users"},
-		ValidArgsFunction: util.ResourceNameCompletionFunc(f, o.GVR),
+		ValidArgsFunction: util.ResourceNameCompletionFunc(f, types.ClusterGVR()),
 		Run: func(cmd *cobra.Command, args []string) {
 			util.CheckErr(listUsers(o, args))
 		},

--- a/internal/cli/printer/printer.go
+++ b/internal/cli/printer/printer.go
@@ -24,23 +24,8 @@ import (
 )
 
 var (
-	boxStyle = table.BoxStyle{
-		PaddingLeft:   "",
-		PaddingRight:  "\t",
-		PageSeparator: "\n",
-		UnfinishedRow: " ~",
-	}
-
-	// StyleKubeCtl renders a Table like kubectl
-	StyleKubeCtl = table.Style{
-		Name:    "StyleKubeCtl",
-		Box:     boxStyle,
-		Color:   table.ColorOptionsDefault,
-		Format:  table.FormatOptionsDefault,
-		HTML:    table.DefaultHTMLOptions,
-		Options: table.OptionsNoBordersAndSeparators,
-		Title:   table.TitleOptionsDefault,
-	}
+	// KubeCtlStyle renders a Table like kubectl
+	KubeCtlStyle table.Style
 
 	// TerminalStyle renders a Table like below:
 	//  +-----+------------+-----------+--------+-----------------------------+
@@ -67,9 +52,24 @@ type TablePrinter struct {
 	tbl table.Writer
 }
 
+func init() {
+	boxStyle := table.StyleBoxDefault
+	boxStyle.PaddingLeft = ""
+	boxStyle.PaddingRight = "   "
+	KubeCtlStyle = table.Style{
+		Name:    "StyleKubeCtl",
+		Box:     boxStyle,
+		Color:   table.ColorOptionsDefault,
+		Format:  table.FormatOptionsDefault,
+		HTML:    table.DefaultHTMLOptions,
+		Options: table.OptionsNoBordersAndSeparators,
+		Title:   table.TitleOptionsDefault,
+	}
+}
+
 func NewTablePrinter(out io.Writer) *TablePrinter {
 	t := table.NewWriter()
-	t.SetStyle(StyleKubeCtl)
+	t.SetStyle(KubeCtlStyle)
 	t.SetOutputMirror(out)
 	return &TablePrinter{tbl: t}
 }

--- a/internal/cli/printer/printer_test.go
+++ b/internal/cli/printer/printer_test.go
@@ -27,18 +27,19 @@ import (
 )
 
 var (
-	colTitleIndex     = "#"
-	colTitleFirstName = "First Name"
-	colTitleLastName  = "Last Name"
-	colTitleSalary    = "Salary"
+	header = []string{"NAME", "NAMESPACE", "CLUSTER-DEFINITION", "VERSION", "TERMINATION-POLICY", "CREATED-TIME"}
 )
 
 func TestPrintTable(t *testing.T) {
 	printer := NewTablePrinter(os.Stdout)
-	printer.SetHeader(colTitleIndex, colTitleFirstName, colTitleLastName, colTitleSalary)
+	headerRow := make([]interface{}, len(header))
+	for i, h := range header {
+		headerRow[i] = h
+	}
+	printer.SetHeader(headerRow...)
 	for _, r := range [][]string{
-		{"1", "Arya", "Stark", "3000"},
-		{"20", "Jon", "Snow", "2000"},
+		{"brier63", "default", "apecloud-mysql", "ac-mysql-8.0.30", "Delete", "Feb 20,2023 16:39 UTC+0800"},
+		{"cedar51", "default", "apecloud-mysql", "ac-mysql-8.0.30", "Delete", "Feb 20,2023 16:39 UTC+0800"},
 	} {
 		row := make([]interface{}, len(r))
 		for i, rr := range r {


### PR DESCRIPTION
make cli table printer similar with kubectl.

Before:
```
NAME   	NAMESPACE	CLUSTER-DEFINITION	VERSION        	TERMINATION-POLICY	CREATED-TIME              	
brier63	default  	apecloud-mysql    	ac-mysql-8.0.30	Delete            	Feb 20,2023 16:39 UTC+0800	
cedar51	default  	apecloud-mysql    	ac-mysql-8.0.30	Delete            	Feb 20,2023 16:39 UTC+0800	
```
Between `ac-mysql-8.0.30` and `Delete` only one space.

After:
```
NAME      NAMESPACE   CLUSTER-DEFINITION   VERSION           TERMINATION-POLICY   CREATED-TIME                 
brier63   default     apecloud-mysql       ac-mysql-8.0.30   Delete               Feb 20,2023 16:39 UTC+0800   
cedar51   default     apecloud-mysql       ac-mysql-8.0.30   Delete               Feb 20,2023 16:39 UTC+0800  
```

Similar with KubeCtl, separate with 3 blank space, kubectl output:
```
$ kubectl get cluster
NAME       CLUSTER-DEFINITION   VERSION           TERMINATION-POLICY   STATUS            AGE
brier63    apecloud-mysql       ac-mysql-8.0.30   Delete               ConditionsError   99m
cedar51    apecloud-mysql       ac-mysql-8.0.30   Delete               ConditionsError   99m
clover61   apecloud-mysql       ac-mysql-8.0.30   Delete               ConditionsError   96m
flax67     apecloud-mysql       ac-mysql-8.0.30   Delete               ConditionsError   138m
mango82    apecloud-mysql       ac-mysql-8.0.30   Delete               ConditionsError   100m
maple52    apecloud-mysql       ac-mysql-8.0.30   Delete               ConditionsError   103m
poplar37   apecloud-mysql       ac-mysql-8.0.30   Delete               ConditionsError   88m

```
