### PR TITLE
chore: update CD.spec.componentDesf.name validatation to be exact match of Cluster.spec.componentSpecs.name as this name could be default name from it.

### DIFF
--- a/apis/apps/v1alpha1/backuppolicytemplate_types.go
+++ b/apis/apps/v1alpha1/backuppolicytemplate_types.go
@@ -48,8 +48,8 @@ type BackupPolicyTemplateSpec struct {
 type BackupPolicy struct {
 	// componentDefRef references componentDef defined in ClusterDefinition spec.
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:MaxLength=63
-	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
+	// +kubebuilder:validation:MaxLength=22
+	// +kubebuilder:validation:Pattern:=`^[a-z]([a-z0-9\-]*[a-z0-9])?$`
 	ComponentDefRef string `json:"componentDefRef"`
 
 	// retention describe how long the Backup should be retained. if not set, will be retained forever.
@@ -118,6 +118,7 @@ type CommonBackupPolicy struct {
 
 	// which backup tool to perform database backup, only support one tool.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
 	BackupToolName string `json:"backupToolName,omitempty"`
 }

--- a/apis/apps/v1alpha1/backuppolicytemplate_types.go
+++ b/apis/apps/v1alpha1/backuppolicytemplate_types.go
@@ -46,7 +46,8 @@ type BackupPolicyTemplateSpec struct {
 }
 
 type BackupPolicy struct {
-	// componentDefRef references componentDef defined in ClusterDefinition spec.
+	// componentDefRef references componentDef defined in ClusterDefinition spec. Need to
+	// comply with IANA Service Naming rule.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MaxLength=22
 	// +kubebuilder:validation:Pattern:=`^[a-z]([a-z0-9\-]*[a-z0-9])?$`

--- a/apis/apps/v1alpha1/cluster_types.go
+++ b/apis/apps/v1alpha1/cluster_types.go
@@ -30,10 +30,12 @@ import (
 type ClusterSpec struct {
 	// Cluster referencing ClusterDefinition name. This is an immutable attribute.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
 	ClusterDefRef string `json:"clusterDefinitionRef"`
 
 	// Cluster referencing ClusterVersion name.
+	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
 	// +optional
 	ClusterVersionRef string `json:"clusterVersionRef,omitempty"`
@@ -102,16 +104,17 @@ type ClusterStatus struct {
 
 // ClusterComponentSpec defines the cluster component spec.
 type ClusterComponentSpec struct {
-	// name defines cluster's component name.
+	// name defines cluster's component name, this name is also part of Service DNS name, so this name will
+	// comply with IANA Service Naming rule.
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:MaxLength=15
-	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
+	// +kubebuilder:validation:MaxLength=22
+	// +kubebuilder:validation:Pattern:=`^[a-z]([a-z0-9\-]*[a-z0-9])?$`
 	Name string `json:"name"`
 
 	// componentDefRef references the componentDef defined in ClusterDefinition spec.
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:MaxLength=63
-	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
+	// +kubebuilder:validation:MaxLength=22
+	// +kubebuilder:validation:Pattern:=`^[a-z]([a-z0-9\-]*[a-z0-9])?$`
 	ComponentDefRef string `json:"componentDefRef"`
 
 	// classDefRef references the class defined in ComponentClassDefinition.
@@ -461,6 +464,8 @@ type ClusterComponentService struct {
 
 type ClassDefRef struct {
 	// Name refers to the name of the ComponentClassDefinition.
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
 	// +optional
 	Name string `json:"name,omitempty"`
 

--- a/apis/apps/v1alpha1/cluster_types.go
+++ b/apis/apps/v1alpha1/cluster_types.go
@@ -111,7 +111,8 @@ type ClusterComponentSpec struct {
 	// +kubebuilder:validation:Pattern:=`^[a-z]([a-z0-9\-]*[a-z0-9])?$`
 	Name string `json:"name"`
 
-	// componentDefRef references the componentDef defined in ClusterDefinition spec.
+	// componentDefRef references componentDef defined in ClusterDefinition spec. Need to
+	// comply with IANA Service Naming rule.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MaxLength=22
 	// +kubebuilder:validation:Pattern:=`^[a-z]([a-z0-9\-]*[a-z0-9])?$`

--- a/apis/apps/v1alpha1/clusterdefinition_types.go
+++ b/apis/apps/v1alpha1/clusterdefinition_types.go
@@ -244,10 +244,13 @@ type VolumeTypeSpec struct {
 // behaviors.
 // +kubebuilder:validation:XValidation:rule="has(self.workloadType) && self.workloadType == 'Consensus' ?  has(self.consensusSpec) : !has(self.consensusSpec)",message="componentDefs.consensusSpec is required when componentDefs.workloadType is Consensus, and forbidden otherwise"
 type ClusterComponentDefinition struct {
-	// name of the component, it can be any valid string.
+	// A component definition name, this name could be used as default name of `Cluster.spec.componentSpecs.name`,
+	// and so this name is need to conform with same validation rules as `Cluster.spec.componentSpecs.name`, that
+	// is currently comply with IANA Service Naming rule. This name will apply to "apps.kubeblocks.io/component-name"
+	// object label value.
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:MaxLength=18
-	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
+	// +kubebuilder:validation:MaxLength=22
+	// +kubebuilder:validation:Pattern:=`^[a-z]([a-z0-9\-]*[a-z0-9])?$`
 	Name string `json:"name"`
 
 	// The description of component definition.

--- a/apis/apps/v1alpha1/clusterversion_types.go
+++ b/apis/apps/v1alpha1/clusterversion_types.go
@@ -25,6 +25,7 @@ import (
 type ClusterVersionSpec struct {
 	// ref ClusterDefinition.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
 	ClusterDefinitionRef string `json:"clusterDefinitionRef"`
 

--- a/apis/apps/v1alpha1/configconstraint_types.go
+++ b/apis/apps/v1alpha1/configconstraint_types.go
@@ -140,7 +140,6 @@ type UnixSignalTrigger struct {
 
 	// processName is process name, sends unix signal to proc.
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
 	ProcessName string `json:"processName"`
 }
 
@@ -163,10 +162,10 @@ type ToolsImageSpec struct {
 }
 
 type ToolConfig struct {
-	// Specify the name of initContainer.
+	// Specify the name of initContainer. Must be a DNS_LABEL name.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MaxLength=63
-	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
+	// +kubebuilder:validation:Pattern:=`^[a-z]([a-z0-9\-]*[a-z0-9])?$`
 	Name string `json:"name,omitempty"`
 
 	// tools Container image name.
@@ -208,6 +207,7 @@ type ScriptConfig struct {
 	// An empty namespace is equivalent to the "default" namespace.
 	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:default="default"
+	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$`
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
 }

--- a/apis/apps/v1alpha1/type.go
+++ b/apis/apps/v1alpha1/type.go
@@ -49,14 +49,17 @@ type ComponentTemplateSpec struct {
 	// Specify the namespace of the referenced the configuration template ConfigMap object.
 	// An empty namespace is equivalent to the "default" namespace.
 	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$`
 	// +kubebuilder:default="default"
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
 
-	// volumeName is the volume name of PodTemplate, which the configuration file produced through the configuration template will be mounted to the corresponding volume.
+	// volumeName is the volume name of PodTemplate, which the configuration file produced through the configuration
+	// template will be mounted to the corresponding volume. Must be a DNS_LABEL name.
 	// The volume name must be defined in podSpec.containers[*].volumeMounts.
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:MaxLength=32
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern:=`^[a-z]([a-z0-9\-]*[a-z0-9])?$`
 	VolumeName string `json:"volumeName"`
 
 	// defaultMode is optional: mode bits used to set permissions on created files by default.
@@ -79,8 +82,9 @@ type LazyRenderedTemplateSpec struct {
 
 	// Specify the namespace of the referenced the configuration template ConfigMap object.
 	// An empty namespace is equivalent to the "default" namespace.
-	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:default="default"
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$`
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
 

--- a/apis/dataprotection/v1alpha1/backup_types.go
+++ b/apis/dataprotection/v1alpha1/backup_types.go
@@ -28,6 +28,7 @@ import (
 type BackupSpec struct {
 	// Which backupPolicy is applied to perform this backup
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
 	BackupPolicyName string `json:"backupPolicyName"`
 

--- a/apis/dataprotection/v1alpha1/backuppolicy_types.go
+++ b/apis/dataprotection/v1alpha1/backuppolicy_types.go
@@ -98,15 +98,20 @@ type CommonBackupPolicy struct {
 
 	// which backup tool to perform database backup, only support one tool.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
 	BackupToolName string `json:"backupToolName,omitempty"`
 }
 
 type PersistentVolumeClaim struct {
 	// the name of the PersistentVolumeClaim.
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
 	Name string `json:"name"`
 
 	// storageClassName is the name of the StorageClass required by the claim.
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
 	// +optional
 	StorageClassName *string `json:"storageClassName,omitempty"`
 
@@ -135,12 +140,17 @@ type PersistentVolumeClaim struct {
 type PersistentVolumeConfigMap struct {
 	// the name of the persistentVolume ConfigMap.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
 	Name string `json:"name"`
 
 	// the namespace of the persistentVolume ConfigMap.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$`
 	Namespace string `json:"namespace"`
 }
+
 type BasePolicy struct {
 	// target database cluster for backup.
 	// +kubebuilder:validation:Required
@@ -181,6 +191,7 @@ type TargetCluster struct {
 type BackupPolicySecret struct {
 	// the secret name
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
 	Name string `json:"name"`
 

--- a/apis/dataprotection/v1alpha1/backuppolicy_types.go
+++ b/apis/dataprotection/v1alpha1/backuppolicy_types.go
@@ -105,6 +105,7 @@ type CommonBackupPolicy struct {
 
 type PersistentVolumeClaim struct {
 	// the name of the PersistentVolumeClaim.
+	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
 	Name string `json:"name"`
@@ -125,7 +126,7 @@ type PersistentVolumeClaim struct {
 	// - IfNotPresent: create the PersistentVolumeClaim if not present and the accessModes only contains 'ReadWriteMany'.
 	// +kubebuilder:default=IfNotPresent
 	// +optional
-	CreatePolicy CreatePVCPolicy `json:"createPolicy"`
+	CreatePolicy CreatePVCPolicy `json:"createPolicy,omitempty"`
 
 	// persistentVolumeConfigMap references the configmap which contains a persistentVolume template.
 	// key must be "persistentVolume" and value is the "PersistentVolume" struct.

--- a/apis/dataprotection/v1alpha1/backuppolicy_types.go
+++ b/apis/dataprotection/v1alpha1/backuppolicy_types.go
@@ -104,10 +104,11 @@ type CommonBackupPolicy struct {
 }
 
 type PersistentVolumeClaim struct {
-	// the name of the PersistentVolumeClaim.
+	// the name of PersistentVolumeClaim to store backup data.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
+	// +kubebuilder:default=kb-backup-data
 	Name string `json:"name"`
 
 	// storageClassName is the name of the StorageClass required by the claim.
@@ -131,7 +132,7 @@ type PersistentVolumeClaim struct {
 	// persistentVolumeConfigMap references the configmap which contains a persistentVolume template.
 	// key must be "persistentVolume" and value is the "PersistentVolume" struct.
 	// support the following built-in Objects:
-	// - $(GENERATE_NAME): generate a specific format "pvcName-pvcNamespace".
+	// - $(GENERATE_NAME): generate a specific format "<PVC NAME>-<PVC NAMESPACE>".
 	// if the PersistentVolumeClaim not exists and CreatePolicy is "IfNotPresent", the controller
 	// will create it by this template. this is a mutually exclusive setting with "storageClassName".
 	// +optional

--- a/apis/extensions/v1alpha1/addon_types.go
+++ b/apis/extensions/v1alpha1/addon_types.go
@@ -281,6 +281,8 @@ type ResourceReqLimItem struct {
 type DataObjectKeySelector struct {
 	// Object name of the referent.
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
 	Name string `json:"name"` // need corev1.LocalObjectReference
 
 	// The key to select.

--- a/config/crd/bases/apps.kubeblocks.io_backuppolicytemplates.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_backuppolicytemplates.yaml
@@ -56,8 +56,8 @@ spec:
                     componentDefRef:
                       description: componentDefRef references componentDef defined
                         in ClusterDefinition spec.
-                      maxLength: 63
-                      pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                      maxLength: 22
+                      pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
                       type: string
                     datafile:
                       description: the policy for datafile backup.
@@ -103,6 +103,7 @@ spec:
                         backupToolName:
                           description: which backup tool to perform database backup,
                             only support one tool.
+                          maxLength: 63
                           pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                           type: string
                         backupsHistoryLimit:
@@ -200,6 +201,7 @@ spec:
                         backupToolName:
                           description: which backup tool to perform database backup,
                             only support one tool.
+                          maxLength: 63
                           pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                           type: string
                         backupsHistoryLimit:

--- a/config/crd/bases/apps.kubeblocks.io_backuppolicytemplates.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_backuppolicytemplates.yaml
@@ -55,7 +55,8 @@ spec:
                   properties:
                     componentDefRef:
                       description: componentDefRef references componentDef defined
-                        in ClusterDefinition spec.
+                        in ClusterDefinition spec. Need to comply with IANA Service
+                        Naming rule.
                       maxLength: 22
                       pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
                       type: string

--- a/config/crd/bases/apps.kubeblocks.io_clusterdefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusterdefinitions.yaml
@@ -105,6 +105,7 @@ spec:
                                   the configuration template ConfigMap object. An
                                   empty namespace is equivalent to the "default" namespace.
                                 maxLength: 63
+                                pattern: ^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$
                                 type: string
                               policy:
                                 default: patch
@@ -135,6 +136,7 @@ spec:
                               configuration template ConfigMap object. An empty namespace
                               is equivalent to the "default" namespace.
                             maxLength: 63
+                            pattern: ^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$
                             type: string
                           templateRef:
                             description: Specify the name of the referenced the configuration
@@ -146,8 +148,10 @@ spec:
                             description: volumeName is the volume name of PodTemplate,
                               which the configuration file produced through the configuration
                               template will be mounted to the corresponding volume.
-                              The volume name must be defined in podSpec.containers[*].volumeMounts.
-                            maxLength: 32
+                              Must be a DNS_LABEL name. The volume name must be defined
+                              in podSpec.containers[*].volumeMounts.
+                            maxLength: 63
+                            pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
                             type: string
                         required:
                         - name
@@ -456,9 +460,14 @@ spec:
                           type: object
                       type: object
                     name:
-                      description: name of the component, it can be any valid string.
-                      maxLength: 18
-                      pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                      description: A component definition name, this name could be
+                        used as default name of `Cluster.spec.componentSpecs.name`,
+                        and so this name is need to conform with same validation rules
+                        as `Cluster.spec.componentSpecs.name`, that is currently comply
+                        with IANA Service Naming rule. This name will apply to "apps.kubeblocks.io/component-name"
+                        object label value.
+                      maxLength: 22
+                      pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
                       type: string
                     podSpec:
                       description: podSpec define pod spec template of the cluster
@@ -8226,6 +8235,7 @@ spec:
                               configuration template ConfigMap object. An empty namespace
                               is equivalent to the "default" namespace.
                             maxLength: 63
+                            pattern: ^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$
                             type: string
                           templateRef:
                             description: Specify the name of the referenced the configuration
@@ -8237,8 +8247,10 @@ spec:
                             description: volumeName is the volume name of PodTemplate,
                               which the configuration file produced through the configuration
                               template will be mounted to the corresponding volume.
-                              The volume name must be defined in podSpec.containers[*].volumeMounts.
-                            maxLength: 32
+                              Must be a DNS_LABEL name. The volume name must be defined
+                              in podSpec.containers[*].volumeMounts.
+                            maxLength: 63
+                            pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
                             type: string
                         required:
                         - name

--- a/config/crd/bases/apps.kubeblocks.io_clusters.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusters.yaml
@@ -175,8 +175,9 @@ spec:
                       - class
                       type: object
                     componentDefRef:
-                      description: componentDefRef references the componentDef defined
-                        in ClusterDefinition spec.
+                      description: componentDefRef references componentDef defined
+                        in ClusterDefinition spec. Need to comply with IANA Service
+                        Naming rule.
                       maxLength: 22
                       pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
                       type: string

--- a/config/crd/bases/apps.kubeblocks.io_clusters.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusters.yaml
@@ -101,10 +101,12 @@ spec:
               clusterDefinitionRef:
                 description: Cluster referencing ClusterDefinition name. This is an
                   immutable attribute.
+                maxLength: 63
                 pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                 type: string
               clusterVersionRef:
                 description: Cluster referencing ClusterVersion name.
+                maxLength: 63
                 pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                 type: string
               componentSpecs:
@@ -166,6 +168,8 @@ spec:
                           type: string
                         name:
                           description: Name refers to the name of the ComponentClassDefinition.
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                           type: string
                       required:
                       - class
@@ -173,8 +177,8 @@ spec:
                     componentDefRef:
                       description: componentDefRef references the componentDef defined
                         in ClusterDefinition spec.
-                      maxLength: 63
-                      pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                      maxLength: 22
+                      pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
                       type: string
                     enabledLogs:
                       description: enabledLogs indicates which log file takes effect
@@ -232,9 +236,11 @@ spec:
                         and export metrics to Time Series Database.
                       type: boolean
                     name:
-                      description: name defines cluster's component name.
-                      maxLength: 15
-                      pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                      description: name defines cluster's component name, this name
+                        is also part of Service DNS name, so this name will comply
+                        with IANA Service Naming rule.
+                      maxLength: 22
+                      pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
                       type: string
                     noCreatePDB:
                       default: false

--- a/config/crd/bases/apps.kubeblocks.io_clusterversions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusterversions.yaml
@@ -53,6 +53,7 @@ spec:
             properties:
               clusterDefinitionRef:
                 description: ref ClusterDefinition.
+                maxLength: 63
                 pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                 type: string
               componentVersions:
@@ -111,6 +112,7 @@ spec:
                                   the configuration template ConfigMap object. An
                                   empty namespace is equivalent to the "default" namespace.
                                 maxLength: 63
+                                pattern: ^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$
                                 type: string
                               policy:
                                 default: patch
@@ -141,6 +143,7 @@ spec:
                               configuration template ConfigMap object. An empty namespace
                               is equivalent to the "default" namespace.
                             maxLength: 63
+                            pattern: ^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$
                             type: string
                           templateRef:
                             description: Specify the name of the referenced the configuration
@@ -152,8 +155,10 @@ spec:
                             description: volumeName is the volume name of PodTemplate,
                               which the configuration file produced through the configuration
                               template will be mounted to the corresponding volume.
-                              The volume name must be defined in podSpec.containers[*].volumeMounts.
-                            maxLength: 32
+                              Must be a DNS_LABEL name. The volume name must be defined
+                              in podSpec.containers[*].volumeMounts.
+                            maxLength: 63
+                            pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
                             type: string
                         required:
                         - name

--- a/config/crd/bases/apps.kubeblocks.io_configconstraints.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_configconstraints.yaml
@@ -236,6 +236,7 @@ spec:
                           script ConfigMap object. An empty namespace is equivalent
                           to the "default" namespace.
                         maxLength: 63
+                        pattern: ^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$
                         type: string
                       scriptConfigMapRef:
                         description: scriptConfigMapRef used to execute for reload.
@@ -253,7 +254,6 @@ spec:
                       processName:
                         description: processName is process name, sends unix signal
                           to proc.
-                        pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
                       signal:
                         description: 'signal is valid for unix signal. e.g: SIGHUP
@@ -307,6 +307,7 @@ spec:
                         script ConfigMap object. An empty namespace is equivalent
                         to the "default" namespace.
                       maxLength: 63
+                      pattern: ^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$
                       type: string
                     scriptConfigMapRef:
                       description: scriptConfigMapRef used to execute for reload.
@@ -390,9 +391,10 @@ spec:
                           description: tools Container image name.
                           type: string
                         name:
-                          description: Specify the name of initContainer.
+                          description: Specify the name of initContainer. Must be
+                            a DNS_LABEL name.
                           maxLength: 63
-                          pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                          pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
                           type: string
                       required:
                       - command

--- a/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -131,7 +131,9 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       name:
-                        description: the name of the PersistentVolumeClaim.
+                        default: kb-backup-data
+                        description: the name of PersistentVolumeClaim to store backup
+                          data.
                         maxLength: 63
                         pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
@@ -140,10 +142,10 @@ spec:
                           which contains a persistentVolume template. key must be
                           "persistentVolume" and value is the "PersistentVolume" struct.
                           support the following built-in Objects: - $(GENERATE_NAME):
-                          generate a specific format "pvcName-pvcNamespace". if the
-                          PersistentVolumeClaim not exists and CreatePolicy is "IfNotPresent",
-                          the controller will create it by this template. this is
-                          a mutually exclusive setting with "storageClassName".'
+                          generate a specific format "<PVC NAME>-<PVC NAMESPACE>".
+                          if the PersistentVolumeClaim not exists and CreatePolicy
+                          is "IfNotPresent", the controller will create it by this
+                          template. this is a mutually exclusive setting with "storageClassName".'
                         properties:
                           name:
                             description: the name of the persistentVolume ConfigMap.
@@ -331,7 +333,9 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       name:
-                        description: the name of the PersistentVolumeClaim.
+                        default: kb-backup-data
+                        description: the name of PersistentVolumeClaim to store backup
+                          data.
                         maxLength: 63
                         pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
@@ -340,10 +344,10 @@ spec:
                           which contains a persistentVolume template. key must be
                           "persistentVolume" and value is the "PersistentVolume" struct.
                           support the following built-in Objects: - $(GENERATE_NAME):
-                          generate a specific format "pvcName-pvcNamespace". if the
-                          PersistentVolumeClaim not exists and CreatePolicy is "IfNotPresent",
-                          the controller will create it by this template. this is
-                          a mutually exclusive setting with "storageClassName".'
+                          generate a specific format "<PVC NAME>-<PVC NAMESPACE>".
+                          if the PersistentVolumeClaim not exists and CreatePolicy
+                          is "IfNotPresent", the controller will create it by this
+                          template. this is a mutually exclusive setting with "storageClassName".'
                         properties:
                           name:
                             description: the name of the persistentVolume ConfigMap.

--- a/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -92,6 +92,7 @@ spec:
                   backupToolName:
                     description: which backup tool to perform database backup, only
                       support one tool.
+                    maxLength: 63
                     pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                     type: string
                   backupsHistoryLimit:
@@ -131,6 +132,8 @@ spec:
                         x-kubernetes-int-or-string: true
                       name:
                         description: the name of the PersistentVolumeClaim.
+                        maxLength: 63
+                        pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
                       persistentVolumeConfigMap:
                         description: 'persistentVolumeConfigMap references the configmap
@@ -144,9 +147,13 @@ spec:
                         properties:
                           name:
                             description: the name of the persistentVolume ConfigMap.
+                            maxLength: 63
+                            pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                             type: string
                           namespace:
                             description: the namespace of the persistentVolume ConfigMap.
+                            maxLength: 63
+                            pattern: ^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$
                             type: string
                         required:
                         - name
@@ -155,6 +162,8 @@ spec:
                       storageClassName:
                         description: storageClassName is the name of the StorageClass
                           required by the claim.
+                        maxLength: 63
+                        pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
                     required:
                     - name
@@ -218,6 +227,7 @@ spec:
                         properties:
                           name:
                             description: the secret name
+                            maxLength: 63
                             pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                             type: string
                           passwordKey:
@@ -282,6 +292,7 @@ spec:
                   backupToolName:
                     description: which backup tool to perform database backup, only
                       support one tool.
+                    maxLength: 63
                     pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                     type: string
                   backupsHistoryLimit:
@@ -321,6 +332,8 @@ spec:
                         x-kubernetes-int-or-string: true
                       name:
                         description: the name of the PersistentVolumeClaim.
+                        maxLength: 63
+                        pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
                       persistentVolumeConfigMap:
                         description: 'persistentVolumeConfigMap references the configmap
@@ -334,9 +347,13 @@ spec:
                         properties:
                           name:
                             description: the name of the persistentVolume ConfigMap.
+                            maxLength: 63
+                            pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                             type: string
                           namespace:
                             description: the namespace of the persistentVolume ConfigMap.
+                            maxLength: 63
+                            pattern: ^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$
                             type: string
                         required:
                         - name
@@ -345,6 +362,8 @@ spec:
                       storageClassName:
                         description: storageClassName is the name of the StorageClass
                           required by the claim.
+                        maxLength: 63
+                        pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
                     required:
                     - name
@@ -408,6 +427,7 @@ spec:
                         properties:
                           name:
                             description: the secret name
+                            maxLength: 63
                             pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                             type: string
                           passwordKey:
@@ -616,6 +636,7 @@ spec:
                         properties:
                           name:
                             description: the secret name
+                            maxLength: 63
                             pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                             type: string
                           passwordKey:

--- a/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
@@ -61,6 +61,7 @@ spec:
             properties:
               backupPolicyName:
                 description: Which backupPolicy is applied to perform this backup
+                maxLength: 63
                 pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                 type: string
               backupType:

--- a/config/crd/bases/dataprotection.kubeblocks.io_restorejobs.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_restorejobs.yaml
@@ -113,6 +113,7 @@ spec:
                     properties:
                       name:
                         description: the secret name
+                        maxLength: 63
                         pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
                       passwordKey:

--- a/config/crd/bases/extensions.kubeblocks.io_addons.yaml
+++ b/config/crd/bases/extensions.kubeblocks.io_addons.yaml
@@ -243,6 +243,8 @@ spec:
                               type: string
                             name:
                               description: Object name of the referent.
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                               type: string
                           required:
                           - key
@@ -261,6 +263,8 @@ spec:
                               type: string
                             name:
                               description: Object name of the referent.
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                               type: string
                           required:
                           - key

--- a/controllers/dataprotection/backuppolicy_controller_test.go
+++ b/controllers/dataprotection/backuppolicy_controller_test.go
@@ -367,7 +367,6 @@ var _ = Describe("Backup Policy Controller", func() {
 					Create(&testCtx).GetObject()
 				backupPolicyKey := client.ObjectKeyFromObject(backupPolicy)
 				Eventually(testapps.CheckObj(&testCtx, backupPolicyKey, func(g Gomega, fetched *dpv1alpha1.BackupPolicy) {
-					fmt.Printf("backupPolicy: %v", fetched.Status)
 					g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.PolicyAvailable))
 				})).Should(Succeed())
 				By("enable schedule for reconfigure")

--- a/deploy/helm/crds/apps.kubeblocks.io_backuppolicytemplates.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_backuppolicytemplates.yaml
@@ -56,8 +56,8 @@ spec:
                     componentDefRef:
                       description: componentDefRef references componentDef defined
                         in ClusterDefinition spec.
-                      maxLength: 63
-                      pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                      maxLength: 22
+                      pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
                       type: string
                     datafile:
                       description: the policy for datafile backup.
@@ -103,6 +103,7 @@ spec:
                         backupToolName:
                           description: which backup tool to perform database backup,
                             only support one tool.
+                          maxLength: 63
                           pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                           type: string
                         backupsHistoryLimit:
@@ -200,6 +201,7 @@ spec:
                         backupToolName:
                           description: which backup tool to perform database backup,
                             only support one tool.
+                          maxLength: 63
                           pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                           type: string
                         backupsHistoryLimit:

--- a/deploy/helm/crds/apps.kubeblocks.io_backuppolicytemplates.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_backuppolicytemplates.yaml
@@ -55,7 +55,8 @@ spec:
                   properties:
                     componentDefRef:
                       description: componentDefRef references componentDef defined
-                        in ClusterDefinition spec.
+                        in ClusterDefinition spec. Need to comply with IANA Service
+                        Naming rule.
                       maxLength: 22
                       pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
                       type: string

--- a/deploy/helm/crds/apps.kubeblocks.io_clusterdefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusterdefinitions.yaml
@@ -105,6 +105,7 @@ spec:
                                   the configuration template ConfigMap object. An
                                   empty namespace is equivalent to the "default" namespace.
                                 maxLength: 63
+                                pattern: ^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$
                                 type: string
                               policy:
                                 default: patch
@@ -135,6 +136,7 @@ spec:
                               configuration template ConfigMap object. An empty namespace
                               is equivalent to the "default" namespace.
                             maxLength: 63
+                            pattern: ^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$
                             type: string
                           templateRef:
                             description: Specify the name of the referenced the configuration
@@ -146,8 +148,10 @@ spec:
                             description: volumeName is the volume name of PodTemplate,
                               which the configuration file produced through the configuration
                               template will be mounted to the corresponding volume.
-                              The volume name must be defined in podSpec.containers[*].volumeMounts.
-                            maxLength: 32
+                              Must be a DNS_LABEL name. The volume name must be defined
+                              in podSpec.containers[*].volumeMounts.
+                            maxLength: 63
+                            pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
                             type: string
                         required:
                         - name
@@ -456,9 +460,14 @@ spec:
                           type: object
                       type: object
                     name:
-                      description: name of the component, it can be any valid string.
-                      maxLength: 18
-                      pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                      description: A component definition name, this name could be
+                        used as default name of `Cluster.spec.componentSpecs.name`,
+                        and so this name is need to conform with same validation rules
+                        as `Cluster.spec.componentSpecs.name`, that is currently comply
+                        with IANA Service Naming rule. This name will apply to "apps.kubeblocks.io/component-name"
+                        object label value.
+                      maxLength: 22
+                      pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
                       type: string
                     podSpec:
                       description: podSpec define pod spec template of the cluster
@@ -8226,6 +8235,7 @@ spec:
                               configuration template ConfigMap object. An empty namespace
                               is equivalent to the "default" namespace.
                             maxLength: 63
+                            pattern: ^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$
                             type: string
                           templateRef:
                             description: Specify the name of the referenced the configuration
@@ -8237,8 +8247,10 @@ spec:
                             description: volumeName is the volume name of PodTemplate,
                               which the configuration file produced through the configuration
                               template will be mounted to the corresponding volume.
-                              The volume name must be defined in podSpec.containers[*].volumeMounts.
-                            maxLength: 32
+                              Must be a DNS_LABEL name. The volume name must be defined
+                              in podSpec.containers[*].volumeMounts.
+                            maxLength: 63
+                            pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
                             type: string
                         required:
                         - name

--- a/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
@@ -175,8 +175,9 @@ spec:
                       - class
                       type: object
                     componentDefRef:
-                      description: componentDefRef references the componentDef defined
-                        in ClusterDefinition spec.
+                      description: componentDefRef references componentDef defined
+                        in ClusterDefinition spec. Need to comply with IANA Service
+                        Naming rule.
                       maxLength: 22
                       pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
                       type: string

--- a/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
@@ -101,10 +101,12 @@ spec:
               clusterDefinitionRef:
                 description: Cluster referencing ClusterDefinition name. This is an
                   immutable attribute.
+                maxLength: 63
                 pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                 type: string
               clusterVersionRef:
                 description: Cluster referencing ClusterVersion name.
+                maxLength: 63
                 pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                 type: string
               componentSpecs:
@@ -166,6 +168,8 @@ spec:
                           type: string
                         name:
                           description: Name refers to the name of the ComponentClassDefinition.
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                           type: string
                       required:
                       - class
@@ -173,8 +177,8 @@ spec:
                     componentDefRef:
                       description: componentDefRef references the componentDef defined
                         in ClusterDefinition spec.
-                      maxLength: 63
-                      pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                      maxLength: 22
+                      pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
                       type: string
                     enabledLogs:
                       description: enabledLogs indicates which log file takes effect
@@ -232,9 +236,11 @@ spec:
                         and export metrics to Time Series Database.
                       type: boolean
                     name:
-                      description: name defines cluster's component name.
-                      maxLength: 15
-                      pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                      description: name defines cluster's component name, this name
+                        is also part of Service DNS name, so this name will comply
+                        with IANA Service Naming rule.
+                      maxLength: 22
+                      pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
                       type: string
                     noCreatePDB:
                       default: false

--- a/deploy/helm/crds/apps.kubeblocks.io_clusterversions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusterversions.yaml
@@ -53,6 +53,7 @@ spec:
             properties:
               clusterDefinitionRef:
                 description: ref ClusterDefinition.
+                maxLength: 63
                 pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                 type: string
               componentVersions:
@@ -111,6 +112,7 @@ spec:
                                   the configuration template ConfigMap object. An
                                   empty namespace is equivalent to the "default" namespace.
                                 maxLength: 63
+                                pattern: ^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$
                                 type: string
                               policy:
                                 default: patch
@@ -141,6 +143,7 @@ spec:
                               configuration template ConfigMap object. An empty namespace
                               is equivalent to the "default" namespace.
                             maxLength: 63
+                            pattern: ^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$
                             type: string
                           templateRef:
                             description: Specify the name of the referenced the configuration
@@ -152,8 +155,10 @@ spec:
                             description: volumeName is the volume name of PodTemplate,
                               which the configuration file produced through the configuration
                               template will be mounted to the corresponding volume.
-                              The volume name must be defined in podSpec.containers[*].volumeMounts.
-                            maxLength: 32
+                              Must be a DNS_LABEL name. The volume name must be defined
+                              in podSpec.containers[*].volumeMounts.
+                            maxLength: 63
+                            pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
                             type: string
                         required:
                         - name

--- a/deploy/helm/crds/apps.kubeblocks.io_configconstraints.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_configconstraints.yaml
@@ -236,6 +236,7 @@ spec:
                           script ConfigMap object. An empty namespace is equivalent
                           to the "default" namespace.
                         maxLength: 63
+                        pattern: ^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$
                         type: string
                       scriptConfigMapRef:
                         description: scriptConfigMapRef used to execute for reload.
@@ -253,7 +254,6 @@ spec:
                       processName:
                         description: processName is process name, sends unix signal
                           to proc.
-                        pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
                       signal:
                         description: 'signal is valid for unix signal. e.g: SIGHUP
@@ -307,6 +307,7 @@ spec:
                         script ConfigMap object. An empty namespace is equivalent
                         to the "default" namespace.
                       maxLength: 63
+                      pattern: ^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$
                       type: string
                     scriptConfigMapRef:
                       description: scriptConfigMapRef used to execute for reload.
@@ -390,9 +391,10 @@ spec:
                           description: tools Container image name.
                           type: string
                         name:
-                          description: Specify the name of initContainer.
+                          description: Specify the name of initContainer. Must be
+                            a DNS_LABEL name.
                           maxLength: 63
-                          pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                          pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
                           type: string
                       required:
                       - command

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -131,7 +131,9 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       name:
-                        description: the name of the PersistentVolumeClaim.
+                        default: kb-backup-data
+                        description: the name of PersistentVolumeClaim to store backup
+                          data.
                         maxLength: 63
                         pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
@@ -140,10 +142,10 @@ spec:
                           which contains a persistentVolume template. key must be
                           "persistentVolume" and value is the "PersistentVolume" struct.
                           support the following built-in Objects: - $(GENERATE_NAME):
-                          generate a specific format "pvcName-pvcNamespace". if the
-                          PersistentVolumeClaim not exists and CreatePolicy is "IfNotPresent",
-                          the controller will create it by this template. this is
-                          a mutually exclusive setting with "storageClassName".'
+                          generate a specific format "<PVC NAME>-<PVC NAMESPACE>".
+                          if the PersistentVolumeClaim not exists and CreatePolicy
+                          is "IfNotPresent", the controller will create it by this
+                          template. this is a mutually exclusive setting with "storageClassName".'
                         properties:
                           name:
                             description: the name of the persistentVolume ConfigMap.
@@ -331,7 +333,9 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       name:
-                        description: the name of the PersistentVolumeClaim.
+                        default: kb-backup-data
+                        description: the name of PersistentVolumeClaim to store backup
+                          data.
                         maxLength: 63
                         pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
@@ -340,10 +344,10 @@ spec:
                           which contains a persistentVolume template. key must be
                           "persistentVolume" and value is the "PersistentVolume" struct.
                           support the following built-in Objects: - $(GENERATE_NAME):
-                          generate a specific format "pvcName-pvcNamespace". if the
-                          PersistentVolumeClaim not exists and CreatePolicy is "IfNotPresent",
-                          the controller will create it by this template. this is
-                          a mutually exclusive setting with "storageClassName".'
+                          generate a specific format "<PVC NAME>-<PVC NAMESPACE>".
+                          if the PersistentVolumeClaim not exists and CreatePolicy
+                          is "IfNotPresent", the controller will create it by this
+                          template. this is a mutually exclusive setting with "storageClassName".'
                         properties:
                           name:
                             description: the name of the persistentVolume ConfigMap.

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -92,6 +92,7 @@ spec:
                   backupToolName:
                     description: which backup tool to perform database backup, only
                       support one tool.
+                    maxLength: 63
                     pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                     type: string
                   backupsHistoryLimit:
@@ -131,6 +132,8 @@ spec:
                         x-kubernetes-int-or-string: true
                       name:
                         description: the name of the PersistentVolumeClaim.
+                        maxLength: 63
+                        pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
                       persistentVolumeConfigMap:
                         description: 'persistentVolumeConfigMap references the configmap
@@ -144,9 +147,13 @@ spec:
                         properties:
                           name:
                             description: the name of the persistentVolume ConfigMap.
+                            maxLength: 63
+                            pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                             type: string
                           namespace:
                             description: the namespace of the persistentVolume ConfigMap.
+                            maxLength: 63
+                            pattern: ^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$
                             type: string
                         required:
                         - name
@@ -155,6 +162,8 @@ spec:
                       storageClassName:
                         description: storageClassName is the name of the StorageClass
                           required by the claim.
+                        maxLength: 63
+                        pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
                     required:
                     - name
@@ -218,6 +227,7 @@ spec:
                         properties:
                           name:
                             description: the secret name
+                            maxLength: 63
                             pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                             type: string
                           passwordKey:
@@ -282,6 +292,7 @@ spec:
                   backupToolName:
                     description: which backup tool to perform database backup, only
                       support one tool.
+                    maxLength: 63
                     pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                     type: string
                   backupsHistoryLimit:
@@ -321,6 +332,8 @@ spec:
                         x-kubernetes-int-or-string: true
                       name:
                         description: the name of the PersistentVolumeClaim.
+                        maxLength: 63
+                        pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
                       persistentVolumeConfigMap:
                         description: 'persistentVolumeConfigMap references the configmap
@@ -334,9 +347,13 @@ spec:
                         properties:
                           name:
                             description: the name of the persistentVolume ConfigMap.
+                            maxLength: 63
+                            pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                             type: string
                           namespace:
                             description: the namespace of the persistentVolume ConfigMap.
+                            maxLength: 63
+                            pattern: ^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$
                             type: string
                         required:
                         - name
@@ -345,6 +362,8 @@ spec:
                       storageClassName:
                         description: storageClassName is the name of the StorageClass
                           required by the claim.
+                        maxLength: 63
+                        pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
                     required:
                     - name
@@ -408,6 +427,7 @@ spec:
                         properties:
                           name:
                             description: the secret name
+                            maxLength: 63
                             pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                             type: string
                           passwordKey:
@@ -616,6 +636,7 @@ spec:
                         properties:
                           name:
                             description: the secret name
+                            maxLength: 63
                             pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                             type: string
                           passwordKey:

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
@@ -61,6 +61,7 @@ spec:
             properties:
               backupPolicyName:
                 description: Which backupPolicy is applied to perform this backup
+                maxLength: 63
                 pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                 type: string
               backupType:

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_restorejobs.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_restorejobs.yaml
@@ -113,6 +113,7 @@ spec:
                     properties:
                       name:
                         description: the secret name
+                        maxLength: 63
                         pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
                       passwordKey:

--- a/deploy/helm/crds/extensions.kubeblocks.io_addons.yaml
+++ b/deploy/helm/crds/extensions.kubeblocks.io_addons.yaml
@@ -243,6 +243,8 @@ spec:
                               type: string
                             name:
                               description: Object name of the referent.
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                               type: string
                           required:
                           - key
@@ -261,6 +263,8 @@ spec:
                               type: string
                             name:
                               description: Object name of the referent.
+                              maxLength: 63
+                              pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                               type: string
                           required:
                           - key

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -277,7 +277,7 @@ admissionWebhooks:
 ## @param dataProtection.backupPVConfigMapNamespace - set the default configmap namespace of pv template.
 dataProtection:
   enableVolumeSnapshot: false
-  backupPVCName: ""
+  backupPVCName: kb-backup-data
   backupPVCInitCapacity: ""
   backupPVCStorageClassName: ""
   backupPVCCreatePolicy: ""

--- a/deploy/kafka-cluster/templates/cluster.yaml
+++ b/deploy/kafka-cluster/templates/cluster.yaml
@@ -75,8 +75,8 @@ spec:
         {{- end }}
       {{- end }}
     {{- else }}
-    - name: controller
-      componentDefRef: kafka-controller
+    - name: kafka-kraft
+      componentDefRef: kafka-kraft
       tls: {{ $.Values.tls }}
       {{- if $.Values.tls }}
       issuer:

--- a/deploy/kafka/templates/clusterdefinition.yaml
+++ b/deploy/kafka/templates/clusterdefinition.yaml
@@ -192,7 +192,7 @@ spec:
                 mountPath: /etc/jmx-kafka
 
     # controller(kraft) Ref: https://kafka.apache.org/documentation/#kraft_role
-    - name: kafka-controller
+    - name: kafka-kraft
       description: |-
         Kafka controller that act as controllers (kraft) only server.
       workloadType: Stateful # Consensus

--- a/deploy/kafka/templates/clusterversion.yaml
+++ b/deploy/kafka/templates/clusterversion.yaml
@@ -29,7 +29,7 @@ spec:
             securityContext:
               runAsNonRoot: true
               runAsUser: 1001
-    - componentDefRef: kafka-controller
+    - componentDefRef: kafka-kraft
       versionsContext:
         containers:
           - name: kafka
@@ -61,7 +61,6 @@ spec:
             securityContext:
               runAsNonRoot: true
               runAsUser: 1001
-
     - componentDefRef: kafka-exporter
       versionsContext:
         containers:

--- a/deploy/prometheus-cluster/templates/cluster.yaml
+++ b/deploy/prometheus-cluster/templates/cluster.yaml
@@ -22,7 +22,7 @@ spec:
     {{- end }}
   componentSpecs:
     - name: server # user-defined
-      componentDefRef: server # ref clusterdefinition components.name
+      componentDefRef: prometheus # ref clusterdefinition components.name
       replicas: {{ .Values.server.replicaCount | default 1 }}
       serviceAccountName: {{ template "prometheus-cluster.server.fullname" . }}
       resources:

--- a/deploy/prometheus/templates/backuppolicytemplate.yaml
+++ b/deploy/prometheus/templates/backuppolicytemplate.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   clusterDefinitionRef: prometheus
   backupPolicies:
-  - componentDefRef: server
+  - componentDefRef: prometheus
     retention:
       ttl: 7d
     schedule:

--- a/deploy/prometheus/templates/clusterdefinition.yaml
+++ b/deploy/prometheus/templates/clusterdefinition.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   type: prometheus
   componentDefs:
-    - name: server
+    - name: prometheus
       workloadType: Stateful
       characterType: prometheus
       service:

--- a/deploy/prometheus/templates/clusterversion.yaml
+++ b/deploy/prometheus/templates/clusterversion.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   clusterDefinitionRef: prometheus
   componentVersions:
-  - componentDefRef: server
+  - componentDefRef: prometheus
     versionsContext:
       containers:
       - name: configmap-reload

--- a/internal/testutil/apps/backuppolicy_factory.go
+++ b/internal/testutil/apps/backuppolicy_factory.go
@@ -102,6 +102,7 @@ func (factory *MockBackupPolicyFactory) AddSnapshotPolicy() *MockBackupPolicyFac
 func (factory *MockBackupPolicyFactory) AddDataFilePolicy() *MockBackupPolicyFactory {
 	factory.get().Spec.Datafile = &dataprotectionv1alpha1.CommonBackupPolicy{
 		PersistentVolumeClaim: dataprotectionv1alpha1.PersistentVolumeClaim{
+			Name:         "backup-data",
 			CreatePolicy: dataprotectionv1alpha1.CreatePVCPolicyIfNotPresent,
 		},
 	}
@@ -112,6 +113,7 @@ func (factory *MockBackupPolicyFactory) AddDataFilePolicy() *MockBackupPolicyFac
 func (factory *MockBackupPolicyFactory) AddLogfilePolicy() *MockBackupPolicyFactory {
 	factory.get().Spec.Logfile = &dataprotectionv1alpha1.CommonBackupPolicy{
 		PersistentVolumeClaim: dataprotectionv1alpha1.PersistentVolumeClaim{
+			Name:         "backup-data",
 			CreatePolicy: dataprotectionv1alpha1.CreatePVCPolicyIfNotPresent,
 		},
 	}


### PR DESCRIPTION
    chore: update CD.spec.componentDesf.name validatation to be exact match of Cluster.spec.componentSpecs.name as this name could be default name from it.
    
    chore: tidy up CRD's validations, ought to comply with DNS Label names for referenced CR object name
