### PR TITLE
chore: useraccount update flag name

### DIFF
--- a/docs/user_docs/cli/kbcli_cluster_create-account.md
+++ b/docs/user_docs/cli/kbcli_cluster_create-account.md
@@ -25,8 +25,8 @@ kbcli cluster create-account [flags]
       --component string   Specify the name of component to be connected. If not specified, the first component will be used.
   -h, --help               help for create-account
   -i, --instance string    Specify the name of instance to be connected.
+      --name string        Required. Specify the name of user, which must be unique.
   -p, --password string    Optional. Specify the password of user. The default value is empty, which means a random password will be generated.
-  -u, --username string    Required. Specify the name of user, which must be unique.
 ```
 
 ### Options inherited from parent commands

--- a/docs/user_docs/cli/kbcli_cluster_delete-account.md
+++ b/docs/user_docs/cli/kbcli_cluster_delete-account.md
@@ -21,7 +21,7 @@ kbcli cluster delete-account [flags]
       --component string   Specify the name of component to be connected. If not specified, the first component will be used.
   -h, --help               help for delete-account
   -i, --instance string    Specify the name of instance to be connected.
-  -u, --username string    Required. Specify the name of user
+      --name string        Required. Specify the name of user
 ```
 
 ### Options inherited from parent commands

--- a/docs/user_docs/cli/kbcli_cluster_describe-account.md
+++ b/docs/user_docs/cli/kbcli_cluster_describe-account.md
@@ -21,7 +21,7 @@ kbcli cluster describe-account [flags]
       --component string   Specify the name of component to be connected. If not specified, the first component will be used.
   -h, --help               help for describe-account
   -i, --instance string    Specify the name of instance to be connected.
-  -u, --username string    Required. Specify the name of user
+      --name string        Required. Specify the name of user
 ```
 
 ### Options inherited from parent commands

--- a/docs/user_docs/cli/kbcli_cluster_grant-role.md
+++ b/docs/user_docs/cli/kbcli_cluster_grant-role.md
@@ -21,8 +21,8 @@ kbcli cluster grant-role [flags]
       --component string   Specify the name of component to be connected. If not specified, the first component will be used.
   -h, --help               help for grant-role
   -i, --instance string    Specify the name of instance to be connected.
+      --name string        Required. Specify the name of user.
   -r, --role string        Role name should be one of {SUPERUSER, READWRITE, READONLY}
-  -u, --username string    Required. Specify the name of user.
 ```
 
 ### Options inherited from parent commands

--- a/docs/user_docs/cli/kbcli_cluster_revoke-role.md
+++ b/docs/user_docs/cli/kbcli_cluster_revoke-role.md
@@ -21,8 +21,8 @@ kbcli cluster revoke-role [flags]
       --component string   Specify the name of component to be connected. If not specified, the first component will be used.
   -h, --help               help for revoke-role
   -i, --instance string    Specify the name of instance to be connected.
+      --name string        Required. Specify the name of user.
   -r, --role string        Role name should be one of {SUPERUSER, READWRITE, READONLY}
-  -u, --username string    Required. Specify the name of user.
 ```
 
 ### Options inherited from parent commands

--- a/internal/cli/cmd/accounts/create.go
+++ b/internal/cli/cmd/accounts/create.go
@@ -38,7 +38,7 @@ func NewCreateUserOptions(f cmdutil.Factory, streams genericclioptions.IOStreams
 
 func (o *CreateUserOptions) AddFlags(cmd *cobra.Command) {
 	o.AccountBaseOptions.AddFlags(cmd)
-	cmd.Flags().StringVarP(&o.info.UserName, "username", "u", "", "Required. Specify the name of user, which must be unique.")
+	cmd.Flags().StringVar(&o.info.UserName, "name", "", "Required. Specify the name of user, which must be unique.")
 	cmd.Flags().StringVarP(&o.info.Password, "password", "p", "", "Optional. Specify the password of user. The default value is empty, which means a random password will be generated.")
 	// TODO:@shanshan add expire flag if needed
 	// cmd.Flags().DurationVar(&o.info.ExpireAt, "expire", 0, "Optional. Specify the expire time of password. The default value is 0, which means the user will never expire.")

--- a/internal/cli/cmd/accounts/delete.go
+++ b/internal/cli/cmd/accounts/delete.go
@@ -38,7 +38,7 @@ func NewDeleteUserOptions(f cmdutil.Factory, streams genericclioptions.IOStreams
 
 func (o *DeleteUserOptions) AddFlags(cmd *cobra.Command) {
 	o.AccountBaseOptions.AddFlags(cmd)
-	cmd.Flags().StringVarP(&o.info.UserName, "username", "u", "", "Required. Specify the name of user")
+	cmd.Flags().StringVar(&o.info.UserName, "name", "", "Required. Specify the name of user")
 }
 
 func (o *DeleteUserOptions) Validate(args []string) error {

--- a/internal/cli/cmd/accounts/describe.go
+++ b/internal/cli/cmd/accounts/describe.go
@@ -37,7 +37,7 @@ func NewDescribeUserOptions(f cmdutil.Factory, streams genericclioptions.IOStrea
 
 func (o *DescribeUserOptions) AddFlags(cmd *cobra.Command) {
 	o.AccountBaseOptions.AddFlags(cmd)
-	cmd.Flags().StringVarP(&o.info.UserName, "username", "u", "", "Required. Specify the name of user")
+	cmd.Flags().StringVar(&o.info.UserName, "name", "", "Required. Specify the name of user")
 }
 
 func (o DescribeUserOptions) Validate(args []string) error {

--- a/internal/cli/cmd/accounts/grant.go
+++ b/internal/cli/cmd/accounts/grant.go
@@ -46,7 +46,7 @@ func NewGrantOptions(f cmdutil.Factory, streams genericclioptions.IOStreams, op 
 
 func (o *GrantOptions) AddFlags(cmd *cobra.Command) {
 	o.AccountBaseOptions.AddFlags(cmd)
-	cmd.Flags().StringVarP(&o.info.UserName, "username", "u", "", "Required. Specify the name of user.")
+	cmd.Flags().StringVar(&o.info.UserName, "name", "", "Required. Specify the name of user.")
 	cmd.Flags().StringVarP(&o.info.RoleName, "role", "r", "", "Role name should be one of {SUPERUSER, READWRITE, READONLY}")
 }
 


### PR DESCRIPTION
fixes #2721 #2714
- #2721 
- #2714 
 
Update flag `username` to `name`