### PR TITLE
fix: return error when uninstall an unsuccessfully installed kubeblocks

### DIFF
--- a/internal/cli/cmd/kubeblocks/uninstall.go
+++ b/internal/cli/cmd/kubeblocks/uninstall.go
@@ -249,7 +249,7 @@ func (o *UninstallOptions) uninstallAddons() error {
 
 			if uninstall {
 				// we only need to uninstall addons that are not disabled
-				if addon.Status.Phase == extensionsv1alpha1.AddonDisabled {
+				if addon.Spec.InstallSpec.IsDisabled() {
 					continue
 				}
 				addons[addon.Name] = addon
@@ -353,7 +353,7 @@ func checkResources(dynamic dynamic.Interface) error {
 func disableAddon(dynamic dynamic.Interface, addon *extensionsv1alpha1.Addon) error {
 	klog.V(1).Infof("Uninstall %s, status %s", addon.Name, addon.Status.Phase)
 	if _, err := dynamic.Resource(types.AddonGVR()).Patch(context.TODO(), addon.Name, k8sapitypes.JSONPatchType,
-		[]byte("[{\"op\": \"replace\", \"path\": \"/spec/install\", \"value\": {\"enabled\": false} }]"),
+		[]byte("[{\"op\": \"replace\", \"path\": \"/spec/install/enabled\", \"value\": false }]"),
 		metav1.PatchOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}


### PR DESCRIPTION
when kbcli kubeblocks install normally, the addon is 
<img width="897" alt="image" src="https://github.com/apecloud/kubeblocks/assets/49025948/7bd331fa-74fa-4397-a019-b925971d80db">
when kbcli kubeblocks install failed, sometimes the addon is
<img width="956" alt="image" src="https://github.com/apecloud/kubeblocks/assets/49025948/8124bff7-64a7-47f8-a408-997da6ec159d">
don't have the `install` field, so the following code will raise error: 
https://github.com/apecloud/kubeblocks/blob/d2d701e37c0f82d6710223fc27cada46eb10a996/internal/cli/cmd/kubeblocks/uninstall.go#L363-L371