### PR TITLE
Support: Add helm install option for kubeblocks-csi-driver

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -74,6 +74,10 @@ dependencies:
     name: snapshot-controller
     # repository: https://piraeus.io/helm-charts
     version: 1.*
+  - condition: kubeblocks-csi-driver.enabled
+    name: kubeblocks-csi-driver
+    # repository: https://apecloud.github.io/helm-charts
+    version: 0.*
   - condition: csi-s3.enabled
     name: csi-s3
     # repository: https://github.com/CloudVE/helm-charts/raw/master

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1339,6 +1339,9 @@ snapshot-controller:
                 values:
                   - "true"
 
+kubeblocks-csi-driver:
+  enabled: false
+
 ## csi-s3 settings
 ## ref: https://artifacthub.io/packages/helm/cloudve/csi-s3#configuration
 ##


### PR DESCRIPTION
Add an option to install kubeblocks-csi-driver via Helm, defaulting to false as snapshot and restore functionality is not yet supported for end-to-end usability.