### PR TITLE
improve: make dataprotection unit test fast.

### DIFF
--- a/controllers/dataprotection/backuppolicy_controller_test.go
+++ b/controllers/dataprotection/backuppolicy_controller_test.go
@@ -430,7 +430,7 @@ var _ = Describe("Backup Policy Controller", func() {
 				By("Secrets missing, the backup policy should never be `ConfigAvailable`")
 				Consistently(testapps.CheckObj(&testCtx, backupPolicyKey, func(g Gomega, fetched *dpv1alpha1.BackupPolicy) {
 					g.Expect(fetched.Status.Phase).NotTo(Equal(dpv1alpha1.ConfigAvailable))
-				})).Should(Succeed())
+				}), time.Millisecond*100).Should(Succeed())
 			})
 
 			It("creating a backupPolicy uses default secret", func() {

--- a/controllers/dataprotection/restorejob_controller.go
+++ b/controllers/dataprotection/restorejob_controller.go
@@ -18,7 +18,6 @@ package dataprotection
 
 import (
 	"context"
-	"time"
 
 	"github.com/spf13/viper"
 	appv1 "k8s.io/api/apps/v1"
@@ -152,7 +151,7 @@ func (r *RestoreJobReconciler) doRestoreNewPhaseAction(
 	if err := r.Client.Status().Update(reqCtx.Ctx, restoreJob); err != nil {
 		return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "")
 	}
-	return intctrlutil.RequeueAfter(time.Second, reqCtx.Log, "")
+	return intctrlutil.Reconciled()
 }
 
 func (r *RestoreJobReconciler) doRestoreInProgressPhyAction(
@@ -162,11 +161,11 @@ func (r *RestoreJobReconciler) doRestoreInProgressPhyAction(
 	if err != nil {
 		// not found backup job, retry create job
 		reqCtx.Log.Info(err.Error())
-		return intctrlutil.RequeueAfter(time.Second, reqCtx.Log, "")
+		return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "")
 	}
 	jobStatusConditions := job.Status.Conditions
 	if len(jobStatusConditions) == 0 {
-		return intctrlutil.RequeueAfter(time.Second, reqCtx.Log, "")
+		return intctrlutil.RequeueAfter(reconcileInterval, reqCtx.Log, "")
 	}
 
 	switch jobStatusConditions[0].Type {

--- a/controllers/dataprotection/suite_test.go
+++ b/controllers/dataprotection/suite_test.go
@@ -22,6 +22,7 @@ import (
 	"go/build"
 	"path/filepath"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -68,6 +69,7 @@ var _ = BeforeSuite(func() {
 			o.TimeEncoder = zapcore.ISO8601TimeEncoder
 		}))
 	}
+	reconcileInterval = time.Millisecond
 
 	ctx, cancel = context.WithCancel(context.TODO())
 

--- a/controllers/dataprotection/type.go
+++ b/controllers/dataprotection/type.go
@@ -26,9 +26,6 @@ import (
 const (
 	// name of our custom finalizer
 	dataProtectionFinalizerName = "dataprotection.kubeblocks.io/finalizer"
-
-	reconcileInterval = time.Second
-
 	// settings keys
 	maxConcurDataProtectionReconKey = "MAXCONCURRENTRECONCILES_DATAPROTECTION"
 
@@ -42,6 +39,8 @@ const (
 	// error status
 	errorJobFailed = "JobFailed"
 )
+
+var reconcileInterval = time.Second
 
 func init() {
 	viper.SetDefault(maxConcurDataProtectionReconKey, runtime.NumCPU()*2)


### PR DESCRIPTION
Unit Test of `dataprotection` improvement: **40sec** >> **9sec**.
```
make test-fast TEST_PACKAGES="./controllers/dataprotection"
KUBEBUILDER_ASSETS="/Users/shaojiang/Library/Application Support/io.kubebuilder.envtest/k8s/1.25.0-darwin-arm64" go test -short -coverprofile cover.out ./controllers/dataprotection
ok  	github.com/apecloud/kubeblocks/controllers/dataprotection	8.703s	coverage: 81.3% of statements
```