### PR TITLE
chore: fix cli kubeblocks status for addon

### DIFF
--- a/internal/cli/cmd/kubeblocks/status.go
+++ b/internal/cli/cmd/kubeblocks/status.go
@@ -195,7 +195,7 @@ func (o *statusOptions) showAddons() {
 	tbl := printer.NewTablePrinter(o.Out)
 	tbl.SetHeader("NAME", "STATUS", "TYPE")
 	for _, addon := range o.addons {
-		tbl.AddRow(addon.Name, addon.Namespace, addon.Status.Phase, addon.Spec.Type)
+		tbl.AddRow(addon.Name, addon.Status.Phase, addon.Spec.Type)
 	}
 	tbl.Print()
 }


### PR DESCRIPTION
Fix kubeblocks status display format:

```
KubeBlocks Addons:
NAME                           STATUS   TYPE              
alertmanager-webhook-adaptor            Enabled    Helm   
apecloud-mysql                          Enabled    Helm   
csi-s3                                  Disabled   Helm   
grafana                                 Enabled    Helm   
loadbalancer                            Disabled   Helm   
postgresql                              Enabled    Helm   
prometheus                              Enabled    Helm   
snapshot-controller                     Disabled   Helm 
```