### PR TITLE
feat: highly available Postgresql using our own image that support pgvector

### DIFF
--- a/deploy/postgresql-patroni-ha/Chart.yaml
+++ b/deploy/postgresql-patroni-ha/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 version: 0.5.0-alpha.3
 
-appVersion: "14.5.0"
+appVersion: "15.2.0"
 
 home: https://kubeblocks.io/
 icon: https://github.com/apecloud/kubeblocks/raw/main/img/logo.png

--- a/deploy/postgresql-patroni-ha/values.yaml
+++ b/deploy/postgresql-patroni-ha/values.yaml
@@ -12,9 +12,9 @@
 ## @param image.debug Specify if debug values should be set
 ##
 image:
-  ## repository: https://hub.docker.com/r/lrengineering/spilo-postgres
-  repository: lrengineering/spilo-postgres
-  tag: 14-2.1-p6
+  registry: registry.cn-hangzhou.aliyuncs.com
+  repository: apecloud/spilo
+  tag: 15.2.0
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -67,7 +67,7 @@ audit:
 ##
 postgresqlSharedPreloadLibraries: "pg_stat_statements, auto_explain"
 ## Start PostgreSQL pod(s) without limitations on shm memory.
-## By default docker and containerd (and possibly other container runtimes) limit `/dev/shm` to `64M`
+## By default, docker and containerd (and possibly other container runtimes) limit `/dev/shm` to `64M`
 ##
 shmVolume:
   ## @param shmVolume.enabled Enable emptyDir volume for /dev/shm for PostgreSQL pod(s)


### PR DESCRIPTION
* resolve #2267
* PostgreSQL with patroni (Spilo) image repo: https://github.com/apecloud/spilo
* Support pgvector: https://github.com/apecloud/spilo/commit/7e32761d007af050cb94dcc838fb94eeea96c483
* Support CI to upload image to docker.io and aliyun: https://github.com/apecloud/spilo/commit/2404fa2f4290eb51ecc25e376aab192bf20f80a2

- [x] wait for 15.2.0 ready https://github.com/apecloud/spilo/actions/runs/4603635149

```
postgres=# select version();
                                                                 version
-----------------------------------------------------------------------------------------------------------------------------------------
 PostgreSQL 15.2 (Ubuntu 15.2-1.pgdg22.04+1) on aarch64-unknown-linux-gnu, compiled by gcc (Ubuntu 11.3.0-1ubuntu1~22.04) 11.3.0, 64-bit
(1 row)

postgres=# \dx
                                            List of installed extensions
        Name        | Version |   Schema   |                              Description
--------------------+---------+------------+------------------------------------------------------------------------
 file_fdw           | 1.0     | public     | foreign-data wrapper for flat file access
 pg_auth_mon        | 1.1     | public     | monitor connection attempts per user
 pg_cron            | 1.5     | pg_catalog | Job scheduler for PostgreSQL
 pg_stat_kcache     | 2.2.1   | public     | Kernel statistics gathering
 pg_stat_statements | 1.10    | public     | track planning and execution statistics of all SQL statements executed
 plpgsql            | 1.0     | pg_catalog | PL/pgSQL procedural language
 plpython3u         | 1.0     | pg_catalog | PL/Python3U untrusted procedural language
 set_user           | 3.0     | public     | similar to SET ROLE but with added logging
(8 rows)

postgres=# create extension vector ;
CREATE EXTENSION
postgres=# \dx
                                            List of installed extensions
        Name        | Version |   Schema   |                              Description
--------------------+---------+------------+------------------------------------------------------------------------
 file_fdw           | 1.0     | public     | foreign-data wrapper for flat file access
 pg_auth_mon        | 1.1     | public     | monitor connection attempts per user
 pg_cron            | 1.5     | pg_catalog | Job scheduler for PostgreSQL
 pg_stat_kcache     | 2.2.1   | public     | Kernel statistics gathering
 pg_stat_statements | 1.10    | public     | track planning and execution statistics of all SQL statements executed
 plpgsql            | 1.0     | pg_catalog | PL/pgSQL procedural language
 plpython3u         | 1.0     | pg_catalog | PL/Python3U untrusted procedural language
 set_user           | 3.0     | public     | similar to SET ROLE but with added logging
 vector             | 0.4.1   | public     | vector data type and ivfflat access method
(9 rows)

postgres=# exit
```