### PR TITLE
chore: add mysql scale configuration

### DIFF
--- a/deploy/apecloud-mysql/config/mysql-scale-config.tpl
+++ b/deploy/apecloud-mysql/config/mysql-scale-config.tpl
@@ -1,0 +1,15 @@
+[vttablet]
+health_check_interval=1s
+shard_sync_retry_delay=1s
+remote_operation_timeout=1s
+db_connect_timeout_ms=500
+[vtconsensus]
+refresh_interval=1s
+scan_repair_timeout=1s
+[vtgate]
+gateway_initial_tablet_timeout=30s
+healthcheck_timeout=2s
+srv_topo_timeout=1s
+grpc_keepalive_time=10s
+grpc_keepalive_timeout=10s
+tablet_refresh_interval=1m

--- a/deploy/apecloud-mysql/config/mysql-scale-vtconsensus-config-constraint.cue
+++ b/deploy/apecloud-mysql/config/mysql-scale-vtconsensus-config-constraint.cue
@@ -1,0 +1,25 @@
+//Copyright (C) 2022-2023 ApeCloud Co., Ltd
+//
+//This file is part of KubeBlocks project
+//
+//This program is free software: you can redistribute it and/or modify
+//it under the terms of the GNU Affero General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//This program is distributed in the hope that it will be useful
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU Affero General Public License for more details.
+//
+//You should have received a copy of the GNU Affero General Public License
+//along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#VtConsensusParameter: {
+  
+  // Refresh interval to load tablets. (default 10s)
+  refresh_interval: string
+
+  // Time to wait for a diagnose and repair operation. (default 3s)
+  scan_repair_timeout: string
+}

--- a/deploy/apecloud-mysql/config/mysql-scale-vtgate-config-constraint.cue
+++ b/deploy/apecloud-mysql/config/mysql-scale-vtgate-config-constraint.cue
@@ -1,0 +1,37 @@
+//Copyright (C) 2022-2023 ApeCloud Co., Ltd
+//
+//This file is part of KubeBlocks project
+//
+//This program is free software: you can redistribute it and/or modify
+//it under the terms of the GNU Affero General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//This program is distributed in the hope that it will be useful
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU Affero General Public License for more details.
+//
+//You should have received a copy of the GNU Affero General Public License
+//along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#VtGateParameter: {
+
+  // At startup, the tabletGateway will wait up to this duration to get at least one tablet per keyspace/shard/tablet type. (default 30s)
+  gateway_initial_tablet_timeout: string
+
+  // After a duration of this time, if the client doesn't see any activity, it pings the server to see if the transport is still alive. (default 10s)
+  grpc_keepalive_time: string
+
+  // After having pinged for keepalive check, the client waits for a duration of Timeout and if no activity is seen even after that the connection is closed. (default 10s)
+  grpc_keepalive_timeout: string
+
+  // The health check timeout period. (default 1m0s)
+  healthcheck_timeout: string
+
+  // Topo server timeout. (default 5s)
+  srv_topo_timeout: string
+
+  // Tablet refresh interval. (default 1m0s)
+  tablet_refresh_interval: string
+}

--- a/deploy/apecloud-mysql/config/mysql-scale-vttablet-config-constraint.cue
+++ b/deploy/apecloud-mysql/config/mysql-scale-vttablet-config-constraint.cue
@@ -1,0 +1,31 @@
+//Copyright (C) 2022-2023 ApeCloud Co., Ltd
+//
+//This file is part of KubeBlocks project
+//
+//This program is free software: you can redistribute it and/or modify
+//it under the terms of the GNU Affero General Public License as published by
+//the Free Software Foundation, either version 3 of the License, or
+//(at your option) any later version.
+//
+//This program is distributed in the hope that it will be useful
+//but WITHOUT ANY WARRANTY; without even the implied warranty of
+//MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//GNU Affero General Public License for more details.
+//
+//You should have received a copy of the GNU Affero General Public License
+//along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#VtTabletParameter: {
+
+  // Connection timeout to mysqld in milliseconds. (0 for no timeout)
+  db_connect_timeout_ms: int
+
+  // Interval between health checks. (default 20s)
+  health_check_interval: string
+
+  // Time to wait for a remote operation. (default 15s)
+  remote_operation_timeout: string
+
+  // Delay between retries of updates to keep the tablet and its shard record in sync. (default 30s)
+  shard_sync_retry_delay: string
+}

