### PR TITLE
fix: add kb-controller toleration as default for kubeblock installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ fmt: ## Run go fmt against code.
 
 .PHONY: vet
 vet: ## Run go vet against code.
-	GOOS=linux $(GO) vet -mod=mod ./...
+	GOOS=$(GOOS) $(GO) vet -mod=mod ./...
 
 .PHONY: cue-fmt
 cue-fmt: cuetool ## Run cue fmt against code.

--- a/internal/cli/cmd/kubeblocks/install.go
+++ b/internal/cli/cmd/kubeblocks/install.go
@@ -54,9 +54,10 @@ import (
 )
 
 const (
-	kNodeAffinity    = "affinity.nodeAffinity=%s"
-	kPodAntiAffinity = "affinity.podAntiAffinity=%s"
-	kTolerations     = "tolerations=%s"
+	kNodeAffinity                     = "affinity.nodeAffinity=%s"
+	kPodAntiAffinity                  = "affinity.podAntiAffinity=%s"
+	kTolerations                      = "tolerations=%s"
+	defaultTolerationsForInstallation = "kb-controller=true:NoSchedule"
 )
 
 type Options struct {
@@ -247,18 +248,17 @@ func (o *InstallOptions) Install() error {
 		o.ValueOpts.JSONValues = append(o.ValueOpts.JSONValues, fmt.Sprintf(kNodeAffinity, string(nodeLabelsJSON)))
 	}
 
-	// parse tolerations and add to values
-	if len(o.TolerationsRaw) > 0 {
-		tolerations, err := util.BuildTolerations(o.TolerationsRaw)
-		if err != nil {
-			return err
-		}
-		tolerationsJSON, err := json.Marshal(tolerations)
-		if err != nil {
-			return err
-		}
-		o.ValueOpts.JSONValues = append(o.ValueOpts.JSONValues, fmt.Sprintf(kTolerations, string(tolerationsJSON)))
+	// parse tolerations and add to values, the default tolerations are defined in var defaultTolerationsForInstallation
+	o.TolerationsRaw = append(o.TolerationsRaw, defaultTolerationsForInstallation)
+	tolerations, err := util.BuildTolerations(o.TolerationsRaw)
+	if err != nil {
+		return err
 	}
+	tolerationsJSON, err := json.Marshal(tolerations)
+	if err != nil {
+		return err
+	}
+	o.ValueOpts.JSONValues = append(o.ValueOpts.JSONValues, fmt.Sprintf(kTolerations, string(tolerationsJSON)))
 
 	// add helm repo
 	s := spinner.New(o.Out, spinnerMsg("Add and update repo "+types.KubeBlocksRepoName))

--- a/internal/cli/cmd/kubeblocks/install_test.go
+++ b/internal/cli/cmd/kubeblocks/install_test.go
@@ -87,6 +87,7 @@ var _ = Describe("kubeblocks install", func() {
 			CreateNamespace: true,
 		}
 		Expect(o.Install()).Should(HaveOccurred())
+		Expect(o.TolerationsRaw).Should(Equal([]string{defaultTolerationsForInstallation}))
 		Expect(o.ValueOpts.Values).Should(HaveLen(0))
 		Expect(o.installChart()).Should(HaveOccurred())
 		o.printNotes()


### PR DESCRIPTION
fix https://github.com/apecloud/kubeblocks/issues/4001

now run 'make vet' in mac is ok 
~/work/kubeblocks  ‹bugfix/installation-with-kb-controller-toleration-issue4001› $ make vet                                                                                                                                                                           2 ↵
GOOS=darwin go vet -mod=mod ./...
~/work/kubeblocks  ‹bugfix/installation-with-kb-controller-toleration-issue4001› $ 
