### PR TITLE
fix: clusterversion specify client image

### DIFF
--- a/apis/apps/v1alpha1/clusterversion_types.go
+++ b/apis/apps/v1alpha1/clusterversion_types.go
@@ -82,6 +82,11 @@ type ClusterComponentVersion struct {
 	// +listMapKey=name
 	ConfigSpecs []ComponentConfigSpec `json:"configSpecs,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name"`
 
+	// clientImage define image for the component to connect database or engines.
+	// This value has a higher proirity over ClusterDefinition.spec.componentDefs.systemAccountSpec.cmdExecutorConfig.image.
+	// +optional
+	ClientImage string `json:"clientImage,omitempty"`
+
 	// versionContext defines containers images' context for component versions,
 	// this value replaces ClusterDefinition.spec.componentDefs.podSpec.[initContainers | containers]
 	VersionsCtx VersionsContext `json:"versionsContext"`

--- a/config/crd/bases/apps.kubeblocks.io_clusterversions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusterversions.yaml
@@ -62,6 +62,11 @@ spec:
                   description: ClusterComponentVersion is an application version component
                     spec.
                   properties:
+                    clientImage:
+                      description: clientImage define image for the component to connect
+                        database or engines. This value has a higher proirity over
+                        ClusterDefinition.spec.componentDefs.systemAccountSpec.cmdExecutorConfig.image.
+                      type: string
                     componentDefRef:
                       description: componentDefRef reference one of the cluster component
                         definition names in ClusterDefinition API (spec.componentDefs.name).

--- a/controllers/apps/systemaccount_controller.go
+++ b/controllers/apps/systemaccount_controller.go
@@ -138,17 +138,24 @@ func (r *SystemAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return intctrlutil.Reconciled()
 	}
 
+	// wait till the cluster is running
+	if cluster.Status.Phase != appsv1alpha1.RunningClusterPhase {
+		reqCtx.Log.V(1).Info("Cluster is not ready yet", "cluster", req.NamespacedName)
+		return intctrlutil.Reconciled()
+	}
+
 	clusterdefinition := &appsv1alpha1.ClusterDefinition{}
 	clusterDefNS := types.NamespacedName{Name: cluster.Spec.ClusterDefRef}
 	if err := r.Client.Get(reqCtx.Ctx, clusterDefNS, clusterdefinition); err != nil {
 		return intctrlutil.RequeueWithErrorAndRecordEvent(cluster, r.Recorder, err, reqCtx.Log)
 	}
 
-	// wait till the cluster is running
-	if cluster.Status.Phase != appsv1alpha1.RunningClusterPhase {
-		reqCtx.Log.V(1).Info("Cluster is not ready yet", "cluster", req.NamespacedName)
-		return intctrlutil.Reconciled()
+	clusterVersion := &appsv1alpha1.ClusterVersion{}
+	if err := r.Client.Get(reqCtx.Ctx, types.NamespacedName{Name: cluster.Spec.ClusterVersionRef}, clusterVersion); err != nil {
+		return intctrlutil.RequeueWithErrorAndRecordEvent(cluster, r.Recorder, err, reqCtx.Log)
 	}
+
+	componentVersions := clusterVersion.Spec.GetDefNameMappingComponents()
 
 	// process accounts per component
 	processAccountsForComponent := func(compDef *appsv1alpha1.ClusterComponentDefinition, compDecl *appsv1alpha1.ClusterComponentSpec,
@@ -205,6 +212,8 @@ func (r *SystemAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			case appsv1alpha1.CreateByStmt:
 				if engine == nil {
 					execConfig := compDef.SystemAccounts.CmdExecutorConfig
+					// complete execConfig with settings from component version
+					completeExecConfig(execConfig, componentVersions[compDef.Name])
 					engine = newCustomizedEngine(execConfig, cluster, compDecl.Name)
 				}
 				if err := r.createByStmt(reqCtx, cluster, compDef, compKey, engine, account, svcEP, headlessEP, strategy); err != nil {

--- a/controllers/apps/systemaccount_util.go
+++ b/controllers/apps/systemaccount_util.go
@@ -390,3 +390,14 @@ func calibrateJobMetaAndSpec(job *batchv1.Job, cluster *appsv1alpha1.Cluster, co
 	tolerations = componetutil.PatchBuiltInToleration(tolerations)
 	job.Spec.Template.Spec.Tolerations = tolerations
 }
+
+// completeExecConfig override the image of execConfig if version is not nil.
+func completeExecConfig(execConfig *appsv1alpha1.CmdExecutorConfig, version *appsv1alpha1.ClusterComponentVersion) {
+	if version == nil {
+		return
+	}
+	if len(version.ClientImage) == 0 {
+		return
+	}
+	execConfig.Image = version.ClientImage
+}

--- a/deploy/helm/crds/apps.kubeblocks.io_clusterversions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusterversions.yaml
@@ -62,6 +62,11 @@ spec:
                   description: ClusterComponentVersion is an application version component
                     spec.
                   properties:
+                    clientImage:
+                      description: clientImage define image for the component to connect
+                        database or engines. This value has a higher proirity over
+                        ClusterDefinition.spec.componentDefs.systemAccountSpec.cmdExecutorConfig.image.
+                      type: string
                     componentDefRef:
                       description: componentDefRef reference one of the cluster component
                         definition names in ClusterDefinition API (spec.componentDefs.name).

--- a/deploy/postgresql/templates/clusterversion.yaml
+++ b/deploy/postgresql/templates/clusterversion.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
       - name: postgresql
         image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
+    clientImage: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
 
 ---
 apiVersion: apps.kubeblocks.io/v1alpha1
@@ -45,4 +46,5 @@ spec:
         containers:
           - name: postgresql
             image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:12.14.0
+      clientImage: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:12.14.0
 ---


### PR DESCRIPTION
- fix #3016   

SystemAccounts create account through client.  And the client image info is specified in ClusterDefintion.  
To lift this constraint,  we should provide a way for user to set his `client image` in each cluster version. 