### PR TITLE
fix: resolve apecloud mysql-scale backup/restore, hscale and reconfig…

### DIFF
--- a/deploy/apecloud-mysql-scale/scripts/mysql-reload.tpl
+++ b/deploy/apecloud-mysql-scale/scripts/mysql-reload.tpl
@@ -28,8 +28,8 @@
 		{{- end }}
 	{{- end }}
 	{{- if ge $var_int 0 }}
-		{{- exec_sql ( printf "SET GLOBAL %s = %d" $pk $var_int ) }}
+		{{- execSql ( printf "SET GLOBAL %s = %d" $pk $var_int ) }}
 	{{- else }}
-		{{- exec_sql ( printf "SET GLOBAL %s = '%s'" $pk $pv ) }}
+		{{- execSql ( printf "SET GLOBAL %s = '%s'" $pk $pv ) }}
 	{{- end }}
 {{- end }}

--- a/deploy/apecloud-mysql-scale/templates/backuppolicytemplateforhscale.yaml
+++ b/deploy/apecloud-mysql-scale/templates/backuppolicytemplateforhscale.yaml
@@ -3,10 +3,10 @@ kind: BackupPolicyTemplate
 metadata:
   name: apecloud-mysql-scale-backup-policy-template-for-hscale
   labels:
-    clusterdefinition.kubeblocks.io/name: apecloud-mysql
+    clusterdefinition.kubeblocks.io/name: apecloud-mysql-scale
     {{- include "apecloud-mysql.labels" . | nindent 4 }}
 spec:
-  clusterDefinitionRef: apecloud-mysql
+  clusterDefinitionRef: apecloud-mysql-scale
   identifier: hscale
   backupPolicies:
   - componentDefRef: mysql

--- a/deploy/apecloud-mysql-scale/templates/backuptool.yaml
+++ b/deploy/apecloud-mysql-scale/templates/backuptool.yaml
@@ -13,7 +13,7 @@ spec:
       value: /data/mysql/data
   physical:
     restoreCommands:
-      - >
+      - |
         set -e;
         mkdir -p ${DATA_DIR}
         res=`ls -A ${DATA_DIR}`

--- a/deploy/apecloud-mysql-scale/templates/clusterdefinition.yaml
+++ b/deploy/apecloud-mysql-scale/templates/clusterdefinition.yaml
@@ -74,6 +74,9 @@ spec:
       horizontalScalePolicy:
         type: Snapshot
         backupPolicyTemplateName: apecloud-mysql-scale-backup-policy-template-for-hscale
+      volumeTypes:
+        - name: data
+          type: data
       podSpec:
         containers:
           - name: mysql

--- a/deploy/apecloud-mysql-scale/templates/configconstraint.yaml
+++ b/deploy/apecloud-mysql-scale/templates/configconstraint.yaml
@@ -10,6 +10,7 @@ spec:
   # tplRef: mysql-3node-tpl-8.0
   reloadOptions:
     tplScriptTrigger:
+      sync: true
       scriptConfigMapRef: mysql-scale-reload-script
       namespace: {{ .Release.Namespace }}
 


### PR DESCRIPTION
fix #2846
Features that has been tested:
* `kbcli cluster hscale`
* `kbcli cluster backup wesql-scale`
* `kbcli cluster backup wesql-scale --type=datafile`
* `kbcli cluster restore`
* `kbcli cluster configure wesql-scale --component=mysql`

Note: please use the latest KubeBlocks, such as version `0.6.0-alpha.16`