### PR TITLE
feat: add kbcli cluster describe-backup command

### DIFF
--- a/docs/user_docs/cli/cli.md
+++ b/docs/user_docs/cli/cli.md
@@ -65,6 +65,7 @@ Cluster command.
 * [kbcli cluster delete-ops](kbcli_cluster_delete-ops.md)	 - Delete an OpsRequest.
 * [kbcli cluster describe](kbcli_cluster_describe.md)	 - Show details of a specific cluster.
 * [kbcli cluster describe-account](kbcli_cluster_describe-account.md)	 - Describe account roles and related information
+* [kbcli cluster describe-backup](kbcli_cluster_describe-backup.md)	 - Describe a backup.
 * [kbcli cluster describe-config](kbcli_cluster_describe-config.md)	 - Show details of a specific reconfiguring.
 * [kbcli cluster describe-ops](kbcli_cluster_describe-ops.md)	 - Show details of a specific OpsRequest.
 * [kbcli cluster diff-config](kbcli_cluster_diff-config.md)	 - Show the difference in parameters between the two submitted OpsRequest.

--- a/docs/user_docs/cli/kbcli_cluster.md
+++ b/docs/user_docs/cli/kbcli_cluster.md
@@ -49,6 +49,7 @@ Cluster command.
 * [kbcli cluster delete-ops](kbcli_cluster_delete-ops.md)	 - Delete an OpsRequest.
 * [kbcli cluster describe](kbcli_cluster_describe.md)	 - Show details of a specific cluster.
 * [kbcli cluster describe-account](kbcli_cluster_describe-account.md)	 - Describe account roles and related information
+* [kbcli cluster describe-backup](kbcli_cluster_describe-backup.md)	 - Describe a backup.
 * [kbcli cluster describe-config](kbcli_cluster_describe-config.md)	 - Show details of a specific reconfiguring.
 * [kbcli cluster describe-ops](kbcli_cluster_describe-ops.md)	 - Show details of a specific OpsRequest.
 * [kbcli cluster diff-config](kbcli_cluster_diff-config.md)	 - Show the difference in parameters between the two submitted OpsRequest.

--- a/docs/user_docs/cli/kbcli_cluster_describe-backup.md
+++ b/docs/user_docs/cli/kbcli_cluster_describe-backup.md
@@ -1,0 +1,53 @@
+---
+title: kbcli cluster describe-backup
+---
+
+Describe a backup.
+
+```
+kbcli cluster describe-backup BACKUP-NAME [flags]
+```
+
+### Examples
+
+```
+  # describe a backup
+  kbcli cluster describe-backup backup-default-mycluster-20230616190023
+```
+
+### Options
+
+```
+  -h, --help   help for describe-backup
+```
+
+### Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --disable-compression            If true, opt-out of response compression for all requests to the server
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --match-server-version           Require server version to match client version
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+### SEE ALSO
+
+* [kbcli cluster](kbcli_cluster.md)	 - Cluster command.
+
+#### Go Back to [CLI Overview](cli.md) Homepage.
+

--- a/docs/user_docs/cli/kbcli_kubeblocks_compare.md
+++ b/docs/user_docs/cli/kbcli_kubeblocks_compare.md
@@ -1,40 +1,27 @@
 ---
-title: kbcli builder template
+title: kbcli kubeblocks compare
 ---
 
