### PR TITLE
fix: do not create fsnotify.Watcher when using sync mode (#3617)

### DIFF
--- a/cmd/reloader/app/cmd.go
+++ b/cmd/reloader/app/cmd.go
@@ -83,11 +83,13 @@ func runConfigManagerCommand(ctx context.Context, opt *VolumeWatcherOpts) error 
 }
 
 func run(ctx context.Context, opt *VolumeWatcherOpts) error {
-	volumeWatcher, err := startVolumeWatcher(ctx, opt)
-	if err != nil {
-		return err
+	if len(opt.VolumeDirs) > 0 {
+		volumeWatcher, err := startVolumeWatcher(ctx, opt)
+		if err != nil {
+			return err
+		}
+		defer volumeWatcher.Close()
 	}
-	defer volumeWatcher.Close()
 
 	serviceOpt := opt.ServiceOpt
 	if serviceOpt.ContainerRuntimeEnable || serviceOpt.RemoteOnlineUpdateEnable {

--- a/internal/configuration/config_manager/volume_watcher.go
+++ b/internal/configuration/config_manager/volume_watcher.go
@@ -94,7 +94,7 @@ func (w *ConfigMapVolumeWatcher) Run() error {
 
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		return cfgcore.MakeError("failed to create fs notify watcher.")
+		return cfgcore.WrapError(err, "failed to create fs notify watcher")
 	}
 
 	go w.loopNotifyEvent(watcher, w.ctx)


### PR DESCRIPTION
(cherry picked from commit da844ed769d31c65922da1717a671c7105490b42)