### PR TITLE
chore: check multi-architecture docker images

### DIFF
--- a/.github/workflows/cicd-pull-request.yml
+++ b/.github/workflows/cicd-pull-request.yml
@@ -80,12 +80,11 @@ jobs:
     name: check helm
     needs: trigger-mode
     if: needs.trigger-mode.outputs.trigger-mode == '[deploy]'
-    uses: apecloud/apecd/.github/workflows/release-charts.yml@v0.4.0
+    uses: apecloud/apecd/.github/workflows/release-charts.yml@v0.5.0
     with:
       MAKE_OPS: "bump-chart-ver"
       VERSION: "v0.4.0-check"
       CHART_NAME: "kubeblocks"
       CHART_DIR: "deploy/helm"
-      HELM_SET: "prometheus.enabled=true,grafana.enabled=true,dashboards.enabled=true,dataProtection.enableVolumeSnapshot=true,snapshot-controller.enabled=true"
       PUSH_ENABLE: false
     secrets: inherit

--- a/.github/workflows/cicd-push.yml
+++ b/.github/workflows/cicd-push.yml
@@ -65,19 +65,38 @@ jobs:
 
   cli-doc:
     needs: trigger-mode
-    runs-on: [self-hosted, eks-fargate-runner ]
+    runs-on: ubuntu-latest
     if: ${{ contains(needs.trigger-mode.outputs.trigger-mode, '[cli]') && github.ref_name != 'main' }}
     steps:
-      - uses: apecloud/checkout@main
+      - uses: actions/checkout@v3
+      - name: install lib
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libbtrfs-dev \
+            libdevmapper-dev
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+
       - name: Check cli doc
+        id: check-cli-doc
         run: |
           make kbcli-doc
-          git config --local user.name "$GITHUB_ACTOR"
-          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git commit -a -m "chore: auto update cli doc changes"
+          FILE_CHANGES=`git diff --name-only ${{ github.sha }}`
+          if [[ ! -z "$FILE_CHANGES" ]]; then
+            echo $FILE_CHANGES
+            git config --local user.name "$GITHUB_ACTOR"
+            git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+            git commit -a -m "chore: auto update cli doc changes"
+          fi
+          echo file_changes=$FILE_CHANGES >> $GITHUB_OUTPUT
 
       - name: Push cli doc changes
         uses: ad-m/github-push-action@master
+        if: ${{ steps.check-cli-doc.outputs.file_changes }}
         with:
           github_token: ${{ env.GITHUB_TOKEN }}
           branch: ${{ github.ref }}
@@ -172,12 +191,11 @@ jobs:
   check-helm:
     needs: trigger-mode
     if: contains(needs.trigger-mode.outputs.trigger-mode, '[deploy]')
-    uses: apecloud/apecd/.github/workflows/release-charts.yml@v0.4.0
+    uses: apecloud/apecd/.github/workflows/release-charts.yml@v0.5.0
     with:
       MAKE_OPS: "bump-chart-ver"
       VERSION: "v0.4.0-check"
       CHART_NAME: "kubeblocks"
       CHART_DIR: "deploy/helm"
-      HELM_SET: "prometheus.enabled=true,grafana.enabled=true,dashboards.enabled=true,dataProtection.enableVolumeSnapshot=true,snapshot-controller.enabled=true"
       PUSH_ENABLE: false
     secrets: inherit

--- a/.github/workflows/release-helm-chart.yml
+++ b/.github/workflows/release-helm-chart.yml
@@ -32,13 +32,12 @@ jobs:
 
   release-chart:
     needs: chart-version
-    uses: apecloud/apecd/.github/workflows/release-charts.yml@v0.4.0
+    uses: apecloud/apecd/.github/workflows/release-charts.yml@v0.5.0
     with:
       MAKE_OPS: "bump-chart-ver"
       VERSION: "${{ needs.chart-version.outputs.chart-version }}"
       CHART_NAME: "kubeblocks"
       CHART_DIR: "deploy/helm"
-      HELM_SET: "prometheus.enabled=true,grafana.enabled=true,dashboards.enabled=true,dataProtection.enableVolumeSnapshot=true,snapshot-controller.enabled=true"
       DEP_CHART_DIR: "deploy/helm/depend-charts"
     secrets: inherit
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -40,9 +40,9 @@ jobs:
   upload-release-assert:
     needs: create-release-kbcli
     name: Upload ${{ matrix.os }}
-    continue-on-error: true
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         os: [linux-amd64, linux-arm64, darwin-amd64, darwin-arm64, windows-amd64]
     steps:
@@ -107,7 +107,6 @@ jobs:
 
       - name: upload release kbcli asset ${{ matrix.os }}
         uses: actions/upload-release-asset@main
-        continue-on-error: true
         env:
           CLI_BINARY: ${{ env.CLI_NAME }}-${{ matrix.os }}-${{ env.TAG_NAME }}.tar.gz
         with:
@@ -117,7 +116,6 @@ jobs:
           asset_content_type: application/zip
 
       - name: upload gitlab kbcli asset ${{ matrix.os }}
-        continue-on-error: true
         env:
           CLI_BINARY: ${{ env.CLI_NAME }}-${{ matrix.os }}-${{ env.TAG_NAME }}.tar.gz
         run: |

--- a/deploy/postgresql-patroni-ha/values.yaml
+++ b/deploy/postgresql-patroni-ha/values.yaml
@@ -100,7 +100,7 @@ metrics:
   image:
     registry: registry.cn-hangzhou.aliyuncs.com
     repository: apecloud/postgres-exporter
-    tag: 0.11.1-debian-11-r49
+    tag: 0.11.1-debian-11-r66
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
1. Adjust the image checking logic, check all helm charts images, and check whether they are compatible with multi-architecture(e.g. amd64/arm64)
resolve #1168 
reference: [check multi-architecture docker images](https://github.com/apecloud/apecd/pull/8/files)
![image](https://user-images.githubusercontent.com/109708205/225794884-f0d68038-02fe-42f1-a5a2-75d9ea7246c5.png)
reference: [check all helm charts images](https://github.com/apecloud/apecd/pull/9/files)
![image](https://user-images.githubusercontent.com/109708205/225796444-75d56aeb-8989-4bd2-915b-247bc2a08d52.png)
![image](https://user-images.githubusercontent.com/109708205/225796591-8fbb0019-ff96-493a-83ed-f8e02d473ef3.png)


2. fix  check cli doc error: nothing to commit
![image](https://user-images.githubusercontent.com/109708205/225794671-b3b9ce67-337f-40da-a3f6-96aa5491df57.png)

3. release kbcli: remove `continue-on-error: true` and change to `fail-fast: false`