### PR TITLE
chore: add validation rule for immutable fields

### DIFF
--- a/apis/apps/v1alpha1/backuppolicytemplate_types.go
+++ b/apis/apps/v1alpha1/backuppolicytemplate_types.go
@@ -25,6 +25,7 @@ type BackupPolicyTemplateSpec struct {
 	// clusterDefinitionRef references ClusterDefinition name, this is an immutable attribute.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="clusterDefinitionRef is immutable"
 	ClusterDefRef string `json:"clusterDefinitionRef"`
 
 	// backupPolicies is a list of backup policy template for the specified componentDefinition.

--- a/apis/apps/v1alpha1/cluster_types.go
+++ b/apis/apps/v1alpha1/cluster_types.go
@@ -31,6 +31,7 @@ type ClusterSpec struct {
 	// Cluster referencing ClusterDefinition name. This is an immutable attribute.
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="clusterDefinitionRef is immutable"
 	ClusterDefRef string `json:"clusterDefinitionRef"`
 
 	// Cluster referencing ClusterVersion name.

--- a/config/crd/bases/apps.kubeblocks.io_backuppolicytemplates.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_backuppolicytemplates.yaml
@@ -435,6 +435,9 @@ spec:
                   this is an immutable attribute.
                 pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                 type: string
+                x-kubernetes-validations:
+                - message: clusterDefinitionRef is immutable
+                  rule: self == oldSelf
               identifier:
                 description: Identifier is a unique identifier for this BackupPolicyTemplate.
                   this identifier will be the suffix of the automatically generated

--- a/config/crd/bases/apps.kubeblocks.io_clusters.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusters.yaml
@@ -103,6 +103,9 @@ spec:
                   immutable attribute.
                 pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                 type: string
+                x-kubernetes-validations:
+                - message: clusterDefinitionRef is immutable
+                  rule: self == oldSelf
               clusterVersionRef:
                 description: Cluster referencing ClusterVersion name.
                 pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$

--- a/controllers/apps/cluster_status_conditions.go
+++ b/controllers/apps/cluster_status_conditions.go
@@ -55,8 +55,10 @@ func conditionIsChanged(oldCondition *metav1.Condition, newCondition metav1.Cond
 }
 
 func setProvisioningStartedCondition(conditions *[]metav1.Condition, clusterName string, clusterGeneration int64, err error) {
-	condition := newProvisioningStartedCondition(clusterName, clusterGeneration)
-	if err != nil {
+	var condition metav1.Condition
+	if err == nil {
+		condition = newProvisioningStartedCondition(clusterName, clusterGeneration)
+	} else {
 		condition = newFailedProvisioningStartedCondition(err)
 	}
 	meta.SetStatusCondition(conditions, condition)

--- a/deploy/helm/crds/apps.kubeblocks.io_backuppolicytemplates.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_backuppolicytemplates.yaml
@@ -435,6 +435,9 @@ spec:
                   this is an immutable attribute.
                 pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                 type: string
+                x-kubernetes-validations:
+                - message: clusterDefinitionRef is immutable
+                  rule: self == oldSelf
               identifier:
                 description: Identifier is a unique identifier for this BackupPolicyTemplate.
                   this identifier will be the suffix of the automatically generated

--- a/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
@@ -103,6 +103,9 @@ spec:
                   immutable attribute.
                 pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                 type: string
+                x-kubernetes-validations:
+                - message: clusterDefinitionRef is immutable
+                  rule: self == oldSelf
               clusterVersionRef:
                 description: Cluster referencing ClusterVersion name.
                 pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$

--- a/internal/controller/builder/builder.go
+++ b/internal/controller/builder/builder.go
@@ -331,13 +331,13 @@ func randomString(length int) string {
 	return rand.String(length)
 }
 
-func BuildConnCredential(clusterDefiniiton *appsv1alpha1.ClusterDefinition, cluster *appsv1alpha1.Cluster,
+func BuildConnCredential(clusterDefinition *appsv1alpha1.ClusterDefinition, cluster *appsv1alpha1.Cluster,
 	component *component.SynthesizedComponent) (*corev1.Secret, error) {
 	const tplFile = "conn_credential_template.cue"
 
 	connCredential := corev1.Secret{}
 	if err := buildFromCUE(tplFile, map[string]any{
-		"clusterdefinition": clusterDefiniiton,
+		"clusterdefinition": clusterDefinition,
 		"cluster":           cluster,
 	}, "secret", &connCredential); err != nil {
 		return nil, err


### PR DESCRIPTION

clusterDefinitionRef in clusterSpec and BackupPolicyTemplateSpec is immutable, add validation rule to avoid being modified.

For example:
```
$ kubectl edit cluster rose55

# Please edit the object below. Lines beginning with a '#' will be ignored,
# and an empty file will abort the edit. If an error occurs while saving this file will be
# reopened with the relevant failures.
#
# clusters.apps.kubeblocks.io "rose55" was not valid:
# * spec.clusterDefinitionRef: Invalid value: "string": clusterDefinitionRef is immutable
#
apiVersion: apps.kubeblocks.io/v1alpha1
kind: Cluster
metadata:
  annotations:
    kubeblocks.io/reconcile: "2023-07-02T16:44:33.011949+08:00"
  creationTimestamp: "2023-07-02T06:07:12Z"
  finalizers:
  - cluster.kubeblocks.io/finalizer
  generation: 3

```