### PR TITLE
fix: output more friendly  when run `kbcli cluster vscale` with invalid input 

### DIFF
--- a/internal/cli/cmd/cluster/operations_test.go
+++ b/internal/cli/cmd/cluster/operations_test.go
@@ -199,6 +199,20 @@ var _ = Describe("operations", func() {
 		in.Write([]byte(o.Name + "\n"))
 		Expect(o.Validate()).Should(HaveOccurred())
 
+		By("validate invalid resource")
+		o.Class = ""
+		o.CPU = "1g"
+		o.Memory = "100Gi"
+		in.Write([]byte(o.Name + "\n"))
+		Expect(o.Validate()).Should(HaveOccurred())
+
+		By("validate invalid resource")
+		o.Class = ""
+		o.CPU = "1"
+		o.Memory = "100MB"
+		in.Write([]byte(o.Name + "\n"))
+		Expect(o.Validate()).Should(HaveOccurred())
+
 		By("expect to validate success with resource")
 		o.Class = ""
 		o.CPU = "1"


### PR DESCRIPTION
- fix: #3859 

What i do:
1. use `recover()` to fix panic and throw an error in a friendly output
2. add UTs

Example:
![image](https://github.com/apecloud/kubeblocks/assets/101848970/c0a2a6f6-8e0c-44be-93ed-3d2378fd6339)
