### PR TITLE
fix: remove csi-s3 endpoint empty values

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1558,7 +1558,6 @@ csi-s3:
   secret:
     accessKey: ""
     secretKey: ""
-    endpoint: ""
   ## csi-s3 storageClass setting
   ## @param csi-s3.storageClass.create -- Specifies whether the storage class should be created.
   ## @param csi-s3.storageClass.singleBucket -- Use a single bucket for all dynamically provisioned persistent volumes.


### PR DESCRIPTION
fix: https://github.com/apecloud/kubeblocks/issues/1912
fix: https://github.com/apecloud/kubeblocks/issues/1903

- [ ] TODO check required args in `kbcli addons enable csi-s3 `