### PR TITLE
chore: zip license and readme.md with kbcli for krew

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -9,7 +9,7 @@ on:
 env:
   GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 #  TAG_NAME: ${{ github.ref_name }}
-  TAG_NAME: "0.5.99"
+  TAG_NAME: "0.5.98"
   GO_VERSION: "1.20"
   CLI_NAME: 'kbcli'
   CLI_REPO: 'apecloud/kbcli'
@@ -87,9 +87,8 @@ jobs:
         if: matrix.os == 'windows-amd64'
         run: |
           mv bin/${{ env.CLI_NAME }}.${{ env.CLI_OS_ARCH }} ${{ matrix.os }}/${{ env.CLI_NAME }}.exe 
-          curl -H 'Accept: application/vnd.github.v3.raw' -o README.md https://api.github.com/repos/${{ env.CLI_REPO }}/readme 
-          cp README.md ${{ matrix.os }}/                        # add readme.md
-          cp ${{ github.workspace }}/LICENSE ${{ matrix.os }}/  # add LICENSE
+          curl -H 'Accept: application/vnd.github.v3.raw' -o ${{ matrix.os }}/README.md https://api.github.com/repos/${{ env.CLI_REPO }}/readme 
+          cp ${{ github.workspace }}/LICENSE ${{ matrix.os }}/  
           cp ${{ matrix.os }}/${{ env.CLI_NAME }}.exe bin/
           zip -r -o ${{ env.CLI_FILENAME }}.zip  ${{ env.CLI_DIR }}
           file ${{ env.CLI_FILENAME }}.zip  # for debug 
@@ -104,8 +103,7 @@ jobs:
         if: matrix.os != 'windows-amd64'
         run: |
           mv bin/${{ env.CLI_NAME }}.${{ env.CLI_OS_ARCH }} ${{ matrix.os }}/${{ env.CLI_NAME }} 
-          curl -H 'Accept: application/vnd.github.v3.raw' -o README.md https://api.github.com/repos/${{ env.CLI_REPO }}/readme
-          cp README.md ${{ matrix.os }}/
+          curl -H 'Accept: application/vnd.github.v3.raw' -o ${{ matrix.os }}/README.md  https://api.github.com/repos/${{ env.CLI_REPO }}/readme
           cp ${{ github.workspace }}/LICENSE ${{ matrix.os }}/
           tar -zcvf ${{ env.CLI_FILENAME }}.tar.gz  ${{ env.CLI_DIR }}
           file ${{ env.CLI_FILENAME }}.tar.gz  # for debug 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,15 +1,13 @@
 name: RELEASE-PUBLISH
 
 on:
-  push:
   release:
     types:
       - published
 
 env:
   GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-#  TAG_NAME: ${{ github.ref_name }}
-  TAG_NAME: "0.5.98"
+  TAG_NAME: ${{ github.ref_name }}
   GO_VERSION: "1.20"
   CLI_NAME: 'kbcli'
   CLI_REPO: 'apecloud/kbcli'
@@ -32,13 +30,13 @@ jobs:
           repository: ${{ env.CLI_REPO }}
           token: ${{ env.GITHUB_TOKEN }}
           prerelease: true
-#      - name: create gitlab release ${{ env.CLI_NAME }}
-#        run: |
-#          bash ${{ github.workspace }}/.github/utils/release_gitlab.sh \
-#            --type 1 \
-#            --project-id ${{ env.GITLAB_KBCLI_PROJECT_ID }} \
-#            --tag-name ${{ env.TAG_NAME }} \
-#            --access-token ${{ env.GITLAB_ACCESS_TOKEN }}
+      - name: create gitlab release ${{ env.CLI_NAME }}
+        run: |
+          bash ${{ github.workspace }}/.github/utils/release_gitlab.sh \
+            --type 1 \
+            --project-id ${{ env.GITLAB_KBCLI_PROJECT_ID }} \
+            --tag-name ${{ env.TAG_NAME }} \
+            --access-token ${{ env.GITLAB_ACCESS_TOKEN }}
 
   upload-release-assert:
     needs: create-release-kbcli
@@ -65,9 +63,9 @@ jobs:
       - name: make generate
         run: make generate
 
-#      - name: Get release
-#        id: get_release
-#        uses: bruceadams/get-release@v1.3.2
+      - name: Get release
+        id: get_release
+        uses: bruceadams/get-release@v1.3.2
 
       - name: make build
         run: |
@@ -114,17 +112,17 @@ jobs:
           echo "ASSET_CONTENT_TYPE=application/gzip" >> $GITHUB_ENV
           echo "CheckSum=${{ env.CLI_FILENAME }}.tar.gz.sha256.txt" >> $GITHUB_ENV
 
