### PR TITLE
fix: mount isn't shared error in csi driver when restart k3d nodes

### DIFF
--- a/internal/cli/cloudprovider/assets/k3d-entrypoint-mount.sh
+++ b/internal/cli/cloudprovider/assets/k3d-entrypoint-mount.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+echo "[$(date -Iseconds)] [mount Fix] Evacuating mount --make-rshared / ..."
+mount --make-rshared /
+echo "[$(date -Iseconds)] [mount Fix] Done"

--- a/internal/cli/cloudprovider/k3d.go
+++ b/internal/cli/cloudprovider/k3d.go
@@ -18,6 +18,7 @@ package cloudprovider
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"io"
 	"net"
@@ -55,6 +56,9 @@ var (
 	// K3dProxyImage is k3d proxy image repo
 	K3dProxyImage = "docker.io/apecloud/k3d-proxy:" + version.K3dVersion
 )
+
+//go:embed assets/k3d-entrypoint-mount.sh
+var k3dMountEntrypoint []byte
 
 // localCloudProvider will handle the k3d playground cluster creation and management
 type localCloudProvider struct {
@@ -371,14 +375,13 @@ func setUpK3d(ctx context.Context, cluster *config.ClusterConfig) error {
 
 	// exec "mount --make-rshared /" to fix csi driver plugins crash
 	cluster.ClusterCreateOpts.NodeHooks = append(cluster.ClusterCreateOpts.NodeHooks, k3d.NodeHook{
-		Stage: k3d.LifecycleStagePostStart,
-		Action: actions.ExecAction{
-			Runtime: runtimes.SelectedRuntime,
-			Command: []string{
-				"sh", "-c", "mount --make-rshared /",
-			},
-			Retries:     0,
-			Description: "Inject 'mount --make-rshared /' for csi driver",
+		Stage: k3d.LifecycleStagePreStart,
+		Action: actions.WriteFileAction{
+			Runtime:     runtimes.SelectedRuntime,
+			Content:     k3dMountEntrypoint,
+			Dest:        "/bin/k3d-entrypoint-mount.sh",
+			Mode:        0744,
+			Description: "Write entrypoint script for mount shared fix",
 		},
 	})
 


### PR DESCRIPTION
Fix k3d mount error when restart k3d node.
This is a bug in k3d([link](https://github.com/k3d-io/k3d/issues/1063)). The solution is to inject the fix script when starting the node, which will completely solve the problem.
- [ ] TODO: kbcli unit test