### PR TITLE
chore: add pg cv 14.7 support amd64/arm64

### DIFF
--- a/deploy/helm/Chart.lock
+++ b/deploy/helm/Chart.lock
@@ -4,10 +4,10 @@ dependencies:
   version: 0.1.8
 - name: postgresql
   repository: file://../postgresql
-  version: 0.1.1
+  version: 0.2.0
 - name: loadbalancer
   repository: file://../loadbalancer
-  version: 0.1.0
+  version: 0.1.1
 - name: grafana
   repository: ""
   version: 6.43.*
@@ -23,5 +23,5 @@ dependencies:
 - name: alertmanager-webhook-adaptor
   repository: ""
   version: 0.1.*
-digest: sha256:9afd1d91f1b11a875afc9f5ecdc7caae4ee53783276379eb86a21e1a496b0c4a
-generated: "2023-03-07T14:45:44.706369+08:00"
+digest: sha256:76cafb289c4128e6e63049b9f3c2c3f82971408bdc54bb2f4ce847e1d096618c
+generated: "2023-03-08T16:38:48.025594+08:00"

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -57,7 +57,7 @@ dependencies:
   - condition: postgresql.enabled
     name: postgresql
     repository: file://../postgresql
-    version: 0.1.*
+    version: 0.2.*
   - condition: loadbalancer.enabled
     name: loadbalancer
     repository: file://../loadbalancer

--- a/deploy/postgresql/Chart.yaml
+++ b/deploy/postgresql/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "14.6.0"
+appVersion: "14.7.0"
 
 home: https://kubeblocks.io/
 icon: https://github.com/apecloud/kubeblocks/raw/main/img/logo.png

--- a/deploy/postgresql/templates/clusterdefinition.yaml
+++ b/deploy/postgresql/templates/clusterdefinition.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps.kubeblocks.io/v1alpha1
 kind: ClusterDefinition
 metadata:
-  name: postgresql
+  name: postgresql-cluster
   labels:
     {{- include "postgresql.labels" . | nindent 4 }}
 spec:
@@ -12,7 +12,7 @@ spec:
     host: "$(SVC_FQDN)"
     port: "$(SVC_PORT_tcp-postgresql)"
   componentDefs:
-    - name: postgresql
+    - name: pg-replicaset
       workloadType: Replication
       characterType: postgresql
       probes:

--- a/deploy/postgresql/templates/clusterversion.yaml
+++ b/deploy/postgresql/templates/clusterversion.yaml
@@ -5,25 +5,10 @@ metadata:
   labels:
     {{- include "postgresql.labels" . | nindent 4 }}
 spec:
-  clusterDefinitionRef: postgresql
+  clusterDefinitionRef: postgresql-cluster
   componentVersions:
-  - componentDefRef: postgresql
+  - componentDefRef: pg-replicaset
     versionsContext:
       containers:
       - name: postgresql
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ default .Values.image.tag .Chart.AppVersion }}
----
-apiVersion: apps.kubeblocks.io/v1alpha1
-kind: ClusterVersion
-metadata:
-  name: postgresql-15.1.0
-  labels:
-    {{- include "postgresql.labels" . | nindent 4 }}
-spec:
-  clusterDefinitionRef: postgresql
-  componentVersions:
-  - componentDefRef: postgresql
-    versionsContext:
-      containers:
-      - name: postgresql
-        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:15.1.0
+        image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}

--- a/deploy/postgresql/values.yaml
+++ b/deploy/postgresql/values.yaml
@@ -14,8 +14,8 @@
 image:
   registry: registry.cn-hangzhou.aliyuncs.com
   repository: apecloud/postgresql
-  tag: 14.6.0-debian-11-r22
-  digest: ""
+  tag:
+
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -100,8 +100,7 @@ metrics:
   image:
     registry: registry.cn-hangzhou.aliyuncs.com
     repository: apecloud/postgres-exporter
-    tag: 0.11.1-debian-11-r49
-    digest: ""
+    tag: 0.11.1-debian-11-r66
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
1. add clusterversion [postgresql-14.7.0](https://hub.docker.com/layers/bitnami/postgresql/14.7.0-debian-11-r9/images/sha256-82ef723023eff7456b6701c914c73fb059621039f0ba010436d7b0d2381ca5b3?context=explore) support amd64/arm64
2. upgrade postgres-exporter to [0.11.1-debian-11-r66](https://hub.docker.com/layers/bitnami/postgres-exporter/0.11.1-debian-11-r66/images/sha256-e087c3070bc01730d9033d7508d518e91a6f20ced17b2e2b5c30b35570fcd02c?context=explore) support postgresql-14.7.0
3. all images have been synchronized to registry.cn-hangzhou.aliyuncs.com/apecloud and docker.io/apecloud
4. resolve #1404 