### PR TITLE
chore: not check fork PR branch name

### DIFF
--- a/.github/workflows/pull-request-check.yml
+++ b/.github/workflows/pull-request-check.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - name: check branch name
         uses: apecloud/check-branch-name@v0.1.0
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           branch_pattern: 'feature/|bugfix/|release/|hotfix/|support/|releasing/|dependabot/'
           comment_for_invalid_branch_name: 'This branch name is not following the standards: feature/|bugfix/|release/|hotfix/|support/|releasing/|dependabot/'

--- a/.github/workflows/pull-request-label-size.yaml
+++ b/.github/workflows/pull-request-label-size.yaml
@@ -1,6 +1,8 @@
 name: PULL-REQUEST-LABEL-SIZE
 
-on: [pull_request]
+on:
+  pull_request_target:
+    types: [ edited, opened, synchronize ]
 
 env:
   GITHUB_TOKEN: ${{ github.token }}
@@ -8,8 +10,6 @@ env:
 jobs:
   size-label:
     runs-on: ubuntu-latest
-    outputs:
-      size-label: ${{ steps.get_size_label.outputs.size_label }}
     steps:
       - uses: actions/checkout@v3
       - name: set size label


### PR DESCRIPTION
1. not check fork PR branch name
2. fix fork PR label error : GraphQL: Resource not accessible by integration (addLabelsToLabelable)
![image](https://github.com/apecloud/kubeblocks/assets/109708205/e5460aae-de74-4a51-924c-c0ba9d418c84)