-tpl - a developer tool integrated with KubeBlocks that can help developers quickly generate rendered configurations or scripts based on Helm templates, and discover errors in the template before creating the database cluster.
+List the changes between two different version KubeBlocks.
 
 ```
-kbcli builder template [flags]
+kbcli kubeblocks compare version [OTHER-VERSION] [flags]
 ```
 
 ### Examples
 
 ```
-  # builder template: Provides a mechanism to rendered template for ComponentConfigSpec and ComponentScriptSpec in the ClusterComponentDefinition.
-  # builder template --helm deploy/redis --memory=64Gi --cpu=16 --replicas=3 --component-name=redis --config-spec=redis-replication-config
+  # compare installed KubeBlocks with specified version
+  kbcli kubeblocks compare 0.4.0
   
-  # build all configspec
-  kbcli builder template --helm deploy/redis -a
+  # compare two specified KubeBlocks version
+  kbcli kubeblocks compare 0.4.0 0.5.0
 ```
 
 ### Options
 
 ```
-      --clean                       specify whether to clear the output dir
-      --cluster string              the cluster yaml file
-      --cluster-definition string   specify the cluster definition name
-      --cluster-version string      specify the cluster version name
-      --component-name string       specify the component name of the clusterdefinition
-      --config-spec string          specify the config spec to be rendered
-      --cpu string                  specify the cpu of the component
-      --helm string                 specify the helm template dir
-      --helm-output string          specify the helm template output dir
-  -h, --help                        help for template
-      --memory string               specify the memory of the component
-  -o, --output-dir string           specify the output directory
-  -r, --replicas int32              specify the replicas of the component (default 1)
-      --volume-name string          specify the data volume name of the component
+  -h, --help   help for compare
 ```
 
 ### Options inherited from parent commands
@@ -47,6 +34,7 @@ kbcli builder template [flags]
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
       --context string                 The name of the kubeconfig context to use
       --disable-compression            If true, opt-out of response compression for all requests to the server
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
@@ -62,7 +50,7 @@ kbcli builder template [flags]
 
 ### SEE ALSO
 
-* [kbcli builder](kbcli_builder.md)	 - builder command.
+* [kbcli kubeblocks](kbcli_kubeblocks.md)	 - KubeBlocks operation commands.
 
 #### Go Back to [CLI Overview](cli.md) Homepage.
 

--- a/internal/cli/cmd/cluster/cluster.go
+++ b/internal/cli/cmd/cluster/cluster.go
@@ -95,6 +95,7 @@ func NewClusterCmd(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobr
 				NewListBackupCmd(f, streams),
 				NewDeleteBackupCmd(f, streams),
 				NewCreateRestoreCmd(f, streams),
+				NewDescribeBackupCmd(f, streams),
 			},
 		},
 		{

--- a/internal/cli/cmd/cluster/dataprotection.go
+++ b/internal/cli/cmd/cluster/dataprotection.go
@@ -114,9 +114,6 @@ var (
 	describeBackupExample = templates.Examples(`
 		# describe a backup
 		kbcli cluster describe-backup backup-default-mycluster-20230616190023
-
-		# using short cmd to describe a backup
-		kbcli cluster desc-bp backup-default-mycluster-20230616190023
 	`)
 )
 

--- a/internal/cli/cmd/cluster/dataprotection.go
+++ b/internal/cli/cmd/cluster/dataprotection.go
@@ -1104,7 +1104,7 @@ func (o *describeBackupOptions) printBackupObj(obj *dpv1alpha1.Backup) error {
 		}
 	}
 
-	// get all events about cluster
+	// get all events about backup
 	events, err := o.client.CoreV1().Events(o.namespace).Search(scheme.Scheme, obj)
 	if err != nil {
 		return err


### PR DESCRIPTION
- add `describe-backup` sub command with following output:
```
kbcli cluster describe-backup backup-default-pg-20230705174337
Name: backup-default-pg-20230705174337	Cluster: pg	Namespace: default

Spec:
  Type:               datafile
  Policy Name:        pg-postgresql-backup-policy

Status:
  Phase:              Completed
  Backup Tool:        postgres-basebackup
  PVC Name:           kb-backup-data
  Duration:           93s
  Expiration Time:    Jul 12,2023 17:43 UTC+0800
  Start Time:         Jul 05,2023 17:43 UTC+0800
  Completion Time:    Jul 05,2023 17:45 UTC+0800

Manifests:
  Log Start Time:     Jul 05,2023 17:33 UTC+0800
  Log Stop Time:      Jul 05,2023 17:33 UTC+0800
  File Path:          /default/pg-696cc9d9-d488-4e88-a933-2ab91478d301/postgresql/backup-default-pg-20230705174337
  Volume Name:        pvc-92edbfc9-e67b-4bf9-a5fa-4a4a5e155e14

Warning Events: <none>
```
fix: #3842 