### PR TITLE
fix: make install failed

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -12,10 +12,6 @@ resources:
 - bases/dataprotection.kubeblocks.io_backups.yaml
 - bases/dataprotection.kubeblocks.io_restorejobs.yaml
 - bases/dataprotection.kubeblocks.io_backuppolicytemplates.yaml
-- bases/apps.kubeblocks.io_opsrequests.yaml
-- bases/apps.kubeblocks.io_configconstraints.yaml
-- bases/troubleshoot.sh_hostpreflights.yaml
-- bases/troubleshoot.sh_preflights.yaml
 - bases/extensions.kubeblocks.io_addons.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 


### PR DESCRIPTION
This PR: https://github.com/apecloud/kubeblocks/pull/1604 cause the problem, temporary fix first.

- Remove duplicate resources from `kustomization.yaml`
- Remove CRD related to troubleshoot from `kustomization.yaml`
`BoolString` is a custom data type that requires special handling. We are currently unable to parse the troubleshooting crds.

https://github.com/replicatedhq/troubleshoot/blob/186180612bdcd5732ea62606f1e8dc262c4e8a70/cmd/schemagen/cli/root.go#L166