### PR TITLE
fix: add missing assert matcher

### DIFF
--- a/controllers/extensions/suite_test.go
+++ b/controllers/extensions/suite_test.go
@@ -110,5 +110,5 @@ var _ = AfterSuite(func() {
 	Eventually(func(g Gomega) {
 		err := testEnv.Stop()
 		Expect(err).NotTo(HaveOccurred())
-	})
+	}).Should(Succeed())
 })


### PR DESCRIPTION
AfterSuite in controllers/extensions/suite_test.go is missing assert matcher, this will cause orphan apiserver and etcd process, as shown below.

![image](https://user-images.githubusercontent.com/1765402/226635026-11ed17ff-0566-4b14-8314-5bf3cacbd6de.png)
