### PR TITLE
fix: set driver for bench config

### DIFF
--- a/internal/cli/cmd/bench/tpcc.go
+++ b/internal/cli/cmd/bench/tpcc.go
@@ -113,6 +113,7 @@ func executeTpcc(action string) error {
 	tpccConfig.DBName = dbName
 	tpccConfig.Threads = threads
 	tpccConfig.Isolation = isolationLevel
+	tpccConfig.Driver = driver
 
 	switch tpccConfig.OutputType {
 	case "csv", "CSV":


### PR DESCRIPTION







* fix #1986

```
$ kbcli bench tpcc prepare --password 12345..
creating table warehouse
creating table district
creating table customer
creating table history
creating table new_order
creating table orders
creating table order_line
creating table stock
creating table item
load to item
load to warehouse in warehouse 1
load to stock in warehouse 1
load to district in warehouse 1
load to warehouse in warehouse 2
load to stock in warehouse 2
load to district in warehouse 2
load to warehouse in warehouse 3
load to stock in warehouse 3
load to district in warehouse 3
load to warehouse in warehouse 4
load to stock in warehouse 4

```