### PR TITLE
fix: fix bug for cli spinner

### DIFF
--- a/internal/cli/printer/spinner.go
+++ b/internal/cli/printer/spinner.go
@@ -54,7 +54,7 @@ func Spinner(w io.Writer, fmtstr string, a ...any) func(result bool) {
 			<-c
 			s.Stop()
 			// Show cursor in terminal.
-			fmt.Fprintf(os.Stdout, "\033[?25h")
+			fmt.Fprintf(s.Writer, "\033[?25h")
 			os.Exit(0)
 		}()
 	}


### PR DESCRIPTION
* fix  #1428

* terminal cursor lost when kubcli kubeblocks install cancelled by shortcut key: command+c or ctl + c
* The main reason is that the spinner program terminates abnormally. Here we can capture the interrupt signal and start the coroutine to restore the cursor state.
result:

![g6xSWthVTk](https://user-images.githubusercontent.com/129354195/231130279-e0377027-bad5-4dcb-944a-eff562de891c.jpg)
