### PR TITLE
fix: kbcli cluster with no default SC describe panic

### DIFF
--- a/internal/cli/cluster/cluster.go
+++ b/internal/cli/cluster/cluster.go
@@ -355,7 +355,6 @@ func (o *ClusterObjects) getStorageInfo(component *appsv1alpha1.ClusterComponent
 			} else {
 				return types.None
 			}
-
 		}
 
 		return types.None


### PR DESCRIPTION
- #2885 
- what i do:

1. add a check before `return StorageClassName`, if the field is nil return types.None

example:
1. do not have a  default StorageClass
![11](https://user-images.githubusercontent.com/101848970/234159947-bdd1ae5f-1622-4b4d-81cf-d1b801a2db4c.png)
2. create a cluster without default StorageClass   ` tips : in 0.6.0  create a cluster without default StorageClass will be prohibited`
![12](https://user-images.githubusercontent.com/101848970/234160515-1a590ec9-82c7-4854-920b-0512c7362366.png)
3. check the pods
![13](https://user-images.githubusercontent.com/101848970/234160524-7b9d73a3-80bb-4a27-aaaa-0bffb4ba38af.png)
4. kbcli describe cluster without StorageClass
![14](https://user-images.githubusercontent.com/101848970/234160553-1f5dc566-6ee6-4b0d-a6bf-0663fd75551c.png)
