### PR TITLE
chore: highlight the default clusterversion

### DIFF
--- a/internal/cli/cmd/clusterversion/clusterversion.go
+++ b/internal/cli/cmd/clusterversion/clusterversion.go
@@ -97,13 +97,17 @@ func run(o *ListClusterVersionOptions) error {
 	}
 	p := printer.NewTablePrinter(o.Out)
 	p.SetHeader("NAME", "CLUSTER-DEFINITION", "STATUS", "IS-DEFAULT", "CREATED-TIME")
-	p.SortBy(1)
+	p.SortBy(2)
 	for _, info := range infos {
 		var cv v1alpha1.ClusterVersion
 		if err = runtime.DefaultUnstructuredConverter.FromUnstructured(info.Object.(*unstructured.Unstructured).Object, &cv); err != nil {
 			return err
 		}
 		isDefaultValue := isDefault(&cv)
+		if isDefaultValue == "true" {
+			p.AddRow(printer.BoldGreen(cv.Name), cv.Labels[constant.ClusterDefLabelKey], cv.Status.Phase, isDefaultValue, util.TimeFormat(&cv.CreationTimestamp))
+			continue
+		}
 		p.AddRow(cv.Name, cv.Labels[constant.ClusterDefLabelKey], cv.Status.Phase, isDefaultValue, util.TimeFormat(&cv.CreationTimestamp))
 	}
 	p.Print()


### PR DESCRIPTION
- fix #3515 

What I Do:
highlight the  default `clusterversion` for `kbcli clusterversion list`. 

Example:
![image](https://github.com/apecloud/kubeblocks/assets/101848970/cbc15da8-1d26-4221-bcd4-cd954b557e3a)
