### PR TITLE
chore: improve cli create cluster output message

### DIFF
--- a/internal/cli/cmd/cluster/create.go
+++ b/internal/cli/cmd/cluster/create.go
@@ -45,6 +45,7 @@ import (
 	dataprotectionv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
 	"github.com/apecloud/kubeblocks/internal/cli/cluster"
 	"github.com/apecloud/kubeblocks/internal/cli/create"
+	"github.com/apecloud/kubeblocks/internal/cli/printer"
 	"github.com/apecloud/kubeblocks/internal/cli/types"
 	"github.com/apecloud/kubeblocks/internal/cli/util"
 	"github.com/apecloud/kubeblocks/internal/constant"


### PR DESCRIPTION


```
$ kbcli cluster create --cluster-definition apecloud-mysql
Info: --cluster-version is not specified, ClusterVersion ac-mysql-8.0.30 is applied by default
Cluster fennel17 created
```