### PR TITLE
test: add smoke tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -822,11 +822,18 @@ minikube-delete: minikube ## Delete minikube cluster.
 	$(MINIKUBE) delete
 
 ##@ Test E2E
+GINKGO=$(shell which ginkgo)
 .PHONY: test-e2e
 test-e2e: ## Test End-to-end.
-	$(MAKE) -e VERSION=$(VERSION) -C test/e2e run
-
+	$(HELM) template mycluster deploy/apecloud-mysql-cluster > test/e2e/testdata/smoketest/wesql/00_wesqlcluster.yaml
+	# $(HELM) template mycluster deploy/mongodb > test/e2e/testdata/smoketest/mongodb/00_mongodbcluster.yaml
+	# $(HELM) template mycluster deploy/mongodb-cluster >> test/e2e/testdata/smoketest/mongodb/00_mongodbcluster.yaml
+	# $(HELM) template mycluster deploy/postgresqlcluster > test/e2e/testdata/smoketest/postgresql/00_postgresqlcluster.yaml
+	# $(HELM) template mycluster deploy/redis > test/e2e/testdata/smoketest/redis/00_rediscluster.yaml
+	# $(HELM) template mycluster deploy/redis-rep-cluster >> test/e2e/testdata/smoketest/redis/00_rediscluster.yaml
+	$(GINKGO) test -process -ginkgo.v test/e2e
 
 # NOTE: include must be at the end
 ##@ Docker containers
 include docker/docker.mk
+

--- a/internal/testutil/k8s/storage_util.go
+++ b/internal/testutil/k8s/storage_util.go
@@ -17,9 +17,10 @@ limitations under the License.
 package testutil
 
 import (
-	"github.com/onsi/gomega"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/kubectl/pkg/util/storage"
+
+	"github.com/onsi/gomega"
 
 	"github.com/apecloud/kubeblocks/internal/testutil"
 )

--- a/test/e2e/Makefile
+++ b/test/e2e/Makefile
@@ -3,6 +3,7 @@ GOPATH ?= $(shell $(GO) env GOPATH)
 
 GINKGO_VERSION = 2.6.1
 GINKGO = $(GOPATH)/bin/ginkgo
+HELM_VERSION ?= v3.9.0
 
 # The help target prints out all targets with their descriptions organized
 # beneath their categories. The categories are represented by '##@' and the
@@ -32,3 +33,15 @@ run: ginkgo ## Run end-to-end tests.
 
 build: ginkgo ## Run ginkgo build e2e test suite binary.
 	$(GINKGO) build .
+
+.PHONY: helmtool
+helmtool: ## Download helm locally if necessary.
+ifeq (, $(shell which helm))
+	@{ \
+	set -e ;\
+	go install github.com/helm/helm@$(HELM_VERSION);\
+	}
+HELM=$(GOBIN)/helm
+else
+HELM=$(shell which helm)
+endif

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/onsi/ginkgo/v2/reporters"
 	"github.com/spf13/viper"
 	"go.uber.org/zap/zapcore"
-
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -40,6 +39,7 @@ import (
 	. "github.com/apecloud/kubeblocks/test/e2e"
 	. "github.com/apecloud/kubeblocks/test/e2e/envcheck"
 	. "github.com/apecloud/kubeblocks/test/e2e/installation"
+	. "github.com/apecloud/kubeblocks/test/e2e/testdata/smoketest"
 )
 
 var cfg *rest.Config
@@ -127,11 +127,14 @@ var _ = AfterSuite(func() {
 	Cancel()
 })
 
-var _ = Describe("Check healthy Kubernetes cluster status", EnvCheckTest)
+var _ = Describe("e2e test", func() {
+	var _ = Describe("Check healthy Kubernetes cluster status", EnvCheckTest)
 
-var _ = Describe("KubeBlocks operator installation", InstallationTest)
+	var _ = Describe("KubeBlocks operator installation", InstallationTest)
 
-// uninstallation tests, should have this in last Describe
-var _ = Describe("KubeBlocks operator uninstallation", UninstallationTest)
+	var _ = Describe("KubeBlocks somektest run", SmokeTest)
+	// uninstallation tests, should have this in last Describe
+	var _ = Describe("KubeBlocks operator uninstallation", UninstallationTest)
 
-// var _ = Describe("Check environment has been cleaned", EnvGotCleanedTest)
+	var _ = Describe("Check environment has been cleaned", EnvGotCleanedTest)
+})

--- a/test/e2e/envcheck/envcheck.go
+++ b/test/e2e/envcheck/envcheck.go
@@ -22,13 +22,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	. "github.com/apecloud/kubeblocks/test/e2e"
-
 	corev1 "k8s.io/api/core/v1"
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
 	dataprotectionv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+
