### PR TITLE
fix: cli playground error when repeatedly init 

### DIFF
--- a/internal/cli/cloudprovider/k3d.go
+++ b/internal/cli/cloudprovider/k3d.go
@@ -379,7 +379,7 @@ func setUpK3d(ctx context.Context, cluster *config.ClusterConfig) error {
 	for _, c := range l {
 		if c.Name == cluster.Name {
 			if c, err := k3dClient.ClusterGet(ctx, runtimes.SelectedRuntime, c); err == nil {
-				fmt.Printf("Detected an existing cluster: %s\n", c.Name)
+				klog.V(1).Infof("Detected an existing cluster: %s", c.Name)
 				return nil
 			}
 			break

--- a/internal/cli/cmd/kubeblocks/install.go
+++ b/internal/cli/cmd/kubeblocks/install.go
@@ -184,13 +184,11 @@ func (o *InstallOptions) PreCheck() error {
 		return err
 	}
 
-	// Todo: KubeBlocks maybe already install but it's status could be Failed.
+	// Todo: KubeBlocks maybe already installed but it's status could be Failed.
 	// For example: 'kbcli playground init' in windows will fail and try 'kbcli playground init' again immediately,
-	// kbcli will output SUCCESSFULLY, however the addon csi is failed and KubeBlocks do not install SUCCESSFULLY
+	// kbcli will output SUCCESSFULLY, however the addon csi is still failed and KubeBlocks is not installed SUCCESSFULLY
 	if v.KubeBlocks != "" {
-		printer.Warning(o.Out, "KubeBlocks %s already exists, repeated installation is not supported.\n\n", v.KubeBlocks)
-		fmt.Fprintln(o.Out, "If you want to upgrade it, please use \"kbcli kubeblocks upgrade\".")
-		return nil
+		return fmt.Errorf("KubeBlocks %s already exists, repeated installation is not supported", v.KubeBlocks)
 	}
 
 	// check whether the namespace exists

--- a/internal/cli/cmd/playground/init.go
+++ b/internal/cli/cmd/playground/init.go
@@ -445,6 +445,12 @@ func (o *initOptions) installKubeBlocks(k8sClusterName string) error {
 	}
 
 	if err = insOpts.PreCheck(); err != nil {
+		// if the KubeBlocks has been installed, we ignore the error
+		errMsg := err.Error()
+		if strings.Contains(errMsg, "repeated installation is not supported") {
+			fmt.Fprintf(o.Out, strings.Split(errMsg, ",")[0]+"\n")
+			return nil
+		}
 		return err
 	}
 	return insOpts.Install()


### PR DESCRIPTION

fix #3649 

cli playground should NOT continue to install KubeBlocks when KubeBlocks already exists