### PR TITLE
fix: sqlchannel QueryOps returns named columnes

### DIFF
--- a/cmd/probe/internal/binding/postgres/postgres_test.go
+++ b/cmd/probe/internal/binding/postgres/postgres_test.go
@@ -60,6 +60,7 @@ func TestOperations(t *testing.T) {
 	assert.NotNil(t, pgOps.OperationMap[GetRoleOperation])
 	assert.NotNil(t, pgOps.OperationMap[ExecOperation])
 	assert.NotNil(t, pgOps.OperationMap[QueryOperation])
+	assert.NotNil(t, pgOps.OperationMap[CheckStatusOperation])
 }
 
 // SETUP TESTS
@@ -91,6 +92,11 @@ func TestPostgresIntegration(t *testing.T) {
 		Metadata:  map[string]string{commandSQLKey: testTableDDL},
 	}
 	ctx := context.TODO()
+	t.Run("Prepase Data", func(t *testing.T) {
+		res, err := b.Invoke(ctx, req)
+		assertResponse(t, res, err, "Success")
+	})
+
 	t.Run("Invoke checkRole", func(t *testing.T) {
 		req.Operation = "checkRole"
 		res, err := b.Invoke(ctx, req)
@@ -176,7 +182,6 @@ func TestPostgresIntegration(t *testing.T) {
 		res, err := b.Invoke(ctx, req)
 		assertResponse(t, res, err, "Success")
 	})
-
 }
 
 func assertResponse(t *testing.T, res *bindings.InvokeResponse, err error, event string) {


### PR DESCRIPTION
fix #2120 