### PR TITLE
chore: refine kb status selector and update status msg

### DIFF
--- a/internal/cli/cmd/kubeblocks/uninstall.go
+++ b/internal/cli/cmd/kubeblocks/uninstall.go
@@ -110,7 +110,9 @@ func (o *UninstallOptions) PreCheck() error {
 	// check if there is any resource should be removed first, if so, return error
 	// and ask user to remove them manually
 	if err := checkResources(o.Dynamic); err != nil {
-		return err
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
 	}
 
 	// verify where kubeblocks is installed
@@ -206,7 +208,7 @@ func (o *UninstallOptions) Uninstall() error {
 	if o.Wait {
 		fmt.Fprintln(o.Out, "Uninstall KubeBlocks done.")
 	} else {
-		fmt.Fprintf(o.Out, "KubeBlocks is uninstalling, run \"kbcli kubeblocks status\" to check status.\n")
+		fmt.Fprintf(o.Out, "KubeBlocks is uninstalling, run \"kbcli kubeblocks status -A\" to check kubeblocks resources.\n")
 	}
 	return nil
 }

--- a/internal/controller/lifecycle/transformer_workloads_last.go
+++ b/internal/controller/lifecycle/transformer_workloads_last.go
@@ -23,8 +23,6 @@ import (
 	appv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	"github.com/apecloud/kubeblocks/internal/constant"
-
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
 	"github.com/apecloud/kubeblocks/internal/constant"
 	"github.com/apecloud/kubeblocks/internal/controller/graph"


### PR DESCRIPTION
this chore simply improves `kb status` command's helm secret selector for performance
construct a selector  "k in (v1, v2 v3...)" instead of interating over "[]{k=v1, k=v2, k=v3...}"