--- a/deploy/apecloud-mysql/templates/clusterdefinition.yaml
+++ b/deploy/apecloud-mysql/templates/clusterdefinition.yaml
@@ -373,6 +373,19 @@ spec:
             port: 40000
             targetPort: delvedebug
       podSpec:
+        initContainers:
+          - name: wait-etcd-ready
+            imagePullPolicy: IfNotPresent
+            image: busybox:1.35
+            env:
+              - name: ETCD_SERVER
+                value: "$(KB_CLUSTER_NAME)-etcd-headless"
+              - name: ETCD_PORT
+                value: "2379"
+            command: ["/scripts/wait-for-service.sh", "etcd", "$(ETCD_SERVER)", "$(ETCD_PORT)"]
+            volumeMounts:
+              - name: scripts
+                mountPath: /scripts
         containers:
           - name: vtctld
             imagePullPolicy: IfNotPresent
@@ -420,6 +433,19 @@ spec:
             port: 40000
             targetPort: delvedebug
       podSpec:
+        initContainers:
+          - name: wait-vtctld-ready
+            imagePullPolicy: IfNotPresent
+            image: busybox:1.35
+            env:
+              - name: VTCTLD_HOST
+                value: "$(KB_CLUSTER_NAME)-vtctld-headless" 
+              - name: VTCTLD_GRPC_PORT
+                value: "15999"
+            command: ["/scripts/wait-for-service.sh", "vtctld", "$(VTCTLD_HOST)", "$(VTCTLD_GRPC_PORT)"]
+            volumeMounts:
+              - name: scripts
+                mountPath: /scripts
         containers:
           - name: vtconsensus
             imagePullPolicy: IfNotPresent
@@ -479,6 +505,19 @@ spec:
             port: 40000
             targetPort: delvedebug
       podSpec:
+        initContainers:
+          - name: wait-vtctld-ready
+            imagePullPolicy: IfNotPresent
+            image: busybox:1.35
+            env:
+              - name: VTCTLD_HOST
+                value: "$(KB_CLUSTER_NAME)-vtctld-headless" 
+              - name: VTCTLD_GRPC_PORT
+                value: "15999"
+            command: ["/scripts/wait-for-service.sh", "vtctld", "$(VTCTLD_HOST)", "$(VTCTLD_GRPC_PORT)"]
+            volumeMounts:
+              - name: scripts
+                mountPath: /scripts
         containers:
           - name: vtgate
             imagePullPolicy: IfNotPresent

--- a/deploy/apecloud-mysql/templates/clusterdefinition.yaml
+++ b/deploy/apecloud-mysql/templates/clusterdefinition.yaml
@@ -41,6 +41,11 @@ spec:
           namespace: {{ .Release.Namespace }}
           volumeName: agamotto-configuration
           defaultMode: 0777
+        - name: mysql-scale-config
+          templateRef: mysql-scale-config-template
+          constraintRef: mysql-scale-vttablet-config-constraints
+          volumeName: mysql-scale-config
+          namespace: {{ .Release.Namespace }}
       scriptSpecs:
         - name: apecloud-mysql-scripts
           templateRef: apecloud-mysql-scripts
@@ -242,6 +247,8 @@ spec:
             volumeMounts:
               - name: scripts
                 mountPath: /scripts
+              - name: mysql-scale-config
+                mountPath: /conf
         volumes:
           - name: annotations
             downwardAPI:
@@ -354,7 +361,7 @@ spec:
                   command: ["/scripts/etcd-post-start.sh"]
     - name: vtctld
       characterType: vtctld
-      workloadType: Stateful
+      workloadType: Stateless
       scriptSpecs:
         - name: apecloud-mysql-scripts
           templateRef: apecloud-mysql-scripts
@@ -417,13 +424,19 @@ spec:
                 mountPath: /scripts 
     - name: vtconsensus
       characterType: vtconsensus
-      workloadType: Stateful
+      workloadType: Stateless
       scriptSpecs:
         - name: apecloud-mysql-scripts
           templateRef: apecloud-mysql-scripts
           namespace: {{ .Release.Namespace }}
           volumeName: scripts
           defaultMode: 493
