### PR TITLE
fix: uninstall removes clusterrole and clusterrolebinding

### DIFF
--- a/internal/cli/cmd/kubeblocks/uninstall.go
+++ b/internal/cli/cmd/kubeblocks/uninstall.go
@@ -143,6 +143,8 @@ func (o *uninstallOptions) preCheck() error {
 	kbNamespace, err := util.GetKubeBlocksNamespace(o.Client)
 	if err != nil {
 		printer.Warning(o.Out, "failed to locate KubeBlocks meta, will clean up all KubeBlocks resources.\n")
+		fmt.Fprintf(o.Out, "to find out the namespace where KubeBlocks is installed, please use:\n\t'kbcli kubeblocks status'\n")
+		fmt.Fprintf(o.Out, "to uninstall KubeBlocks completely, please use:\n\t`kbcli kubeblocks uninstall -n <namespace>`\n")
 	} else if o.Namespace != kbNamespace {
 		o.Namespace = kbNamespace
 		fmt.Fprintf(o.Out, "Uninstall KubeBlocks in namespace \"%s\"\n", kbNamespace)

--- a/internal/cli/types/types.go
+++ b/internal/cli/types/types.go
@@ -21,6 +21,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
@@ -79,6 +80,14 @@ const (
 	KindRestoreJob                   = "RestoreJob"
 	KindBackupPolicyTemplate         = "BackupPolicyTemplate"
 	KindOps                          = "OpsRequest"
+)
+
+// K8S rbac API group
+const (
+	RBACAPIGroup        = rbacv1.GroupName
+	RBACAPIVersion      = "v1"
+	ClusterRoles        = "clusterroles"
+	ClusterRoleBindings = "clusterrolebindings"
 )
 
 // Annotations
@@ -257,4 +266,11 @@ func MutatingWebhookConfigurationGVR() schema.GroupVersionResource {
 		Version:  K8sWebhookAPIVersion,
 		Resource: ResourceMutatingWebhookConfigurations,
 	}
+}
+
+func ClusterRoleGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: RBACAPIGroup, Version: RBACAPIVersion, Resource: ClusterRoles}
+}
+func ClusterRoleBindingGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: RBACAPIGroup, Version: RBACAPIVersion, Resource: ClusterRoleBindings}
 }


### PR DESCRIPTION
fix #2247 this patch following issues for `kbcli kubeblocks uninstall`
- when uninstall kubeblocks, removes clusterroles and clusterrolebindings as well.  
- add info msg when detected helm meta is missing.