### PR TITLE
fix: persistant redis account

### DIFF
--- a/deploy/redis/config/redis7-config.tpl
+++ b/deploy/redis/config/redis7-config.tpl
@@ -72,10 +72,10 @@ rdb-save-incremental-fsync yes
 jemalloc-bg-thread yes
 enable-debug-command yes
 protected-mode no
+aclfile /etc/redis/users.acl
 
 # maxmemory <bytes>
 {{- $request_memory := getContainerRequestMemory ( index $.podSpec.containers 0 ) }}
 {{- if gt $request_memory 0 }}
 maxmemory {{ $request_memory }}
 {{- end -}}
-

--- a/deploy/redis/scripts/redis7-start.sh.tpl
+++ b/deploy/redis/scripts/redis7-start.sh.tpl
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -ex
+echo "include /etc/conf/redis.conf" >> /etc/redis/redis.conf
+echo "replica-announce-ip $KB_POD_FQDN" >> /etc/redis/redis.conf
+{{- $data_root := getVolumePathByName ( index $.podSpec.containers 0 ) "data" }}
+touch {{ $data_root }}/users.acl
+echo "aclfile /data/users.acl" >> /etc/redis/redis.conf
+exec redis-server /etc/redis/redis.conf \
+--loadmodule /opt/redis-stack/lib/redisearch.so ${REDISEARCH_ARGS} \
+--loadmodule /opt/redis-stack/lib/redisgraph.so ${REDISGRAPH_ARGS} \
+--loadmodule /opt/redis-stack/lib/redistimeseries.so ${REDISTIMESERIES_ARGS} \
+--loadmodule /opt/redis-stack/lib/rejson.so ${REDISJSON_ARGS} \
+--loadmodule /opt/redis-stack/lib/redisbloom.so ${REDISBLOOM_ARGS}

--- a/deploy/redis/templates/clusterdefinition.yaml
+++ b/deploy/redis/templates/clusterdefinition.yaml
@@ -138,7 +138,7 @@ spec:
           - sh
           - -c
           args:
-          - "redis-cli -h $(KB_ACCOUNT_ENDPOINT) $(KB_ACCOUNT_STATEMENT)"
+          - "redis-cli -h $(KB_ACCOUNT_ENDPOINT) $(KB_ACCOUNT_STATEMENT) | redis-cli -h $(KB_ACCOUNT_ENDPOINT) acl save "
         passwordConfig:
           length: 10
           numDigits: 5

--- a/deploy/redis/templates/scripts.yaml
+++ b/deploy/redis/templates/scripts.yaml
@@ -17,16 +17,7 @@ data:
       redis-cli -h 127.0.0.1 -p 6379 replicaof $KB_PRIMARY_POD_NAME 6379 || exit 1
     fi
   redis-start.sh: |
-    #!/bin/sh
-    set -ex
-    echo "include /etc/conf/redis.conf" >> /etc/redis/redis.conf
-    echo "replica-announce-ip $KB_POD_FQDN" >> /etc/redis/redis.conf
-    exec redis-server /etc/redis/redis.conf \
-    --loadmodule /opt/redis-stack/lib/redisearch.so ${REDISEARCH_ARGS} \
-    --loadmodule /opt/redis-stack/lib/redisgraph.so ${REDISGRAPH_ARGS} \
-    --loadmodule /opt/redis-stack/lib/redistimeseries.so ${REDISTIMESERIES_ARGS} \
-    --loadmodule /opt/redis-stack/lib/rejson.so ${REDISJSON_ARGS} \
-    --loadmodule /opt/redis-stack/lib/redisbloom.so ${REDISBLOOM_ARGS}
+    {{- .Files.Get "scripts/redis7-start.sh.tpl" | nindent 4 }}
   redis-sentinel-setup.sh: |-
     {{- .Files.Get "scripts/redis-sentinel-setup.sh.tpl" | nindent 4 }}
   redis-sentinel-start.sh: |-


### PR DESCRIPTION
- fix: #3395   

Added `aclfile` config and save acl info after accounts are created. changes made to the chart are: 
1. config `aclfile` and and place the file to redis's `data` dir (should be a persistent volume)
2. execute `redis-cli acl save` to flush acl info to file.   
 
So that accounts endure cluster deletion.