### PR TITLE
chore: support xengine for apecloud-mysql

### DIFF
--- a/deploy/apecloud-mysql/config/mysql8-config-constraint.cue
+++ b/deploy/apecloud-mysql/config/mysql8-config-constraint.cue
@@ -165,6 +165,9 @@
 	// Write a core file if mysqld dies.
 	"core-file"?: string & "0" | "1" | "OFF" | "ON"
 
+	// xengine enable
+	"xengine"?: string & "0" | "1" | "OFF" | "ON"
+
 	// Abort a recursive common table expression if it does more than this number of iterations.
 	cte_max_recursion_depth: int & >=0 & <=4294967295 | *1000
 
@@ -181,7 +184,7 @@
 	default_password_lifetime: int & >=0 & <=65535 | *0
 
 	// The default storage engine (table type).
-	default_storage_engine?: string & "InnoDB" | "MRG_MYISAM" | "BLACKHOLE" | "CSV" | "MEMORY" | "FEDERATED" | "ARCHIVE" | "MyISAM"
+	default_storage_engine?: string & "InnoDB" | "MRG_MYISAM" | "BLACKHOLE" | "CSV" | "MEMORY" | "FEDERATED" | "ARCHIVE" | "MyISAM" | "xengine"
 
 	// Server current time zone
 	default_time_zone?: string

--- a/deploy/apecloud-mysql/config/mysql8-config-effect-scope.yaml
+++ b/deploy/apecloud-mysql/config/mysql8-config-effect-scope.yaml
@@ -5,6 +5,7 @@
 ## if all the changed parameters are in the dynamicParameters list, this change executes reload without process restart.
 ## if the above two conditions are not met, by default, parameter change operation follow the rule for using staticParameters.
 staticParameters:
+  - xengine
   - allow-suspicious-udfs
   - auto_generate_certs
   - back_log

--- a/deploy/apecloud-mysql/config/mysql8-config.tpl
+++ b/deploy/apecloud-mysql/config/mysql8-config.tpl
@@ -6,6 +6,7 @@
 {{- $mysql_port_info := getPortByName ( index $.podSpec.containers 0 ) "mysql" }}
 {{- $pool_buffer_size := ( callBufferSizeByResource ( index $.podSpec.containers 0 ) ) }}
 {{- $phy_memory := getContainerMemory ( index $.podSpec.containers 0 ) }}
+{{- $phy_cpu := getContainerCPU ( index $.podSpec.containers 0 ) }}
 
 {{- if $pool_buffer_size }}
 innodb_buffer_pool_size={{ $pool_buffer_size }}
@@ -165,6 +166,60 @@ ssl_ca={{ $ca_file }}
 ssl_cert={{ $cert_file }}
 ssl_key={{ $key_file }}
 {{- end }}
