### PR TITLE
fix: the restart logic of the configure operator is inconsistent with the judged by kbcli

### DIFF
--- a/internal/cli/cmd/cluster/config_edit.go
+++ b/internal/cli/cmd/cluster/config_edit.go
@@ -34,6 +34,7 @@ import (
 	"github.com/apecloud/kubeblocks/internal/cli/util"
 	"github.com/apecloud/kubeblocks/internal/cli/util/prompt"
 	cfgcore "github.com/apecloud/kubeblocks/internal/configuration"
+	cfgcm "github.com/apecloud/kubeblocks/internal/configuration/config_manager"
 )
 
 type editConfigOptions struct {
@@ -114,7 +115,7 @@ func (o *editConfigOptions) Run(fn func(info *cfgcore.ConfigPatchInfo, cc *appsv
 	}
 
 	confirmPrompt := confirmApplyReconfigurePrompt
-	if !dynamicUpdated {
+	if !dynamicUpdated || !cfgcm.IsSupportReload(configConstraint.Spec.ReloadOptions) {
 		confirmPrompt = restartConfirmPrompt
 	}
 	yes, err := o.confirmReconfigure(confirmPrompt)

--- a/internal/cli/cmd/cluster/config_ops.go
+++ b/internal/cli/cmd/cluster/config_ops.go
@@ -33,6 +33,7 @@ import (
 	"github.com/apecloud/kubeblocks/internal/cli/util"
 	"github.com/apecloud/kubeblocks/internal/cli/util/prompt"
 	cfgcore "github.com/apecloud/kubeblocks/internal/configuration"
+	cfgcm "github.com/apecloud/kubeblocks/internal/configuration/config_manager"
 )
 
 type configOpsOptions struct {
@@ -127,6 +128,10 @@ func (o *configOpsOptions) checkChangedParamsAndDoubleConfirm(cc *appsv1alpha1.C
 			r[key] = ""
 		}
 		return r
+	}
+
+	if !cfgcm.IsSupportReload(cc.ReloadOptions) {
+		return o.confirmReconfigureWithRestart()
 	}
 
 	configPatch, _, err := cfgcore.CreateConfigPatch(mockEmptyData(data), data, cc.FormatterConfig.Format, tpl.Keys, false)


### PR DESCRIPTION
restart logic：
1.  reloadOptions indicates whether the process supports reload. if not set, restart.
2. if set reloadOptions, restart or reload depending on whether any parameters in the StaticParameters have been modified.