### PR TITLE
feat: support arm64 xtrabackup for apecloud mysql backup tool.

### DIFF
--- a/deploy/apecloud-mysql-scale/templates/backuptool.yaml
+++ b/deploy/apecloud-mysql-scale/templates/backuptool.yaml
@@ -6,7 +6,7 @@ metadata:
     clusterdefinition.kubeblocks.io/name: apecloud-mysql
     {{- include "apecloud-mysql.labels" . | nindent 4 }}
 spec:
-  image: registry.cn-hangzhou.aliyuncs.com/apecloud/percona-xtrabackup
+  image: registry.cn-hangzhou.aliyuncs.com/apecloud/apecloud-xtrabackup:latest
   deployKind: job
   env:
     - name: DATA_DIR

--- a/deploy/apecloud-mysql/templates/backuptool.yaml
+++ b/deploy/apecloud-mysql/templates/backuptool.yaml
@@ -6,7 +6,7 @@ metadata:
     clusterdefinition.kubeblocks.io/name: apecloud-mysql
     {{- include "apecloud-mysql.labels" . | nindent 4 }}
 spec:
-  image: registry.cn-hangzhou.aliyuncs.com/apecloud/percona-xtrabackup
+  image: registry.cn-hangzhou.aliyuncs.com/apecloud/apecloud-xtrabackup:latest
   deployKind: job
   env:
     - name: DATA_DIR


### PR DESCRIPTION
support arm64 xtrabackup for apecloud mysql backup tool.
fix: #3576