### PR TITLE
feat: kbcli bench need more clear tips

### DIFF
--- a/docs/user_docs/cli/cli.md
+++ b/docs/user_docs/cli/cli.md
@@ -53,7 +53,7 @@ Manage classes
 Cluster command.
 
 * [kbcli cluster backup](kbcli_cluster_backup.md)	 - Create a backup for the cluster.
-* [kbcli cluster cancel-ops](kbcli_cluster_cancel-ops.md)	 - cancel the pending/creating/running OpsRequest which type is vscale or hscale.
+* [kbcli cluster cancel-ops](kbcli_cluster_cancel-ops.md)	 - Cancel the pending/creating/running OpsRequest which type is vscale or hscale.
 * [kbcli cluster configure](kbcli_cluster_configure.md)	 - Configure parameters with the specified components in the cluster.
 * [kbcli cluster connect](kbcli_cluster_connect.md)	 - Connect to a cluster or instance.
 * [kbcli cluster create](kbcli_cluster_create.md)	 - Create a cluster.
@@ -84,6 +84,7 @@ Cluster command.
 * [kbcli cluster list-logs](kbcli_cluster_list-logs.md)	 - List supported log files in cluster.
 * [kbcli cluster list-ops](kbcli_cluster_list-ops.md)	 - List all opsRequests.
 * [kbcli cluster logs](kbcli_cluster_logs.md)	 - Access cluster log file.
+* [kbcli cluster promote](kbcli_cluster_promote.md)	 - Promote a non-primary or non-leader instance as the new primary or leader of the cluster
 * [kbcli cluster restart](kbcli_cluster_restart.md)	 - Restart the specified components in the cluster.
 * [kbcli cluster restore](kbcli_cluster_restore.md)	 - Restore a new cluster from backup.
 * [kbcli cluster revoke-role](kbcli_cluster_revoke-role.md)	 - Revoke role from account

--- a/docs/user_docs/cli/kbcli_bench_sysbench.md
+++ b/docs/user_docs/cli/kbcli_bench_sysbench.md
@@ -5,7 +5,26 @@ title: kbcli bench sysbench
 run a SysBench benchmark
 
 ```
-kbcli bench sysbench [flags]
+kbcli bench sysbench [ClusterName] [flags]
+```
+
+### Examples
+
+```
+  # sysbench on a cluster
+  kbcli bench sysbench mycluster --user xxx --password xxx --database mydb
+  
+  # sysbench on a cluster with different threads
+  kbcli bench sysbench mycluster --user xxx --password xxx --database mydb --threads 4,8
+  
+  # sysbench on a cluster with different type
+  kbcli bench sysbench mycluster --user xxx --password xxx --database mydb --type oltp_read_only,oltp_read_write
+  
+  # sysbench on a cluster with specified read/write ratio
+  kbcli bench sysbench mycluster --user xxx --password xxx  --database mydb --type oltp_read_write_pct --read-percent 80 --write-percent 80
+  
+  # sysbench on a cluster with specified tables and size
+  kbcli bench sysbench mycluster --user xxx --password xxx --database mydb --tables 10 --size 25000
 ```
 
 ### Options

--- a/docs/user_docs/cli/kbcli_bench_sysbench_cleanup.md
+++ b/docs/user_docs/cli/kbcli_bench_sysbench_cleanup.md
@@ -5,7 +5,17 @@ title: kbcli bench sysbench cleanup
 Cleanup the data of SysBench for cluster
 
 ```
-kbcli bench sysbench cleanup [NAME] [flags]
+kbcli bench sysbench cleanup [ClusterName] [flags]
+```
+
+### Examples
+
+```
+  # sysbench cleanup data on a cluster
+  kbcli bench sysbench cleanup mycluster --user xxx --password xxx --database mydb
+  
+  # sysbench cleanup data on a cluster with specified tables and size
+  kbcli bench sysbench cleanup mycluster --user xxx --password xxx --database mydb --tables 10 --size 25000
 ```
 
 ### Options

--- a/docs/user_docs/cli/kbcli_bench_sysbench_prepare.md
+++ b/docs/user_docs/cli/kbcli_bench_sysbench_prepare.md
@@ -5,7 +5,17 @@ title: kbcli bench sysbench prepare
 Prepare the data of SysBench for a cluster
 
 ```
-kbcli bench sysbench prepare [NAME] [flags]
+kbcli bench sysbench prepare [ClusterName] [flags]
+```
+
+### Examples
+
+```
+  # sysbench prepare data on a cluster
+  kbcli bench sysbench prepare mycluster --user xxx --password xxx --database mydb
+  
+  # sysbench prepare data on a cluster with specified tables and size
+  kbcli bench sysbench prepare mycluster --user xxx --password xxx --database mydb --tables 10 --size 25000
 ```
 
 ### Options