+      configSpecs:
+        - name: mysql-scale-config
+          templateRef: mysql-scale-config-template
+          constraintRef: mysql-scale-vtconsensus-config-constraints
+          volumeName: mysql-scale-config
+          namespace: {{ .Release.Namespace }}
       service:
         ports:
           - name: port
@@ -481,15 +494,23 @@ spec:
             volumeMounts:
               - name: scripts
                 mountPath: /scripts
+              - name: mysql-scale-config
+                mountPath: /conf
     - name: vtgate
       characterType: vtgate
-      workloadType: Stateful
+      workloadType: Stateless
       scriptSpecs:
         - name: apecloud-mysql-scripts
           templateRef: apecloud-mysql-scripts
           namespace: {{ .Release.Namespace }}
           volumeName: scripts
           defaultMode: 493
+      configSpecs:
+        - name: mysql-scale-config
+          templateRef: mysql-scale-config-template
+          constraintRef: mysql-scale-vtgate-config-constraints
+          volumeName: mysql-scale-config
+          namespace: {{ .Release.Namespace }}
       service:
         ports:
           - name: webport
@@ -561,3 +582,5 @@ spec:
             volumeMounts:
               - name: scripts
                 mountPath: /scripts
+              - name: mysql-scale-config
+                mountPath: /conf

--- a/deploy/apecloud-mysql/templates/clusterdefinition.yaml
+++ b/deploy/apecloud-mysql/templates/clusterdefinition.yaml
@@ -315,6 +315,12 @@ spec:
     - name: etcd
       characterType: etcd
       workloadType: Stateful
+      scriptSpecs:
+        - name: apecloud-mysql-scripts
+          templateRef: apecloud-mysql-scripts
+          namespace: {{ .Release.Namespace }}
+          volumeName: scripts
+          defaultMode: 493
       service:
         ports:
           - name: client
@@ -338,52 +344,23 @@ spec:
                 value: "2379"
               - name: TOPOLOGY_FLAGS
                 value: "--topo_implementation etcd2 --topo_global_server_address $(ETCD_SERVER):$(ETCD_PORT) --topo_global_root /vitess/global"
-            command:
-              - /bin/bash
-              - -c
-              - |
-                echo "staring etcd."
-                etcd_port=${ETCD_PORT:-'2379'}
-                etcd_server=${ETCD_SERVER:-'127.0.0.1'}
-
-                cell=${CELL:-'zone1'}
-                export ETCDCTL_API=2
-
-                etcd --enable-v2=true --data-dir "${VTDATAROOT}/etcd/"  \
-                  --listen-client-urls "http://0.0.0.0:${etcd_port}" \
-                  --advertise-client-urls "http://0.0.0.0:${etcd_port}"
+            command: ["/scripts/etcd.sh"]
+            volumeMounts:
+              - name: scripts
+                mountPath: /scripts
             lifecycle:
               postStart:
                 exec:
-                  command:
-                    - /bin/bash
-                    - -c
-                    - |
-                      etcd_port=${ETCD_PORT:-'2379'}
-                      etcd_server=${ETCD_SERVER:-'127.0.0.1'}
-
-                      cell=${CELL:-'zone1'}
-                      export ETCDCTL_API=2
-
-                      echo "add /vitess/global"
-                      etcdctl --endpoints "http://127.0.0.1:${etcd_port}" mkdir /vitess/global
-
-                      echo "add /vitess/$cell"
-                      etcdctl --endpoints "http://127.0.0.1:${etcd_port}" mkdir /vitess/$cell
-
-                      # And also add the CellInfo description for the cell.
-                      # If the node already exists, it's fine, means we used existing data.
-                      echo "add $cell CellInfo"
-                      set +e
-                      vtctl --topo_implementation etcd2 \
-                        --topo_global_server_address "127.0.0.1:${etcd_port}" \
-                        --topo_global_root /vitess/global VtctldCommand AddCellInfo \
-                        --root /vitess/$cell \
-                        --server-address "${etcd_server}:${etcd_port}" \
-                        $cell
+                  command: ["/scripts/etcd-post-start.sh"]
     - name: vtctld
       characterType: vtctld
       workloadType: Stateful
