### PR TITLE
feat: add apecloud-otel-collector and support running log for mongodb

### DIFF
--- a/deploy/mongodb-cluster/values.yaml
+++ b/deploy/mongodb-cluster/values.yaml
@@ -306,3 +306,6 @@ ingress:
   ##             name: http
   ##
   extraRules: []
+
+enabledLogs:
+  - running

--- a/deploy/mongodb/templates/clusterdefinition.yaml
+++ b/deploy/mongodb/templates/clusterdefinition.yaml
@@ -13,13 +13,29 @@ spec:
     port: "$(SVC_PORT_tcp-monogdb)"
   componentDefs:
     - name: replicaset
+      characterType: mongodb
       scriptSpecs:
         - name: mongodb-scripts
           templateRef: mongodb-scripts
           volumeName: scripts
           namespace: {{ .Release.Namespace }}
           defaultMode: 493
-      characterType: mongodb
+      configSpecs:
+        - name: mongodb-metrics-config
+          templateRef: mongodb-metrics-config
+          namespace: {{ .Release.Namespace }}
+          volumeName: mongodb-metrics-config
+          defaultMode: 0777
+      monitor:
+        builtIn: false
+        exporterConfig:
+          scrapePath: /metrics
+          scrapePort: 9216
+      logConfigs:
+        {{- range $name,$pattern := .Values.logConfigs }}
+        - name: {{ $name }}
+          filePathPattern: {{ $pattern }}
+        {{- end }}
       workloadType: Consensus
       consensusSpec:
         leader:
@@ -75,6 +91,32 @@ spec:
               - name: scripts
                 mountPath: /scripts/replicaset-post-start.sh
                 subPath: replicaset-post-start.sh
+          - name: metrics
+            image:  {{ .Values.metrics.image.registry | default "docker.io" }}/{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}
+            imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1001
+            env:
+              - name: MONGODB_ROOT_USER
+                valueFrom:
+                  secretKeyRef:
+                    name: $(CONN_CREDENTIAL_SECRET_NAME)
+                    key: username
+              - name: MONGODB_ROOT_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: $(CONN_CREDENTIAL_SECRET_NAME)
+                    key: password
+            command:
+              - "/bin/ape-collector"
+              - "--config=/opt/conf/metrics-config.yaml"
+            ports:
+              - name: http-metrics
+                containerPort: 9216
+            volumeMounts:
+              - name: mongodb-metrics-config
+                mountPath: /opt/conf
     - name: mongos
       scriptSpecs:
         - name: mongodb-scripts

--- a/deploy/mongodb/templates/configmap.yaml
+++ b/deploy/mongodb/templates/configmap.yaml
@@ -17,9 +17,10 @@ data:
 
     RPL_SET_NAME=$(echo $KB_POD_NAME | grep -o ".*-");
     RPL_SET_NAME=${RPL_SET_NAME%-};
+    mkdir -p /data/mongodb/log
     PORT=27018
     MODE=$1
-    mongod $MODE --bind_ip_all --port $PORT --replSet $RPL_SET_NAME
+    mongod $MODE --bind_ip_all --port $PORT --replSet $RPL_SET_NAME --logappend --logpath /data/mongodb/log/mongodb.log
   replicaset-post-start.sh: |-
     #!/bin/sh
     # usage: replicaset-post-start.sh type_name is_configsvr

--- a/deploy/mongodb/templates/metrics-configmap.yaml
+++ b/deploy/mongodb/templates/metrics-configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mongodb-metrics-config
+  labels:
+    {{- include "mongodb.labels" . | nindent 4 }}
+data:
+  metrics-config.yaml: {{ toYaml .Values.metrics.config | quote }}

--- a/deploy/mongodb/values.yaml
+++ b/deploy/mongodb/values.yaml
@@ -28,3 +28,66 @@ auth:
   ## @param auth.database Name for a custom database to create
   ##
   database: "admin"
+
+logConfigs:
+  running: /data/mongodb/log/mongodb.log*
+
+metrics:
+  image:
+    registry: registry.cn-hangzhou.aliyuncs.com
+    repository: apecloud/apecloud-otel-collector
+    tag: 0.0.2-alpha
+    pullPolicy: IfNotPresent
+  config:
+    extensions:
+      memory_ballast:
+        size_mib: 512
+      health_check:
+        endpoint: localhost:13133
+        path: /health/status
+        check_collector_pipeline:
+          enabled: true
+          interval: 2m
+          exporter_failure_threshold: 5
+
+    receivers:
+      apecloudmongodb:
+        # uri: mongodb://${env:MONGODB_ROOT_USER}:${env:MONGODB_ROOT_PASSWORD}@127.0.0.1:27018/admin?ssl=false&authSource=admin
+        uri: mongodb://127.0.0.1:27018
+        collect-all: true
+        collection_interval: 15s
+        direct-connect: true
+        global-conn-pool: false
+        log-level: info
+
+    processors:
+      batch:
+        timeout: 10s
+      memory_limiter:
+        limit_mib: 1024
+        spike_limit_mib: 256
+        check_interval: 10s
+
+    exporters:
+      prometheus:
+        endpoint: localhost:9216
+        const_labels: [ ]
+        send_timestamps: false
+        metric_expiration: 30s
+        enable_open_metrics: false
+        resource_to_telemetry_conversion:
+          enabled: true
+
+    service:
+      telemetry:
+        logs:
+          level: info
+        metrics:
+          address: localhost:8888
+      pipelines:
+        metrics:
+          receivers: [ apecloudmongodb ]
+          processors: [ memory_limiter ]
+          exporters: [ prometheus ]
+
+      extensions: [ memory_ballast, health_check ]


### PR DESCRIPTION
as described in title
fix #2312  for adding apecloud-otel-collector for mongodb，a agent substitutes for mongodb_exporter, and the behaviours keep consistent with mongodb_exporter
fix https://github.com/apecloud/kubeblocks/issues/2196 for supporting running log for mongodb