### PR TITLE
fea: support startWindowMinutes for cron backup

### DIFF
--- a/apis/apps/v1alpha1/backuppolicytemplate_types.go
+++ b/apis/apps/v1alpha1/backuppolicytemplate_types.go
@@ -84,7 +84,7 @@ type RetentionSpec struct {
 }
 
 type Schedule struct {
-	// startWindowMinutes starts the job in this time window if it misses scheduled
+	// startWindowMinutes defines the time window for starting the job if it misses scheduled
 	// time for any reason. the unit of time is minute.
 	// +optional
 	// +kubebuilder:validation:Minimum=0

--- a/apis/apps/v1alpha1/backuppolicytemplate_types.go
+++ b/apis/apps/v1alpha1/backuppolicytemplate_types.go
@@ -88,6 +88,7 @@ type Schedule struct {
 	// time for any reason. the unit of time is minute.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=1440
 	StartWindowMinutes *int64 `json:"startWindowMinutes,omitempty"`
 
 	// schedule policy for snapshot backup.

--- a/apis/apps/v1alpha1/backuppolicytemplate_types.go
+++ b/apis/apps/v1alpha1/backuppolicytemplate_types.go
@@ -84,6 +84,12 @@ type RetentionSpec struct {
 }
 
 type Schedule struct {
+	// startWindowMinutes starts the job in this time window if it misses scheduled
+	// time for any reason. the unit of time is minute.
+	// +optional
+	// +kubebuilder:validation:Minimum=0
+	StartWindowMinutes *int64 `json:"startWindowMinutes,omitempty"`
+
 	// schedule policy for snapshot backup.
 	// +optional
 	Snapshot *SchedulePolicy `json:"snapshot,omitempty"`

--- a/apis/dataprotection/v1alpha1/backuppolicy_types.go
+++ b/apis/dataprotection/v1alpha1/backuppolicy_types.go
@@ -58,6 +58,12 @@ type RetentionSpec struct {
 }
 
 type Schedule struct {
+	// startWindowMinutes defines the time window for starting the job if it misses scheduled
+	// time for any reason. the unit of time is minute.
+	// +optional
+	// +kubebuilder:validation:Minimum=0
+	StartWindowMinutes *int64 `json:"startWindowMinutes,omitempty"`
+
 	// schedule policy for snapshot backup.
 	// +optional
 	Snapshot *SchedulePolicy `json:"snapshot,omitempty"`

--- a/apis/dataprotection/v1alpha1/backuppolicy_types.go
+++ b/apis/dataprotection/v1alpha1/backuppolicy_types.go
@@ -62,6 +62,7 @@ type Schedule struct {
 	// time for any reason. the unit of time is minute.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=1440
 	StartWindowMinutes *int64 `json:"startWindowMinutes,omitempty"`
 
 	// schedule policy for snapshot backup.

--- a/config/crd/bases/apps.kubeblocks.io_backuppolicytemplates.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_backuppolicytemplates.yaml
@@ -312,6 +312,13 @@ spec:
                           - cronExpression
                           - enable
                           type: object
+                        startWindowMinutes:
+                          description: startWindowMinutes starts the job in this time
+                            window if it misses scheduled time for any reason. the
+                            unit of time is minute.
+                          format: int64
+                          minimum: 0
+                          type: integer
                       type: object
                     snapshot:
                       description: the policy for snapshot backup.

--- a/config/crd/bases/apps.kubeblocks.io_backuppolicytemplates.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_backuppolicytemplates.yaml
@@ -313,9 +313,9 @@ spec:
                           - enable
                           type: object
                         startWindowMinutes:
-                          description: startWindowMinutes starts the job in this time
-                            window if it misses scheduled time for any reason. the
-                            unit of time is minute.
+                          description: startWindowMinutes defines the time window
+                            for starting the job if it misses scheduled time for any
+                            reason. the unit of time is minute.
                           format: int64
                           minimum: 0
                           type: integer

--- a/config/crd/bases/apps.kubeblocks.io_backuppolicytemplates.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_backuppolicytemplates.yaml
@@ -317,6 +317,7 @@ spec:
                             for starting the job if it misses scheduled time for any
                             reason. the unit of time is minute.
                           format: int64
+                          maximum: 1440
                           minimum: 0
                           type: integer
                       type: object

--- a/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -508,6 +508,13 @@ spec:
                     - cronExpression
                     - enable
                     type: object
+                  startWindowMinutes:
+                    description: startWindowMinutes defines the time window for starting
+                      the job if it misses scheduled time for any reason. the unit
+                      of time is minute.
+                    format: int64
+                    minimum: 0
+                    type: integer
                 type: object
               snapshot:
                 description: the policy for snapshot backup.

--- a/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -513,6 +513,7 @@ spec:
                       the job if it misses scheduled time for any reason. the unit
                       of time is minute.
                     format: int64
+                    maximum: 1440
                     minimum: 0
                     type: integer
                 type: object

--- a/controllers/apps/transformer_backup_policy_tpl.go
+++ b/controllers/apps/transformer_backup_policy_tpl.go
@@ -214,7 +214,7 @@ func (r *BackupPolicyTPLTransformer) buildBackupPolicy(policyTPL appsv1alpha1.Ba
 			TTL: policyTPL.Retention.TTL,
 		}
 	}
-
+	bpSpec.Schedule.StartWindowMinutes = policyTPL.Schedule.StartWindowMinutes
 	bpSpec.Schedule.Snapshot = r.convertSchedulePolicy(policyTPL.Schedule.Snapshot)
 	bpSpec.Schedule.Datafile = r.convertSchedulePolicy(policyTPL.Schedule.Datafile)
 	bpSpec.Schedule.Logfile = r.convertSchedulePolicy(policyTPL.Schedule.Logfile)

--- a/controllers/dataprotection/backuppolicy_controller.go
+++ b/controllers/dataprotection/backuppolicy_controller.go
@@ -448,7 +448,7 @@ func (r *BackupPolicyReconciler) removeCronJobFinalizer(reqCtx intctrlutil.Reque
 func (r *BackupPolicyReconciler) reconcileCronJob(reqCtx intctrlutil.RequestCtx,
 	backupPolicy *dataprotectionv1alpha1.BackupPolicy,
 	basePolicy dataprotectionv1alpha1.BasePolicy,
-	cronExpression string,
+	schedulePolicy *dataprotectionv1alpha1.SchedulePolicy,
 	backType dataprotectionv1alpha1.BackupType) error {
 	// get cronjob from labels
 	cronJob := &batchv1.CronJob{}
@@ -465,8 +465,7 @@ func (r *BackupPolicyReconciler) reconcileCronJob(reqCtx intctrlutil.RequestCtx,
 	} else if len(cronJobList.Items) > 0 {
 		cronJob = &cronJobList.Items[0]
 	}
-
-	if len(cronExpression) == 0 {
+	if schedulePolicy == nil || !schedulePolicy.Enable {
 		if len(cronJob.Name) != 0 {
 			// delete the old cronjob.
 			if err := r.removeCronJobFinalizer(reqCtx, cronJob); err != nil {
@@ -477,20 +476,25 @@ func (r *BackupPolicyReconciler) reconcileCronJob(reqCtx intctrlutil.RequestCtx,
 		// if no cron expression, return
 		return nil
 	}
-	cronjobProto, err := r.buildCronJob(backupPolicy, basePolicy.Target, cronExpression, backType, cronJob.Name)
+	cronjobProto, err := r.buildCronJob(backupPolicy, basePolicy.Target, schedulePolicy.CronExpression, backType, cronJob.Name)
 	if err != nil {
 		return err
 	}
 
+	if backupPolicy.Spec.Schedule.StartWindowMinutes != nil {
+		startingDeadlineSeconds := *backupPolicy.Spec.Schedule.StartWindowMinutes * 60
+		cronjobProto.Spec.StartingDeadlineSeconds = &startingDeadlineSeconds
+	}
 	if len(cronJob.Name) == 0 {
 		// if no cronjob, create it.
 		return r.Client.Create(reqCtx.Ctx, cronjobProto)
 	}
 	// sync the cronjob with the current backup policy configuration.
 	patch := client.MergeFrom(cronJob.DeepCopy())
+	cronJob.Spec.StartingDeadlineSeconds = cronjobProto.Spec.StartingDeadlineSeconds
 	cronJob.Spec.JobTemplate.Spec.BackoffLimit = &basePolicy.OnFailAttempted
 	cronJob.Spec.JobTemplate.Spec.Template = cronjobProto.Spec.JobTemplate.Spec.Template
-	cronJob.Spec.Schedule = cronExpression
+	cronJob.Spec.Schedule = schedulePolicy.CronExpression
 	return r.Client.Patch(reqCtx.Ctx, cronJob, patch)
 }
 
@@ -498,15 +502,14 @@ func (r *BackupPolicyReconciler) reconcileCronJob(reqCtx intctrlutil.RequestCtx,
 func (r *BackupPolicyReconciler) handlePolicy(reqCtx intctrlutil.RequestCtx,
 	backupPolicy *dataprotectionv1alpha1.BackupPolicy,
 	basePolicy dataprotectionv1alpha1.BasePolicy,
-	cronExpression string,
+	schedulePolicy *dataprotectionv1alpha1.SchedulePolicy,
 	backType dataprotectionv1alpha1.BackupType) error {
 
 	if err := r.reconfigure(reqCtx, backupPolicy, basePolicy, backType); err != nil {
 		return err
 	}
 	// create/delete/patch cronjob workload
-	if err := r.reconcileCronJob(reqCtx, backupPolicy, basePolicy,
-		cronExpression, backType); err != nil {
+	if err := r.reconcileCronJob(reqCtx, backupPolicy, basePolicy, schedulePolicy, backType); err != nil {
 		return err
 	}
 	return r.removeOldestBackups(reqCtx, backupPolicy.Name, backType, basePolicy.BackupsHistoryLimit)
@@ -520,13 +523,8 @@ func (r *BackupPolicyReconciler) handleSnapshotPolicy(
 		// TODO delete cronjob if exists
 		return nil
 	}
-	var cronExpression string
-	schedule := backupPolicy.Spec.Schedule.Snapshot
-	if schedule != nil && schedule.Enable {
-		cronExpression = schedule.CronExpression
-	}
 	return r.handlePolicy(reqCtx, backupPolicy, backupPolicy.Spec.Snapshot.BasePolicy,
-		cronExpression, dataprotectionv1alpha1.BackupTypeSnapshot)
+		backupPolicy.Spec.Schedule.Snapshot, dataprotectionv1alpha1.BackupTypeSnapshot)
 }
 
 // handleDatafilePolicy handles datafile policy.
@@ -537,14 +535,9 @@ func (r *BackupPolicyReconciler) handleDatafilePolicy(
 		// TODO delete cronjob if exists
 		return nil
 	}
-	var cronExpression string
-	schedule := backupPolicy.Spec.Schedule.Datafile
-	if schedule != nil && schedule.Enable {
-		cronExpression = schedule.CronExpression
-	}
 	r.setGlobalPersistentVolumeClaim(backupPolicy.Spec.Datafile)
 	return r.handlePolicy(reqCtx, backupPolicy, backupPolicy.Spec.Datafile.BasePolicy,
-		cronExpression, dataprotectionv1alpha1.BackupTypeDataFile)
+		backupPolicy.Spec.Schedule.Datafile, dataprotectionv1alpha1.BackupTypeDataFile)
 }
 
 // handleLogFilePolicy handles logfile policy.
@@ -559,17 +552,16 @@ func (r *BackupPolicyReconciler) handleLogfilePolicy(
 	if err != nil {
 		return err
 	}
-	schedule := backupPolicy.Spec.Schedule.Logfile
-	var cronExpression string
-	if schedule != nil && schedule.Enable {
-		cronExpression = schedule.CronExpression
-	}
 	r.setGlobalPersistentVolumeClaim(logfile)
+	schedule := backupPolicy.Spec.Schedule.Logfile
 	if backupTool.Spec.DeployKind == dataprotectionv1alpha1.DeployKindStatefulSet {
+		var cronExpression string
+		if schedule != nil && schedule.Enable {
+			cronExpression = schedule.CronExpression
+		}
 		return r.reconcileForStatefulSetKind(reqCtx.Ctx, backupPolicy, dataprotectionv1alpha1.BackupTypeLogFile, cronExpression)
 	}
-	return r.handlePolicy(reqCtx, backupPolicy, logfile.BasePolicy,
-		cronExpression, dataprotectionv1alpha1.BackupTypeLogFile)
+	return r.handlePolicy(reqCtx, backupPolicy, logfile.BasePolicy, schedule, dataprotectionv1alpha1.BackupTypeLogFile)
 }
 
 // setGlobalPersistentVolumeClaim sets global config of pvc to common policy.

--- a/controllers/dataprotection/backuppolicy_controller_test.go
+++ b/controllers/dataprotection/backuppolicy_controller_test.go
@@ -143,6 +143,7 @@ var _ = Describe("Backup Policy Controller", func() {
 		Context("creates a backup policy", func() {
 			var backupPolicyKey types.NamespacedName
 			var backupPolicy *dpv1alpha1.BackupPolicy
+			var startWindowMinutes int64 = 60
 			BeforeEach(func() {
 				By("By creating a backupPolicy from backupTool: " + backupToolName)
 				backupPolicy = testapps.NewBackupPolicyFactory(testCtx.DefaultNamespace, backupPolicyName).
@@ -150,6 +151,7 @@ var _ = Describe("Backup Policy Controller", func() {
 					SetBackupToolName(backupToolName).
 					SetBackupsHistoryLimit(1).
 					SetSchedule(defaultSchedule, true).
+					SetScheduleStartWindowMinutes(&startWindowMinutes).
 					SetTTL(defaultTTL).
 					AddMatchLabels(constant.AppInstanceLabelKey, clusterName).
 					SetTargetSecretName(clusterName).
@@ -169,6 +171,8 @@ var _ = Describe("Backup Policy Controller", func() {
 					g.Expect(fetched.Spec.JobTemplate.Spec.Template.Spec.NodeSelector).ShouldNot(BeEmpty())
 					g.Expect(fetched.Spec.JobTemplate.Spec.Template.Spec.Affinity).ShouldNot(BeNil())
 					g.Expect(fetched.Spec.JobTemplate.Spec.Template.Spec.Affinity.NodeAffinity).ShouldNot(BeNil())
+					g.Expect(fetched.Spec.StartingDeadlineSeconds).ShouldNot(BeNil())
+					g.Expect(*fetched.Spec.StartingDeadlineSeconds).Should(Equal(startWindowMinutes * 60))
 				})).Should(Succeed())
 			})
 			It("limit backups to 1", func() {

--- a/deploy/apecloud-mysql/templates/backuppolicytemplate.yaml
+++ b/deploy/apecloud-mysql/templates/backuppolicytemplate.yaml
@@ -14,6 +14,7 @@ spec:
     retention:
       ttl: 7d
     schedule:
+      startWindowMinutes: 120
       snapshot:
         enable: false
         cronExpression: "0 18 * * *"

--- a/deploy/helm/crds/apps.kubeblocks.io_backuppolicytemplates.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_backuppolicytemplates.yaml
@@ -312,6 +312,13 @@ spec:
                           - cronExpression
                           - enable
                           type: object
+                        startWindowMinutes:
+                          description: startWindowMinutes starts the job in this time
+                            window if it misses scheduled time for any reason. the
+                            unit of time is minute.
+                          format: int64
+                          minimum: 0
+                          type: integer
                       type: object
                     snapshot:
                       description: the policy for snapshot backup.

--- a/deploy/helm/crds/apps.kubeblocks.io_backuppolicytemplates.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_backuppolicytemplates.yaml
@@ -313,9 +313,9 @@ spec:
                           - enable
                           type: object
                         startWindowMinutes:
-                          description: startWindowMinutes starts the job in this time
-                            window if it misses scheduled time for any reason. the
-                            unit of time is minute.
+                          description: startWindowMinutes defines the time window
+                            for starting the job if it misses scheduled time for any
+                            reason. the unit of time is minute.
                           format: int64
                           minimum: 0
                           type: integer

--- a/deploy/helm/crds/apps.kubeblocks.io_backuppolicytemplates.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_backuppolicytemplates.yaml
@@ -317,6 +317,7 @@ spec:
                             for starting the job if it misses scheduled time for any
                             reason. the unit of time is minute.
                           format: int64
+                          maximum: 1440
                           minimum: 0
                           type: integer
                       type: object

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -508,6 +508,13 @@ spec:
                     - cronExpression
                     - enable
                     type: object
+                  startWindowMinutes:
+                    description: startWindowMinutes defines the time window for starting
+                      the job if it misses scheduled time for any reason. the unit
+                      of time is minute.
+                    format: int64
+                    minimum: 0
+                    type: integer
                 type: object
               snapshot:
                 description: the policy for snapshot backup.

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -513,6 +513,7 @@ spec:
                       the job if it misses scheduled time for any reason. the unit
                       of time is minute.
                     format: int64
+                    maximum: 1440
                     minimum: 0
                     type: integer
                 type: object

--- a/deploy/mongodb/templates/backuppolicytemplate.yaml
+++ b/deploy/mongodb/templates/backuppolicytemplate.yaml
@@ -12,6 +12,7 @@ spec:
     retention:
       ttl: 7d
     schedule:
+      startWindowMinutes: 120
       snapshot:
         enable: false
         cronExpression: "0 18 * * *"

--- a/deploy/postgresql/templates/backuppolicytemplate.yaml
+++ b/deploy/postgresql/templates/backuppolicytemplate.yaml
@@ -24,6 +24,7 @@ spec:
     retention:
       ttl: 7d
     schedule:
+      startWindowMinutes: 120
       snapshot:
         enable: false
         cronExpression: "0 18 * * *"

--- a/deploy/redis/templates/backuppolicytemplate.yaml
+++ b/deploy/redis/templates/backuppolicytemplate.yaml
@@ -12,6 +12,7 @@ spec:
     retention:
       ttl: 7d
     schedule:
+      startWindowMinutes: 120
       snapshot:
         enable: false
         cronExpression: "0 18 * * 0"

--- a/internal/testutil/apps/backuppolicy_factory.go
+++ b/internal/testutil/apps/backuppolicy_factory.go
@@ -136,6 +136,11 @@ func (factory *MockBackupPolicyFactory) SetSchedule(schedule string, enable bool
 	return factory
 }
 
+func (factory *MockBackupPolicyFactory) SetScheduleStartWindowMinutes(startWindowMinutes *int64) *MockBackupPolicyFactory {
+	factory.get().Spec.Schedule.StartWindowMinutes = startWindowMinutes
+	return factory
+}
+
 func (factory *MockBackupPolicyFactory) SetTTL(duration string) *MockBackupPolicyFactory {
 	factory.get().Spec.Retention = &dataprotectionv1alpha1.RetentionSpec{
 		TTL: &duration,


### PR DESCRIPTION
`startWindowMinutes` defines the time window for starting the job if it misses scheduled time for any reason. the unit of time is minute.