+      scriptSpecs:
+        - name: apecloud-mysql-scripts
+          templateRef: apecloud-mysql-scripts
+          namespace: {{ .Release.Namespace }}
+          volumeName: scripts
+          defaultMode: 493
       service:
         ports:
           - name: webport
@@ -421,32 +398,19 @@ spec:
                 value: "2379"
               - name: TOPOLOGY_FLAGS
                 value: "--topo_implementation etcd2 --topo_global_server_address $(ETCD_SERVER):$(ETCD_PORT) --topo_global_root /vitess/global"
-            command:
-              - /bin/bash
-              - -c
-              - |
-                echo "starting vtctld"
-                cell=${CELL:-'zone1'}
-                grpc_port=${VTCTLD_GRPC_PORT:-'15999'}
-                vtctld_web_port=${VTCTLD_WEB_PORT:-'15000'}
-                topology_fags=${TOPOLOGY_FLAGS:-'--topo_implementation etcd2 --topo_global_server_address 127.0.0.1:2379 --topo_global_root /vitess/global'}
-
-                su vitess <<EOF
-                exec vtctld \
-                $topology_fags \
-                --alsologtostderr \
-                --cell $cell \
-                --service_map 'grpc-vtctl,grpc-vtctld' \
-                --backup_storage_implementation file \
-                --file_backup_storage_root $VTDATAROOT/backups \
-                --log_dir $VTDATAROOT \
-                --port $vtctld_web_port \
-                --grpc_port $grpc_port \
-                --pid_file $VTDATAROOT/vtctld.pid
-                EOF
+            command: ["/scripts/vtctld.sh"]
+            volumeMounts:
+              - name: scripts
+                mountPath: /scripts 
     - name: vtconsensus
       characterType: vtconsensus
       workloadType: Stateful
+      scriptSpecs:
+        - name: apecloud-mysql-scripts
+          templateRef: apecloud-mysql-scripts
+          namespace: {{ .Release.Namespace }}
+          volumeName: scripts
+          defaultMode: 493
       service:
         ports:
           - name: port
@@ -487,29 +451,19 @@ spec:
                 value: "2379"
               - name: TOPOLOGY_FLAGS
                 value: "--topo_implementation etcd2 --topo_global_server_address $(ETCD_SERVER):$(ETCD_PORT) --topo_global_root /vitess/global"
-            command:
-              - /bin/bash
-              - -c
-              - |
-                echo "starting vtconsensus"
-                cell=${CELL:-'zone1'}
-
-                vtconsensusport=${VTCONSENSUS_PORT:-'16000'}
-                topology_fags=${TOPOLOGY_FLAGS:-'--topo_implementation etcd2 --topo_global_server_address 127.0.0.1:2379 --topo_global_root /vitess/global'}
-
-                su vitess <<EOF
-                exec vtconsensus \
-                  $topology_fags \
-                  --alsologtostderr \
-                  --refresh_interval 1s \
-                  --scan_repair_timeout 1s \
-                  --log_dir ${VTDATAROOT} \
-                  --db_username "$MYSQL_ROOT_USER" \
-                  --db_password "$MYSQL_ROOT_PASSWORD"
-                EOF
+            command: ["/scripts/vtconsensus.sh"]
+            volumeMounts:
+              - name: scripts
+                mountPath: /scripts
     - name: vtgate
       characterType: vtgate
       workloadType: Stateful
+      scriptSpecs:
+        - name: apecloud-mysql-scripts
+          templateRef: apecloud-mysql-scripts
+          namespace: {{ .Release.Namespace }}
+          volumeName: scripts
+          defaultMode: 493
       service:
         ports:
           - name: webport
@@ -564,36 +518,7 @@ spec:
                 value: "2379"
               - name: TOPOLOGY_FLAGS
                 value: "--topo_implementation etcd2 --topo_global_server_address $(ETCD_SERVER):$(ETCD_PORT) --topo_global_root /vitess/global"
