### PR TITLE
fix: github action uploads kbcli asset for windows

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -80,7 +80,6 @@ jobs:
           echo "CLI_DIR=${{ env.CLI_NAME }}-${{ matrix.os }}-v${RELEASE_VERSION}" >> $GITHUB_ENV
           echo "CLI_FILENAME=${{ env.CLI_NAME }}-${{ matrix.os }}" >> $GITHUB_ENV
 
-
       - name: make zip
         if: matrix.os == 'windows-amd64'
         run: |
@@ -116,7 +115,7 @@ jobs:
             --github-repo ${{ env.CLI_REPO }} \
             --github-token ${{ env.GITHUB_TOKEN }}` >> $GITHUB_ENV
 
-      - name: upload release kbcli asset
+      - name: upload release kbcli asset ${{ matrix.os }}
         uses: actions/upload-release-asset@main
         with:
           upload_url: ${{ env.UPLOAD_URL }}
@@ -124,12 +123,12 @@ jobs:
           asset_name: ${{ env.ASSET_NAME }}
           asset_content_type: ${{ env.ASSET_CONTENT_TYPE }}
 
-      - name: upload gitlab kbcli asset 
+      - name: upload gitlab kbcli asset ${{ matrix.os }}
         run: |
           bash ${{ github.workspace }}/.github/utils/release_gitlab.sh \
             --type 2 \
             --project-id ${{ env.GITLAB_KBCLI_PROJECT_ID }} \
             --tag-name ${{ env.TAG_NAME }} \
             --asset-path ./bin/${{ env.ASSET_NAME }} \
-            --asset-name ${{ env.ASSET_NAME }}\
+            --asset-name ${{ env.ASSET_NAME }} \
             --access-token ${{ secrets.GITLAB_ACCESS_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -248,8 +248,6 @@ CLI_LD_FLAGS ="-s -w \
 	-X github.com/apecloud/kubeblocks/version.K3dVersion=$(K3D_VERSION) \
 	-X github.com/apecloud/kubeblocks/version.DefaultKubeBlocksVersion=$(VERSION)"
 
-
-
 bin/kbcli.%: ## Cross build bin/kbcli.$(OS).$(ARCH).
 	GOOS=$(word 2,$(subst ., ,$@)) GOARCH=$(word 3,$(subst ., ,$@)) CGO_ENABLED=0 $(GO) build -ldflags=${CLI_LD_FLAGS} -o $@ cmd/cli/main.go
 


### PR DESCRIPTION
For these problems of `kbcli` in windos OS:
1. missing binary suffixes `.exe`
2. the `tar` tool is not available
3. zip too deep and the compressed folder's name containing `.`  causes error
4. adjusted the install shell script for Linux and Mac due to the change of the compressed folder's name, the original shell script was not working.

modified the `hack/install_cli.sh` and `.github/workflows/release-publish.yaml` .

TODO:
- [x] update install.sh to use new asset name
- [x] test a release and check, add more info at this PR description