### PR TITLE
fix: cli ops command output lost ops name

### DIFF
--- a/internal/cli/create/create.go
+++ b/internal/cli/create/create.go
@@ -263,14 +263,14 @@ func (o *BaseOptions) Run(inputs Inputs) error {
 			return err
 		}
 		if dryRunStrategy != DryRunServer {
-			o.Name = unstructuredObj.GetName()
+			o.Name = previewObj.GetName()
 			if o.Quiet {
 				return nil
 			}
 			if inputs.CustomOutPut != nil {
 				inputs.CustomOutPut(o)
 			} else {
-				fmt.Fprintf(o.Out, "%s %s created\n", unstructuredObj.GetKind(), unstructuredObj.GetName())
+				fmt.Fprintf(o.Out, "%s %s created\n", previewObj.GetKind(), previewObj.GetName())
 			}
 			return nil
 		}


### PR DESCRIPTION
* fix #2902

Before:
```shell
$ kbcli cluster hscale laurel81 --replicas=2
Please type the name again(separate with white space when more than one): laurel81
OpsRequest  created successfully, you can view the progress:
        kbcli cluster describe-ops  -n default

```

After:
```shell
$ kbcli cluster hscale laurel81 --replicas=2
Please type the name again(separate with white space when more than one): laurel81
OpsRequest laurel81-horizontalscaling-d8hcm created successfully, you can view the progress:
        kbcli cluster describe-ops laurel81-horizontalscaling-d8hcm -n default
$ kbcli cluster stop laurel81               
Please type the name again(separate with white space when more than one): laurel81
OpsRequest laurel81-stop-mt2mk created successfully, you can view the progress:
        kbcli cluster describe-ops laurel81-stop-mt2mk -n default

```