### PR TITLE
feat: check chaos-mesh if enable before injecting faults

### DIFF
--- a/internal/cli/cmd/fault/fault.go
+++ b/internal/cli/cmd/fault/fault.go
@@ -119,7 +119,7 @@ func (o *FaultBaseOptions) AddCommonFlag(cmd *cobra.Command) {
 
 func (o *FaultBaseOptions) BaseValidate() error {
 	enable, _ := o.checkChaosMeshEnable()
-	if !enable && o.DryRun != "none" {
+	if !enable && o.DryRun == "none" {
 		return fmt.Errorf("chaos-mesh is not enabled")
 	}
 

--- a/internal/cli/cmd/fault/fault.go
+++ b/internal/cli/cmd/fault/fault.go
@@ -119,12 +119,14 @@ func (o *FaultBaseOptions) AddCommonFlag(cmd *cobra.Command) {
 }
 
 func (o *FaultBaseOptions) BaseValidate() error {
-	enable, err := o.checkChaosMeshEnable()
-	if err != nil {
-		return err
-	}
-	if !enable && o.DryRun == "none" {
-		return fmt.Errorf("chaos-mesh is not enabled, use `kbcli addon enable chaos-mesh` to  enable chaos-mesh first")
+	if o.DryRun == "none" {
+		enable, err := o.checkChaosMeshEnable()
+		if err != nil {
+			return err
+		}
+		if !enable {
+			return fmt.Errorf("chaos-mesh is not enabled, use `kbcli addon enable chaos-mesh` to  enable chaos-mesh first")
+		}
 	}
 
 	if ok, err := IsRegularMatch(o.Duration); !ok {

--- a/internal/cli/cmd/fault/fault.go
+++ b/internal/cli/cmd/fault/fault.go
@@ -118,9 +118,12 @@ func (o *FaultBaseOptions) AddCommonFlag(cmd *cobra.Command) {
 }
 
 func (o *FaultBaseOptions) BaseValidate() error {
-	enable, _ := o.checkChaosMeshEnable()
+	enable, err := o.checkChaosMeshEnable()
+	if err != nil {
+		return err
+	}
 	if !enable && o.DryRun == "none" {
-		return fmt.Errorf("chaos-mesh is not enabled")
+		return fmt.Errorf("chaos-mesh is not enabled, use `kbcli addon enable chaos-mesh` to  enable chaos-mesh first")
 	}
 
 	if ok, err := IsRegularMatch(o.Duration); !ok {

--- a/internal/cli/cmd/fault/fault.go
+++ b/internal/cli/cmd/fault/fault.go
@@ -20,14 +20,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package fault
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 
 	"github.com/apecloud/kubeblocks/internal/cli/create"
@@ -115,6 +118,11 @@ func (o *FaultBaseOptions) AddCommonFlag(cmd *cobra.Command) {
 }
 
 func (o *FaultBaseOptions) BaseValidate() error {
+	enable, _ := o.checkChaosMeshEnable()
+	if !enable && o.DryRun != "none" {
+		return fmt.Errorf("chaos-mesh is not enabled")
+	}
+
 	if ok, err := IsRegularMatch(o.Duration); !ok {
 		return err
 	}
@@ -159,4 +167,27 @@ func IsInteger(str string) (bool, error) {
 
 func GetGVR(group, version, resourceName string) schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: group, Version: version, Resource: resourceName}
+}
+
+func (o *FaultBaseOptions) checkChaosMeshEnable() (bool, error) {
+	config, err := o.Factory.ToRESTConfig()
+	if err != nil {
+		return false, err
+	}
+
+	clientSet, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return false, err
+	}
+	podList, err := clientSet.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/part-of=chaos-mesh",
+	})
+	if err != nil {
+		return false, err
+	}
+
+	if len(podList.Items) > 0 {
+		return true, nil
+	}
+	return false, nil
 }

--- a/internal/cli/cmd/fault/fault.go
+++ b/internal/cli/cmd/fault/fault.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 
 	"github.com/apecloud/kubeblocks/internal/cli/create"
@@ -186,6 +187,7 @@ func (o *FaultBaseOptions) checkChaosMeshEnable() (bool, error) {
 		LabelSelector: "app.kubernetes.io/part-of=chaos-mesh",
 	})
 	if err != nil {
+		klog.V(1).Info(err)
 		return false, err
 	}
 

--- a/internal/cli/cmd/fault/fault_http_test.go
+++ b/internal/cli/cmd/fault/fault_http_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Fault Network HTPP", func() {
 
 		It("fault network http delay", func() {
 			inputs := [][]string{
-				{""},
+				{"--dry-run=client"},
 				{"--delay=50s", "--dry-run=client"},
 			}
 			o := NewHTTPChaosOptions(tf, streams, "")


### PR DESCRIPTION
* resolve: #3552

After installing chaos-mesh in the cluster for the first time, regardless of whether chaos-mesh is uninstalled or not, k8s can detect related CRDs, so even if chaos-mesh is not installed, it is possible to create crd resources such as podchaos and netwokchaos. This will make the user feel that the fault has been successfully injected. So here is a hint if chaos-mesh is not installed. The effect is as follows:

```
./bin/kbcli fault network partition mysql-cluster-mysql-0
error: chaos-mesh is not enabled, use `kbcli addon enable chaos-mesh` to  enable chaos-mesh first
```