### PR TITLE
chore: tidyup ClusterDefintion.spec.componentDefs.service go struct type, remove corev1.ServiceSpec usage

### DIFF
--- a/apis/apps/v1alpha1/cluster_types.go
+++ b/apis/apps/v1alpha1/cluster_types.go
@@ -506,50 +506,47 @@ func (r ClusterSpec) GetDefNameMappingComponents() map[string][]ClusterComponent
 }
 
 // GetMessage gets message map deep copy object
-func (in *ClusterComponentStatus) GetMessage() ComponentMessageMap {
+func (r ClusterComponentStatus) GetMessage() ComponentMessageMap {
 	messageMap := map[string]string{}
-	for k, v := range in.Message {
+	for k, v := range r.Message {
 		messageMap[k] = v
 	}
 	return messageMap
 }
 
 // SetMessage override message map object
-func (in *ClusterComponentStatus) SetMessage(messageMap ComponentMessageMap) {
-	if in == nil {
+func (r *ClusterComponentStatus) SetMessage(messageMap ComponentMessageMap) {
+	if r == nil {
 		return
 	}
-	in.Message = messageMap
+	r.Message = messageMap
 }
 
 // SetObjectMessage sets k8s workload message to component status message map
-func (in *ClusterComponentStatus) SetObjectMessage(objectKind, objectName, message string) {
-	if in == nil {
+func (r *ClusterComponentStatus) SetObjectMessage(objectKind, objectName, message string) {
+	if r == nil {
 		return
 	}
-	if in.Message == nil {
-		in.Message = map[string]string{}
+	if r.Message == nil {
+		r.Message = map[string]string{}
 	}
 	messageKey := fmt.Sprintf("%s/%s", objectKind, objectName)
-	in.Message[messageKey] = message
+	r.Message[messageKey] = message
 }
 
 // GetObjectMessage gets the k8s workload message in component status message map
-func (in *ClusterComponentStatus) GetObjectMessage(objectKind, objectName string) string {
-	if in == nil {
-		return ""
-	}
+func (r ClusterComponentStatus) GetObjectMessage(objectKind, objectName string) string {
 	messageKey := fmt.Sprintf("%s/%s", objectKind, objectName)
-	return in.Message[messageKey]
+	return r.Message[messageKey]
 }
 
 // SetObjectMessage sets k8s workload message to component status message map
-func (m ComponentMessageMap) SetObjectMessage(objectKind, objectName, message string) {
-	if m == nil {
+func (r ComponentMessageMap) SetObjectMessage(objectKind, objectName, message string) {
+	if r == nil {
 		return
 	}
 	messageKey := fmt.Sprintf("%s/%s", objectKind, objectName)
-	m[messageKey] = message
+	r[messageKey] = message
 }
 
 // SetComponentStatus does safe operation on ClusterStatus.Components map object update.

--- a/apis/apps/v1alpha1/clusterdefinition_types.go
+++ b/apis/apps/v1alpha1/clusterdefinition_types.go
@@ -354,10 +354,8 @@ type ClusterComponentDefinition struct {
 
 	// service defines the behavior of a service spec.
 	// provide read-write service when WorkloadType is Consensus.
-	// https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-	// +kubebuilder:pruning:PreserveUnknownFields
 	// +optional
-	Service *corev1.ServiceSpec `json:"service,omitempty"`
+	Service *ServiceSpec `json:"service,omitempty"`
 
 	// consensusSpec defines consensus related spec if workloadType is Consensus, required if workloadType is Consensus.
 	// +optional
@@ -396,6 +394,80 @@ type ClusterComponentDefinition struct {
 	// +listMapKey=key
 	// +optional
 	CustomLabelSpecs []CustomLabelSpec `json:"customLabelSpecs,omitempty"`
+}
+
+type ServiceSpec struct {
+	// The list of ports that are exposed by this service.
+	// More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+	// +patchMergeKey=port
+	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=port
+	// +listMapKey=protocol
+	Ports []ServicePort `json:"ports,omitempty" patchStrategy:"merge" patchMergeKey:"port" protobuf:"bytes,1,rep,name=ports"`
+}
+
+func (r *ServiceSpec) toSVCPorts() []corev1.ServicePort {
+	ports := make([]corev1.ServicePort, 0, len(r.Ports))
+	for _, p := range r.Ports {
+		ports = append(ports, p.toSVCPort())
+	}
+	return ports
+}
+
+func (r ServiceSpec) ToSVCSpec() corev1.ServiceSpec {
+	return corev1.ServiceSpec{
+		Ports: r.toSVCPorts(),
+	}
+}
+
+type ServicePort struct {
+	// The name of this port within the service. This must be a DNS_LABEL.
+	// All ports within a ServiceSpec must have unique names. When considering
+	// the endpoints for a Service, this must match the 'name' field in the
+	// EndpointPort.
+	// +kubebuilder:validation:Required
+	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
+
+	// The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+	// Default is TCP.
+	// +kubebuilder:validation:Enum={TCP,UDP,SCTP}
+	// +default="TCP"
+	// +optional
+	Protocol corev1.Protocol `json:"protocol,omitempty" protobuf:"bytes,2,opt,name=protocol,casttype=Protocol"`
+
+	// The application protocol for this port.
+	// This field follows standard Kubernetes label syntax.
+	// Un-prefixed names are reserved for IANA standard service names (as per
+	// RFC-6335 and https://www.iana.org/assignments/service-names).
+	// Non-standard protocols should use prefixed names such as
+	// mycompany.com/my-custom-protocol.
+	// +optional
+	AppProtocol *string `json:"appProtocol,omitempty" protobuf:"bytes,6,opt,name=appProtocol"`
+
+	// The port that will be exposed by this service.
+	Port int32 `json:"port" protobuf:"varint,3,opt,name=port"`
+
+	// Number or name of the port to access on the pods targeted by the service.
+	// Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+	// If this is a string, it will be looked up as a named port in the
+	// target Pod's container ports. If this is not specified, the value
+	// of the 'port' field is used (an identity map).
+	// This field is ignored for services with clusterIP=None, and should be
+	// omitted or set equal to the 'port' field.
+	// More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
+	// +optional
+	TargetPort intstr.IntOrString `json:"targetPort,omitempty" protobuf:"bytes,4,opt,name=targetPort"`
+}
+
+func (r *ServicePort) toSVCPort() corev1.ServicePort {
+	return corev1.ServicePort{
+		Name:        r.Name,
+		Protocol:    r.Protocol,
+		AppProtocol: r.AppProtocol,
+		Port:        r.Port,
+		TargetPort:  r.TargetPort,
+	}
 }
 
 type HorizontalScalePolicy struct {
@@ -454,7 +526,6 @@ type ClusterDefinitionProbe struct {
 }
 
 type ClusterDefinitionProbes struct {
-
 	// Probe for DB running check.
 	// +optional
 	RunningProbe *ClusterDefinitionProbe `json:"runningProbe,omitempty"`

--- a/config/crd/bases/apps.kubeblocks.io_clusterdefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusterdefinitions.yaml
@@ -8344,214 +8344,11 @@ spec:
                     service:
                       description: service defines the behavior of a service spec.
                         provide read-write service when WorkloadType is Consensus.
-                        https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                       properties:
-                        allocateLoadBalancerNodePorts:
-                          description: allocateLoadBalancerNodePorts defines if NodePorts
-                            will be automatically allocated for services with type
-                            LoadBalancer.  Default is "true". It may be set to "false"
-                            if the cluster load-balancer does not rely on NodePorts.  If
-                            the caller requests specific NodePorts (by specifying
-                            a value), those requests will be respected, regardless
-                            of this field. This field may only be set for services
-                            with type LoadBalancer and will be cleared if the type
-                            is changed to any other type.
-                          type: boolean
-                        clusterIP:
-                          description: 'clusterIP is the IP address of the service
-                            and is usually assigned randomly. If an address is specified
-                            manually, is in-range (as per system configuration), and
-                            is not in use, it will be allocated to the service; otherwise
-                            creation of the service will fail. This field may not
-                            be changed through updates unless the type field is also
-                            being changed to ExternalName (which requires this field
-                            to be blank) or the type field is being changed from ExternalName
-                            (in which case this field may optionally be specified,
-                            as describe above).  Valid values are "None", empty string
-                            (""), or a valid IP address. Setting this to "None" makes
-                            a "headless service" (no virtual IP), which is useful
-                            when direct endpoint connections are preferred and proxying
-                            is not required.  Only applies to types ClusterIP, NodePort,
-                            and LoadBalancer. If this field is specified when creating
-                            a Service of type ExternalName, creation will fail. This
-                            field will be wiped when updating a Service to type ExternalName.
-                            More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                          type: string
-                        clusterIPs:
-                          description: "ClusterIPs is a list of IP addresses assigned
-                            to this service, and are usually assigned randomly.  If
-                            an address is specified manually, is in-range (as per
-                            system configuration), and is not in use, it will be allocated
-                            to the service; otherwise creation of the service will
-                            fail. This field may not be changed through updates unless
-                            the type field is also being changed to ExternalName (which
-                            requires this field to be empty) or the type field is
-                            being changed from ExternalName (in which case this field
-                            may optionally be specified, as describe above).  Valid
-                            values are \"None\", empty string (\"\"), or a valid IP
-                            address.  Setting this to \"None\" makes a \"headless
-                            service\" (no virtual IP), which is useful when direct
-                            endpoint connections are preferred and proxying is not
-                            required.  Only applies to types ClusterIP, NodePort,
-                            and LoadBalancer. If this field is specified when creating
-                            a Service of type ExternalName, creation will fail. This
-                            field will be wiped when updating a Service to type ExternalName.
-                            \ If this field is not specified, it will be initialized
-                            from the clusterIP field.  If this field is specified,
-                            clients must ensure that clusterIPs[0] and clusterIP have
-                            the same value. \n This field may hold a maximum of two
-                            entries (dual-stack IPs, in either order). These IPs must
-                            correspond to the values of the ipFamilies field. Both
-                            clusterIPs and ipFamilies are governed by the ipFamilyPolicy
-                            field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
-                          items:
-                            type: string
-                          type: array
-                          x-kubernetes-list-type: atomic
-                        externalIPs:
-                          description: externalIPs is a list of IP addresses for which
-                            nodes in the cluster will also accept traffic for this
-                            service.  These IPs are not managed by Kubernetes.  The
-                            user is responsible for ensuring that traffic arrives
-                            at a node with this IP.  A common example is external
-                            load-balancers that are not part of the Kubernetes system.
-                          items:
-                            type: string
-                          type: array
-                        externalName:
-                          description: externalName is the external reference that
-                            discovery mechanisms will return as an alias for this
-                            service (e.g. a DNS CNAME record). No proxying will be
-                            involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
-                            and requires `type` to be "ExternalName".
-                          type: string
-                        externalTrafficPolicy:
-                          description: externalTrafficPolicy describes how nodes distribute
-                            service traffic they receive on one of the Service's "externally-facing"
-                            addresses (NodePorts, ExternalIPs, and LoadBalancer IPs).
-                            If set to "Local", the proxy will configure the service
-                            in a way that assumes that external load balancers will
-                            take care of balancing the service traffic between nodes,
-                            and so each node will deliver traffic only to the node-local
-                            endpoints of the service, without masquerading the client
-                            source IP. (Traffic mistakenly sent to a node with no
-                            endpoints will be dropped.) The default value, "Cluster",
-                            uses the standard behavior of routing to all endpoints
-                            evenly (possibly modified by topology and other features).
-                            Note that traffic sent to an External IP or LoadBalancer
-                            IP from within the cluster will always get "Cluster" semantics,
-                            but clients sending to a NodePort from within the cluster
-                            may need to take traffic policy into account when picking
-                            a node.
-                          type: string
-                        healthCheckNodePort:
-                          description: healthCheckNodePort specifies the healthcheck
-                            nodePort for the service. This only applies when type
-                            is set to LoadBalancer and externalTrafficPolicy is set
-                            to Local. If a value is specified, is in-range, and is
-                            not in use, it will be used.  If not specified, a value
-                            will be automatically allocated.  External systems (e.g.
-                            load-balancers) can use this port to determine if a given
-                            node holds endpoints for this service or not.  If this
-                            field is specified when creating a Service which does
-                            not need it, creation will fail. This field will be wiped
-                            when updating a Service to no longer need it (e.g. changing
-                            type). This field cannot be updated once set.
-                          format: int32
-                          type: integer
-                        internalTrafficPolicy:
-                          description: InternalTrafficPolicy describes how nodes distribute
-                            service traffic they receive on the ClusterIP. If set
-                            to "Local", the proxy will assume that pods only want
-                            to talk to endpoints of the service on the same node as
-                            the pod, dropping the traffic if there are no local endpoints.
-                            The default value, "Cluster", uses the standard behavior
-                            of routing to all endpoints evenly (possibly modified
-                            by topology and other features).
-                          type: string
-                        ipFamilies:
-                          description: "IPFamilies is a list of IP families (e.g.
-                            IPv4, IPv6) assigned to this service. This field is usually
-                            assigned automatically based on cluster configuration
-                            and the ipFamilyPolicy field. If this field is specified
-                            manually, the requested family is available in the cluster,
-                            and ipFamilyPolicy allows it, it will be used; otherwise
-                            creation of the service will fail. This field is conditionally
-                            mutable: it allows for adding or removing a secondary
-                            IP family, but it does not allow changing the primary
-                            IP family of the Service. Valid values are \"IPv4\" and
-                            \"IPv6\".  This field only applies to Services of types
-                            ClusterIP, NodePort, and LoadBalancer, and does apply
-                            to \"headless\" services. This field will be wiped when
-                            updating a Service to type ExternalName. \n This field
-                            may hold a maximum of two entries (dual-stack families,
-                            in either order).  These families must correspond to the
-                            values of the clusterIPs field, if specified. Both clusterIPs
-                            and ipFamilies are governed by the ipFamilyPolicy field."
-                          items:
-                            description: IPFamily represents the IP Family (IPv4 or
-                              IPv6). This type is used to express the family of an
-                              IP expressed by a type (e.g. service.spec.ipFamilies).
-                            type: string
-                          type: array
-                          x-kubernetes-list-type: atomic
-                        ipFamilyPolicy:
-                          description: IPFamilyPolicy represents the dual-stack-ness
-                            requested or required by this Service. If there is no
-                            value provided, then this field will be set to SingleStack.
-                            Services can be "SingleStack" (a single IP family), "PreferDualStack"
-                            (two IP families on dual-stack configured clusters or
-                            a single IP family on single-stack clusters), or "RequireDualStack"
-                            (two IP families on dual-stack configured clusters, otherwise
-                            fail). The ipFamilies and clusterIPs fields depend on
-                            the value of this field. This field will be wiped when
-                            updating a service to type ExternalName.
-                          type: string
-                        loadBalancerClass:
-                          description: loadBalancerClass is the class of the load
-                            balancer implementation this Service belongs to. If specified,
-                            the value of this field must be a label-style identifier,
-                            with an optional prefix, e.g. "internal-vip" or "example.com/internal-vip".
-                            Unprefixed names are reserved for end-users. This field
-                            can only be set when the Service type is 'LoadBalancer'.
-                            If not set, the default load balancer implementation is
-                            used, today this is typically done through the cloud provider
-                            integration, but should apply for any default implementation.
-                            If set, it is assumed that a load balancer implementation
-                            is watching for Services with a matching class. Any default
-                            load balancer implementation (e.g. cloud providers) should
-                            ignore Services that set this field. This field can only
-                            be set when creating or updating a Service to type 'LoadBalancer'.
-                            Once set, it can not be changed. This field will be wiped
-                            when a service is updated to a non 'LoadBalancer' type.
-                          type: string
-                        loadBalancerIP:
-                          description: 'Only applies to Service Type: LoadBalancer.
-                            This feature depends on whether the underlying cloud-provider
-                            supports specifying the loadBalancerIP when a load balancer
-                            is created. This field will be ignored if the cloud-provider
-                            does not support the feature. Deprecated: This field was
-                            under-specified and its meaning varies across implementations,
-                            and it cannot support dual-stack. As of Kubernetes v1.24,
-                            users are encouraged to use implementation-specific annotations
-                            when available. This field may be removed in a future
-                            API version.'
-                          type: string
-                        loadBalancerSourceRanges:
-                          description: 'If specified and supported by the platform,
-                            this will restrict traffic through the cloud-provider
-                            load-balancer will be restricted to the specified client
-                            IPs. This field will be ignored if the cloud-provider
-                            does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
-                          items:
-                            type: string
-                          type: array
                         ports:
                           description: 'The list of ports that are exposed by this
                             service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
                           items:
-                            description: ServicePort contains information on service's
-                              port.
                             properties:
                               appProtocol:
                                 description: The application protocol for this port.
@@ -8566,23 +8363,8 @@ spec:
                                   This must be a DNS_LABEL. All ports within a ServiceSpec
                                   must have unique names. When considering the endpoints
                                   for a Service, this must match the 'name' field
-                                  in the EndpointPort. Optional if only one ServicePort
-                                  is defined on this service.
+                                  in the EndpointPort.
                                 type: string
-                              nodePort:
-                                description: 'The port on each node on which this
-                                  service is exposed when type is NodePort or LoadBalancer.  Usually
-                                  assigned by the system. If a value is specified,
-                                  in-range, and not in use it will be used, otherwise
-                                  the operation will fail.  If not specified, a port
-                                  will be allocated if this Service requires one.  If
-                                  this field is specified when creating a Service
-                                  which does not need it, creation will fail. This
-                                  field will be wiped when updating a Service to no
-                                  longer need it (e.g. changing type from NodePort
-                                  to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
-                                format: int32
-                                type: integer
                               port:
                                 description: The port that will be exposed by this
                                   service.
@@ -8592,6 +8374,10 @@ spec:
                                 default: TCP
                                 description: The IP protocol for this port. Supports
                                   "TCP", "UDP", and "SCTP". Default is TCP.
+                                enum:
+                                - TCP
+                                - UDP
+                                - SCTP
                                 type: string
                               targetPort:
                                 anyOf:
@@ -8616,75 +8402,7 @@ spec:
                           - port
                           - protocol
                           x-kubernetes-list-type: map
-                        publishNotReadyAddresses:
-                          description: publishNotReadyAddresses indicates that any
-                            agent which deals with endpoints for this Service should
-                            disregard any indications of ready/not-ready. The primary
-                            use case for setting this field is for a StatefulSet's
-                            Headless Service to propagate SRV DNS records for its
-                            Pods for the purpose of peer discovery. The Kubernetes
-                            controllers that generate Endpoints and EndpointSlice
-                            resources for Services interpret this to mean that all
-                            endpoints are considered "ready" even if the Pods themselves
-                            are not. Agents which consume only Kubernetes generated
-                            endpoints through the Endpoints or EndpointSlice resources
-                            can safely assume this behavior.
-                          type: boolean
-                        selector:
-                          additionalProperties:
-                            type: string
-                          description: 'Route service traffic to pods with label keys
-                            and values matching this selector. If empty or not present,
-                            the service is assumed to have an external process managing
-                            its endpoints, which Kubernetes will not modify. Only
-                            applies to types ClusterIP, NodePort, and LoadBalancer.
-                            Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        sessionAffinity:
-                          description: 'Supports "ClientIP" and "None". Used to maintain
-                            session affinity. Enable client IP based session affinity.
-                            Must be ClientIP or None. Defaults to None. More info:
-                            https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                          type: string
-                        sessionAffinityConfig:
-                          description: sessionAffinityConfig contains the configurations
-                            of session affinity.
-                          properties:
-                            clientIP:
-                              description: clientIP contains the configurations of
-                                Client IP based session affinity.
-                              properties:
-                                timeoutSeconds:
-                                  description: timeoutSeconds specifies the seconds
-                                    of ClientIP type session sticky time. The value
-                                    must be >0 && <=86400(for 1 day) if ServiceAffinity
-                                    == "ClientIP". Default value is 10800(for 3 hours).
-                                  format: int32
-                                  type: integer
-                              type: object
-                          type: object
-                        type:
-                          description: 'type determines how the Service is exposed.
-                            Defaults to ClusterIP. Valid options are ExternalName,
-                            ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates
-                            a cluster-internal IP address for load-balancing to endpoints.
-                            Endpoints are determined by the selector or if that is
-                            not specified, by manual construction of an Endpoints
-                            object or EndpointSlice objects. If clusterIP is "None",
-                            no virtual IP is allocated and the endpoints are published
-                            as a set of endpoints rather than a virtual IP. "NodePort"
-                            builds on ClusterIP and allocates a port on every node
-                            which routes to the same endpoints as the clusterIP. "LoadBalancer"
-                            builds on NodePort and creates an external load-balancer
-                            (if supported in the current cloud) which routes to the
-                            same endpoints as the clusterIP. "ExternalName" aliases
-                            this service to the specified externalName. Several other
-                            fields do not apply to ExternalName services. More info:
-                            https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
-                          type: string
                       type: object
-                      x-kubernetes-preserve-unknown-fields: true
                     systemAccounts:
                       description: Statement to create system account.
                       properties:

--- a/deploy/apecloud-mysql-scale/templates/clusterdefinition.yaml
+++ b/deploy/apecloud-mysql-scale/templates/clusterdefinition.yaml
@@ -55,22 +55,18 @@ spec:
             accessMode: Readonly
       service:
         ports:
-          - protocol: TCP
+          - name: mysql
             port: 3306
             targetPort: mysql
-            name: mysql
-          - protocol: TCP
-            port: 15100  
+          - name: vttabletport
+            port: 15100
             targetPort: vttabletport
-            name: vttabletport
-          - protocol: TCP
+          - name: vttabletgrpc
             port: 16100
             targetPort: vttabletgrpc
-            name: vttabletgrpc
-          - protocol: TCP
+          - name: delvedebug
             port: 40000
             targetPort: delvedebug
-            name: delvedebug   
       horizontalScalePolicy:
         type: Snapshot
         backupTemplateSelector:
@@ -173,14 +169,11 @@ spec:
             imagePullPolicy: {{ default .Values.wesqlscale.image.pullPolicy "IfNotPresent" }} 
             ports:
               - containerPort: 15100
-                protocol: TCP
-                name: vttabletport 
+                name: vttabletport
               - containerPort: 16100
-                protocol: TCP
                 name: vttabletgrpc
               - containerPort: 40000
-                protocol: TCP
-                name: delvedebug  
+                name: delvedebug
             env:
               - name: CELL
                 value: {{ .Values.wesqlscale.cell | default "zone1" | quote }}
@@ -340,17 +333,15 @@ spec:
       workloadType: Stateful
       service:
         ports:
-          - protocol: TCP
+          - name: client
             port: 2379
             targetPort: client 
-            name: client
       podSpec:
         containers:
           - name: etcd
             imagePullPolicy: IfNotPresent
             ports:
               - containerPort: 2379
-                protocol: TCP
                 name: client
             env:
               - name: CELL
@@ -411,31 +402,25 @@ spec:
       workloadType: Stateful
       service:
         ports:
-          - protocol: TCP
+          - name: webport
             port: 15000
             targetPort: webport
-            name: webport 
-          - protocol: TCP
+          - name: grpcport
             port: 15999
             targetPort: grpcport
-            name: grpcport
-          - protocol: TCP
+          - name: delvedebug
             port: 40000
             targetPort: delvedebug
-            name: delvedebug  
       podSpec:
         containers:
           - name: vtctld
             imagePullPolicy: IfNotPresent
             ports:
               - containerPort: 15000
-                protocol: TCP
                 name: webport
               - containerPort: 15999
-                protocol: TCP
                 name: grpcport
               - containerPort: 40000
-                protocol: TCP
                 name: delvedebug
             env:
               - name: CELL
@@ -480,24 +465,20 @@ spec:
       workloadType: Stateful
       service:
         ports:
-          - protocol: TCP
+          - name: port
             port: 16000
             targetPort: port
-            name: port
-          - protocol: TCP
+          - name: delvedebug
             port: 40000
             targetPort: delvedebug
-            name: delvedebug
       podSpec:
         containers:
           - name: vtconsensus
             imagePullPolicy: IfNotPresent
             ports:
               - containerPort: 16000
-                protocol: TCP
                 name: port
               - containerPort: 40000
-                protocol: TCP
                 name: delvedebug
             env:
               - name: CELL
@@ -548,39 +529,31 @@ spec:
       workloadType: Stateful
       service:
         ports:
-          - protocol: TCP
+          - name: webport
             port: 15001
             targetPort: webport
-            name: webport 
-          - protocol: TCP
+          - name: grpcport
             port: 15991
             targetPort: grpcport
-            name: grpcport
-          - protocol: TCP
+          - name: serverport
             port: 15306
             targetPort: serverport
-            name: serverport     
-          - protocol: TCP
+          - name: delvedebug
             port: 40000
             targetPort: delvedebug
-            name: delvedebug       
       podSpec:
         containers:
           - name: vtgate
             imagePullPolicy: IfNotPresent
             ports:
               - containerPort: 15001
-                protocol: TCP
                 name: webport
               - containerPort: 15991
-                protocol: TCP
                 name: grpcport
               - containerPort: 15306
-                protocol: TCP
-                name: serverport 
+                name: serverport
               - containerPort: 40000
-                protocol: TCP
-                name: delvedebug 
+                name: delvedebug
             env:
               - name: MYSQL_ROOT_USER
                 valueFrom:

--- a/deploy/apecloud-mysql/templates/clusterdefinition.yaml
+++ b/deploy/apecloud-mysql/templates/clusterdefinition.yaml
@@ -51,7 +51,7 @@ spec:
             accessMode: Readonly
       service:
         ports:
-          - protocol: TCP
+          - name: mysql
             port: 3306
             targetPort: mysql
       horizontalScalePolicy:

--- a/deploy/clickhouse/templates/clusterdefinition.yaml
+++ b/deploy/clickhouse/templates/clusterdefinition.yaml
@@ -111,22 +111,16 @@ spec:
             ports:
               - name: http
                 containerPort: 8123
-                # protocol: TCP
               - name: tcp
                 containerPort: 9000
-                # protocol: TCP
               - name: tcp-postgresql
                 containerPort: 9005
-                # protocol: TCP
               - name: tcp-mysql
                 containerPort: 9004
-                # protocol: TCP
               - name: http-intersrv
                 containerPort: 9009
-                # protocol: TCP
               - name: http-metrics
                 containerPort: 8001
-                # protocol: TCP
             livenessProbe:
               failureThreshold: 3
               initialDelaySeconds: 10
@@ -175,13 +169,9 @@ spec:
           - name: tcp
             targetPort: tcp
             port: 2181
-            protocol: TCP
-            nodePort: null
           - name: http-metrics
             targetPort: http-metrics
             port: 8001
-            protocol: TCP
-            nodePort: null
       podSpec:
         securityContext:
           fsGroup: 1001
@@ -213,13 +203,10 @@ spec:
             ports:
               - name: tcp
                 containerPort: 2181
-                # protocol: TCP
               - name: raft
                 containerPort: 9444
-                # protocol: TCP
               - name: http-metrics
                 containerPort: 8001
-                # protocol: TCP
             # livenessProbe:
             #   failureThreshold: 6
             #   initialDelaySeconds: 30
@@ -360,16 +347,12 @@ spec:
             ports:
               - name: client
                 containerPort: 2181
-                # protocol: TCP
               - name: follower
                 containerPort: 2888
-                # protocol: TCP
               - name: election
                 containerPort: 3888
-                # protocol: TCP
               - name: metrics
                 containerPort: 9141
-                # protocol: TCP
             livenessProbe:
               failureThreshold: 6
               initialDelaySeconds: 30

--- a/deploy/etcd/templates/clusterdefinition.yaml
+++ b/deploy/etcd/templates/clusterdefinition.yaml
@@ -23,18 +23,17 @@ spec:
           failureThreshold: 3
       service:
         ports:
-          - protocol: TCP
+          - name: client
             port: 2379
+            targetPort: client
       podSpec:
         containers:
           - name: etcd
             imagePullPolicy: IfNotPresent
             ports:
               - containerPort: 2379
-                protocol: TCP
                 name: client
               - containerPort: 2380
-                protocol: TCP
                 name: peer
             volumeMounts:
               - name: data

--- a/deploy/helm/crds/apps.kubeblocks.io_clusterdefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusterdefinitions.yaml
@@ -8344,214 +8344,11 @@ spec:
                     service:
                       description: service defines the behavior of a service spec.
                         provide read-write service when WorkloadType is Consensus.
-                        https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
                       properties:
-                        allocateLoadBalancerNodePorts:
-                          description: allocateLoadBalancerNodePorts defines if NodePorts
-                            will be automatically allocated for services with type
-                            LoadBalancer.  Default is "true". It may be set to "false"
-                            if the cluster load-balancer does not rely on NodePorts.  If
-                            the caller requests specific NodePorts (by specifying
-                            a value), those requests will be respected, regardless
-                            of this field. This field may only be set for services
-                            with type LoadBalancer and will be cleared if the type
-                            is changed to any other type.
-                          type: boolean
-                        clusterIP:
-                          description: 'clusterIP is the IP address of the service
-                            and is usually assigned randomly. If an address is specified
-                            manually, is in-range (as per system configuration), and
-                            is not in use, it will be allocated to the service; otherwise
-                            creation of the service will fail. This field may not
-                            be changed through updates unless the type field is also
-                            being changed to ExternalName (which requires this field
-                            to be blank) or the type field is being changed from ExternalName
-                            (in which case this field may optionally be specified,
-                            as describe above).  Valid values are "None", empty string
-                            (""), or a valid IP address. Setting this to "None" makes
-                            a "headless service" (no virtual IP), which is useful
-                            when direct endpoint connections are preferred and proxying
-                            is not required.  Only applies to types ClusterIP, NodePort,
-                            and LoadBalancer. If this field is specified when creating
-                            a Service of type ExternalName, creation will fail. This
-                            field will be wiped when updating a Service to type ExternalName.
-                            More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                          type: string
-                        clusterIPs:
-                          description: "ClusterIPs is a list of IP addresses assigned
-                            to this service, and are usually assigned randomly.  If
-                            an address is specified manually, is in-range (as per
-                            system configuration), and is not in use, it will be allocated
-                            to the service; otherwise creation of the service will
-                            fail. This field may not be changed through updates unless
-                            the type field is also being changed to ExternalName (which
-                            requires this field to be empty) or the type field is
-                            being changed from ExternalName (in which case this field
-                            may optionally be specified, as describe above).  Valid
-                            values are \"None\", empty string (\"\"), or a valid IP
-                            address.  Setting this to \"None\" makes a \"headless
-                            service\" (no virtual IP), which is useful when direct
-                            endpoint connections are preferred and proxying is not
-                            required.  Only applies to types ClusterIP, NodePort,
-                            and LoadBalancer. If this field is specified when creating
-                            a Service of type ExternalName, creation will fail. This
-                            field will be wiped when updating a Service to type ExternalName.
-                            \ If this field is not specified, it will be initialized
-                            from the clusterIP field.  If this field is specified,
-                            clients must ensure that clusterIPs[0] and clusterIP have
-                            the same value. \n This field may hold a maximum of two
-                            entries (dual-stack IPs, in either order). These IPs must
-                            correspond to the values of the ipFamilies field. Both
-                            clusterIPs and ipFamilies are governed by the ipFamilyPolicy
-                            field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies"
-                          items:
-                            type: string
-                          type: array
-                          x-kubernetes-list-type: atomic
-                        externalIPs:
-                          description: externalIPs is a list of IP addresses for which
-                            nodes in the cluster will also accept traffic for this
-                            service.  These IPs are not managed by Kubernetes.  The
-                            user is responsible for ensuring that traffic arrives
-                            at a node with this IP.  A common example is external
-                            load-balancers that are not part of the Kubernetes system.
-                          items:
-                            type: string
-                          type: array
-                        externalName:
-                          description: externalName is the external reference that
-                            discovery mechanisms will return as an alias for this
-                            service (e.g. a DNS CNAME record). No proxying will be
-                            involved.  Must be a lowercase RFC-1123 hostname (https://tools.ietf.org/html/rfc1123)
-                            and requires `type` to be "ExternalName".
-                          type: string
-                        externalTrafficPolicy:
-                          description: externalTrafficPolicy describes how nodes distribute
-                            service traffic they receive on one of the Service's "externally-facing"
-                            addresses (NodePorts, ExternalIPs, and LoadBalancer IPs).
-                            If set to "Local", the proxy will configure the service
-                            in a way that assumes that external load balancers will
-                            take care of balancing the service traffic between nodes,
-                            and so each node will deliver traffic only to the node-local
-                            endpoints of the service, without masquerading the client
-                            source IP. (Traffic mistakenly sent to a node with no
-                            endpoints will be dropped.) The default value, "Cluster",
-                            uses the standard behavior of routing to all endpoints
-                            evenly (possibly modified by topology and other features).
-                            Note that traffic sent to an External IP or LoadBalancer
-                            IP from within the cluster will always get "Cluster" semantics,
-                            but clients sending to a NodePort from within the cluster
-                            may need to take traffic policy into account when picking
-                            a node.
-                          type: string
-                        healthCheckNodePort:
-                          description: healthCheckNodePort specifies the healthcheck
-                            nodePort for the service. This only applies when type
-                            is set to LoadBalancer and externalTrafficPolicy is set
-                            to Local. If a value is specified, is in-range, and is
-                            not in use, it will be used.  If not specified, a value
-                            will be automatically allocated.  External systems (e.g.
-                            load-balancers) can use this port to determine if a given
-                            node holds endpoints for this service or not.  If this
-                            field is specified when creating a Service which does
-                            not need it, creation will fail. This field will be wiped
-                            when updating a Service to no longer need it (e.g. changing
-                            type). This field cannot be updated once set.
-                          format: int32
-                          type: integer
-                        internalTrafficPolicy:
-                          description: InternalTrafficPolicy describes how nodes distribute
-                            service traffic they receive on the ClusterIP. If set
-                            to "Local", the proxy will assume that pods only want
-                            to talk to endpoints of the service on the same node as
-                            the pod, dropping the traffic if there are no local endpoints.
-                            The default value, "Cluster", uses the standard behavior
-                            of routing to all endpoints evenly (possibly modified
-                            by topology and other features).
-                          type: string
-                        ipFamilies:
-                          description: "IPFamilies is a list of IP families (e.g.
-                            IPv4, IPv6) assigned to this service. This field is usually
-                            assigned automatically based on cluster configuration
-                            and the ipFamilyPolicy field. If this field is specified
-                            manually, the requested family is available in the cluster,
-                            and ipFamilyPolicy allows it, it will be used; otherwise
-                            creation of the service will fail. This field is conditionally
-                            mutable: it allows for adding or removing a secondary
-                            IP family, but it does not allow changing the primary
-                            IP family of the Service. Valid values are \"IPv4\" and
-                            \"IPv6\".  This field only applies to Services of types
-                            ClusterIP, NodePort, and LoadBalancer, and does apply
-                            to \"headless\" services. This field will be wiped when
-                            updating a Service to type ExternalName. \n This field
-                            may hold a maximum of two entries (dual-stack families,
-                            in either order).  These families must correspond to the
-                            values of the clusterIPs field, if specified. Both clusterIPs
-                            and ipFamilies are governed by the ipFamilyPolicy field."
-                          items:
-                            description: IPFamily represents the IP Family (IPv4 or
-                              IPv6). This type is used to express the family of an
-                              IP expressed by a type (e.g. service.spec.ipFamilies).
-                            type: string
-                          type: array
-                          x-kubernetes-list-type: atomic
-                        ipFamilyPolicy:
-                          description: IPFamilyPolicy represents the dual-stack-ness
-                            requested or required by this Service. If there is no
-                            value provided, then this field will be set to SingleStack.
-                            Services can be "SingleStack" (a single IP family), "PreferDualStack"
-                            (two IP families on dual-stack configured clusters or
-                            a single IP family on single-stack clusters), or "RequireDualStack"
-                            (two IP families on dual-stack configured clusters, otherwise
-                            fail). The ipFamilies and clusterIPs fields depend on
-                            the value of this field. This field will be wiped when
-                            updating a service to type ExternalName.
-                          type: string
-                        loadBalancerClass:
-                          description: loadBalancerClass is the class of the load
-                            balancer implementation this Service belongs to. If specified,
-                            the value of this field must be a label-style identifier,
-                            with an optional prefix, e.g. "internal-vip" or "example.com/internal-vip".
-                            Unprefixed names are reserved for end-users. This field
-                            can only be set when the Service type is 'LoadBalancer'.
-                            If not set, the default load balancer implementation is
-                            used, today this is typically done through the cloud provider
-                            integration, but should apply for any default implementation.
-                            If set, it is assumed that a load balancer implementation
-                            is watching for Services with a matching class. Any default
-                            load balancer implementation (e.g. cloud providers) should
-                            ignore Services that set this field. This field can only
-                            be set when creating or updating a Service to type 'LoadBalancer'.
-                            Once set, it can not be changed. This field will be wiped
-                            when a service is updated to a non 'LoadBalancer' type.
-                          type: string
-                        loadBalancerIP:
-                          description: 'Only applies to Service Type: LoadBalancer.
-                            This feature depends on whether the underlying cloud-provider
-                            supports specifying the loadBalancerIP when a load balancer
-                            is created. This field will be ignored if the cloud-provider
-                            does not support the feature. Deprecated: This field was
-                            under-specified and its meaning varies across implementations,
-                            and it cannot support dual-stack. As of Kubernetes v1.24,
-                            users are encouraged to use implementation-specific annotations
-                            when available. This field may be removed in a future
-                            API version.'
-                          type: string
-                        loadBalancerSourceRanges:
-                          description: 'If specified and supported by the platform,
-                            this will restrict traffic through the cloud-provider
-                            load-balancer will be restricted to the specified client
-                            IPs. This field will be ignored if the cloud-provider
-                            does not support the feature." More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
-                          items:
-                            type: string
-                          type: array
                         ports:
                           description: 'The list of ports that are exposed by this
                             service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
                           items:
-                            description: ServicePort contains information on service's
-                              port.
                             properties:
                               appProtocol:
                                 description: The application protocol for this port.
@@ -8566,23 +8363,8 @@ spec:
                                   This must be a DNS_LABEL. All ports within a ServiceSpec
                                   must have unique names. When considering the endpoints
                                   for a Service, this must match the 'name' field
-                                  in the EndpointPort. Optional if only one ServicePort
-                                  is defined on this service.
+                                  in the EndpointPort.
                                 type: string
-                              nodePort:
-                                description: 'The port on each node on which this
-                                  service is exposed when type is NodePort or LoadBalancer.  Usually
-                                  assigned by the system. If a value is specified,
-                                  in-range, and not in use it will be used, otherwise
-                                  the operation will fail.  If not specified, a port
-                                  will be allocated if this Service requires one.  If
-                                  this field is specified when creating a Service
-                                  which does not need it, creation will fail. This
-                                  field will be wiped when updating a Service to no
-                                  longer need it (e.g. changing type from NodePort
-                                  to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
-                                format: int32
-                                type: integer
                               port:
                                 description: The port that will be exposed by this
                                   service.
@@ -8592,6 +8374,10 @@ spec:
                                 default: TCP
                                 description: The IP protocol for this port. Supports
                                   "TCP", "UDP", and "SCTP". Default is TCP.
+                                enum:
+                                - TCP
+                                - UDP
+                                - SCTP
                                 type: string
                               targetPort:
                                 anyOf:
@@ -8616,75 +8402,7 @@ spec:
                           - port
                           - protocol
                           x-kubernetes-list-type: map
-                        publishNotReadyAddresses:
-                          description: publishNotReadyAddresses indicates that any
-                            agent which deals with endpoints for this Service should
-                            disregard any indications of ready/not-ready. The primary
-                            use case for setting this field is for a StatefulSet's
-                            Headless Service to propagate SRV DNS records for its
-                            Pods for the purpose of peer discovery. The Kubernetes
-                            controllers that generate Endpoints and EndpointSlice
-                            resources for Services interpret this to mean that all
-                            endpoints are considered "ready" even if the Pods themselves
-                            are not. Agents which consume only Kubernetes generated
-                            endpoints through the Endpoints or EndpointSlice resources
-                            can safely assume this behavior.
-                          type: boolean
-                        selector:
-                          additionalProperties:
-                            type: string
-                          description: 'Route service traffic to pods with label keys
-                            and values matching this selector. If empty or not present,
-                            the service is assumed to have an external process managing
-                            its endpoints, which Kubernetes will not modify. Only
-                            applies to types ClusterIP, NodePort, and LoadBalancer.
-                            Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/'
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        sessionAffinity:
-                          description: 'Supports "ClientIP" and "None". Used to maintain
-                            session affinity. Enable client IP based session affinity.
-                            Must be ClientIP or None. Defaults to None. More info:
-                            https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies'
-                          type: string
-                        sessionAffinityConfig:
-                          description: sessionAffinityConfig contains the configurations
-                            of session affinity.
-                          properties:
-                            clientIP:
-                              description: clientIP contains the configurations of
-                                Client IP based session affinity.
-                              properties:
-                                timeoutSeconds:
-                                  description: timeoutSeconds specifies the seconds
-                                    of ClientIP type session sticky time. The value
-                                    must be >0 && <=86400(for 1 day) if ServiceAffinity
-                                    == "ClientIP". Default value is 10800(for 3 hours).
-                                  format: int32
-                                  type: integer
-                              type: object
-                          type: object
-                        type:
-                          description: 'type determines how the Service is exposed.
-                            Defaults to ClusterIP. Valid options are ExternalName,
-                            ClusterIP, NodePort, and LoadBalancer. "ClusterIP" allocates
-                            a cluster-internal IP address for load-balancing to endpoints.
-                            Endpoints are determined by the selector or if that is
-                            not specified, by manual construction of an Endpoints
-                            object or EndpointSlice objects. If clusterIP is "None",
-                            no virtual IP is allocated and the endpoints are published
-                            as a set of endpoints rather than a virtual IP. "NodePort"
-                            builds on ClusterIP and allocates a port on every node
-                            which routes to the same endpoints as the clusterIP. "LoadBalancer"
-                            builds on NodePort and creates an external load-balancer
-                            (if supported in the current cloud) which routes to the
-                            same endpoints as the clusterIP. "ExternalName" aliases
-                            this service to the specified externalName. Several other
-                            fields do not apply to ExternalName services. More info:
-                            https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types'
-                          type: string
                       type: object
-                      x-kubernetes-preserve-unknown-fields: true
                     systemAccounts:
                       description: Statement to create system account.
                       properties:

--- a/deploy/kafka/templates/clusterdefinition.yaml
+++ b/deploy/kafka/templates/clusterdefinition.yaml
@@ -56,20 +56,15 @@ spec:
           - name: kafka-ctrlr
             targetPort: kafka-ctrlr
             port: 9093
-            nodePort: null
           - name: kafka-client
             targetPort: kafka-client
             port: 9092
-            nodePort: null
           - name: metrics
             targetPort: metrics
             port: 5556
-            nodePort: null
-
       podSpec:
         securityContext:
           fsGroup: 1001
-          
         containers:
           - name: kafka
             image: docker.io/bitnami/kafka:3.4.0-debian-11-r8
@@ -245,12 +240,9 @@ spec:
           - name: kafka-ctrlr
             targetPort: kafka-ctrlr
             port: 9093
-            nodePort: null
           - name: metrics
             targetPort: metrics
             port: 5556
-            nodePort: null
-
       podSpec:
         securityContext:
           fsGroup: 1001
@@ -413,12 +405,9 @@ spec:
           - name: kafka-client
             targetPort: kafka-client
             port: 9092
-            nodePort: null
           - name: metrics
             targetPort: metrics
             port: 5556
-            nodePort: null
-
       podSpec:
         securityContext:
           fsGroup: 1001

--- a/deploy/milvus/templates/clusterdefinition.yaml
+++ b/deploy/milvus/templates/clusterdefinition.yaml
@@ -33,7 +33,6 @@ spec:
       service:
         ports:
           - name: tcp-milvus
-            protocol: TCP
             port: 19530
             targetPort: tcp-milvus
       volumeTypes:
@@ -173,10 +172,8 @@ spec:
             ports:
               - name: client
                 containerPort: 2379
-                protocol: TCP
               - name: peer
                 containerPort: 2380
-                protocol: TCP
             env:
               - name: BITNAMI_DEBUG
                 value: "false"
@@ -235,7 +232,6 @@ spec:
       service:
         ports:
           - name: http
-            protocol: TCP
             port: 9000
             targetPort: 9000
       volumeTypes:

--- a/deploy/mongodb/templates/clusterdefinition.yaml
+++ b/deploy/mongodb/templates/clusterdefinition.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     {{- include "mongodb.labels" . | nindent 4 }}
 spec:
+  connectionCredential:
+    username: admin
+    password: ""
   componentDefs:
     - name: mongos
       scriptSpecs:
@@ -16,14 +19,14 @@ spec:
       workloadType: Stateless
       service:
         ports:
-          - protocol: TCP
+          - name: mongos
             port: 27017
+            targetPort: mongos
       podSpec:
         containers:
           - name: mongos
             ports:
-              - protocol: TCP
-                name: mongos
+              - name: mongos
                 containerPort: 27017
             command:
               - /scripts/mongos-setup.sh
@@ -54,14 +57,14 @@ spec:
           failureThreshold: 3
       service:
         ports:
-          - protocol: TCP
+          - name: configsvr
             port: 27018
+            targetPort: configsvr
       podSpec:
         containers:
           - name: configsvr
             ports:
               - name: configsvr
-                protocol: TCP
                 containerPort: 27018
             command:
               - /scripts/replicaset-setup.sh
@@ -103,14 +106,14 @@ spec:
           failureThreshold: 3
       service:
         ports:
-          - protocol: TCP
+          - name: shard
             port: 27018
+            targetPort: shard
       podSpec:
         containers:
           - name: shard
             ports:
               - name: shard
-                protocol: TCP
                 containerPort: 27018
             command:
               - /scripts/replicaset-setup.sh
@@ -136,6 +139,3 @@ spec:
               - name: scripts
                 mountPath: /scripts/shard-agent.sh
                 subPath: shard-agent.sh
-  connectionCredential:
-    username: admin
-    password: ""

--- a/deploy/postgresql-patroni-ha/templates/clusterdefinition.yaml
+++ b/deploy/postgresql-patroni-ha/templates/clusterdefinition.yaml
@@ -63,7 +63,6 @@ spec:
       service:
         ports:
           - name: tcp-postgresql
-            protocol: TCP
             port: 5432
             targetPort: tcp-postgresql
           - name: http-metrics-postgresql

--- a/deploy/postgresql/templates/clusterdefinition.yaml
+++ b/deploy/postgresql/templates/clusterdefinition.yaml
@@ -53,7 +53,6 @@ spec:
       service:
         ports:
           - name: tcp-postgresql
-            protocol: TCP
             port: 5432
             targetPort: tcp-postgresql
           - name: http-metrics-postgresql

--- a/deploy/qdrant/templates/clusterdefinition.yaml
+++ b/deploy/qdrant/templates/clusterdefinition.yaml
@@ -31,11 +31,9 @@ spec:
       service:
         ports:
           - name: tcp-qdrant
-            protocol: TCP
             port: 6333
             targetPort: tcp-qdrant
           - name: grpc-qdrant
-            protocol: TCP
             port: 6334
             targetPort: grpc-qdrant
       volumeTypes:

--- a/deploy/redis/templates/clusterdefinition.yaml
+++ b/deploy/redis/templates/clusterdefinition.yaml
@@ -57,13 +57,10 @@ spec:
       service:
         ports:
           - name: redis
-            protocol: TCP
             port: 6379
             targetPort: redis
           - name: metrics
             targetPort: metrics
-            port: 9121
-            nodePort: null
       configSpecs:
         - name: redis-replication-config
           templateRef: redis7-config-template
@@ -119,7 +116,6 @@ spec:
             ports:
               - name: metrics
                 containerPort: 9121
-                protocol: TCP
             livenessProbe:
               httpGet:
                 path: /
@@ -181,7 +177,6 @@ spec:
       service:
         ports:
           - name: redis-sentinel
-            protocol: TCP
             targetPort: redis-sentinel
             port: 26379
       configSpecs:
@@ -219,7 +214,6 @@ spec:
           ports:
             - containerPort: 26379
               name: redis-sentinel
-              protocol: TCP
           volumeMounts:
             - name: data
               mountPath: /data

--- a/deploy/weaviate/templates/clusterdefinition.yaml
+++ b/deploy/weaviate/templates/clusterdefinition.yaml
@@ -31,7 +31,6 @@ spec:
       service:
         ports:
           - name: tcp-weaviate
-            protocol: TCP
             port: 8080
             targetPort: tcp-weaviate
       volumeTypes:

--- a/internal/controller/component/component.go
+++ b/internal/controller/component/component.go
@@ -106,7 +106,7 @@ func BuildComponent(
 	}
 
 	if clusterCompDefObj.Service != nil {
-		service := corev1.Service{Spec: *clusterCompDefObj.Service}
+		service := corev1.Service{Spec: clusterCompDefObj.Service.ToSVCSpec()}
 		service.Spec.Type = corev1.ServiceTypeClusterIP
 		component.Services = append(component.Services, service)
 
@@ -116,7 +116,7 @@ func BuildComponent(
 					Name:        item.Name,
 					Annotations: item.Annotations,
 				},
-				Spec: *clusterCompDefObj.Service,
+				Spec: service.Spec,
 			}
 			service.Spec.Type = item.ServiceType
 			component.Services = append(component.Services, service)

--- a/internal/testutil/apps/clusterdef_factory.go
+++ b/internal/testutil/apps/clusterdef_factory.go
@@ -77,8 +77,8 @@ func (factory *MockClusterDefFactory) AddServicePort(port int32) *MockClusterDef
 	if comp == nil {
 		return nil
 	}
-	comp.Service = &corev1.ServiceSpec{
-		Ports: []corev1.ServicePort{{
+	comp.Service = &appsv1alpha1.ServiceSpec{
+		Ports: []appsv1alpha1.ServicePort{{
 			Protocol: corev1.ProtocolTCP,
 			Port:     port,
 		}},
@@ -160,7 +160,7 @@ func (factory *MockClusterDefFactory) AddHorizontalScalePolicy(policy appsv1alph
 }
 
 func (factory *MockClusterDefFactory) SetConnectionCredential(
-	connectionCredential map[string]string, svc *corev1.ServiceSpec) *MockClusterDefFactory {
+	connectionCredential map[string]string, svc *appsv1alpha1.ServiceSpec) *MockClusterDefFactory {
 	factory.get().Spec.ConnectionCredential = connectionCredential
 	factory.SetServiceSpec(svc)
 	return factory
@@ -182,7 +182,7 @@ func (factory *MockClusterDefFactory) getLastCompDef() *appsv1alpha1.ClusterComp
 	return &comps[l-1]
 }
 
-func (factory *MockClusterDefFactory) SetServiceSpec(svc *corev1.ServiceSpec) *MockClusterDefFactory {
+func (factory *MockClusterDefFactory) SetServiceSpec(svc *appsv1alpha1.ServiceSpec) *MockClusterDefFactory {
 	comp := factory.get1stCompDef()
 	if comp == nil {
 		return factory

--- a/internal/testutil/apps/constant.go
+++ b/internal/testutil/apps/constant.go
@@ -64,8 +64,8 @@ var (
 				Name: DefaultNginxContainerName,
 			}},
 		},
-		Service: &corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{{
+		Service: &appsv1alpha1.ServiceSpec{
+			Ports: []appsv1alpha1.ServicePort{{
 				Protocol: corev1.ProtocolTCP,
 				Port:     80,
 			}},
@@ -86,8 +86,8 @@ var (
 
 	// defaultSvc value are corresponding to defaultMySQLContainer.Ports name mapping and
 	// corresponding to defaultConnectionCredential variable placeholder
-	defaultSvcSpec = corev1.ServiceSpec{
-		Ports: []corev1.ServicePort{
+	defaultSvcSpec = appsv1alpha1.ServiceSpec{
+		Ports: []appsv1alpha1.ServicePort{
 			{
 				Name: "mysql",
 				TargetPort: intstr.IntOrString{
@@ -175,8 +175,8 @@ var (
 		UpdateStrategy: appsv1alpha1.BestEffortParallelStrategy,
 	}
 
-	defaultMySQLService = corev1.ServiceSpec{
-		Ports: []corev1.ServicePort{{
+	defaultMySQLService = appsv1alpha1.ServiceSpec{
+		Ports: []appsv1alpha1.ServicePort{{
 			Protocol: corev1.ProtocolTCP,
 			Port:     3306,
 		}},
@@ -199,8 +199,8 @@ var (
 		},
 	}
 
-	defaultRedisService = corev1.ServiceSpec{
-		Ports: []corev1.ServicePort{{
+	defaultRedisService = appsv1alpha1.ServiceSpec{
+		Ports: []appsv1alpha1.ServicePort{{
 			Protocol: corev1.ProtocolTCP,
 			Port:     6379,
 		}},


### PR DESCRIPTION
chore: tidyup ClusterDefintion.spec.componentDefs.service go struct type, remove corev1.ServiceSpec usage