### PR TITLE
fix: playground without sa, role and rolebinding

### DIFF
--- a/internal/cli/cmd/cluster/create.go
+++ b/internal/cli/cmd/cluster/create.go
@@ -172,8 +172,6 @@ type CreateOptions struct {
 	SetFile           string                   `json:"-"`
 	Values            []string                 `json:"-"`
 
-	shouldCreateDependencies bool `json:"-"`
-
 	// backup name to restore in creation
 	Backup string `json:"backup,omitempty"`
 	UpdatableFlags
@@ -385,7 +383,6 @@ func (o *CreateOptions) buildDependenciesFn(cd *appsv1alpha1.ClusterDefinition,
 
 	// set component service account name
 	compSpec.ServiceAccountName = saNamePrefix + o.Name
-	o.shouldCreateDependencies = true
 	return nil
 }
 
@@ -395,10 +392,6 @@ func (o *CreateOptions) CreateDependencies(dryRun []string) error {
 		roleName        = roleNamePrefix + o.Name
 		roleBindingName = roleBindingNamePrefix + o.Name
 	)
-
-	if !o.shouldCreateDependencies {
-		return nil
-	}
 
 	klog.V(1).Infof("create dependencies for cluster %s", o.Name)
 	// create service account


### PR DESCRIPTION

* fix #3420

```
$ k get sa,role,rolebinding
NAME                             SECRETS   AGE
serviceaccount/default           1         8m41s
serviceaccount/kb-sa-mycluster   1         7m

NAME                                               CREATED AT
role.rbac.authorization.k8s.io/kb-role-mycluster   2023-05-24T08:48:28Z

NAME                                                             ROLE                     AGE
rolebinding.rbac.authorization.k8s.io/kb-rolebinding-mycluster   Role/kb-role-mycluster   7m

```