### PR TITLE
chore: refactore controllers/apps/components/* packages and structs naming

### DIFF
--- a/controllers/apps/cluster_controller_test.go
+++ b/controllers/apps/cluster_controller_test.go
@@ -42,7 +42,7 @@ import (
 
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
 	dataprotectionv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
-	"github.com/apecloud/kubeblocks/controllers/apps/components/replicationset"
+	"github.com/apecloud/kubeblocks/controllers/apps/components/replication"
 	"github.com/apecloud/kubeblocks/controllers/apps/components/util"
 	"github.com/apecloud/kubeblocks/internal/constant"
 	"github.com/apecloud/kubeblocks/internal/controller/lifecycle"
@@ -1479,7 +1479,7 @@ var _ = Describe("Cluster Controller", func() {
 			for i := int32(0); i < *sts.Spec.Replicas; i++ {
 				podName := fmt.Sprintf("%s-%d", sts.Name, i)
 				testapps.MockReplicationComponentStsPod(nil, testCtx, sts, clusterObj.Name,
-					testapps.DefaultRedisCompName, podName, replicationset.DefaultRole(i))
+					testapps.DefaultRedisCompName, podName, replication.DefaultRole(i))
 			}
 			Eventually(testapps.GetClusterPhase(&testCtx, clusterKey)).Should(Equal(appsv1alpha1.RunningClusterPhase))
 		})

--- a/controllers/apps/components/component.go
+++ b/controllers/apps/components/component.go
@@ -26,8 +26,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
-	"github.com/apecloud/kubeblocks/controllers/apps/components/consensusset"
-	"github.com/apecloud/kubeblocks/controllers/apps/components/replicationset"
+	"github.com/apecloud/kubeblocks/controllers/apps/components/consensus"
+	"github.com/apecloud/kubeblocks/controllers/apps/components/replication"
 	"github.com/apecloud/kubeblocks/controllers/apps/components/stateful"
 	"github.com/apecloud/kubeblocks/controllers/apps/components/stateless"
 	"github.com/apecloud/kubeblocks/controllers/apps/components/types"
@@ -59,9 +59,9 @@ func NewComponentByType(
 	}
 	switch componentDef.WorkloadType {
 	case appsv1alpha1.Consensus:
-		return consensusset.NewConsensusComponent(cli, cluster, component, componentDef)
+		return consensus.NewConsensusComponent(cli, cluster, component, componentDef)
 	case appsv1alpha1.Replication:
-		return replicationset.NewReplicationComponent(cli, cluster, component, componentDef)
+		return replication.NewReplicationComponent(cli, cluster, component, componentDef)
 	case appsv1alpha1.Stateful:
 		return stateful.NewStatefulComponent(cli, cluster, component, componentDef)
 	case appsv1alpha1.Stateless:

--- a/controllers/apps/components/consensus/consensus_test.go
+++ b/controllers/apps/components/consensus/consensus_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package consensusset
+package consensus
 
 import (
 	"fmt"

--- a/controllers/apps/components/consensus/consensus_utils.go
+++ b/controllers/apps/components/consensus/consensus_utils.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package consensusset
+package consensus
 
 import (
 	"context"

--- a/controllers/apps/components/consensus/consensus_utils_test.go
+++ b/controllers/apps/components/consensus/consensus_utils_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package consensusset
+package consensus
 
 import (
 	"strconv"

--- a/controllers/apps/components/consensus/suite_test.go
+++ b/controllers/apps/components/consensus/suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package consensusset
+package consensus
 
 import (
 	"context"
@@ -55,7 +55,7 @@ func init() {
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 
-	RunSpecs(t, "ConsensusSet Controller Suite")
+	RunSpecs(t, "Consensus Controller Suite")
 }
 
 var _ = BeforeSuite(func() {

--- a/controllers/apps/components/replication/replication_switch.go
+++ b/controllers/apps/components/replication/replication_switch.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package replicationset
+package replication
 
 import (
 	"context"

--- a/controllers/apps/components/replication/replication_switch_test.go
+++ b/controllers/apps/components/replication/replication_switch_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package replicationset
+package replication
 
 import (
 	"fmt"

--- a/controllers/apps/components/replication/replication_switch_utils.go
+++ b/controllers/apps/components/replication/replication_switch_utils.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package replicationset
+package replication
 
 import (
 	"context"

--- a/controllers/apps/components/replication/replication_switch_utils_test.go
+++ b/controllers/apps/components/replication/replication_switch_utils_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package replicationset
+package replication
 
 import (
 	"fmt"

--- a/controllers/apps/components/replication/replication_test.go
+++ b/controllers/apps/components/replication/replication_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package replicationset
+package replication
 
 import (
 	. "github.com/onsi/ginkgo/v2"

--- a/controllers/apps/components/replication/replication_utils.go
+++ b/controllers/apps/components/replication/replication_utils.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package replicationset
+package replication
 
 import (
 	"context"

--- a/controllers/apps/components/replication/replication_utils_test.go
+++ b/controllers/apps/components/replication/replication_utils_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package replicationset
+package replication
 
 import (
 	"context"

--- a/controllers/apps/components/replication/suite_test.go
+++ b/controllers/apps/components/replication/suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package replicationset
+package replication
 
 import (
 	"context"

--- a/controllers/apps/components/stateful/stateful.go
+++ b/controllers/apps/components/stateful/stateful.go
@@ -33,11 +33,11 @@ import (
 	intctrlutil "github.com/apecloud/kubeblocks/internal/controllerutil"
 )
 
-type Stateful types.ComponentBase
+type StatefulComponent types.ComponentBase
 
-var _ types.Component = &Stateful{}
+var _ types.Component = &StatefulComponent{}
 
-func (r *Stateful) IsRunning(ctx context.Context, obj client.Object) (bool, error) {
+func (r *StatefulComponent) IsRunning(ctx context.Context, obj client.Object) (bool, error) {
 	if obj == nil {
 		return false, nil
 	}
@@ -49,7 +49,7 @@ func (r *Stateful) IsRunning(ctx context.Context, obj client.Object) (bool, erro
 	return util.StatefulSetOfComponentIsReady(sts, isRevisionConsistent, &r.Component.Replicas), nil
 }
 
-func (r *Stateful) PodsReady(ctx context.Context, obj client.Object) (bool, error) {
+func (r *StatefulComponent) PodsReady(ctx context.Context, obj client.Object) (bool, error) {
 	if obj == nil {
 		return false, nil
 	}
@@ -57,7 +57,7 @@ func (r *Stateful) PodsReady(ctx context.Context, obj client.Object) (bool, erro
 	return util.StatefulSetPodsAreReady(sts, r.Component.Replicas), nil
 }
 
-func (r *Stateful) PodIsAvailable(pod *corev1.Pod, minReadySeconds int32) bool {
+func (r *StatefulComponent) PodIsAvailable(pod *corev1.Pod, minReadySeconds int32) bool {
 	if pod == nil {
 		return false
 	}
@@ -65,12 +65,12 @@ func (r *Stateful) PodIsAvailable(pod *corev1.Pod, minReadySeconds int32) bool {
 }
 
 // HandleProbeTimeoutWhenPodsReady the Stateful component has no role detection, empty implementation here.
-func (r *Stateful) HandleProbeTimeoutWhenPodsReady(ctx context.Context, recorder record.EventRecorder) (bool, error) {
+func (r *StatefulComponent) HandleProbeTimeoutWhenPodsReady(ctx context.Context, recorder record.EventRecorder) (bool, error) {
 	return false, nil
 }
 
 // GetPhaseWhenPodsNotReady gets the component phase when the pods of component are not ready.
-func (r *Stateful) GetPhaseWhenPodsNotReady(ctx context.Context, componentName string) (appsv1alpha1.ClusterComponentPhase, error) {
+func (r *StatefulComponent) GetPhaseWhenPodsNotReady(ctx context.Context, componentName string) (appsv1alpha1.ClusterComponentPhase, error) {
 	stsList := &appsv1.StatefulSetList{}
 	podList, err := util.GetCompRelatedObjectList(ctx, r.Cli, *r.Cluster, componentName, stsList)
 	if err != nil || len(stsList.Items) == 0 {
@@ -86,7 +86,7 @@ func (r *Stateful) GetPhaseWhenPodsNotReady(ctx context.Context, componentName s
 		stsObj.Status.AvailableReplicas, checkExistFailedPodOfLatestRevision), nil
 }
 
-func (r *Stateful) HandleUpdate(ctx context.Context, obj client.Object) error {
+func (r *StatefulComponent) HandleUpdate(ctx context.Context, obj client.Object) error {
 	return nil
 }
 
@@ -99,7 +99,7 @@ func NewStatefulComponent(
 	if err := util.ComponentRuntimeReqArgsCheck(cli, cluster, component); err != nil {
 		return nil, err
 	}
-	return &Stateful{
+	return &StatefulComponent{
 		Cli:          cli,
 		Cluster:      cluster,
 		Component:    component,

--- a/controllers/apps/components/stateless/stateless.go
+++ b/controllers/apps/components/stateless/stateless.go
@@ -42,18 +42,18 @@ import (
 // is at least the minimum available pods that need to run for the deployment.
 const NewRSAvailableReason = "NewReplicaSetAvailable"
 
-type Stateless types.ComponentBase
+type StatelessComponent types.ComponentBase
 
-var _ types.Component = &Stateless{}
+var _ types.Component = &StatelessComponent{}
 
-func (stateless *Stateless) IsRunning(ctx context.Context, obj client.Object) (bool, error) {
+func (stateless *StatelessComponent) IsRunning(ctx context.Context, obj client.Object) (bool, error) {
 	if stateless == nil {
 		return false, nil
 	}
 	return stateless.PodsReady(ctx, obj)
 }
 
-func (stateless *Stateless) PodsReady(ctx context.Context, obj client.Object) (bool, error) {
+func (stateless *StatelessComponent) PodsReady(ctx context.Context, obj client.Object) (bool, error) {
 	if stateless == nil {
 		return false, nil
 	}
@@ -64,7 +64,7 @@ func (stateless *Stateless) PodsReady(ctx context.Context, obj client.Object) (b
 	return deploymentIsReady(deploy, &stateless.Component.Replicas), nil
 }
 
-func (stateless *Stateless) PodIsAvailable(pod *corev1.Pod, minReadySeconds int32) bool {
+func (stateless *StatelessComponent) PodIsAvailable(pod *corev1.Pod, minReadySeconds int32) bool {
 	if stateless == nil || pod == nil {
 		return false
 	}
@@ -72,13 +72,13 @@ func (stateless *Stateless) PodIsAvailable(pod *corev1.Pod, minReadySeconds int3
 }
 
 // HandleProbeTimeoutWhenPodsReady the stateless component has no role detection, empty implementation here.
-func (stateless *Stateless) HandleProbeTimeoutWhenPodsReady(ctx context.Context,
+func (stateless *StatelessComponent) HandleProbeTimeoutWhenPodsReady(ctx context.Context,
 	recorder record.EventRecorder) (bool, error) {
 	return false, nil
 }
 
 // GetPhaseWhenPodsNotReady gets the component phase when the pods of component are not ready.
-func (stateless *Stateless) GetPhaseWhenPodsNotReady(ctx context.Context,
+func (stateless *StatelessComponent) GetPhaseWhenPodsNotReady(ctx context.Context,
 	componentName string) (appsv1alpha1.ClusterComponentPhase, error) {
 	deployList := &appsv1.DeploymentList{}
 	podList, err := util.GetCompRelatedObjectList(ctx, stateless.Cli, *stateless.Cluster, componentName, deployList)
@@ -95,7 +95,7 @@ func (stateless *Stateless) GetPhaseWhenPodsNotReady(ctx context.Context,
 		deploy.Status.AvailableReplicas, checkExistFailedPodOfNewRS), nil
 }
 
-func (stateless *Stateless) HandleUpdate(ctx context.Context, obj client.Object) error {
+func (stateless *StatelessComponent) HandleUpdate(ctx context.Context, obj client.Object) error {
 	return nil
 }
 
@@ -107,7 +107,7 @@ func NewStatelessComponent(
 	if err := util.ComponentRuntimeReqArgsCheck(cli, cluster, component); err != nil {
 		return nil, err
 	}
-	return &Stateless{
+	return &StatelessComponent{
 		Cli:          cli,
 		Cluster:      cluster,
 		Component:    component,

--- a/controllers/apps/configuration/policy_util.go
+++ b/controllers/apps/configuration/policy_util.go
@@ -26,7 +26,7 @@ import (
 	"github.com/spf13/viper"
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/apecloud/kubeblocks/controllers/apps/components/consensusset"
+	"github.com/apecloud/kubeblocks/controllers/apps/components/consensus"
 	"github.com/apecloud/kubeblocks/controllers/apps/components/util"
 	cfgcore "github.com/apecloud/kubeblocks/internal/configuration"
 	cfgproto "github.com/apecloud/kubeblocks/internal/configuration/proto"
@@ -158,7 +158,7 @@ func getConsensusPods(params reconfigureParams) ([]corev1.Pod, error) {
 	}
 
 	// sort pods
-	consensusset.SortPods(pods, consensusset.ComposeRolePriorityMap(*params.Component))
+	consensus.SortPods(pods, consensus.ComposeRolePriorityMap(*params.Component))
 	r := make([]corev1.Pod, 0, len(pods))
 	for i := len(pods); i > 0; i-- {
 		r = append(r, pods[i-1:i]...)

--- a/controllers/apps/opsrequest_controller_test.go
+++ b/controllers/apps/opsrequest_controller_test.go
@@ -32,7 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
-	"github.com/apecloud/kubeblocks/controllers/apps/components/replicationset"
+	"github.com/apecloud/kubeblocks/controllers/apps/components/replication"
 	opsutil "github.com/apecloud/kubeblocks/controllers/apps/operations/util"
 	"github.com/apecloud/kubeblocks/internal/constant"
 	"github.com/apecloud/kubeblocks/internal/controller/lifecycle"
@@ -369,7 +369,7 @@ var _ = Describe("OpsRequest Controller", func() {
 			for i := int32(0); i < *sts.Spec.Replicas; i++ {
 				podName := fmt.Sprintf("%s-%d", sts.Name, i)
 				pod := testapps.MockReplicationComponentStsPod(nil, testCtx, sts, clusterObj.Name,
-					testapps.DefaultRedisCompName, podName, replicationset.DefaultRole(i))
+					testapps.DefaultRedisCompName, podName, replication.DefaultRole(i))
 				podList = append(podList, pod)
 			}
 		}

--- a/controllers/k8score/event_controller.go
+++ b/controllers/k8score/event_controller.go
@@ -32,8 +32,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
-	"github.com/apecloud/kubeblocks/controllers/apps/components/consensusset"
-	"github.com/apecloud/kubeblocks/controllers/apps/components/replicationset"
+	"github.com/apecloud/kubeblocks/controllers/apps/components/consensus"
+	"github.com/apecloud/kubeblocks/controllers/apps/components/replication"
 	componentutil "github.com/apecloud/kubeblocks/controllers/apps/components/util"
 	"github.com/apecloud/kubeblocks/internal/constant"
 	intctrlutil "github.com/apecloud/kubeblocks/internal/controllerutil"
@@ -182,9 +182,9 @@ func handleRoleChangedEvent(cli client.Client, reqCtx intctrlutil.RequestCtx, re
 	}
 	switch componentDef.WorkloadType {
 	case appsv1alpha1.Consensus:
-		return role, consensusset.UpdateConsensusSetRoleLabel(cli, reqCtx, componentDef, pod, role)
+		return role, consensus.UpdateConsensusSetRoleLabel(cli, reqCtx, componentDef, pod, role)
 	case appsv1alpha1.Replication:
-		return role, replicationset.HandleReplicationSetRoleChangeEvent(cli, reqCtx, cluster, compName, pod, role)
+		return role, replication.HandleReplicationSetRoleChangeEvent(cli, reqCtx, cluster, compName, pod, role)
 	}
 	return role, nil
 }

--- a/internal/controller/plan/prepare.go
+++ b/internal/controller/plan/prepare.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
-	"github.com/apecloud/kubeblocks/controllers/apps/components/replicationset"
+	"github.com/apecloud/kubeblocks/controllers/apps/components/replication"
 	componentutil "github.com/apecloud/kubeblocks/controllers/apps/components/util"
 	cfgutil "github.com/apecloud/kubeblocks/controllers/apps/configuration"
 	cfgcore "github.com/apecloud/kubeblocks/internal/configuration"
@@ -154,13 +154,13 @@ func PrepareComponentResources(reqCtx intctrlutil.RequestCtx, cli client.Client,
 		// If the statefulSets already exists, check whether there is an HA switching and the HA process is prioritized to handle.
 		// TODO(xingran) After refactoring, HA switching will be handled in the replicationSet controller.
 		if len(existStsList.Items) > 0 {
-			primaryIndexChanged, _, err := replicationset.CheckPrimaryIndexChanged(reqCtx.Ctx, cli, task.Cluster,
+			primaryIndexChanged, _, err := replication.CheckPrimaryIndexChanged(reqCtx.Ctx, cli, task.Cluster,
 				task.Component.Name, task.Component.GetPrimaryIndex())
 			if err != nil {
 				return err
 			}
 			if primaryIndexChanged {
-				if err := replicationset.HandleReplicationSetHASwitch(reqCtx.Ctx, cli, task.Cluster,
+				if err := replication.HandleReplicationSetHASwitch(reqCtx.Ctx, cli, task.Cluster,
 					componentutil.GetClusterComponentSpecByName(*task.Cluster, task.Component.Name)); err != nil {
 					return err
 				}
@@ -196,7 +196,7 @@ func PrepareComponentResources(reqCtx intctrlutil.RequestCtx, cli client.Client,
 		case appsv1alpha1.Consensus:
 			addLeaderSelectorLabels(svc, task.Component)
 		case appsv1alpha1.Replication:
-			svc.Spec.Selector[constant.RoleLabelKey] = string(replicationset.Primary)
+			svc.Spec.Selector[constant.RoleLabelKey] = string(replication.Primary)
 		}
 		task.AppendResource(svc)
 	}

--- a/test/integration/redis_hscale_test.go
+++ b/test/integration/redis_hscale_test.go
@@ -29,7 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
-	"github.com/apecloud/kubeblocks/controllers/apps/components/replicationset"
+	"github.com/apecloud/kubeblocks/controllers/apps/components/replication"
 	"github.com/apecloud/kubeblocks/controllers/apps/components/util"
 	"github.com/apecloud/kubeblocks/internal/constant"
 	intctrlutil "github.com/apecloud/kubeblocks/internal/generics"
@@ -110,9 +110,9 @@ var _ = Describe("Redis Horizontal Scale function", func() {
 		By("Checking statefulSet role label")
 		for _, sts := range stsList.Items {
 			if strings.HasSuffix(sts.Name, strconv.Itoa(testapps.DefaultReplicationPrimaryIndex)) {
-				Expect(sts.Labels[constant.RoleLabelKey]).Should(BeEquivalentTo(replicationset.Primary))
+				Expect(sts.Labels[constant.RoleLabelKey]).Should(BeEquivalentTo(replication.Primary))
 			} else {
-				Expect(sts.Labels[constant.RoleLabelKey]).Should(BeEquivalentTo(replicationset.Secondary))
+				Expect(sts.Labels[constant.RoleLabelKey]).Should(BeEquivalentTo(replication.Secondary))
 			}
 		}
 
@@ -122,9 +122,9 @@ var _ = Describe("Redis Horizontal Scale function", func() {
 			Expect(err).To(Succeed())
 			Expect(len(podList)).Should(BeEquivalentTo(1))
 			if strings.HasSuffix(sts.Name, strconv.Itoa(testapps.DefaultReplicationPrimaryIndex)) {
-				Expect(podList[0].Labels[constant.RoleLabelKey]).Should(BeEquivalentTo(replicationset.Primary))
+				Expect(podList[0].Labels[constant.RoleLabelKey]).Should(BeEquivalentTo(replication.Primary))
 			} else {
-				Expect(podList[0].Labels[constant.RoleLabelKey]).Should(BeEquivalentTo(replicationset.Secondary))
+				Expect(podList[0].Labels[constant.RoleLabelKey]).Should(BeEquivalentTo(replication.Secondary))
 			}
 		}
 
@@ -179,11 +179,11 @@ var _ = Describe("Redis Horizontal Scale function", func() {
 
 			replicationRedisConfigVolumeMounts := []corev1.VolumeMount{
 				{
-					Name:      string(replicationset.Primary),
+					Name:      string(replication.Primary),
 					MountPath: "/etc/conf/primary",
 				},
 				{
-					Name:      string(replicationset.Secondary),
+					Name:      string(replication.Secondary),
 					MountPath: "/etc/conf/secondary",
 				},
 			}
@@ -193,8 +193,8 @@ var _ = Describe("Redis Horizontal Scale function", func() {
 			clusterDefObj = testapps.NewClusterDefFactory(clusterDefName).
 				AddComponentDef(testapps.ReplicationRedisComponent, testapps.DefaultRedisCompDefName).
 				AddScriptTemplate(scriptConfigName, scriptConfigName, testCtx.DefaultNamespace, testapps.ScriptsVolumeName, &mode).
-				AddConfigTemplate(primaryConfigName, primaryConfigName, "", testCtx.DefaultNamespace, string(replicationset.Primary)).
-				AddConfigTemplate(secondaryConfigName, secondaryConfigName, "", testCtx.DefaultNamespace, string(replicationset.Secondary)).
+				AddConfigTemplate(primaryConfigName, primaryConfigName, "", testCtx.DefaultNamespace, string(replication.Primary)).
+				AddConfigTemplate(secondaryConfigName, secondaryConfigName, "", testCtx.DefaultNamespace, string(replication.Secondary)).
 				AddInitContainerVolumeMounts(testapps.DefaultRedisInitContainerName, replicationRedisConfigVolumeMounts).
 				AddContainerVolumeMounts(testapps.DefaultRedisContainerName, replicationRedisConfigVolumeMounts).
 				Create(&testCtx).GetObject()


### PR DESCRIPTION
chore: refactore controllers/apps/components/* packages and structs naming

(cherry picked from commit a9f21f88261c8e9fea6efaa1d0fbaa8f56af0d5a)