### PR TITLE
chore: support postgresql 14.7 instead of 15.2

### DIFF
--- a/deploy/postgresql-cluster/Chart.yaml
+++ b/deploy/postgresql-cluster/Chart.yaml
@@ -6,4 +6,4 @@ type: application
 
 version: 0.5.0-alpha.3
 
-appVersion: "15.2.0"
+appVersion: "14.7.0"

--- a/deploy/postgresql/Chart.yaml
+++ b/deploy/postgresql/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 
 version: 0.5.0-alpha.3
 
-appVersion: "15.2.0"
+appVersion: "14.7.0"
 
 home: https://kubeblocks.io/
 icon: https://github.com/apecloud/kubeblocks/raw/main/img/logo.png

--- a/deploy/postgresql/values.yaml
+++ b/deploy/postgresql/values.yaml
@@ -11,7 +11,7 @@
 image:
   registry: registry.cn-hangzhou.aliyuncs.com
   repository: apecloud/spilo
-  tag: 15.2.0
+  tag: 14.7.0
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
Now, user need PostgreSQL 14.7, so replace 15.2 with 14.7.

```
➜  ~ docker ps |grep spilo
de28300169d9   apecloud/spilo:14.7.0                 "/bin/sh /launch.sh …"   11 seconds ago   Up 10 seconds   5432/tcp, 8008/tcp, 8080/tcp                                                                                                 dazzling_fermi
➜  ~ docker exec -ti de28300169d9 bash

 ____        _ _
/ ___| _ __ (_) | ___
\___ \| '_ \| | |/ _ \
 ___) | |_) | | | (_) |
|____/| .__/|_|_|\___/
      |_|

This container is managed by runit, when stopping/starting services use sv

Examples:

sv stop cron
sv restart patroni

Current status: (sv status /etc/service/*)

run: /etc/service/etcd: (pid 34) 15s
run: /etc/service/patroni: (pid 35) 15s
run: /etc/service/pgqd: (pid 36) 15s
root@de28300169d9:/home/postgres# psql
psql: error: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: FATAL:  role "root" does not exist
root@de28300169d9:/home/postgres# psql -Upostgres
psql (14.7 (Ubuntu 14.7-1.pgdg22.04+1))
Type "help" for help.

postgres=# select version();
                                                                 version
-----------------------------------------------------------------------------------------------------------------------------------------
 PostgreSQL 14.7 (Ubuntu 14.7-1.pgdg22.04+1) on aarch64-unknown-linux-gnu, compiled by gcc (Ubuntu 11.3.0-1ubuntu1~22.04) 11.3.0, 64-bit
(1 row)

postgres=# \dx
                                            List of installed extensions
        Name        | Version |   Schema   |                              Description
--------------------+---------+------------+------------------------------------------------------------------------
 file_fdw           | 1.0     | public     | foreign-data wrapper for flat file access
 pg_auth_mon        | 1.1     | public     | monitor connection attempts per user
 pg_cron            | 1.5     | pg_catalog | Job scheduler for PostgreSQL
 pg_stat_kcache     | 2.2.1   | public     | Kernel statistics gathering
 pg_stat_statements | 1.9     | public     | track planning and execution statistics of all SQL statements executed
 plpgsql            | 1.0     | pg_catalog | PL/pgSQL procedural language
 plpython3u         | 1.0     | pg_catalog | PL/Python3U untrusted procedural language
 set_user           | 3.0     | public     | similar to SET ROLE but with added logging
(8 rows)

postgres=# create extension vector;
CREATE EXTENSION
postgres=# \dx
                                            List of installed extensions
        Name        | Version |   Schema   |                              Description
--------------------+---------+------------+------------------------------------------------------------------------
 file_fdw           | 1.0     | public     | foreign-data wrapper for flat file access
 pg_auth_mon        | 1.1     | public     | monitor connection attempts per user
 pg_cron            | 1.5     | pg_catalog | Job scheduler for PostgreSQL
 pg_stat_kcache     | 2.2.1   | public     | Kernel statistics gathering
 pg_stat_statements | 1.9     | public     | track planning and execution statistics of all SQL statements executed
 plpgsql            | 1.0     | pg_catalog | PL/pgSQL procedural language
 plpython3u         | 1.0     | pg_catalog | PL/Python3U untrusted procedural language
 set_user           | 3.0     | public     | similar to SET ROLE but with added logging
 vector             | 0.4.1   | public     | vector data type and ivfflat access method
(9 rows)

postgres=# exit
```