### PR TITLE
chore: build tools image dockerfile add testdata

### DIFF
--- a/docker/Dockerfile-tools
+++ b/docker/Dockerfile-tools
@@ -41,6 +41,7 @@ COPY externalapis/ externalapis/
 COPY version/ version/
 COPY cmd/cli/ cmd/cli/
 COPY apis/ apis/
+COPY test/testdata/testdata.go test/testdata/testdata.go
 
 # Download binaries
 RUN curl -fsSL https://dl.k8s.io/v1.26.3/kubernetes-client-${TARGETOS}-${TARGETARCH}.tar.gz | tar -zxv


### PR DESCRIPTION
fix make build-tools-image failed.
failed action: https://github.com/apecloud/kubeblocks/actions/runs/4777757400/jobs/8493834173