### PR TITLE
chore: add examples and test cases for kubeblocks describe-config

### DIFF
--- a/docs/user_docs/cli/cli.md
+++ b/docs/user_docs/cli/cli.md
@@ -53,7 +53,7 @@ Manage classes
 Cluster command.
 
 * [kbcli cluster backup](kbcli_cluster_backup.md)	 - Create a backup for the cluster.
-* [kbcli cluster cancel-ops](kbcli_cluster_cancel-ops.md)	 - cancel the pending/creating/running OpsRequest which type is vscale or hscale.
+* [kbcli cluster cancel-ops](kbcli_cluster_cancel-ops.md)	 - Cancel the pending/creating/running OpsRequest which type is vscale or hscale.
 * [kbcli cluster configure](kbcli_cluster_configure.md)	 - Configure parameters with the specified components in the cluster.
 * [kbcli cluster connect](kbcli_cluster_connect.md)	 - Connect to a cluster or instance.
 * [kbcli cluster create](kbcli_cluster_create.md)	 - Create a cluster.
@@ -84,6 +84,7 @@ Cluster command.
 * [kbcli cluster list-logs](kbcli_cluster_list-logs.md)	 - List supported log files in cluster.
 * [kbcli cluster list-ops](kbcli_cluster_list-ops.md)	 - List all opsRequests.
 * [kbcli cluster logs](kbcli_cluster_logs.md)	 - Access cluster log file.
+* [kbcli cluster promote](kbcli_cluster_promote.md)	 - Promote a non-primary or non-leader instance as the new primary or leader of the cluster
 * [kbcli cluster restart](kbcli_cluster_restart.md)	 - Restart the specified components in the cluster.
 * [kbcli cluster restore](kbcli_cluster_restore.md)	 - Restore a new cluster from backup.
 * [kbcli cluster revoke-role](kbcli_cluster_revoke-role.md)	 - Revoke role from account
@@ -139,7 +140,7 @@ Inject faults to pod.
 KubeBlocks operation commands.
 
 * [kbcli kubeblocks config](kbcli_kubeblocks_config.md)	 - KubeBlocks config.
-* [kbcli kubeblocks describe-config](kbcli_kubeblocks_describe-config.md)	 - describe KubeBlocks config.
+* [kbcli kubeblocks describe-config](kbcli_kubeblocks_describe-config.md)	 - Describe KubeBlocks config.
 * [kbcli kubeblocks install](kbcli_kubeblocks_install.md)	 - Install KubeBlocks.
 * [kbcli kubeblocks list-versions](kbcli_kubeblocks_list-versions.md)	 - List KubeBlocks versions.
 * [kbcli kubeblocks preflight](kbcli_kubeblocks_preflight.md)	 - Run and retrieve preflight checks for KubeBlocks.

--- a/docs/user_docs/cli/kbcli_cluster.md
+++ b/docs/user_docs/cli/kbcli_cluster.md
@@ -38,7 +38,7 @@ Cluster command.
 
 
 * [kbcli cluster backup](kbcli_cluster_backup.md)	 - Create a backup for the cluster.
-* [kbcli cluster cancel-ops](kbcli_cluster_cancel-ops.md)	 - cancel the pending/creating/running OpsRequest which type is vscale or hscale.
+* [kbcli cluster cancel-ops](kbcli_cluster_cancel-ops.md)	 - Cancel the pending/creating/running OpsRequest which type is vscale or hscale.
 * [kbcli cluster configure](kbcli_cluster_configure.md)	 - Configure parameters with the specified components in the cluster.
 * [kbcli cluster connect](kbcli_cluster_connect.md)	 - Connect to a cluster or instance.
 * [kbcli cluster create](kbcli_cluster_create.md)	 - Create a cluster.
@@ -69,6 +69,7 @@ Cluster command.
 * [kbcli cluster list-logs](kbcli_cluster_list-logs.md)	 - List supported log files in cluster.
 * [kbcli cluster list-ops](kbcli_cluster_list-ops.md)	 - List all opsRequests.
 * [kbcli cluster logs](kbcli_cluster_logs.md)	 - Access cluster log file.
+* [kbcli cluster promote](kbcli_cluster_promote.md)	 - Promote a non-primary or non-leader instance as the new primary or leader of the cluster
 * [kbcli cluster restart](kbcli_cluster_restart.md)	 - Restart the specified components in the cluster.
 * [kbcli cluster restore](kbcli_cluster_restore.md)	 - Restore a new cluster from backup.
 * [kbcli cluster revoke-role](kbcli_cluster_revoke-role.md)	 - Revoke role from account

