### PR TITLE
fix: cli  not logged as error in memcache discovery client

### DIFF
--- a/internal/cli/cmd/cli.go
+++ b/internal/cli/cmd/cli.go
@@ -26,8 +26,10 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/klog/v2"
 	kccmd "k8s.io/kubectl/pkg/cmd"
 	kcplugin "k8s.io/kubectl/pkg/cmd/plugin"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -68,6 +70,14 @@ func init() {
 	// put the download directory of the plugin into the PATH
 	if err := util.AddDirToPath(fmt.Sprintf("%s/.%s/plugins/bin", os.Getenv("HOME"), cliName)); err != nil {
 		fmt.Println("Failed to add kbcli bin dir to PATH:", err)
+	}
+
+	// when the kubernetes cluster is not ready, the runtime will output the error
+	// message like "couldn't get resource list for", we ignore it
+	utilruntime.ErrorHandlers[0] = func(err error) {
+		if klog.V(2).Enabled() {
+			klog.ErrorDepth(2, err)
+		}
 	}
 }
 

--- a/internal/cli/cmd/cli_test.go
+++ b/internal/cli/cmd/cli_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright (C) 2022-2023 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package cmd
+
+import (
+	"testing"
+)
+
+func TestNewCli(t *testing.T) {
+	cmd := NewCliCmd()
+	if cmd == nil {
+		t.Fatal("command should not be nil")
+	} else {
+		cmd.Run(cmd, []string{"help"})
+	}
+}

--- a/internal/cli/cmd/playground/init.go
+++ b/internal/cli/cmd/playground/init.go
@@ -31,7 +31,6 @@ import (
 	"golang.org/x/exp/slices"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/klog/v2"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -373,14 +372,6 @@ func (o *initOptions) setKubeConfig(info *cp.K8sClusterInfo) error {
 
 func (o *initOptions) installKBAndCluster(info *cp.K8sClusterInfo) error {
 	var err error
-
-	// when the kubernetes cluster is not ready, the runtime will output the error
-	// message like "couldn't get resource list for", we ignore it
-	runtime.ErrorHandlers[0] = func(err error) {
-		if klog.V(1).Enabled() {
-			klog.ErrorDepth(2, err)
-		}
-	}
 
 	// write kubeconfig content to a temporary file and use it
 	if err = writeAndUseKubeConfig(info.KubeConfig, o.kubeConfigPath, o.Out); err != nil {


### PR DESCRIPTION

* fix #3759

Reproduce:
1. create a k3d cluster
2. edit the metrics-server, use a wrong image, the metrics-server will disabled
3. install KubeBlocks

```bash
kubectl get pods -A
NAMESPACE     NAME                                                     READY   STATUS             RESTARTS   AGE
kube-system   local-path-provisioner-76d776f6f9-bsh6v                  1/1     Running            0          60m
kube-system   coredns-59b4f5bbd5-m6sz4                                 1/1     Running            0          60m
kube-system   helm-install-traefik-crd-fxc9j                           0/1     Completed          0          60m
kube-system   helm-install-traefik-29g6d                               0/1     Completed          1          60m
kube-system   svclb-traefik-a782e64e-5wtc6                             2/2     Running            0          57m
kube-system   traefik-56b8c5fb5c-fffqt                                 1/1     Running            0          57m
kube-system   metrics-server-75b9bd6fb6-wk8f8                          0/1     ImagePullBackOff   0          51m

```

Before:

```bash
bin/kbcli kb install --version 0.5.2
KubeBlocks will be installed to namespace "kb-system"
Kubernetes version 1.26.4+k3s1
kbcli version 0.5.0-alpha.0
Add and update repo kubeblocks                     OK
⣾ Install KubeBlocks 0.5.2                          E0613 20:31:51.982957   34833 memcache.go:255] couldn't get resource list for metrics.k8s.io/v1beta1: the server is currently unable to handle the request
E0613 20:31:51.999899   34833 memcache.go:255] couldn't get resource list for metrics.k8s.io/v1beta1: the server is currently unable to handle the request
⣽ Install KubeBlocks 0.5.2                          E0613 20:31:52.005190   34833 memcache.go:106] couldn't get resource list for metrics.k8s.io/v1beta1: the server is currently unable to handle the request
⣾ Install KubeBlocks 0.5.2                          ^C%                                                                            
```

Fixed:
```bash
$bin/kbcli kb install --version 0.5.2
KubeBlocks will be installed to namespace "kb-system"
Kubernetes version 1.26.4+k3s1
kbcli version 0.5.0-alpha.0
Add and update repo kubeblocks                     OK
Install KubeBlocks 0.5.2                           OK
Wait for addons to be enabled
  alertmanager-webhook-adaptor                     OK
  apecloud-mysql                                   OK
  grafana                                          OK
  milvus                                           OK
  mongodb                                          OK
  postgresql                                       OK
  prometheus                                       OK
  qdrant                                           OK
  redis                                            OK
  snapshot-controller                              OK
  weaviate                                         OK

KubeBlocks 0.5.2 installed to namespace kb-system SUCCESSFULLY!

-> Basic commands for cluster:
    kbcli cluster create -h     # help information about creating a database cluster
    kbcli cluster list          # list all database clusters
    kbcli cluster describe <cluster name>  # get cluster information

-> Uninstall KubeBlocks:
    kbcli kubeblocks uninstall

-> To view the monitoring add-ons web console:
    kbcli dashboard list        # list all monitoring web consoles
    kbcli dashboard open <name> # open the web console in the default browser

```