--- a/docs/user_docs/cli/kbcli_cluster.md
+++ b/docs/user_docs/cli/kbcli_cluster.md
@@ -38,7 +38,7 @@ Cluster command.
 
 
 * [kbcli cluster backup](kbcli_cluster_backup.md)	 - Create a backup for the cluster.
-* [kbcli cluster cancel-ops](kbcli_cluster_cancel-ops.md)	 - cancel the pending/creating/running OpsRequest which type is vscale or hscale.
+* [kbcli cluster cancel-ops](kbcli_cluster_cancel-ops.md)	 - Cancel the pending/creating/running OpsRequest which type is vscale or hscale.
 * [kbcli cluster configure](kbcli_cluster_configure.md)	 - Configure parameters with the specified components in the cluster.
 * [kbcli cluster connect](kbcli_cluster_connect.md)	 - Connect to a cluster or instance.
 * [kbcli cluster create](kbcli_cluster_create.md)	 - Create a cluster.
@@ -69,6 +69,7 @@ Cluster command.
 * [kbcli cluster list-logs](kbcli_cluster_list-logs.md)	 - List supported log files in cluster.
 * [kbcli cluster list-ops](kbcli_cluster_list-ops.md)	 - List all opsRequests.
 * [kbcli cluster logs](kbcli_cluster_logs.md)	 - Access cluster log file.
+* [kbcli cluster promote](kbcli_cluster_promote.md)	 - Promote a non-primary or non-leader instance as the new primary or leader of the cluster
 * [kbcli cluster restart](kbcli_cluster_restart.md)	 - Restart the specified components in the cluster.
 * [kbcli cluster restore](kbcli_cluster_restore.md)	 - Restore a new cluster from backup.
 * [kbcli cluster revoke-role](kbcli_cluster_revoke-role.md)	 - Revoke role from account

--- a/docs/user_docs/cli/kbcli_cluster_cancel-ops.md
+++ b/docs/user_docs/cli/kbcli_cluster_cancel-ops.md
@@ -2,7 +2,7 @@
 title: kbcli cluster cancel-ops
 ---
 
-cancel the pending/creating/running OpsRequest which type is vscale or hscale.
+Cancel the pending/creating/running OpsRequest which type is vscale or hscale.
 
 ```
 kbcli cluster cancel-ops NAME [flags]

--- a/docs/user_docs/cli/kbcli_cluster_promote.md
+++ b/docs/user_docs/cli/kbcli_cluster_promote.md
@@ -1,36 +1,37 @@
 ---
-title: kbcli bench sysbench run
+title: kbcli cluster promote
 ---
 
-Run  SysBench on cluster
+Promote a non-primary or non-leader instance as the new primary or leader of the cluster
 
 ```
-kbcli bench sysbench run [ClusterName] [flags]
+kbcli cluster promote NAME [--component=<comp-name>] [--instance <instance-name>] [flags]
 ```
 
 ### Examples
 
 ```
-  # sysbench run on a cluster
-  kbcli bench sysbench run mycluster --user xxx --password xxx --database mydb
+  # Promote the instance mycluster-mysql-1 as the new primary or leader.
+  kbcli cluster promote mycluster --instance mycluster-mysql-1
   
-  # sysbench run on a cluster with different threads
-  kbcli bench sysbench run  mycluster --user xxx --password xxx --database mydb --threads 4,8
+  # Promote a non-primary or non-leader instance as the new primary or leader, the new primary or leader is determined by the system.
+  kbcli cluster promote mycluster
   
-  # sysbench run on a cluster with different type
-  kbcli bench sysbench run mycluster --user xxx --password xxx --database mydb --type oltp_read_only,oltp_read_write
-  
-  # sysbench run on a cluster with specified read/write ratio
-  kbcli bench sysbench run  mycluster --user xxx --password xxx  --database mydb --type oltp_read_write_pct --read-percent 80 --write-percent 80
-  
-  # sysbench run on a cluster with specified tables and size
-  kbcli bench sysbench run mycluster --user xxx --password xxx --database mydb --tables 10 --size 25000
+  # If the cluster has multiple components, you need to specify a component, otherwise an error will be reported.
+  kbcli cluster promote mycluster --component=mysql --instance mycluster-mysql-1
 ```
 
 ### Options
 
 ```
