### PR TITLE
chore: support redis maxmemory setup with request memory

### DIFF
--- a/deploy/redis-cluster/values.yaml
+++ b/deploy/redis-cluster/values.yaml
@@ -18,18 +18,17 @@ primaryIndex: 0
 switchPolicy:
   type: Noop
 
-resources: { }
+resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-
-  # limits:
-  #   cpu: 500m
-  #   memory: 2Gi
-  # requests:
-  #   cpu: 100m
-  #   memory: 1Gi
+  limits:
+    cpu: 500m
+    memory: 3Gi
+  requests:
+    cpu: 500m
+    memory: 1Gi
 
 persistence:
   enabled: true

--- a/deploy/redis/config/redis7-config.tpl
+++ b/deploy/redis/config/redis7-config.tpl
@@ -71,3 +71,9 @@ jemalloc-bg-thread yes
 enable-debug-command yes
 protected-mode no
 
+# maxmemory <bytes>
+{{- $request_memory := getContainerRequestMemory ( index $.podSpec.containers 0 ) }}
+{{- if gt $request_memory 0 }}
+maxmemory {{ $request_memory }}
+{{- end -}}
+

--- a/internal/controller/plan/builtin_functions.go
+++ b/internal/controller/plan/builtin_functions.go
@@ -211,6 +211,15 @@ func getContainerMemory(args interface{}) (int64, error) {
 	return intctrlutil.GetMemorySize(*container), nil
 }
 
+// getContainerRequestMemory for general built-in
+func getContainerRequestMemory(args interface{}) (int64, error) {
+	container, err := fromJSONObject[corev1.Container](args)
+	if err != nil {
+		return 0, err
+	}
+	return intctrlutil.GetRequestMemorySize(*container), nil
+}
+
 // getArgByName for general built-in
 func getArgByName(args interface{}, argName string) string {
 	// TODO Support parse command args

--- a/internal/controller/plan/config_template.go
+++ b/internal/controller/plan/config_template.go
@@ -42,13 +42,14 @@ const (
 
 // General Built-in functions
 const (
-	builtInGetVolumeFunctionName          = "getVolumePathByName"
-	builtInGetPvcFunctionName             = "getPVCByName"
-	builtInGetEnvFunctionName             = "getEnvByName"
-	builtInGetArgFunctionName             = "getArgByName"
-	builtInGetPortFunctionName            = "getPortByName"
-	builtInGetContainerFunctionName       = "getContainerByName"
-	builtInGetContainerMemoryFunctionName = "getContainerMemory"
+	builtInGetVolumeFunctionName                 = "getVolumePathByName"
+	builtInGetPvcFunctionName                    = "getPVCByName"
+	builtInGetEnvFunctionName                    = "getEnvByName"
+	builtInGetArgFunctionName                    = "getArgByName"
+	builtInGetPortFunctionName                   = "getPortByName"
+	builtInGetContainerFunctionName              = "getContainerByName"
+	builtInGetContainerMemoryFunctionName        = "getContainerMemory"
+	builtInGetContainerRequestMemoryFunctionName = "getContainerRequestMemory"
 
 	// BuiltinMysqlCalBufferFunctionName Mysql Built-in
 	// TODO: This function migrate to configuration template
@@ -172,17 +173,18 @@ func (c *configTemplateBuilder) injectBuiltInObjectsAndFunctions(
 func (c *configTemplateBuilder) injectBuiltInFunctions(component *component.SynthesizedComponent, task *intctrltypes.ReconcileTask) error {
 	// TODO add built-in function
 	c.builtInFunctions = &gotemplate.BuiltInObjectsFunc{
-		builtInMysqlCalBufferFunctionName:     calDBPoolSize,
-		builtInGetVolumeFunctionName:          getVolumeMountPathByName,
-		builtInGetPvcFunctionName:             getPVCByName,
-		builtInGetEnvFunctionName:             wrapGetEnvByName(c, task),
-		builtInGetPortFunctionName:            getPortByName,
-		builtInGetArgFunctionName:             getArgByName,
-		builtInGetContainerFunctionName:       getPodContainerByName,
-		builtInGetContainerMemoryFunctionName: getContainerMemory,
-		builtInGetCAFile:                      getCAFile,
-		builtInGetCertFile:                    getCertFile,
-		builtInGetKeyFile:                     getKeyFile,
+		builtInMysqlCalBufferFunctionName:            calDBPoolSize,
+		builtInGetVolumeFunctionName:                 getVolumeMountPathByName,
+		builtInGetPvcFunctionName:                    getPVCByName,
+		builtInGetEnvFunctionName:                    wrapGetEnvByName(c, task),
+		builtInGetPortFunctionName:                   getPortByName,
+		builtInGetArgFunctionName:                    getArgByName,
+		builtInGetContainerFunctionName:              getPodContainerByName,
+		builtInGetContainerMemoryFunctionName:        getContainerMemory,
+		builtInGetContainerRequestMemoryFunctionName: getContainerRequestMemory,
+		builtInGetCAFile:                             getCAFile,
+		builtInGetCertFile:                           getCertFile,
+		builtInGetKeyFile:                            getKeyFile,
 	}
 	return nil
 }

--- a/internal/controllerutil/pod_utils.go
+++ b/internal/controllerutil/pod_utils.go
@@ -217,6 +217,16 @@ func GetMemorySize(container corev1.Container) int64 {
 	return 0
 }
 
+// GetRequestMemorySize function description:
+// if not Resource field, return 0 else Resources.Limits.memory
+func GetRequestMemorySize(container corev1.Container) int64 {
+	requests := container.Resources.Requests
+	if val, ok := (requests)[corev1.ResourceMemory]; ok {
+		return val.Value()
+	}
+	return 0
+}
+
 // PodIsReady check the pod is ready
 func PodIsReady(pod *corev1.Pod) bool {
 	if pod.Status.Conditions == nil {


### PR DESCRIPTION
The current redis instance does not set maxmemory, and now set it with the value of resource.request.mem. At the same time, it is recommended that users set the resource.limit.mem to 2-3 times the request when using the redis cluster, because redis will have bgsave and other behaviors which will double the memory resources used.

resources:
  limits:
    cpu: 500m
    memory: 3Gi
  requests:
    cpu: 500m
    memory: 1Gi

![image](https://user-images.githubusercontent.com/12824920/231706496-30d556bf-39ce-4810-b724-6e10a63cbc47.png)
