### PR TITLE
chore: addon support to set private helm registry

### DIFF
--- a/controllers/extensions/addon_controller_stages.go
+++ b/controllers/extensions/addon_controller_stages.go
@@ -62,6 +62,7 @@ func init() {
 		"--atomic",
 		"--cleanup-on-fail",
 		"--wait",
+		"--insecure-skip-tls-verify",
 	})
 	viper.SetDefault(addonHelmUninstallOptKey, []string{})
 }

--- a/controllers/extensions/addon_controller_stages.go
+++ b/controllers/extensions/addon_controller_stages.go
@@ -62,7 +62,6 @@ func init() {
 		"--atomic",
 		"--cleanup-on-fail",
 		"--wait",
-		"--insecure-skip-tls-verify",
 	})
 	viper.SetDefault(addonHelmUninstallOptKey, []string{})
 }

--- a/deploy/helm/templates/addons/alertmanager-webhook-adaptor-addon.yaml
+++ b/deploy/helm/templates/addons/alertmanager-webhook-adaptor-addon.yaml
@@ -14,8 +14,16 @@ spec:
   type: Helm
 
   helm:
-    # chartLocationURL: https://github.com/apecloud/helm-charts/releases/download/alertmanager-webhook-adaptor-0.1.4/alertmanager-webhook-adaptor-0.1.4.tgz
+    {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+    chartLocationURL: {{ .Values.addonChartLocationBase }}/alertmanager-webhook-adaptor
+    {{- else }}
     chartLocationURL: {{ .Values.addonChartLocationBase }}/alertmanager-webhook-adaptor-0.1.4.tgz
+    {{- end }}
+
+    installOptions:
+      {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+      version: 0.1.4
+      {{- end }}
 
     installValues:
       configMapRefs:

--- a/deploy/helm/templates/addons/apecloud-mysql-addon.yaml
+++ b/deploy/helm/templates/addons/apecloud-mysql-addon.yaml
@@ -16,8 +16,16 @@ spec:
   type: Helm
 
   helm:
-    # chartLocationURL: https://github.com/apecloud/helm-charts/releases/download/apecloud-mysql-{{ default .Chart.Version .Values.versionOverride }}/apecloud-mysql-{{ default .Chart.Version .Values.versionOverride }}.tgz
+    {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+    chartLocationURL: {{ .Values.addonChartLocationBase }}/apecloud-mysql
+    {{- else }}
     chartLocationURL: {{ .Values.addonChartLocationBase }}/apecloud-mysql-{{ default .Chart.Version .Values.versionOverride }}.tgz
+    {{- end }}
+
+    installOptions:
+      {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+      version: {{ default .Chart.Version .Values.versionOverride }}
+      {{- end }}
 
   defaultInstallValues:
     - enabled: true

--- a/deploy/helm/templates/addons/aws-loadbalancer-controller-addon.yaml
+++ b/deploy/helm/templates/addons/aws-loadbalancer-controller-addon.yaml
@@ -13,8 +13,16 @@ spec:
   type: Helm
 
   helm:
-    # origin: https://aws.github.io/eks-charts/aws-load-balancer-controller-1.4.8.tgz
+    {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+    chartLocationURL: {{ .Values.addonChartLocationBase }}/aws-load-balancer-controller
+    {{- else }}
     chartLocationURL: {{ .Values.addonChartLocationBase }}/aws-load-balancer-controller-1.4.8.tgz
+    {{- end }}
+
+    installOptions:
+      {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+      version: 1.4.8
+      {{- end }}
 
     installValues:
       configMapRefs:

--- a/deploy/helm/templates/addons/csi-driver-addon.yaml
+++ b/deploy/helm/templates/addons/csi-driver-addon.yaml
@@ -14,8 +14,17 @@ spec:
   type: Helm
 
   helm:
-    # chartLocationURL: https://github.com/apecloud/helm-charts/releases/download/kubeblocks-csi-driver-0.1.0/kubeblocks-csi-driver-0.1.0.tgz
+    {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+    chartLocationURL: {{ .Values.addonChartLocationBase }}/kubeblocks-csi-driver
+    {{- else }}
     chartLocationURL: {{ .Values.addonChartLocationBase }}/kubeblocks-csi-driver-0.1.0.tgz
+    {{- end }}
+
+    installOptions:
+     {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+      version: 0.1.0
+     {{- end }}
+
     valuesMapping:
       valueMap:
         replicaCount: controller.replicaCount

--- a/deploy/helm/templates/addons/csi-hostpath-driver-addon.yaml
+++ b/deploy/helm/templates/addons/csi-hostpath-driver-addon.yaml
@@ -14,7 +14,17 @@ spec:
   type: Helm
 
   helm:
+    {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+    chartLocationURL: {{ .Values.addonChartLocationBase }}/csi-hostpath-driver
+    {{- else }}
     chartLocationURL: {{ .Values.addonChartLocationBase }}/csi-hostpath-driver-{{ default .Chart.Version .Values.versionOverride }}.tgz
+    {{- end }}
+
+    installOptions:
+      {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+      version: {{ default .Chart.Version .Values.versionOverride }}
+      {{- end }}
+
     installValues:
       configMapRefs:
         - name: csi-hostpath-driver-chart-kubeblocks-values

--- a/deploy/helm/templates/addons/csi-s3-addon.yaml
+++ b/deploy/helm/templates/addons/csi-s3-addon.yaml
@@ -14,8 +14,17 @@ spec:
   type: Helm
 
   helm:
-    # chartLocationURL: https://raw.githubusercontent.com/cloudve/helm-charts/master/charts/csi-s3-0.31.3.tgz
+    {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+    chartLocationURL: {{ .Values.addonChartLocationBase }}/csi-s3
+    {{- else }}
     chartLocationURL: {{ .Values.addonChartLocationBase }}/csi-s3-{{ default .Chart.Version .Values.versionOverride }}.tgz
+    {{- end }}
+
+    installOptions:
+      {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+      version: {{ default .Chart.Version .Values.versionOverride }}
+      {{- end }}
+
     installValues:
       configMapRefs:
         - name: csi-s3-chart-kubeblocks-values

--- a/deploy/helm/templates/addons/grafana-addon.yaml
+++ b/deploy/helm/templates/addons/grafana-addon.yaml
@@ -14,8 +14,17 @@ spec:
   type: Helm
 
   helm:
-    # chartLocationURL: https://github.com/grafana/helm-charts/releases/download/grafana-6.43.5/grafana-6.43.5.tgz
+    {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+    chartLocationURL: {{ .Values.addonChartLocationBase }}/grafana
+    {{- else }}
     chartLocationURL: {{ .Values.addonChartLocationBase }}/grafana-6.43.5.tgz
+    {{- end }}
+
+    installOptions:
+      {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+      version: 6.43.5
+      {{- end }}
+
     installValues:
       configMapRefs:
         - name: grafana-chart-kubeblocks-values

--- a/deploy/helm/templates/addons/migration-addon.yaml
+++ b/deploy/helm/templates/addons/migration-addon.yaml
@@ -15,7 +15,17 @@ spec:
   type: Helm
 
   helm:
+    {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+    chartLocationURL: {{ .Values.addonChartLocationBase }}/dt-platform
+    {{- else }}
     chartLocationURL: {{ .Values.addonChartLocationBase }}/dt-platform-0.1.0.tgz
+    {{- end }}
+
+    installOptions:
+      {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+      version: 0.1.0
+      {{- end }}
+
     valuesMapping:
       valueMap:
         replicaCount: replicaCount

--- a/deploy/helm/templates/addons/milvus-addon.yaml
+++ b/deploy/helm/templates/addons/milvus-addon.yaml
@@ -15,7 +15,16 @@ spec:
   type: Helm
 
   helm:
+    {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+    chartLocationURL: {{ .Values.addonChartLocationBase }}/milvus
+    {{- else }}
     chartLocationURL: {{ .Values.addonChartLocationBase }}/milvus-{{ default .Chart.Version .Values.versionOverride }}.tgz
+    {{- end }}
+
+    installOptions:
+      {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+      version: {{ default .Chart.Version .Values.versionOverride }}
+      {{- end }}
 
   installable:
     autoInstall: false

--- a/deploy/helm/templates/addons/mongodb-addon.yaml
+++ b/deploy/helm/templates/addons/mongodb-addon.yaml
@@ -15,8 +15,16 @@ spec:
   type: Helm
 
   helm:
-    # chartLocationURL: https://github.com/apecloud/helm-charts/releases/download/mongodb-{{ default .Chart.Version .Values.versionOverride }}/mongodb-{{ default .Chart.Version .Values.versionOverride }}.tgz
+    {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+    chartLocationURL: {{ .Values.addonChartLocationBase }}/mongodb
+    {{- else }}
     chartLocationURL: {{ .Values.addonChartLocationBase }}/mongodb-{{ default .Chart.Version .Values.versionOverride }}.tgz
+    {{- end }}
+
+    installOptions:
+      {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+      version: {{ default .Chart.Version .Values.versionOverride }}
+      {{- end }}
 
   installable:
     autoInstall: true

--- a/deploy/helm/templates/addons/nyancat-addon.yaml
+++ b/deploy/helm/templates/addons/nyancat-addon.yaml
@@ -15,8 +15,17 @@ spec:
   type: Helm
 
   helm:
-    # chartLocationURL: {{ .Values.addonChartLocationBase }}/nyancat-{{ default .Chart.Version .Values.versionOverride }}.tgz
+    {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+    chartLocationURL: {{ .Values.addonChartLocationBase }}/nyancat
+    {{- else }}
     chartLocationURL: {{ .Values.addonChartLocationBase }}/nyancat-{{ default .Chart.Version .Values.versionOverride }}.tgz
+    {{- end }}
+
+    installOptions:
+     {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+      version: {{ default .Chart.Version .Values.versionOverride }}
+     {{- end }}
+
     valuesMapping:
       valueMap:
         replicaCount: replicaCount

--- a/deploy/helm/templates/addons/postgresql-addon.yaml
+++ b/deploy/helm/templates/addons/postgresql-addon.yaml
@@ -15,8 +15,16 @@ spec:
   type: Helm
 
   helm:
-    # chartLocationURL: https://github.com/apecloud/helm-charts/releases/download/postgresql-{{ default .Chart.Version .Values.versionOverride }}/postgresql-{{ default .Chart.Version .Values.versionOverride }}.tgz
+    {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+    chartLocationURL: {{ .Values.addonChartLocationBase }}/postgresql
+    {{- else }}
     chartLocationURL: {{ .Values.addonChartLocationBase }}/postgresql-{{ default .Chart.Version .Values.versionOverride }}.tgz
+    {{- end }}
+
+    installOptions:
+      {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+      version: {{ default .Chart.Version .Values.versionOverride }}
+      {{- end }}
 
   installable:
     autoInstall: true

--- a/deploy/helm/templates/addons/prometheus-addon.yaml
+++ b/deploy/helm/templates/addons/prometheus-addon.yaml
@@ -14,8 +14,17 @@ spec:
   type: Helm
 
   helm:
-    # chartLocationURL: https://github.com/prometheus-community/helm-charts/releases/download/prometheus-15.16.1/prometheus-15.16.1.tgz
+    {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+    chartLocationURL: {{ .Values.addonChartLocationBase }}/prometheus
+    {{- else }}
     chartLocationURL: {{ .Values.addonChartLocationBase }}/prometheus-15.16.1.tgz
+    {{- end }}
+
+    installOptions:
+      {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+      version: 15.16.1
+      {{- end }}
+
     installValues:
       configMapRefs:
         - name: {{ include "addon.prometheus.name" . }}-chart-kubeblocks-values

--- a/deploy/helm/templates/addons/qdrant-addon.yaml
+++ b/deploy/helm/templates/addons/qdrant-addon.yaml
@@ -15,7 +15,16 @@ spec:
   type: Helm
 
   helm:
+    {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+    chartLocationURL: {{ .Values.addonChartLocationBase }}/qdrant
+    {{- else }}
     chartLocationURL: {{ .Values.addonChartLocationBase }}/qdrant-{{ default .Chart.Version .Values.versionOverride }}.tgz
+    {{- end }}
+
+    installOptions:
+      {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+      version: {{ default .Chart.Version .Values.versionOverride }}
+      {{- end }}
 
   installable:
     autoInstall: false

--- a/deploy/helm/templates/addons/redis-addon.yaml
+++ b/deploy/helm/templates/addons/redis-addon.yaml
@@ -15,8 +15,16 @@ spec:
   type: Helm
 
   helm:
-    # chartLocationURL: https://github.com/apecloud/helm-charts/releases/download/redis-{{ default .Chart.Version .Values.versionOverride }}/redis-{{ default .Chart.Version .Values.versionOverride }}.tgz
+    {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+    chartLocationURL: {{ .Values.addonChartLocationBase }}/redis
+    {{- else }}
     chartLocationURL: {{ .Values.addonChartLocationBase }}/redis-{{ default .Chart.Version .Values.versionOverride }}.tgz
+    {{- end }}
+
+    installOptions:
+     {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+      version: {{ default .Chart.Version .Values.versionOverride }}
+     {{- end }}
 
   installable:
     autoInstall: true

--- a/deploy/helm/templates/addons/snapshot-controller-addon.yaml
+++ b/deploy/helm/templates/addons/snapshot-controller-addon.yaml
@@ -16,8 +16,17 @@ spec:
   type: Helm
 
   helm:
-    # chartLocationURL: https://github.com/piraeusdatastore/helm-charts/releases/download/snapshot-controller-1.7.2/snapshot-controller-1.7.2.tgz
+    {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+    chartLocationURL: {{ .Values.addonChartLocationBase }}/snapshot-controller
+    {{- else }}
     chartLocationURL: {{ .Values.addonChartLocationBase }}/snapshot-controller-1.7.2.tgz
+    {{- end }}
+
+    installOptions:
+     {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+      version: 1.7.2
+     {{- end }}
+
     installValues:
       configMapRefs:
         - name: snapshot-controller-chart-kubeblocks-values

--- a/deploy/helm/templates/addons/weaviate-addon.yaml
+++ b/deploy/helm/templates/addons/weaviate-addon.yaml
@@ -15,7 +15,16 @@ spec:
   type: Helm
 
   helm:
+    {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+    chartLocationURL: {{ .Values.addonChartLocationBase }}/weaviate
+    {{- else }}
     chartLocationURL: {{ .Values.addonChartLocationBase }}/weaviate-{{ default .Chart.Version .Values.versionOverride }}.tgz
+    {{- end }}
+
+    installOptions:
+      {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
+      version: {{ default .Chart.Version .Values.versionOverride }}
+      {{- end }}
 
   installable:
     autoInstall: false

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -95,6 +95,8 @@ spec:
               value: {{ .jobImagePullPolicy | default "IfNotPresent" }}
             - name: KUBEBLOCKS_ADDON_SA_NAME
               value: {{ include "kubeblocks.addonSAName" . }}
+            - name: KUBEBLOCKS_ADDON_HELM_INSTALL_OPTIONS
+              value: {{ .Values.addonHelmInstallOptions }}
             {{- end }}
           {{- with .Values.securityContext }}
           securityContext:

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -96,7 +96,7 @@ spec:
             - name: KUBEBLOCKS_ADDON_SA_NAME
               value: {{ include "kubeblocks.addonSAName" . }}
             - name: KUBEBLOCKS_ADDON_HELM_INSTALL_OPTIONS
-              value: {{ .Values.addonHelmInstallOptions }}
+              value: {{ join " " .Values.addonHelmInstallOptions }}
             {{- end }}
           {{- with .Values.securityContext }}
           securityContext:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -302,6 +302,13 @@ keepAddons: false
 ## @param addonChartLocationBase - KubeBlocks official addon's chart location base, to be released in an air-gapped environment.
 addonChartLocationBase: https://jihulab.com/api/v4/projects/85949/packages/helm/stable/charts
 
+## @param addonHelmInstallOptions - addon helm install options.
+addonHelmInstallOptions:
+  - "--atomic"
+  - "--cleanup-on-fail"
+  - "--wait"
+  - "--insecure-skip-tls-verify"
+
 ## Dashboards settings
 ##
 ## @param dashboards.enabled - If false, dashboards will not be installed.


### PR DESCRIPTION
If addonChartLocationURL has prefix "oci://", use the oci url as chart location, and add `version` to addon installOptions.