-  -h, --help   help for run
+      --auto-approve                   Skip interactive approval before promote the instance
+      --component string               Specify the component name of the cluster, if the cluster has multiple components, you need to specify a component
+      --dry-run string[="unchanged"]   Must be "client", or "server". If with client strategy, only print the object that would be sent, and no data is actually sent. If with server strategy, submit the server-side request, but no data is persistent. (default "none")
+  -h, --help                           help for promote
+      --instance string                Specify the instance name as the new primary or leader of the cluster, you can get the instance name by running "kbcli cluster list-instances"
+      --name string                    OpsRequest name. if not specified, it will be randomly generated 
+  -o, --output format                  prints the output in the specified format. Allowed values: JSON and YAML (default yaml)
+      --ttlSecondsAfterSucceed int     Time to live after the OpsRequest succeed
 ```
 
 ### Options inherited from parent commands
@@ -45,34 +46,21 @@ kbcli bench sysbench run [ClusterName] [flags]
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
       --context string                 The name of the kubeconfig context to use
-      --database string                database name
       --disable-compression            If true, opt-out of response compression for all requests to the server
-      --driver string                  database driver
-      --flag int                       the flag of sysbench, 0(normal), 1(long), 2(three nodes)
-      --host string                    the host of database
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
       --match-server-version           Require server version to match client version
   -n, --namespace string               If present, the namespace scope for this CLI request
-      --password string                the password of database
-      --port int                       the port of database
-      --read-percent int               the percent of read, only useful when type is oltp_read_write_pct
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server
-      --size int                       the data size of per table (default 25000)
-      --tables int                     the number of tables (default 10)
-      --threads ints                   the number of threads, you can set multiple values, like 4,8 (default [4])
-      --times int                      the number of test times (default 60)
       --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
       --token string                   Bearer token for authentication to the API server
-      --type strings                   sysbench type, you can set multiple values (default [oltp_read_write])
-      --user string                    the user of database
-      --write-percent int              the percent of write, only useful when type is oltp_read_write_pct
+      --user string                    The name of the kubeconfig user to use
 ```
 
 ### SEE ALSO
 
-* [kbcli bench sysbench](kbcli_bench_sysbench.md)	 - run a SysBench benchmark
+* [kbcli cluster](kbcli_cluster.md)	 - Cluster command.
 
 #### Go Back to [CLI Overview](cli.md) Homepage.
 

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.1-0.20220423185008-bf980b35cac4
 	github.com/onsi/ginkgo/v2 v2.9.1
 	github.com/onsi/gomega v1.27.4
+	github.com/opencontainers/image-spec v1.1.0-rc2
 	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/redis/go-redis/v9 v9.0.1
@@ -286,7 +287,6 @@ require (
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/nsf/termbox-go v0.0.0-20190121233118-02980233997d // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.0-rc2 // indirect
 	github.com/opencontainers/runc v1.1.5 // indirect
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 // indirect
 	github.com/opencontainers/selinux v1.10.2 // indirect

--- a/internal/cli/cmd/bench/bench.go
+++ b/internal/cli/cmd/bench/bench.go
@@ -52,7 +52,7 @@ func (o *BenchBaseOptions) BaseValidate() error {
 	}
 
 	if o.Database == "" {
-		return fmt.Errorf("database name should be specifed")
+		return fmt.Errorf("database name should be specified")
 	}
 
 	if o.Host == "" {

--- a/internal/cli/cmd/bench/bench.go
+++ b/internal/cli/cmd/bench/bench.go
@@ -52,7 +52,7 @@ func (o *BenchBaseOptions) BaseValidate() error {
 	}
 
 	if o.Database == "" {
-		return fmt.Errorf("database is required")
+		return fmt.Errorf("database name should be specifed")
 	}
 
 	if o.Host == "" {

--- a/internal/cli/cmd/bench/bench_test.go
+++ b/internal/cli/cmd/bench/bench_test.go
@@ -115,7 +115,7 @@ var _ = Describe("bench", func() {
 			factory:   tf,
 			IOStreams: streams,
 		}
-		Expect(o.Complete(clusterName)).Should(BeNil())
+		Expect(o.Complete([]string{clusterName})).Should(BeNil())
 		Expect(o.Validate()).Should(BeNil())
 		Expect(o.Run()).Should(BeNil())
 	})


### PR DESCRIPTION
```sh
run a SysBench benchmark

Examples:
  # sysbench on a cluster
  kbcli bench sysbench mycluster --user xxx --password xxx --database mydb
  
  # sysbench on a cluster with different threads
  kbcli bench sysbench mycluster --user xxx --password xxx --database mydb --threads 4,8
  
  # sysbench on a cluster with different type
  kbcli bench sysbench mycluster --user xxx --password xxx --database mydb --type oltp_read_only,oltp_read_write
  
  # sysbench on a cluster with specified read/write ratio
  kbcli bench sysbench mycluster --user xxx --password xxx  --database mydb --type oltp_read_write_pct --read-percent 80
--write-percent 80
  
  # sysbench on a cluster with specified tables and size
  kbcli bench sysbench mycluster --user xxx --password xxx --database mydb --tables 10 --size 25000

Available Commands:
  cleanup       Cleanup the data of SysBench for cluster
  prepare       Prepare the data of SysBench for a cluster
  run           Run  SysBench on cluster

Usage:
  kbcli bench sysbench [flags] [options]

Use "kbcli <command> --help" for more information about a given command.
Use "kbcli options" for a list of global command-line options (applies to all commands).
```