### PR TITLE
chore: update unstable testcases and add events for failed jobs

### DIFF
--- a/controllers/apps/systemaccount_controller.go
+++ b/controllers/apps/systemaccount_controller.go
@@ -485,12 +485,14 @@ func (r *SystemAccountReconciler) jobCompletionHandler() *handler.Funcs {
 			clusterName := job.Labels[constant.AppInstanceLabelKey]
 			componentName := job.Labels[constant.KBAppComponentLabelKey]
 
+			// filter out jobs that are not for system account
 			if len(accountName) == 0 || len(clusterName) == 0 || len(componentName) == 0 {
 				return
 			}
-
+			// filter out jobs that have not reached completion (either completed or failed) or have been handled
 			if !containsJobCondition(*job, job.Status.Conditions, batchv1.JobFailed, corev1.ConditionTrue) &&
-				!containsJobCondition(*job, job.Status.Conditions, batchv1.JobComplete, corev1.ConditionTrue) {
+				!containsJobCondition(*job, job.Status.Conditions, batchv1.JobComplete, corev1.ConditionTrue) ||
+				!controllerutil.ContainsFinalizer(job, constant.DBClusterFinalizerName) {
 				return
 			}
 

--- a/controllers/apps/systemaccount_controller.go
+++ b/controllers/apps/systemaccount_controller.go
@@ -477,29 +477,23 @@ func (r *SystemAccountReconciler) jobCompletionHandler() *handler.Funcs {
 				return
 			}
 
-			if job.DeletionTimestamp != nil || job.Annotations == nil || job.Labels == nil {
+			if job.Annotations == nil || job.Labels == nil {
 				return
 			}
 
-			accountName := job.ObjectMeta.Labels[constant.ClusterAccountLabelKey]
-			clusterName := job.ObjectMeta.Labels[constant.AppInstanceLabelKey]
-			componentName := job.ObjectMeta.Labels[constant.KBAppComponentLabelKey]
+			accountName := job.Labels[constant.ClusterAccountLabelKey]
+			clusterName := job.Labels[constant.AppInstanceLabelKey]
+			componentName := job.Labels[constant.KBAppComponentLabelKey]
 
 			if len(accountName) == 0 || len(clusterName) == 0 || len(componentName) == 0 {
 				return
 			}
 
-			if containsJobCondition(*job, job.Status.Conditions, batchv1.JobFailed, corev1.ConditionTrue) {
-				logger.V(1).Info("job failed", "job", job.Name)
-				jobTerminated = true
+			if !containsJobCondition(*job, job.Status.Conditions, batchv1.JobFailed, corev1.ConditionTrue) &&
+				!containsJobCondition(*job, job.Status.Conditions, batchv1.JobComplete, corev1.ConditionTrue) {
 				return
 			}
 
-			if !containsJobCondition(*job, job.Status.Conditions, batchv1.JobComplete, corev1.ConditionTrue) {
-				return
-			}
-
-			logger.V(1).Info("job succeeded", "job", job.Name)
 			jobTerminated = true
 			clusterKey := types.NamespacedName{Namespace: job.Namespace, Name: clusterName}
 			cluster := &appsv1alpha1.Cluster{}
@@ -508,12 +502,18 @@ func (r *SystemAccountReconciler) jobCompletionHandler() *handler.Funcs {
 				return
 			}
 
+			if containsJobCondition(*job, job.Status.Conditions, batchv1.JobFailed, corev1.ConditionTrue) {
+				logger.V(1).Info("job failed", "job", job.Name)
+				r.Recorder.Eventf(cluster, corev1.EventTypeNormal, SysAcctCreate,
+					"Failed to create accounts for cluster: %s, component: %s, accounts: %s", cluster.Name, componentName, accountName)
+				return
+			}
+
 			compKey := componentUniqueKey{
 				namespace:     job.Namespace,
 				clusterName:   clusterName,
 				componentName: componentName,
 			}
-
 			// get password from job
 			passwd := job.Annotations[systemAccountPasswdAnnotation]
 			secret := renderSecretWithPwd(compKey, accountName, passwd)
@@ -528,7 +528,7 @@ func (r *SystemAccountReconciler) jobCompletionHandler() *handler.Funcs {
 			}
 
 			r.Recorder.Eventf(cluster, corev1.EventTypeNormal, SysAcctCreate,
-				"Created Accounts for cluster: %s, component: %s, accounts: %s", cluster.Name, componentName, accountName)
+				"Created accounts for cluster: %s, component: %s, accounts: %s", cluster.Name, componentName, accountName)
 		},
 	}
 }

--- a/controllers/apps/systemaccount_util_test.go
+++ b/controllers/apps/systemaccount_util_test.go
@@ -61,15 +61,13 @@ func mockSystemAccountsSpec() *appsv1alpha1.SystemAccountSpec {
 
 	var account appsv1alpha1.SystemAccountConfig
 	var scope appsv1alpha1.ProvisionScope
-	for _, name := range getAllSysAccounts() {
-		randomToss := rand.Intn(10)
-		if randomToss%2 == 0 {
+	for idx, name := range getAllSysAccounts() {
+		if idx%2 == 0 {
 			scope = appsv1alpha1.AnyPods
 		} else {
 			scope = appsv1alpha1.AllPods
 		}
-
-		if randomToss%3 == 0 {
+		if idx%3 == 0 {
 			account = mockCreateByRefSystemAccount(name, scope)
 		} else {
 			account = mockCreateByStmtSystemAccount(name)


### PR DESCRIPTION
- fix #3739 

This path updates the code in : 
1. add a job failed event to cluster 
2. update testcase, there is no need to delete jobs explicitly, all jobs will be delete in `cleanUp` stage.  

The root cause of this unstable case is:  we are racing others to remove finalizer.  
1. a object under deletion has an `orphan` fianlizer, added by apiserver, and will later be removed by GC (Garbage Collector)
2. the testcase explicitly removes the finalizer, racing against the GC module in the envtest.   
But if this `oprhan` finalizer is deleted by that GC module,  we will get an Object Not Found error.  The testcase should leave the work to `cleanUp` function and leave jobs as they are.