### PR TITLE
chore: change ci typos version

### DIFF
--- a/.github/workflows/cicd-push.yml
+++ b/.github/workflows/cicd-push.yml
@@ -38,7 +38,7 @@ jobs:
             --filter="$FILE_PATH"
 
       - name: Spell Check with Typos
-        uses: crate-ci/typos@master
+        uses: crate-ci/typos@v1.13.14
         with:
           files: ${{ github.workspace }}/docs/
           config: ${{ github.workspace }}/.github/utils/typos.toml


### PR DESCRIPTION
change typos version from master to release version 
![image](https://user-images.githubusercontent.com/109708205/222320442-1c09913b-34bf-4c96-8f2b-44b93314659a.png)
