### PR TITLE
chore: cli set default cluster value based on workload and component type

### DIFF
--- a/internal/cli/cmd/cluster/create_test.go
+++ b/internal/cli/cmd/cluster/create_test.go
@@ -292,8 +292,8 @@ var _ = Describe("create", func() {
 				true,
 			},
 			{
-				[]string{"type=comp1,cpu=1,memory=2Gi,class=general-2c4g", "type=comp2,storage=10Gi,cpu=2,class=mo-1c8g"},
-				[]string{"my-comp"},
+				[]string{"type=comp1,cpu=1,memory=2Gi,class=general-2c4g", "type=comp2,storage=10Gi,cpu=2,class=mo-1c8g,replicas=3"},
+				[]string{"comp1", "comp2"},
 				map[string]map[setKey]string{
 					"comp1": {
 						keyType:   "comp1",
@@ -302,10 +302,11 @@ var _ = Describe("create", func() {
 						keyClass:  "general-2c4g",
 					},
 					"comp2": {
-						keyType:    "comp2",
-						keyCPU:     "2",
-						keyStorage: "10Gi",
-						keyClass:   "mo-1c8g",
+						keyType:     "comp2",
+						keyCPU:      "2",
+						keyStorage:  "10Gi",
+						keyClass:    "mo-1c8g",
+						keyReplicas: "3",
 					},
 				},
 				true,


### PR DESCRIPTION
cli set default cluster value based on workload type and component type, make it easier for users to create clusters using kbcli.

* set replicationSet workload default replicas to 2
* set redis sentinel replicas to 3, and cpu to 200m, memory to 200Mi
* check if specified type is defined in the cluster definition


```
$ kbcli cluster create --cluster-definition redis                                                                                     
Warning: cluster version is not specified, use the recently created ClusterVersion redis-7.0.6
Cluster willow87 created

$ kbcli cluster describe willow87                
Name: willow87   Created Time: Apr 19,2023 20:37 UTC+0800
NAMESPACE   CLUSTER-DEFINITION   VERSION       STATUS     TERMINATION-POLICY   
default     redis                redis-7.0.6   Creating   Delete               

Endpoints:
COMPONENT        MODE        INTERNAL                                                  EXTERNAL   
redis            ReadWrite   willow87-redis.default.svc.cluster.local:6379             <none>     
                             willow87-redis.default.svc.cluster.local:9121                        
redis-sentinel   ReadWrite   willow87-redis-sentinel.default.svc.cluster.local:26379   <none>     

Topology:
COMPONENT        INSTANCE                    ROLE        STATUS    AZ       NODE                    CREATED-TIME                 
redis            willow87-redis-0            primary     Pending   <none>   minikube/192.168.49.2   Apr 19,2023 20:37 UTC+0800   
redis            willow87-redis-1            secondary   Pending   <none>   minikube/192.168.49.2   Apr 19,2023 20:37 UTC+0800   
redis-sentinel   willow87-redis-sentinel-0   <none>      Pending   <none>   minikube/192.168.49.2   Apr 19,2023 20:37 UTC+0800   
redis-sentinel   willow87-redis-sentinel-1   <none>      Pending   <none>   minikube/192.168.49.2   Apr 19,2023 20:37 UTC+0800   
redis-sentinel   willow87-redis-sentinel-2   <none>      Pending   <none>   minikube/192.168.49.2   Apr 19,2023 20:37 UTC+0800   

Resources Allocation:
COMPONENT        DEDICATED   CPU(REQUEST/LIMIT)   MEMORY(REQUEST/LIMIT)   STORAGE-SIZE   STORAGE-CLASS   
redis            false       1 / 1                1Gi / 1Gi               data:20Gi      standard        
redis-sentinel   false       200m / 200m          200Mi / 200Mi           data:20Gi      standard        

Images:
COMPONENT        TYPE             IMAGE                                
redis            redis            redis/redis-stack-server:7.0.6-RC8   
redis-sentinel   redis-sentinel   redis/redis-stack-server:7.0.6-RC8   

Data Protection:
AUTO-BACKUP   BACKUP-SCHEDULE   TYPE       BACKUP-TTL   LAST-SCHEDULE   RECOVERABLE-TIME   
Disabled      0 18 * * 0        snapshot   7d           <none>          <none>             

$ kbcli cluster create --cluster-definition redis --set type=test
error: the type "test" is not a valid component definition name


```