### PR TITLE
fix: change preflight checks rule for low spec machine in test case

### DIFF
--- a/internal/cli/testing/testdata/hostpreflight.yaml
+++ b/internal/cli/testing/testdata/hostpreflight.yaml
@@ -9,11 +9,11 @@ spec:
     - cpu:
         outcomes:
           - fail:
-              when: "physical < 4"
-              message: At least 4 physical CPU cores are required
+              when: "physical < 1"
+              message: At least 1 physical CPU cores are required
           - fail:
-              when: "logical < 8"
-              message: At least 8 CPU cores are required
+              when: "logical < 1"
+              message: At least 1 CPU cores are required
           - warn:
               when: "count < 16"
               message: At least 16 CPU cores preferred

--- a/internal/cli/testing/testdata/hostpreflight_nil.yaml
+++ b/internal/cli/testing/testdata/hostpreflight_nil.yaml
@@ -8,11 +8,11 @@ spec:
     - cpu:
         outcomes:
           - fail:
-              when: "physical < 4"
-              message: At least 4 physical CPU cores are required
+              when: "physical < 1"
+              message: At least 1 physical CPU cores are required
           - fail:
-              when: "logical < 8"
-              message: At least 8 CPU cores are required
+              when: "logical < 1"
+              message: At least 1 CPU cores are required
           - warn:
               when: "count < 16"
               message: At least 16 CPU cores preferred


### PR DESCRIPTION
This pr will fix test fail when KB is installed in a low-spec machine, such as just 2 core cpu in ecs.