### PR TITLE
fix: miss vttablet container for mysql

### DIFF
--- a/deploy/apecloud-mysql-cluster/templates/cluster.yaml
+++ b/deploy/apecloud-mysql-cluster/templates/cluster.yaml
@@ -1,4 +1,16 @@
-{{- include "kblib.clusterCommon" . }}
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: Cluster
+metadata:
+  name: {{ include "kblib.clusterName" . }}
+  labels: {{ include "kblib.clusterLabels" . | nindent 4 }}
+  {{- if and (eq .Values.mode "raftGroup") .Values.proxyEnabled }}
+  annotations:
+    kubeblocks.io/extra-env: '{"KB_PROXY_ENABLED":"on"}'
+  {{- end }}
+spec:
+  clusterVersionRef: {{ .Values.version }}
+  terminationPolicy: {{ .Values.extra.terminationPolicy }}
+  {{- include "kblib.affinity" . | indent 2 }}
   clusterDefinitionRef: apecloud-mysql # ref clusterdefinition.name
   componentSpecs:
     - name: mysql

--- a/deploy/apecloud-mysql/templates/clusterdefinition.yaml
+++ b/deploy/apecloud-mysql/templates/clusterdefinition.yaml
@@ -238,62 +238,10 @@ spec:
                     name: $(CONN_CREDENTIAL_SECRET_NAME)
                     key: password
                     optional: false
-            command:
-              - /bin/bash
-              - -c
-              - |
-                cell=${CELL:-'zone1'}
-                uid="${KB_POD_NAME##*-}"
-                mysql_root=${MYSQL_ROOT_USER:-'root'}
-                mysql_root_passwd=${MYSQL_ROOT_PASSWORD:-'123456'}
-                mysql_port=${MYSQL_PORT:-'3306'}
-                port=${VTTABLET_PORT:-'15100'}
-                grpc_port=${VTTABLET_GRPC_PORT:-'16100'}
-                vtctld_host=${VTCTLD_HOST:-'127.0.0.1'}
-                vtctld_web_port=${VTCTLD_WEB_PORT:-'15000'}
-                printf -v alias '%s-%010d' $cell $uid
-                printf -v tablet_dir 'vt_%010d' $uid
-                tablet_hostname=$(eval echo \$KB_"$uid"_HOSTNAME)
-                printf -v tablet_logfile 'vttablet_%010d_querylog.txt' $uid
-
-                tablet_type=replica
-                topology_fags=${TOPOLOGY_FLAGS:-'--topo_implementation etcd2 --topo_global_server_address 127.0.0.1:2379 --topo_global_root /vitess/global'}
-
-                echo "starting vttablet for $alias..."
-
-                su vitess <<EOF
-                exec vttablet \
-                $topology_fags \
-                --alsologtostderr \
-                --log_dir $VTDATAROOT \
-                --log_queries_to_file $VTDATAROOT/$tablet_logfile \
-                --tablet-path $alias \
-                --tablet_hostname "$tablet_hostname" \
-                --init_tablet_type $tablet_type \
-                --health_check_interval 1s \
-                --shard_sync_retry_delay 1s \
-                --remote_operation_timeout 1s \
-                --db_connect_timeout_ms 500 \
-                --enable_replication_reporter \
-                --backup_storage_implementation file \
-                --file_backup_storage_root $VTDATAROOT/backups \
-                --port $port \
-                --db_port $mysql_port \
-                --db_host $tablet_hostname \
-                --db_allprivs_user $mysql_root \
-                --db_allprivs_password $mysql_root_passwd \
-                --db_dba_user $mysql_root \
-                --db_dba_password $mysql_root_passwd \
-                --db_app_user $mysql_root \
-                --db_app_password $mysql_root_passwd \
-                --db_filtered_user $mysql_root \
-                --db_filtered_password $mysql_root_passwd \
-                --grpc_port $grpc_port \
-                --service_map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream' \
-                --pid_file $VTDATAROOT/vttablet.pid \
-                --vtctld_addr http://$vtctld_host:$vtctld_web_port/ \
-                --disable_active_reparents
-                EOF
+            command: ["/scripts/vttablet.sh"]
+            volumeMounts:
+              - name: scripts
+                mountPath: /scripts
         volumes:
           - name: annotations
             downwardAPI:

