### PR TITLE
chore: support legitimacy validation for logfile backup and display availablePods for running backup

### DIFF
--- a/apis/dataprotection/v1alpha1/backup_types.go
+++ b/apis/dataprotection/v1alpha1/backup_types.go
@@ -84,6 +84,10 @@ type BackupStatus struct {
 	// +optional
 	BackupToolName string `json:"backupToolName,omitempty"`
 
+	// availableReplicas available replicas for statefulSet which created by backup.
+	// +optional
+	AvailableReplicas *int32 `json:"availableReplicas,omitempty"`
+
 	// manifests determines the backup metadata info.
 	// +optional
 	Manifests *ManifestsStatus `json:"manifests,omitempty"`

--- a/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
@@ -79,6 +79,11 @@ spec:
           status:
             description: BackupStatus defines the observed state of Backup.
             properties:
+              availableReplicas:
+                description: availableReplicas available replicas for statefulSet
+                  which created by backup.
+                format: int32
+                type: integer
               backupToolName:
                 description: backupToolName references the backup tool name.
                 type: string

--- a/controllers/apps/cluster_controller_test.go
+++ b/controllers/apps/cluster_controller_test.go
@@ -1324,13 +1324,14 @@ var _ = Describe("Cluster Controller", func() {
 		for _, pod := range pods {
 			Expect(controllerutil.SetControllerReference(sts, &pod, scheme.Scheme)).Should(Succeed())
 			Expect(testCtx.CreateObj(testCtx.Ctx, &pod)).Should(Succeed())
+			patch := client.MergeFrom(pod.DeepCopy())
 			// mock the status to pass the isReady(pod) check in consensus_set
 			pod.Status.Conditions = []corev1.PodCondition{{
 				Type:   corev1.PodReady,
 				Status: corev1.ConditionTrue,
 			}}
 			// ERROR: the object has been modified; please apply your changes to the latest version and try again
-			Eventually(k8sClient.Status().Update(ctx, &pod)).Should(Succeed())
+			Eventually(k8sClient.Status().Patch(ctx, &pod, patch)).Should(Succeed())
 		}
 
 		By("Creating mock role changed events")

--- a/controllers/dataprotection/backuppolicy_controller_test.go
+++ b/controllers/dataprotection/backuppolicy_controller_test.go
@@ -475,6 +475,7 @@ var _ = Describe("Backup Policy Controller", func() {
 					Namespace: testCtx.DefaultNamespace,
 				}, func(g Gomega, tmpBackup *dpv1alpha1.Backup) {
 					g.Expect(tmpBackup.Generation).Should(Equal(int64(1)))
+					g.Expect(tmpBackup.Status.Phase).Should(Equal(dpv1alpha1.BackupRunning))
 				})).Should(Succeed())
 
 				By("disable logfile, expect the backup phase to Completed and sts is deleted")
@@ -496,10 +497,12 @@ var _ = Describe("Backup Policy Controller", func() {
 				Expect(testapps.ChangeObj(&testCtx, backupPolicy, func(policy *dpv1alpha1.BackupPolicy) {
 					backupPolicy.Spec.Schedule.Logfile.Enable = true
 				})).Should(Succeed())
-				Eventually(testapps.CheckObjExists(&testCtx, types.NamespacedName{
+				Eventually(testapps.CheckObj(&testCtx, types.NamespacedName{
 					Name:      backupName,
 					Namespace: testCtx.DefaultNamespace,
-				}, sts, true)).Should(Succeed())
+				}, func(g Gomega, tmpBackup *dpv1alpha1.Backup) {
+					g.Expect(tmpBackup.Status.Phase).Should(Equal(dpv1alpha1.BackupRunning))
+				})).Should(Succeed())
 
 				By("delete cluster, expect to backup phase to Completed")
 				testapps.DeleteObject(&testCtx, types.NamespacedName{

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
@@ -79,6 +79,11 @@ spec:
           status:
             description: BackupStatus defines the observed state of Backup.
             properties:
+              availableReplicas:
+                description: availableReplicas available replicas for statefulSet
+                  which created by backup.
+                format: int32
+                type: integer
               backupToolName:
                 description: backupToolName references the backup tool name.
                 type: string

--- a/internal/cli/cmd/cluster/dataprotection.go
+++ b/internal/cli/cmd/cluster/dataprotection.go
@@ -40,7 +40,7 @@ import (
 	"k8s.io/kubectl/pkg/util/templates"
 
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
-	dataprotectionv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
 	"github.com/apecloud/kubeblocks/internal/cli/cluster"
 	"github.com/apecloud/kubeblocks/internal/cli/create"
 	"github.com/apecloud/kubeblocks/internal/cli/delete"
@@ -128,17 +128,24 @@ func (o *CreateBackupOptions) CompleteBackup() error {
 }
 
 func (o *CreateBackupOptions) Validate() error {
-	// validate
 	if o.Name == "" {
 		return fmt.Errorf("missing cluster name")
 	}
 	if o.BackupPolicy == "" {
-		return o.completeDefaultBackupPolicy()
+		if err := o.completeDefaultBackupPolicy(); err != nil {
+			return err
+		}
+	} else {
+		// check if backup policy exists
+		if _, err := o.Dynamic.Resource(types.BackupPolicyGVR()).Namespace(o.Namespace).Get(context.TODO(), o.BackupPolicy, metav1.GetOptions{}); err != nil {
+			return err
+		}
 	}
-	// check if backup policy exists
-	_, err := o.Dynamic.Resource(types.BackupPolicyGVR()).Namespace(o.Namespace).Get(context.TODO(), o.BackupPolicy, metav1.GetOptions{})
+	if o.BackupType == string(dpv1alpha1.BackupTypeLogFile) {
+		return fmt.Errorf(`can not create logfile backup, you can create it by enabling spec.schedule.logfile in BackupPolicy "%s"`, o.BackupPolicy)
+	}
 	// TODO: check if pvc exists
-	return err
+	return nil
 }
 
 // completeDefaultBackupPolicy completes the default backup policy.
@@ -212,6 +219,7 @@ func NewCreateBackupCmd(f cmdutil.Factory, streams genericclioptions.IOStreams) 
 		ValidArgsFunction: util.ResourceNameCompletionFunc(f, types.ClusterGVR()),
 		Run: func(cmd *cobra.Command, args []string) {
 			o.Args = args
+			cmdutil.BehaviorOnFatal(printer.FatalWithRedColor)
 			cmdutil.CheckErr(o.CompleteBackup())
 			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.Run())
@@ -266,7 +274,7 @@ func printBackupList(o ListBackupOptions) error {
 	tbl := printer.NewTablePrinter(o.Out)
 	tbl.SetHeader("NAME", "CLUSTER", "TYPE", "STATUS", "TOTAL-SIZE", "DURATION", "CREATE-TIME", "COMPLETION-TIME", "EXPIRATION")
 	for _, obj := range backupList.Items {
-		backup := &dataprotectionv1alpha1.Backup{}
+		backup := &dpv1alpha1.Backup{}
 		if err = runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, backup); err != nil {
 			return err
 		}
@@ -278,14 +286,18 @@ func printBackupList(o ListBackupOptions) error {
 		if backup.Status.Duration != nil {
 			durationStr = duration.HumanDuration(backup.Status.Duration.Duration)
 		}
+		statusString := string(backup.Status.Phase)
+		if backup.Status.Phase == dpv1alpha1.BackupRunning && backup.Status.AvailableReplicas != nil {
+			statusString = fmt.Sprintf("%s(AvailablePods: %d)", statusString, *backup.Status.AvailableReplicas)
+		}
 		if len(o.BackupName) > 0 {
 			if o.BackupName == obj.GetName() {
-				tbl.AddRow(backup.Name, clusterName, backup.Spec.BackupType, backup.Status.Phase, backup.Status.TotalSize,
+				tbl.AddRow(backup.Name, clusterName, backup.Spec.BackupType, statusString, backup.Status.TotalSize,
 					durationStr, util.TimeFormat(&backup.CreationTimestamp), util.TimeFormat(backup.Status.CompletionTimestamp))
 			}
 			continue
 		}
-		tbl.AddRow(backup.Name, clusterName, backup.Spec.BackupType, backup.Status.Phase, backup.Status.TotalSize,
+		tbl.AddRow(backup.Name, clusterName, backup.Spec.BackupType, statusString, backup.Status.TotalSize,
 			durationStr, util.TimeFormat(&backup.CreationTimestamp), util.TimeFormat(backup.Status.CompletionTimestamp),
 			util.TimeFormat(backup.Status.Expiration))
 	}
@@ -304,6 +316,7 @@ func NewListBackupCmd(f cmdutil.Factory, streams genericclioptions.IOStreams) *c
 		Run: func(cmd *cobra.Command, args []string) {
 			o.LabelSelector = util.BuildLabelSelectorByNames(o.LabelSelector, args)
 			o.Names = nil
+			cmdutil.BehaviorOnFatal(printer.FatalWithRedColor)
 			util.CheckErr(o.Complete())
 			util.CheckErr(printBackupList(*o))
 		},
@@ -321,6 +334,7 @@ func NewDeleteBackupCmd(f cmdutil.Factory, streams genericclioptions.IOStreams) 
 		Example:           deleteBackupExample,
 		ValidArgsFunction: util.ResourceNameCompletionFunc(f, types.ClusterGVR()),
 		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.BehaviorOnFatal(printer.FatalWithRedColor)
 			util.CheckErr(completeForDeleteBackup(o, args))
 			util.CheckErr(o.Run())
 		},
@@ -363,7 +377,7 @@ type CreateRestoreOptions struct {
 	create.CreateOptions `json:"-"`
 }
 
-func (o *CreateRestoreOptions) getClusterObject(backup *dataprotectionv1alpha1.Backup) (*appsv1alpha1.Cluster, error) {
+func (o *CreateRestoreOptions) getClusterObject(backup *dpv1alpha1.Backup) (*appsv1alpha1.Cluster, error) {
 	clusterName := backup.Labels[constant.AppInstanceLabelKey]
 	clusterObj, err := cluster.GetClusterByName(o.Dynamic, clusterName, o.Namespace)
 	if err != nil && !apierrors.IsNotFound(err) {
@@ -391,11 +405,11 @@ func (o *CreateRestoreOptions) Run() error {
 
 func (o *CreateRestoreOptions) runRestoreFromBackup() error {
 	// get backup
-	backup := &dataprotectionv1alpha1.Backup{}
+	backup := &dpv1alpha1.Backup{}
 	if err := cluster.GetK8SClientObject(o.Dynamic, backup, types.BackupGVR(), o.Namespace, o.Backup); err != nil {
 		return err
 	}
-	if backup.Status.Phase != dataprotectionv1alpha1.BackupCompleted {
+	if backup.Status.Phase != dpv1alpha1.BackupCompleted {
 		return errors.Errorf(`backup "%s" is not completed.`, backup.Name)
 	}
 	if len(backup.Labels[constant.AppInstanceLabelKey]) == 0 {
@@ -449,7 +463,7 @@ func (o *CreateRestoreOptions) runPITR() error {
 	if err != nil {
 		return err
 	}
-	backup := &dataprotectionv1alpha1.Backup{}
+	backup := &dpv1alpha1.Backup{}
 
 	// no need to check items len because it is validated by o.validateRestoreTime().
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(objs.Items[0].Object, backup); err != nil {
@@ -497,15 +511,15 @@ func (o *CreateRestoreOptions) validateRestoreTime() error {
 	if err != nil {
 		return err
 	}
-	backups := make([]dataprotectionv1alpha1.Backup, 0)
+	backups := make([]dpv1alpha1.Backup, 0)
 	for _, i := range objs.Items {
-		obj := dataprotectionv1alpha1.Backup{}
+		obj := dpv1alpha1.Backup{}
 		if err = runtime.DefaultUnstructuredConverter.FromUnstructured(i.Object, &obj); err != nil {
 			return err
 		}
 		backups = append(backups, obj)
 	}
-	recoverableTime := dataprotectionv1alpha1.GetRecoverableTimeRange(backups)
+	recoverableTime := dpv1alpha1.GetRecoverableTimeRange(backups)
 	for _, i := range recoverableTime {
 		if isTimeInRange(restoreTime, i.StartTime.Time, i.StopTime.Time) {
 			return nil
@@ -551,6 +565,7 @@ func NewCreateRestoreCmd(f cmdutil.Factory, streams genericclioptions.IOStreams)
 		ValidArgsFunction: util.ResourceNameCompletionFunc(f, types.ClusterGVR()),
 		Run: func(cmd *cobra.Command, args []string) {
 			o.Args = args
+			cmdutil.BehaviorOnFatal(printer.FatalWithRedColor)
 			util.CheckErr(o.Complete())
 			util.CheckErr(o.Validate())
 			util.CheckErr(o.Run())
@@ -573,6 +588,7 @@ func NewListBackupPolicyCmd(f cmdutil.Factory, streams genericclioptions.IOStrea
 		Run: func(cmd *cobra.Command, args []string) {
 			o.LabelSelector = util.BuildLabelSelectorByNames(o.LabelSelector, args)
 			o.Names = nil
+			cmdutil.BehaviorOnFatal(printer.FatalWithRedColor)
 			util.CheckErr(o.Complete())
 			util.CheckErr(printBackupPolicyList(*o))
 		},
@@ -604,7 +620,7 @@ func printBackupPolicyList(o list.ListOptions) error {
 	tbl.SetHeader("NAME", "DEFAULT", "CLUSTER", "CREATE-TIME", "STATUS")
 	for _, obj := range backupPolicyList.Items {
 		defaultPolicy, ok := obj.GetAnnotations()[constant.DefaultBackupPolicyAnnotationKey]
-		backupPolicy := &dataprotectionv1alpha1.BackupPolicy{}
+		backupPolicy := &dpv1alpha1.BackupPolicy{}
 		if err = runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, backupPolicy); err != nil {
 			return err
 		}
@@ -629,6 +645,7 @@ func NewEditBackupPolicyCmd(f cmdutil.Factory, streams genericclioptions.IOStrea
 		Example:               editExample,
 		ValidArgsFunction:     util.ResourceNameCompletionFunc(f, types.BackupPolicyGVR()),
 		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.BehaviorOnFatal(printer.FatalWithRedColor)
 			cmdutil.CheckErr(o.Complete(cmd, args))
 			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.Run())

--- a/internal/cli/cmd/cluster/dataprotection_test.go
+++ b/internal/cli/cmd/cluster/dataprotection_test.go
@@ -40,7 +40,7 @@ import (
 	clientfake "k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 
-	dataprotectionv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
 	"github.com/apecloud/kubeblocks/internal/cli/create"
 	"github.com/apecloud/kubeblocks/internal/cli/delete"
 	"github.com/apecloud/kubeblocks/internal/cli/list"
@@ -67,7 +67,7 @@ var _ = Describe("DataProtection", func() {
 	})
 
 	Context("backup", func() {
-		initClient := func(policies ...*dataprotectionv1alpha1.BackupPolicy) {
+		initClient := func(policies ...*dpv1alpha1.BackupPolicy) {
 			clusterDef := testing.FakeClusterDef()
 			cluster := testing.FakeCluster(testing.ClusterName, testing.Namespace)
 			clusterDefLabel := map[string]string{
@@ -138,6 +138,23 @@ var _ = Describe("DataProtection", func() {
 			// must succeed otherwise exit 1 and make test fails
 			_ = cmd.Flags().Set("backup-policy", defaultBackupPolicy.Name)
 			cmd.Run(cmd, []string{testing.ClusterName})
+
+			By("test with logfile type")
+			o := &CreateBackupOptions{
+				CreateOptions: create.CreateOptions{
+					IOStreams:       streams,
+					Factory:         tf,
+					GVR:             types.BackupGVR(),
+					CueTemplateName: "backup_template.cue",
+					Name:            testing.ClusterName,
+				},
+				BackupPolicy: defaultBackupPolicy.Name,
+				BackupType:   string(dpv1alpha1.BackupTypeLogFile),
+			}
+			Expect(o.CompleteBackup()).Should(Succeed())
+			err := o.Validate()
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("can not create logfile backup, you can create it by enabling spec.schedule.logfile in BackupPolicy"))
 		})
 	})
 
@@ -180,10 +197,14 @@ var _ = Describe("DataProtection", func() {
 		backup1.Labels = map[string]string{
 			constant.AppInstanceLabelKey: "apecloud-mysql",
 		}
+		AvailableReplicas := int32(1)
+		backup1.Status.Phase = dpv1alpha1.BackupRunning
+		backup1.Status.AvailableReplicas = &AvailableReplicas
 		tf.FakeDynamicClient = testing.FakeDynamicClient(backup1)
 		Expect(printBackupList(o)).Should(Succeed())
 		Expect(o.Out.(*bytes.Buffer).String()).Should(ContainSubstring("test1"))
 		Expect(o.Out.(*bytes.Buffer).String()).Should(ContainSubstring("apecloud-mysql (deleted)"))
+		Expect(o.Out.(*bytes.Buffer).String()).Should(ContainSubstring("(AvailablePods: 1)"))
 	})
 
 	It("restore", func() {
@@ -252,13 +273,13 @@ var _ = Describe("DataProtection", func() {
 		}
 		now := metav1.Now()
 		baseBackup := testapps.NewBackupFactory(testing.Namespace, "backup-base").
-			SetBackupType(dataprotectionv1alpha1.BackupTypeSnapshot).
+			SetBackupType(dpv1alpha1.BackupTypeSnapshot).
 			SetBackLog(now.Add(-time.Minute), now.Add(-time.Second)).
 			SetLabels(backupLabels).GetObject()
 		baseBackup.TypeMeta = backupTypeMeta
-		baseBackup.Status.Phase = dataprotectionv1alpha1.BackupCompleted
+		baseBackup.Status.Phase = dpv1alpha1.BackupCompleted
 		incrBackup := testapps.NewBackupFactory(testing.Namespace, backupName).
-			SetBackupType(dataprotectionv1alpha1.BackupTypeLogFile).
+			SetBackupType(dpv1alpha1.BackupTypeLogFile).
 			SetBackLog(now.Add(-time.Minute), now.Add(time.Minute)).
 			SetLabels(backupLabels).GetObject()
 		incrBackup.TypeMeta = backupTypeMeta

--- a/internal/controllerutil/errors.go
+++ b/internal/controllerutil/errors.go
@@ -56,6 +56,8 @@ const (
 	ErrorTypeBackupJobFailed          ErrorType = "BackupJobFailed"          // backup job failed
 	ErrorTypeStorageNotMatch          ErrorType = "ErrorTypeStorageNotMatch"
 	ErrorTypeReconfigureFailed        ErrorType = "ErrorTypeReconfigureFailed"
+	ErrorTypeInvalidLogfileBackupName ErrorType = "InvalidLogfileBackupName"
+	ErrorTypeBackupScheduleDisabled   ErrorType = "BackupScheduleDisabled"
 
 	// ErrorType for cluster controller
 	ErrorTypeBackupFailed ErrorType = "BackupFailed"
@@ -129,4 +131,14 @@ func NewBackupPVCNameIsEmpty(backupType, backupPolicyName string) *Error {
 // NewBackupJobFailed returns a new Error with ErrorTypeBackupJobFailed.
 func NewBackupJobFailed(jobName string) *Error {
 	return NewErrorf(ErrorTypeBackupJobFailed, `backup job "%s" failed`, jobName)
+}
+
+// NewInvalidLogfileBackupName returns a new Error with ErrorTypeInvalidLogfileBackupName.
+func NewInvalidLogfileBackupName(backupPolicyName string) *Error {
+	return NewErrorf(ErrorTypeInvalidLogfileBackupName, `backup name is incorrect for logfile, you can create the logfile backup by enabling the schedule in BackupPolicy "%s"`, backupPolicyName)
+}
+
+// NewBackupScheduleDisabled returns a new Error with ErrorTypeBackupScheduleDisabled.
+func NewBackupScheduleDisabled(backupType, backupPolicyName string) *Error {
+	return NewErrorf(ErrorTypeBackupScheduleDisabled, `%s schedule is disabled, you can enable spec.schedule.%s in BackupPolicy "%s"`, backupType, backupType, backupPolicyName)
 }


### PR DESCRIPTION
add legitimacy validation and dispaly availablePods for running backup:
1. only can create logfile backup by enabling logfile schedule in backupPolicy.
2. display the availablePods for running backup.