### PR TITLE
chore: parallel testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ __debug_bin
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+cover
 cover.html
 .coverage/
 

--- a/controllers/apps/operations/util/suite_test.go
+++ b/controllers/apps/operations/util/suite_test.go
@@ -57,7 +57,7 @@ func init() {
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 
-	RunSpecs(t, "Operation Controller Suite")
+	RunSpecs(t, "Operation util Suite")
 }
 
 var _ = BeforeSuite(func() {

--- a/controllers/extensions/suite_test.go
+++ b/controllers/extensions/suite_test.go
@@ -65,6 +65,7 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+
 	if viper.GetBool("ENABLE_DEBUG_LOG") {
 		logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), func(o *zap.Options) {
 			o.TimeEncoder = zapcore.ISO8601TimeEncoder
@@ -124,9 +125,8 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
+	cancel()
 	By("tearing down the test environment")
-	Eventually(func(g Gomega) {
-		err := testEnv.Stop()
-		Expect(err).NotTo(HaveOccurred())
-	})
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
 })


### PR DESCRIPTION
We can improve test efficiency by enabling multiple-level paralleling.
1. Enable parallel jobs in Makefile with `--jobs`.
2. Use ginkgo to parallel run cases in controllers package, such as `controllers/apps` and`controllers/dataprotection`, as these packages are time-cost and go test can only serially run specs in one ginkgo suite.

Before enabling parallel testing, `time make test` cost 6:00.20 total, after enabling parallel testing, `time make test` cost 2:26.50 total, and test efficiency significantly improved.

Detailed test results before enabling parallel testing, we can see the total cost is 6:00.20 at the bottom.
```bash
time make test
go generate -x ./internal/testutil/k8s/mocks/...
go run github.com/golang/mock/mockgen -copyright_file ../../../../hack/boilerplate.go.txt -package mocks -destination k8sclient_mocks.go sigs.k8s.io/controller-runtime/pkg/client Client
go generate -x ./internal/configuration/container/mocks/...
go run github.com/golang/mock/mockgen -copyright_file ../../../../hack/boilerplate.go.txt -package mocks -destination dockerclient_mocks.go github.com/docker/docker/client ContainerAPIClient
go run github.com/golang/mock/mockgen -copyright_file ../../../../hack/boilerplate.go.txt -package mocks -destination criclient_mocks.go k8s.io/cri-api/pkg/apis/runtime/v1 RuntimeServiceClient
go generate -x ./internal/configuration/proto/mocks/...
go run github.com/golang/mock/mockgen -copyright_file ../../../../hack/boilerplate.go.txt -package mocks -destination reconfigure_client_mocks.go github.com/apecloud/kubeblocks/internal/configuration/proto ReconfigureClient
/Users/ziang/git/kubeblocks/bin/controller-gen rbac:roleName=manager-role crd:generateEmbeddedObjectMeta=true webhook paths="./cmd/manager/...;./apis/...;./controllers/...;./internal/..." output:crd:artifacts:config=config/crd/bases
/Users/ziang/git/kubeblocks/bin/controller-gen rbac:roleName=loadbalancer-role  paths="./cmd/loadbalancer/..." output:dir=config/loadbalancer
/Users/ziang/git/kubeblocks/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./apis/...;./externalapis/..."
gofmt -l -w -s $(git ls-files --exclude-standard | grep "\.go$")
GOOS=linux go vet -mod=mod ./...
KUBEBUILDER_ASSETS="/Users/ziang/Library/Application Support/io.kubebuilder.envtest/k8s/1.25.0-darwin-arm64" go test -short -coverprofile cover.out ./internal/... ./apis/... ./controllers/... ./cmd/...
ok  	github.com/apecloud/kubeblocks/internal/cli/cloudprovider	1.737s	coverage: 30.0% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/cluster	0.670s	coverage: 74.9% of statements
?   	github.com/apecloud/kubeblocks/internal/cli/cmd	[no test files]
ok  	github.com/apecloud/kubeblocks/internal/cli/cmd/addon	2.539s	coverage: 7.8% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/cmd/alert	2.147s	coverage: 74.2% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/cmd/backupconfig	1.369s	coverage: 66.7% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/cmd/bench	0.355s	coverage: 70.4% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/cmd/cluster	2.865s	coverage: 60.3% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/cmd/clusterdefinition	1.140s	coverage: 70.0% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/cmd/clusterversion	2.707s	coverage: 70.0% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/cmd/dashboard	5.386s	coverage: 66.0% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/cmd/kubeblocks	1.545s	coverage: 53.3% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/cmd/options	0.317s	coverage: 100.0% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/cmd/playground	42.958s	coverage: 38.9% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/cmd/version	1.119s	coverage: 52.4% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/create	1.185s	coverage: 68.8% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/delete	1.205s	coverage: 85.9% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/engine	1.552s	coverage: 57.1% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/exec	1.967s	coverage: 70.8% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/list	0.821s	coverage: 75.4% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/patch	0.457s	coverage: 86.7% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/printer	0.896s	coverage: 62.3% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/testing	0.984s	coverage: 66.9% of statements
?   	github.com/apecloud/kubeblocks/internal/cli/types	[no test files]
ok  	github.com/apecloud/kubeblocks/internal/cli/util	6.540s	coverage: 54.5% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/util/helm	1.709s	coverage: 57.1% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/util/prompt	0.311s	coverage: 100.0% of statements
ok  	github.com/apecloud/kubeblocks/internal/configuration	0.818s	coverage: 84.4% of statements
ok  	github.com/apecloud/kubeblocks/internal/configuration/config_manager	6.497s	coverage: 64.7% of statements
ok  	github.com/apecloud/kubeblocks/internal/configuration/container	1.445s	coverage: 72.1% of statements
?   	github.com/apecloud/kubeblocks/internal/configuration/container/mocks	[no test files]
?   	github.com/apecloud/kubeblocks/internal/configuration/proto	[no test files]
?   	github.com/apecloud/kubeblocks/internal/configuration/proto/mocks	[no test files]
?   	github.com/apecloud/kubeblocks/internal/constant	[no test files]
ok  	github.com/apecloud/kubeblocks/internal/controller/builder	7.694s	coverage: 79.7% of statements
ok  	github.com/apecloud/kubeblocks/internal/controller/component	8.580s	coverage: 83.1% of statements
ok  	github.com/apecloud/kubeblocks/internal/controller/plan	7.924s	coverage: 59.0% of statements
?   	github.com/apecloud/kubeblocks/internal/controller/types	[no test files]
ok  	github.com/apecloud/kubeblocks/internal/controllerutil	6.294s	coverage: 60.7% of statements
?   	github.com/apecloud/kubeblocks/internal/generics	[no test files]
ok  	github.com/apecloud/kubeblocks/internal/gotemplate	1.292s	coverage: 84.1% of statements
ok  	github.com/apecloud/kubeblocks/internal/preflight	0.753s	coverage: 56.4% of statements
ok  	github.com/apecloud/kubeblocks/internal/preflight/analyzer	0.586s	coverage: 88.5% of statements
ok  	github.com/apecloud/kubeblocks/internal/preflight/collector	0.689s	coverage: 79.1% of statements
?   	github.com/apecloud/kubeblocks/internal/preflight/interactive	[no test files]
ok  	github.com/apecloud/kubeblocks/internal/preflight/util	0.345s	coverage: 100.0% of statements
ok  	github.com/apecloud/kubeblocks/internal/sqlchannel	1.242s	coverage: 93.1% of statements
?   	github.com/apecloud/kubeblocks/internal/testutil	[no test files]
?   	github.com/apecloud/kubeblocks/internal/testutil/apps	[no test files]
?   	github.com/apecloud/kubeblocks/internal/testutil/k8s	[no test files]
?   	github.com/apecloud/kubeblocks/internal/testutil/k8s/mocks	[no test files]
ok  	github.com/apecloud/kubeblocks/internal/unstructured	0.541s	coverage: 83.1% of statements
ok  	github.com/apecloud/kubeblocks/internal/unstructured/redis	0.401s	coverage: 45.9% of statements
?   	github.com/apecloud/kubeblocks/internal/webhook	[no test files]
ok  	github.com/apecloud/kubeblocks/apis/apps/v1alpha1	9.329s	coverage: 35.9% of statements
?   	github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1	[no test files]
ok  	github.com/apecloud/kubeblocks/apis/extensions/v1alpha1	0.393s	coverage: 19.7% of statements
ok  	github.com/apecloud/kubeblocks/controllers/apps	310.684s	coverage: 78.6% of statements
ok  	github.com/apecloud/kubeblocks/controllers/apps/components	14.979s	coverage: 86.1% of statements
ok  	github.com/apecloud/kubeblocks/controllers/apps/components/consensusset	8.090s	coverage: 20.7% of statements
ok  	github.com/apecloud/kubeblocks/controllers/apps/components/replicationset	9.042s	coverage: 74.2% of statements
ok  	github.com/apecloud/kubeblocks/controllers/apps/components/stateful	7.278s	coverage: 75.0% of statements
ok  	github.com/apecloud/kubeblocks/controllers/apps/components/stateless	8.057s	coverage: 78.3% of statements
?   	github.com/apecloud/kubeblocks/controllers/apps/components/types	[no test files]
ok  	github.com/apecloud/kubeblocks/controllers/apps/components/util	8.092s	coverage: 62.9% of statements
ok  	github.com/apecloud/kubeblocks/controllers/apps/configuration	51.653s	coverage: 75.5% of statements
ok  	github.com/apecloud/kubeblocks/controllers/apps/operations	13.320s	coverage: 81.1% of statements
ok  	github.com/apecloud/kubeblocks/controllers/apps/operations/util	7.697s	coverage: 88.1% of statements
ok  	github.com/apecloud/kubeblocks/controllers/dataprotection	139.159s	coverage: 81.4% of statements
ok  	github.com/apecloud/kubeblocks/controllers/extensions	30.464s	coverage: 75.1% of statements
ok  	github.com/apecloud/kubeblocks/controllers/k8score	7.689s	coverage: 28.8% of statements
?   	github.com/apecloud/kubeblocks/cmd/cli	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer	[no test files]
ok  	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/agent	0.546s	coverage: 64.7% of statements
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/agent/mocks	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/cloud	[no test files]
ok  	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/cloud/aws	53.459s	coverage: 68.0% of statements
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/cloud/aws/mocks	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/cloud/factory	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/cloud/mocks	[no test files]
ok  	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/config	0.381s	coverage: 98.0% of statements
ok  	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/controllers	13.358s	coverage: 76.9% of statements
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/iptables	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/netlink	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/netlink/mocks	[no test files]
ok  	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/network	0.343s	coverage: 0.0% of statements
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/network/mocks	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/procfs	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/procfs/mocks	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/protocol	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/protocol/mocks	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/manager	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/probe	[no test files]
ok  	github.com/apecloud/kubeblocks/cmd/probe/internal/binding	0.551s	coverage: 83.3% of statements
ok  	github.com/apecloud/kubeblocks/cmd/probe/internal/binding/etcd	0.809s	coverage: 33.3% of statements
ok  	github.com/apecloud/kubeblocks/cmd/probe/internal/binding/mongodb	0.735s	coverage: 19.7% of statements
ok  	github.com/apecloud/kubeblocks/cmd/probe/internal/binding/mysql	0.312s	coverage: 82.6% of statements
ok  	github.com/apecloud/kubeblocks/cmd/probe/internal/binding/postgres	0.291s	coverage: 15.1% of statements
ok  	github.com/apecloud/kubeblocks/cmd/probe/internal/binding/redis	0.331s	coverage: 37.5% of statements
ok  	github.com/apecloud/kubeblocks/cmd/probe/internal/component/redis	0.488s	coverage: 18.2% of statements
ok  	github.com/apecloud/kubeblocks/cmd/probe/internal/middleware/http/probe	0.380s	coverage: 79.2% of statements
?   	github.com/apecloud/kubeblocks/cmd/reloader	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/reloader/app	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/reloader/container_killer	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/reloader/tools	[no test files]
make test  303.81s user 62.39s system 101% cpu 6:00.20 total
```


Detailed test results after enabling parallel testing, we can see the total cost is 2:26.50 at the bottom.

```bash
time make test
go generate -x ./internal/testutil/k8s/mocks/...
/Users/ziang/git/kubeblocks/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./apis/...;./externalapis/..."
gofmt -l -w -s $(git ls-files --exclude-standard | grep "\.go$")
GOOS=linux go vet -mod=mod ./...
go run github.com/golang/mock/mockgen -copyright_file ../../../../hack/boilerplate.go.txt -package mocks -destination k8sclient_mocks.go sigs.k8s.io/controller-runtime/pkg/client Client
rm -rf /Users/ziang/git/kubeblocks/cover
mkdir -p /Users/ziang/git/kubeblocks/cover
KUBEBUILDER_ASSETS="/Users/ziang/Library/Application Support/io.kubebuilder.envtest/k8s/1.25.0-darwin-arm64" /Users/ziang/go/bin/ginkgo run --procs 4 -output-dir /Users/ziang/git/kubeblocks/cover --succinct -coverprofile apps.cover ./controllers/apps/
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    4.8.1
  Mismatched package versions found:
    2.6.1 used by apps

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.

KUBEBUILDER_ASSETS="/Users/ziang/Library/Application Support/io.kubebuilder.envtest/k8s/1.25.0-darwin-arm64" /Users/ziang/go/bin/ginkgo run --procs 4 -output-dir /Users/ziang/git/kubeblocks/cover --succinct -coverprofile components.cover ./controllers/apps/components/...
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.8.1
  Mismatched package versions found:
    2.6.1 used by components, consensusset, replicationset, stateful, stateless, util

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.

KUBEBUILDER_ASSETS="/Users/ziang/Library/Application Support/io.kubebuilder.envtest/k8s/1.25.0-darwin-arm64" /Users/ziang/go/bin/ginkgo run --procs 4 -output-dir /Users/ziang/git/kubeblocks/cover --succinct -coverprofile configuration.cover ./controllers/apps/configuration/...
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.8.1
  Mismatched package versions found:
    2.6.1 used by configuration

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.

go generate -x ./internal/configuration/container/mocks/...
go run github.com/golang/mock/mockgen -copyright_file ../../../../hack/boilerplate.go.txt -package mocks -destination dockerclient_mocks.go github.com/docker/docker/client ContainerAPIClient
go run github.com/golang/mock/mockgen -copyright_file ../../../../hack/boilerplate.go.txt -package mocks -destination criclient_mocks.go k8s.io/cri-api/pkg/apis/runtime/v1 RuntimeServiceClient
go generate -x ./internal/configuration/proto/mocks/...
go run github.com/golang/mock/mockgen -copyright_file ../../../../hack/boilerplate.go.txt -package mocks -destination reconfigure_client_mocks.go github.com/apecloud/kubeblocks/internal/configuration/proto ReconfigureClient
KUBEBUILDER_ASSETS="/Users/ziang/Library/Application Support/io.kubebuilder.envtest/k8s/1.25.0-darwin-arm64" /Users/ziang/go/bin/ginkgo run --procs 4 -output-dir /Users/ziang/git/kubeblocks/cover --succinct -coverprofile operations.cover ./controllers/apps/operations/...
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.8.1
  Mismatched package versions found:
    2.6.1 used by operations, util

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.

[1679042742] Component Controller Suite - 14/14 specs - 4 procs [1679042744] Configuration Suite - 19/19 specs - 4 procs [1679042741] Controller Suite - 48/48 specs - 4 procs •••••••••••••••••••••••••••••••• SUCCESS! 16.077642s
[1679042749] Operation Controller Suite - 13/13 specs - 4 procs coverage: 84.2% of statements
[1679042742] ConsensusSet Controller Suite - 1/1 specs - 4 procs •••••••••••••••••• SUCCESS! 7.494774s
coverage: 20.7% of statements
[1679042742] ReplicationSet Controller Suite - 7/7 specs - 4 procs • SUCCESS! 11.160298s
coverage: 81.1% of statements
[1679042749] Operation util Suite - 1/1 specs - 4 procs ••••••••••• SUCCESS! 7.867804s
coverage: 74.2% of statements
•[1679042742] Stateful Controller Suite - 1/1 specs - 4 procs •• SUCCESS! 7.349935s
••••••coverage: 88.1% of statements
•composite coverage: 81.3% of statements

Ginkgo ran 2 suites in 37.324789834s
Test Suite Passed
KUBEBUILDER_ASSETS="/Users/ziang/Library/Application Support/io.kubebuilder.envtest/k8s/1.25.0-darwin-arm64" /Users/ziang/go/bin/ginkgo run --procs 4 -output-dir /Users/ziang/git/kubeblocks/cover --succinct -coverprofile dataprotection.cover ./controllers/dataprotection/...
Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.8.1
  Mismatched package versions found:
    2.6.1 used by dataprotection

  Ginkgo will continue to attempt to run but you may see errors (including flag
  parsing errors) and should either update your go.mod or your version of the
  Ginkgo CLI to match.

  To install the matching version of the CLI run
    go install github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file.  Alternatively you can use
    go run github.com/onsi/ginkgo/v2/ginkgo
  from a path that contains a go.mod file to invoke the matching version of the
  Ginkgo CLI.

  If you are attempting to test multiple packages that each have a different
  version of the Ginkgo library with a single Ginkgo CLI that is currently
  unsupported.

•••[1679042787] Data Protection Controller Suite - 23/23 specs - 4 procs •• SUCCESS! 6.677589s
coverage: 75.0% of statements
[1679042742] Stateless Controller Suite - 1/1 specs - 4 procs
------------------------------
[BeforeSuite] PASSED [3.160 seconds]
[BeforeSuite]
/Users/ziang/git/kubeblocks/controllers/dataprotection/suite_test.go:65

  Captured StdOut/StdErr Output >>
  config settings: map[clearresourcepollinginterval:1s clearresourcetimeout:1m0s cm_namespace: consistentlyduration:3s consistentlypollinginterval:1s dp_backup_schedule:0 3 * * * dp_backup_ttl:168h0m0s eventuallypollinginterval:1s eventuallytimeout:10s kubeblocks_image:apecloud/kubeblocks:latest maxconcurrentreconciles_dataprotection:20]
  << Captured StdOut/StdErr Output
------------------------------
••[BeforeSuite] PASSED [3.892 seconds]
[BeforeSuite]
/Users/ziang/git/kubeblocks/controllers/dataprotection/suite_test.go:65

  Captured StdOut/StdErr Output >>
  config settings: map[clearresourcepollinginterval:1s clearresourcetimeout:1m0s cm_namespace: consistentlyduration:3s consistentlypollinginterval:1s dp_backup_schedule:0 3 * * * dp_backup_ttl:168h0m0s eventuallypollinginterval:1s eventuallytimeout:10s kubeblocks_image:apecloud/kubeblocks:latest maxconcurrentreconciles_dataprotection:20]
  << Captured StdOut/StdErr Output
------------------------------
[BeforeSuite] PASSED [3.925 seconds]
[BeforeSuite]
/Users/ziang/git/kubeblocks/controllers/dataprotection/suite_test.go:65

  Captured StdOut/StdErr Output >>
  config settings: map[clearresourcepollinginterval:1s clearresourcetimeout:1m0s cm_namespace: consistentlyduration:3s consistentlypollinginterval:1s dp_backup_schedule:0 3 * * * dp_backup_ttl:168h0m0s eventuallypollinginterval:1s eventuallytimeout:10s kubeblocks_image:apecloud/kubeblocks:latest maxconcurrentreconciles_dataprotection:20]
  << Captured StdOut/StdErr Output
------------------------------
•[BeforeSuite] PASSED [4.371 seconds]
[BeforeSuite]
/Users/ziang/git/kubeblocks/controllers/dataprotection/suite_test.go:65

  Captured StdOut/StdErr Output >>
  config settings: map[clearresourcepollinginterval:1s clearresourcetimeout:1m0s cm_namespace: consistentlyduration:3s consistentlypollinginterval:1s dp_backup_schedule:0 3 * * * dp_backup_ttl:168h0m0s eventuallypollinginterval:1s eventuallytimeout:10s kubeblocks_image:apecloud/kubeblocks:latest maxconcurrentreconciles_dataprotection:20]
  << Captured StdOut/StdErr Output
------------------------------
• SUCCESS! 43.086122s
•coverage: 75.9% of statements
composite coverage: 75.9% of statements

Ginkgo ran 1 suite in 51.38615575s
Test Suite Passed
KUBEBUILDER_ASSETS="/Users/ziang/Library/Application Support/io.kubebuilder.envtest/k8s/1.25.0-darwin-arm64" go test -short -outputdir /Users/ziang/git/kubeblocks/cover -coverprofile test.cover ./internal/... ./apis/... ./cmd/... ./controllers/extensions/... ./controllers/k8score/...
•• SUCCESS! 7.029959s
•coverage: 78.3% of statements
••[1679042742] Component Util. Suite - 2/2 specs - 4 procs •••••••••••ok  	github.com/apecloud/kubeblocks/internal/cli/cloudprovider	3.131s	coverage: 30.2% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/cluster	0.469s	coverage: 74.9% of statements
?   	github.com/apecloud/kubeblocks/internal/cli/cmd	[no test files]
ok  	github.com/apecloud/kubeblocks/internal/cli/cmd/addon	1.175s	coverage: 7.8% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/cmd/alert	2.264s	coverage: 74.2% of statements
•• SUCCESS! 9.271611s
ok  	github.com/apecloud/kubeblocks/internal/cli/cmd/backupconfig	0.759s	coverage: 66.7% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/cmd/bench	0.142s	coverage: 70.4% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/cmd/cluster	3.591s	coverage: 60.3% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/cmd/clusterdefinition	2.674s	coverage: 70.0% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/cmd/clusterversion	1.709s	coverage: 70.0% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/cmd/dashboard	3.730s	coverage: 61.7% of statements
•coverage: 62.9% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/cmd/kubeblocks	1.383s	coverage: 53.5% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/cmd/options	2.158s	coverage: 100.0% of statements
••composite coverage: 62.0% of statements

Ginkgo ran 6 suites in 1m9.651773667s
Test Suite Passed
/Users/ziang/git/kubeblocks/bin/controller-gen rbac:roleName=manager-role crd:generateEmbeddedObjectMeta=true webhook paths="./cmd/manager/...;./apis/...;./controllers/...;./internal/..." output:crd:artifacts:config=config/crd/bases
••••••/Users/ziang/git/kubeblocks/bin/controller-gen rbac:roleName=loadbalancer-role  paths="./cmd/loadbalancer/..." output:dir=config/loadbalancer
••••••••••••••••• SUCCESS! 46.282876s
coverage: 81.2% of statements
composite coverage: 81.2% of statements

Ginkgo ran 1 suite in 49.85767225s
Test Suite Passed
•••• SUCCESS! 1m30.817899s
coverage: 78.6% of statements
composite coverage: 78.6% of statements

Ginkgo ran 1 suite in 1m42.836150583s
Test Suite Passed
ok  	github.com/apecloud/kubeblocks/internal/cli/cmd/playground	26.278s	coverage: 40.3% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/cmd/version	1.419s	coverage: 60.9% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/create	0.642s	coverage: 68.8% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/delete	1.067s	coverage: 85.9% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/engine	0.746s	coverage: 57.1% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/exec	0.482s	coverage: 70.8% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/list	1.518s	coverage: 75.4% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/patch	0.938s	coverage: 86.7% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/printer	1.165s	coverage: 64.7% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/testing	0.586s	coverage: 66.9% of statements
?   	github.com/apecloud/kubeblocks/internal/cli/types	[no test files]
ok  	github.com/apecloud/kubeblocks/internal/cli/util	9.530s	coverage: 53.1% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/util/helm	0.633s	coverage: 57.1% of statements
ok  	github.com/apecloud/kubeblocks/internal/cli/util/prompt	0.451s	coverage: 100.0% of statements
ok  	github.com/apecloud/kubeblocks/internal/configuration	0.616s	coverage: 84.4% of statements
ok  	github.com/apecloud/kubeblocks/internal/configuration/config_manager	5.488s	coverage: 64.7% of statements
ok  	github.com/apecloud/kubeblocks/internal/configuration/container	0.924s	coverage: 72.1% of statements
?   	github.com/apecloud/kubeblocks/internal/configuration/container/mocks	[no test files]
?   	github.com/apecloud/kubeblocks/internal/configuration/proto	[no test files]
?   	github.com/apecloud/kubeblocks/internal/configuration/proto/mocks	[no test files]
?   	github.com/apecloud/kubeblocks/internal/constant	[no test files]
ok  	github.com/apecloud/kubeblocks/internal/controller/builder	8.133s	coverage: 79.7% of statements
ok  	github.com/apecloud/kubeblocks/internal/controller/component	9.493s	coverage: 83.1% of statements
ok  	github.com/apecloud/kubeblocks/internal/controller/plan	8.038s	coverage: 59.0% of statements
?   	github.com/apecloud/kubeblocks/internal/controller/types	[no test files]
ok  	github.com/apecloud/kubeblocks/internal/controllerutil	7.054s	coverage: 60.7% of statements
?   	github.com/apecloud/kubeblocks/internal/generics	[no test files]
ok  	github.com/apecloud/kubeblocks/internal/gotemplate	0.458s	coverage: 84.1% of statements
ok  	github.com/apecloud/kubeblocks/internal/preflight	1.147s	coverage: 56.4% of statements
ok  	github.com/apecloud/kubeblocks/internal/preflight/analyzer	1.576s	coverage: 88.5% of statements
ok  	github.com/apecloud/kubeblocks/internal/preflight/collector	0.460s	coverage: 79.1% of statements
?   	github.com/apecloud/kubeblocks/internal/preflight/interactive	[no test files]
ok  	github.com/apecloud/kubeblocks/internal/preflight/util	0.205s	coverage: 100.0% of statements
ok  	github.com/apecloud/kubeblocks/internal/sqlchannel	2.137s	coverage: 93.1% of statements
?   	github.com/apecloud/kubeblocks/internal/testutil	[no test files]
?   	github.com/apecloud/kubeblocks/internal/testutil/apps	[no test files]
?   	github.com/apecloud/kubeblocks/internal/testutil/k8s	[no test files]
?   	github.com/apecloud/kubeblocks/internal/testutil/k8s/mocks	[no test files]
ok  	github.com/apecloud/kubeblocks/internal/unstructured	0.735s	coverage: 83.1% of statements
ok  	github.com/apecloud/kubeblocks/internal/unstructured/redis	0.084s	coverage: 45.9% of statements
?   	github.com/apecloud/kubeblocks/internal/webhook	[no test files]
ok  	github.com/apecloud/kubeblocks/apis/apps/v1alpha1	7.593s	coverage: 35.9% of statements
?   	github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1	[no test files]
ok  	github.com/apecloud/kubeblocks/apis/extensions/v1alpha1	1.058s	coverage: 19.7% of statements
?   	github.com/apecloud/kubeblocks/cmd/cli	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer	[no test files]
ok  	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/agent	0.634s	coverage: 65.1% of statements
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/agent/mocks	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/cloud	[no test files]
ok  	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/cloud/aws	54.098s	coverage: 68.0% of statements
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/cloud/aws/mocks	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/cloud/factory	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/cloud/mocks	[no test files]
ok  	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/config	0.797s	coverage: 98.0% of statements
ok  	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/controllers	13.549s	coverage: 76.9% of statements
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/iptables	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/netlink	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/netlink/mocks	[no test files]
ok  	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/network	0.895s	coverage: 0.0% of statements
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/network/mocks	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/procfs	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/procfs/mocks	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/protocol	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/loadbalancer/internal/protocol/mocks	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/manager	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/probe	[no test files]
ok  	github.com/apecloud/kubeblocks/cmd/probe/internal/binding	0.258s	coverage: 83.8% of statements
ok  	github.com/apecloud/kubeblocks/cmd/probe/internal/binding/etcd	1.936s	coverage: 33.3% of statements
ok  	github.com/apecloud/kubeblocks/cmd/probe/internal/binding/mongodb	0.118s	coverage: 19.7% of statements
ok  	github.com/apecloud/kubeblocks/cmd/probe/internal/binding/mysql	0.108s	coverage: 82.6% of statements
ok  	github.com/apecloud/kubeblocks/cmd/probe/internal/binding/postgres	0.176s	coverage: 17.5% of statements
ok  	github.com/apecloud/kubeblocks/cmd/probe/internal/binding/redis	0.113s	coverage: 37.5% of statements
ok  	github.com/apecloud/kubeblocks/cmd/probe/internal/component/redis	0.123s	coverage: 18.2% of statements
ok  	github.com/apecloud/kubeblocks/cmd/probe/internal/middleware/http/probe	0.079s	coverage: 79.2% of statements
?   	github.com/apecloud/kubeblocks/cmd/reloader	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/reloader/app	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/reloader/container_killer	[no test files]
?   	github.com/apecloud/kubeblocks/cmd/reloader/tools	[no test files]
ok  	github.com/apecloud/kubeblocks/controllers/extensions	30.110s	coverage: 75.1% of statements
ok  	github.com/apecloud/kubeblocks/controllers/k8score	7.677s	coverage: 42.5% of statements
make test  407.49s user 102.84s system 348% cpu 2:26.50 total
```