--- a/docs/user_docs/cli/kbcli_cluster_promote.md
+++ b/docs/user_docs/cli/kbcli_cluster_promote.md
@@ -1,25 +1,37 @@
 ---
-title: kbcli cluster cancel-ops
+title: kbcli cluster promote
 ---
 
-Cancel the pending/creating/running OpsRequest which type is vscale or hscale.
+Promote a non-primary or non-leader instance as the new primary or leader of the cluster
 
 ```
-kbcli cluster cancel-ops NAME [flags]
+kbcli cluster promote NAME [--component=<comp-name>] [--instance <instance-name>] [flags]
 ```
 
 ### Examples
 
 ```
-  # cancel the opsRequest which is not completed.
-  kbcli cluster cancel-ops <opsRequestName>
+  # Promote the instance mycluster-mysql-1 as the new primary or leader.
+  kbcli cluster promote mycluster --instance mycluster-mysql-1
+  
+  # Promote a non-primary or non-leader instance as the new primary or leader, the new primary or leader is determined by the system.
+  kbcli cluster promote mycluster
+  
+  # If the cluster has multiple components, you need to specify a component, otherwise an error will be reported.
+  kbcli cluster promote mycluster --component=mysql --instance mycluster-mysql-1
 ```
 
 ### Options
 
 ```
-      --auto-approve   Skip interactive approval before cancel the opsRequest
-  -h, --help           help for cancel-ops
+      --auto-approve                   Skip interactive approval before promote the instance
+      --component string               Specify the component name of the cluster, if the cluster has multiple components, you need to specify a component
+      --dry-run string[="unchanged"]   Must be "client", or "server". If with client strategy, only print the object that would be sent, and no data is actually sent. If with server strategy, submit the server-side request, but no data is persistent. (default "none")
+  -h, --help                           help for promote
+      --instance string                Specify the instance name as the new primary or leader of the cluster, you can get the instance name by running "kbcli cluster list-instances"
+      --name string                    OpsRequest name. if not specified, it will be randomly generated 
+  -o, --output format                  prints the output in the specified format. Allowed values: JSON and YAML (default yaml)
+      --ttlSecondsAfterSucceed int     Time to live after the OpsRequest succeed
 ```
 
 ### Options inherited from parent commands

--- a/docs/user_docs/cli/kbcli_kubeblocks.md
+++ b/docs/user_docs/cli/kbcli_kubeblocks.md
@@ -38,7 +38,7 @@ KubeBlocks operation commands.
 
 
 * [kbcli kubeblocks config](kbcli_kubeblocks_config.md)	 - KubeBlocks config.
-* [kbcli kubeblocks describe-config](kbcli_kubeblocks_describe-config.md)	 - describe KubeBlocks config.
+* [kbcli kubeblocks describe-config](kbcli_kubeblocks_describe-config.md)	 - Describe KubeBlocks config.
 * [kbcli kubeblocks install](kbcli_kubeblocks_install.md)	 - Install KubeBlocks.
 * [kbcli kubeblocks list-versions](kbcli_kubeblocks_list-versions.md)	 - List KubeBlocks versions.
 * [kbcli kubeblocks preflight](kbcli_kubeblocks_preflight.md)	 - Run and retrieve preflight checks for KubeBlocks.

--- a/docs/user_docs/cli/kbcli_kubeblocks_describe-config.md
+++ b/docs/user_docs/cli/kbcli_kubeblocks_describe-config.md
@@ -2,7 +2,7 @@
 title: kbcli kubeblocks describe-config
 ---
 
-describe KubeBlocks config.
+Describe KubeBlocks config.
 
 ```
 kbcli kubeblocks describe-config [flags]
@@ -13,12 +13,17 @@ kbcli kubeblocks describe-config [flags]
 ```
   # Describe the KubeBlocks config.
   kbcli kubeblocks describe-config
+  # Describe all the KubeBlocks configs
+  kbcli kubeblocks describe-config --all
+  # Describe the desired KubeBlocks configs by filter conditions
+  kbcli kubeblocks describe-config --filter=addonController,affinity
 ```
 
 ### Options
 
 ```
   -A, --all             show all kubeblocks configs value
