### PR TITLE
feat: cli plugin support auto completion like kubectl

### DIFF
--- a/internal/cli/cmd/cli.go
+++ b/internal/cli/cmd/cli.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cliflag "k8s.io/component-base/cli/flag"
 	kccmd "k8s.io/kubectl/pkg/cmd"
+	kcplugin "k8s.io/kubectl/pkg/cmd/plugin"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	utilcomp "k8s.io/kubectl/pkg/util/completion"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -59,6 +60,9 @@ func init() {
 	if _, err := util.GetCliHomeDir(); err != nil {
 		fmt.Println("Failed to create kbcli home dir:", err)
 	}
+
+	// replace the kubectl plugin filename prefixes with ours
+	kcplugin.ValidPluginFilenamePrefixes = plugin.ValidPluginFilenamePrefixes
 }
 
 func NewDefaultCliCmd() *cobra.Command {
@@ -116,6 +120,12 @@ A Command Line Interface for KubeBlocks`,
 
 		Run: func(cmd *cobra.Command, args []string) {
 			_ = cmd.Help()
+		},
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Name() == cobra.ShellCompRequestCmd {
+				kcplugin.SetupPluginCompletion(cmd, args)
+			}
+			return nil
 		},
 	}
 


### PR DESCRIPTION
the usage like kubectl, see https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/sample-cli-plugin/README.md#shell-completion

<img width="784" alt="image" src="https://github.com/apecloud/kubeblocks/assets/49025948/7c92f651-39ef-47a6-9cd4-773d88352e25">

the `kbcli_complete-ns` : 
```sh
#!/usr/bin/env bash

# If we are completing a flag, use Cobra's builtin completion system.
# To know if we are completing a flag we need the last argument starts with a `-` and does not contain an `=`
args=("$@")
lastArg=${args[((${#args[@]}-1))]}
if [[ "$lastArg" == -* ]]; then
   if [[ "$lastArg" != *=* ]]; then
      kbcli ns __complete "$@"
   fi
else
   # TODO Make sure we are not completing the value of a flag.
   # TODO Only complete a single argument.
   # Both are pretty hard to do in a shell script.  The better way to do this would be to let
   # Cobra do all the completions by using `cobra.ValidArgsFunction` in the program.
   # But the below, although imperfect, is a nice example for plugins that don't use Cobra.

   # We are probably completing an argument.  This plugin only accepts namespaces, let's fetch them.
   kubectl get namespaces --output go-template='{{ range .items }}{{ .metadata.name }}{{"\n"}}{{ end }}'

   # Turn off file completion.  See the ShellCompDirective documentation within
   # https://github.com/spf13/cobra/blob/main/shell_completions.md#completion-of-nouns
   echo :4
fi
```
