### PR TITLE
fix: vscale example typo (#2723)

### DIFF
--- a/docs/user_docs/cli/kbcli_cluster_vscale.md
+++ b/docs/user_docs/cli/kbcli_cluster_vscale.md
@@ -15,7 +15,7 @@ kbcli cluster vscale [flags]
   kbcli cluster vscale <my-cluster> --components=<component-name> --cpu=500m --memory=500Mi
   
   # scale the computing resources of specified components by class, available classes can be get by executing the command "kbcli class list --cluster-definition <cluster-definition-name>"
-  kbcli cluster vscale <my-cluster> --components=<component-name> --set class=general-1c4g
+  kbcli cluster vscale <my-cluster> --components=<component-name> --class=<class-name>
 ```
 
 ### Options

--- a/internal/cli/cmd/cluster/operations.go
+++ b/internal/cli/cmd/cluster/operations.go
@@ -349,7 +349,7 @@ var verticalScalingExample = templates.Examples(`
 		kbcli cluster vscale <my-cluster> --components=<component-name> --cpu=500m --memory=500Mi 
 
 		# scale the computing resources of specified components by class, available classes can be get by executing the command "kbcli class list --cluster-definition <cluster-definition-name>"
-		kbcli cluster vscale <my-cluster> --components=<component-name> --set class=general-1c4g
+		kbcli cluster vscale <my-cluster> --components=<component-name> --class=<class-name>
 `)
 
 // NewVerticalScalingCmd creates a vertical scaling command


### PR DESCRIPTION
(cherry picked from commit b2467b802b317ddfb10f097ae5540d13e4b88519)