### PR TITLE
chore: cli incorrect conversion between integer types

### DIFF
--- a/internal/cli/cmd/addon/addon.go
+++ b/internal/cli/cmd/addon/addon.go
@@ -601,7 +601,7 @@ func (o *addonCmdOpts) buildEnablePatch(flags []*pflag.Flag, spec, install map[s
 	f := o.addonEnableFlags
 	for _, v := range f.ReplicaCountSets {
 		if err := twoTuplesProcessor(v, "replicas", func(s, flag string) (interface{}, error) {
-			v, err := strconv.Atoi(s)
+			v, err := strconv.ParseInt(s, 10, 32)
 			if err != nil {
 				return nil, fmt.Errorf("wrong flag value --%s=%s, with error %v", flag, s, err)
 			}

--- a/internal/cli/cmd/cluster/create.go
+++ b/internal/cli/cmd/cluster/create.go
@@ -764,7 +764,7 @@ func buildClusterComp(cd *appsv1alpha1.ClusterDefinition, setsMap map[string]map
 		}
 
 		// get replicas
-		setReplicas, err := strconv.Atoi(getVal(&c, keyReplicas, sets))
+		setReplicas, err := strconv.ParseInt(getVal(&c, keyReplicas, sets), 10, 32)
 		if err != nil {
 			return nil, fmt.Errorf("repicas is illegal " + err.Error())
 		}


### PR DESCRIPTION
Fix code scanning alert [4](https://github.com/apecloud/kubeblocks/security/code-scanning/4) and [5](https://github.com/apecloud/kubeblocks/security/code-scanning/5).