### PR TITLE
chore: speed up helm packaging by skipping refresh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -469,7 +469,7 @@ helm-package: bump-chart-ver ## Do helm package.
 ## this is a hack fix: decompress the tgz from the depend-charts directory to the charts directory
 ## before dependency update.
 	cd $(CHART_PATH)/charts && ls ../depend-charts/*.tgz | xargs -n1 tar xf
-	$(HELM) dependency update $(CHART_PATH)
+	$(HELM) dependency update --skip-refresh $(CHART_PATH)
 	$(HELM) package $(CHART_PATH)
 
 ##@ Build Dependencies


### PR DESCRIPTION
As the dependency chart binary already exists in the directory `deploy/helm/depend-charts`, refreshing these charts is useless. Adding the `--skip-refresh` flag to `helm dependency update` will speed up packaging significantly.

`make helm-pacakge` without the `--skip-refresh` flag cost almost 2 minutes.
![image](https://user-images.githubusercontent.com/1765402/223308693-ff1777e5-2b62-44b0-a725-d5d444aebdd2.png)

`make helm-pacakge` with the `--skip-refresh` flag cost just 2 seconds.
![image](https://user-images.githubusercontent.com/1765402/223308834-9871c56e-c06d-48cc-af91-e98b05a99b09.png)
