### PR TITLE
chore: cli cluster describe does not show events

### DIFF
--- a/internal/cli/cmd/cluster/describe.go
+++ b/internal/cli/cmd/cluster/describe.go
@@ -41,7 +41,6 @@ import (
 	"github.com/apecloud/kubeblocks/internal/cli/printer"
 	"github.com/apecloud/kubeblocks/internal/cli/types"
 	"github.com/apecloud/kubeblocks/internal/cli/util"
-	"github.com/apecloud/kubeblocks/internal/constant"
 )
 
 var (
@@ -135,7 +134,6 @@ func (o *describeOptions) describeCluster(name string) error {
 			WithClusterDef:     true,
 			WithService:        true,
 			WithPod:            true,
-			WithEvent:          true,
 			WithPVC:            true,
 			WithDataProtection: true,
 		},
@@ -166,7 +164,7 @@ func (o *describeOptions) describeCluster(name string) error {
 	showDataProtection(o.BackupPolicies, o.Backups, o.Out)
 
 	// events
-	showEvents(o.Events, o.Cluster.Name, o.Cluster.Namespace, o.Out)
+	showEvents(o.Cluster.Name, o.Cluster.Namespace, o.Out)
 	fmt.Fprintln(o.Out)
 
 	return nil
@@ -206,27 +204,9 @@ func showImages(comps []*cluster.ComponentInfo, out io.Writer) {
 	tbl.Print()
 }
 
-func showEvents(events *corev1.EventList, name string, namespace string, out io.Writer) {
-	objs := util.SortEventsByLastTimestamp(events, corev1.EventTypeWarning)
-
-	// print last 5 events
-	title := fmt.Sprintf("\nEvents(last 5 warnings, see more:kbcli cluster list-events -n %s %s):", namespace, name)
-	tbl := newTbl(out, title, "TIME", "TYPE", "REASON", "OBJECT", "MESSAGE")
-	cnt := 0
-	for _, o := range *objs {
-		e := o.(*corev1.Event)
-		// do not output KubeBlocks probe events
-		if e.InvolvedObject.FieldPath == constant.ProbeCheckRolePath {
-			continue
-		}
-
-		tbl.AddRow(util.GetEventTimeStr(e), e.Type, e.Reason, util.GetEventObject(e), e.Message)
-		cnt++
-		if cnt == 5 {
-			break
-		}
-	}
-	tbl.Print()
+func showEvents(name string, namespace string, out io.Writer) {
+	// hint user how to get events
+	fmt.Fprintf(out, "\nShow cluster events: kbcli cluster list-events -n %s %s", namespace, name)
 }
 
 func showEndpoints(c *appsv1alpha1.Cluster, svcList *corev1.ServiceList, out io.Writer) {

--- a/internal/cli/cmd/cluster/describe_test.go
+++ b/internal/cli/cmd/cluster/describe_test.go
@@ -109,13 +109,8 @@ var _ = Describe("Expose", func() {
 
 	It("showEvents", func() {
 		out := &bytes.Buffer{}
-		showEvents(testing.FakeEvents(), "test-cluster", namespace, out)
-		strs := strings.Split(out.String(), "\n")
-
-		// sorted
-		firstEvent := strs[3]
-		secondEvent := strs[4]
-		Expect(strings.Compare(firstEvent, secondEvent) < 0).Should(BeTrue())
+		showEvents("test-cluster", namespace, out)
+		Expect(out.String()).ShouldNot(BeEmpty())
 	})
 
 	It("showDataProtections", func() {


### PR DESCRIPTION

Before:
```
kbcli cluster describe mycluster 
Name: mycluster  Created Time: May 05,2023 16:57 UTC+0800
NAMESPACE   CLUSTER-DEFINITION   VERSION           STATUS    TERMINATION-POLICY   
default     apecloud-mysql       ac-mysql-8.0.30   Running   WipeOut              

Endpoints:
COMPONENT   MODE        INTERNAL                                         EXTERNAL   
mysql       ReadWrite   mycluster-mysql.default.svc.cluster.local:3306   <none>     

Topology:
COMPONENT   INSTANCE            ROLE       STATUS    AZ       NODE                                    CREATED-TIME                 
mysql       mycluster-mysql-0   leader     Running   <none>   k3d-kb-playground-server-0/172.21.0.6   May 05,2023 16:57 UTC+0800   
mysql       mycluster-mysql-2   follower   Running   <none>   k3d-kb-playground-server-0/172.21.0.6   May 05,2023 16:57 UTC+0800   
mysql       mycluster-mysql-1   follower   Running   <none>   k3d-kb-playground-server-0/172.21.0.6   May 05,2023 16:57 UTC+0800   

Resources Allocation:
COMPONENT   DEDICATED   CPU(REQUEST/LIMIT)   MEMORY(REQUEST/LIMIT)   STORAGE-SIZE   STORAGE-CLASS     
mysql       false       500m / 500m          512Mi / 512Mi           data:20Gi      csi-hostpath-sc   

Images:
COMPONENT   TYPE    IMAGE                                                                                                  
mysql       mysql   registry.cn-hangzhou.aliyuncs.com/apecloud/apecloud-mysql-server:8.0.30-5.alpha5.20230319.g28f261a.5   

Data Protection:
AUTO-BACKUP   BACKUP-SCHEDULE   TYPE       BACKUP-TTL   LAST-SCHEDULE   RECOVERABLE-TIME   
Disabled      <none>            <none>     <none>       <none>          <none>             
Disabled      0 18 * * 0        snapshot   7d           <none>          <none>             

Events(last 5 warnings, see more:kbcli cluster list-events -n default mycluster):
TIME                         TYPE      REASON                 OBJECT              MESSAGE                                                                                                                                                             
May 05,2023 16:57 UTC+0800   Warning   ApplyResourcesFailed   Cluster/mycluster   Operation cannot be fulfilled on statefulsets.apps "mycluster-mysql": the object has been modified; please apply your changes to the latest version and try again   

```

Now:
```
$ kbcli cluster describe mycluster
Name: mycluster  Created Time: May 05,2023 16:57 UTC+0800
NAMESPACE   CLUSTER-DEFINITION   VERSION           STATUS    TERMINATION-POLICY   
default     apecloud-mysql       ac-mysql-8.0.30   Running   WipeOut              

Endpoints:
COMPONENT   MODE        INTERNAL                                         EXTERNAL   
mysql       ReadWrite   mycluster-mysql.default.svc.cluster.local:3306   <none>     

Topology:
COMPONENT   INSTANCE            ROLE       STATUS    AZ       NODE                                    CREATED-TIME                 
mysql       mycluster-mysql-0   leader     Running   <none>   k3d-kb-playground-server-0/172.21.0.6   May 05,2023 16:57 UTC+0800   
mysql       mycluster-mysql-2   follower   Running   <none>   k3d-kb-playground-server-0/172.21.0.6   May 05,2023 16:57 UTC+0800   
mysql       mycluster-mysql-1   follower   Running   <none>   k3d-kb-playground-server-0/172.21.0.6   May 05,2023 16:57 UTC+0800   

Resources Allocation:
COMPONENT   DEDICATED   CPU(REQUEST/LIMIT)   MEMORY(REQUEST/LIMIT)   STORAGE-SIZE   STORAGE-CLASS     
mysql       false       500m / 500m          512Mi / 512Mi           data:20Gi      csi-hostpath-sc   

Images:
COMPONENT   TYPE    IMAGE                                                                                                  
mysql       mysql   registry.cn-hangzhou.aliyuncs.com/apecloud/apecloud-mysql-server:8.0.30-5.alpha5.20230319.g28f261a.5   

Data Protection:
AUTO-BACKUP   BACKUP-SCHEDULE   TYPE       BACKUP-TTL   LAST-SCHEDULE   RECOVERABLE-TIME   
Disabled      <none>            <none>     <none>       <none>          <none>             
Disabled      0 18 * * 0        snapshot   7d           <none>          <none>             

Show cluster events: kbcli cluster list-events -n default mycluster
```