### PR TITLE
fix: playground csi-hostpath-driver failed in windows

### DIFF
--- a/internal/cli/cloudprovider/k3d.go
+++ b/internal/cli/cloudprovider/k3d.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 
@@ -35,6 +36,7 @@ import (
 	l "github.com/k3d-io/k3d/v5/pkg/logger"
 	"github.com/k3d-io/k3d/v5/pkg/runtimes"
 	k3d "github.com/k3d-io/k3d/v5/pkg/types"
+	"github.com/k3d-io/k3d/v5/pkg/types/fixes"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/tools/clientcmd"
@@ -55,6 +57,9 @@ var (
 
 	// K3dProxyImage is k3d proxy image repo
 	K3dProxyImage = "docker.io/apecloud/k3d-proxy:" + version.K3dVersion
+
+	// K3dFixEnv
+	KBEnvFix fixes.K3DFixEnv = "KB_FIX_MOUNTS"
 )
 
 //go:embed assets/k3d-entrypoint-mount.sh
@@ -353,6 +358,12 @@ func buildKubeconfigOptions() config.SimpleConfigOptionsKubeconfig {
 }
 
 func setUpK3d(ctx context.Context, cluster *config.ClusterConfig) error {
+	// add fix Envs
+	if err := os.Setenv(string(KBEnvFix), "1"); err != nil {
+		return err
+	}
+	fixes.FixEnvs = append(fixes.FixEnvs, KBEnvFix)
+
 	l, err := k3dClient.ClusterList(ctx, runtimes.SelectedRuntime)
 	if err != nil {
 		return err
@@ -381,14 +392,6 @@ func setUpK3d(ctx context.Context, cluster *config.ClusterConfig) error {
 			Dest:        "/bin/k3d-entrypoint-mount.sh",
 			Mode:        0744,
 			Description: "Write entrypoint script for mount shared fix",
-		},
-	}, k3d.NodeHook{
-		Stage: k3d.LifecycleStagePostStart,
-		Action: actions.ExecAction{
-			Runtime:     runtimes.SelectedRuntime,
-			Command:     []string{"sh", "-c", " /bin/k3d-entrypoint-mount.sh"},
-			Description: "Execute entrypoint script for mount shared fix",
-			Retries:     5,
 		},
 	})
 


### PR DESCRIPTION
- fix : #2978

What i do:
For the `kbcli playground init` Error:

`failed generate container mount "23cc63afbab3c77b66233e6b9ddec079ead0f5b875bf8e567e9d4faa4c427fd8 spec: failed to generate spec: path var lib/kubelet/pods" mounted on "/var/lib/kubelet" but is not shared` 

When i create a k3d cluster and install  the csi-hostpath-driver locally, i find the command `mount --make-rshared /` do take effect but need to be executed both in the container `k3d-kb-playground-serverlb` and `k3d-kb-playground-server0`. And Sir @ldming find in our code there are only a `WriteFileAction` but lack of an `ExecAction`.  So we add an `ExecAction` and that's worked !

Example：
![image](https://github.com/apecloud/kubeblocks/assets/101848970/e39d8d76-1b3d-4afb-b383-041bb8cf676f)
