### PR TITLE
feat: support multiple services for one component

### DIFF
--- a/apis/apps/v1alpha1/cluster_types.go
+++ b/apis/apps/v1alpha1/cluster_types.go
@@ -166,25 +166,9 @@ type ClusterComponentSpec struct {
 	// +patchStrategy=merge,retainKeys
 	VolumeClaimTemplates []ClusterComponentVolumeClaimTemplate `json:"volumeClaimTemplates,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name"`
 
-	// serviceType determines how the Service is exposed. Valid
-	// options are ClusterIP, NodePort, and LoadBalancer.
-	// "ClusterIP" allocates a cluster-internal IP address for load-balancing
-	// to endpoints. Endpoints are determined by the selector or if that is not
-	// specified, by manual construction of an Endpoints object or
-	// EndpointSlice objects. If clusterIP is "None", no virtual IP is
-	// allocated and the endpoints are published as a set of endpoints rather
-	// than a virtual IP.
-	// "NodePort" builds on ClusterIP and allocates a port on every node which
-	// routes to the same endpoints as the clusterIP.
-	// "LoadBalancer" builds on NodePort and creates an external load-balancer
-	// (if supported in the current cloud) which routes to the same endpoints
-	// as the clusterIP.
-	// More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
-	// +kubebuilder:default=ClusterIP
-	// +kubebuilder:validation:Enum={ClusterIP,NodePort,LoadBalancer}
-	// +kubebuilder:pruning:PreserveUnknownFields
+	// Services expose endpoints can be accessed by clients
 	// +optional
-	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
+	Services []ClusterComponentService `json:"services,omitempty"`
 
 	// primaryIndex determines which index is primary when workloadType is Replication, index number starts from zero.
 	// +kubebuilder:validation:Minimum=0
@@ -373,6 +357,37 @@ type TLSSecretRef struct {
 	// Key of TLS private key in Secret
 	// +kubebuilder:validation:Required
 	Key string `json:"key"`
+}
+
+type ClusterComponentService struct {
+	// Service name
+	// +kubebuilder:validation:Required
+	Name string `json:"name"`
+
+	// serviceType determines how the Service is exposed. Valid
+	// options are ClusterIP, NodePort, and LoadBalancer.
+	// "ClusterIP" allocates a cluster-internal IP address for load-balancing
+	// to endpoints. Endpoints are determined by the selector or if that is not
+	// specified, by manual construction of an Endpoints object or
+	// EndpointSlice objects. If clusterIP is "None", no virtual IP is
+	// allocated and the endpoints are published as a set of endpoints rather
+	// than a virtual IP.
+	// "NodePort" builds on ClusterIP and allocates a port on every node which
+	// routes to the same endpoints as the clusterIP.
+	// "LoadBalancer" builds on NodePort and creates an external load-balancer
+	// (if supported in the current cloud) which routes to the same endpoints
+	// as the clusterIP.
+	// More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+	// +kubebuilder:default=ClusterIP
+	// +kubebuilder:validation:Enum={ClusterIP,NodePort,LoadBalancer}
+	// +kubebuilder:pruning:PreserveUnknownFields
+	// +optional
+	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
+
+	// If ServiceType is LoadBalancer, cloud provider related parameters can be put here
+	// More info: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+	// +optional
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/apps.kubeblocks.io_clusters.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusters.yaml
@@ -285,27 +285,45 @@ spec:
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
-                    serviceType:
-                      default: ClusterIP
-                      description: 'serviceType determines how the Service is exposed.
-                        Valid options are ClusterIP, NodePort, and LoadBalancer. "ClusterIP"
-                        allocates a cluster-internal IP address for load-balancing
-                        to endpoints. Endpoints are determined by the selector or
-                        if that is not specified, by manual construction of an Endpoints
-                        object or EndpointSlice objects. If clusterIP is "None", no
-                        virtual IP is allocated and the endpoints are published as
-                        a set of endpoints rather than a virtual IP. "NodePort" builds
-                        on ClusterIP and allocates a port on every node which routes
-                        to the same endpoints as the clusterIP. "LoadBalancer" builds
-                        on NodePort and creates an external load-balancer (if supported
-                        in the current cloud) which routes to the same endpoints as
-                        the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
-                      enum:
-                      - ClusterIP
-                      - NodePort
-                      - LoadBalancer
-                      type: string
-                      x-kubernetes-preserve-unknown-fields: true
+                    services:
+                      description: Services expose endpoints can be accessed by clients
+                      items:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: 'If ServiceType is LoadBalancer, cloud provider
+                              related parameters can be put here More info: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer'
+                            type: object
+                          name:
+                            description: Service name
+                            type: string
+                          serviceType:
+                            default: ClusterIP
+                            description: 'serviceType determines how the Service is
+                              exposed. Valid options are ClusterIP, NodePort, and
+                              LoadBalancer. "ClusterIP" allocates a cluster-internal
+                              IP address for load-balancing to endpoints. Endpoints
+                              are determined by the selector or if that is not specified,
+                              by manual construction of an Endpoints object or EndpointSlice
+                              objects. If clusterIP is "None", no virtual IP is allocated
+                              and the endpoints are published as a set of endpoints
+                              rather than a virtual IP. "NodePort" builds on ClusterIP
+                              and allocates a port on every node which routes to the
+                              same endpoints as the clusterIP. "LoadBalancer" builds
+                              on NodePort and creates an external load-balancer (if
+                              supported in the current cloud) which routes to the
+                              same endpoints as the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                            enum:
+                            - ClusterIP
+                            - NodePort
+                            - LoadBalancer
+                            type: string
+                            x-kubernetes-preserve-unknown-fields: true
+                        required:
+                        - name
+                        type: object
+                      type: array
                     switchPolicy:
                       description: switchPolicy defines the strategy for switchover
                         and failover when workloadType is Replication.

--- a/controllers/apps/cluster_controller_test.go
+++ b/controllers/apps/cluster_controller_test.go
@@ -25,6 +25,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"golang.org/x/exp/slices"
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -169,6 +170,73 @@ var _ = Describe("Cluster Controller", func() {
 			}, client.InNamespace(clusterKey.Namespace))).Should(Equal(2))
 	}
 
