### PR TITLE
fix: fix the file name error in kubeblocks.io

### DIFF
--- a/docs/user_docs/installation/uninstall-kbcli-and-kubeblocks.md
+++ b/docs/user_docs/installation/uninstall-kbcli-and-kubeblocks.md
@@ -65,7 +65,7 @@ For Homebrew, run
 brew uninstall kbcli
 ```
 
-kbcli creates a hidden folder named `~./kbcli` under the HOME directory to store configuration information and temporary files. You can delete this folder after uninstalling kbcli.
+kbcli creates a hidden folder named `~/.kbcli` under the HOME directory to store configuration information and temporary files. You can delete this folder after uninstalling kbcli.
 
 </TabItem>
 
@@ -88,7 +88,7 @@ kbcli creates a hidden folder named `~./kbcli` under the HOME directory to store
 
 3. Delete a folder named `.kbcli`.
 
-   kbcli creates a folder named `./kbcli` under the C:\Users\username directory to store configuration information and temporary files. You can delete this folder after uninstalling kbcli.
+   kbcli creates a folder named `/.kbcli` under the C:\Users\username directory to store configuration information and temporary files. You can delete this folder after uninstalling kbcli.
 
 </TabItem>
 

--- a/docs/user_docs/installation/uninstall-kbcli-and-kubeblocks.md
+++ b/docs/user_docs/installation/uninstall-kbcli-and-kubeblocks.md
@@ -88,7 +88,7 @@ kbcli creates a hidden folder named `~/.kbcli` under the HOME directory to store
 
 3. Delete a folder named `.kbcli`.
 
-   kbcli creates a folder named `/.kbcli` under the C:\Users\username directory to store configuration information and temporary files. You can delete this folder after uninstalling kbcli.
+   kbcli creates a folder named `.kbcli` under the C:\Users\username directory to store configuration information and temporary files. You can delete this folder after uninstalling kbcli.
 
 </TabItem>
 


### PR DESCRIPTION
- fix https://kubeblocks.io/docs/release-0.5/user_docs/installation/uninstall-kbcli-and-kubeblocks
`~./kbcli` to `~/.kbcli`