### PR TITLE
auto enable snapshot-controller

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1608,7 +1608,7 @@ grafana:
 snapshot-controller:
   ## @param snapshot-controller.enabled -- Enable snapshot-controller chart.
   ##
-  enabled: false
+  enabled: true
   ## @param snapshot-controller.replicaCount -- Number of replicas to deploy.
   ##
   replicaCount: 1


### PR DESCRIPTION
- set snapshot-controller.enabled to `true` at kubeblocks install.(and `tke` does not contain)
```
kbcli addon list
NAME                           TYPE   STATUS     EXTRAS         AUTO-INSTALL   AUTO-INSTALLABLE-SELECTOR
snapshot-controller            Helm   Enabled                   true           {key=KubeGitVersion,op=DoesNotContain,values=[tke]}
```