### PR TITLE
chore: add release homebrew-tap

### DIFF
--- a/.github/workflows/release-sync.yml
+++ b/.github/workflows/release-sync.yml
@@ -1,6 +1,7 @@
 name: RELEASE-SYNC
 
 on:
+  workflow_dispatch:
   release:
     types: [ released, prereleased ]
 
@@ -12,9 +13,12 @@ jobs:
   update-release-kbcli:
     name: Update Release kbcli
     runs-on: ubuntu-latest
+    outputs:
+      release-version: ${{ steps.get_latest_version.outputs.release_version }}
     steps:
       - uses: actions/checkout@v3
       - name: update release ${{ env.CLI_NAME }} latest
+        id: get_latest_version
         run: |
           LATEST_RELEASE_TAG=`bash ${{ github.workspace }}/.github/utils/utils.sh \
             --type 4 \
@@ -31,3 +35,15 @@ jobs:
             --tag-name $LATEST_RELEASE_TAG \
             --project-id ${{ env.GITLAB_KBCLI_PROJECT_ID }} \
             --access-token ${{ secrets.GITLAB_ACCESS_TOKEN }}
+          
+          echo release_version=$LATEST_RELEASE_TAG >> $GITHUB_OUTPUT
+
+  release-homebrew-tap:
+    needs: update-release-kbcli
+    uses: apecloud/apecd/.github/workflows/trigger-workflow.yml@v0.5.1
+    with:
+      GITHUB_REPO: "apecloud/homebrew-tap"
+      WORKFLOW_ID: "release.yml"
+      VERSION: "${{ needs.update-release-kbcli.outputs.release-version }}"
+    secrets: inherit
+


### PR DESCRIPTION
fix https://github.com/apecloud/kubeblocks/issues/1139 

1. add brew tap
```
brew tap apecloud/homebrew-tap
```
2. install kbcli
```
brew install kbcli
or
brew install kbcli@0.4.0
```
3. update
```
brew update
brew unlink kbcli
brew install kbcli
```
4. uninstall kbcli
```
brew uninstall kbcli
or
brew uninstall kbcli@0.4.0
```
5. remove tap
```
brew untap apecloud/homebrew-tap
```
reference:
https://github.com/apecloud/homebrew-tap/pull/1/files
https://github.com/apecloud/homebrew-tap/pull/2/files
