### PR TITLE
fix: don't attach a finalizer to the auto created backup PVC

### DIFF
--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -289,8 +289,6 @@ func (r *BackupReconciler) createPVCWithStorageClassName(reqCtx intctrlutil.Requ
 			},
 		},
 	}
-	// add a finalizer
-	controllerutil.AddFinalizer(pvc, dataProtectionFinalizerName)
 	err := r.Client.Create(reqCtx.Ctx, pvc)
 	return client.IgnoreAlreadyExists(err)
 }


### PR DESCRIPTION
We don't actually handle the deletion of PVC, so don't attach a finalizer to avoid blocking the user.

fix #3155 