### PR TITLE
fix: display one user role with the highest priv

### DIFF
--- a/cmd/probe/internal/binding/mysql/mysql_test.go
+++ b/cmd/probe/internal/binding/mysql/mysql_test.go
@@ -499,7 +499,7 @@ func TestMySQLAccounts(t *testing.T) {
 		assert.Equal(t, 1, len(users))
 		assert.Equal(t, userName, users[0].UserName)
 		assert.NotEmpty(t, users[0].RoleName)
-		assert.Equal(t, users[0].RoleName, ReadOnlyRole)
+		assert.True(t, ReadOnlyRole.EqualTo(users[0].RoleName))
 	})
 
 	t.Run("List accounts", func(t *testing.T) {
@@ -550,7 +550,7 @@ func TestMySQLAccounts(t *testing.T) {
 		assert.Equal(t, ErrNoRoleName.Error(), result[RespTypMsg])
 
 		req.Metadata["roleName"] = roleName
-		roleDesc, err := mysqlOps.renderRoleByName(req.Metadata["roleName"])
+		roleDesc, err := mysqlOps.role2Priv(req.Metadata["roleName"])
 		assert.Nil(t, err)
 		grantRoleCmd := fmt.Sprintf("GRANT %s TO '%s'@'%%';", roleDesc, req.Metadata["userName"])
 
@@ -580,7 +580,7 @@ func TestMySQLAccounts(t *testing.T) {
 		assert.Equal(t, ErrNoRoleName.Error(), result[RespTypMsg])
 
 		req.Metadata["roleName"] = roleName
-		roleDesc, err := mysqlOps.renderRoleByName(req.Metadata["roleName"])
+		roleDesc, err := mysqlOps.role2Priv(req.Metadata["roleName"])
 		assert.Nil(t, err)
 		revokeRoleCmd := fmt.Sprintf("REVOKE %s FROM '%s'@'%%';", roleDesc, req.Metadata["userName"])
 

--- a/cmd/probe/internal/binding/postgres/postgres.go
+++ b/cmd/probe/internal/binding/postgres/postgres.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -30,6 +29,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
+	"golang.org/x/exp/slices"
 
 	. "github.com/apecloud/kubeblocks/cmd/probe/internal/binding"
 	. "github.com/apecloud/kubeblocks/cmd/probe/util"
@@ -42,12 +42,12 @@ const (
 
 	listUserTpl = `
 	SELECT usename AS userName, valuntil <now() AS expired,  usesuper,
-	ARRAY(SELECT 
-		case 
+	ARRAY(SELECT
+		case
 			when b.rolname = 'pg_read_all_data' THEN 'readonly'
 			when b.rolname = 'pg_write_all_data' THEN 'readwrite'
 		else b.rolname
-		end 
+		end
 	FROM pg_catalog.pg_auth_members m
 	JOIN pg_catalog.pg_roles b ON (m.roleid = b.oid)
 	WHERE m.member = usesysid ) as roles
@@ -57,12 +57,12 @@ const (
 	`
 	descUserTpl = `
 	SELECT usename AS userName,  valuntil <now() AS expired, usesuper,
-	ARRAY(SELECT 
-	 case 
+	ARRAY(SELECT
+	 case
 		 when b.rolname = 'pg_read_all_data' THEN 'readonly'
 		 when b.rolname = 'pg_write_all_data' THEN 'readwrite'
 	 else b.rolname
-	 end 
+	 end
 	FROM pg_catalog.pg_auth_members m
 	JOIN pg_catalog.pg_roles b ON (m.roleid = b.oid)
 	WHERE m.member = usesysid ) as roles
@@ -428,14 +428,14 @@ func (pgOps *PostgresOperations) managePrivillege(ctx context.Context, req *bind
 		object = UserInfo{}
 
 		sqlTplRend = func(user UserInfo) string {
-			if user.RoleName == SuperUserRole {
+			if SuperUserRole.EqualTo(user.UserName) {
 				if op == GrantUserRoleOp {
 					return "ALTER USER " + user.UserName + " WITH SUPERUSER;"
 				} else {
 					return "ALTER USER " + user.UserName + " WITH NOSUPERUSER;"
 				}
 			}
-			roleDesc, _ := pgOps.renderRoleByName(user.RoleName)
+			roleDesc, _ := pgOps.role2PGRole(user.RoleName)
 			return fmt.Sprintf(sqlTpl, roleDesc, user.UserName)
 		}
 
@@ -502,17 +502,29 @@ func pgUserRolesProcessor(data interface{}) (interface{}, error) {
 	// parse roles
 	users := make([]UserInfo, len(pgUsers))
 	for i := range pgUsers {
-		if pgUsers[i].Super {
-			pgUsers[i].Roles = append(pgUsers[i].Roles, "superuser")
-		}
 		users[i] = UserInfo{
 			UserName: pgUsers[i].UserName,
-			RoleName: strings.Join(pgUsers[i].Roles, ","),
 		}
+
 		if pgUsers[i].Expired {
 			users[i].Expired = "T"
 		} else {
 			users[i].Expired = "F"
+		}
+
+		// parse Super attribute
+		if pgUsers[i].Super {
+			pgUsers[i].Roles = append(pgUsers[i].Roles, string(SuperUserRole))
+		}
+
+		// convert to RoleType and sort by weight
+		roleTypes := make([]RoleType, 0)
+		for _, role := range pgUsers[i].Roles {
+			roleTypes = append(roleTypes, String2RoleType(role))
+		}
+		slices.SortFunc(roleTypes, SortRoleByWeight)
+		if len(roleTypes) > 0 {
+			users[i].RoleName = string(roleTypes[0])
 		}
 	}
 	if jsonData, err := json.Marshal(users); err != nil {
@@ -522,13 +534,13 @@ func pgUserRolesProcessor(data interface{}) (interface{}, error) {
 	}
 }
 
-func (pgOps *PostgresOperations) renderRoleByName(roleName string) (string, error) {
-	switch strings.ToLower(roleName) {
+func (pgOps *PostgresOperations) role2PGRole(roleName string) (string, error) {
+	roleType := String2RoleType(roleName)
+	switch roleType {
 	case ReadWriteRole:
 		return "pg_write_all_data", nil
 	case ReadOnlyRole:
 		return "pg_read_all_data", nil
-	default:
-		return "", fmt.Errorf("role name: %s is not supported", roleName)
 	}
+	return "", fmt.Errorf("role name: %s is not supported", roleName)
 }

--- a/cmd/probe/internal/binding/redis/redis.go
+++ b/cmd/probe/internal/binding/redis/redis.go
@@ -18,7 +18,6 @@ package redis
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -29,6 +28,10 @@ import (
 
 	bindings "github.com/dapr/components-contrib/bindings"
 	"github.com/dapr/kit/logger"
+
+	// import this json-iterator package to replace the default
+	// to avoid the error: 'json: unsupported type: map[interface {}]interface {}'
+	json "github.com/json-iterator/go"
 
 	. "github.com/apecloud/kubeblocks/cmd/probe/internal/binding"
 	rediscomponent "github.com/apecloud/kubeblocks/cmd/probe/internal/component/redis"
@@ -156,6 +159,9 @@ func (r *Redis) GetLogger() logger.Logger {
 // InternalQuery is used for internal query, implement BaseInternalOps interface.
 func (r *Redis) InternalQuery(ctx context.Context, cmd string) ([]byte, error) {
 	redisArgs := tokenizeCmd2Args(cmd)
+	// Be aware of the result type.
+	// type of result could be string, []string, []interface{}, map[interface]interface{}
+	// it is not solely determined by the command, but also the redis version.
 	result, err := r.query(ctx, redisArgs...)
 	if err != nil {
 		return nil, err
@@ -271,48 +277,24 @@ func (r *Redis) listUsersOps(ctx context.Context, req *bindings.InvokeRequest, r
 func (r *Redis) describeUserOps(ctx context.Context, req *bindings.InvokeRequest, resp *bindings.InvokeResponse) (OpsResult, error) {
 	var (
 		object        = UserInfo{}
+		profile       map[string]string
+		err           error
 		dataProcessor = func(data interface{}) (interface{}, error) {
-			redisUserPrivContxt := []string{"commands", "keys", "channels", "selectors"}
-			redisUserInfoContext := []string{"flags", "passwords"}
-
-			profile := make(map[string]string, 0)
-			results := make([]interface{}, 0)
-			err := json.Unmarshal(data.([]byte), &results)
+			// parse it to a map or an []interface
+			// try map first
+			profile, err = parseCommandAndKeyFromMap(data)
 			if err != nil {
-				return nil, err
-			}
-
-			var context string
-			for i := 0; i < len(results); i++ {
-				result := results[i]
-				switch result := result.(type) {
-				case string:
-					strVal := strings.TrimSpace(result)
-					if len(strVal) == 0 {
-						continue
-					}
-					if slices.Contains(redisUserInfoContext, strVal) {
-						i++
-						continue
-					}
-					if slices.Contains(redisUserPrivContxt, strVal) {
-						context = strVal
-					} else {
-						profile[context] = strVal
-					}
-				case []interface{}:
-					selectors := make([]string, 0)
-					for _, sel := range result {
-						selectors = append(selectors, sel.(string))
-					}
-					profile[context] = strings.Join(selectors, " ")
+				// try list
+				profile, err = parseCommandAndKeyFromList(data)
+				if err != nil {
+					return nil, err
 				}
 			}
 
 			users := make([]UserInfo, 0)
 			user := UserInfo{
 				UserName: object.UserName,
-				RoleName: redisPriv2RoleName(profile["commands"] + " " + profile["keys"]),
+				RoleName: (string)(r.priv2Role(profile["commands"] + " " + profile["keys"])),
 			}
 			users = append(users, user)
 			if jsonData, err := json.Marshal(users); err != nil {
@@ -334,6 +316,83 @@ func (r *Redis) describeUserOps(ctx context.Context, req *bindings.InvokeRequest
 	}
 
 	return QueryObject(ctx, r, req, DescribeUserOp, cmdRender, dataProcessor, object)
+}
+
+func parseCommandAndKeyFromList(data interface{}) (map[string]string, error) {
+	var (
+		redisUserPrivContxt  = []string{"commands", "keys", "channels", "selectors"}
+		redisUserInfoContext = []string{"flags", "passwords"}
+	)
+
+	profile := make(map[string]string, 0)
+	results := make([]interface{}, 0)
+
+	err := json.Unmarshal(data.([]byte), &results)
+	if err != nil {
+		return nil, err
+	}
+	// parse line by line
+	var context string
+	for i := 0; i < len(results); i++ {
+		result := results[i]
+		switch result := result.(type) {
+		case string:
+			strVal := strings.TrimSpace(result)
+			if len(strVal) == 0 {
+				continue
+			}
+			if slices.Contains(redisUserInfoContext, strVal) {
+				i++
+				continue
+			}
+			if slices.Contains(redisUserPrivContxt, strVal) {
+				context = strVal
+			} else {
+				profile[context] = strVal
+			}
+		case []interface{}:
+			selectors := make([]string, 0)
+			for _, sel := range result {
+				selectors = append(selectors, sel.(string))
+			}
+			profile[context] = strings.Join(selectors, " ")
+		}
+	}
+	return profile, nil
+}
+
+func parseCommandAndKeyFromMap(data interface{}) (map[string]string, error) {
+	var (
+		redisUserPrivContxt = []string{"commands", "keys", "channels", "selectors"}
+	)
+
+	profile := make(map[string]string, 0)
+	results := make(map[string]interface{}, 0)
+
+	err := json.Unmarshal(data.([]byte), &results)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range results {
+		// each key is string, and each v is eigher a string or a list of string
+		if !slices.Contains(redisUserPrivContxt, k) {
+			continue
+		}
+
+		switch v := v.(type) {
+		case string:
+			profile[k] = v
+		case []interface{}:
+			selectors := make([]string, 0)
+			for _, sel := range v {
+				selectors = append(selectors, sel.(string))
+			}
+			profile[k] = strings.Join(selectors, " ")
+		default:
+			return nil, fmt.Errorf("unknown data type: %v", v)
+		}
+	}
+	return profile, nil
 }
 
 func (r *Redis) createUserOps(ctx context.Context, req *bindings.InvokeRequest, resp *bindings.InvokeResponse) (OpsResult, error) {
@@ -399,7 +458,7 @@ func (r *Redis) managePrivillege(ctx context.Context, req *bindings.InvokeReques
 		object = UserInfo{}
 
 		cmdRend = func(user UserInfo) string {
-			command := roleName2RedisPriv(op, user.RoleName)
+			command := r.role2Priv(op, user.RoleName)
 			return fmt.Sprintf("ACL SETUSER %s %s", user.UserName, command)
 		}
 
@@ -418,7 +477,7 @@ func (r *Redis) managePrivillege(ctx context.Context, req *bindings.InvokeReques
 	return ExecuteObject(ctx, r, req, op, cmdRend, msgTplRend, object)
 }
 
-func roleName2RedisPriv(op bindings.OperationKind, roleName string) string {
+func (r *Redis) role2Priv(op bindings.OperationKind, roleName string) string {
 	const (
 		grantPrefix  = "+"
 		revokePrefix = "-"
@@ -430,22 +489,23 @@ func roleName2RedisPriv(op bindings.OperationKind, roleName string) string {
 		prefix = revokePrefix
 	}
 	var command string
-	switch roleName {
-	case ReadOnlyRole:
-		command = fmt.Sprintf("-@all %s@read allkeys", prefix)
-	case ReadWriteRole:
-		command = fmt.Sprintf("-@all %s@write %s@read allkeys", prefix, prefix)
+
+	roleType := String2RoleType(roleName)
+	switch roleType {
 	case SuperUserRole:
 		command = fmt.Sprintf("%s@all allkeys", prefix)
+	case ReadWriteRole:
+		command = fmt.Sprintf("-@all %s@write %s@read allkeys", prefix, prefix)
+	case ReadOnlyRole:
+		command = fmt.Sprintf("-@all %s@read allkeys", prefix)
 	}
 	return command
 }
 
-func redisPriv2RoleName(commands string) string {
+func (r *Redis) priv2Role(commands string) RoleType {
 	if commands == "-@all" {
 		return NoPrivileges
 	}
-
 	switch commands {
 	case "-@all +@read ~*":
 		return ReadOnlyRole

--- a/cmd/probe/internal/binding/redis/redis_test.go
+++ b/cmd/probe/internal/binding/redis/redis_test.go
@@ -299,7 +299,7 @@ func TestRedisAccounts(t *testing.T) {
 				testName: "validInput",
 				testMetaData: map[string]string{
 					"userName": userName,
-					"roleName": roleName,
+					"roleName": (string)(roleName),
 				},
 				expectEveType: RespEveSucc,
 			},
@@ -307,7 +307,7 @@ func TestRedisAccounts(t *testing.T) {
 
 		for _, ops := range []bindings.OperationKind{GrantUserRoleOp, RevokeUserRoleOp} {
 			// mock exepctation
-			args := tokenizeCmd2Args(fmt.Sprintf("ACL SETUSER %s %s", userName, roleName2RedisPriv(ops, roleName)))
+			args := tokenizeCmd2Args(fmt.Sprintf("ACL SETUSER %s %s", userName, r.role2Priv(ops, (string)(roleName))))
 			mock.ExpectDo(args...).SetVal("ok")
 
 			request := &bindings.InvokeRequest{
@@ -353,6 +353,15 @@ func TestRedisAccounts(t *testing.T) {
 				"selectors",
 				[]interface{}{},
 			}
+
+			userInfoMap = map[string]interface{}{
+				"flags":     []interface{}{"on"},
+				"passwords": []interface{}{"mock-password"},
+				"commands":  "+@all",
+				"keys":      "~*",
+				"channels":  "",
+				"selectors": []interface{}{},
+			}
 		)
 
 		testCases := []redisTestCase{
@@ -383,10 +392,18 @@ func TestRedisAccounts(t *testing.T) {
 				},
 				expectEveType: RespEveSucc,
 			},
+			{
+				testName: "validInputAsMap",
+				testMetaData: map[string]string{
+					"userName": userName,
+				},
+				expectEveType: RespEveSucc,
+			},
 		}
 
 		mock.ExpectDo("ACL", "GETUSER", userName).RedisNil()
 		mock.ExpectDo("ACL", "GETUSER", userName).SetVal(userInfo)
+		mock.ExpectDo("ACL", "GETUSER", userName).SetVal(userInfoMap)
 
 		for _, accTest := range testCases {
 			request.Metadata = accTest.testMetaData
@@ -407,7 +424,7 @@ func TestRedisAccounts(t *testing.T) {
 				assert.Len(t, users, 1)
 				user := users[0]
 				assert.Equal(t, userName, user.UserName)
-				assert.Equal(t, SuperUserRole, user.RoleName)
+				assert.True(t, SuperUserRole.EqualTo(user.RoleName))
 			}
 		}
 		mock.ClearExpect()
@@ -464,7 +481,7 @@ func TestRedisAccounts(t *testing.T) {
 
 	t.Run("RoleName Conversion", func(t *testing.T) {
 		type roleTestCase struct {
-			roleName   string
+			roleName   RoleType
 			redisPrivs string
 		}
 		grantTestCases := []roleTestCase{
@@ -482,12 +499,12 @@ func TestRedisAccounts(t *testing.T) {
 			},
 		}
 		for _, test := range grantTestCases {
-			cmd := roleName2RedisPriv(GrantUserRoleOp, test.roleName)
+			cmd := r.role2Priv(GrantUserRoleOp, (string)(test.roleName))
 			assert.Equal(t, test.redisPrivs, cmd)
 
 			// allkeys -> ~*
 			cmd = strings.Replace(cmd, "allkeys", "~*", 1)
-			inferredRole := redisPriv2RoleName(cmd)
+			inferredRole := r.priv2Role(cmd)
 			assert.Equal(t, test.roleName, inferredRole)
 		}
 
@@ -506,7 +523,7 @@ func TestRedisAccounts(t *testing.T) {
 			},
 		}
 		for _, test := range revokeTestCases {
-			cmd := roleName2RedisPriv(RevokeUserRoleOp, test.roleName)
+			cmd := r.role2Priv(RevokeUserRoleOp, (string)(test.roleName))
 			assert.Equal(t, test.redisPrivs, cmd)
 		}
 	})

--- a/cmd/probe/internal/binding/types.go
+++ b/cmd/probe/internal/binding/types.go
@@ -18,6 +18,7 @@ package binding
 
 import (
 	"fmt"
+	"strings"
 )
 
 const (
@@ -61,18 +62,41 @@ const (
 	RespEveSucc = "Success"
 	RespEveFail = "Failed"
 
-	SuperUserRole  string = "superuser"
-	ReadWriteRole  string = "readwrite"
-	ReadOnlyRole   string = "readonly"
-	NoPrivileges   string = ""
-	CustomizedRole string = "customized"
-	InvalidRole    string = "invalid"
-
 	PRIMARY   = "primary"
 	SECONDARY = "secondary"
 	MASTER    = "master"
 	SLAVE     = "slave"
 )
+
+type RoleType string
+
+const (
+	SuperUserRole  RoleType = "superuser"
+	ReadWriteRole  RoleType = "readwrite"
+	ReadOnlyRole   RoleType = "readonly"
+	NoPrivileges   RoleType = ""
+	CustomizedRole RoleType = "customized"
+	InvalidRole    RoleType = "invalid"
+)
+
+func (r RoleType) EqualTo(role string) bool {
+	return strings.EqualFold(string(r), role)
+}
+
+func (r RoleType) GetWeight() int32 {
+	switch r {
+	case SuperUserRole:
+		return 1 << 3
+	case ReadWriteRole:
+		return 1 << 2
+	case ReadOnlyRole:
+		return 1 << 1
+	case CustomizedRole:
+		return 1
+	default:
+		return 0
+	}
+}
 
 const (
 	errMsgNoSQL           = "no sql provided"

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/hashicorp/terraform-exec v0.18.0
 	github.com/jackc/pgx/v5 v5.2.0
 	github.com/jedib0t/go-pretty/v6 v6.4.4
+	github.com/json-iterator/go v1.1.12
 	github.com/k3d-io/k3d/v5 v5.4.4
 	github.com/kubernetes-csi/external-snapshotter/client/v6 v6.2.0
 	github.com/leaanthony/debme v1.2.1
@@ -224,7 +225,6 @@ require (
 	github.com/jmoiron/sqlx v1.3.5 // indirect
 	github.com/jonboulle/clockwork v0.2.2 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/klauspost/compress v1.15.15 // indirect
 	github.com/klauspost/pgzip v1.2.6-0.20220930104621-17e8dac29df8 // indirect

--- a/internal/controller/lifecycle/transformer_fill_class.go
+++ b/internal/controller/lifecycle/transformer_fill_class.go
@@ -1,3 +1,19 @@
+/*
+Copyright ApeCloud, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package lifecycle
 
 import (

--- a/internal/controller/lifecycle/transformer_fix_cluster_labels.go
+++ b/internal/controller/lifecycle/transformer_fix_cluster_labels.go
@@ -1,3 +1,19 @@
+/*
+Copyright ApeCloud, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package lifecycle
 
 import (


### PR DESCRIPTION
- fix #2530  
- fix #2531 
- adapt to changes in redis result set. The struct of `ACL GETUSER` could be either a `[]interface{}` (redis 7.0.4 and earlier) or `map[string]interface{}` (e.g. redis 7.0.8).  we should handle both cases.