+      --filter string   filter the desired kubeblocks configs, multiple filtered strings are comma separated
   -h, --help            help for describe-config
   -o, --output format   prints the output in the specified format. Allowed values: table, json, yaml, wide (default table)
 ```

--- a/internal/cli/cmd/kubeblocks/config.go
+++ b/internal/cli/cmd/kubeblocks/config.go
@@ -42,6 +42,9 @@ import (
 )
 
 var showAllConfig = false
+var filterConfig = ""
+
+// keyWhiteList is a list of which kubeblocks configs are rolled out by default
 var keyWhiteList = []string{
 	"addonController",
 	"dataProtection",
@@ -84,6 +87,10 @@ var backupConfigExample = templates.Examples(`
 var describeConfigExample = templates.Examples(`
 		# Describe the KubeBlocks config.
 		kbcli kubeblocks describe-config
+		# Describe all the KubeBlocks configs
+		kbcli kubeblocks describe-config --all
+		# Describe the desired KubeBlocks configs by filter conditions
+		kbcli kubeblocks describe-config --filter=addonController,affinity
 `)
 
 // NewConfigCmd creates the config command
@@ -119,7 +126,7 @@ func NewDescribeConfigCmd(f cmdutil.Factory, streams genericclioptions.IOStreams
 	var output printer.Format
 	cmd := &cobra.Command{
 		Use:     "describe-config",
-		Short:   "describe KubeBlocks config.",
+		Short:   "Describe KubeBlocks config.",
 		Example: describeConfigExample,
 		Args:    cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -129,6 +136,7 @@ func NewDescribeConfigCmd(f cmdutil.Factory, streams genericclioptions.IOStreams
 	}
 	printer.AddOutputFlag(cmd, &output)
 	cmd.Flags().BoolVarP(&showAllConfig, "all", "A", false, "show all kubeblocks configs value")
+	cmd.Flags().StringVar(&filterConfig, "filter", "", "filter the desired kubeblocks configs, multiple filtered strings are comma separated")
 	return cmd
 }
 
@@ -153,14 +161,22 @@ func getHelmValues(release string, opt *Options) (map[string]interface{}, error)
 	for _, item := range list.Items {
 		delete(values, item.GetName())
 	}
+	return pruningConfigResults(values), nil
+}
+
+// pruningConfigResults prunes the configs results by options
+func pruningConfigResults(configs map[string]interface{}) map[string]interface{} {
 	if showAllConfig {
-		return values, nil
+		return configs
 	}
-	res := make(map[string]interface{})
-	for i := range keyWhiteList {
-		res[keyWhiteList[i]] = values[keyWhiteList[i]]
+	if filterConfig != "" {
+		keyWhiteList = strings.Split(filterConfig, ",")
 	}
-	return res, nil
+	res := make(map[string]interface{}, len(keyWhiteList))
+	for _, whiteKey := range keyWhiteList {
+		res[whiteKey] = configs[whiteKey]
+	}
+	return res
 }
 
 type fn func(release string, opt *Options) (map[string]interface{}, error)

--- a/internal/cli/cmd/kubeblocks/config_test.go
+++ b/internal/cli/cmd/kubeblocks/config_test.go
@@ -127,6 +127,58 @@ var _ = Describe("backupconfig", func() {
 		Expect(o.PreCheck()).Should(HaveOccurred())
 	})
 
+	It("pruningConfigResults test, and expected success", func() {
+		configs := map[string]interface{}{
+			"key1": "value1",
+			"key2": "value2",
+			"key3": "value3",
+		}
+		tests := []struct {
+			configs       map[string]interface{}
+			showAllConfig bool
+			filterConfig  string
+			keyWhiteList  []string
+			results       map[string]interface{}
+		}{
+			{
+				configs,
+				true,
+				"",
+				keyWhiteList,
+				configs,
+			}, {
+				configs,
+				false,
+				"key1",
+				keyWhiteList,
+				map[string]interface{}{
+					"key1": "value1",
+				},
+			}, {
+				configs,
+				false,
+				"",
+				[]string{"key2"},
+				map[string]interface{}{
+					"key2": "value2",
+				},
+			}, {
+				configs,
+				false,
+				"",
+				[]string{},
+				map[string]interface{}{},
+			}}
+		Eventually(func(g Gomega) {
+			for _, t := range tests {
+				showAllConfig = t.showAllConfig
+				filterConfig = t.filterConfig
+				keyWhiteList = t.keyWhiteList
+				g.Expect(pruningConfigResults(t.configs)).Should(Equal(t.results))
+			}
+		}).Should(Succeed())
+	})
+
 	Context("run describe config cmd", func() {
 		var output printer.Format
 


### PR DESCRIPTION
This pr has following changes:
1: add examples and test cases for `kubeblocks describe-config` cmd
2: sync cli-doc
3: refactor code