### PR TITLE
chore: remove cachestore in sysaccounts

### DIFF
--- a/controllers/apps/systemaccount_controller.go
+++ b/controllers/apps/systemaccount_controller.go
@@ -22,6 +22,7 @@ package apps
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/viper"
@@ -29,16 +30,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
@@ -51,9 +51,8 @@ import (
 // SystemAccountReconciler reconciles a SystemAccount object.
 type SystemAccountReconciler struct {
 	client.Client
-	Scheme         *runtime.Scheme
-	Recorder       record.EventRecorder
-	SecretMapStore *secretMapStore
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
 }
 
 // componentUniqueKey is used internally to uniquely identify a component, by namespace-clusterName-componentName.
@@ -87,7 +86,9 @@ const (
 
 // ENABLE_DEBUG_SYSACCOUNTS is used for debug only.
 const (
-	systemAccountsDebugMode string = "ENABLE_DEBUG_SYSACCOUNTS"
+	systemAccountsDebugMode       string = "ENABLE_DEBUG_SYSACCOUNTS"
+	systemAccountPasswdAnnotation string = "passwd"
+	systemAccountjobPrefix               = "sysacc"
 )
 
 var (
@@ -181,7 +182,7 @@ func (r *SystemAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 		// facts: accounts have been created, in form of k8s secrets.
 		if detectedK8SFacts, err = r.getAccountFacts(reqCtx, compKey); err != nil {
-			reqCtx.Log.V(1).Error(err, "failed to get secrets")
+			reqCtx.Log.Error(err, "failed to get secrets")
 			return err
 		}
 		reqCtx.Log.V(1).Info("detected k8s facts", "cluster", req.NamespacedName, "accounts", detectedK8SFacts)
@@ -222,6 +223,7 @@ func (r *SystemAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 					completeExecConfig(execConfig, componentVersions[compDef.Name])
 					engine = newCustomizedEngine(execConfig, cluster, compDecl.Name)
 				}
+				reqCtx.Log.V(1).Info("create account by stmt", "cluster", req.NamespacedName, "account", account.Name, "strategy", strategy)
 				if err := r.createByStmt(reqCtx, cluster, compDef, compKey, engine, account, svcEP, headlessEP, strategy); err != nil {
 					return err
 				}
@@ -271,9 +273,8 @@ func (r *SystemAccountReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *SystemAccountReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	r.SecretMapStore = newSecretMapStore()
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&appsv1alpha1.Cluster{}, r.clusterDeletionHander()).
+		For(&appsv1alpha1.Cluster{}).
 		Owns(&corev1.Secret{}).
 		Watches(&source.Kind{Type: &batchv1.Job{}}, r.jobCompletionHander()).
 		Complete(r)
@@ -286,41 +287,47 @@ func (r *SystemAccountReconciler) createByStmt(reqCtx intctrlutil.RequestCtx,
 	engine *customizedEngine,
 	account appsv1alpha1.SystemAccountConfig,
 	svcEP *corev1.Endpoints, headlessEP *corev1.Endpoints, strategy updateStrategy) error {
-	// render statements
-	scheme, _ := appsv1alpha1.SchemeBuilder.Build()
 	policy := account.ProvisionPolicy
 
-	stmts, secret := getCreationStmtForAccount(compKey, compDef.SystemAccounts.PasswordConfig, account, strategy)
-
-	uprefErr := controllerutil.SetControllerReference(cluster, secret, scheme)
-	if uprefErr != nil {
-		return uprefErr
+	generateJobName := func() string {
+		// render a job object, named after account name
+		randSuffix := rand.String(5)
+		fullJobName := strings.Join([]string{systemAccountjobPrefix, compKey.clusterName, compKey.componentName, string(account.Name), randSuffix}, "-")
+		if len(fullJobName) > 63 {
+			return systemAccountjobPrefix + "-" + string(account.Name) + "-" + randSuffix
+		} else {
+			return fullJobName
+		}
 	}
 
+	stmts, passwd := getCreationStmtForAccount(compKey, compDef.SystemAccounts.PasswordConfig, account, strategy)
+
 	for _, ep := range retrieveEndpoints(policy.Scope, svcEP, headlessEP) {
-		// render a job object
-		job := renderJob(engine, compKey, stmts, ep)
+		job := renderJob(generateJobName(), engine, compKey, stmts, ep)
+		controllerutil.AddFinalizer(job, constant.DBClusterFinalizerName)
+		if job.Annotations == nil {
+			job.Annotations = map[string]string{}
+		}
+		job.Annotations[systemAccountPasswdAnnotation] = passwd
+
 		// before creating job, we adjust job's attributes, such as labels, tolerations w.r.t cluster info.
 		if err := calibrateJobMetaAndSpec(job, cluster, compKey, account.Name); err != nil {
 			return err
 		}
 		// update owner reference
-		if err := controllerutil.SetControllerReference(cluster, job, scheme); err != nil {
+		if err := controllerutil.SetControllerReference(cluster, job, r.Scheme); err != nil {
 			return err
 		}
 		// create job
 		if err := r.Client.Create(reqCtx.Ctx, job); err != nil {
 			return err
 		}
+		reqCtx.Log.V(1).Info("created job", "job", job.Name, "passwd", passwd)
 	}
-	// push secret to global SecretMapStore, and secret will not be created until job succeeds.
-	key := concatSecretName(compKey, (string)(account.Name))
-	return r.SecretMapStore.addSecret(key, secret)
+	return nil
 }
 
 func (r *SystemAccountReconciler) createByReferingToExisting(reqCtx intctrlutil.RequestCtx, cluster *appsv1alpha1.Cluster, key componentUniqueKey, account appsv1alpha1.SystemAccountConfig) error {
-	scheme, _ := appsv1alpha1.SchemeBuilder.Build()
-
 	// get secret
 	secret := &corev1.Secret{}
 	secretRef := account.ProvisionPolicy.SecretRef
@@ -330,7 +337,7 @@ func (r *SystemAccountReconciler) createByReferingToExisting(reqCtx intctrlutil.
 	}
 	// and make a copy of it
 	newSecret := renderSecretByCopy(key, (string)(account.Name), secret)
-	if uprefErr := controllerutil.SetControllerReference(cluster, newSecret, scheme); uprefErr != nil {
+	if uprefErr := controllerutil.SetControllerReference(cluster, newSecret, r.Scheme); uprefErr != nil {
 		return uprefErr
 	}
 
@@ -389,15 +396,6 @@ func (r *SystemAccountReconciler) getAccountFacts(reqCtx intctrlutil.RequestCtx,
 
 	detectedFacts := getAccountFacts(secrets, jobs)
 	reqCtx.Log.V(1).Info("Detected account facts", "facts", detectedFacts)
-
-	for _, accName := range getAllSysAccounts() {
-		key := concatSecretName(key, string(accName))
-		_, exists, _ := r.SecretMapStore.getSecret(key)
-		if exists {
-			detectedFacts |= accName.GetAccountID()
-		}
-	}
-	reqCtx.Log.V(1).Info("Detected account facts with those from cache", "facts", detectedFacts)
 	return detectedFacts, nil
 }
 
@@ -450,109 +448,87 @@ func (r *SystemAccountReconciler) jobCompletionHander() *handler.Funcs {
 		return false
 	}
 
+	// check against a job to make sure it
+	// 1. works for sysaccount (by checking labels)
+	// 2. has completed (either successed or failed)
+	// 3. is under deletion (either by user or by TTL, where deletionTimestamp is set)
 	return &handler.Funcs{
-		DeleteFunc: func(e event.DeleteEvent, q workqueue.RateLimitingInterface) {
-			if e.Object == nil {
+		UpdateFunc: func(e event.UpdateEvent, q workqueue.RateLimitingInterface) {
+			var (
+				jobTerminated = false
+				job           *batchv1.Job
+				ok            bool
+			)
+
+			defer func() {
+				// prepare a patch by removing finalizer
+				if jobTerminated {
+					patch := client.MergeFrom(job.DeepCopy())
+					controllerutil.RemoveFinalizer(job, constant.DBClusterFinalizerName)
+					_ = r.Client.Patch(context.Background(), job, patch)
+				}
+			}()
+
+			if e.ObjectNew == nil {
 				return
 			}
 
-			job, ok := e.Object.(*batchv1.Job)
-			if !ok {
+			if job, ok = e.ObjectNew.(*batchv1.Job); !ok {
 				return
 			}
 
-			ml := job.ObjectMeta.Labels
-			accountName := ml[constant.ClusterAccountLabelKey]
-			clusterName := ml[constant.AppInstanceLabelKey]
-			componentName := ml[constant.KBAppComponentLabelKey]
+			if job.DeletionTimestamp != nil || job.Annotations == nil || job.Labels == nil {
+				return
+			}
+
+			accountName := job.ObjectMeta.Labels[constant.ClusterAccountLabelKey]
+			clusterName := job.ObjectMeta.Labels[constant.AppInstanceLabelKey]
+			componentName := job.ObjectMeta.Labels[constant.KBAppComponentLabelKey]
+
 			if len(accountName) == 0 || len(clusterName) == 0 || len(componentName) == 0 {
 				return
 			}
 
-			// job failed, reconcile
+			if containsJobCondition(*job, job.Status.Conditions, batchv1.JobFailed, corev1.ConditionTrue) {
+				logger.V(1).Info("job failed", "job", job.Name)
+				jobTerminated = true
+				return
+			}
+
 			if !containsJobCondition(*job, job.Status.Conditions, batchv1.JobComplete, corev1.ConditionTrue) {
 				return
 			}
 
-			// job for cluster-component-account succeeded
-			// create secret for this account
+			logger.V(1).Info("job succeeded", "job", job.Name)
+			jobTerminated = true
+			clusterKey := types.NamespacedName{Namespace: job.Namespace, Name: clusterName}
+			cluster := &appsv1alpha1.Cluster{}
+			if err := r.Client.Get(context.TODO(), clusterKey, cluster); err != nil {
+				logger.Error(err, "failed to get cluster", "cluster key", clusterKey)
+				return
+			}
+
 			compKey := componentUniqueKey{
 				namespace:     job.Namespace,
 				clusterName:   clusterName,
 				componentName: componentName,
 			}
-
-			key := concatSecretName(compKey, accountName)
-			entry, ok, err := r.SecretMapStore.getSecret(key)
-			if err != nil || !ok {
+			// get password from job
+			passwd := job.Annotations[systemAccountPasswdAnnotation]
+			secret := renderSecretWithPwd(compKey, accountName, passwd)
+			if err := controllerutil.SetControllerReference(cluster, secret, r.Scheme); err != nil {
+				logger.Error(err, "failed to set ownere reference for secret", secret.Name)
 				return
 			}
 
-			logger.V(1).Info("job succeeded", "job", job.Name, "account", accountName, "cluster", clusterName, "secret", key)
-
-			if err = r.Client.Create(context.TODO(), entry.value); err != nil {
-				logger.Error(err, "failed to create secret, will try later", "secret key", key)
+			if err := r.Client.Create(context.TODO(), secret); err != nil {
+				logger.Error(err, "failed to create secret", secret.Name)
 				return
 			}
-
-			clusterKey := types.NamespacedName{Namespace: job.Namespace, Name: clusterName}
-			cluster := &appsv1alpha1.Cluster{}
-			if err := r.Client.Get(context.TODO(), clusterKey, cluster); err != nil {
-				logger.Error(err, "failed to get cluster", "cluster key", clusterKey)
-			} else {
-				r.Recorder.Eventf(cluster, corev1.EventTypeNormal, SysAcctCreate,
-					"Created Accounts for cluster: %s, component: %s, accounts: %s", cluster.Name, componentName, accountName)
-				// delete secret from cache store
-				if err = r.SecretMapStore.deleteSecret(key); err != nil {
-					logger.Error(err, "failed to delete secret by key", "secret key", key)
-				}
-			}
+			r.Recorder.Eventf(cluster, corev1.EventTypeNormal, SysAcctCreate,
+				"Created Accounts for cluster: %s, component: %s, accounts: %s", cluster.Name, componentName, accountName)
 		},
 	}
-}
-
-// Delete removes cached entries from SystemAccountReconciler.SecretMapStore
-func (r *SystemAccountReconciler) clusterDeletionHander() builder.Predicates {
-	logger := systemAccountLog.WithName("clusterDeletionHandler")
-	predicate := predicate.Funcs{
-		DeleteFunc: func(e event.DeleteEvent) bool {
-			if e.Object == nil {
-				return false
-			}
-			cluster, ok := e.Object.(*appsv1alpha1.Cluster)
-			if !ok {
-				return false
-			}
-
-			// for each component from the cluster, delete cached secrets
-			for _, comp := range cluster.Spec.ComponentSpecs {
-				compKey := componentUniqueKey{
-					namespace:     cluster.Namespace,
-					clusterName:   cluster.Name,
-					componentName: comp.Name,
-				}
-				for _, accName := range getAllSysAccounts() {
-					key := concatSecretName(compKey, string(accName))
-					// delete left-over secrets, and ignore errors if it has been removed.
-					_, exists, err := r.SecretMapStore.getSecret(key)
-					if err != nil {
-						logger.Error(err, "failed to get secrets", "secret key", key)
-						continue
-					}
-					if !exists {
-						continue
-					}
-					err = r.SecretMapStore.deleteSecret(key)
-					if err != nil {
-						logger.Error(err, "failed to delete secrets", "secret key", key)
-					}
-				}
-			}
-			logger.V(1).Info("cluster deleted", "cluster", cluster.Name, "namespace", cluster.Namespace, "secretMapStore", r.SecretMapStore.ListKeys())
-			return false
-		},
-	}
-	return builder.WithPredicates(predicate)
 }
 
 // existsOperations checks if the cluster is doing operations

--- a/controllers/apps/systemaccount_controller_test.go
+++ b/controllers/apps/systemaccount_controller_test.go
@@ -27,6 +27,7 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -57,7 +58,7 @@ var _ = Describe("SystemAccount Controller", func() {
 		* To test the behavior of system accounts controller, we conduct following tests:
 		* 1. construct two components, one with all accounts set, and one with none.
 		* 2. create two clusters, one cluster for each component, and verify
-	  * a) the number of secrets, jobs, and cached secrets are as expected
+	  * a) the number of secrets, jobs are as expected
 		* b) secret will be created, once corresponding job succeeds.
 		* c) secrets, deleted accidentally, will be re-created during next cluster reconciliation round.
 		*
@@ -68,9 +69,8 @@ var _ = Describe("SystemAccount Controller", func() {
 
 	// sysAcctResourceInfo defines the number of jobs and secrets to be created per account.
 	type sysAcctResourceInfo struct {
-		jobNum           int
-		secretNum        int
-		cachedSecretsNum int
+		jobNum    int
+		secretNum int
 	}
 	// sysAcctTestCase defines the info to setup test env, cluster and their expected result to verify against.
 	type sysAcctTestCase struct {
@@ -99,13 +99,6 @@ var _ = Describe("SystemAccount Controller", func() {
 		inNS := client.InNamespace(testCtx.DefaultNamespace)
 		ml := client.HasLabels{testCtx.TestObjLabelKey}
 		testapps.ClearResources(&testCtx, intctrlutil.EndpointsSignature, inNS, ml)
-	}
-
-	cleanInternalCache := func() {
-		secretKeys := systemAccountReconciler.SecretMapStore.ListKeys()
-		for _, key := range secretKeys {
-			_ = systemAccountReconciler.SecretMapStore.deleteSecret(key)
-		}
 	}
 
 	/**
@@ -207,7 +200,7 @@ var _ = Describe("SystemAccount Controller", func() {
 		Expect(clusterDefObj).NotTo(BeNil())
 
 		Expect(len(testCases)).To(BeNumerically(">", 0))
-		// fill the number of secrets, jobs, and cached secrets
+		// fill the number of secrets, jobs
 		for _, testCase := range testCases {
 			compDef := clusterDefObj.GetComponentDefByName(testCase.componentDefRef)
 			Expect(compDef).NotTo(BeNil())
@@ -217,14 +210,13 @@ var _ = Describe("SystemAccount Controller", func() {
 			if testCase.resourceMap == nil {
 				testCase.resourceMap = make(map[appsv1alpha1.AccountName]sysAcctResourceInfo)
 			}
-			var jobNum, secretNum, cachedSecretNum int
+			var jobNum, secretNum int
 			for _, account := range compDef.SystemAccounts.Accounts {
 				name := account.Name
 				policy := account.ProvisionPolicy
 				switch policy.Type {
 				case appsv1alpha1.CreateByStmt:
-					secretNum = 0
-					cachedSecretNum = 1
+					secretNum = 1
 					if policy.Scope == appsv1alpha1.AnyPods {
 						jobNum = 1
 					} else {
@@ -232,13 +224,11 @@ var _ = Describe("SystemAccount Controller", func() {
 					}
 				case appsv1alpha1.ReferToExisting:
 					jobNum = 0
-					cachedSecretNum = 0
 					secretNum = 1
 				}
 				testCase.resourceMap[name] = sysAcctResourceInfo{
-					jobNum:           jobNum,
-					cachedSecretsNum: cachedSecretNum,
-					secretNum:        secretNum,
+					jobNum:    jobNum,
+					secretNum: secretNum,
 				}
 			}
 		}
@@ -281,9 +271,6 @@ var _ = Describe("SystemAccount Controller", func() {
 			cleanEnv()
 			DeferCleanup(cleanEnv)
 
-			cleanInternalCache()
-			DeferCleanup(cleanInternalCache)
-
 			// setup testcase
 			mysqlTestCases = map[string]*sysAcctTestCase{
 				"wesql-no-accts": {
@@ -300,13 +287,12 @@ var _ = Describe("SystemAccount Controller", func() {
 			clustersMap = initSysAccountTestsAndCluster(mysqlTestCases)
 		})
 
-		It("Should create jobs and cache secrets as expected for each test case", func() {
+		It("Should create jobs and secrets as expected for each test case", func() {
 			for testName, testCase := range mysqlTestCases {
 				var (
-					acctList        appsv1alpha1.KBAccountType
-					jobsNum         int
-					secretsNum      int
-					cachedSecretNum int
+					acctList   appsv1alpha1.KBAccountType
+					jobsNum    int
+					secretsNum int
 				)
 
 				for _, acc := range testCase.accounts {
@@ -314,7 +300,6 @@ var _ = Describe("SystemAccount Controller", func() {
 					acctList |= acc.GetAccountID()
 					jobsNum += resource.jobNum
 					secretsNum += resource.secretNum
-					cachedSecretNum += resource.cachedSecretsNum
 				}
 
 				clusterKey, ok := clustersMap[testName]
@@ -328,9 +313,9 @@ var _ = Describe("SystemAccount Controller", func() {
 
 				ml := getLabelsForSecretsAndJobs(componentUniqueKey{namespace: cluster.Namespace, clusterName: cluster.Name, componentName: testCase.componentName})
 
-				if secretsNum == 0 && jobsNum == 0 && cachedSecretNum == 0 {
+				if secretsNum == 0 && jobsNum == 0 {
 					By("No accouts should be create for test case: " + testName)
-					// verify nothing will be created or cached till timeout
+					// verify nothing will be created till timeout
 					Consistently(func(g Gomega) {
 						accounts := getAccounts(g, cluster, ml)
 						g.Expect(accounts).To(BeEquivalentTo(acctList))
@@ -343,11 +328,6 @@ var _ = Describe("SystemAccount Controller", func() {
 					accounts := getAccounts(g, cluster, ml)
 					g.Expect(accounts).To(BeEquivalentTo(acctList))
 				}).Should(Succeed())
-
-				By("Assure some secrets have been cached")
-				Eventually(func() int {
-					return len(systemAccountReconciler.SecretMapStore.ListKeys())
-				}).Should(BeEquivalentTo(cachedSecretNum))
 
 				By("Verify all jobs created have their labels set correctly")
 				// get all jobs
@@ -366,13 +346,12 @@ var _ = Describe("SystemAccount Controller", func() {
 			}
 		})
 
-		It("Cached secrets should be created when jobs succeeds", func() {
+		It("Secrets should be created when jobs succeeds", func() {
 			for testName, testCase := range mysqlTestCases {
 				var (
-					acctList        appsv1alpha1.KBAccountType
-					jobsNum         int
-					secretsNum      int
-					cachedSecretNum int
+					acctList   appsv1alpha1.KBAccountType
+					jobsNum    int
+					secretsNum int
 				)
 
 				for _, acc := range testCase.accounts {
@@ -380,10 +359,9 @@ var _ = Describe("SystemAccount Controller", func() {
 					acctList |= acc.GetAccountID()
 					jobsNum += resource.jobNum
 					secretsNum += resource.secretNum
-					cachedSecretNum += resource.cachedSecretsNum
 				}
 
-				if secretsNum == 0 && jobsNum == 0 && cachedSecretNum == 0 {
+				if secretsNum == 0 && jobsNum == 0 {
 					continue
 				}
 				// get a cluster instance from map, created during preparation
@@ -413,9 +391,6 @@ var _ = Describe("SystemAccount Controller", func() {
 					g.Expect(k8sClient.List(ctx, jobs, client.InNamespace(cluster.Namespace), ml)).To(Succeed())
 					g.Expect(len(jobs.Items)).To(BeEquivalentTo(jobsNum))
 				}).Should(Succeed())
-
-				By("Verify secrets cached are correct")
-				Eventually(len(systemAccountReconciler.SecretMapStore.ListKeys())).Should(BeEquivalentTo(cachedSecretNum))
 
 				// wait for a while till all jobs are created
 				By("Mock all jobs are completed and deleted")
@@ -450,7 +425,7 @@ var _ = Describe("SystemAccount Controller", func() {
 				Eventually(func(g Gomega) {
 					secrets := &corev1.SecretList{}
 					g.Expect(k8sClient.List(ctx, secrets, client.InNamespace(cluster.Namespace), ml)).To(Succeed())
-					g.Expect(len(secrets.Items)).To(BeEquivalentTo(secretsNum + cachedSecretNum))
+					g.Expect(len(secrets.Items)).To(BeEquivalentTo(secretsNum))
 				}).Should(Succeed())
 
 				By("Verify all secrets created have their finalizer and labels set correctly")
@@ -467,8 +442,6 @@ var _ = Describe("SystemAccount Controller", func() {
 					}
 				}).Should(Succeed())
 			}
-			// all jobs succeeded, and there should be no cached secrets left behind.
-			Expect(len(systemAccountReconciler.SecretMapStore.ListKeys())).To(BeEquivalentTo(0))
 		})
 	}) // end of context
 
@@ -481,9 +454,6 @@ var _ = Describe("SystemAccount Controller", func() {
 		BeforeEach(func() {
 			cleanEnv()
 			DeferCleanup(cleanEnv)
-
-			cleanInternalCache()
-			DeferCleanup(cleanInternalCache)
 
 			// setup testcase
 			mysqlTestCases = map[string]*sysAcctTestCase{
@@ -503,13 +473,12 @@ var _ = Describe("SystemAccount Controller", func() {
 		})
 
 		It("Should clear relevant expectations and secrets after cluster deletion", func() {
-			var totalJobs, totalSecrets, totalCachedSecrets int
+			var totalJobs, totalSecrets int
 			for testName, testCase := range mysqlTestCases {
 				var (
-					acctList        appsv1alpha1.KBAccountType
-					jobsNum         int
-					secretsNum      int
-					cachedSecretNum int
+					acctList   appsv1alpha1.KBAccountType
+					jobsNum    int
+					secretsNum int
 				)
 
 				for _, acc := range testCase.accounts {
@@ -517,11 +486,9 @@ var _ = Describe("SystemAccount Controller", func() {
 					acctList |= acc.GetAccountID()
 					jobsNum += resource.jobNum
 					secretsNum += resource.secretNum
-					cachedSecretNum += resource.cachedSecretsNum
 				}
 				totalJobs += jobsNum
 				totalSecrets += secretsNum
-				totalCachedSecrets += cachedSecretNum
 
 				// get a cluster instance from map, created during preparation
 				clusterKey, ok := clustersMap[testName]
@@ -548,31 +515,22 @@ var _ = Describe("SystemAccount Controller", func() {
 				}).Should(Succeed())
 			}
 
-			By("Verify secrets and jobs size")
-			Eventually(func(g Gomega) {
-				g.Expect(len(systemAccountReconciler.SecretMapStore.ListKeys())).To(BeEquivalentTo(totalCachedSecrets), "before delete, there are %d cached secrets", totalCachedSecrets)
-			}).Should(Succeed())
-
 			clusterKeys := make([]types.NamespacedName, 0, len(clustersMap))
 			for _, v := range clustersMap {
 				clusterKeys = append(clusterKeys, v)
 			}
 
-			By("Delete 0-th cluster from list, there should be no change in cached secrets size")
+			By("Delete 0-th cluster from list, there should be no change in secrets size")
 			cluster := &appsv1alpha1.Cluster{}
 			Expect(k8sClient.Get(ctx, clusterKeys[0], cluster)).To(Succeed())
 			Expect(k8sClient.Delete(ctx, cluster)).To(Succeed())
 
-			By("Delete remaining cluster before jobs are done, all cached secrets should be removed")
+			By("Delete remaining cluster before jobs are done, all secrets should be removed")
 			for i := 1; i < len(clusterKeys); i++ {
 				cluster = &appsv1alpha1.Cluster{}
 				Expect(k8sClient.Get(ctx, clusterKeys[i], cluster)).To(Succeed())
 				Expect(k8sClient.Delete(ctx, cluster)).To(Succeed())
 			}
-
-			Eventually(func(g Gomega) {
-				g.Expect(len(systemAccountReconciler.SecretMapStore.ListKeys())).To(BeEquivalentTo(0))
-			}).Should(Succeed())
 		})
 	}) // end of context
 
@@ -585,9 +543,6 @@ var _ = Describe("SystemAccount Controller", func() {
 		BeforeEach(func() {
 			cleanEnv()
 			DeferCleanup(cleanEnv)
-
-			cleanInternalCache()
-			DeferCleanup(cleanInternalCache)
 
 			// setup testcase
 			mysqlTestCases = map[string]*sysAcctTestCase{
@@ -637,10 +592,6 @@ var _ = Describe("SystemAccount Controller", func() {
 					jobs := &batchv1.JobList{}
 					g.Expect(k8sClient.List(ctx, jobs, client.InNamespace(cluster.Namespace), ml)).To(Succeed())
 					g.Expect(len(jobs.Items)).To(BeEquivalentTo(jobsNum))
-
-					secrets := &corev1.SecretList{}
-					g.Expect(k8sClient.List(ctx, secrets, client.InNamespace(cluster.Namespace), ml)).To(Succeed())
-					g.Expect(len(secrets.Items)).To(BeEquivalentTo(secretsNum))
 				}).Should(Succeed())
 
 				By("Enable monitor, no more jobs or secrets should be created")
@@ -655,13 +606,8 @@ var _ = Describe("SystemAccount Controller", func() {
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.List(ctx, jobs, client.InNamespace(cluster.Namespace), ml)).To(Succeed())
 					g.Expect(len(jobs.Items)).To(BeEquivalentTo(jobsNum))
-					// nothing changed since last time updates
-					secrets := &corev1.SecretList{}
-					g.Expect(k8sClient.List(ctx, secrets, client.InNamespace(cluster.Namespace), ml)).To(Succeed())
-					g.Expect(len(secrets.Items)).To(BeEquivalentTo(secretsNum))
 				}).Should(Succeed())
 
-				cachedSecretNum := len(systemAccountReconciler.SecretMapStore.ListKeys())
 				By("Mark partial jobs as completed and make sure it cannot be found")
 				// mark one jobs as completed
 				if jobsNum < 2 {
@@ -676,13 +622,15 @@ var _ = Describe("SystemAccount Controller", func() {
 				Eventually(func(g Gomega) {
 					tmpJob := &batchv1.Job{}
 					g.Expect(k8sClient.Get(ctx, jobKey, tmpJob)).To(Succeed())
-					g.Expect(len(tmpJob.ObjectMeta.Finalizers)).To(BeEquivalentTo(1))
+					g.Expect(len(tmpJob.ObjectMeta.Finalizers)).To(BeEquivalentTo(2))
 					g.Expect(testapps.ChangeObj(&testCtx, tmpJob, func(ljob *batchv1.Job) {
 						controllerutil.RemoveFinalizer(ljob, orphanFinalizerName)
+						controllerutil.RemoveFinalizer(ljob, constant.DBClusterFinalizerName)
 					})).To(Succeed())
 				}).Should(Succeed())
 
-				By("Verify jobs size decreased and secrets size increased")
+				By("Verify jobs size decreased and secrets size does not increase")
+				var secretsLen int
 				Eventually(func(g Gomega) {
 					g.Expect(k8sClient.List(ctx, jobs, client.InNamespace(cluster.Namespace), ml)).To(Succeed())
 					jobSize2 := len(jobs.Items)
@@ -690,15 +638,11 @@ var _ = Describe("SystemAccount Controller", func() {
 
 					secrets := &corev1.SecretList{}
 					g.Expect(k8sClient.List(ctx, secrets, client.InNamespace(cluster.Namespace), ml)).To(Succeed())
-					secretsSize2 := len(secrets.Items)
-					g.Expect(secretsSize2).To(BeEquivalentTo(secretsNum))
-
-					cachedSecretsSize2 := len(systemAccountReconciler.SecretMapStore.ListKeys())
-					g.Expect(cachedSecretsSize2).To(BeEquivalentTo(cachedSecretNum))
+					secretsLen = len(secrets.Items)
 				}).Should(Succeed())
 
 				// delete one job directly, but the job is completed.
-				By("Delete one job directly, the system should not create new secrets.")
+				By("Delete one job and mark it as JobComplete, the system should create new secrets.")
 				jobKey = client.ObjectKeyFromObject(&jobs.Items[0])
 				Eventually(func(g Gomega) {
 					tmpJob := &batchv1.Job{}
@@ -709,17 +653,16 @@ var _ = Describe("SystemAccount Controller", func() {
 							Status: corev1.ConditionTrue,
 						}}
 					})).To(Succeed())
-					g.Expect(k8sClient.Delete(ctx, tmpJob)).To(Succeed())
-				}).Should(Succeed())
-
-				Eventually(func(g Gomega) {
-					tmpJob := &batchv1.Job{}
-					err := k8sClient.Get(ctx, jobKey, tmpJob)
-					g.Expect(err).To(Succeed())
-					g.Expect(len(tmpJob.ObjectMeta.Finalizers)).To(BeEquivalentTo(1))
+					g.Expect(k8sClient.Delete(ctx, tmpJob)).Should(Succeed())
 					g.Expect(testapps.ChangeObj(&testCtx, tmpJob, func(ljob *batchv1.Job) {
 						controllerutil.RemoveFinalizer(ljob, orphanFinalizerName)
 					})).To(Succeed())
+
+				}).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					err := k8sClient.Get(ctx, jobKey, &batchv1.Job{})
+					g.Expect(apierrors.IsNotFound(err)).To(BeTrue())
 				}).Should(Succeed())
 
 				By("Verify jobs size decreased and secrets size increased")
@@ -727,10 +670,7 @@ var _ = Describe("SystemAccount Controller", func() {
 					secrets := &corev1.SecretList{}
 					g.Expect(k8sClient.List(ctx, secrets, client.InNamespace(cluster.Namespace), ml)).To(Succeed())
 					secretsSize2 := len(secrets.Items)
-					g.Expect(secretsSize2).To(BeNumerically(">", secretsNum))
-
-					cachedSecretsSize2 := len(systemAccountReconciler.SecretMapStore.ListKeys())
-					g.Expect(cachedSecretsSize2).To(BeNumerically("<", cachedSecretNum))
+					g.Expect(secretsSize2).To(BeNumerically(">", secretsLen))
 				}).Should(Succeed())
 			}
 		})

--- a/controllers/apps/systemaccount_util.go
+++ b/controllers/apps/systemaccount_util.go
@@ -20,7 +20,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package apps
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -29,29 +28,12 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
 	"github.com/apecloud/kubeblocks/internal/constant"
 	componetutil "github.com/apecloud/kubeblocks/internal/controller/component"
 )
-
-const (
-	jobPrefix = "job-system-account-"
-)
-
-// SecretMapStore is a cache, recording all (key, secret) pairs for accounts to be created.
-type secretMapStore struct {
-	cache.Store
-}
-
-// SecretMapEntry records (key, secret) pairs for account to be created.
-type secretMapEntry struct {
-	key   string
-	value *corev1.Secret
-}
 
 // customizedEngine helps render jobs.
 type customizedEngine struct {
@@ -61,54 +43,6 @@ type customizedEngine struct {
 	command       []string
 	args          []string
 	envVarList    []corev1.EnvVar
-}
-
-// SecretKeyFunc to parse out the key from a SecretMapEntry.
-var secretKeyFunc = func(obj interface{}) (string, error) {
-	if e, ok := obj.(*secretMapEntry); ok {
-		return e.key, nil
-	}
-	return "", fmt.Errorf("could not find key for obj %#v", obj)
-}
-
-func newSecretMapStore() *secretMapStore {
-	return &secretMapStore{cache.NewStore(secretKeyFunc)}
-}
-
-func (r *secretMapStore) addSecret(key string, value *corev1.Secret) error {
-	_, exists, err := r.getSecret(key)
-	if err != nil {
-		return err
-	}
-	entry := &secretMapEntry{key: key, value: value}
-	if exists {
-		klog.V(1).Infof("secrets %s already cached, update key", key)
-		return r.Update(entry)
-	}
-	return r.Add(entry)
-}
-
-func (r *secretMapStore) getSecret(key string) (*secretMapEntry, bool, error) {
-	exp, exists, err := r.GetByKey(key)
-	if err != nil {
-		return nil, false, err
-	}
-	if exists {
-		return exp.(*secretMapEntry), true, nil
-	}
-	return nil, false, nil
-}
-
-func (r *secretMapStore) deleteSecret(key string) error {
-	exp, exist, err := r.GetByKey(key)
-	if err != nil {
-		return err
-	}
-	if exist {
-		klog.V(1).Infof("deleted cached secret %s", key)
-		return r.Delete(exp)
-	}
-	return nil
 }
 
 func (e *customizedEngine) getImage() string {
@@ -173,10 +107,7 @@ func getLabelsForSecretsAndJobs(key componentUniqueKey) client.MatchingLabels {
 	}
 }
 
-func renderJob(engine *customizedEngine, key componentUniqueKey, statement []string, endpoint string) *batchv1.Job {
-	randomStr, _ := password.Generate(6, 0, 0, true, false)
-	jobName := jobPrefix + key.clusterName + "-" + randomStr
-
+func renderJob(jobName string, engine *customizedEngine, key componentUniqueKey, statement []string, endpoint string) *batchv1.Job {
 	// inject one more system env variables
 	statementEnv := corev1.EnvVar{
 		Name:  kbAccountStmtEnvName,
@@ -207,7 +138,7 @@ func renderJob(engine *customizedEngine, key componentUniqueKey, statement []str
 					RestartPolicy: corev1.RestartPolicyNever,
 					Containers: []corev1.Container{
 						{
-							Name:            randomStr,
+							Name:            jobName,
 							Image:           engine.getImage(),
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Command:         engine.getCommand(),
@@ -224,9 +155,10 @@ func renderJob(engine *customizedEngine, key componentUniqueKey, statement []str
 }
 
 func renderSecretWithPwd(key componentUniqueKey, username, passwd string) *corev1.Secret {
-	secretData := map[string][]byte{}
-	secretData[constant.AccountNameForSecret] = []byte(username)
-	secretData[constant.AccountPasswdForSecret] = []byte(passwd)
+	secretData := map[string][]byte{
+		constant.AccountNameForSecret:   []byte(username),
+		constant.AccountPasswdForSecret: []byte(passwd),
+	}
 
 	ml := getLabelsForSecretsAndJobs(key)
 	ml[constant.ClusterAccountLabelKey] = username
@@ -305,12 +237,8 @@ func updateFacts(accountName appsv1alpha1.AccountName, detectedFacts *appsv1alph
 	}
 }
 
-func concatSecretName(key componentUniqueKey, username string) string {
-	return fmt.Sprintf("%s-%s-%s-%s", key.namespace, key.clusterName, key.componentName, username)
-}
-
 func getCreationStmtForAccount(key componentUniqueKey, passConfig appsv1alpha1.PasswordConfig,
-	accountConfig appsv1alpha1.SystemAccountConfig, strategy updateStrategy) ([]string, *corev1.Secret) {
+	accountConfig appsv1alpha1.SystemAccountConfig, strategy updateStrategy) ([]string, string) {
 	// generated password with mixedcases = true
 	passwd, _ := password.Generate((int)(passConfig.Length), (int)(passConfig.NumDigits), (int)(passConfig.NumSymbols), false, false)
 	// refine password to upper or lower cases w.r.t configuration
@@ -341,8 +269,8 @@ func getCreationStmtForAccount(key componentUniqueKey, passConfig appsv1alpha1.P
 		stmt := componetutil.ReplaceNamedVars(namedVars, statements.CreationStatement, -1, true)
 		execStmts = append(execStmts, stmt)
 	}
-	secret := renderSecretWithPwd(key, userName, passwd)
-	return execStmts, secret
+	// secret := renderSecretWithPwd(key, userName, passwd)
+	return execStmts, passwd
 }
 
 func getAllSysAccounts() []appsv1alpha1.AccountName {
@@ -379,7 +307,7 @@ func calibrateJobMetaAndSpec(job *batchv1.Job, cluster *appsv1alpha1.Cluster, co
 	if debugModeOn {
 		job.Spec.TTLSecondsAfterFinished = nil
 	} else {
-		defaultTTLZero := (int32)(0)
+		defaultTTLZero := (int32)(1)
 		job.Spec.TTLSecondsAfterFinished = &defaultTTLZero
 	}
 
@@ -390,6 +318,7 @@ func calibrateJobMetaAndSpec(job *batchv1.Job, cluster *appsv1alpha1.Cluster, co
 		return err
 	}
 	job.Spec.Template.Spec.Tolerations = tolerations
+
 	return nil
 }
 

--- a/controllers/apps/systemaccount_util_test.go
+++ b/controllers/apps/systemaccount_util_test.go
@@ -209,16 +209,17 @@ func TestRenderJob(t *testing.T) {
 			}
 			// render job with debug mode off
 			endpoint := "10.0.0.1"
-			job := renderJob(engine, compKey, creationStmt, endpoint)
+			mockJobName := "mock-job" + testCtx.GetRandomStr()
+			job := renderJob(mockJobName, engine, compKey, creationStmt, endpoint)
 			assert.NotNil(t, job)
 			_ = calibrateJobMetaAndSpec(job, cluster, compKey, acc.Name)
 			assert.NotNil(t, job.Spec.TTLSecondsAfterFinished)
-			assert.Equal(t, (int32)(0), *job.Spec.TTLSecondsAfterFinished)
+			assert.Equal(t, (int32)(1), *job.Spec.TTLSecondsAfterFinished)
 			envList := job.Spec.Template.Spec.Containers[0].Env
 			assert.GreaterOrEqual(t, len(envList), 1)
 			assert.Equal(t, job.Spec.Template.Spec.Containers[0].Image, cmdExecutorConfig.Image)
 			// render job with debug mode on
-			job = renderJob(engine, compKey, creationStmt, endpoint)
+			job = renderJob(mockJobName, engine, compKey, creationStmt, endpoint)
 			assert.NotNil(t, job)
 			// set debug mode on
 			cluster.Annotations[debugClusterAnnotationKey] = "True"
@@ -231,7 +232,7 @@ func TestRenderJob(t *testing.T) {
 			toleration := make([]corev1.Toleration, 0)
 			toleration = append(toleration, generateToleration())
 			cluster.Spec.Tolerations = toleration
-			job = renderJob(engine, compKey, creationStmt, endpoint)
+			job = renderJob(mockJobName, engine, compKey, creationStmt, endpoint)
 			assert.NotNil(t, job)
 			_ = calibrateJobMetaAndSpec(job, cluster, compKey, acc.Name)
 			jobToleration := job.Spec.Template.Spec.Tolerations


### PR DESCRIPTION
- fix #3546 
This pr is an improvement over current implementation.  
Since KB creates secrets only  when JOB completing on success, and KB knows clearly how to construct secret for each JOB. There is no need to use a `store` for caching. 