### PR TITLE
fix: redis edit-config and configure behave inconsistently

### DIFF
--- a/internal/unstructured/redis_config.go
+++ b/internal/unstructured/redis_config.go
@@ -50,7 +50,7 @@ func (r *redisConfig) Update(key string, value any) error {
 }
 
 func (r *redisConfig) setString(key string, value string) error {
-	keys := strings.Split(key, ".")
+	keys := strings.Split(key, " ")
 	v := r.GetItem(keys)
 	lineNo := math.MaxInt32
 	if v != nil {
@@ -107,7 +107,7 @@ func (r *redisConfig) GetItem(keys []string) *redis.Item {
 }
 
 func (r *redisConfig) GetString(key string) (string, error) {
-	keys := strings.Split(key, ".")
+	keys := strings.Split(key, " ")
 	item := r.GetItem(keys)
 	if item == nil {
 		return "", nil

--- a/internal/unstructured/redis_config_test.go
+++ b/internal/unstructured/redis_config_test.go
@@ -58,21 +58,21 @@ func TestRedisConfig(t *testing.T) {
 		valueArgs: "256mb 64mb 60",
 		wantErr:   false,
 		testKey: map[string]string{
-			"client-output-buffer-limit.pubsub": "256mb 64mb 60",
+			"client-output-buffer-limit pubsub": "256mb 64mb 60",
 		},
 	}, {
 		keyArgs:   []string{"client-output-buffer-limit", "normal"},
 		valueArgs: "128mb 32mb 0",
 		wantErr:   false,
 		testKey: map[string]string{
-			"client-output-buffer-limit.normal": "128mb 32mb 0",
-			"client-output-buffer-limit.pubsub": "256mb 64mb 60",
+			"client-output-buffer-limit normal": "128mb 32mb 0",
+			"client-output-buffer-limit pubsub": "256mb 64mb 60",
 			"port":                              "6379",
 		},
 	}}
 	for _, tt := range tests {
 		t.Run("config_test", func(t *testing.T) {
-			if err := c.Update(strings.Join(tt.keyArgs, "."), tt.valueArgs); (err != nil) != tt.wantErr {
+			if err := c.Update(strings.Join(tt.keyArgs, " "), tt.valueArgs); (err != nil) != tt.wantErr {
 				t.Errorf("Update() error = %v, wantErr %v", err, tt.wantErr)
 			}
 


### PR DESCRIPTION
(cherry picked from commit b98d78bf3fa664d1158c02e88a8324ace82fbea8)