### PR TITLE
chore: cli dashboard use custom port to avoid conflict

### DIFF
--- a/internal/cli/cmd/dashboard/dashboard.go
+++ b/internal/cli/cmd/dashboard/dashboard.go
@@ -57,21 +57,25 @@ type dashboard struct {
 }
 
 var (
+	// we do not use the default port to port-forward to avoid conflict with other services
 	dashboards = [...]*dashboard{
 		{
-			Name:      "kubeblocks-grafana",
-			AddonName: "kb-addon-grafana",
-			Label:     "app.kubernetes.io/instance=kb-addon-grafana,app.kubernetes.io/name=grafana",
+			Name:       "kubeblocks-grafana",
+			AddonName:  "kb-addon-grafana",
+			Label:      "app.kubernetes.io/instance=kb-addon-grafana,app.kubernetes.io/name=grafana",
+			TargetPort: "13000",
 		},
 		{
-			Name:      "kubeblocks-prometheus-alertmanager",
-			AddonName: "kb-addon-prometheus-alertmanager",
-			Label:     "app=prometheus,component=alertmanager,release=kb-addon-prometheus",
+			Name:       "kubeblocks-prometheus-alertmanager",
+			AddonName:  "kb-addon-prometheus-alertmanager",
+			Label:      "app=prometheus,component=alertmanager,release=kb-addon-prometheus",
+			TargetPort: "19093",
 		},
 		{
-			Name:      "kubeblocks-prometheus-server",
-			AddonName: "kb-addon-prometheus-server",
-			Label:     "app=prometheus,component=server,release=kb-addon-prometheus",
+			Name:       "kubeblocks-prometheus-server",
+			AddonName:  "kb-addon-prometheus-server",
+			Label:      "app=prometheus,component=server,release=kb-addon-prometheus",
+			TargetPort: "19090",
 		},
 	}
 )
@@ -277,7 +281,9 @@ func getDashboardInfo(client *kubernetes.Clientset) error {
 		d.CreationTime = util.TimeFormat(&svc.CreationTimestamp)
 		if len(svc.Spec.Ports) > 0 {
 			d.Port = fmt.Sprintf("%d", svc.Spec.Ports[0].Port)
-			d.TargetPort = svc.Spec.Ports[0].TargetPort.String()
+			if d.TargetPort == "" {
+				d.TargetPort = svc.Spec.Ports[0].TargetPort.String()
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
The 9090 is easy to conflict with the local service, change all dashboard port-forward ports to avoid conflict.

```
kbcli dashboard open kubeblocks-prometheus-server 
Unable to listen on port 9090: Listeners failed to create with the following errors: [unable to create listener: Error listen tcp4 127.0.0.1:9090: bind: address already in use]
error: unable to listen on any of the requested ports: [{9090 9090}]

```