### PR TITLE
fix: nil pointer dereference when configurationSchema has empty CUE field

### DIFF
--- a/internal/cli/util/util.go
+++ b/internal/cli/util/util.go
@@ -548,6 +548,9 @@ func IsSupportReconfigureParams(tpl appsv1alpha1.ComponentConfigSpec, values map
 		if err != nil {
 			return false, err
 		}
+		if schema.Schema == nil {
+			return true, nil
+		}
 	}
 
 	schemaSpec := schema.Schema.Properties["spec"]

--- a/internal/cli/util/util_test.go
+++ b/internal/cli/util/util_test.go
@@ -207,12 +207,15 @@ var _ = Describe("util", func() {
 					}
 				}
 			})
+		badcaseCCObject := configConstraintObj.DeepCopy()
+		badcaseCCObject.Spec.CfgSchemaTopLevelName = "badcase"
+		badcaseCCObject.SetName("badcase")
 
 		tf := cmdtesting.NewTestFactory().WithNamespace(testNS)
 		defer tf.Cleanup()
 
 		Expect(appsv1alpha1.AddToScheme(scheme.Scheme)).Should(Succeed())
-		mockClient := dynamicfakeclient.NewSimpleDynamicClientWithCustomListKinds(scheme.Scheme, nil, configConstraintObj)
+		mockClient := dynamicfakeclient.NewSimpleDynamicClientWithCustomListKinds(scheme.Scheme, nil, configConstraintObj, badcaseCCObject)
 		configSpec := appsv1alpha1.ComponentConfigSpec{
 			ComponentTemplateSpec: appsv1alpha1.ComponentTemplateSpec{
 				Name:        "for_test",
@@ -244,6 +247,20 @@ var _ = Describe("util", func() {
 				updatedParams: testapps.WithMap("not_exist_field", "1"),
 			},
 			expected: false,
+		}, {
+			name: "badcase test",
+			args: args{
+				configSpec: appsv1alpha1.ComponentConfigSpec{
+					ComponentTemplateSpec: appsv1alpha1.ComponentTemplateSpec{
+						Name:        "for_test",
+						TemplateRef: ccName,
+						VolumeName:  "config",
+					},
+					ConfigConstraintRef: "badcase",
+				},
+				updatedParams: testapps.WithMap("automatic_sp_privileges", "1"),
+			},
+			expected: true,
 		}}
 
 		for _, tt := range tests {


### PR DESCRIPTION
I encountered a `nil pointer dereference` panic after add another configSpec in apecloud-mysql cd and reconfiguration with `kbcli cluster configure vt --set=max_connections=200`. That is because `cfgcore.GenerateOpenAPISchema` returned `nil,nil` when configurationSchema has empty CUE field and `CfgSchemaTopLevelName`. 
I have added a check and now return `true, nil` directly to prevent this panic.

<img width="683" alt="image" src="https://github.com/apecloud/kubeblocks/assets/32926461/6dafa9a7-eaae-4209-800c-7b490b168c79">