--- a/deploy/apecloud-mysql/templates/clusterdefinition.yaml
+++ b/deploy/apecloud-mysql/templates/clusterdefinition.yaml
@@ -199,6 +199,101 @@ spec:
             volumeMounts:
               - name: agamotto-configuration
                 mountPath: /opt/agamotto
+          - name: vttablet
+            image: {{ .Values.wesqlscale.image.registry | default "docker.io" }}/{{ .Values.wesqlscale.image.repository }}:{{ .Values.wesqlscale.image.tag }}
+            imagePullPolicy: {{ default .Values.wesqlscale.image.pullPolicy "IfNotPresent" }}
+            ports:
+              - containerPort: 15100
+                name: vttabletport
+              - containerPort: 16100
+                name: vttabletgrpc
+              - containerPort: 40000
+                name: delvedebug
+            env:
+              - name: CELL
+                value: {{ .Values.wesqlscale.cell | default "zone1" | quote }}
+              - name: ETCD_SERVER
+                value: "$(KB_CLUSTER_NAME)-etcd-headless"
+              - name: ETCD_PORT
+                value: "2379"
+              - name: TOPOLOGY_FLAGS
+                value: "--topo_implementation etcd2 --topo_global_server_address $(ETCD_SERVER):$(ETCD_PORT) --topo_global_root /vitess/global"
+              - name: VTTABLET_PORT
+                value: "15100"
+              - name: VTTABLET_GRPC_PORT
+                value: "16100"
+              - name: VTCTLD_HOST
+                value: "$(KB_CLUSTER_NAME)-vtctld-headless"
+              - name: VTCTLD_WEB_PORT
+                value: "15000"
+              - name: MYSQL_ROOT_USER
+                valueFrom:
+                  secretKeyRef:
+                    name: $(CONN_CREDENTIAL_SECRET_NAME)
+                    key: username
+                    optional: false
+              - name: MYSQL_ROOT_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: $(CONN_CREDENTIAL_SECRET_NAME)
+                    key: password
+                    optional: false
+            command:
+              - /bin/bash
+              - -c
+              - |
+                cell=${CELL:-'zone1'}
+                uid="${KB_POD_NAME##*-}"
+                mysql_root=${MYSQL_ROOT_USER:-'root'}
+                mysql_root_passwd=${MYSQL_ROOT_PASSWORD:-'123456'}
+                mysql_port=${MYSQL_PORT:-'3306'}
+                port=${VTTABLET_PORT:-'15100'}
+                grpc_port=${VTTABLET_GRPC_PORT:-'16100'}
+                vtctld_host=${VTCTLD_HOST:-'127.0.0.1'}
+                vtctld_web_port=${VTCTLD_WEB_PORT:-'15000'}
+                printf -v alias '%s-%010d' $cell $uid
+                printf -v tablet_dir 'vt_%010d' $uid
+                tablet_hostname=$(eval echo \$KB_"$uid"_HOSTNAME)
+                printf -v tablet_logfile 'vttablet_%010d_querylog.txt' $uid
+
+                tablet_type=replica
+                topology_fags=${TOPOLOGY_FLAGS:-'--topo_implementation etcd2 --topo_global_server_address 127.0.0.1:2379 --topo_global_root /vitess/global'}
+
+                echo "starting vttablet for $alias..."
+
+                su vitess <<EOF
+                exec vttablet \
+                $topology_fags \
+                --alsologtostderr \
+                --log_dir $VTDATAROOT \
+                --log_queries_to_file $VTDATAROOT/$tablet_logfile \
+                --tablet-path $alias \
+                --tablet_hostname "$tablet_hostname" \
+                --init_tablet_type $tablet_type \
+                --health_check_interval 1s \
+                --shard_sync_retry_delay 1s \
+                --remote_operation_timeout 1s \
+                --db_connect_timeout_ms 500 \
+                --enable_replication_reporter \
+                --backup_storage_implementation file \
+                --file_backup_storage_root $VTDATAROOT/backups \
+                --port $port \
+                --db_port $mysql_port \
+                --db_host $tablet_hostname \
+                --db_allprivs_user $mysql_root \
+                --db_allprivs_password $mysql_root_passwd \
+                --db_dba_user $mysql_root \
+                --db_dba_password $mysql_root_passwd \
+                --db_app_user $mysql_root \
+                --db_app_password $mysql_root_passwd \
+                --db_filtered_user $mysql_root \
+                --db_filtered_password $mysql_root_passwd \
+                --grpc_port $grpc_port \
+                --service_map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream' \
+                --pid_file $VTDATAROOT/vttablet.pid \
+                --vtctld_addr http://$vtctld_host:$vtctld_web_port/ \
+                --disable_active_reparents
+                EOF
         volumes:
           - name: annotations
             downwardAPI:

--- a/deploy/apecloud-mysql/templates/scripts.yaml
+++ b/deploy/apecloud-mysql/templates/scripts.yaml
@@ -148,3 +148,61 @@ data:
         break
       fi
     done
+  vttablet.sh: |-
+    #!/bin/bash
+    while [ "$KB_PROXY_ENABLED" != "on" ]
+    do
+      sleep 60
+    done
+    cell=${CELL:-'zone1'}
+    uid="${KB_POD_NAME##*-}"
+    mysql_root=${MYSQL_ROOT_USER:-'root'}
+    mysql_root_passwd=${MYSQL_ROOT_PASSWORD:-'123456'}
+    mysql_port=${MYSQL_PORT:-'3306'}
+    port=${VTTABLET_PORT:-'15100'}
+    grpc_port=${VTTABLET_GRPC_PORT:-'16100'}
+    vtctld_host=${VTCTLD_HOST:-'127.0.0.1'}
+    vtctld_web_port=${VTCTLD_WEB_PORT:-'15000'}
+    printf -v alias '%s-%010d' $cell $uid
+    printf -v tablet_dir 'vt_%010d' $uid
+    tablet_hostname=$(eval echo \$KB_"$uid"_HOSTNAME)
+    printf -v tablet_logfile 'vttablet_%010d_querylog.txt' $uid
+
+    tablet_type=replica
+    topology_fags=${TOPOLOGY_FLAGS:-'--topo_implementation etcd2 --topo_global_server_address 127.0.0.1:2379 --topo_global_root /vitess/global'}
+
+    echo "starting vttablet for $alias..."
+
+    su vitess <<EOF
+    exec vttablet \
+    $topology_fags \
+    --alsologtostderr \
+    --log_dir $VTDATAROOT \
+    --log_queries_to_file $VTDATAROOT/$tablet_logfile \
+    --tablet-path $alias \
+    --tablet_hostname "$tablet_hostname" \
+    --init_tablet_type $tablet_type \
+    --health_check_interval 1s \
+    --shard_sync_retry_delay 1s \
+    --remote_operation_timeout 1s \
+    --db_connect_timeout_ms 500 \
+    --enable_replication_reporter \
+    --backup_storage_implementation file \
+    --file_backup_storage_root $VTDATAROOT/backups \
+    --port $port \
+    --db_port $mysql_port \
+    --db_host $tablet_hostname \
+    --db_allprivs_user $mysql_root \
+    --db_allprivs_password $mysql_root_passwd \
+    --db_dba_user $mysql_root \
+    --db_dba_password $mysql_root_passwd \
+    --db_app_user $mysql_root \
+    --db_app_password $mysql_root_passwd \
+    --db_filtered_user $mysql_root \
+    --db_filtered_password $mysql_root_passwd \
+    --grpc_port $grpc_port \
+    --service_map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream' \
+    --pid_file $VTDATAROOT/vttablet.pid \
+    --vtctld_addr http://$vtctld_host:$vtctld_web_port/ \
+    --disable_active_reparents
+    EOF


### PR DESCRIPTION
* fix #4036

add annotation to set container environment:
```
    kubeblocks.io/extra-env: '{"KB_PROXY_ENABLED":"on"}'
```

Now, support to enable or disable proxy dynamicly.

create cluster without proxy:

![image](https://github.com/apecloud/kubeblocks/assets/726412/72c679d1-b085-4b7e-ad30-5dac3dfe100b)

enable the proxy:

```
 helm upgrade my ./deploy/apecloud-mysql-cluster --set mode=raftGroup,proxyEnabled=true
```

![image](https://github.com/apecloud/kubeblocks/assets/726412/ce252e9f-8a99-41e0-a3d8-36559ee9177a)

When disable proxy, the extra proxy components existing again, maybe a bug, delete them manually and enable again.

![image](https://github.com/apecloud/kubeblocks/assets/726412/fecb0f0f-29f4-4daa-adc3-2b5c38e75daa)

![fsQzdc3MbL](https://github.com/apecloud/kubeblocks/assets/726412/62cddf59-5826-441e-a38e-f50bb1f01639)