-            command:
-              - /bin/bash
-              - -c
-              - |
-                cell=${CELL:-'zone1'}
-                web_port=${VTGATE_WEB_PORT:-'15001'}
-                grpc_port=${VTGATE_GRPC_PORT:-'15991'}
-                mysql_server_port=${VTGATE_MYSQL_PORT:-'15306'}
-                mysql_server_socket_path="/tmp/mysql.sock"
-
-                echo "starting vtgate."
-                su vitess <<EOF
-                exec vtgate \
-                  $TOPOLOGY_FLAGS \
-                  --alsologtostderr \
-                  --gateway_initial_tablet_timeout 30s \
-                  --healthcheck_timeout 2s \
-                  --srv_topo_timeout 1s \
-                  --grpc_keepalive_time 10s \
-                  --grpc_keepalive_timeout 10s \
-                  --log_dir $VTDATAROOT \
-                  --log_queries_to_file $VTDATAROOT/vtgate_querylog.txt \
-                  --port $web_port \
-                  --grpc_port $grpc_port \
-                  --mysql_server_port $mysql_server_port \
-                  --mysql_server_socket_path $mysql_server_socket_path \
-                  --cell $cell \
-                  --cells_to_watch $cell \
-                  --tablet_types_to_wait PRIMARY,REPLICA \
-                  --service_map 'grpc-vtgateservice' \
-                  --pid_file $VTDATAROOT/vtgate.pid \
-                  --mysql_auth_server_impl none
-                EOF
+            command: ["/scripts/vtgate.sh"]
+            volumeMounts:
+              - name: scripts
+                mountPath: /scripts

--- a/deploy/apecloud-mysql/templates/configconstraint.yaml
+++ b/deploy/apecloud-mysql/templates/configconstraint.yaml
@@ -57,3 +57,51 @@ spec:
     format: ini
     iniConfig:
       sectionName: mysqld
+---
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: ConfigConstraint
+metadata:
+  name: mysql-scale-vttablet-config-constraints
+  labels:
+    {{- include "apecloud-mysql.labels" . | nindent 4 }}
+spec:
+  configurationSchema:
+    cue: ""
+
+  # mysql-scale configuration file format
+  formatterConfig:
+    format: ini
+    iniConfig:
+      sectionName: vttablet
+---
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: ConfigConstraint
+metadata:
+  name: mysql-scale-vtconsensus-config-constraints
+  labels:
+    {{- include "apecloud-mysql.labels" . | nindent 4 }}
+spec:
+  configurationSchema:
+    cue: ""
+
+  # mysql-scale configuration file format
+  formatterConfig:
+    format: ini
+    iniConfig:
+      sectionName: vtconsensus
+---
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: ConfigConstraint
+metadata:
+  name: mysql-scale-vtgate-config-constraints
+  labels:
+    {{- include "apecloud-mysql.labels" . | nindent 4 }}
+spec:
+  configurationSchema:
+    cue: ""
+
+  # mysql-scale configuration file format
+  formatterConfig:
+    format: ini
+    iniConfig:
+      sectionName: vtgate

--- a/deploy/apecloud-mysql/templates/configconstraint.yaml
+++ b/deploy/apecloud-mysql/templates/configconstraint.yaml
@@ -65,8 +65,11 @@ metadata:
   labels:
     {{- include "apecloud-mysql.labels" . | nindent 4 }}
 spec:
+  cfgSchemaTopLevelName: VtTabletParameter
+
   configurationSchema:
-    cue: ""
+    cue: |-
+      {{- .Files.Get "config/mysql-scale-vttablet-config-constraint.cue" | nindent 6 }}
 
   # mysql-scale configuration file format
   formatterConfig:
@@ -81,8 +84,11 @@ metadata:
   labels:
     {{- include "apecloud-mysql.labels" . | nindent 4 }}
 spec:
+  cfgSchemaTopLevelName: VtConsensusParameter
+
   configurationSchema:
-    cue: ""
+    cue: |-
+      {{- .Files.Get "config/mysql-scale-vtconsensus-config-constraint.cue" | nindent 6 }}
 
   # mysql-scale configuration file format
   formatterConfig:
@@ -97,8 +103,11 @@ metadata:
   labels:
     {{- include "apecloud-mysql.labels" . | nindent 4 }}
 spec:
+  cfgSchemaTopLevelName: VtGateParameter
+
   configurationSchema:
-    cue: ""
+    cue: |-
+      {{- .Files.Get "config/mysql-scale-vtgate-config-constraint.cue" | nindent 6 }}
 
   # mysql-scale configuration file format
   formatterConfig:

