### PR TITLE
feat: integrate BackupRepo to backup controller

### DIFF
--- a/apis/dataprotection/v1alpha1/backuppolicy_types.go
+++ b/apis/dataprotection/v1alpha1/backuppolicy_types.go
@@ -119,7 +119,6 @@ type CommonBackupPolicy struct {
 type PersistentVolumeClaim struct {
 	// the name of PersistentVolumeClaim to store backup data.
 	// +kubebuilder:validation:MaxLength=63
-	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
 	// +optional
 	Name *string `json:"name,omitempty"`
 

--- a/apis/dataprotection/v1alpha1/backuppolicy_types.go
+++ b/apis/dataprotection/v1alpha1/backuppolicy_types.go
@@ -100,8 +100,14 @@ type CommonBackupPolicy struct {
 	BasePolicy `json:",inline"`
 
 	// refer to PersistentVolumeClaim and the backup data will be stored in the corresponding persistent volume.
-	// +kubebuilder:validation:Required
-	PersistentVolumeClaim PersistentVolumeClaim `json:"persistentVolumeClaim"`
+	// +optional
+	PersistentVolumeClaim PersistentVolumeClaim `json:"persistentVolumeClaim,omitempty"`
+
+	// refer to BackupRepo and the backup data will be stored in the corresponding repo.
+	// +kubebuilder:validation:MaxLength=63
+	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
+	// +optional
+	BackupRepoName *string `json:"backupRepoName,omitempty"`
 
 	// which backup tool to perform database backup, only support one tool.
 	// +kubebuilder:validation:Required
@@ -112,10 +118,10 @@ type CommonBackupPolicy struct {
 
 type PersistentVolumeClaim struct {
 	// the name of PersistentVolumeClaim to store backup data.
-	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MaxLength=63
-	// +kubebuilder:default=kb-backup-data
-	Name string `json:"name"`
+	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
+	// +optional
+	Name *string `json:"name,omitempty"`
 
 	// storageClassName is the name of the StorageClass required by the claim.
 	// +kubebuilder:validation:MaxLength=63

--- a/apis/dataprotection/v1alpha1/backuprepo_types.go
+++ b/apis/dataprotection/v1alpha1/backuprepo_types.go
@@ -39,6 +39,7 @@ type BackupRepoSpec struct {
 	PVReclaimPolicy corev1.PersistentVolumeReclaimPolicy `json:"pvReclaimPolicy"`
 
 	// Non-secret configurations for the storage provider.
+	// +optional
 	Config map[string]string `json:"config,omitempty"`
 
 	// A secret that contains the credentials needed by the storage provider.

--- a/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -140,7 +140,6 @@ spec:
                         description: the name of PersistentVolumeClaim to store backup
                           data.
                         maxLength: 63
-                        pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
                       persistentVolumeConfigMap:
                         description: 'persistentVolumeConfigMap references the configmap
@@ -344,7 +343,6 @@ spec:
                         description: the name of PersistentVolumeClaim to store backup
                           data.
                         maxLength: 63
-                        pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
                       persistentVolumeConfigMap:
                         description: 'persistentVolumeConfigMap references the configmap

--- a/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -53,6 +53,12 @@ spec:
               datafile:
                 description: the policy for datafile backup.
                 properties:
+                  backupRepoName:
+                    description: refer to BackupRepo and the backup data will be stored
+                      in the corresponding repo.
+                    maxLength: 63
+                    pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                    type: string
                   backupStatusUpdates:
                     description: define how to update metadata for backup status.
                     items:
@@ -131,10 +137,10 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       name:
-                        default: kb-backup-data
                         description: the name of PersistentVolumeClaim to store backup
                           data.
                         maxLength: 63
+                        pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
                       persistentVolumeConfigMap:
                         description: 'persistentVolumeConfigMap references the configmap
@@ -166,8 +172,6 @@ spec:
                         maxLength: 63
                         pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
-                    required:
-                    - name
                     type: object
                   target:
                     description: target database cluster for backup.
@@ -248,12 +252,17 @@ spec:
                     - labelsSelector
                     type: object
                 required:
-                - persistentVolumeClaim
                 - target
                 type: object
               logfile:
                 description: the policy for logfile backup.
                 properties:
+                  backupRepoName:
+                    description: refer to BackupRepo and the backup data will be stored
+                      in the corresponding repo.
+                    maxLength: 63
+                    pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                    type: string
                   backupStatusUpdates:
                     description: define how to update metadata for backup status.
                     items:
@@ -332,10 +341,10 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       name:
-                        default: kb-backup-data
                         description: the name of PersistentVolumeClaim to store backup
                           data.
                         maxLength: 63
+                        pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
                       persistentVolumeConfigMap:
                         description: 'persistentVolumeConfigMap references the configmap
@@ -367,8 +376,6 @@ spec:
                         maxLength: 63
                         pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
-                    required:
-                    - name
                     type: object
                   target:
                     description: target database cluster for backup.
@@ -449,7 +456,6 @@ spec:
                     - labelsSelector
                     type: object
                 required:
-                - persistentVolumeClaim
                 - target
                 type: object
               retention:

--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -70,6 +70,11 @@ const (
 	deleteBackupFilesJobNamePrefix = "delete-"
 )
 
+var (
+	// errBreakReconcile is not a real error, it is used to break the current reconciliation
+	errBreakReconcile = errors.New("break reconcile")
+)
+
 // BackupReconciler reconciles a Backup object
 type BackupReconciler struct {
 	client.Client
@@ -353,25 +358,30 @@ func (r *BackupReconciler) doNewPhaseAction(
 		if commonPolicy == nil {
 			return r.updateStatusIfFailed(reqCtx, backup, intctrlutil.NewBackupNotSupported(string(backup.Spec.BackupType), backupPolicy.Name))
 		}
-		// save the backup message for restore
-		backupToolName := commonPolicy.BackupToolName
-		backup.Status.PersistentVolumeClaimName = commonPolicy.PersistentVolumeClaim.Name
-		backup.Status.BackupToolName = backupToolName
-		pathPrefix := getBackupPathPrefix(backup, backupPolicy.Annotations[constant.BackupDataPathPrefixAnnotationKey])
 		if backup.Status.Manifests == nil {
 			backup.Status.Manifests = &dataprotectionv1alpha1.ManifestsStatus{}
 		}
 		if backup.Status.Manifests.BackupTool == nil {
 			backup.Status.Manifests.BackupTool = &dataprotectionv1alpha1.BackupToolManifestsStatus{}
 		}
+		// handle the PVC used in this backup
+		pvcName, pvName, err := r.handlePersistentVolumeClaim(reqCtx, backup, backupPolicy.Name, commonPolicy)
+		if err != nil {
+			if errors.Is(err, errBreakReconcile) {
+				// wait for the PVC to be created
+				return intctrlutil.Reconciled()
+			}
+			return r.updateStatusIfFailed(reqCtx, backup, err)
+		}
+		// record volume name
+		backup.Status.PersistentVolumeClaimName = pvcName
+		backup.Status.Manifests.BackupTool.VolumeName = pvName
+		// save the backup message for restore
+		backupToolName := commonPolicy.BackupToolName
+		backup.Status.BackupToolName = backupToolName
+		pathPrefix := getBackupPathPrefix(backup, backupPolicy.Annotations[constant.BackupDataPathPrefixAnnotationKey])
 		backup.Status.Manifests.BackupTool.FilePath = pathPrefix
 		targetCluster = commonPolicy.Target
-		if volumeName, err := r.handlePersistentVolumeClaim(reqCtx, backup.Spec.BackupType, backupPolicy.Name, commonPolicy); err != nil {
-			return r.updateStatusIfFailed(reqCtx, backup, err)
-		} else {
-			// record volume name
-			backup.Status.Manifests.BackupTool.VolumeName = volumeName
-		}
 		backupTool, err := getBackupToolByName(reqCtx, r.Client, backupToolName)
 		if err != nil {
 			return r.updateStatusIfFailed(reqCtx, backup, intctrlutil.NewNotFound("backupTool: %s not found", backupToolName))
@@ -417,27 +427,80 @@ func (r *BackupReconciler) doNewPhaseAction(
 	return intctrlutil.Reconciled()
 }
 
-// handlePersistentVolumeClaim handles the persistent volume claim for the backup, the rules are as follows
+func (r *BackupReconciler) handlePersistentVolumeClaim(reqCtx intctrlutil.RequestCtx,
+	backup *dataprotectionv1alpha1.Backup,
+	backupPolicyName string,
+	commonPolicy *dataprotectionv1alpha1.CommonBackupPolicy) (pvcName string, pvName string, err error) {
+	// check the legacy PVC field first for compatibility,
+	// and fallback to the backup repo approach if the legacy PVC field is empty
+	if commonPolicy.PersistentVolumeClaim.Name != nil {
+		pvcName = *commonPolicy.PersistentVolumeClaim.Name
+	}
+	pvName, err = r.handlePersistentVolumeClaimLegacy(reqCtx, backup.Spec.BackupType, backupPolicyName, commonPolicy)
+	if err == nil || !intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeBackupPVCNameIsEmpty) {
+		return pvcName, pvName, err
+	}
+
+	// check the PVC from backup repo
+	repo, err := r.getBackupRepo(reqCtx, backup, commonPolicy)
+	if err != nil {
+		return "", "", err
+	}
+	pvcName = repo.Status.BackupPVCName
+	if pvcName == "" {
+		err = intctrlutil.NewBackupPVCNameIsEmpty(string(backup.Spec.BackupType), backupPolicyName)
+		return "", "", err
+	}
+	pvc := &corev1.PersistentVolumeClaim{}
+	err = r.Client.Get(reqCtx.Ctx, client.ObjectKey{
+		Namespace: reqCtx.Req.Namespace,
+		Name:      pvcName,
+	}, pvc)
+	if err != nil && !apierrors.IsNotFound(err) {
+		// error occurred
+		return "", "", err
+	}
+	if err == nil {
+		// the PVC is already present
+		_, err = r.patchBackupObjectLabels(reqCtx, backup, map[string]string{
+			dataProtectionBackupRepoKey: repo.Name,
+		})
+		return pvcName, pvc.Spec.VolumeName, err
+	}
+	// the PVC is not present
+	// add a special annotation and wait for the backup repo controller
+	// to create the PVC.
+	_, err = r.patchBackupObjectLabels(reqCtx, backup, map[string]string{
+		dataProtectionBackupRepoKey:  repo.Name,
+		dataProtectionNeedRepoPVCKey: trueVal,
+	})
+	if err != nil {
+		return "", "", err
+	}
+	return "", "", errBreakReconcile
+}
+
+// handlePersistentVolumeClaimLegacy handles the persistent volume claim for the backup, the rules are as follows
 // - if CreatePolicy is "Never", it will check if the pvc exists. if not existed, then report an error.
 // - if CreatePolicy is "IfNotPresent" and the pvc not existed, then create the pvc automatically.
-func (r *BackupReconciler) handlePersistentVolumeClaim(reqCtx intctrlutil.RequestCtx,
+func (r *BackupReconciler) handlePersistentVolumeClaimLegacy(reqCtx intctrlutil.RequestCtx,
 	backupType dataprotectionv1alpha1.BackupType,
 	backupPolicyName string,
 	commonPolicy *dataprotectionv1alpha1.CommonBackupPolicy) (string, error) {
 	pvcConfig := commonPolicy.PersistentVolumeClaim
-	if len(pvcConfig.Name) == 0 {
+	if pvcConfig.Name == nil || len(*pvcConfig.Name) == 0 {
 		return "", intctrlutil.NewBackupPVCNameIsEmpty(string(backupType), backupPolicyName)
 	}
 	pvc := &corev1.PersistentVolumeClaim{}
 	if err := r.Client.Get(reqCtx.Ctx, client.ObjectKey{Namespace: reqCtx.Req.Namespace,
-		Name: pvcConfig.Name}, pvc); err != nil && !apierrors.IsNotFound(err) {
+		Name: *pvcConfig.Name}, pvc); err != nil && !apierrors.IsNotFound(err) {
 		return "", err
 	}
 	if len(pvc.Name) > 0 {
 		return pvc.Spec.VolumeName, nil
 	}
 	if pvcConfig.CreatePolicy == dataprotectionv1alpha1.CreatePVCPolicyNever {
-		return "", intctrlutil.NewNotFound(`persistent volume claim "%s" not found`, pvcConfig.Name)
+		return "", intctrlutil.NewNotFound(`persistent volume claim "%s" not found`, *pvcConfig.Name)
 	}
 	if pvcConfig.PersistentVolumeConfigMap != nil &&
 		(pvcConfig.StorageClassName == nil || *pvcConfig.StorageClassName == "") {
@@ -450,13 +513,42 @@ func (r *BackupReconciler) handlePersistentVolumeClaim(reqCtx intctrlutil.Reques
 	return "", r.createPVCWithStorageClassName(reqCtx, backupPolicyName, pvcConfig)
 }
 
+// getBackupRepo returns the backup repo specified by the backup object or the policy.
+// if no backup repo specified, it will return the default one.
+func (r *BackupReconciler) getBackupRepo(
+	reqCtx intctrlutil.RequestCtx,
+	backup *dataprotectionv1alpha1.Backup,
+	commonPolicy *dataprotectionv1alpha1.CommonBackupPolicy) (*dataprotectionv1alpha1.BackupRepo, error) {
+	// use the specified backup repo
+	var repoName string
+	if val := backup.Labels[dataProtectionBackupRepoKey]; val != "" {
+		repoName = val
+	} else if commonPolicy.BackupRepoName != nil && *commonPolicy.BackupRepoName != "" {
+		repoName = *commonPolicy.BackupRepoName
+	}
+	if repoName != "" {
+		repo := &dataprotectionv1alpha1.BackupRepo{}
+		err := r.Client.Get(reqCtx.Ctx, client.ObjectKey{Name: repoName}, repo)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, intctrlutil.NewNotFound("backup repo %s not found", repoName)
+			}
+			return nil, err
+		}
+		return repo, nil
+	}
+	// fallback to use the default repo
+	// TODO: cache the default repo?
+	return getDefaultBackupRepo(reqCtx.Ctx, r.Client)
+}
+
 // createPVCWithStorageClassName creates the persistent volume claim with the storageClassName.
 func (r *BackupReconciler) createPVCWithStorageClassName(reqCtx intctrlutil.RequestCtx,
 	backupPolicyName string,
 	pvcConfig dataprotectionv1alpha1.PersistentVolumeClaim) error {
 	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        pvcConfig.Name,
+			Name:        *pvcConfig.Name,
 			Namespace:   reqCtx.Req.Namespace,
 			Annotations: buildAutoCreationAnnotations(backupPolicyName),
 		},
@@ -490,7 +582,7 @@ func (r *BackupReconciler) createPersistentVolumeWithTemplate(reqCtx intctrlutil
 	if pvTemplate == "" {
 		return intctrlutil.NewBackupPVTemplateNotFound(pvConfig.Namespace, pvConfig.Name)
 	}
-	pvName := fmt.Sprintf("%s-%s", pvcConfig.Name, reqCtx.Req.Namespace)
+	pvName := fmt.Sprintf("%s-%s", *pvcConfig.Name, reqCtx.Req.Namespace)
 	pvTemplate = strings.ReplaceAll(pvTemplate, "$(GENERATE_NAME)", pvName)
 	pv := &corev1.PersistentVolume{}
 	if err := yaml.Unmarshal([]byte(pvTemplate), pv); err != nil {
@@ -499,7 +591,7 @@ func (r *BackupReconciler) createPersistentVolumeWithTemplate(reqCtx intctrlutil
 	pv.Name = pvName
 	pv.Spec.ClaimRef = &corev1.ObjectReference{
 		Namespace: reqCtx.Req.Namespace,
-		Name:      pvcConfig.Name,
+		Name:      *pvcConfig.Name,
 	}
 	pv.Annotations = buildAutoCreationAnnotations(backupPolicyName)
 	// set the storageClassName to empty for the persistentVolumeClaim to avoid the dynamic provisioning
@@ -795,7 +887,7 @@ func (r *BackupReconciler) buildManifestsUpdaterContainer(backup *dataprotection
 		return container, err
 	}
 	container.VolumeMounts = []corev1.VolumeMount{
-		{Name: fmt.Sprintf("backup-%s", commonPolicy.PersistentVolumeClaim.Name), MountPath: backupPathBase},
+		{Name: fmt.Sprintf("backup-%s", backup.Status.PersistentVolumeClaimName), MountPath: backupPathBase},
 	}
 	container.Env = []corev1.EnvVar{
 		{Name: constant.DPBackupInfoFile, Value: buildBackupInfoENV(pathPrefix)},
@@ -891,6 +983,24 @@ func (r *BackupReconciler) getCluster(
 		return nil
 	}
 	return cluster
+}
+
+// patchBackupObjectLabels add missed labels to the backup object.
+func (r *BackupReconciler) patchBackupObjectLabels(
+	reqCtx intctrlutil.RequestCtx,
+	backup *dataprotectionv1alpha1.Backup,
+	labels map[string]string) (bool, error) {
+	oldBackup := backup.DeepCopy()
+	if backup.Labels == nil {
+		backup.Labels = make(map[string]string)
+	}
+	for k, v := range labels {
+		backup.Labels[k] = v
+	}
+	if reflect.DeepEqual(oldBackup.ObjectMeta, backup.ObjectMeta) {
+		return false, nil
+	}
+	return true, r.Client.Patch(reqCtx.Ctx, backup, client.MergeFrom(oldBackup))
 }
 
 // patchBackupObjectMeta patches backup object metaObject include cluster snapshot.
@@ -1704,7 +1814,7 @@ func (r *BackupReconciler) buildBackupToolPodSpec(reqCtx intctrlutil.RequestCtx,
 	podSpec.RestartPolicy = corev1.RestartPolicyNever
 
 	// mount the backup volume to the pod of backup tool
-	pvcName := commonPolicy.PersistentVolumeClaim.Name
+	pvcName := backup.Status.PersistentVolumeClaimName
 	r.appendBackupVolumeMount(pvcName, &podSpec, &podSpec.Containers[0])
 
 	// the pod of job needs to be scheduled on the same node as the workload pod, because it needs to share one pvc
@@ -1789,7 +1899,7 @@ func (r *BackupReconciler) buildMetadataCollectionPodSpec(
 		container.Env = []corev1.EnvVar{
 			{Name: "BACKUP_INFO_FILE", Value: buildBackupInfoENV(pathPrefix)},
 		}
-		r.appendBackupVolumeMount(commonPolicy.PersistentVolumeClaim.Name, &podSpec, &container)
+		r.appendBackupVolumeMount(backup.Status.PersistentVolumeClaimName, &podSpec, &container)
 	} else {
 		args = "set -o errexit; set -o nounset;" +
 			"OUTPUT=$(kubectl -n %s exec -it pod/%s -c %s -- %s);" +

--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -468,7 +468,7 @@ func (r *BackupReconciler) handlePersistentVolumeClaim(reqCtx intctrlutil.Reques
 		return pvcName, pvc.Spec.VolumeName, err
 	}
 	// the PVC is not present
-	// add a special annotation and wait for the backup repo controller
+	// add a special label and wait for the backup repo controller
 	// to create the PVC.
 	_, err = r.patchBackupObjectLabels(reqCtx, backup, map[string]string{
 		dataProtectionBackupRepoKey:  repo.Name,
@@ -538,7 +538,6 @@ func (r *BackupReconciler) getBackupRepo(
 		return repo, nil
 	}
 	// fallback to use the default repo
-	// TODO: cache the default repo?
 	return getDefaultBackupRepo(reqCtx.Ctx, r.Client)
 }
 

--- a/controllers/dataprotection/backup_controller_test.go
+++ b/controllers/dataprotection/backup_controller_test.go
@@ -693,6 +693,8 @@ var _ = Describe("Backup Controller test", func() {
 			By("creating backup tool")
 			backupTool = testapps.CreateCustomizedObj(&testCtx, "backup/backuptool.yaml",
 				&dpv1alpha1.BackupTool{}, testapps.RandomizedObjName())
+
+			viper.SetDefault(constant.CfgKeyBackupPVCName, "")
 		})
 
 		Context("explicitly specify backup repo", func() {

--- a/controllers/dataprotection/backup_controller_test.go
+++ b/controllers/dataprotection/backup_controller_test.go
@@ -24,20 +24,20 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	"github.com/spf13/viper"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	storagev1alpha1 "github.com/apecloud/kubeblocks/apis/storage/v1alpha1"
 	"github.com/apecloud/kubeblocks/internal/constant"
 	intctrlutil "github.com/apecloud/kubeblocks/internal/controllerutil"
 	"github.com/apecloud/kubeblocks/internal/generics"
@@ -79,6 +79,8 @@ var _ = Describe("Backup Controller test", func() {
 		// non-namespaced
 		testapps.ClearResources(&testCtx, generics.BackupToolSignature, ml)
 		testapps.ClearResources(&testCtx, generics.StorageClassSignature, ml)
+		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.BackupRepoSignature, true, ml)
+		testapps.ClearResources(&testCtx, generics.StorageProviderSignature, ml)
 	}
 	var nodeName string
 	var pvcName string
@@ -624,6 +626,171 @@ var _ = Describe("Backup Controller test", func() {
 					g.Expect(backup.Status.Phase).Should(Equal(dpv1alpha1.BackupFailed))
 					expectErr := intctrlutil.NewBackupScheduleDisabled(string(dpv1alpha1.BackupTypeLogFile), backupPolicyName)
 					g.Expect(backup.Status.FailureReason).Should(Equal(expectErr.Error()))
+				})).Should(Succeed())
+			})
+		})
+	})
+	When("with backup repo", func() {
+		var sp *storagev1alpha1.StorageProvider
+		var repo *dpv1alpha1.BackupRepo
+		var repoPVCName string
+		var backupTool *dpv1alpha1.BackupTool
+
+		createBackupPolicy := func(pvcName string, repoName string) *dpv1alpha1.BackupPolicy {
+			builder := testapps.NewBackupPolicyFactory(testCtx.DefaultNamespace, backupPolicyName).
+				AddDataFilePolicy().
+				SetPVC(pvcName).
+				SetBackupRepo(repoName).
+				SetBackupToolName(backupTool.Name).
+				AddMatchLabels(constant.AppInstanceLabelKey, clusterName)
+			return builder.Create(&testCtx).GetObject()
+		}
+
+		createBackup := func(policy *dpv1alpha1.BackupPolicy, change func(*dpv1alpha1.Backup)) *dpv1alpha1.Backup {
+			if change == nil {
+				change = func(*dpv1alpha1.Backup) {} // set nop
+			}
+			backup := testapps.NewBackupFactory(testCtx.DefaultNamespace, backupName).
+				SetBackupPolicyName(backupPolicyName).
+				SetBackupType(dpv1alpha1.BackupTypeDataFile).
+				Apply(change).
+				Create(&testCtx).GetObject()
+			return backup
+		}
+
+		createStorageProvider := func() *storagev1alpha1.StorageProvider {
+			sp := testapps.CreateCustomizedObj(&testCtx, "backup/storageprovider.yaml",
+				&storagev1alpha1.StorageProvider{})
+			// the storage provider controller is not running, so set the status manually
+			Expect(testapps.ChangeObjStatus(&testCtx, sp, func() {
+				sp.Status.Phase = storagev1alpha1.StorageProviderReady
+			})).Should(Succeed())
+			return sp
+		}
+
+		createRepo := func(change func(repo *dpv1alpha1.BackupRepo)) (*dpv1alpha1.BackupRepo, string) {
+			repo := testapps.CreateCustomizedObj(&testCtx, "backup/backuprepo.yaml",
+				&dpv1alpha1.BackupRepo{}, func(obj *dpv1alpha1.BackupRepo) {
+					obj.Spec.StorageProviderRef = sp.Name
+					if change != nil {
+						change(obj)
+					}
+				})
+			var repoPVCName string
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(repo), func(g Gomega, repo *dpv1alpha1.BackupRepo) {
+				g.Expect(repo.Status.Phase).Should(BeEquivalentTo(dpv1alpha1.BackupRepoReady))
+				g.Expect(repo.Status.BackupPVCName).ShouldNot(BeEmpty())
+				repoPVCName = repo.Status.BackupPVCName
+			})).Should(Succeed())
+			return repo, repoPVCName
+		}
+
+		BeforeEach(func() {
+			By("creating backup repo")
+			sp = createStorageProvider()
+			repo, repoPVCName = createRepo(nil)
+
+			By("creating backup tool")
+			backupTool = testapps.CreateCustomizedObj(&testCtx, "backup/backuptool.yaml",
+				&dpv1alpha1.BackupTool{}, testapps.RandomizedObjName())
+		})
+
+		Context("explicitly specify backup repo", func() {
+			It("should use the backup repo specified in the policy", func() {
+				By("creating backup policy and backup")
+				policy := createBackupPolicy("", repo.Name)
+				backup := createBackup(policy, nil)
+				By("checking backup, it should use the PVC from the backup repo")
+				Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(backup), func(g Gomega, backup *dpv1alpha1.Backup) {
+					g.Expect(backup.Status.PersistentVolumeClaimName).Should(BeEquivalentTo(repoPVCName))
+				})).Should(Succeed())
+			})
+
+			It("should use the backup repo specified in the backup object", func() {
+				By("creating a second backup repo")
+				repo2, repoPVCName2 := createRepo(nil)
+				By("creating backup policy and backup")
+				policy := createBackupPolicy("", repo.Name)
+				backup := createBackup(policy, func(backup *dpv1alpha1.Backup) {
+					if backup.Labels == nil {
+						backup.Labels = map[string]string{}
+					}
+					backup.Labels[dataProtectionBackupRepoKey] = repo2.Name
+				})
+				By("checking backup, it should use the PVC from repo2")
+				Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(backup), func(g Gomega, backup *dpv1alpha1.Backup) {
+					g.Expect(backup.Status.PersistentVolumeClaimName).Should(BeEquivalentTo(repoPVCName2))
+				})).Should(Succeed())
+			})
+		})
+
+		Context("default backup repo", func() {
+			It("should use the default backup repo if it's not specified", func() {
+				By("creating backup policy and backup")
+				policy := createBackupPolicy("", "")
+				backup := createBackup(policy, nil)
+				By("checking backup, it should use the PVC from the backup repo")
+				Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(backup), func(g Gomega, backup *dpv1alpha1.Backup) {
+					g.Expect(backup.Status.PersistentVolumeClaimName).Should(BeEquivalentTo(repoPVCName))
+				})).Should(Succeed())
+			})
+
+			Context("multiple default backup repos", func() {
+				var repoPVCName2 string
+				var policy *dpv1alpha1.BackupPolicy
+				BeforeEach(func() {
+					By("creating a second backup repo")
+					sp2 := createStorageProvider()
+					_, repoPVCName2 = createRepo(func(repo *dpv1alpha1.BackupRepo) {
+						repo.Spec.StorageProviderRef = sp2.Name
+					})
+					By("creating backup policy")
+					policy = createBackupPolicy("", "")
+				})
+
+				It("should fail if there are multiple default backup repos", func() {
+					By("creating backup")
+					backup := createBackup(policy, nil)
+					By("checking backup, it should fail because there are multiple default backup repos")
+					Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(backup), func(g Gomega, backup *dpv1alpha1.Backup) {
+						g.Expect(backup.Status.Phase).Should(BeEquivalentTo(dpv1alpha1.BackupFailed))
+						g.Expect(backup.Status.FailureReason).Should(ContainSubstring("multiple default BackupRepo found"))
+					})).Should(Succeed())
+				})
+
+				It("should only repos in ready status can be selected as the default backup repo", func() {
+					By("making repo to failed status")
+					Eventually(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKeyFromObject(sp),
+						func(fetched *storagev1alpha1.StorageProvider) {
+							fetched.Status.Phase = storagev1alpha1.StorageProviderNotReady
+						})).ShouldNot(HaveOccurred())
+					Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(repo),
+						func(g Gomega, repo *dpv1alpha1.BackupRepo) {
+							g.Expect(repo.Status.Phase).Should(BeEquivalentTo(dpv1alpha1.BackupRepoFailed))
+						})).Should(Succeed())
+					By("creating backup")
+					backup := createBackup(policy, func(backup *dpv1alpha1.Backup) {
+						backup.Name = "second-backup"
+					})
+					By("checking backup, it should use the PVC from repo2")
+					Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(backup), func(g Gomega, backup *dpv1alpha1.Backup) {
+						g.Expect(backup.Status.PersistentVolumeClaimName).Should(BeEquivalentTo(repoPVCName2))
+					})).Should(Succeed())
+				})
+			})
+		})
+
+		Context("no backup repo available", func() {
+			It("should fail if there is no available backup repo", func() {
+				By("deleting backup repo")
+				testapps.DeleteObject(&testCtx, client.ObjectKeyFromObject(repo), &dpv1alpha1.BackupRepo{})
+				By("creating backup")
+				policy := createBackupPolicy("", "")
+				backup := createBackup(policy, nil)
+				By("checking backup, it should fail because there are multiple default backup repos")
+				Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(backup), func(g Gomega, backup *dpv1alpha1.Backup) {
+					g.Expect(backup.Status.Phase).Should(BeEquivalentTo(dpv1alpha1.BackupFailed))
+					g.Expect(backup.Status.FailureReason).Should(ContainSubstring("no default BackupRepo found"))
 				})).Should(Succeed())
 			})
 		})

