### PR TITLE
fix: update redis clusterdef for accounts config

### DIFF
--- a/deploy/redis/templates/clusterdefinition.yaml
+++ b/deploy/redis/templates/clusterdefinition.yaml
@@ -151,33 +151,33 @@ spec:
           - name: kbadmin
             provisionPolicy:
               type: CreateByStmt
-              scope: AnyPods
+              scope: AllPods
               statements:
-                creation: ACL SETUSER $(USERNAME) ON >$(PASSWD) allcommands allkeys
+                creation: ACL SETUSER $(USERNAME) ON \>$(PASSWD) allcommands allkeys
           - name: kbdataprotection
             provisionPolicy:
               type: CreateByStmt
-              scope: AnyPods
+              scope: AllPods
               statements:
-                creation: ACL SETUSER $(USERNAME) ON >$(PASSWD) allcommands allkeys
+                creation: ACL SETUSER $(USERNAME) ON \>$(PASSWD) allcommands allkeys
           - name: kbmonitoring
             provisionPolicy:
               type: CreateByStmt
-              scope: AnyPods
+              scope: AllPods
               statements:
-                creation: ACL SETUSER $(USERNAME) ON >$(PASSWD) allkeys +get
+                creation: ACL SETUSER $(USERNAME) ON \>$(PASSWD) allkeys +get
           - name: kbprobe
             provisionPolicy:
               type: CreateByStmt
-              scope: AnyPods
+              scope: AllPods
               statements:
-                creation: ACL SETUSER $(USERNAME) ON >$(PASSWD) allkeys +get
+                creation: ACL SETUSER $(USERNAME) ON \>$(PASSWD) allkeys +get
           - name: kbreplicator
             provisionPolicy:
               type: CreateByStmt
-              scope: AnyPods
+              scope: AllPods
               statements:
-                creation: ACL SETUSER $(USERNAME) ON >$(PASSWD) +psync +replconf +ping
+                creation: ACL SETUSER $(USERNAME) ON \>$(PASSWD) +psync +replconf +ping
     - name: redis-sentinel
       workloadType: Stateful
       characterType: redis


### PR DESCRIPTION
fix #2562  
this request update cluster def in : 
- update stmt, escape '>' , otherwise password is empty 
- use `allpods` instead of `anypods`, latter only creates accounts on primary/leader node, former ceates on all pods.