+	. "github.com/apecloud/kubeblocks/test/e2e"
 )
 
 func EnvCheckTest() {

--- a/test/e2e/installation/installcheck.go
+++ b/test/e2e/installation/installcheck.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package envcheck
+package installation
 
 import (
 	"context"
@@ -24,13 +24,12 @@ import (
 
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli/values"
-
-	. "github.com/apecloud/kubeblocks/test/e2e"
-
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/apecloud/kubeblocks/internal/cli/util/helm"
+
+	. "github.com/apecloud/kubeblocks/test/e2e"
 )
 
 const releaseName = "kubeblocks"

--- a/test/e2e/testdata/smoketest/smoketestrun.go
+++ b/test/e2e/testdata/smoketest/smoketestrun.go
@@ -1,0 +1,55 @@
+package smoketest
+
+import (
+	"log"
+	"os"
+	_ "path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	e2eutil "github.com/apecloud/kubeblocks/test/e2e/util"
+)
+
+func SmokeTest() {
+	BeforeEach(func() {
+	})
+
+	AfterEach(func() {
+	})
+
+	Context("KubeBlocks smoke test", func() {
+		It("run test cases", func() {
+			dir, err := os.Getwd()
+			if err != nil {
+				log.Println(err)
+			}
+			folders, _ := e2eutil.GetFolders(dir + "/testdata/smoketest")
+			for _, folder := range folders {
+				if folder == dir+"/testdata/smoketest" {
+					continue
+				}
+				log.Println("folder: " + folder)
+				files, _ := e2eutil.GetFiles(folder)
+				for _, file := range files {
+					By("test " + file)
+					b := e2eutil.OpsYaml(file, "apply")
+					Expect(b).Should(BeTrue())
+					e2eutil.WaitTime()
+					podStatusResult := e2eutil.CheckPodStatus()
+					log.Println(podStatusResult)
+					for _, result := range podStatusResult {
+						Expect(result).Should(BeTrue())
+					}
+					e2eutil.WaitTime()
+					clusterStatusResult := e2eutil.CheckClusterStatus()
+					Expect(clusterStatusResult).Should(BeTrue())
+				}
+				if len(files) > 0 {
+					file := e2eutil.GetClusterCreateYaml(files)
+					e2eutil.OpsYaml(file, "delete")
+				}
+			}
+		})
+	})
+}

--- a/test/e2e/testdata/smoketest/wesql/00_wesqlcluster.yaml
+++ b/test/e2e/testdata/smoketest/wesql/00_wesqlcluster.yaml
@@ -1,0 +1,34 @@
+---
+# Source: apecloud-mysql-cluster/templates/cluster.yaml
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: Cluster
+metadata:
+  name: mycluster
+  labels: 
+    helm.sh/chart: apecloud-mysql-cluster-0.1.3
+    app.kubernetes.io/name: apecloud-mysql-cluster
+    app.kubernetes.io/instance: mycluster
+    app.kubernetes.io/version: "8.0.30"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  clusterDefinitionRef: apecloud-mysql  # ref clusterdefinition.name
+  clusterVersionRef: ac-mysql-8.0.30 # ref clusterversion.name
+  terminationPolicy: Delete
+  affinity:
+    topologyKeys: 
+      - kubernetes.io/hostname
+  componentSpecs:
+    - name: mysql # user-defined
+      componentDefRef: mysql # ref clusterdefinition componentDefs.name
+      monitor: false
+      replicas: 3
+      enabledLogs:     ["slow","error"]
+      volumeClaimTemplates:
+        - name: data # ref clusterdefinition components.containers.volumeMounts.name
+          spec:
+            storageClassName: 
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 1Gi

--- a/test/e2e/testdata/smoketest/wesql/01_vscale.yaml
+++ b/test/e2e/testdata/smoketest/wesql/01_vscale.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: OpsRequest
+metadata:
+  name: ops-vscale
+spec:
+  clusterRef: mycluster
+  type: VerticalScaling
+  verticalScaling:
+    - componentName: mysql
+      requests:
+        memory: "500Mi"
+        cpu: "0.5"
+      limits:
+        memory: "1000Mi"
+        cpu: "1"

--- a/test/e2e/testdata/smoketest/wesql/02_hscale.yaml
+++ b/test/e2e/testdata/smoketest/wesql/02_hscale.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: OpsRequest
+metadata:
+  name: ops-hscale
+spec:
+  clusterRef: mycluster
+  type: HorizontalScaling
+  horizontalScaling:
+    - componentName: mysql
+      replicas: 5

--- a/test/e2e/testdata/smoketest/wesql/03_vexpand.yaml
+++ b/test/e2e/testdata/smoketest/wesql/03_vexpand.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: OpsRequest
+metadata:
+  name: ops-vexpand
+spec:
+  clusterRef: mycluster
+  type: VolumeExpansion
+  volumeExpansion:
+    - componentName: mysql
+      volumeClaimTemplates:
+        - name: data
+          storage: "2Gi"

--- a/test/e2e/testdata/smoketest/wesql/04_cv.yaml
+++ b/test/e2e/testdata/smoketest/wesql/04_cv.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: ClusterVersion
+metadata:
+  name: ac-mysql-8.0.30-latest
+spec:
+  clusterDefinitionRef: apecloud-mysql
+  components:
+    - podSpec:
+        containers:
+          - image: docker.io/apecloud/apecloud-mysql-server:latest
+            imagePullPolicy: IfNotPresent
+            name: mysql
+            resources: {}
+      type: mysql

--- a/test/e2e/testdata/smoketest/wesql/05_upgrade.yaml
+++ b/test/e2e/testdata/smoketest/wesql/05_upgrade.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: OpsRequest
+metadata:
+  name: ops-upgrade
+spec:
+  clusterRef: mycluster
+  type: Upgrade
+  upgrade:
+    clusterVersionRef: ac-mysql-8.0.30-latest

--- a/test/e2e/testdata/smoketest/wesql/06_restart.yaml
+++ b/test/e2e/testdata/smoketest/wesql/06_restart.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: OpsRequest
+metadata:
+  name: ops-restart
+spec:
+  clusterRef: mycluster
+  ttlSecondsAfterSucceed: 3600
+  type: Restart
+  restart:
+    - componentName: mysql

--- a/test/e2e/testdata/smoketest/wesql/07_backuppolicy.yaml
+++ b/test/e2e/testdata/smoketest/wesql/07_backuppolicy.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: BackupPolicy
+metadata:
+  name: backup-policy-mycluster
+spec:
+  backupToolName: xtrabackup-mysql
+  hooks:
+    postCommands:
+      - rm -f /data/mysql/data/.restore_new_cluster; sync
+    preCommands:
+      - touch /data/mysql/data/.restore_new_cluster; sync
+  remoteVolume:
+    name: backup-remote-volume
+    persistentVolumeClaim:
+      claimName: backup-host-path-pvc
+  schedule: 0 3 * * *
+  target:
+    databaseEngine: mysql
+    labelsSelector:
+      matchLabels:
+        app.kubernetes.io/instance: mycluster
+    secret:
+      name: mycluster-conn-credential
+  ttl: 168h0m0s
+
+

--- a/test/e2e/testdata/smoketest/wesql/08_backup_snapshot.yaml
+++ b/test/e2e/testdata/smoketest/wesql/08_backup_snapshot.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: Backup
+metadata:
+  labels:
+    app.kubernetes.io/instance: mycluster
+    dataprotection.kubeblocks.io/backup-type: snapshot
+  name: backup-sbapshot-mycluster
+spec:
+  backupPolicyName: backup-policy-mycluster
+  backupType: snapshot
+  ttl: 168h0m0s

--- a/test/e2e/testdata/smoketest/wesql/09_backup_snapshot_restore.yaml
+++ b/test/e2e/testdata/smoketest/wesql/09_backup_snapshot_restore.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: Cluster
+metadata:
+  name: snapshot-mycluster
+spec:
+  clusterDefinitionRef: apecloud-mysql
+  clusterVersionRef: ac-mysql-8.0.30
+  terminationPolicy: WipeOut
+  affinity:
+    topologyKeys:
+      - kubernetes.io/hostname
+  components:
+    - name: mysql
+      type: mysql
+      monitor: false
+      replicas: 3
+      enabledLogs:     ["slow","error"]
+      volumeClaimTemplates:
+        - name: data
+          spec:
+            storageClassName:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 2Gi
+            dataSource:
+              apiGroup: snapshot.storage.k8s.io
+              kind: VolumeSnapshot
+              name: backup-sbapshot-mycluster

--- a/test/e2e/testdata/smoketest/wesql/10_reconfigure.yaml
+++ b/test/e2e/testdata/smoketest/wesql/10_reconfigure.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: OpsRequest
+metadata:
+  name: ops-reconfigure
+spec:
+  clusterRef: mycluster
+  reconfigure:
+    componentName: mysql
+    configurations:
+      - keys:
+          - key: my.cnf
+            parameters:
+              - key: general_log
+                value: "OFF"
+              - key: max_connections
+                value: "2000"
+        name: mysql-3node-tpl
+  type: Reconfiguring

--- a/test/e2e/util/client.go
+++ b/test/e2e/util/client.go
@@ -1,0 +1,46 @@
+package util
+
+import (
+	"github.com/vmware-tanzu/velero/pkg/client"
+	"k8s.io/client-go/kubernetes"
+	kbclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestClient defines the desired type of Client
+type TestClient struct {
+	Kubebuilder    kbclient.Client
+	ClientGo       kubernetes.Interface
+	dynamicFactory client.DynamicFactory
+}
+
+// NewTestClient returns a set of ready-to-use API clients.
+func NewTestClient(kubecontext string) (TestClient, error) {
+	return InitTestClient(kubecontext)
+}
+
+// InitTestClient init different type clients
+func InitTestClient(kubecontext string) (TestClient, error) {
+	config, err := client.LoadConfig()
+	if err != nil {
+		return TestClient{}, err
+	}
+	f := client.NewFactory("e2e", kubecontext, config)
+	clientGo, err := f.KubeClient()
+	if err != nil {
+		return TestClient{}, err
+	}
+	kb, err := f.KubebuilderClient()
+	if err != nil {
+		return TestClient{}, err
+	}
+	dynamicClient, err := f.DynamicClient()
+	if err != nil {
+		return TestClient{}, err
+	}
+	factory := client.NewDynamicFactory(dynamicClient)
+	return TestClient{
+		Kubebuilder:    kb,
+		ClientGo:       clientGo,
+		dynamicFactory: factory,
+	}, nil
+}

--- a/test/e2e/util/common.go
+++ b/test/e2e/util/common.go
@@ -1,0 +1,279 @@
+/*
+Copyright the Velero contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os/exec"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/vmware-tanzu/velero/pkg/builder"
+	veleroexec "github.com/vmware-tanzu/velero/pkg/util/exec"
+	"github.com/vmware-tanzu/velero/test/e2e/util/common"
+	"golang.org/x/net/context"
+	corev1api "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func EnsureClusterExists(ctx context.Context) error {
+	return exec.CommandContext(ctx, "kubectl", "cluster-info").Run()
+}
+
+func CreateSecretFromFiles(ctx context.Context, client TestClient, namespace string, name string, files map[string]string) error {
+	data := make(map[string][]byte)
+
+	for key, filePath := range files {
+		contents, err := ioutil.ReadFile(filePath)
+		if err != nil {
+			return errors.WithMessagef(err, "Failed to read secret file %q", filePath)
+		}
+
+		data[key] = contents
+	}
+	secret := builder.ForSecret(namespace, name).Data(data).Result()
+	_, err := client.ClientGo.CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{})
+	return err
+}
+
+// WaitForPods waits until all of the pods have gone to PodRunning state
+func WaitForPods(ctx context.Context, client TestClient, namespace string, pods []string) error {
+	timeout := 5 * time.Minute
+	interval := 5 * time.Second
+	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+		for _, podName := range pods {
+			checkPod, err := client.ClientGo.CoreV1().Pods(namespace).Get(context.TODO(), podName, metav1.GetOptions{})
+			if err != nil {
+				fmt.Println(errors.Wrap(err, fmt.Sprintf("Failed to verify pod %s/%s is %s, try again...\n", namespace, podName, corev1api.PodRunning)))
+				return false, nil
+			}
+			// If any pod is still waiting we don't need to check any more so return and wait for next poll interval
+			if checkPod.Status.Phase != corev1api.PodRunning {
+				fmt.Printf("Pod %s is in state %s waiting for it to be %s\n", podName, checkPod.Status.Phase, corev1api.PodRunning)
+				return false, nil
+			}
+		}
+		// All pods were in PodRunning state, we're successful
+		return true, nil
+	})
+	if err != nil {
+		return errors.Wrapf(err, fmt.Sprintf("Failed to wait for pods in namespace %s to start running", namespace))
+	}
+	return nil
+}
+
+func GetPvcByPodName(ctx context.Context, namespace, podName string) ([]string, error) {
+	// Example:
+	//    NAME                                  STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS             AGE
+	//    kibishii-data-kibishii-deployment-0   Bound    pvc-94b9fdf2-c30f-4a7b-87bf-06eadca0d5b6   1Gi        RWO            kibishii-storage-class   115s
+	cmds := []*common.OsCommandLine{}
+	cmd := &common.OsCommandLine{
+		Cmd:  "kubectl",
+		Args: []string{"get", "pvc", "-n", namespace},
+	}
+	cmds = append(cmds, cmd)
+
+	cmd = &common.OsCommandLine{
+		Cmd:  "grep",
+		Args: []string{podName},
+	}
+	cmds = append(cmds, cmd)
+
+	cmd = &common.OsCommandLine{
+		Cmd:  "awk",
+		Args: []string{"{print $1}"},
+	}
+	cmds = append(cmds, cmd)
+
+	return common.GetListByCmdPipes(ctx, cmds)
+}
+
+func GetPvByPvc(ctx context.Context, namespace, pvc string) ([]string, error) {
+	// Example:
+	// 	  NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                              STORAGECLASS             REASON   AGE
+	//    pvc-3f784366-58db-40b2-8fec-77307807e74b   1Gi        RWO            Delete           Bound    bsl-deletion/kibishii-data-kibishii-deployment-0   kibishii-storage-class            6h41m
+	cmds := []*common.OsCommandLine{}
+	cmd := &common.OsCommandLine{
+		Cmd:  "kubectl",
+		Args: []string{"get", "pv"},
+	}
+	cmds = append(cmds, cmd)
+
+	cmd = &common.OsCommandLine{
+		Cmd:  "grep",
+		Args: []string{namespace + "/" + pvc},
+	}
+	cmds = append(cmds, cmd)
+
+	cmd = &common.OsCommandLine{
+		Cmd:  "awk",
+		Args: []string{"{print $1}"},
+	}
+	cmds = append(cmds, cmd)
+
+	return common.GetListByCmdPipes(ctx, cmds)
+}
+
+func CRDShouldExist(ctx context.Context, name string) error {
+	return CRDCountShouldBe(ctx, name, 1)
+}
+
+func CRDShouldNotExist(ctx context.Context, name string) error {
+	return CRDCountShouldBe(ctx, name, 0)
+}
+
+func CRDCountShouldBe(ctx context.Context, name string, count int) error {
+	crdList, err := GetCRD(ctx, name)
+	if err != nil {
+		return errors.Wrap(err, "Fail to get CRDs")
+	}
+	len := len(crdList)
+	if len != count {
+		return errors.New(fmt.Sprintf("CRD count is expected as %d instead of %d", count, len))
+	}
+	return nil
+}
+
+func GetCRD(ctx context.Context, name string) ([]string, error) {
+	cmds := []*common.OsCommandLine{}
+	cmd := &common.OsCommandLine{
+		Cmd:  "kubectl",
+		Args: []string{"get", "crd"},
+	}
+	cmds = append(cmds, cmd)
+
+	cmd = &common.OsCommandLine{
+		Cmd:  "grep",
+		Args: []string{name},
+	}
+	cmds = append(cmds, cmd)
+
+	cmd = &common.OsCommandLine{
+		Cmd:  "awk",
+		Args: []string{"{print $1}"},
+	}
+	cmds = append(cmds, cmd)
+
+	return common.GetListByCmdPipes(ctx, cmds)
+}
+
+func AddLabelToPv(ctx context.Context, pv, label string) error {
+	return exec.CommandContext(ctx, "kubectl", "label", "pv", pv, label).Run()
+}
+
+func AddLabelToPvc(ctx context.Context, pvc, namespace, label string) error {
+	args := []string{"label", "pvc", pvc, "-n", namespace, label}
+	fmt.Println(args)
+	return exec.CommandContext(ctx, "kubectl", args...).Run()
+}
+
+func AddLabelToPod(ctx context.Context, podName, namespace, label string) error {
+	args := []string{"label", "pod", podName, "-n", namespace, label}
+	fmt.Println(args)
+	return exec.CommandContext(ctx, "kubectl", args...).Run()
+}
+
+func AddLabelToCRD(ctx context.Context, crd, label string) error {
+	args := []string{"label", "crd", crd, label}
+	fmt.Println(args)
+	return exec.CommandContext(ctx, "kubectl", args...).Run()
+}
+
+func KubectlApplyByFile(ctx context.Context, file string) error {
+	args := []string{"apply", "-f", file, "--force=true"}
+	return exec.CommandContext(ctx, "kubectl", args...).Run()
+}
+
+func KubectlConfigUseContext(ctx context.Context, kubectlContext string) error {
+	cmd := exec.CommandContext(ctx, "kubectl",
+		"config", "use-context", kubectlContext)
+	fmt.Printf("Kubectl config use-context cmd =%v\n", cmd)
+	stdout, stderr, err := veleroexec.RunCommand(cmd)
+	fmt.Print(stdout)
+	fmt.Print(stderr)
+	return err
+}
+
+func GetAPIVersions(client *TestClient, name string) ([]string, error) {
+	var version []string
+	APIGroup, err := client.ClientGo.Discovery().ServerGroups()
+	if err != nil {
+		return nil, errors.Wrap(err, "Fail to get server API groups")
+	}
+	for _, group := range APIGroup.Groups {
+		fmt.Println(group.Name)
+		if group.Name == name {
+			for _, v := range group.Versions {
+				fmt.Println(v.Version)
+				version = append(version, v.Version)
+			}
+			return version, nil
+		}
+	}
+	return nil, errors.New("Server API groups is empty")
+}
+
+func CreateFileToPod(ctx context.Context, namespace, podName, volume, filename, content string) error {
+	arg := []string{"exec", "-n", namespace, "-c", podName, podName,
+		"--", "/bin/sh", "-c", fmt.Sprintf("echo ns-%s pod-%s volume-%s  > /%s/%s", namespace, podName, volume, volume, filename)}
+	cmd := exec.CommandContext(ctx, "kubectl", arg...)
+	fmt.Printf("Kubectl exec cmd =%v\n", cmd)
+	return cmd.Run()
+}
+func ReadFileFromPodVolume(ctx context.Context, namespace, podName, volume, filename string) (string, error) {
+	arg := []string{"exec", "-n", namespace, "-c", podName, podName,
+		"--", "cat", fmt.Sprintf("/%s/%s", volume, filename)}
+	cmd := exec.CommandContext(ctx, "kubectl", arg...)
+	fmt.Printf("Kubectl exec cmd =%v\n", cmd)
+	stdout, stderr, err := veleroexec.RunCommand(cmd)
+	fmt.Print(stdout)
+	fmt.Print(stderr)
+	return stdout, err
+}
+
+func KubectlGetInfo(cmdName string, arg []string) {
+	cmd := exec.CommandContext(context.Background(), cmdName, arg...)
+	fmt.Printf("Kubectl exec cmd =%v\n", cmd)
+	stdout, stderr, err := veleroexec.RunCommand(cmd)
+	fmt.Println(stdout)
+	if err != nil {
+		fmt.Println(stderr)
+		fmt.Println(err)
+	}
+}
+
+func DeleteVeleroDs(ctx context.Context) error {
+	args := []string{"delete", "ds", "-n", "velero", "--all", "--force", "--grace-period", "0"}
+	fmt.Println(args)
+	return exec.CommandContext(ctx, "kubectl", args...).Run()
+}
+
+func WaitForCRDEstablished(crdName string) error {
+	arg := []string{"wait", "--for", "condition=established", "--timeout=60s", "crd/" + crdName}
+	cmd := exec.CommandContext(context.Background(), "kubectl", arg...)
+	fmt.Printf("Kubectl exec cmd =%v\n", cmd)
+	stdout, stderr, err := veleroexec.RunCommand(cmd)
+	fmt.Println(stdout)
+	if err != nil {
+		fmt.Println(stderr)
+		fmt.Println(err)
+		return err
+	}
+	return nil
+}

--- a/test/e2e/util/smoke_util.go
+++ b/test/e2e/util/smoke_util.go
@@ -1,0 +1,207 @@
+package util
+
+import (
+	"bufio"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/pkg/errors"
+	"k8s.io/utils/exec"
+)
+
+const label = "app.kubernetes.io/instance"
+const name = "mycluster"
+const namespace = "default"
+
+func GetFiles(path string) ([]string, error) {
+	var result []string
+	e := filepath.Walk(path, func(path string, fi os.FileInfo, err error) error {
+		if err != nil {
+			log.Println(err)
+			return err
+		}
+		if !fi.IsDir() {
+			if strings.HasSuffix(path, ".yaml") || strings.HasSuffix(path, ".yml") {
+				result = append(result, path)
+			}
+		}
+		return nil
+	})
+	if e != nil {
+		log.Println(e)
+		return result, e
+	}
+	return result, nil
+}
+
+func GetFolders(path string) ([]string, error) {
+	var result []string
+	e := filepath.Walk(path, func(path string, fi os.FileInfo, err error) error {
+		if err != nil {
+			log.Println(err)
+			return err
+		}
+		if fi.IsDir() {
+			result = append(result, path)
+		}
+		return nil
+	})
+	if e != nil {
+		log.Println(e)
+		return result, e
+	}
+	return result, nil
+}
+
+func CheckClusterStatus() bool {
+	cmd := "kubectl get cluster " + name + " -n " + namespace + " | grep " + name + " | awk '{print $5}'"
+	log.Println(cmd)
+	clusterStatus := ExecCommand(cmd)
+	log.Println("clusterStatus is " + clusterStatus)
+	return strings.TrimSpace(clusterStatus) == "Running"
+}
+
+func CheckPodStatus() map[string]bool {
+	var podStatusResult = make(map[string]bool)
+	cmd := "kubectl get pod -n " + namespace + " -l '" + label + "=" + name + "'| grep " + name + " | awk '{print $1}'"
+	log.Println(cmd)
+	arr := ExecCommandReadline(cmd)
+	log.Println(arr)
+	if len(arr) > 0 {
+		for _, podName := range arr {
+			command := "kubectl get pod " + podName + " -n " + namespace + " | grep " + podName + " | awk '{print $3}'"
+			log.Println(command)
+			podStatus := ExecCommand(command)
+			log.Println("podStatus is " + podStatus)
+			if strings.TrimSpace(podStatus) == "Running" {
+				podStatusResult[podName] = true
+			} else {
+				podStatusResult[podName] = false
+			}
+		}
+	}
+	return podStatusResult
+}
+
+func OpsYaml(file string, ops string) bool {
+	cmd := "kubectl " + ops + " -f " + file
+	log.Println(cmd)
+	b := ExecuteCommand(cmd)
+	return b
+}
+
+func ExecuteCommand(command string) bool {
+	exeFlag := true
+	cmd := exec.New().Command("bash", "-c", command)
+	// Create a fetch command output pipe
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		log.Printf("Error:can not obtain stdout pipe for command:%s\n", err)
+		exeFlag = false
+	}
+	// Create a fetch command err output pipe
+	stderr, err1 := cmd.StderrPipe()
+	if err1 != nil {
+		log.Printf("Error:can not obtain stderr pipe for command:%s\n", err1)
+		exeFlag = false
+	}
+	// Run command
+	if err := cmd.Start(); err != nil {
+		log.Printf("Error:The command is err:%s\n", err)
+		exeFlag = false
+	}
+	// Use buffered readers
+	go asyncLog(stdout)
+	go asyncLog(stderr)
+	if err := cmd.Wait(); err != nil {
+		log.Printf("wait:%s\n", err.Error())
+		exeFlag = false
+	}
+	return exeFlag
+}
+
+func asyncLog(reader io.Reader) {
+	cache := ""
+	buf := make([]byte, 1024)
+	for {
+		num, err := reader.Read(buf)
+		if err != nil && errors.Is(err, io.EOF) {
+			return
+		}
+		if num > 0 {
+			b := buf[:num]
+			s := strings.Split(string(b), "\n")
+			line := strings.Join(s[:len(s)-1], "\n")
+			log.Printf("%s%s\n", cache, line)
+			cache = s[len(s)-1]
+		}
+		if errors.Is(err, io.EOF) {
+			break
+		}
+	}
+}
+
+func ExecCommandReadline(strCommand string) []string {
+	var arr []string
+	cmd := exec.New().Command("/bin/bash", "-c", strCommand)
+	stdout, _ := cmd.StdoutPipe()
+	if err := cmd.Start(); err != nil {
+		log.Printf("Execute failed when Start:%s\n\n", err.Error())
+	}
+	reader := bufio.NewReader(stdout)
+	for {
+		line, err := reader.ReadString('\n')
+		line = strings.TrimSpace(line)
+		if err != nil || io.EOF == err {
+			break
+		}
+		arr = append(arr, line)
+	}
+	if err := cmd.Wait(); err != nil {
+		log.Printf("wait:%s\n\n", err.Error())
+	}
+	return arr
+}
+
+func ExecCommand(strCommand string) string {
+	cmd := exec.New().Command("/bin/bash", "-c", strCommand)
+	stdout, _ := cmd.StdoutPipe()
+	if err := cmd.Start(); err != nil {
+		log.Printf("Execute failed when Start:%s\n", err.Error())
+		return ""
+	}
+	outBytes, _ := io.ReadAll(stdout)
+	err := stdout.Close()
+	if err != nil {
+		return ""
+	}
+	if err := cmd.Wait(); err != nil {
+		log.Printf("Execute failed when Wait:%s\n", err.Error())
+		return ""
+	}
+	return string(outBytes)
+}
+
+func WaitTime() {
+	wg := sync.WaitGroup{}
+	wg.Add(int(400000000))
+	for i := 0; i < int(400000000); i++ {
+		go func(i int) {
+			defer wg.Done()
+		}(i)
+	}
+	wg.Wait()
+}
+
+func GetClusterCreateYaml(files []string) string {
+	for _, file := range files {
+		if strings.Contains(file, "00") {
+			return file
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
```
➜  kubeblocks git:(feature/smoke-test) ✗ make test-e2e
/opt/homebrew/bin/helm template mycluster deploy/apecloud-mysql-cluster > test/e2e/testdata/smoketest/wesql/00_wesqlcluster.yaml
# /opt/homebrew/bin/helm template mycluster deploy/mongodb > test/e2e/testdata/smoketest/mongodb/00_mongodbcluster.yaml
# /opt/homebrew/bin/helm template mycluster deploy/mongodb-cluster >> test/e2e/testdata/smoketest/mongodb/00_mongodbcluster.yaml
# /opt/homebrew/bin/helm template mycluster deploy/postgresqlcluster > test/e2e/testdata/smoketest/postgresql/00_postgresqlcluster.yaml
# /opt/homebrew/bin/helm template mycluster deploy/redis > test/e2e/testdata/smoketest/redis/00_rediscluster.yaml
# /opt/homebrew/bin/helm template mycluster deploy/redis-rep-cluster >> test/e2e/testdata/smoketest/redis/00_rediscluster.yaml
/Users/hanling/go/bin/ginkgo test -process -ginkgo.v test/e2e
Running Suite: E2e Suite - /Users/hanling/dbass/kubeblocks/test/e2e
===================================================================
Random Seed: 1677221668

Will run 5 of 5 specs
I0224 14:54:42.421033   47415 request.go:690] Waited for 1.047089041s due to client-side throttling, not priority and fairness, request: GET:https://0.0.0.0:56649/apis/discovery.k8s.io/v1?timeout=32s
••2023/02/24 14:55:12 folder: /Users/hanling/dbass/kubeblocks/test/e2e/testdata/smoketest/wesql
2023/02/24 14:55:12 kubectl apply -f /Users/hanling/dbass/kubeblocks/test/e2e/testdata/smoketest/wesql/00_wesqlcluster.yaml
2023/02/24 14:55:13 cluster.apps.kubeblocks.io/mycluster created
2023/02/24 14:57:34 kubectl get pod -n default -l 'app.kubernetes.io/instance=mycluster'| grep mycluster | awk '{print $1}'
2023/02/24 14:57:35 [mycluster-mysql-1 mycluster-mysql-2 mycluster-mysql-0]
2023/02/24 14:57:35 kubectl get pod mycluster-mysql-1 -n default | grep mycluster-mysql-1 | awk '{print $3}'
2023/02/24 14:57:35 podStatus is Running

2023/02/24 14:57:35 kubectl get pod mycluster-mysql-2 -n default | grep mycluster-mysql-2 | awk '{print $3}'
2023/02/24 14:57:35 podStatus is Running

2023/02/24 14:57:35 kubectl get pod mycluster-mysql-0 -n default | grep mycluster-mysql-0 | awk '{print $3}'
2023/02/24 14:57:35 podStatus is Running

2023/02/24 14:57:35 map[mycluster-mysql-0:true mycluster-mysql-1:true mycluster-mysql-2:true]
2023/02/24 14:59:54 kubectl get cluster mycluster -n default | grep mycluster | awk '{print $5}'
2023/02/24 14:59:54 clusterStatus is Running

2023/02/24 14:59:54 kubectl apply -f /Users/hanling/dbass/kubeblocks/test/e2e/testdata/smoketest/wesql/01_vscale.yaml
2023/02/24 14:59:54 opsrequest.apps.kubeblocks.io/ops-vscale created
2023/02/24 15:02:20 kubectl get pod -n default -l 'app.kubernetes.io/instance=mycluster'| grep mycluster | awk '{print $1}'
2023/02/24 15:02:20 [mycluster-mysql-2 mycluster-mysql-0 mycluster-mysql-1]
2023/02/24 15:02:20 kubectl get pod mycluster-mysql-2 -n default | grep mycluster-mysql-2 | awk '{print $3}'
2023/02/24 15:02:20 podStatus is Running

2023/02/24 15:02:20 kubectl get pod mycluster-mysql-0 -n default | grep mycluster-mysql-0 | awk '{print $3}'
2023/02/24 15:02:20 podStatus is Running

2023/02/24 15:02:20 kubectl get pod mycluster-mysql-1 -n default | grep mycluster-mysql-1 | awk '{print $3}'
2023/02/24 15:02:20 podStatus is Running

2023/02/24 15:02:20 map[mycluster-mysql-0:true mycluster-mysql-1:true mycluster-mysql-2:true]
2023/02/24 15:04:46 kubectl get cluster mycluster -n default | grep mycluster | awk '{print $5}'
2023/02/24 15:04:47 clusterStatus is Running

2023/02/24 15:04:47 kubectl apply -f /Users/hanling/dbass/kubeblocks/test/e2e/testdata/smoketest/wesql/02_hscale.yaml
2023/02/24 15:04:47 opsrequest.apps.kubeblocks.io/ops-hscale created
2023/02/24 15:07:16 kubectl get pod -n default -l 'app.kubernetes.io/instance=mycluster'| grep mycluster | awk '{print $1}'
2023/02/24 15:07:16 [mycluster-mysql-2 mycluster-mysql-0 mycluster-mysql-1]
2023/02/24 15:07:16 kubectl get pod mycluster-mysql-2 -n default | grep mycluster-mysql-2 | awk '{print $3}'
2023/02/24 15:07:16 podStatus is Running

2023/02/24 15:07:16 kubectl get pod mycluster-mysql-0 -n default | grep mycluster-mysql-0 | awk '{print $3}'
2023/02/24 15:07:16 podStatus is Running

2023/02/24 15:07:16 kubectl get pod mycluster-mysql-1 -n default | grep mycluster-mysql-1 | awk '{print $3}'
2023/02/24 15:07:16 podStatus is Running

2023/02/24 15:07:16 map[mycluster-mysql-0:true mycluster-mysql-1:true mycluster-mysql-2:true]
2023/02/24 15:09:47 kubectl get cluster mycluster -n default | grep mycluster | awk '{print $5}'
2023/02/24 15:09:47 clusterStatus is HorizontalScaling


------------------------------
• [FAILED] [874.690 seconds]
e2e test KubeBlocks somektest run KubeBlocks smoke test [It] run test cases
/Users/hanling/dbass/kubeblocks/test/e2e/testdata/smoketest/smoketestrun.go:22

  Timeline >>
  STEP: test /Users/hanling/dbass/kubeblocks/test/e2e/testdata/smoketest/wesql/00_wesqlcluster.yaml @ 02/24/23 14:55:12.892
  STEP: test /Users/hanling/dbass/kubeblocks/test/e2e/testdata/smoketest/wesql/01_vscale.yaml @ 02/24/23 14:59:54.608
  STEP: test /Users/hanling/dbass/kubeblocks/test/e2e/testdata/smoketest/wesql/02_hscale.yaml @ 02/24/23 15:04:47.183
  [FAILED] in [It] - /Users/hanling/dbass/kubeblocks/test/e2e/testdata/smoketest/smoketestrun.go:46 @ 02/24/23 15:09:47.618
  << Timeline

  [FAILED] Expected
      <bool>: false
  to be true
  In [It] at: /Users/hanling/dbass/kubeblocks/test/e2e/testdata/smoketest/smoketestrun.go:46 @ 02/24/23 15:09:47.618
------------------------------
•
------------------------------
• [FAILED] [0.081 seconds]
e2e test Check environment has been cleaned Real Kubernetes Cluster [It] Check no KubeBlocks CRD installed
/Users/hanling/dbass/kubeblocks/test/e2e/envcheck/envcheck.go:67

  [FAILED] Expected
      <bool>: true
  to be false
  In [It] at: /Users/hanling/dbass/kubeblocks/test/e2e/envcheck/envcheck.go:81 @ 02/24/23 15:09:47.719
------------------------------
[AfterSuite] [FAILED] [600.941 seconds]
[AfterSuite] 
/Users/hanling/dbass/kubeblocks/test/e2e/e2e_suite_test.go:119

  Timeline >>
  STEP: delete helm release in e2e-test environment @ 02/24/23 15:09:47.719
  [FAILED] in [AfterSuite] - /Users/hanling/dbass/kubeblocks/test/e2e/installation/installcheck.go:101 @ 02/24/23 15:19:48.631
  << Timeline

  [FAILED] Unexpected error:
      <*errors.fundamental | 0x1400261bfc8>: {
          msg: "uninstallation completed with 2 error(s): timed out waiting for the condition; uninstall: Failed to purge the release: release: not found",
          stack: [0x101b85620, 0x101b8d7b4, 0x101b8d634, 0x101b8c408, 0x101b8d5c8, 0x101b8e1f0, 0x101b90b68, 0x1014c7344, 0x1014d7848, 0x1004cb6e4],
      }
      uninstallation completed with 2 error(s): timed out waiting for the condition; uninstall: Failed to purge the release: release: not found
  occurred
  In [AfterSuite] at: /Users/hanling/dbass/kubeblocks/test/e2e/installation/installcheck.go:101 @ 02/24/23 15:19:48.631
------------------------------

Summarizing 3 Failures:
  [FAIL] e2e test KubeBlocks somektest run KubeBlocks smoke test [It] run test cases
  /Users/hanling/dbass/kubeblocks/test/e2e/testdata/smoketest/smoketestrun.go:46
  [FAIL] e2e test Check environment has been cleaned Real Kubernetes Cluster [It] Check no KubeBlocks CRD installed
  /Users/hanling/dbass/kubeblocks/test/e2e/envcheck/envcheck.go:81
  [FAIL] [AfterSuite] 
  /Users/hanling/dbass/kubeblocks/test/e2e/installation/installcheck.go:101

Ran 5 of 5 Specs in 1507.663 seconds
FAIL! -- 3 Passed | 2 Failed | 0 Pending | 0 Skipped
--- FAIL: TestE2e (1507.73s)
FAIL
You're using deprecated Ginkgo functionality:
=============================================
  Support for custom reporters has been removed in V2.  Please read the documentation linked to below for Ginkgo's new behavior and for a migration path:
  Learn more at: https://onsi.github.io/ginkgo/MIGRATING_TO_V2#removed-custom-reporters

To silence deprecations that can be silenced set the following environment variable:
  ACK_GINKGO_DEPRECATIONS=2.6.1


Ginkgo ran 1 suite in 25m19.925144875s

Test Suite Failed
make: *** [test-e2e] Error 1

```