--- a/deploy/apecloud-mysql/templates/configmap.yaml
+++ b/deploy/apecloud-mysql/templates/configmap.yaml
@@ -15,7 +15,7 @@ metadata:
   labels:
     {{- include "apecloud-mysql.labels" . | nindent 4 }}
 data:
-  my.cnf: |-
+  wesql-scale.cnf: |-
     {{- .Files.Get "config/mysql-scale-config.tpl" | nindent 4 }}
 ---
 apiVersion: v1

--- a/deploy/apecloud-mysql/templates/configmap.yaml
+++ b/deploy/apecloud-mysql/templates/configmap.yaml
@@ -11,6 +11,16 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  name: mysql-scale-config-template
+  labels:
+    {{- include "apecloud-mysql.labels" . | nindent 4 }}
+data:
+  my.cnf: |-
+    {{- .Files.Get "config/mysql-scale-config.tpl" | nindent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
   name: mysql-reload-script
   labels:
     {{- include "apecloud-mysql.labels" . | nindent 4 }}

--- a/deploy/apecloud-mysql/templates/scripts.yaml
+++ b/deploy/apecloud-mysql/templates/scripts.yaml
@@ -13,6 +13,22 @@ data:
     printf "-"
     done
     echo -e "  >> $1 has started"
+  set_config_variables.sh: |
+    #!/bin/bash
+    function set_config_variables(){
+      echo "set config variables [$1]"
+      config_file="/conf/my.cnf"
+      config_content=$(sed -n '/\['$1'\]/,/\[/ { /\['$1'\]/d; /\[/q; p; }' $config_file)
+      while read line
+      do
+        if [[ $line =~ ^[a-zA-Z_][a-zA-Z0-9_]*=[a-zA-Z0-9_]*$ ]]; then
+          echo $line
+          eval "export $line"
+        elif ! [[ $line =~ ^[[:space:]]*# ]]; then 
+          echo "bad format: $line"
+        fi
+      done <<< "$(echo -e "$config_content")"
+    }
   setup.sh: |
     #!/bin/bash
     exec docker-entrypoint.sh
@@ -162,6 +178,10 @@ data:
     do
       sleep 60
     done
+
+    . /scripts/set_config_variables.sh
+    set_config_variables vttablet
+
     cell=${CELL:-'zone1'}
     uid="${KB_POD_NAME##*-}"
     mysql_root=${MYSQL_ROOT_USER:-'root'}
@@ -190,10 +210,10 @@ data:
     --tablet-path $alias \
     --tablet_hostname "$tablet_hostname" \
     --init_tablet_type $tablet_type \
-    --health_check_interval 1s \
-    --shard_sync_retry_delay 1s \
-    --remote_operation_timeout 1s \
-    --db_connect_timeout_ms 500 \
+    --health_check_interval $health_check_interval \
+    --shard_sync_retry_delay $shard_sync_retry_delay \
+    --remote_operation_timeout $remote_operation_timeout \
+    --db_connect_timeout_ms $db_connect_timeout_ms \
     --enable_replication_reporter \
     --backup_storage_implementation file \
     --file_backup_storage_root $VTDATAROOT/backups \
@@ -273,6 +293,9 @@ data:
     EOF
   vtconsensus.sh: |-
     #!/bin/bash
+    . /scripts/set_config_variables.sh
+    set_config_variables vtconsensus
+
     echo "starting vtconsensus"
     cell=${CELL:-'zone1'}
 
@@ -283,14 +306,17 @@ data:
     exec vtconsensus \
       $topology_fags \
       --alsologtostderr \
-      --refresh_interval 1s \
-      --scan_repair_timeout 1s \
+      --refresh_interval $refresh_interval \
+      --scan_repair_timeout $scan_repair_timeout \
       --log_dir ${VTDATAROOT} \
       --db_username "$MYSQL_ROOT_USER" \
       --db_password "$MYSQL_ROOT_PASSWORD"
     EOF
   vtgate.sh: |-
     #!/bin/bash
+    . /scripts/set_config_variables.sh
+    set_config_variables vtgate
+
     cell=${CELL:-'zone1'}
     web_port=${VTGATE_WEB_PORT:-'15001'}
     grpc_port=${VTGATE_GRPC_PORT:-'15991'}
@@ -302,11 +328,11 @@ data:
     exec vtgate \
       $TOPOLOGY_FLAGS \
       --alsologtostderr \
-      --gateway_initial_tablet_timeout 30s \
-      --healthcheck_timeout 2s \
-      --srv_topo_timeout 1s \
-      --grpc_keepalive_time 10s \
-      --grpc_keepalive_timeout 10s \
+      --gateway_initial_tablet_timeout $gateway_initial_tablet_timeout \
+      --healthcheck_timeout $healthcheck_timeout \
+      --srv_topo_timeout $srv_topo_timeout \
+      --grpc_keepalive_time $grpc_keepalive_time \
+      --grpc_keepalive_timeout $grpc_keepalive_timeout \
       --log_dir $VTDATAROOT \
       --log_queries_to_file $VTDATAROOT/vtgate_querylog.txt \
       --port $web_port \
@@ -316,6 +342,7 @@ data:
       --cell $cell \
       --cells_to_watch $cell \
       --tablet_types_to_wait PRIMARY,REPLICA \
+      --tablet_refresh_interval $tablet_refresh_interval \
       --service_map 'grpc-vtgateservice' \
       --pid_file $VTDATAROOT/vtgate.pid \
       --mysql_auth_server_impl none

--- a/deploy/apecloud-mysql/templates/scripts.yaml
+++ b/deploy/apecloud-mysql/templates/scripts.yaml
@@ -5,6 +5,14 @@ metadata:
   labels:
     {{- include "apecloud-mysql.labels" . | nindent 4 }}
 data:
+  wait-for-service.sh: |
+    #!/bin/sh
+    echo "wait for $1"
+    while ! nc -z $2 $3
+    do sleep 1
+    printf "-"
+    done
+    echo -e "  >> $1 has started"
   setup.sh: |
     #!/bin/bash
     exec docker-entrypoint.sh

--- a/deploy/apecloud-mysql/templates/scripts.yaml
+++ b/deploy/apecloud-mysql/templates/scripts.yaml
@@ -17,7 +17,7 @@ data:
     #!/bin/bash
     function set_config_variables(){
       echo "set config variables [$1]"
-      config_file="/conf/my.cnf"
+      config_file="/conf/wesql-scale.cnf"
       config_content=$(sed -n '/\['$1'\]/,/\[/ { /\['$1'\]/d; /\[/q; p; }' $config_file)
       while read line
       do

--- a/deploy/apecloud-mysql/templates/scripts.yaml
+++ b/deploy/apecloud-mysql/templates/scripts.yaml
@@ -206,3 +206,109 @@ data:
     --vtctld_addr http://$vtctld_host:$vtctld_web_port/ \
     --disable_active_reparents
     EOF
+  etcd.sh: |-
+    #!/bin/bash
+    echo "staring etcd."
+    etcd_port=${ETCD_PORT:-'2379'}
+    etcd_server=${ETCD_SERVER:-'127.0.0.1'}
+
+    cell=${CELL:-'zone1'}
+    export ETCDCTL_API=2
+
+    etcd --enable-v2=true --data-dir "${VTDATAROOT}/etcd/"  \
+      --listen-client-urls "http://0.0.0.0:${etcd_port}" \
+      --advertise-client-urls "http://0.0.0.0:${etcd_port}"
+  etcd-post-start.sh: |-
+    #!/bin/bash
+    etcd_port=${ETCD_PORT:-'2379'}
+    etcd_server=${ETCD_SERVER:-'127.0.0.1'}
+
+    cell=${CELL:-'zone1'}
+    export ETCDCTL_API=2
+
+    echo "add /vitess/global"
+    etcdctl --endpoints "http://127.0.0.1:${etcd_port}" mkdir /vitess/global
+
+    echo "add /vitess/$cell"
+    etcdctl --endpoints "http://127.0.0.1:${etcd_port}" mkdir /vitess/$cell
+
+    # And also add the CellInfo description for the cell.
+    # If the node already exists, it's fine, means we used existing data.
+    echo "add $cell CellInfo"
+    set +e
+    vtctl --topo_implementation etcd2 \
+      --topo_global_server_address "127.0.0.1:${etcd_port}" \
+      --topo_global_root /vitess/global VtctldCommand AddCellInfo \
+      --root /vitess/$cell \
+      --server-address "${etcd_server}:${etcd_port}" \
+      $cell
+  vtctld.sh: |-
+    #!/bin/bash
+    echo "starting vtctld"
+    cell=${CELL:-'zone1'}
+    grpc_port=${VTCTLD_GRPC_PORT:-'15999'}
+    vtctld_web_port=${VTCTLD_WEB_PORT:-'15000'}
+    topology_fags=${TOPOLOGY_FLAGS:-'--topo_implementation etcd2 --topo_global_server_address 127.0.0.1:2379 --topo_global_root /vitess/global'}
+
+    su vitess <<EOF
+    exec vtctld \
+    $topology_fags \
+    --alsologtostderr \
+    --cell $cell \
+    --service_map 'grpc-vtctl,grpc-vtctld' \
+    --backup_storage_implementation file \
+    --file_backup_storage_root $VTDATAROOT/backups \
+    --log_dir $VTDATAROOT \
+    --port $vtctld_web_port \
+    --grpc_port $grpc_port \
+    --pid_file $VTDATAROOT/vtctld.pid
+    EOF
+  vtconsensus.sh: |-
+    #!/bin/bash
+    echo "starting vtconsensus"
+    cell=${CELL:-'zone1'}
+
+    vtconsensusport=${VTCONSENSUS_PORT:-'16000'}
+    topology_fags=${TOPOLOGY_FLAGS:-'--topo_implementation etcd2 --topo_global_server_address 127.0.0.1:2379 --topo_global_root /vitess/global'}
+
+    su vitess <<EOF
+    exec vtconsensus \
+      $topology_fags \
+      --alsologtostderr \
+      --refresh_interval 1s \
+      --scan_repair_timeout 1s \
+      --log_dir ${VTDATAROOT} \
+      --db_username "$MYSQL_ROOT_USER" \
+      --db_password "$MYSQL_ROOT_PASSWORD"
+    EOF
+  vtgate.sh: |-
+    #!/bin/bash
+    cell=${CELL:-'zone1'}
+    web_port=${VTGATE_WEB_PORT:-'15001'}
+    grpc_port=${VTGATE_GRPC_PORT:-'15991'}
+    mysql_server_port=${VTGATE_MYSQL_PORT:-'15306'}
+    mysql_server_socket_path="/tmp/mysql.sock"
+
+    echo "starting vtgate."
+    su vitess <<EOF
+    exec vtgate \
+      $TOPOLOGY_FLAGS \
+      --alsologtostderr \
+      --gateway_initial_tablet_timeout 30s \
+      --healthcheck_timeout 2s \
+      --srv_topo_timeout 1s \
+      --grpc_keepalive_time 10s \
+      --grpc_keepalive_timeout 10s \
+      --log_dir $VTDATAROOT \
+      --log_queries_to_file $VTDATAROOT/vtgate_querylog.txt \
+      --port $web_port \
+      --grpc_port $grpc_port \
+      --mysql_server_port $mysql_server_port \
+      --mysql_server_socket_path $mysql_server_socket_path \
+      --cell $cell \
+      --cells_to_watch $cell \
+      --tablet_types_to_wait PRIMARY,REPLICA \
+      --service_map 'grpc-vtgateservice' \
+      --pid_file $VTDATAROOT/vtgate.pid \
+      --mysql_auth_server_impl none
+    EOF


### PR DESCRIPTION
* move the wesql scale component's startup scripts to scripts.yaml.
* add `initContainers` in `vtgate`,`vtconsensus` and `vtctld` components to avoid Failed status during the cluster startup.
* add mysql scale configuration.

Reconfigure command example:
```
kbcli cluster configure vt --set=healthcheck_timeout=10s --component=vtgate
kbcli cluster configure vt --set=health_check_interval=4s --component=mysql --config-spec=mysql-scale-config
```
all mysql scale related configurations are treated as static parameters.

!!! **Please note** that this change will impact the MySQL configuration. This means that after installing the cluster using `helm install mysql-cluster deploy/apecloud-mysql-cluster --set mode=raftGroup`，when reconfiguring MySQL, you must include `--config-spec`, for example:
```
kbcli cluster configure vt --set=max_connections=200 --config-spec=mysql-consensusset-config
```
I'm not sure what the best approach is.

My test environment:
```
Kubernetes: v1.26.4+k3s1
KubeBlocks: 0.6.0-alpha.28
kbcli: 0.6.0-alpha.28
```