### PR TITLE
fix: sqlchannel-parse-unsupportd-binding-response

### DIFF
--- a/internal/sqlchannel/client.go
+++ b/internal/sqlchannel/client.go
@@ -196,6 +196,7 @@ type OperationHTTPClient struct {
 	httpRequestPrefix string
 	RequestTimeout    time.Duration
 	containerName     string
+	characterType     string
 }
 
 // NewHTTPClientWithChannelPod create a new OperationHTTPClient with sqlchannel container
@@ -225,6 +226,7 @@ func NewHTTPClientWithChannelPod(pod *corev1.Pod, characterType string) (*Operat
 		httpRequestPrefix: fmt.Sprintf(HTTPRequestPrefx, port, characterType),
 		RequestTimeout:    10 * time.Second,
 		containerName:     container,
+		characterType:     characterType,
 	}
 	return client, nil
 }
@@ -232,10 +234,10 @@ func NewHTTPClientWithChannelPod(pod *corev1.Pod, characterType string) (*Operat
 // SendRequest exec sql operation, this is a blocking operation and it will use pod EXEC subresource to send an http request to the probe pod
 func (cli *OperationHTTPClient) SendRequest(exec *exec.ExecOptions, request SQLChannelRequest) (SQLChannelResponse, error) {
 	var (
-		response  = SQLChannelResponse{}
 		strBuffer bytes.Buffer
 		errBuffer bytes.Buffer
 		err       error
+		response  = SQLChannelResponse{}
 	)
 
 	if jsonData, err := json.Marshal(request); err != nil {
@@ -249,9 +251,35 @@ func (cli *OperationHTTPClient) SendRequest(exec *exec.ExecOptions, request SQLC
 	if err = exec.RunWithRedirect(&strBuffer, &errBuffer); err != nil {
 		return response, err
 	}
+	return parseResponse(strBuffer.Bytes(), request.Operation, cli.characterType)
+}
 
-	if err = json.Unmarshal(strBuffer.Bytes(), &response); err != nil {
+type errorResponse struct {
+	ErrorCode string `json:"errorCode"`
+	Message   string `json:"message"`
+}
+
+func parseResponse(data []byte, operation string, charType string) (SQLChannelResponse, error) {
+	// conver to errorResponse first, and check error code
+	// if error code is not empty, it means the request failed
+	errorResponse := errorResponse{}
+	response := SQLChannelResponse{}
+	if err := json.Unmarshal(data, &errorResponse); err != nil {
 		return response, err
+	} else if len(errorResponse.ErrorCode) > 0 {
+		return SQLChannelResponse{
+			Event:   RespEveFail,
+			Message: fmt.Sprintf("Operation `%s` on component of type `%s` is not supported yet.", operation, charType),
+			Metadata: SQLChannelMeta{
+				Operation: operation,
+				StartTime: time.Now(),
+				EndTime:   time.Now(),
+				Extra:     errorResponse.Message,
+			},
+		}, nil
 	}
-	return response, nil
+
+	// conver it to SQLChannelResponse
+	err := json.Unmarshal(data, &response)
+	return response, err
 }


### PR DESCRIPTION
- fix #2769  
 
If OutBinding is not supported, SqlChannel returns an error response message(it's actually DAPR's early termination resposne).
We shall distinguish following types of msg:  
- output binding not supported
```json
{"errorCode":"ERR_INVOKE_OUTPUT_BINDING","message":"error when invoke output binding ..."}
``` 
- output binding is supoorted but with error
```json
{"event":"Failed","message":"db not ready"} 
```
- output binding succes 
```json 
{"event":"Success","message":"..."}  
``` 