### PR TITLE
chore: update sysaccount job name

### DIFF
--- a/controllers/apps/systemaccount_controller_test.go
+++ b/controllers/apps/systemaccount_controller_test.go
@@ -363,116 +363,108 @@ var _ = Describe("SystemAccount Controller", func() {
 			}
 		})
 
-		// It("Cached secrets should be created when jobs succeeds", func() {
-		// 	for testName, testCase := range mysqlTestCases {
-		// 		var (
-		// 			acctList        appsv1alpha1.KBAccountType
-		// 			jobsNum         int
-		// 			secretsNum      int
-		// 			cachedSecretNum int
-		// 		)
+		It("Cached secrets should be created when jobs succeeds", func() {
+			for testName, testCase := range mysqlTestCases {
+				var (
+					acctList        appsv1alpha1.KBAccountType
+					jobsNum         int
+					secretsNum      int
+					cachedSecretNum int
+				)
 
-		// 		for _, acc := range testCase.accounts {
-		// 			resource := testCase.resourceMap[acc]
-		// 			acctList |= acc.GetAccountID()
-		// 			jobsNum += resource.jobNum
-		// 			secretsNum += resource.secretNum
-		// 			cachedSecretNum += resource.cachedSecretsNum
-		// 		}
+				for _, acc := range testCase.accounts {
+					resource := testCase.resourceMap[acc]
+					acctList |= acc.GetAccountID()
+					jobsNum += resource.jobNum
+					secretsNum += resource.secretNum
+					cachedSecretNum += resource.cachedSecretsNum
+				}
 
-		// 		if secretsNum == 0 && jobsNum == 0 && cachedSecretNum == 0 {
-		// 			continue
-		// 		}
-		// 		// get a cluster instance from map, created during preparation
-		// 		clusterKey, ok := clustersMap[testName]
-		// 		Expect(ok).To(BeTrue())
-		// 		// patch cluster to running
-		// 		patchClusterToRunning(clusterKey, testCase.componentName)
+				if secretsNum == 0 && jobsNum == 0 && cachedSecretNum == 0 {
+					continue
+				}
+				// get a cluster instance from map, created during preparation
+				clusterKey, ok := clustersMap[testName]
+				Expect(ok).To(BeTrue())
+				// patch cluster to running
+				patchClusterToRunning(clusterKey, testCase.componentName)
 
-		// 		// get cluster object
-		// 		cluster := &appsv1alpha1.Cluster{}
-		// 		Expect(k8sClient.Get(ctx, clusterKey, cluster)).Should(Succeed())
+				// get cluster object
+				cluster := &appsv1alpha1.Cluster{}
+				Expect(k8sClient.Get(ctx, clusterKey, cluster)).Should(Succeed())
 
-		// 		ml := getLabelsForSecretsAndJobs(componentUniqueKey{
-		// 			namespace:     cluster.Namespace,
-		// 			clusterName:   cluster.Name,
-		// 			componentName: testCase.componentName})
+				ml := getLabelsForSecretsAndJobs(componentUniqueKey{
+					namespace:     cluster.Namespace,
+					clusterName:   cluster.Name,
+					componentName: testCase.componentName})
 
-		// 		By("Verify accounts to be created are correct")
-		// 		Eventually(func(g Gomega) {
-		// 			accounts := getAccounts(g, cluster, ml)
-		// 			g.Expect(accounts).To(BeEquivalentTo(acctList))
-		// 		}).Should(Succeed())
+				By("Verify accounts to be created are correct")
+				Eventually(func(g Gomega) {
+					accounts := getAccounts(g, cluster, ml)
+					g.Expect(accounts).To(BeEquivalentTo(acctList))
+				}).Should(Succeed())
 
-		// 		// REVIEW: need to revise this test case, caught intermittent error:
-		// 		//  [FAILED] Expected
-		// 		//   <int>: 3
-		// 		//   to be equivalent to
-		// 		// 	 <int>: 4
-		// 		// [FAILED] Timed out after 10.000s.
-		// 		//   Expected
-		// 		// 	 <int>: 2
-		// 		//   to be equivalent to
-		// 		// 	 <int>: 3
-		// 		// [FAILED] Timed out after 10.000s.
-		// 		// Expected
-		// 		// 	<int>: 3
-		// 		// to be equivalent to
-		// 		// 	<int>: 4
-		// 		By("Verify secrets cached are correct")
-		// 		Eventually(len(systemAccountReconciler.SecretMapStore.ListKeys())).Should(BeEquivalentTo(cachedSecretNum))
+				By("Check Jobs are created")
+				Eventually(func(g Gomega) {
+					jobs := &batchv1.JobList{}
+					g.Expect(k8sClient.List(ctx, jobs, client.InNamespace(cluster.Namespace), ml)).To(Succeed())
+					g.Expect(len(jobs.Items)).To(BeEquivalentTo(jobsNum))
+				}).Should(Succeed())
 
-		// 		// wait for a while till all jobs are created
-		// 		By("Mock all jobs are completed and deleted")
-		// 		Eventually(func(g Gomega) {
-		// 			jobs := &batchv1.JobList{}
-		// 			g.Expect(k8sClient.List(ctx, jobs, client.InNamespace(cluster.Namespace), ml)).To(Succeed())
-		// 			g.Expect(len(jobs.Items)).To(BeEquivalentTo(jobsNum))
-		// 			for _, job := range jobs.Items {
-		// 				g.Expect(testapps.ChangeObjStatus(&testCtx, &job, func() {
-		// 					job.Status.Conditions = []batchv1.JobCondition{{
-		// 						Type:   batchv1.JobComplete,
-		// 						Status: corev1.ConditionTrue,
-		// 					}}
-		// 				})).To(Succeed())
-		// 				g.Expect(k8sClient.Delete(ctx, &job)).To(Succeed())
-		// 			}
-		// 		}).Should(Succeed())
+				By("Verify secrets cached are correct")
+				Eventually(len(systemAccountReconciler.SecretMapStore.ListKeys())).Should(BeEquivalentTo(cachedSecretNum))
 
-		// 		// remove 'orphan' finalizers to make sure all jobs can be deleted.
-		// 		Eventually(func(g Gomega) {
-		// 			jobs := &batchv1.JobList{}
-		// 			g.Expect(k8sClient.List(ctx, jobs, client.InNamespace(cluster.Namespace), ml)).To(Succeed())
-		// 			for _, job := range jobs.Items {
-		// 				g.Expect(testapps.ChangeObj(&testCtx, &job, func() { controllerutil.RemoveFinalizer(&job, orphanFinalizerName) })).To(Succeed())
-		// 			}
-		// 			g.Expect(len(jobs.Items)).To(Equal(0), "Verify all jobs completed and deleted")
-		// 		}).Should(Succeed())
+				// wait for a while till all jobs are created
+				By("Mock all jobs are completed and deleted")
+				Eventually(func(g Gomega) {
+					jobs := &batchv1.JobList{}
+					g.Expect(k8sClient.List(ctx, jobs, client.InNamespace(cluster.Namespace), ml)).To(Succeed())
+					g.Expect(len(jobs.Items)).To(BeEquivalentTo(jobsNum))
+					for _, job := range jobs.Items {
+						g.Expect(testapps.ChangeObjStatus(&testCtx, &job, func() {
+							job.Status.Conditions = []batchv1.JobCondition{{
+								Type:   batchv1.JobComplete,
+								Status: corev1.ConditionTrue,
+							}}
+						})).To(Succeed())
+						g.Expect(k8sClient.Delete(ctx, &job)).To(Succeed())
+					}
+				}).Should(Succeed())
 
-		// 		By("Check secrets created")
-		// 		Eventually(func(g Gomega) {
-		// 			secrets := &corev1.SecretList{}
-		// 			g.Expect(k8sClient.List(ctx, secrets, client.InNamespace(cluster.Namespace), ml)).To(Succeed())
-		// 			g.Expect(len(secrets.Items)).To(BeEquivalentTo(secretsNum + cachedSecretNum))
-		// 		}).Should(Succeed())
+				// remove 'orphan' finalizers to make sure all jobs can be deleted.
+				Eventually(func(g Gomega) {
+					jobs := &batchv1.JobList{}
+					g.Expect(k8sClient.List(ctx, jobs, client.InNamespace(cluster.Namespace), ml)).To(Succeed())
+					for _, job := range jobs.Items {
+						g.Expect(testapps.ChangeObj(&testCtx, &job, func() { controllerutil.RemoveFinalizer(&job, orphanFinalizerName) })).To(Succeed())
+					}
+					g.Expect(len(jobs.Items)).To(Equal(0), "Verify all jobs completed and deleted")
+				}).Should(Succeed())
 
-		// 		By("Verify all secrets created have their finalizer and lables set correctly")
-		// 		// get all secrets, and check their lables and finalizer
-		// 		Eventually(func(g Gomega) {
-		// 			// get secrets matching filter
-		// 			secretsForAcct := &corev1.SecretList{}
-		// 			g.Expect(k8sClient.List(ctx, secretsForAcct, ml)).To(Succeed())
-		// 			for _, secret := range secretsForAcct.Items {
-		// 				// each secret has finalizer
-		// 				g.Expect(controllerutil.ContainsFinalizer(&secret, dbClusterFinalizerName)).To(BeTrue())
-		// 				g.Expect(len(secret.ObjectMeta.OwnerReferences)).To(BeEquivalentTo(1))
-		// 				g.Expect(checkOwnerReferenceToObj(secret.OwnerReferences[0], cluster)).To(BeTrue())
-		// 			}
-		// 		}).Should(Succeed())
-		// 	}
-		// 	// all jobs succeeded, and there should be no cached secrets left behind.
-		// 	Expect(len(systemAccountReconciler.SecretMapStore.ListKeys())).To(BeEquivalentTo(0))
-		// })
+				By("Check secrets created")
+				Eventually(func(g Gomega) {
+					secrets := &corev1.SecretList{}
+					g.Expect(k8sClient.List(ctx, secrets, client.InNamespace(cluster.Namespace), ml)).To(Succeed())
+					g.Expect(len(secrets.Items)).To(BeEquivalentTo(secretsNum + cachedSecretNum))
+				}).Should(Succeed())
+
+				By("Verify all secrets created have their finalizer and lables set correctly")
+				// get all secrets, and check their lables and finalizer
+				Eventually(func(g Gomega) {
+					// get secrets matching filter
+					secretsForAcct := &corev1.SecretList{}
+					g.Expect(k8sClient.List(ctx, secretsForAcct, ml)).To(Succeed())
+					for _, secret := range secretsForAcct.Items {
+						// each secret has finalizer
+						g.Expect(controllerutil.ContainsFinalizer(&secret, dbClusterFinalizerName)).To(BeTrue())
+						g.Expect(len(secret.ObjectMeta.OwnerReferences)).To(BeEquivalentTo(1))
+						g.Expect(checkOwnerReferenceToObj(secret.OwnerReferences[0], cluster)).To(BeTrue())
+					}
+				}).Should(Succeed())
+			}
+			// all jobs succeeded, and there should be no cached secrets left behind.
+			Expect(len(systemAccountReconciler.SecretMapStore.ListKeys())).To(BeEquivalentTo(0))
+		})
 	}) // end of context
 
 	Context("When Delete Cluster", func() {

--- a/controllers/apps/systemaccount_util.go
+++ b/controllers/apps/systemaccount_util.go
@@ -34,6 +34,10 @@ import (
 	componetutil "github.com/apecloud/kubeblocks/internal/controller/component"
 )
 
+const (
+	jobPrefix = "job-system-account-"
+)
+
 // SecretMapStore is a cache, recording all (key, secret) pair for accounts to be created.
 type secretMapStore struct {
 	cache.Store
@@ -165,7 +169,7 @@ func getLabelsForSecretsAndJobs(key componentUniqueKey) client.MatchingLabels {
 
 func renderJob(engine *customizedEngine, key componentUniqueKey, statement []string, endpoint string) *batchv1.Job {
 	randomStr, _ := password.Generate(6, 0, 0, true, false)
-	jobName := key.clusterName + "-" + randomStr
+	jobName := jobPrefix + key.clusterName + "-" + randomStr
 
 	// inject one more system env variables
 	statementEnv := corev1.EnvVar{


### PR DESCRIPTION
fix #2208  update jod name and add test cases back.  
The test case was disabled due to unstability previously.  After some tracing,  I found the root cause is: we should wait for a few time till all jobs are created, before checking secrets or cached secrets number.   
Adjusted the case by counting jobs num,  and repeat the test several times, and it works smoothly. 