### PR TITLE
feat: support nebula-console in nebula-cluster

### DIFF
--- a/deploy/nebula-cluster/templates/cluster.yaml
+++ b/deploy/nebula-cluster/templates/cluster.yaml
@@ -9,6 +9,22 @@ spec:
   clusterVersionRef: nebula-{{ default .Chart.AppVersion .Values.clusterVersionOverride }}
   terminationPolicy: {{ .Values.nebula.terminationPolicy }}
   componentSpecs:
+    - name: nebula-console
+      componentDefRef: nebula-console
+      replicas: 1
+      {{- with  .Values.nebula.metad.resources }}
+      resources:
+        {{- with .limits }}
+        limits:
+          cpu: {{ .cpu | quote }}
+          memory: {{ .memory | quote }}
+        {{- end }}
+        {{- with .requests }}
+        requests:
+          cpu: {{ .cpu | quote }}
+          memory: {{ .memory | quote }}
+        {{- end }}
+      {{- end }}
     - name: nebula-metad
       componentDefRef: nebula-metad
       replicas: {{ .Values.nebula.metad.replicas }}

--- a/deploy/nebula/scripts/nebula-console-start.sh.tpl
+++ b/deploy/nebula/scripts/nebula-console-start.sh.tpl
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -ex
+{{- $clusterName := $.cluster.metadata.name }}
+{{- $namespace := $.cluster.metadata.namespace }}
+{{- $graphd_port := 9669 }}
+{{- $storaged_port := 9779 }}
+{{- $nebula_storaged_component := fromJson "{}" }}
+{{- $nebula_graphd_component := fromJson "{}" }}
+{{- range $i, $e := $.cluster.spec.componentSpecs }}
+    {{- if eq $e.componentDefRef "nebula-graphd" }}
+        {{- $nebula_graphd_component = $e }}
+    {{- else if eq $e.componentDefRef "nebula-storaged" }}
+        {{- $nebula_storaged_component = $e }}
+    {{- end }}
+{{- end }}
+{{- $graphd_svc := printf "%s-%s.%s.svc.cluster.local" $clusterName $nebula_graphd_component.name $namespace }}
+{{- $storaged_svc_suffix := printf "%s-%s-headless.%s.svc.cluster.local" $clusterName $nebula_storaged_component.name $namespace }}
+
+echo "Waiting for graphd service {{ $graphd_svc }} to be ready..."
+until /usr/local/bin/nebula-console --addr {{ $graphd_svc }} --port {{$graphd_port}} --user root --password nebula -e "show spaces"; do sleep 1; done
+echo "graphd service is ready, add storaged address..."
+id=0
+while [ $id -lt {{$nebula_storaged_component.replicas}} ]
+do
+  /usr/local/bin/nebula-console --addr {{ $graphd_svc }} --port {{$graphd_port}} --user root --password nebula -e "ADD HOSTS \"{{ $clusterName }}-{{ $nebula_storaged_component.name }}-$id.{{ $storaged_svc_suffix }}\":{{ $storaged_port }};"
+  id=$(( $id + 1 ))
+done
+echo "Start Console succeeded!"

--- a/deploy/nebula/templates/clusterdefinition.yaml
+++ b/deploy/nebula/templates/clusterdefinition.yaml
@@ -14,14 +14,38 @@ spec:
     accesskey: ""
     secretkey: ""
   componentDefs:
+    - name: nebula-console
+      workloadType: Stateless
+      characterType: nebula-console
+      scriptSpecs:
+        - name: nebula-console-scripts
+          templateRef: nebula-console-scripts-template
+          namespace: {{ .Release.Namespace }}
+          volumeName: scripts
+          defaultMode: 493
+      podSpec:
+        containers:
+          - name: nebula-console
+            imagePullPolicy: {{default .Values.nebula.metad.image.pullPolicy "IfNotPresent"}}
+            command: ["/bin/sh"]
+            args: ["-c", "exec /bin/sh -c 'trap : TERM INT; sleep infinity & wait'"]
+            lifecycle:
+              postStart:
+                exec:
+                  command: ["/bin/sh", "-c", "/scripts/nebula-console-start.sh"]
+            volumeMounts:
+              - name: scripts
+                mountPath: /scripts
     - name: nebula-metad
       configSpecs:
         - name: nebula-metad-config
           templateRef: nebula-metad-config-template
+          namespace: {{ .Release.Namespace }}
           volumeName: nebula-metad
       scriptSpecs:
         - name: nebula-metad-scripts
           templateRef: nebula-metad-scripts-template
+          namespace: {{ .Release.Namespace }}
           volumeName: scripts
           defaultMode: 493
       workloadType: Stateful
@@ -69,10 +93,12 @@ spec:
       configSpecs:
         - name: nebula-graphd-config
           templateRef: nebula-graphd-config-template
+          namespace: {{ .Release.Namespace }}
           volumeName: nebula-graphd
       scriptSpecs:
         - name: nebula-graphd-scripts
           templateRef: nebula-graphd-scripts-template
+          namespace: {{ .Release.Namespace }}
           volumeName: scripts
           defaultMode: 493
       workloadType: Stateful
@@ -136,10 +162,12 @@ spec:
       configSpecs:
         - name: nebula-storaged-config
           templateRef: nebula-storaged-config-template
+          namespace: {{ .Release.Namespace }}
           volumeName: nebula-storaged
       scriptSpecs:
         - name: nebula-storaged-scripts
           templateRef: nebula-storaged-scripts-template
+          namespace: {{ .Release.Namespace }}
           volumeName: scripts
           defaultMode: 493
       workloadType: Stateful

--- a/deploy/nebula/templates/clusterversion.yaml
+++ b/deploy/nebula/templates/clusterversion.yaml
@@ -7,6 +7,11 @@ metadata:
 spec:
   clusterDefinitionRef: nebula
   componentVersions:
+    - componentDefRef: nebula-console
+      versionsContext:
+        containers:
+        - name: nebula-console
+          image: {{ .Values.nebula.console.image.repository }}:{{ default .Chart.AppVersion .Values.nebula.console.image.tag }}
     - componentDefRef: nebula-graphd
       versionsContext:
         containers:

--- a/deploy/nebula/templates/scripts.yaml
+++ b/deploy/nebula/templates/scripts.yaml
@@ -27,3 +27,13 @@ metadata:
 data:
   nebula-metad-start.sh: |
     {{- .Files.Get "scripts/nebula-metad-start.sh.tpl" | nindent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nebula-console-scripts-template
+  labels:
+    {{- include "nebula.labels" . | nindent 4 }}
+data:
+  nebula-console-start.sh: |
+    {{- .Files.Get "scripts/nebula-console-start.sh.tpl" | nindent 4 }}

--- a/deploy/nebula/values.yaml
+++ b/deploy/nebula/values.yaml
@@ -20,3 +20,9 @@ nebula:
       repository: docker.io/vesoft/nebula-storaged
       tag: v3.5.0
       pullPolicy: IfNotPresent
+  console:
+    ## @param nebula.console.image, container image settings
+    image:
+      repository: docker.io/vesoft/nebula-console
+      tag: v3.5.0
+      pullPolicy: IfNotPresent


### PR DESCRIPTION
- fix #3980  
In this commit, we introduced a new component `nebula-console` to Nebula ClusterDefinition. It plays the role of nebula client, and helps regists `storaged`  to `metad` to setup the cluster.