-#      - name: upload gitlab kbcli asset ${{ matrix.os }}
-#        env:
-#          CLI_BINARY: ${{ env.CLI_NAME }}-${{ matrix.os }}-${{ env.TAG_NAME }}.tar.gz
-#        run: |
-#          bash ${{ github.workspace }}/.github/utils/release_gitlab.sh \
-#            --type 2 \
-#            --project-id ${{ env.GITLAB_KBCLI_PROJECT_ID }} \
-#            --tag-name ${{ env.TAG_NAME }} \
-#            --asset-path ./bin/${{ env.ASSET_NAME }} \
-#            --asset-name ${{ env.ASSET_NAME }} \
-#            --access-token ${{ env.GITLAB_ACCESS_TOKEN }}
+      - name: upload gitlab kbcli asset ${{ matrix.os }}
+        env:
+          CLI_BINARY: ${{ env.CLI_NAME }}-${{ matrix.os }}-${{ env.TAG_NAME }}.tar.gz
+        run: |
+          bash ${{ github.workspace }}/.github/utils/release_gitlab.sh \
+            --type 2 \
+            --project-id ${{ env.GITLAB_KBCLI_PROJECT_ID }} \
+            --tag-name ${{ env.TAG_NAME }} \
+            --asset-path ./bin/${{ env.ASSET_NAME }} \
+            --asset-name ${{ env.ASSET_NAME }} \
+            --access-token ${{ env.GITLAB_ACCESS_TOKEN }}
 
       - name: get release kbcli upload url
         run: |
@@ -142,69 +140,69 @@ jobs:
           asset_name: ${{ env.ASSET_NAME }}
           asset_content_type: ${{ env.ASSET_CONTENT_TYPE }}
 
-#      - name: upload kbcli binary release for winget
-#        if: matrix.os == 'windows-amd64'
-#        uses: actions/upload-release-asset@main
-#        with:
-#          upload_url: ${{ env.UPLOAD_URL }}
-#          asset_path: ./bin/${{ env.CLI_NAME }}.exe
-#          asset_name: ${{ env.CLI_NAME }}.exe
-#          asset_content_type: application/octet-stream
+      - name: upload kbcli binary release for winget
+        if: matrix.os == 'windows-amd64'
+        uses: actions/upload-release-asset@main
+        with:
+          upload_url: ${{ env.UPLOAD_URL }}
+          asset_path: ./bin/${{ env.CLI_NAME }}.exe
+          asset_name: ${{ env.CLI_NAME }}.exe
+          asset_content_type: application/octet-stream
 
-#      - name: upload checksum for kbcli assets
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: sha256
-#          path: sha256/
+      - name: upload checksum for kbcli assets
+        uses: actions/upload-artifact@v3
+        with:
+          name: sha256
+          path: sha256/
 
-#      - name: upload release asset ${{ matrix.os }}
-#        continue-on-error: true
-#        uses: actions/upload-release-asset@main
-#        with:
-#          upload_url: ${{ steps.get_release.outputs.upload_url }}
-#          asset_path: ./bin/${{ env.ASSET_NAME }}
-#          asset_name: ${{ env.ASSET_NAME }}
-#          asset_content_type: ${{ env.ASSET_CONTENT_TYPE }}
+      - name: upload release asset ${{ matrix.os }}
+        continue-on-error: true
+        uses: actions/upload-release-asset@main
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: ./bin/${{ env.ASSET_NAME }}
+          asset_name: ${{ env.ASSET_NAME }}
+          asset_content_type: ${{ env.ASSET_CONTENT_TYPE }}
 
