### PR TITLE
fix: fix goreleaser build

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,6 +29,8 @@ builds:
     env:
       - ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=go1.20
       - CGO_ENABLED=0
+    tags:
+      - containers_image_openpgp
     ldflags:
       - -s -w -X github.com/apecloud/kubeblocks/version.BuildDate={{ .Date }}
       - -s -w -X github.com/apecloud/kubeblocks/version.GitCommit={{ .FullCommit }}


### PR DESCRIPTION
* resolve  #4161


The bug of the cotainers package requires the cgo option to be enabled for compilation. If you do not want to enable cgo, you can add tags `containers_image_openpgp`. 

For details, see:
https://github.com/containers/image/pull/1638
