### PR TITLE
fix: kbcli list-backup with arg `-l <labels>` does not work

### DIFF
--- a/internal/cli/util/util.go
+++ b/internal/cli/util/util.go
@@ -382,7 +382,7 @@ func CheckEmpty(str string) string {
 // like "instance-key in (name1, name2)"
 func BuildLabelSelectorByNames(selector string, names []string) string {
 	if len(names) == 0 {
-		return ""
+		return selector
 	}
 
 	label := fmt.Sprintf("%s in (%s)", intctrlutil.AppInstanceLabelKey, strings.Join(names, ","))


### PR DESCRIPTION
fix with list-backup with labelselector args:  -l xxx
reproduce following commands:
```
kbcli cluster list-backup -l app.kubernetes.io/instance=mycluster
# will output all backups
NAME                                TYPE       STATUS      TOTAL-SIZE   DURATION   CREATE-TIME            COMPLETION-TIME
backup-default-my-20230310173810    snapshot   Completed   10Gi         21s        2023-03-10T09:38:11Z   2023-03-10T09:38:33Z
backup-default-pg2-20230310174251   snapshot   Completed   10Gi         3s         2023-03-10T09:42:51Z   2023-03-10T09:42:54Z
```
fix: #1911
- [ ] TODO UT tests.