### PR TITLE
fix: kbcli kubeblocks install block by helm install leftover configmaps

### DIFF
--- a/internal/cli/cmd/kubeblocks/uninstall.go
+++ b/internal/cli/cmd/kubeblocks/uninstall.go
@@ -168,7 +168,7 @@ func (o *UninstallOptions) Uninstall() error {
 		helm.RemoveRepo(&repo.Entry{Name: types.KubeBlocksChartName}))
 
 	// get KubeBlocks objects, then try to remove them
-	objs, err := getKBObjects(o.Dynamic, o.Namespace, o.addons)
+	objs, err := getKBObjects(o.Dynamic, "", o.addons)
 	if err != nil {
 		fmt.Fprintf(o.ErrOut, "Failed to get KubeBlocks objects %s", err.Error())
 	}


### PR DESCRIPTION
<img width="1406" alt="image" src="https://github.com/apecloud/kubeblocks/assets/49025948/454e0cec-d0db-4e4c-a415-08d0b2f2accd">
