### PR TITLE
chore: update the csi-s3 pvc default capacity to 20Gi

### DIFF
--- a/internal/constant/const.go
+++ b/internal/constant/const.go
@@ -229,4 +229,4 @@ const (
 	AccountPasswdForSecret = "password"
 )
 
-const DefaultBackupPvcInitCapacity = "100Gi"
+const DefaultBackupPvcInitCapacity = "20Gi"


### PR DESCRIPTION
The default 100Gi is too large,  changed to 20Gi (Although no capacity will actually be allocated on the csi-s3). 