+
+## xengine base config
+#default_storage_engine=xengine
+default_tmp_storage_engine=innodb
+xengine=0
+
+# log_error_verbosity=3
+# binlog_format=ROW
+
+## non classes config
+
+loose_xengine_datadir={{ $data_root }}/xengine
+loose_xengine_wal_dir={{ $data_root }}/xengine
+loose_xengine_flush_log_at_trx_commit=1
+loose_xengine_enable_2pc=1
+loose_xengine_batch_group_slot_array_size=5
+loose_xengine_batch_group_max_group_size=15
+loose_xengine_batch_group_max_leader_wait_time_us=50
+loose_xengine_block_size=16384
+loose_xengine_disable_auto_compactions=0
+loose_xengine_dump_memtable_limit_size=0
+
+loose_xengine_min_write_buffer_number_to_merge=1
+loose_xengine_level0_file_num_compaction_trigger=64
+loose_xengine_level0_layer_num_compaction_trigger=2
+loose_xengine_level1_extent s_major_compaction_trigger=1000
+loose_xengine_level2_usage_percent=70
+loose_xengine_flush_delete_percent=70
+loose_xengine_compaction_delete_percent=50
+loose_xengine_flush_delete_percent_trigger=700000
+loose_xengine_flush_delete_record_trigger=700000
+loose_xengine_scan_add_blocks_limit=100
+
+loose_xengine_compression_per_level=kZSTD:kZSTD:kZSTD
+
+
+## classes classes config
+
+{{- if gt $phy_memory 0 }}
+{{- $phy_memory := div $phy_memory ( mul 1024 1024 ) }}
+#loose_xengine_write_buffer_size={{ min ( max 32 ( mulf $phy_memory 0.01 ) ) 256 | int | mul 1024 1024 }}
+#loose_xengine_db_write_buffer_size={{ mulf $phy_memory 0.3 | int | mul 1024 1024 }}
+#loose_xengine_db_total_write_buffer_size={{ mulf $phy_memory 0.3 | int | mul 1024 1024 }}
+#loose_xengine_block_cache_size={{ mulf $phy_memory 0.3 | int | mul 1024 1024 }}
+#loose_xengine_row_cache_size={{ mulf $phy_memory 0.1 | int | mul 1024 1024 }}
+#loose_xengine_max_total_wal_size={{ min ( mulf $phy_memory 0.3 ) ( mul 12 1024 ) | int | mul 1024 1024 }}
+{{- end }}
+
+{{- if gt $phy_cpu 0 }}
+loose_xengine_max_background_flushes={{ max 1 ( min ( div $phy_cpu 2 ) 8 ) | int }}
+loose_xengine_base_background_compactions={{ max 1 ( min ( div $phy_cpu 2 ) 8 ) | int }}
+loose_xengine_max_background_compactions={{ max 1 (min ( div $phy_cpu 2 ) 12 ) | int }}
+{{- end }}
+
 
 [client]
 port={{ $mysql_port }}

--- a/internal/controller/plan/builtin_functions.go
+++ b/internal/controller/plan/builtin_functions.go
@@ -202,6 +202,15 @@ func getPVCByName(args []interface{}, volumeName string) (interface{}, error) {
 	return nil, nil
 }
 
+// getContainerCPU for general built-in
+func getContainerCPU(args interface{}) (int64, error) {
+	container, err := fromJSONObject[corev1.Container](args)
+	if err != nil {
+		return 0, err
+	}
+	return intctrlutil.GetCoreNum(*container), nil
+}
+
 // getContainerMemory for general built-in
 func getContainerMemory(args interface{}) (int64, error) {
 	container, err := fromJSONObject[corev1.Container](args)

--- a/internal/controller/plan/config_template.go
+++ b/internal/controller/plan/config_template.go
@@ -48,6 +48,7 @@ const (
 	builtInGetArgFunctionName                    = "getArgByName"
 	builtInGetPortFunctionName                   = "getPortByName"
 	builtInGetContainerFunctionName              = "getContainerByName"
+	builtInGetContainerCPUFunctionName           = "getContainerCPU"
 	builtInGetContainerMemoryFunctionName        = "getContainerMemory"
 	builtInGetContainerRequestMemoryFunctionName = "getContainerRequestMemory"
 
@@ -180,6 +181,7 @@ func (c *configTemplateBuilder) injectBuiltInFunctions(component *component.Synt
 		builtInGetPortFunctionName:                   getPortByName,
 		builtInGetArgFunctionName:                    getArgByName,
 		builtInGetContainerFunctionName:              getPodContainerByName,
+		builtInGetContainerCPUFunctionName:           getContainerCPU,
 		builtInGetContainerMemoryFunctionName:        getContainerMemory,
 		builtInGetContainerRequestMemoryFunctionName: getContainerRequestMemory,
 		builtInGetCAFile:                             getCAFile,


### PR DESCRIPTION
enable xengine:
`kbcli cluster configure {cluster-name} --set xengine=ON,binlog_format=ROW,default_storage_engine=xengine`

disable xengine:
`kbcli cluster configure {cluster-name} --set xengine=OFF,binlog_format=MIXED,default_storage_engine=innodb`