### PR TITLE
feat: support warning version difference between kbcli and kubeblocks

### DIFF
--- a/internal/cli/cmd/version/version.go
+++ b/internal/cli/cmd/version/version.go
@@ -71,4 +71,8 @@ func (o *versionOptions) Run(f cmdutil.Factory) {
 		fmt.Printf("  Compiler: %s\n", runtime.Compiler)
 		fmt.Printf("  Platform: %s/%s\n", runtime.GOOS, runtime.GOARCH)
 	}
+
+	if v.KubeBlocks != "" && v.Cli != v.KubeBlocks {
+		fmt.Printf("WARNING: version difference between kbcli (%s) and kubeblocks (%s) \n", v.Cli, v.KubeBlocks)
+	}
 }


### PR DESCRIPTION
<img width="715" alt="image" src="https://github.com/apecloud/kubeblocks/assets/49025948/8821d980-4129-44d5-93a4-bf41936ccbbe">
