### PR TITLE
chore: cli playground output more message

### DIFF
--- a/internal/cli/cloudprovider/aws.go
+++ b/internal/cli/cloudprovider/aws.go
@@ -102,7 +102,7 @@ func (p *awsCloudProvider) DeleteK8sCluster(name string) error {
 	// destroy load balancer
 	fmt.Fprintf(p.stdout, "\nDestroy loadbalancer in %s\n", subPaths[1])
 	if err = tfDestroy(subPaths[1], p.stdout, p.stderr, tfexec.Var("cluster_name="+p.clusterName)); err != nil {
-		return err
+		fmt.Fprintln(p.stdout, err.Error())
 	}
 
 	// destroy EKS cluster

--- a/internal/cli/cmd/playground/playground_test.go
+++ b/internal/cli/cmd/playground/playground_test.go
@@ -59,9 +59,9 @@ var _ = Describe("playground", func() {
 			},
 		}
 		Expect(o.validate()).Should(Succeed())
-		Expect(o.run()).To(MatchError(MatchRegexp("failed to set up k3d cluster")))
+		Expect(o.run()).Should(HaveOccurred())
 		Expect(o.installKubeBlocks()).Should(HaveOccurred())
-		Expect(o.installCluster()).Should(HaveOccurred())
+		Expect(o.createCluster()).Should(HaveOccurred())
 	})
 
 	It("init at remote cloud", func() {
@@ -82,7 +82,7 @@ var _ = Describe("playground", func() {
 		o := &destroyOptions{
 			IOStreams: streams,
 		}
-		Expect(o.destroyPlayground()).Should(HaveOccurred())
+		Expect(o.destroy()).Should(HaveOccurred())
 	})
 
 	It("guide", func() {

--- a/internal/cli/cmd/playground/suite_test.go
+++ b/internal/cli/cmd/playground/suite_test.go
@@ -21,6 +21,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	cp "github.com/apecloud/kubeblocks/internal/cli/cloudprovider"
 )
 
 func TestPlayground(t *testing.T) {
@@ -29,6 +31,11 @@ func TestPlayground(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	// set fake image info
+	cp.K3sImage = "fake-k3s-image"
+	cp.K3dToolsImage = "fake-k3s-tools-image"
+	cp.K3dProxyImage = "fake-k3d-proxy-image"
+
 	// set default cluster name to test
 	k8sClusterName = "playground-test"
 	kbClusterName = "playground-test-cluster"


### PR DESCRIPTION

* `destroy` **DO NOT** break by error
* output more message when destroy
* fix failed test case

```bash
$ kbcli playground destroy --cloud-provider aws --region cn-northwest-1
Warning: This action will directly delete the kubernetes cluster, which may
  result in some residual resources, such as Volume, please confirm and manually
  clean up related resources after this action.

  In order to minimize resource residue, you can use the following commands
  to clean up the clusters and uninstall KubeBlocks before this action.
  
  # list all clusters created by KubeBlocks
  kbcli cluster list -A

  # delete clusters
  kbcli cluster delete <cluster-1> <cluster-2>

  # uninstall KubeBlocks and remove PVC and PV
  kbcli kubeblocks uninstall --remove-pvcs --remove-pvs

Do you really want to destroy the kubernetes cluster kb-playground-wmgks?
  This is no undo. Only 'yes' will be accepted to confirm.

Enter a value: █

```