--- a/controllers/dataprotection/backup_controller_test.go
+++ b/controllers/dataprotection/backup_controller_test.go
@@ -784,8 +784,10 @@ var _ = Describe("Backup Controller test", func() {
 
 		Context("no backup repo available", func() {
 			It("should fail if there is no available backup repo", func() {
-				By("deleting backup repo")
-				testapps.DeleteObject(&testCtx, client.ObjectKeyFromObject(repo), &dpv1alpha1.BackupRepo{})
+				By("making the backup repo as non-default")
+				Eventually(testapps.GetAndChangeObj(&testCtx, client.ObjectKeyFromObject(repo), func(repo *dpv1alpha1.BackupRepo) {
+					delete(repo.Annotations, constant.DefaultBackupRepoAnnotationKey)
+				})).Should(Succeed())
 				By("creating backup")
 				policy := createBackupPolicy("", "")
 				backup := createBackup(policy, nil)

--- a/controllers/dataprotection/backuppolicy_controller.go
+++ b/controllers/dataprotection/backuppolicy_controller.go
@@ -339,7 +339,7 @@ func (r *BackupPolicyReconciler) reconcileForStatefulSetKind(
 	backup.Labels[constant.AppManagedByLabelKey] = constant.AppName
 	backup.Labels[dataProtectionLabelBackupPolicyKey] = backupPolicy.Name
 	backup.Labels[dataProtectionLabelBackupTypeKey] = string(backType)
-	backup.Labels[dataProtectionLabelAutoBackupKey] = "true"
+	backup.Labels[dataProtectionLabelAutoBackupKey] = trueVal
 	if !exists {
 		if cronExpression == "" {
 			return nil
@@ -568,8 +568,8 @@ func (r *BackupPolicyReconciler) handleLogfilePolicy(
 func (r *BackupPolicyReconciler) setGlobalPersistentVolumeClaim(backupPolicy *dataprotectionv1alpha1.CommonBackupPolicy) {
 	pvcCfg := backupPolicy.PersistentVolumeClaim
 	globalPVCName := viper.GetString(constant.CfgKeyBackupPVCName)
-	if len(pvcCfg.Name) == 0 && globalPVCName != "" {
-		backupPolicy.PersistentVolumeClaim.Name = globalPVCName
+	if (pvcCfg.Name == nil || len(*pvcCfg.Name) == 0) && globalPVCName != "" {
+		backupPolicy.PersistentVolumeClaim.Name = &globalPVCName
 	}
 
 	globalInitCapacity := viper.GetString(constant.CfgKeyBackupPVCInitCapacity)

--- a/controllers/dataprotection/backuppolicy_controller_test.go
+++ b/controllers/dataprotection/backuppolicy_controller_test.go
@@ -339,7 +339,8 @@ var _ = Describe("Backup Policy Controller", func() {
 				backupPolicyKey := client.ObjectKeyFromObject(backupPolicy)
 				Eventually(testapps.CheckObj(&testCtx, backupPolicyKey, func(g Gomega, fetched *dpv1alpha1.BackupPolicy) {
 					g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.PolicyAvailable))
-					g.Expect(fetched.Spec.Datafile.PersistentVolumeClaim.Name).To(Equal(pvcName))
+					g.Expect(fetched.Spec.Datafile.PersistentVolumeClaim.Name).ToNot(BeNil())
+					g.Expect(*fetched.Spec.Datafile.PersistentVolumeClaim.Name).To(Equal(pvcName))
 					g.Expect(fetched.Spec.Datafile.PersistentVolumeClaim.InitCapacity.String()).To(Equal(pvcInitCapacity))
 				})).Should(Succeed())
 			})

--- a/controllers/dataprotection/backuprepo_controller.go
+++ b/controllers/dataprotection/backuprepo_controller.go
@@ -425,11 +425,12 @@ func (r *BackupRepoReconciler) listAssociatedBackups(
 	}
 	err := r.Client.List(reqCtx.Ctx, backupList, selectors)
 	var filtered []*dpv1alpha1.Backup
-	for _, backup := range backupList.Items {
+	for idx := range backupList.Items {
+		backup := &backupList.Items[idx]
 		if backup.Status.Phase == dpv1alpha1.BackupFailed {
 			continue
 		}
-		filtered = append(filtered, backup.DeepCopy())
+		filtered = append(filtered, backup)
 	}
 	return filtered, err
 }

--- a/controllers/dataprotection/backuprepo_controller_test.go
+++ b/controllers/dataprotection/backuprepo_controller_test.go
@@ -531,7 +531,7 @@ parameters:
 			Eventually(testapps.CheckObj(&testCtx, pvcKey, func(g Gomega, pvc *corev1.PersistentVolumeClaim) {
 				g.Expect(pvc).ShouldNot(BeNil())
 			})).Should(Succeed())
-			return
+			return backup, pvcName
 		}
 
 		It("should create a PVC in Backup's namespace (in default namespace)", func() {

--- a/controllers/dataprotection/type.go
+++ b/controllers/dataprotection/type.go
@@ -30,6 +30,10 @@ import (
 )
 
 const (
+	trueVal = "true"
+)
+
+const (
 	// name of our custom finalizer
 	dataProtectionFinalizerName = "dataprotection.kubeblocks.io/finalizer"
 	// settings keys
@@ -48,7 +52,6 @@ const (
 	dataProtectionNeedRepoPVCKey = "dataprotection.kubeblocks.io/need-repo-pvc"
 
 	// annotation keys
-	dataProtectionRepoPVCNameAnnotationKey       = "dataprotection.kubeblocks.io/repo-pvc-name"
 	dataProtectionSecretTemplateMD5AnnotationKey = "dataprotection.kubeblocks.io/secret-template-md5"
 	dataProtectionTemplateValuesMD5AnnotationKey = "dataprotection.kubeblocks.io/template-values-md5"
 

--- a/controllers/dataprotection/utils.go
+++ b/controllers/dataprotection/utils.go
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package dataprotection
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -267,6 +268,30 @@ func buildDeleteBackupFilesJobNamespacedName(backup *dataprotectionv1alpha1.Back
 		jobName = jobName[:63]
 	}
 	return types.NamespacedName{Namespace: backup.Namespace, Name: jobName}
+}
+
+func getDefaultBackupRepo(ctx context.Context, cli client.Client) (*dataprotectionv1alpha1.BackupRepo, error) {
+	backupList := &dataprotectionv1alpha1.BackupRepoList{}
+	err := cli.List(ctx, backupList)
+	if err != nil {
+		return nil, err
+	}
+	var defaultRepo *dataprotectionv1alpha1.BackupRepo
+	for _, repo := range backupList.Items {
+		if repo.Annotations[constant.DefaultBackupRepoAnnotationKey] == trueVal &&
+			repo.Status.Phase == dataprotectionv1alpha1.BackupRepoReady {
+			if defaultRepo == nil {
+				defaultRepo = repo.DeepCopy()
+			} else {
+				return nil, fmt.Errorf("multiple default BackupRepo found, both %s and %s are default",
+					defaultRepo.Name, repo.Name)
+			}
+		}
+	}
+	if defaultRepo == nil {
+		return nil, fmt.Errorf("no default BackupRepo found")
+	}
+	return defaultRepo, nil
 }
 
 // ============================================================================

--- a/controllers/dataprotection/utils.go
+++ b/controllers/dataprotection/utils.go
@@ -271,17 +271,18 @@ func buildDeleteBackupFilesJobNamespacedName(backup *dataprotectionv1alpha1.Back
 }
 
 func getDefaultBackupRepo(ctx context.Context, cli client.Client) (*dataprotectionv1alpha1.BackupRepo, error) {
-	backupList := &dataprotectionv1alpha1.BackupRepoList{}
-	err := cli.List(ctx, backupList)
+	backupRepoList := &dataprotectionv1alpha1.BackupRepoList{}
+	err := cli.List(ctx, backupRepoList)
 	if err != nil {
 		return nil, err
 	}
 	var defaultRepo *dataprotectionv1alpha1.BackupRepo
-	for _, repo := range backupList.Items {
+	for idx := range backupRepoList.Items {
+		repo := &backupRepoList.Items[idx]
 		if repo.Annotations[constant.DefaultBackupRepoAnnotationKey] == trueVal &&
 			repo.Status.Phase == dataprotectionv1alpha1.BackupRepoReady {
 			if defaultRepo == nil {
-				defaultRepo = repo.DeepCopy()
+				defaultRepo = repo
 			} else {
 				return nil, fmt.Errorf("multiple default BackupRepo found, both %s and %s are default",
 					defaultRepo.Name, repo.Name)

--- a/controllers/dataprotection/utils.go
+++ b/controllers/dataprotection/utils.go
@@ -279,15 +279,16 @@ func getDefaultBackupRepo(ctx context.Context, cli client.Client) (*dataprotecti
 	var defaultRepo *dataprotectionv1alpha1.BackupRepo
 	for idx := range backupRepoList.Items {
 		repo := &backupRepoList.Items[idx]
-		if repo.Annotations[constant.DefaultBackupRepoAnnotationKey] == trueVal &&
-			repo.Status.Phase == dataprotectionv1alpha1.BackupRepoReady {
-			if defaultRepo == nil {
-				defaultRepo = repo
-			} else {
-				return nil, fmt.Errorf("multiple default BackupRepo found, both %s and %s are default",
-					defaultRepo.Name, repo.Name)
-			}
+		// skip non-default repo
+		if !(repo.Annotations[constant.DefaultBackupRepoAnnotationKey] == trueVal &&
+			repo.Status.Phase == dataprotectionv1alpha1.BackupRepoReady) {
+			continue
 		}
+		if defaultRepo != nil {
+			return nil, fmt.Errorf("multiple default BackupRepo found, both %s and %s are default",
+				defaultRepo.Name, repo.Name)
+		}
+		defaultRepo = repo
 	}
 	if defaultRepo == nil {
 		return nil, fmt.Errorf("no default BackupRepo found")

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -140,7 +140,6 @@ spec:
                         description: the name of PersistentVolumeClaim to store backup
                           data.
                         maxLength: 63
-                        pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
                       persistentVolumeConfigMap:
                         description: 'persistentVolumeConfigMap references the configmap
@@ -344,7 +343,6 @@ spec:
                         description: the name of PersistentVolumeClaim to store backup
                           data.
                         maxLength: 63
-                        pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
                       persistentVolumeConfigMap:
                         description: 'persistentVolumeConfigMap references the configmap

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -53,6 +53,12 @@ spec:
               datafile:
                 description: the policy for datafile backup.
                 properties:
+                  backupRepoName:
+                    description: refer to BackupRepo and the backup data will be stored
+                      in the corresponding repo.
+                    maxLength: 63
+                    pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                    type: string
                   backupStatusUpdates:
                     description: define how to update metadata for backup status.
                     items:
@@ -131,10 +137,10 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       name:
-                        default: kb-backup-data
                         description: the name of PersistentVolumeClaim to store backup
                           data.
                         maxLength: 63
+                        pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
                       persistentVolumeConfigMap:
                         description: 'persistentVolumeConfigMap references the configmap
@@ -166,8 +172,6 @@ spec:
                         maxLength: 63
                         pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
-                    required:
-                    - name
                     type: object
                   target:
                     description: target database cluster for backup.
@@ -248,12 +252,17 @@ spec:
                     - labelsSelector
                     type: object
                 required:
-                - persistentVolumeClaim
                 - target
                 type: object
               logfile:
                 description: the policy for logfile backup.
                 properties:
+                  backupRepoName:
+                    description: refer to BackupRepo and the backup data will be stored
+                      in the corresponding repo.
+                    maxLength: 63
+                    pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                    type: string
                   backupStatusUpdates:
                     description: define how to update metadata for backup status.
                     items:
@@ -332,10 +341,10 @@ spec:
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       name:
-                        default: kb-backup-data
                         description: the name of PersistentVolumeClaim to store backup
                           data.
                         maxLength: 63
+                        pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
                       persistentVolumeConfigMap:
                         description: 'persistentVolumeConfigMap references the configmap
@@ -367,8 +376,6 @@ spec:
                         maxLength: 63
                         pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                         type: string
-                    required:
-                    - name
                     type: object
                   target:
                     description: target database cluster for backup.
@@ -449,7 +456,6 @@ spec:
                     - labelsSelector
                     type: object
                 required:
-                - persistentVolumeClaim
                 - target
                 type: object
               retention:

--- a/internal/cli/cmd/cluster/dataprotection.go
+++ b/internal/cli/cmd/cluster/dataprotection.go
@@ -736,7 +736,7 @@ func (o *editBackupPolicyOptions) complete(args []string) error {
 	}
 	updatePVCName := func(commonPolicy *dpv1alpha1.CommonBackupPolicy, targetVal string) error {
 		if commonPolicy != nil {
-			commonPolicy.PersistentVolumeClaim.Name = targetVal
+			commonPolicy.PersistentVolumeClaim.Name = &targetVal
 		}
 		return nil
 	}

--- a/internal/cli/testing/fake.go
+++ b/internal/cli/testing/fake.go
@@ -365,7 +365,7 @@ func FakeBackupPolicy(backupPolicyName, clusterName string) *dpv1alpha1.BackupPo
 					BackupsHistoryLimit: 1,
 				},
 				PersistentVolumeClaim: dpv1alpha1.PersistentVolumeClaim{
-					Name: "test1",
+					Name: pointer.String("test1"),
 				},
 			},
 			Logfile: &dpv1alpha1.CommonBackupPolicy{
@@ -373,7 +373,7 @@ func FakeBackupPolicy(backupPolicyName, clusterName string) *dpv1alpha1.BackupPo
 					BackupsHistoryLimit: 1,
 				},
 				PersistentVolumeClaim: dpv1alpha1.PersistentVolumeClaim{
-					Name: "test1",
+					Name: pointer.String("test1"),
 				},
 			},
 			Schedule: dpv1alpha1.Schedule{

--- a/internal/testutil/apps/backuppolicy_factory.go
+++ b/internal/testutil/apps/backuppolicy_factory.go
@@ -22,6 +22,7 @@ package apps
 import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 
 	dataprotectionv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
 	"github.com/apecloud/kubeblocks/internal/constant"
@@ -102,7 +103,7 @@ func (factory *MockBackupPolicyFactory) AddSnapshotPolicy() *MockBackupPolicyFac
 func (factory *MockBackupPolicyFactory) AddDataFilePolicy() *MockBackupPolicyFactory {
 	factory.get().Spec.Datafile = &dataprotectionv1alpha1.CommonBackupPolicy{
 		PersistentVolumeClaim: dataprotectionv1alpha1.PersistentVolumeClaim{
-			Name:         "backup-data",
+			Name:         pointer.String("backup-data"),
 			CreatePolicy: dataprotectionv1alpha1.CreatePVCPolicyIfNotPresent,
 		},
 	}
@@ -113,7 +114,7 @@ func (factory *MockBackupPolicyFactory) AddDataFilePolicy() *MockBackupPolicyFac
 func (factory *MockBackupPolicyFactory) AddLogfilePolicy() *MockBackupPolicyFactory {
 	factory.get().Spec.Logfile = &dataprotectionv1alpha1.CommonBackupPolicy{
 		PersistentVolumeClaim: dataprotectionv1alpha1.PersistentVolumeClaim{
-			Name:         "backup-data",
+			Name:         pointer.String("backup-data"),
 			CreatePolicy: dataprotectionv1alpha1.CreatePVCPolicyIfNotPresent,
 		},
 	}
@@ -206,8 +207,23 @@ func (factory *MockBackupPolicyFactory) AddHookPostCommand(postCommand string) *
 
 func (factory *MockBackupPolicyFactory) SetPVC(pvcName string) *MockBackupPolicyFactory {
 	factory.setCommonPolicyField(func(commonPolicy *dataprotectionv1alpha1.CommonBackupPolicy) {
-		commonPolicy.PersistentVolumeClaim.Name = pvcName
+		if pvcName == "" {
+			commonPolicy.PersistentVolumeClaim.Name = nil
+		} else {
+			commonPolicy.PersistentVolumeClaim.Name = &pvcName
+		}
 		commonPolicy.PersistentVolumeClaim.InitCapacity = resource.MustParse(constant.DefaultBackupPvcInitCapacity)
+	})
+	return factory
+}
+
+func (factory *MockBackupPolicyFactory) SetBackupRepo(repoName string) *MockBackupPolicyFactory {
+	factory.setCommonPolicyField(func(commonPolicy *dataprotectionv1alpha1.CommonBackupPolicy) {
+		if repoName == "" {
+			commonPolicy.BackupRepoName = nil
+		} else {
+			commonPolicy.BackupRepoName = &repoName
+		}
 	})
 	return factory
 }

--- a/internal/testutil/apps/backuprepo_factory.go
+++ b/internal/testutil/apps/backuprepo_factory.go
@@ -1,0 +1,82 @@
+/*
+Copyright (C) 2022-2023 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package apps
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	dataprotectionv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	"github.com/apecloud/kubeblocks/internal/constant"
+)
+
+type MockBackupRepoFactory struct {
+	BaseFactory[dataprotectionv1alpha1.BackupRepo, *dataprotectionv1alpha1.BackupRepo, MockBackupRepoFactory]
+}
+
+func NewBackupRepoFactory(namespace, name string) *MockBackupRepoFactory {
+	f := &MockBackupRepoFactory{}
+	f.init(namespace, name,
+		&dataprotectionv1alpha1.BackupRepo{
+			Spec: dataprotectionv1alpha1.BackupRepoSpec{
+				VolumeCapacity:  resource.MustParse("100Gi"),
+				PVReclaimPolicy: "Retain",
+			},
+		}, f)
+	return f
+}
+
+func (factory *MockBackupRepoFactory) SetStorageProviderRef(providerName string) *MockBackupRepoFactory {
+	factory.get().Spec.StorageProviderRef = providerName
+	return factory
+}
+
+func (factory *MockBackupRepoFactory) SetVolumeCapacity(amount string) *MockBackupRepoFactory {
+	factory.get().Spec.VolumeCapacity = resource.MustParse(amount)
+	return factory
+}
+
+func (factory *MockBackupRepoFactory) SetPVReclaimPolicy(policy string) *MockBackupRepoFactory {
+	factory.get().Spec.PVReclaimPolicy = corev1.PersistentVolumeReclaimPolicy(policy)
+	return factory
+}
+
+func (factory *MockBackupRepoFactory) SetConfig(config map[string]string) *MockBackupRepoFactory {
+	factory.get().Spec.Config = config
+	return factory
+}
+
+func (factory *MockBackupRepoFactory) SetCredential(ref *corev1.SecretReference) *MockBackupRepoFactory {
+	factory.get().Spec.Credential = ref
+	return factory
+}
+
+func (factory *MockBackupRepoFactory) SetAsDefaultRepo(v bool) *MockBackupRepoFactory {
+	if v {
+		obj := factory.get()
+		if obj.Annotations == nil {
+			obj.Annotations = map[string]string{}
+		}
+		obj.Annotations[constant.DefaultBackupRepoAnnotationKey] = "true"
+	} else {
+		delete(factory.get().Annotations, constant.DefaultBackupRepoAnnotationKey)
+	}
+	return factory
+}

--- a/internal/testutil/apps/base_factory.go
+++ b/internal/testutil/apps/base_factory.go
@@ -136,6 +136,11 @@ func (factory *BaseFactory[T, PT, F]) AddFinalizers(finalizers []string) *F {
 	return factory.concreteFactory
 }
 
+func (factory *BaseFactory[T, PT, F]) Apply(changeFn func(PT)) *F {
+	changeFn(factory.object)
+	return factory.concreteFactory
+}
+
 func (factory *BaseFactory[T, PT, F]) Create(testCtx *testutil.TestContext) *F {
 	gomega.Expect(testCtx.CreateObj(testCtx.Ctx, factory.get())).Should(gomega.Succeed())
 	return factory.concreteFactory

--- a/test/testdata/backup/backuprepo.yaml
+++ b/test/testdata/backup/backuprepo.yaml
@@ -1,0 +1,10 @@
+apiVersion: dataprotection.kubeblocks.io/v1alpha1
+kind: BackupRepo
+metadata:
+  generateName: backup-repo-
+  annotations:
+    dataprotection.kubeblocks.io/is-default-repo: "true"
+spec:
+  storageProviderRef: "storage-provider-test"
+  pvReclaimPolicy: "Retain"
+  volumeCapacity: 100Gi

--- a/test/testdata/backup/storageprovider.yaml
+++ b/test/testdata/backup/storageprovider.yaml
@@ -1,0 +1,11 @@
+apiVersion: storage.kubeblocks.io/v1alpha1
+kind: StorageProvider
+metadata:
+  generateName: storage-provider-
+spec:
+  csiDriverName: testcsidriver.kubeblocks.io
+  storageClassTemplate: |
+    provisioner: testcsidriver.kubeblocks.io
+    reclaimPolicy: Retain
+    allowVolumeExpansion: true
+    volumeBindingMode: Immediate


### PR DESCRIPTION
This PR integrates BackupRepo with the backup controller.

To be compatible with the old backup behavior, it will only use the PVC created by BackupRepo if `CommonBackupPolicy.PersistentVolumeClaim.Name` is empty.

The backup object searches for an available backup repo in the following order:
* Use the repo specified by the `dataprotection.kubeblocks.io/backup-repo-name` label in the backup object.
* Use the repo specified in the backup policy.
* Use the global default repo.

If there are multiple default repos in the system, the backup will fail because it cannot select a repo. This behavior follows the k8s StorageClass.

to #3407.