### PR TITLE
chore: upgrade golangci to v1.51.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -528,7 +528,7 @@ install-docker-buildx: ## Create `docker buildx` builder.
 	docker buildx create --platform linux/amd64,linux/arm64 --name x-builder --driver docker-container --use
 
 .PHONY: golangci
-golangci: GOLANGCILINT_VERSION = v1.49.0
+golangci: GOLANGCILINT_VERSION = v1.51.2
 golangci: ## Download golangci-lint locally if necessary.
 ifneq ($(shell which golangci-lint),)
 	echo golangci-lint is already installed


### PR DESCRIPTION
The current latest release version of Go is 1.20.x, if users use Go version 1.20.x, building Kubeblocks will cause OOM kill due to memory leaks in old versions of golangci https://github.com/golangci/golangci-lint/pull/3414. 

Upgrading to the latest release version of golangci can solve this problem, which has been tested in Go versions 1.19.x and 1.20.x.