### PR TITLE
fix: sqlchannel-parse-unsupportd-binding-response (#2790)

### DIFF
--- a/internal/sqlchannel/client_test.go
+++ b/internal/sqlchannel/client_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	pb "github.com/dapr/go-sdk/dapr/proto/runtime/v1"
+	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	corev1 "k8s.io/api/core/v1"
 
@@ -143,6 +144,46 @@ func TestGetRole(t *testing.T) {
 		if len(cli.cache) != 0 {
 			t.Errorf("cache should be cleared: %v", cli.cache)
 		}
+	})
+}
+
+func TestParseSqlChannelResult(t *testing.T) {
+	t.Run("Binding Not Supported", func(t *testing.T) {
+		result := `
+	{"errorCode":"ERR_INVOKE_OUTPUT_BINDING","message":"error when invoke output binding mongodb: binding mongodb does not support operation listUsers. supported operations:checkRunning checkRole getRole"}
+	`
+		sqlResposne, err := parseResponse(([]byte)(result), "listUsers", "mongodb")
+		assert.Nil(t, err)
+		assert.Equal(t, sqlResposne.Event, RespEveFail)
+		assert.Contains(t, sqlResposne.Message, "not supported")
+	})
+
+	t.Run("Binding Exec Failed", func(t *testing.T) {
+		result := `
+	{"event":"Failed","message":"db not ready"}
+	`
+		sqlResposne, err := parseResponse(([]byte)(result), "listUsers", "mongodb")
+		assert.Nil(t, err)
+		assert.Equal(t, sqlResposne.Event, RespEveFail)
+		assert.Contains(t, sqlResposne.Message, "db not ready")
+	})
+
+	t.Run("Binding Exec Success", func(t *testing.T) {
+		result := `
+	{"event":"Success","message":"[]"}
+	`
+		sqlResposne, err := parseResponse(([]byte)(result), "listUsers", "mongodb")
+		assert.Nil(t, err)
+		assert.Equal(t, sqlResposne.Event, RespEveSucc)
+	})
+
+	t.Run("Invalid Resonse Format", func(t *testing.T) {
+		// msg cannot be parsed to json
+		result := `
+	{"event":"Success","message":"[]
+	`
+		_, err := parseResponse(([]byte)(result), "listUsers", "mongodb")
+		assert.NotNil(t, err)
 	})
 }
 


### PR DESCRIPTION
fix #2769 (cherry picked from commit ac077b9a31d27664f818fd4c102a43c3eb0b3c16)