### PR TITLE
chore: disable hook when uninstall KubeBlocks

### DIFF
--- a/internal/cli/cmd/kubeblocks/uninstall.go
+++ b/internal/cli/cmd/kubeblocks/uninstall.go
@@ -178,6 +178,10 @@ func (o *UninstallOptions) Uninstall() error {
 	chart := helm.InstallOpts{
 		Name:      types.KubeBlocksChartName,
 		Namespace: o.Namespace,
+
+		// KubeBlocks chart has a hook to delete addons, but we have already deleted addons,
+		// and that webhook may fail, so we need to disable hooks.
+		DisableHooks: true,
 	}
 	printSpinner(newSpinner("Uninstall helm release "+types.KubeBlocksReleaseName+" "+v.KubeBlocks),
 		chart.Uninstall(o.HelmCfg))

--- a/internal/cli/util/helm/helm.go
+++ b/internal/cli/util/helm/helm.go
@@ -66,6 +66,7 @@ type InstallOpts struct {
 	ValueOpts       *values.Options
 	Timeout         time.Duration
 	Atomic          bool
+	DisableHooks    bool
 }
 
 type Option func(*cli.EnvSettings)
@@ -282,6 +283,7 @@ func (i *InstallOpts) tryUninstall(cfg *action.Configuration) error {
 	client := action.NewUninstall(cfg)
 	client.Wait = i.Wait
 	client.Timeout = defaultTimeout
+	client.DisableHooks = i.DisableHooks
 
 	// Create context and prepare the handle of SIGTERM
 	ctx := context.Background()


### PR DESCRIPTION

```
k get pods -A
NAMESPACE     NAME                                                             READY   STATUS             RESTARTS        AGE
kb-system     kb-addon-alertmanager-webhook-adaptor-5bd87c4697-hvrcf           2/2     Running            0               8m36s
kb-system     kb-addon-grafana-77c7f45cd6-5g84t                                3/3     Running            0               9m40s
kb-system     kb-addon-prometheus-alertmanager-0                               2/2     Running            0               6m50s
kb-system     kb-addon-prometheus-server-0                                     2/2     Running            0               6m50s
kb-system     kubeblocks-58479995c-rvgp9                                       1/1     Running            6 (6m52s ago)   12m
kb-system     kubeblocks-addon-removal-j4vql                                   0/1     CrashLoopBackOff   5 (47s ago)     4m20s

```

The job `kubeblocks-addon-removal` is created by KubeBlocks helm hook.