### PR TITLE
chore: add a fixed uid for redis dashboard

### DIFF
--- a/deploy/helm/dashboards/redis-overview.json
+++ b/deploy/helm/dashboards/redis-overview.json
@@ -2433,6 +2433,7 @@
   },
   "timezone": "browser",
   "title": "Redis",
+  "uid": "9ZKoACxVk",
   "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
Convenient for users to obtain UID through ConfigMap to embed in the dashboard page.