### PR TITLE
fix: mongodb restart alert title is incorrect (#3171)

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1100,7 +1100,7 @@ prometheus:
                 description: 'MongoDB instance is down\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}'
       
             - alert: MongodbRestarted
-              expr: 'time() - process_start_time_seconds < 60'
+              expr: 'mongodb_instance_uptime_seconds < 60'
               for: 0m
               labels:
                 severity: info

--- a/deploy/mongodb/values.yaml
+++ b/deploy/mongodb/values.yaml
@@ -39,8 +39,6 @@ metrics:
     pullPolicy: IfNotPresent
   config:
     extensions:
-      memory_ballast:
-        size_mib: 512
       health_check:
         endpoint: 0.0.0.0:13133
         path: /health/status
@@ -90,4 +88,4 @@ metrics:
           processors: [memory_limiter]
           exporters: [prometheus]
 
-      extensions: [memory_ballast, health_check]
+      extensions: [health_check]


### PR DESCRIPTION
(cherry picked from commit 3dec1f6b5114308826993335e4fa31e3a8274676)