### PR TITLE
chore: image check ignore kubeblocks

### DIFF
--- a/.github/utils/helm_image_check.sh
+++ b/.github/utils/helm_image_check.sh
@@ -4,7 +4,7 @@ main() {
     local EXIT_STATUS=0
     images=`helm get manifest kubeblocks | grep 'image:' | awk '{print $2}' | sort -u | sed 's/"//g'`
     for image in $images; do
-        if [[ "$image" == "docker.io/apecloud/kubeblocks"* ]]; then
+        if [[ "$image" == "docker.io/apecloud/kubeblocks"* || "$image" == "registry.cn-hangzhou.aliyuncs.com/apecloud/kubeblocks"* ]]; then
             continue
         fi
         echo "check image: $image"

--- a/docker/docker.mk
+++ b/docker/docker.mk
@@ -81,7 +81,7 @@ endif
 
 
 .PHONY: push-manager-image
-push-manager-image: test ## Push Operator manager container image.
+push-manager-image: ## Push Operator manager container image.
 ifneq ($(BUILDX_ENABLED), true)
 ifeq ($(TAG_LATEST), true)
 	docker push ${IMG}:latest
@@ -109,7 +109,7 @@ endif
 endif
 
 .PHONY: push-loadbalancer-image
-push-loadbalancer-image: test ## Push docker image with the loadbalancer.
+push-loadbalancer-image: ## Push docker image with the loadbalancer.
 ifneq ($(BUILDX_ENABLED), true)
 ifeq ($(TAG_LATEST), true)
 	docker push ${LB_IMG}:latest


### PR DESCRIPTION
1. Ignore check aliyun kubeblocks image.
2. Remove test in release image: it is already running in ci, it will be time consuming.