### PR TITLE
fix: github action uploads kbcli asset for windows and add powershell script to install on windows

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -118,8 +118,6 @@ jobs:
 
       - name: upload release kbcli asset ${{ matrix.os }}
         uses: actions/upload-release-asset@main
-        env:
-          CLI_BINARY: ${{ env.CLI_NAME }}-${{ matrix.os }}-${{ env.TAG_NAME }}.tar.gz
         with:
           upload_url: ${{ env.UPLOAD_URL }}
           asset_path: ./bin/${{ env.ASSET_NAME }}

--- a/hack/install_cli.ps1
+++ b/hack/install_cli.ps1
@@ -23,7 +23,7 @@ function verifySupported {
         Write-Output "AMD64 is supported..."
         return
     }
-    Write-Output "No support for x86 systems"
+    Write-Output "No support to your pc $arch ARCH"
     exit 1
 }
 


### PR DESCRIPTION
* fix #2423 
* resolve #1313 

For these problems of `kbcli` in windos OS:
1. missing binary suffixes `.exe`.
2. the `tar` tool is not available.
3. zip too deep ~~and he compressed folder's name containing `.`  causes error.~~
4. `do not` change the `install_cli.sh` for linux and mac to ensure installation support for older versions.

Only modified `.github/workflows/release-publish.yaml` .


