### PR TITLE
feat: support User-defined environment variables

### DIFF
--- a/internal/constant/const.go
+++ b/internal/constant/const.go
@@ -130,6 +130,7 @@ const (
 	KBParameterUpdateSourceAnnotationKey        = "config.kubeblocks.io/reconfigure-source"
 	UpgradeRestartAnnotationKey                 = "config.kubeblocks.io/restart"
 	KubeBlocksGenerationKey                     = "kubeblocks.io/generation"
+	ExtraEnvAnnotationKey                       = "kubeblocks.io/extra-env"
 
 	// kubeblocks.io well-known finalizers
 	DBClusterFinalizerName             = "cluster.kubeblocks.io/finalizer"


### PR DESCRIPTION
https://github.com/apecloud/kubeblocks/issues/3795

when users create a cluster, they can customize the environment variables through annotation: "kubeblocks.io/extra-env", and finally these environment variables will be applied to all containers under the cluster.