### PR TITLE
Revert "fix: sqlchannel QueryOps returns named columnes"

### DIFF
--- a/cmd/probe/internal/binding/postgres/postgres.go
+++ b/cmd/probe/internal/binding/postgres/postgres.go
@@ -87,11 +87,7 @@ func (pgOps *PostgresOperations) initIfNeed() bool {
 	if pgOps.db == nil {
 		go func() {
 			err := pgOps.InitDelay()
-			if err != nil {
-				pgOps.Logger.Errorf("Postgres connection init failed: %v", err)
-			} else {
-				pgOps.Logger.Info("Postgres connection init success: %s", pgOps.db.Config().ConnConfig)
-			}
+			pgOps.Logger.Errorf("Postgres connection init failed: %v", err)
 		}()
 		return true
 	}
@@ -263,34 +259,21 @@ func (pgOps *PostgresOperations) query(ctx context.Context, sql string) (result 
 	if err != nil {
 		return nil, fmt.Errorf("error executing query: %w", err)
 	}
-	defer func() {
-		rows.Close()
-		_ = rows.Err()
-	}()
 
-	rs := make([]interface{}, 0)
-	columnTypes := rows.FieldDescriptions()
+	rs := make([]any, 0)
 	for rows.Next() {
-		values := make([]interface{}, len(columnTypes))
-		for i := range values {
-			values[i] = new(interface{})
+		val, rowErr := rows.Values()
+		if rowErr != nil {
+			return nil, fmt.Errorf("error parsing result '%v': %w", rows.Err(), rowErr)
 		}
-
-		if err = rows.Scan(values...); err != nil {
-			return
-		}
-
-		r := map[string]interface{}{}
-		for i, ct := range columnTypes {
-			r[ct.Name] = values[i]
-		}
-		rs = append(rs, r)
+		rs = append(rs, val) //nolint:asasalint
 	}
 
 	if result, err = json.Marshal(rs); err != nil {
 		err = fmt.Errorf("error serializing results: %w", err)
 	}
-	return result, err
+
+	return
 }
 
 func (pgOps *PostgresOperations) exec(ctx context.Context, sql string) (result int64, err error) {

--- a/cmd/probe/internal/binding/postgres/postgres_test.go
+++ b/cmd/probe/internal/binding/postgres/postgres_test.go
@@ -60,7 +60,6 @@ func TestOperations(t *testing.T) {
 	assert.NotNil(t, pgOps.OperationMap[GetRoleOperation])
 	assert.NotNil(t, pgOps.OperationMap[ExecOperation])
 	assert.NotNil(t, pgOps.OperationMap[QueryOperation])
-	assert.NotNil(t, pgOps.OperationMap[CheckStatusOperation])
 }
 
 // SETUP TESTS
@@ -92,11 +91,6 @@ func TestPostgresIntegration(t *testing.T) {
 		Metadata:  map[string]string{commandSQLKey: testTableDDL},
 	}
 	ctx := context.TODO()
-	t.Run("Prepase Data", func(t *testing.T) {
-		res, err := b.Invoke(ctx, req)
-		assertResponse(t, res, err, "Success")
-	})
-
 	t.Run("Invoke checkRole", func(t *testing.T) {
 		req.Operation = "checkRole"
 		res, err := b.Invoke(ctx, req)
@@ -182,6 +176,7 @@ func TestPostgresIntegration(t *testing.T) {
 		res, err := b.Invoke(ctx, req)
 		assertResponse(t, res, err, "Success")
 	})
+
 }
 
 func assertResponse(t *testing.T, res *bindings.InvokeResponse, err error, event string) {


### PR DESCRIPTION
Reverts apecloud/kubeblocks#2129