+	testServiceAddAndDelete := func() {
+		By("Creating a cluster with two LoadBalancer services")
+		clusterObj = testapps.NewClusterFactory(testCtx.DefaultNamespace, clusterNamePrefix,
+			clusterDefObj.Name, clusterVersionObj.Name).
+			AddComponent(mysqlCompName, mysqlCompType).SetReplicas(1).
+			AddService(testapps.ServiceVPCName, corev1.ServiceTypeLoadBalancer).
+			AddService(testapps.ServiceInternetName, corev1.ServiceTypeLoadBalancer).
+			WithRandomName().Create(&testCtx).GetObject()
+		clusterKey = client.ObjectKeyFromObject(clusterObj)
+
+		By("Waiting for the cluster initialized")
+		Eventually(testapps.GetClusterObservedGeneration(&testCtx, clusterKey)).Should(BeEquivalentTo(1))
+
+		existSvc := func(total int, svcName string) bool {
+			svcList := &corev1.ServiceList{}
+			Expect(k8sClient.List(testCtx.Ctx, svcList, client.MatchingLabels{
+				constant.AppInstanceLabelKey:    clusterKey.Name,
+				constant.KBAppComponentLabelKey: mysqlCompName,
+			}, client.InNamespace(clusterKey.Namespace))).Should(Succeed())
+			if len(svcList.Items) != total {
+				return false
+			}
+			return slices.IndexFunc(svcList.Items, func(e corev1.Service) bool {
+				return strings.HasSuffix(e.Name, svcName)
+			}) >= 0
+		}
+
+		Expect(existSvc(4, testapps.ServiceVPCName)).Should(BeTrue())
+		Expect(existSvc(4, testapps.ServiceInternetName)).Should(BeTrue())
+
+		By("Delete a LoadBalancer service")
+		Eventually(testapps.GetAndChangeObj(&testCtx, clusterKey, func(cluster *appsv1alpha1.Cluster) {
+			for idx, comp := range cluster.Spec.ComponentSpecs {
+				if comp.ComponentDefRef != mysqlCompType {
+					continue
+				}
+				var services []appsv1alpha1.ClusterComponentService
+				for _, item := range comp.Services {
+					if item.Name == testapps.ServiceVPCName {
+						continue
+					}
+					services = append(services, item)
+				}
+				cluster.Spec.ComponentSpecs[idx].Services = services
+				return
+			}
+
+		})).Should(Succeed())
+		Eventually(func() bool { return existSvc(3, testapps.ServiceVPCName) }).Should(BeFalse())
+
+		By("Add the deleted LoadBalancer service back")
+		Eventually(testapps.GetAndChangeObj(&testCtx, clusterKey, func(cluster *appsv1alpha1.Cluster) {
+			for idx, comp := range cluster.Spec.ComponentSpecs {
+				if comp.ComponentDefRef != mysqlCompType {
+					continue
+				}
+				comp.Services = append(comp.Services, appsv1alpha1.ClusterComponentService{
+					Name:        testapps.ServiceVPCName,
+					ServiceType: corev1.ServiceTypeLoadBalancer,
+				})
+				cluster.Spec.ComponentSpecs[idx] = comp
+				return
+			}
+		}))
+		Eventually(func() bool { return existSvc(4, testapps.ServiceVPCName) }).Should(BeTrue())
+	}
+
 	checkAllServicesCreate := func() {
 		By("Creating a cluster")
 		clusterObj = testapps.NewClusterFactory(testCtx.DefaultNamespace, clusterNamePrefix,
@@ -200,7 +268,7 @@ var _ = Describe("Cluster Controller", func() {
 		}
 		Expect(existsExternalClusterIP).To(BeTrue())
 
-		By("Checking replicasets should have internal headless service")
+		By("Checking mysql should have internal headless service")
 		getHeadlessSvcPorts := func(compDefName string) []corev1.ServicePort {
 			fetched := &appsv1alpha1.Cluster{}
 			Expect(k8sClient.Get(testCtx.Ctx, clusterKey, fetched)).To(Succeed())
@@ -228,10 +296,19 @@ var _ = Describe("Cluster Controller", func() {
 			constant.AppInstanceLabelKey:    clusterKey.Name,
 			constant.KBAppComponentLabelKey: mysqlCompName,
 		}, client.InNamespace(clusterKey.Namespace))).Should(Succeed())
-		Expect(len(svcList2.Items)).Should(BeEquivalentTo(1))
-		Expect(svcList2.Items[0].Spec.Type == corev1.ServiceTypeClusterIP).To(BeTrue())
-		Expect(svcList2.Items[0].Spec.ClusterIP == corev1.ClusterIPNone).To(BeTrue())
-		Expect(reflect.DeepEqual(svcList2.Items[0].Spec.Ports,
+		Expect(len(svcList2.Items)).Should(BeEquivalentTo(2))
+
+		idx := slices.IndexFunc(svcList2.Items, func(e corev1.Service) bool {
+			if e.Spec.Type != corev1.ServiceTypeClusterIP {
+				return false
+			}
+			if e.Spec.ClusterIP != corev1.ClusterIPNone {
+				return false
+			}
+			return true
+		})
+		Expect(idx).Should(BeNumerically(">=", 0))
+		Expect(reflect.DeepEqual(svcList2.Items[idx].Spec.Ports,
 			getHeadlessSvcPorts(mysqlCompType))).Should(BeTrue())
 	}
 
@@ -1110,6 +1187,10 @@ var _ = Describe("Cluster Controller", func() {
 
 		It("should create corresponding services correctly", func() {
 			checkAllServicesCreate()
+		})
+
+		It("should add and delete service correctly", func() {
+			testServiceAddAndDelete()
 		})
 
 		It("should successfully h-scale with multiple components", func() {

--- a/controllers/apps/components/consensusset/consensus_set_utils_test.go
+++ b/controllers/apps/components/consensusset/consensus_set_utils_test.go
@@ -20,7 +20,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/apecloud/kubeblocks/internal/controllerutil"
 	"github.com/stretchr/testify/assert"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -30,6 +29,7 @@ import (
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
 	"github.com/apecloud/kubeblocks/controllers/apps/components/util"
 	"github.com/apecloud/kubeblocks/internal/constant"
+	"github.com/apecloud/kubeblocks/internal/controllerutil"
 	testk8s "github.com/apecloud/kubeblocks/internal/testutil/k8s"
 )
 

--- a/controllers/apps/configuration/parallel_upgrade_policy_test.go
+++ b/controllers/apps/configuration/parallel_upgrade_policy_test.go
@@ -20,12 +20,13 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/golang/mock/gomock"
+
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
 	cfgcore "github.com/apecloud/kubeblocks/internal/configuration"
 	cfgproto "github.com/apecloud/kubeblocks/internal/configuration/proto"
 	mock_proto "github.com/apecloud/kubeblocks/internal/configuration/proto/mocks"
 	testutil "github.com/apecloud/kubeblocks/internal/testutil/k8s"
-	"github.com/golang/mock/gomock"
 )
 
 var parallelPolicy = parallelUpgradePolicy{}

--- a/controllers/apps/lifecycle_utils.go
+++ b/controllers/apps/lifecycle_utils.go
@@ -27,6 +27,7 @@ import (
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	"github.com/pkg/errors"
 	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -98,7 +99,7 @@ func reconcileClusterWorkloads(
 	prepareComp := func(synthesizedComp *component.SynthesizedComponent) error {
 		iParams := task
 		iParams.Component = synthesizedComp
-		if process1stComp && synthesizedComp.Service != nil {
+		if process1stComp && len(synthesizedComp.Services) > 0 {
 			if err := prepareConnCredential(reqCtx, cli, &iParams); err != nil {
 				return err
 			}
@@ -484,6 +485,34 @@ func createOrReplaceResources(reqCtx intctrlutil.RequestCtx,
 		return nil
 	}
 
+	cleanUselessServices := func(expSvcList []*corev1.Service) error {
+		var (
+			allSvcList = corev1.ServiceList{}
+			ml         = getServiceMatchingLabels(cluster.Name, "")
+		)
+		if err = cli.List(reqCtx.Ctx, &allSvcList, ml); err != nil {
+			return err
+		}
+
+		for _, svc := range allSvcList.Items {
+			idx := slices.IndexFunc(expSvcList, func(service *corev1.Service) bool {
+				return client.ObjectKeyFromObject(service) == client.ObjectKeyFromObject(&svc)
+			})
+			if idx >= 0 {
+				continue
+			}
+			patch := client.MergeFrom(svc.DeepCopy())
+			controllerutil.RemoveFinalizer(&svc, dbClusterFinalizerName)
+			if err = cli.Patch(reqCtx.Ctx, &svc, patch); err != nil {
+				return client.IgnoreNotFound(err)
+			}
+			if err = cli.Delete(reqCtx.Ctx, &svc); err != nil {
+				return client.IgnoreNotFound(err)
+			}
+		}
+		return nil
+	}
+
 	// why create tls certs here? or why not use prepare-checkedCreate pattern?
 	// tls certs generation is very time-consuming, if using prepare-checkedCreate pattern,
 	// we shall generate certs in every component Update which will slow down the cluster reconcile loop
@@ -491,30 +520,20 @@ func createOrReplaceResources(reqCtx intctrlutil.RequestCtx,
 		return false, err
 	}
 
-	var stsList []*appsv1.StatefulSet
+	objsByKind := make(map[string][]client.Object)
 	for _, obj := range objs {
 		logger.V(1).Info("create or update", "objs", obj)
 		if err := intctrlutil.SetOwnership(cluster, obj, scheme, dbClusterFinalizerName); err != nil {
 			return false, err
 		}
-		// appendToStsList is used to handle statefulSets horizontal scaling when workloadType is replication
-		appendToStsList := func(stsList []*appsv1.StatefulSet) []*appsv1.StatefulSet {
-			stsObj, ok := obj.(*appsv1.StatefulSet)
-			if ok {
-				stsList = append(stsList, stsObj)
-			}
-			return stsList
-		}
 
-		err := cli.Create(ctx, obj)
-		if err == nil {
-			stsList = appendToStsList(stsList)
+		kind := obj.GetObjectKind().GroupVersionKind().Kind
+		objsByKind[kind] = append(objsByKind[kind], obj)
+
+		if err := cli.Create(ctx, obj); err == nil {
 			continue
-		}
-		if !apierrors.IsAlreadyExists(err) {
+		} else if !apierrors.IsAlreadyExists(err) {
 			return false, err
-		} else {
-			stsList = appendToStsList(stsList)
 		}
 
 		// Secret kind objects should only be applied once
@@ -561,6 +580,19 @@ func createOrReplaceResources(reqCtx intctrlutil.RequestCtx,
 		}
 	}
 
+	var svcList []*corev1.Service
+	for _, obj := range objsByKind[constant.ServiceKind] {
+		svcList = append(svcList, obj.(*corev1.Service))
+	}
+	if err := cleanUselessServices(svcList); err != nil {
+		return false, err
+	}
+
+	// stsList is used to handle statefulSets horizontal scaling when workloadType is replication
+	var stsList []*appsv1.StatefulSet
+	for _, obj := range objsByKind[constant.StatefulSetKind] {
+		stsList = append(stsList, obj.(*appsv1.StatefulSet))
+	}
 	if err := replicationset.HandleReplicationSet(reqCtx.Ctx, cli, cluster, stsList); err != nil {
 		return false, err
 	}
@@ -1023,6 +1055,17 @@ func isPVCExists(cli client.Client,
 		return false, client.IgnoreNotFound(err)
 	}
 	return true, nil
+}
+
+func getServiceMatchingLabels(clusterName string, componentName string) client.MatchingLabels {
+	result := map[string]string{
+		constant.AppInstanceLabelKey:  clusterName,
+		constant.AppManagedByLabelKey: constant.AppName,
+	}
+	if componentName != "" {
+		result[constant.KBAppComponentLabelKey] = componentName
+	}
+	return result
 }
 
 func getBackupMatchingLabels(clusterName string, componentName string) client.MatchingLabels {

--- a/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
@@ -285,27 +285,45 @@ spec:
                           type: object
                       type: object
                       x-kubernetes-preserve-unknown-fields: true
-                    serviceType:
-                      default: ClusterIP
-                      description: 'serviceType determines how the Service is exposed.
-                        Valid options are ClusterIP, NodePort, and LoadBalancer. "ClusterIP"
-                        allocates a cluster-internal IP address for load-balancing
-                        to endpoints. Endpoints are determined by the selector or
-                        if that is not specified, by manual construction of an Endpoints
-                        object or EndpointSlice objects. If clusterIP is "None", no
-                        virtual IP is allocated and the endpoints are published as
-                        a set of endpoints rather than a virtual IP. "NodePort" builds
-                        on ClusterIP and allocates a port on every node which routes
-                        to the same endpoints as the clusterIP. "LoadBalancer" builds
-                        on NodePort and creates an external load-balancer (if supported
-                        in the current cloud) which routes to the same endpoints as
-                        the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
-                      enum:
-                      - ClusterIP
-                      - NodePort
-                      - LoadBalancer
-                      type: string
-                      x-kubernetes-preserve-unknown-fields: true
+                    services:
+                      description: Services expose endpoints can be accessed by clients
+                      items:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: 'If ServiceType is LoadBalancer, cloud provider
+                              related parameters can be put here More info: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer'
+                            type: object
+                          name:
+                            description: Service name
+                            type: string
+                          serviceType:
+                            default: ClusterIP
+                            description: 'serviceType determines how the Service is
+                              exposed. Valid options are ClusterIP, NodePort, and
+                              LoadBalancer. "ClusterIP" allocates a cluster-internal
+                              IP address for load-balancing to endpoints. Endpoints
+                              are determined by the selector or if that is not specified,
+                              by manual construction of an Endpoints object or EndpointSlice
+                              objects. If clusterIP is "None", no virtual IP is allocated
+                              and the endpoints are published as a set of endpoints
+                              rather than a virtual IP. "NodePort" builds on ClusterIP
+                              and allocates a port on every node which routes to the
+                              same endpoints as the clusterIP. "LoadBalancer" builds
+                              on NodePort and creates an external load-balancer (if
+                              supported in the current cloud) which routes to the
+                              same endpoints as the clusterIP. More info: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
+                            enum:
+                            - ClusterIP
+                            - NodePort
+                            - LoadBalancer
+                            type: string
+                            x-kubernetes-preserve-unknown-fields: true
+                        required:
+                        - name
+                        type: object
+                      type: array
                     switchPolicy:
                       description: switchPolicy defines the strategy for switchover
                         and failover when workloadType is Replication.

--- a/internal/configuration/config_manager/signal_unknown.go
+++ b/internal/configuration/config_manager/signal_unknown.go
@@ -20,6 +20,7 @@ package configmanager
 
 import (
 	"os"
+	"runtime"
 
 	cfgcore "github.com/apecloud/kubeblocks/internal/configuration"
 )

--- a/internal/constant/const.go
+++ b/internal/constant/const.go
@@ -112,6 +112,7 @@ const (
 	CronJob                   = "CronJob"
 	ReplicaSet                = "ReplicaSet"
 	VolumeSnapshotKind        = "VolumeSnapshot"
+	ServiceKind               = "Service"
 )
 
 const (

--- a/internal/controller/builder/builder_test.go
+++ b/internal/controller/builder/builder_test.go
@@ -109,6 +109,8 @@ var _ = Describe("builder", func() {
 			clusterDefObj.Name, clusterVersionObj.Name).
 			AddComponent(mysqlCompName, mysqlCompType).SetReplicas(1).
 			AddVolumeClaimTemplate(testapps.DataVolumeName, &pvcSpec).
+			AddService(testapps.ServiceVPCName, corev1.ServiceTypeLoadBalancer).
+			AddService(testapps.ServiceInternetName, corev1.ServiceTypeLoadBalancer).
 			GetObject()
 		key := client.ObjectKeyFromObject(clusterObj)
 		if needCreate {
@@ -208,9 +210,9 @@ var _ = Describe("builder", func() {
 
 		It("builds Service correctly", func() {
 			params := newParams()
-			svc, err := BuildSvc(*params, true)
+			svcList, err := BuildSvcList(*params)
 			Expect(err).Should(BeNil())
-			Expect(svc).ShouldNot(BeNil())
+			Expect(svcList).ShouldNot(BeEmpty())
 		})
 
 		It("builds Conn. Credential correctly", func() {
@@ -245,7 +247,7 @@ var _ = Describe("builder", func() {
 				params.Cluster.Namespace)
 			var mysqlPort corev1.ServicePort
 			var paxosPort corev1.ServicePort
-			for _, s := range params.Component.Service.Ports {
+			for _, s := range params.Component.Services[0].Spec.Ports {
 				switch s.Name {
 				case "mysql":
 					mysqlPort = s

--- a/internal/controller/builder/cue/headless_service_template.cue
+++ b/internal/controller/builder/cue/headless_service_template.cue
@@ -27,7 +27,6 @@ component: {
 		scrapePath: string
 	}
 	podSpec: containers: [...]
-	volumeClaimTemplates: [...]
 }
 
 service: {

--- a/internal/controller/builder/cue/service_template.cue
+++ b/internal/controller/builder/cue/service_template.cue
@@ -18,29 +18,41 @@ cluster: {
 		name:      string
 	}
 }
+
 component: {
 	clusterDefName: string
 	name:           string
-	service: {
-		ports: [...]
-		type: string
-	}
-	podSpec: containers: [...]
-	volumeClaimTemplates: [...]
 }
 
 service: {
+	metadata: {
+		name: string
+		annotations: {}
+	}
+	spec: {
+		ports: [...]
+		type: string
+	}
+}
+
+svc: {
 	"apiVersion": "v1"
 	"kind":       "Service"
 	"metadata": {
 		namespace: cluster.metadata.namespace
-		name:      "\(cluster.metadata.name)-\(component.name)"
+		if service.metadata.name != _|_ {
+			name:      "\(cluster.metadata.name)-\(component.name)-\(service.metadata.name)"
+		}
+		if service.metadata.name == _|_ {
+			name:      "\(cluster.metadata.name)-\(component.name)"
+		}
 		labels: {
 			"app.kubernetes.io/name":            "\(component.clusterDefName)"
 			"app.kubernetes.io/instance":        cluster.metadata.name
 			"app.kubernetes.io/managed-by":      "kubeblocks"
 			"apps.kubeblocks.io/component-name": "\(component.name)"
 		}
+		annotations: service.metadata.annotations
 	}
 	"spec": {
 		"selector": {
@@ -48,9 +60,9 @@ service: {
 			"app.kubernetes.io/managed-by":      "kubeblocks"
 			"apps.kubeblocks.io/component-name": "\(component.name)"
 		}
-		ports: component.service.ports
-		if component.service.type != _|_ {
-			type: component.service.type
+		ports: service.spec.ports
+		if service.spec.type != _|_ {
+			type: service.spec.type
 		}
 	}
 }

--- a/internal/controller/component/probe_utils.go
+++ b/internal/controller/component/probe_utils.go
@@ -132,8 +132,9 @@ func buildProbeServiceContainer(component *SynthesizedComponent, container *core
 		"--config", "/config/probe/config.yaml",
 		"--components-path", "/config/probe/components"}
 
-	if component.Service != nil && len(component.Service.Ports) > 0 {
-		port := component.Service.Ports[0]
+	if len(component.Services) > 0 && len(component.Services[0].Spec.Ports) > 0 {
+		service := component.Services[0]
+		port := service.Spec.Ports[0]
 		dbPort := port.TargetPort.IntValue()
 		if dbPort == 0 {
 			dbPort = int(port.Port)

--- a/internal/controller/component/probe_utils_test.go
+++ b/internal/controller/component/probe_utils_test.go
@@ -19,8 +19,8 @@ package component
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
 	intctrlutil "github.com/apecloud/kubeblocks/internal/controllerutil"
@@ -46,12 +46,17 @@ var _ = Describe("probe_utils", func() {
 			clusterDefProbe.FailureThreshold = 1
 			component = &SynthesizedComponent{}
 			component.CharacterType = "mysql"
-			component.Service = &corev1.ServiceSpec{
-				Ports: []corev1.ServicePort{{
-					Protocol: corev1.ProtocolTCP,
-					Port:     3306,
-				}},
-			}
+			component.Services = append(component.Services, corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "mysql",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{
+						Protocol: corev1.ProtocolTCP,
+						Port:     3306,
+					}},
+				},
+			})
 			component.ConsensusSpec = &appsv1alpha1.ConsensusSetSpec{
 				Leader: appsv1alpha1.ConsensusMember{
 					Name:       "leader",

--- a/internal/controller/component/type.go
+++ b/internal/controller/component/type.go
@@ -40,7 +40,7 @@ type SynthesizedComponent struct {
 	ConsensusSpec         *v1alpha1.ConsensusSetSpec          `json:"consensusSpec,omitempty"`
 	PrimaryIndex          *int32                              `json:"primaryIndex,omitempty"`
 	PodSpec               *v12.PodSpec                        `json:"podSpec,omitempty"`
-	Service               *v12.ServiceSpec                    `json:"service,omitempty"`
+	Services              []v12.Service                       `json:"services,omitempty"`
 	Probes                *v1alpha1.ClusterDefinitionProbes   `json:"probes,omitempty"`
 	VolumeClaimTemplates  []v12.PersistentVolumeClaimTemplate `json:"volumeClaimTemplates,omitempty"`
 	Monitor               *MonitorConfig                      `json:"monitor,omitempty"`

--- a/internal/controller/plan/prepare.go
+++ b/internal/controller/plan/prepare.go
@@ -63,7 +63,7 @@ func PrepareComponentResources(reqCtx intctrlutil.RequestCtx, cli client.Client,
 			task.AppendResource(workload)
 		}()
 
-		svc, err := builder.BuildSvc(task.GetBuilderParams(), true)
+		svc, err := builder.BuildHeadlessSvc(task.GetBuilderParams())
 		if err != nil {
 			return err
 		}
@@ -185,11 +185,11 @@ func PrepareComponentResources(reqCtx intctrlutil.RequestCtx, cli client.Client,
 		task.AppendResource(pdb)
 	}
 
-	if task.Component.Service != nil && len(task.Component.Service.Ports) > 0 {
-		svc, err := builder.BuildSvc(task.GetBuilderParams(), false)
-		if err != nil {
-			return err
-		}
+	svcList, err := builder.BuildSvcList(task.GetBuilderParams())
+	if err != nil {
+		return err
+	}
+	for _, svc := range svcList {
 		if task.Component.WorkloadType == appsv1alpha1.Consensus {
 			addLeaderSelectorLabels(svc, task.Component)
 		}

--- a/internal/controller/plan/prepare_test.go
+++ b/internal/controller/plan/prepare_test.go
@@ -136,7 +136,7 @@ var _ = Describe("Cluster Controller", func() {
 				GetObject()
 		})
 
-		It("should construct env, headless service and statefuset objects and should not render config template", func() {
+		It("should construct env, default ClusterIP service, headless service and statefuset objects and should not render config template", func() {
 			reqCtx := intctrlutil.RequestCtx{
 				Ctx: ctx,
 				Log: logger,
@@ -153,7 +153,7 @@ var _ = Describe("Cluster Controller", func() {
 			Expect(PrepareComponentResources(reqCtx, testCtx.Cli, task)).Should(Succeed())
 
 			resources := *task.Resources
-			Expect(len(resources)).Should(Equal(3))
+			Expect(len(resources)).Should(Equal(4))
 			Expect(reflect.TypeOf(resources[0]).String()).Should(ContainSubstring("ConfigMap"))
 			Expect(reflect.TypeOf(resources[1]).String()).Should(ContainSubstring("Service"))
 			Expect(reflect.TypeOf(resources[2]).String()).Should(ContainSubstring("StatefulSet"))
@@ -208,7 +208,7 @@ var _ = Describe("Cluster Controller", func() {
 			Expect(PrepareComponentResources(reqCtx, testCtx.Cli, task)).Should(Succeed())
 
 			resources := *task.Resources
-			Expect(len(resources)).Should(Equal(4))
+			Expect(len(resources)).Should(Equal(5))
 			Expect(reflect.TypeOf(resources[0]).String()).Should(ContainSubstring("ConfigMap"))
 			Expect(reflect.TypeOf(resources[1]).String()).Should(ContainSubstring("Service"))
 			Expect(reflect.TypeOf(resources[2]).String()).Should(ContainSubstring("ConfigMap"))
@@ -261,7 +261,7 @@ var _ = Describe("Cluster Controller", func() {
 			Expect(PrepareComponentResources(reqCtx, testCtx.Cli, task)).Should(Succeed())
 
 			resources := *task.Resources
-			Expect(len(resources)).Should(Equal(4))
+			Expect(len(resources)).Should(Equal(5))
 			Expect(reflect.TypeOf(resources[0]).String()).Should(ContainSubstring("ConfigMap"))
 			Expect(reflect.TypeOf(resources[1]).String()).Should(ContainSubstring("Service"))
 			Expect(reflect.TypeOf(resources[2]).String()).Should(ContainSubstring("ConfigMap"))

--- a/internal/testutil/apps/cluster_factory.go
+++ b/internal/testutil/apps/cluster_factory.go
@@ -176,3 +176,18 @@ func (factory *MockClusterFactory) SetIssuer(issuer *appsv1alpha1.Issuer) *MockC
 	factory.get().Spec.ComponentSpecs = comps
 	return factory
 }
+
+func (factory *MockClusterFactory) AddService(serviceName string, serviceType corev1.ServiceType) *MockClusterFactory {
+	comps := factory.get().Spec.ComponentSpecs
+	if len(comps) > 0 {
+		comp := comps[len(comps)-1]
+		comp.Services = append(comp.Services,
+			appsv1alpha1.ClusterComponentService{
+				Name:        serviceName,
+				ServiceType: serviceType,
+			})
+		comps[len(comps)-1] = comp
+	}
+	factory.get().Spec.ComponentSpecs = comps
+	return factory
+}

--- a/internal/testutil/apps/constant.go
+++ b/internal/testutil/apps/constant.go
@@ -25,11 +25,13 @@ import (
 )
 
 const (
-	KubeBlocks        = "kubeblocks"
-	LogVolumeName     = "log"
-	ConfVolumeName    = "conf"
-	DataVolumeName    = "data"
-	ScriptsVolumeName = "scripts"
+	KubeBlocks          = "kubeblocks"
+	LogVolumeName       = "log"
+	ConfVolumeName      = "conf"
+	DataVolumeName      = "data"
+	ScriptsVolumeName   = "scripts"
+	ServiceVPCName      = "a-vpc-lb-service-for-app"
+	ServiceInternetName = "a-internet-lb-service-for-app"
 
 	ReplicationPodRoleVolume       = "pod-role"
 	ReplicationRoleLabelFieldPath  = "metadata.labels['kubeblocks.io/role']"
@@ -149,6 +151,7 @@ var (
 	statefulMySQLComponent = appsv1alpha1.ClusterComponentDefinition{
 		WorkloadType:  appsv1alpha1.Stateful,
 		CharacterType: "mysql",
+		Service:       &defaultMySQLService,
 		PodSpec: &corev1.PodSpec{
 			Containers: []corev1.Container{defaultMySQLContainer},
 		},


### PR DESCRIPTION
Currently, only one ClusterIP service is created for each component. However, a component may have multiple endpoints, so we should support multiple services for a single component. 