-#  generate-kbcli-sha256:
-#    runs-on: ubuntu-latest
-#    needs: upload-release-assert
-#    steps:
-#      - uses: actions/checkout@v3
-#      - uses: actions/download-artifact@v3
-#        with:
-#          name: sha256
-#          path: sha256
-#      - name: generate kbcli release-notes
-#        run: |
-#          mkdir -p ./docs/release_notes/${{ env.TAG_NAME }}
-#          python ./.github/utils/generate_kbcli_sha256.py ${{ env.TAG_NAME }} sha256
-#      - name: release kbcli with release notes
-#        run: |
-#          bash .github/utils/utils.sh --type 13 \
-#            --github-repo 'apecloud/kbcli' \
-#            --tag-name ${{ env.TAG_NAME }} \
-#            --file "./docs/release_notes/${{ env.TAG_NAME }}/kbcli.md" \
-#            --github-token ${{ env.GITHUB_TOKEN }}
-#      - name: remove artifact
-#        uses: geekyeggo/delete-artifact@v2
-#        with:
-#          name: sha256
-#
-#  send-message:
-#    runs-on: ubuntu-latest
-#    needs: upload-release-assert
-#    if: ${{ always() }}
-#    steps:
-#      - uses: actions/checkout@v3
-#      - name: send message
-#        run: |
-#          CONTENT="release\u00a0${{ env.TAG_NAME }}\u00a0kbcli\u00a0error"
-#          if [[ "${{ needs.upload-release-assert.result }}" == "success" ]]; then
-#              CONTENT="release\u00a0${{ env.TAG_NAME }}\u00a0kbcli\u00a0success"
-#          fi
-#          bash .github/utils/utils.sh --type 12 \
-#            --tag-name ${{ env.TAG_NAME }} \
-#            --content "${CONTENT}"\
-#            --bot-webhook ${{ env.RELEASE_BOT_WEBHOOK }} \
-#            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+  generate-kbcli-sha256:
+    runs-on: ubuntu-latest
+    needs: upload-release-assert
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+        with:
+          name: sha256
+          path: sha256
+      - name: generate kbcli release-notes
+        run: |
+          mkdir -p ./docs/release_notes/${{ env.TAG_NAME }}
+          python ./.github/utils/generate_kbcli_sha256.py ${{ env.TAG_NAME }} sha256
+      - name: release kbcli with release notes
+        run: |
+          bash .github/utils/utils.sh --type 13 \
+            --github-repo 'apecloud/kbcli' \
+            --tag-name ${{ env.TAG_NAME }} \
+            --file "./docs/release_notes/${{ env.TAG_NAME }}/kbcli.md" \
+            --github-token ${{ env.GITHUB_TOKEN }}
+      - name: remove artifact
+        uses: geekyeggo/delete-artifact@v2
+        with:
+          name: sha256
+
+  send-message:
+    runs-on: ubuntu-latest
+    needs: upload-release-assert
+    if: ${{ always() }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: send message
+        run: |
+          CONTENT="release\u00a0${{ env.TAG_NAME }}\u00a0kbcli\u00a0error"
+          if [[ "${{ needs.upload-release-assert.result }}" == "success" ]]; then
+              CONTENT="release\u00a0${{ env.TAG_NAME }}\u00a0kbcli\u00a0success"
+          fi
+          bash .github/utils/utils.sh --type 12 \
+            --tag-name ${{ env.TAG_NAME }} \
+            --content "${CONTENT}"\
+            --bot-webhook ${{ env.RELEASE_BOT_WEBHOOK }} \
+            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,13 +1,15 @@
 name: RELEASE-PUBLISH
 
 on:
+  push:
   release:
     types:
       - published
 
 env:
   GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-  TAG_NAME: ${{ github.ref_name }}
+#  TAG_NAME: ${{ github.ref_name }}
+  TAG_NAME: "0.5.99"
   GO_VERSION: "1.20"
   CLI_NAME: 'kbcli'
   CLI_REPO: 'apecloud/kbcli'
@@ -30,13 +32,13 @@ jobs:
           repository: ${{ env.CLI_REPO }}
           token: ${{ env.GITHUB_TOKEN }}
           prerelease: true
-      - name: create gitlab release ${{ env.CLI_NAME }}
-        run: |
-          bash ${{ github.workspace }}/.github/utils/release_gitlab.sh \
-            --type 1 \
-            --project-id ${{ env.GITLAB_KBCLI_PROJECT_ID }} \
-            --tag-name ${{ env.TAG_NAME }} \
-            --access-token ${{ env.GITLAB_ACCESS_TOKEN }}
+#      - name: create gitlab release ${{ env.CLI_NAME }}
+#        run: |
+#          bash ${{ github.workspace }}/.github/utils/release_gitlab.sh \
+#            --type 1 \
+#            --project-id ${{ env.GITLAB_KBCLI_PROJECT_ID }} \
+#            --tag-name ${{ env.TAG_NAME }} \
+#            --access-token ${{ env.GITLAB_ACCESS_TOKEN }}
 
   upload-release-assert:
     needs: create-release-kbcli
@@ -63,9 +65,9 @@ jobs:
       - name: make generate
         run: make generate
 
-      - name: Get release
-        id: get_release
-        uses: bruceadams/get-release@v1.3.2
+#      - name: Get release
+#        id: get_release
+#        uses: bruceadams/get-release@v1.3.2
 
       - name: make build
         run: |
@@ -85,6 +87,9 @@ jobs:
         if: matrix.os == 'windows-amd64'
         run: |
           mv bin/${{ env.CLI_NAME }}.${{ env.CLI_OS_ARCH }} ${{ matrix.os }}/${{ env.CLI_NAME }}.exe 
+          curl -H 'Accept: application/vnd.github.v3.raw' -o README.md https://api.github.com/repos/${{ env.CLI_REPO }}/readme 
+          cp README.md ${{ matrix.os }}/                        # add readme.md
+          cp ${{ github.workspace }}/LICENSE ${{ matrix.os }}/  # add LICENSE
           cp ${{ matrix.os }}/${{ env.CLI_NAME }}.exe bin/
           zip -r -o ${{ env.CLI_FILENAME }}.zip  ${{ env.CLI_DIR }}
           file ${{ env.CLI_FILENAME }}.zip  # for debug 
@@ -99,6 +104,9 @@ jobs:
         if: matrix.os != 'windows-amd64'
         run: |
           mv bin/${{ env.CLI_NAME }}.${{ env.CLI_OS_ARCH }} ${{ matrix.os }}/${{ env.CLI_NAME }} 
+          curl -H 'Accept: application/vnd.github.v3.raw' -o README.md https://api.github.com/repos/${{ env.CLI_REPO }}/readme
+          cp README.md ${{ matrix.os }}/
+          cp ${{ github.workspace }}/LICENSE ${{ matrix.os }}/
           tar -zcvf ${{ env.CLI_FILENAME }}.tar.gz  ${{ env.CLI_DIR }}
           file ${{ env.CLI_FILENAME }}.tar.gz  # for debug 
           mkdir -p sha256
@@ -108,17 +116,17 @@ jobs:
           echo "ASSET_CONTENT_TYPE=application/gzip" >> $GITHUB_ENV
           echo "CheckSum=${{ env.CLI_FILENAME }}.tar.gz.sha256.txt" >> $GITHUB_ENV
 
-      - name: upload gitlab kbcli asset ${{ matrix.os }}
-        env:
-          CLI_BINARY: ${{ env.CLI_NAME }}-${{ matrix.os }}-${{ env.TAG_NAME }}.tar.gz
-        run: |
-          bash ${{ github.workspace }}/.github/utils/release_gitlab.sh \
-            --type 2 \
-            --project-id ${{ env.GITLAB_KBCLI_PROJECT_ID }} \
-            --tag-name ${{ env.TAG_NAME }} \
-            --asset-path ./bin/${{ env.ASSET_NAME }} \
-            --asset-name ${{ env.ASSET_NAME }} \
-            --access-token ${{ env.GITLAB_ACCESS_TOKEN }}
+#      - name: upload gitlab kbcli asset ${{ matrix.os }}
+#        env:
+#          CLI_BINARY: ${{ env.CLI_NAME }}-${{ matrix.os }}-${{ env.TAG_NAME }}.tar.gz
+#        run: |
+#          bash ${{ github.workspace }}/.github/utils/release_gitlab.sh \
+#            --type 2 \
+#            --project-id ${{ env.GITLAB_KBCLI_PROJECT_ID }} \
+#            --tag-name ${{ env.TAG_NAME }} \
+#            --asset-path ./bin/${{ env.ASSET_NAME }} \
+#            --asset-name ${{ env.ASSET_NAME }} \
+#            --access-token ${{ env.GITLAB_ACCESS_TOKEN }}
 
       - name: get release kbcli upload url
         run: |
@@ -136,69 +144,69 @@ jobs:
           asset_name: ${{ env.ASSET_NAME }}
           asset_content_type: ${{ env.ASSET_CONTENT_TYPE }}
 
-      - name: upload kbcli binary release for winget
-        if: matrix.os == 'windows-amd64'
-        uses: actions/upload-release-asset@main
-        with:
-          upload_url: ${{ env.UPLOAD_URL }}
-          asset_path: ./bin/${{ env.CLI_NAME }}.exe
-          asset_name: ${{ env.CLI_NAME }}.exe
-          asset_content_type: application/octet-stream
+#      - name: upload kbcli binary release for winget
+#        if: matrix.os == 'windows-amd64'
+#        uses: actions/upload-release-asset@main
+#        with:
+#          upload_url: ${{ env.UPLOAD_URL }}
+#          asset_path: ./bin/${{ env.CLI_NAME }}.exe
+#          asset_name: ${{ env.CLI_NAME }}.exe
+#          asset_content_type: application/octet-stream
 
-      - name: upload checksum for kbcli assets
-        uses: actions/upload-artifact@v3
-        with:
-          name: sha256
-          path: sha256/
+#      - name: upload checksum for kbcli assets
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: sha256
+#          path: sha256/
 
-      - name: upload release asset ${{ matrix.os }}
-        continue-on-error: true
-        uses: actions/upload-release-asset@main
-        with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: ./bin/${{ env.ASSET_NAME }}
-          asset_name: ${{ env.ASSET_NAME }}
-          asset_content_type: ${{ env.ASSET_CONTENT_TYPE }}
+#      - name: upload release asset ${{ matrix.os }}
+#        continue-on-error: true
+#        uses: actions/upload-release-asset@main
+#        with:
+#          upload_url: ${{ steps.get_release.outputs.upload_url }}
+#          asset_path: ./bin/${{ env.ASSET_NAME }}
+#          asset_name: ${{ env.ASSET_NAME }}
+#          asset_content_type: ${{ env.ASSET_CONTENT_TYPE }}
 
-  generate-kbcli-sha256:
-    runs-on: ubuntu-latest
-    needs: upload-release-assert
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
-        with:
-          name: sha256
-          path: sha256
-      - name: generate kbcli release-notes
-        run: |
-          mkdir -p ./docs/release_notes/${{ env.TAG_NAME }}
-          python ./.github/utils/generate_kbcli_sha256.py ${{ env.TAG_NAME }} sha256
-      - name: release kbcli with release notes
-        run: |
-          bash .github/utils/utils.sh --type 13 \
-            --github-repo 'apecloud/kbcli' \
-            --tag-name ${{ env.TAG_NAME }} \
-            --file "./docs/release_notes/${{ env.TAG_NAME }}/kbcli.md" \
-            --github-token ${{ env.GITHUB_TOKEN }}
-      - name: remove artifact
-        uses: geekyeggo/delete-artifact@v2
-        with:
-          name: sha256
-
-  send-message:
-    runs-on: ubuntu-latest
-    needs: upload-release-assert
-    if: ${{ always() }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: send message
-        run: |
-          CONTENT="release\u00a0${{ env.TAG_NAME }}\u00a0kbcli\u00a0error"
-          if [[ "${{ needs.upload-release-assert.result }}" == "success" ]]; then
-              CONTENT="release\u00a0${{ env.TAG_NAME }}\u00a0kbcli\u00a0success"
-          fi
-          bash .github/utils/utils.sh --type 12 \
-            --tag-name ${{ env.TAG_NAME }} \
-            --content "${CONTENT}"\
-            --bot-webhook ${{ env.RELEASE_BOT_WEBHOOK }} \
-            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+#  generate-kbcli-sha256:
+#    runs-on: ubuntu-latest
+#    needs: upload-release-assert
+#    steps:
+#      - uses: actions/checkout@v3
+#      - uses: actions/download-artifact@v3
+#        with:
+#          name: sha256
+#          path: sha256
+#      - name: generate kbcli release-notes
+#        run: |
+#          mkdir -p ./docs/release_notes/${{ env.TAG_NAME }}
+#          python ./.github/utils/generate_kbcli_sha256.py ${{ env.TAG_NAME }} sha256
+#      - name: release kbcli with release notes
+#        run: |
+#          bash .github/utils/utils.sh --type 13 \
+#            --github-repo 'apecloud/kbcli' \
+#            --tag-name ${{ env.TAG_NAME }} \
+#            --file "./docs/release_notes/${{ env.TAG_NAME }}/kbcli.md" \
+#            --github-token ${{ env.GITHUB_TOKEN }}
+#      - name: remove artifact
+#        uses: geekyeggo/delete-artifact@v2
+#        with:
+#          name: sha256
+#
+#  send-message:
+#    runs-on: ubuntu-latest
+#    needs: upload-release-assert
+#    if: ${{ always() }}
+#    steps:
+#      - uses: actions/checkout@v3
+#      - name: send message
+#        run: |
+#          CONTENT="release\u00a0${{ env.TAG_NAME }}\u00a0kbcli\u00a0error"
+#          if [[ "${{ needs.upload-release-assert.result }}" == "success" ]]; then
+#              CONTENT="release\u00a0${{ env.TAG_NAME }}\u00a0kbcli\u00a0success"
+#          fi
+#          bash .github/utils/utils.sh --type 12 \
+#            --tag-name ${{ env.TAG_NAME }} \
+#            --content "${CONTENT}"\
+#            --bot-webhook ${{ env.RELEASE_BOT_WEBHOOK }} \
+#            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"


### PR DESCRIPTION
- To meet the requirements for `krew`.
- Add the kbcli `license` and `README.md` in .tar.gz 