### PR TITLE
chore: change push tag actions

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -10,6 +10,9 @@ on:
 
 run-name: ref_name:${{ github.ref_name }} release_version:${{ inputs.release_version }}
 
+env:
+  GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+
 
 jobs:
   release-version:
@@ -19,6 +22,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: push tag
-        run: |
-          git tag ${{ inputs.release_version }}
-          git push origin ${{ inputs.release_version }}
+        uses: mathieudutour/github-tag-action@v6.1
+        with:
+          custom_tag: ${{ inputs.release_version }}
+          github_token: ${{ env.GITHUB_TOKEN }}
+          tag_prefix: ""


### PR DESCRIPTION
1. change push tag actions to mathieudutour/github-tag-action@v6.1 which can trigger create_release workflow