### PR TITLE
feat: add loki dashboard for kubernetes pods log

### DIFF
--- a/deploy/helm/dashboards/container-log.json
+++ b/deploy/helm/dashboards/container-log.json
@@ -21,7 +21,7 @@
       }
     ]
   },
-  "description": "Basic dashboard for Kubernetes Logs from Loki.",
+  "description": "Basic dashboard for Kubernetes Container Logs from Loki.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "gnetId": 18494,
@@ -279,7 +279,7 @@
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-30m",
     "to": "now"
   },
   "timepicker": {
@@ -294,8 +294,8 @@
     ]
   },
   "timezone": "",
-  "title": "Kubernetes Logs",
-  "uid": "kubernetes-logs",
+  "title": "Container Logs",
+  "uid": "container-logs",
   "version": 1,
   "weekStart": ""
 }

--- a/deploy/helm/dashboards/kubernetes-log.json
+++ b/deploy/helm/dashboards/kubernetes-log.json
@@ -1,0 +1,301 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Basic dashboard for Kubernetes Logs from Loki.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": 18494,
+  "graphTooltip": 0,
+  "id": 12,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki-kubeblocks"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 42,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki-kubeblocks"
+          },
+          "editorMode": "builder",
+          "expr": "sum(count_over_time({namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\"} |~ `$search` [$__interval]))",
+          "legendFormat": "{{container}}",
+          "queryType": "range",
+          "refId": "A",
+          "resolution": 4
+        }
+      ],
+      "title": "Logs Trend",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "loki-kubeblocks"
+      },
+      "gridPos": {
+        "h": 26,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 3,
+      "options": {
+        "dedupStrategy": "exact",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": true,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki-kubeblocks"
+          },
+          "editorMode": "builder",
+          "expr": "{namespace=~\"$namespace\", pod=~\"$pod\", container=~\"$container\"} |~ `(?i)$search`",
+          "queryType": "range",
+          "refId": "A"
+        }
+      ],
+      "title": "Logs Panel",
+      "type": "logs"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".+",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "loki",
+          "uid": "loki-kubeblocks"
+        },
+        "definition": "",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Namespace",
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "label": "namespace",
+          "refId": "LokiVariableQueryEditor-VariableQuery",
+          "stream": "",
+          "type": 1
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "type": "query"
+      },
+      {
+        "allValue": ".+",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "loki",
+          "uid": "loki-kubeblocks"
+        },
+        "definition": "",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Pod",
+        "multi": false,
+        "name": "pod",
+        "options": [],
+        "query": {
+          "label": "pod",
+          "refId": "LokiVariableQueryEditor-VariableQuery",
+          "stream": "{namespace=~\"$namespace\"}",
+          "type": 1
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "type": "query"
+      },
+      {
+        "allValue": ".+",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "loki",
+          "uid": "loki-kubeblocks"
+        },
+        "definition": "",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Container",
+        "multi": false,
+        "name": "container",
+        "options": [],
+        "query": {
+          "label": "container",
+          "refId": "LokiVariableQueryEditor-VariableQuery",
+          "stream": "{namespace=~\"$namespace\", pod=~\"$pod\"}",
+          "type": 1
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 5,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "hide": 0,
+        "label": "Search Term",
+        "name": "search",
+        "options": [
+          {
+            "selected": true,
+            "text": "",
+            "value": ""
+          }
+        ],
+        "query": "",
+        "skipUrlSync": false,
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Kubernetes Logs",
+  "uid": "kubernetes-logs",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/helm/templates/grafana/configmaps-datasources.yaml
+++ b/deploy/helm/templates/grafana/configmaps-datasources.yaml
@@ -42,5 +42,12 @@ data:
       isDefault: false
       jsonData:
         timeInterval: 15s
+    - name: Loki
+      type: loki
+      uid: loki-kubeblocks
+      access: proxy
+      url: http://loki-gateway:80
+      jsonData:
+        maxLines: 1000
 {{- end }}
 {{- end }}

--- a/internal/cli/cmd/dashboard/dashboard.go
+++ b/internal/cli/cmd/dashboard/dashboard.go
@@ -50,7 +50,7 @@ const (
 	defaultPodExecTimeout = 60 * time.Second
 	grafanaAddonName      = "kubeblocks-grafana"
 	lokiAddonName         = "kubeblocks-loki"
-	lokiGrafanaDirect     = "kubernetes-logs"
+	lokiGrafanaDirect     = "container-logs"
 	localAdd              = "127.0.0.1"
 )
 

--- a/internal/cli/cmd/dashboard/dashboard.go
+++ b/internal/cli/cmd/dashboard/dashboard.go
@@ -48,6 +48,10 @@ import (
 const (
 	podRunningTimeoutFlag = "pod-running-timeout"
 	defaultPodExecTimeout = 60 * time.Second
+	grafanaAddonName      = "kubeblocks-grafana"
+	lokiAddonName         = "kubeblocks-loki"
+	lokiGrafanaDirect     = "kubernetes-logs"
+	localAdd              = "127.0.0.1"
 )
 
 type dashboard struct {
@@ -83,7 +87,7 @@ var (
 	// we do not use the default port to port-forward to avoid conflict with other services
 	dashboards = [...]*dashboard{
 		{
-			Name:       "kubeblocks-grafana",
+			Name:       grafanaAddonName,
 			AddonName:  "kb-addon-grafana",
 			Label:      "app.kubernetes.io/instance=kb-addon-grafana,app.kubernetes.io/name=grafana",
 			TargetPort: "13000",
@@ -105,6 +109,12 @@ var (
 			AddonName:  "kb-addon-nyancat",
 			Label:      "app.kubernetes.io/instance=kb-addon-nyancat",
 			TargetPort: "8087",
+		},
+		{
+			Name:       lokiAddonName,
+			AddonName:  "kb-addon-loki",
+			Label:      "app.kubernetes.io/instance=kb-addon-loki",
+			TargetPort: "13100",
 		},
 	}
 )
@@ -248,8 +258,12 @@ func (o *openOptions) complete(cmd *cobra.Command, args []string) error {
 	if err = getDashboardInfo(client); err != nil {
 		return err
 	}
-
-	dash := getDashboardByName(o.name)
+	dashName := o.name
+	// opening loki dashboard redirects to grafana dashboard
+	if o.name == lokiAddonName {
+		dashName = grafanaAddonName
+	}
+	dash := getDashboardByName(dashName)
 	if dash == nil {
 		return fmt.Errorf("failed to find dashboard \"%s\", run \"kbcli dashboard list\" to list all dashboards", o.name)
 	}
@@ -257,19 +271,30 @@ func (o *openOptions) complete(cmd *cobra.Command, args []string) error {
 		clusterType = args[1]
 	}
 	if o.localPort == "" {
-		o.localPort = dash.TargetPort
+		if o.name == lokiAddonName {
+			// revert the target port for loki dashboard
+			o.localPort = getDashboardByName(lokiAddonName).TargetPort
+		} else {
+			o.localPort = dash.TargetPort
+		}
 	}
-
 	pfArgs := []string{fmt.Sprintf("svc/%s", dash.AddonName), fmt.Sprintf("%s:%s", o.localPort, dash.Port)}
 	o.portForwardOptions.Namespace = dash.Namespace
-	o.portForwardOptions.Address = []string{"127.0.0.1"}
+	o.portForwardOptions.Address = []string{localAdd}
 	return o.portForwardOptions.Complete(newFactory(dash.Namespace), cmd, pfArgs)
 }
 
 func (o *openOptions) run() error {
-	url := "http://127.0.0.1:" + o.localPort
+	url := fmt.Sprintf("http://%s:%s", localAdd, o.localPort)
 	if o.name == "kubeblocks-grafana" {
 		err := buildGrafanaDirectURL(&url, clusterType)
+		if err != nil {
+			return err
+		}
+	}
+	// customized by loki
+	if o.name == lokiAddonName {
+		err := buildGrafanaDirectURL(&url, lokiGrafanaDirect)
 		if err != nil {
 			return err
 		}
@@ -281,7 +306,6 @@ func (o *openOptions) run() error {
 			fmt.Fprintf(o.ErrOut, "Failed to open browser: %v", err)
 		}
 	}()
-
 	return o.portForwardOptions.RunPortForward()
 }
 

--- a/internal/cli/cmd/dashboard/grafana_direct.go
+++ b/internal/cli/cmd/dashboard/grafana_direct.go
@@ -37,6 +37,7 @@ var (
 		"postgresql",
 		"redis",
 		"weaviate",
+		lokiGrafanaDirect,
 	}
 )
 


### PR DESCRIPTION
This pr has two functions:
1. add loki dashboard for kubernetes pods log
2. add `kbcli dashboard open kubeblocks-loki` to rediect http://127.0.0.1:13100/d/kubernetes-logs/kubernetes-logs?orgId=1

<img width="1555" alt="截屏2023-06-21 17 23 59" src="https://github.com/apecloud/kubeblocks/assets/5415905/cb9cac15-8f44-45bc-b3d7-cff155f4680d">