### PR TITLE
chore: merge etcd,vtconsensus and vtctld components of wesql-scale into one

### DIFF
--- a/deploy/apecloud-mysql-cluster/templates/_helpers.tpl
+++ b/deploy/apecloud-mysql-cluster/templates/_helpers.tpl
@@ -13,14 +13,8 @@ The proxy cpu cores is 1/6 of the cluster total cpu cores.
 {{- if eq (mod $proxyCPU 2) 1 }}
 {{- $proxyCPU = add $proxyCPU 1 }}
 {{- end }}
-- name: etcd
-  componentDefRef: etcd # ref clusterdefinition componentDefs.name
-  replicas: 1
-- name: vtctld
-  componentDefRef: vtctld # ref clusterdefinition componentDefs.name
-  replicas: 1
-- name: vtconsensus
-  componentDefRef: vtconsensus # ref clusterdefinition componentDefs.name
+- name: vitess
+  componentDefRef: vitess # ref clusterdefinition componentDefs.name
   replicas: 1
 - name: vtgate
   componentDefRef: vtgate # ref clusterdefinition componentDefs.name

--- a/deploy/apecloud-mysql-cluster/templates/_helpers.tpl
+++ b/deploy/apecloud-mysql-cluster/templates/_helpers.tpl
@@ -15,6 +15,14 @@ The proxy cpu cores is 1/6 of the cluster total cpu cores.
 {{- end }}
 - name: vitess
   componentDefRef: vitess # ref clusterdefinition componentDefs.name
+  volumeClaimTemplates:
+    - name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi
   replicas: 1
 - name: vtgate
   componentDefRef: vtgate # ref clusterdefinition componentDefs.name

--- a/deploy/apecloud-mysql/templates/clusterdefinition.yaml
+++ b/deploy/apecloud-mysql/templates/clusterdefinition.yaml
@@ -339,6 +339,9 @@ spec:
     - name: vitess
       charactorType: vitess
       workloadType: Stateful
+      volumeTypes:
+        - name: data
+          type: data
       scriptSpecs:
         - name: apecloud-mysql-scripts
           templateRef: apecloud-mysql-scripts
@@ -384,6 +387,8 @@ spec:
             volumeMounts:
               - name: scripts
                 mountPath: /scripts
+              - name: data
+                mountPath: /vtdataroot/etcd
             lifecycle:
               postStart:
                 exec:

--- a/deploy/apecloud-mysql/templates/clusterdefinition.yaml
+++ b/deploy/apecloud-mysql/templates/clusterdefinition.yaml
@@ -231,7 +231,7 @@ spec:
               - name: CELL
                 value: {{ .Values.wesqlscale.cell | default "zone1" | quote }}
               - name: ETCD_SERVER
-                value: "$(KB_CLUSTER_NAME)-etcd-headless"
+                value: "$(KB_CLUSTER_NAME)-vitess-headless"
               - name: ETCD_PORT
                 value: "2379"
               - name: TOPOLOGY_FLAGS
@@ -241,7 +241,7 @@ spec:
               - name: VTTABLET_GRPC_PORT
                 value: "16100"
               - name: VTCTLD_HOST
-                value: "$(KB_CLUSTER_NAME)-vtctld-headless"
+                value: "$(KB_CLUSTER_NAME)-vitess-headless"
               - name: VTCTLD_WEB_PORT
                 value: "15000"
               - name: MYSQL_ROOT_USER
@@ -336,112 +336,9 @@ spec:
               statements:
                 creation: CREATE USER $(USERNAME) IDENTIFIED BY '$(PASSWD)'; GRANT REPLICATION SLAVE ON *.* TO $(USERNAME) WITH GRANT OPTION;
                 update: ALTER USER $(USERNAME) IDENTIFIED BY '$(PASSWD)';
-    - name: etcd
-      characterType: etcd
+    - name: vitess
+      charactorType: vitess
       workloadType: Stateful
-      scriptSpecs:
-        - name: apecloud-mysql-scripts
-          templateRef: apecloud-mysql-scripts
-          namespace: {{ .Release.Namespace }}
-          volumeName: scripts
-          defaultMode: 493
-      service:
-        ports:
-          - name: client
-            port: 2379
-            targetPort: client
-      podSpec:
-        containers:
-          - name: etcd
-            imagePullPolicy: IfNotPresent
-            ports:
-              - containerPort: 2379
-                name: client
-            env:
-              - name: CELL
-                value: {{ .Values.wesqlscale.cell | default "zone1" | quote }}
-              - name: ETCDCTL_API
-                value: "2"
-              - name: ETCD_SERVER
-                value: "$(KB_CLUSTER_NAME)-etcd-headless"
-              - name: ETCD_PORT
-                value: "2379"
-              - name: TOPOLOGY_FLAGS
-                value: "--topo_implementation etcd2 --topo_global_server_address $(ETCD_SERVER):$(ETCD_PORT) --topo_global_root /vitess/global"
-            command: ["/scripts/etcd.sh"]
-            volumeMounts:
-              - name: scripts
-                mountPath: /scripts
-            lifecycle:
-              postStart:
-                exec:
-                  command: ["/scripts/etcd-post-start.sh"]
-    - name: vtctld
-      characterType: vtctld
-      workloadType: Stateless
-      scriptSpecs:
-        - name: apecloud-mysql-scripts
-          templateRef: apecloud-mysql-scripts
-          namespace: {{ .Release.Namespace }}
-          volumeName: scripts
-          defaultMode: 493
-      service:
-        ports:
-          - name: webport
-            port: 15000
-            targetPort: webport
-          - name: grpcport
-            port: 15999
-            targetPort: grpcport
-          - name: delvedebug
-            port: 40000
-            targetPort: delvedebug
-      podSpec:
-        initContainers:
-          - name: wait-etcd-ready
-            imagePullPolicy: IfNotPresent
-            image: busybox:1.35
-            env:
-              - name: ETCD_SERVER
-                value: "$(KB_CLUSTER_NAME)-etcd-headless"
-              - name: ETCD_PORT
-                value: "2379"
-            command: ["/scripts/wait-for-service.sh", "etcd", "$(ETCD_SERVER)", "$(ETCD_PORT)"]
-            volumeMounts:
-              - name: scripts
-                mountPath: /scripts
-        containers:
-          - name: vtctld
-            imagePullPolicy: IfNotPresent
-            ports:
-              - containerPort: 15000
-                name: webport
-              - containerPort: 15999
-                name: grpcport
-              - containerPort: 40000
-                name: delvedebug
-            env:
-              - name: CELL
-                value: {{ .Values.wesqlscale.cell | default "zone1" | quote }}
-              - name: VTCTLD_SERVER
-                value: "$(KB_CLUSTER_NAME)-vtctld-headless"
-              - name: VTCTLD_WEB_PORT
-                value: "15000"
-              - name: VTCTLD_GRPC_PORT
-                value: "15999"
-              - name: ETCD_SERVER
-                value: "$(KB_CLUSTER_NAME)-etcd-headless"
-              - name: ETCD_PORT
-                value: "2379"
-              - name: TOPOLOGY_FLAGS
-                value: "--topo_implementation etcd2 --topo_global_server_address $(ETCD_SERVER):$(ETCD_PORT) --topo_global_root /vitess/global"
-            command: ["/scripts/vtctld.sh"]
-            volumeMounts:
-              - name: scripts
-                mountPath: /scripts 
-    - name: vtconsensus
-      characterType: vtconsensus
-      workloadType: Stateless
       scriptSpecs:
         - name: apecloud-mysql-scripts
           templateRef: apecloud-mysql-scripts
@@ -456,34 +353,72 @@ spec:
           namespace: {{ .Release.Namespace }}
       service:
         ports:
-          - name: port
-            port: 16000
-            targetPort: port
-          - name: delvedebug
-            port: 40000
-            targetPort: delvedebug
+          - name: etcd-port
+            port: 2379
+            targetPort: etcd-client
+          - name: vtctld-webport
+            port: 15000
+            targetPort: vtctld-webport
+          - name: vtctld-grpcport
+            port: 15999
+            targetPort: vtctld-grpcport
       podSpec:
-        initContainers:
-          - name: wait-vtctld-ready
-            imagePullPolicy: IfNotPresent
-            image: busybox:1.35
+        containers:
+          - name: etcd
+            imagePullPolicy: {{ default .Values.wesqlscale.image.pullPolicy "IfNotPresent" }}
+            ports:
+              - containerPort: 2379
+                name: etcd-client
             env:
-              - name: VTCTLD_HOST
-                value: "$(KB_CLUSTER_NAME)-vtctld-headless" 
-              - name: VTCTLD_GRPC_PORT
-                value: "15999"
-            command: ["/scripts/wait-for-service.sh", "vtctld", "$(VTCTLD_HOST)", "$(VTCTLD_GRPC_PORT)"]
+              - name: CELL
+                value: {{ .Values.wesqlscale.cell | default "zone1" | quote }}
+              - name: ETCDCTL_API
+                value: "2"
+              - name: ETCD_SERVER
+                value: "$(KB_CLUSTER_NAME)-vitess-headless"
+              - name: ETCD_PORT
+                value: "2379"
+              - name: TOPOLOGY_FLAGS
+                value: "--topo_implementation etcd2 --topo_global_server_address $(ETCD_SERVER):$(ETCD_PORT) --topo_global_root /vitess/global"
+            command: ["/scripts/etcd.sh"]
             volumeMounts:
               - name: scripts
                 mountPath: /scripts
-        containers:
+            lifecycle:
+              postStart:
+                exec:
+                  command: ["/scripts/etcd-post-start.sh"]
+          - name: vtctld
+            imagePullPolicy: {{ default .Values.wesqlscale.image.pullPolicy "IfNotPresent" }}
+            ports:
+              - containerPort: 15000
+                name: vtctld-webport
+              - containerPort: 15999
+                name: vtctld-grpcport
+            env:
+              - name: CELL
+                value: {{ .Values.wesqlscale.cell | default "zone1" | quote }}
+              - name: VTCTLD_SERVER
+                value: "$(KB_CLUSTER_NAME)-vitess-headless"
+              - name: VTCTLD_WEB_PORT
+                value: "15000"
+              - name: VTCTLD_GRPC_PORT
+                value: "15999"
+              - name: ETCD_SERVER
+                value: "localhost"
+              - name: ETCD_PORT
+                value: "2379"
+              - name: TOPOLOGY_FLAGS
+                value: "--topo_implementation etcd2 --topo_global_server_address $(ETCD_SERVER):$(ETCD_PORT) --topo_global_root /vitess/global"
+            command: ["/scripts/vtctld.sh"]
+            volumeMounts:
+              - name: scripts
+                mountPath: /scripts 
           - name: vtconsensus
-            imagePullPolicy: IfNotPresent
+            imagePullPolicy: {{ default .Values.wesqlscale.image.pullPolicy "IfNotPresent" }}
             ports:
               - containerPort: 16000
                 name: port
-              - containerPort: 40000
-                name: delvedebug
             env:
               - name: CELL
                 value: {{ .Values.wesqlscale.cell | default "zone1" | quote }}
@@ -502,7 +437,7 @@ spec:
               - name: VTCONSENSUS_PORT
                 value: "16000"
               - name: ETCD_SERVER
-                value: "$(KB_CLUSTER_NAME)-etcd-headless"
+                value: "localhost"
               - name: ETCD_PORT
                 value: "2379"
               - name: TOPOLOGY_FLAGS
@@ -549,7 +484,7 @@ spec:
             image: busybox:1.35
             env:
               - name: VTCTLD_HOST
-                value: "$(KB_CLUSTER_NAME)-vtctld-headless" 
+                value: "$(KB_CLUSTER_NAME)-vitess-headless" 
               - name: VTCTLD_GRPC_PORT
                 value: "15999"
             command: ["/scripts/wait-for-service.sh", "vtctld", "$(VTCTLD_HOST)", "$(VTCTLD_GRPC_PORT)"]
@@ -590,7 +525,7 @@ spec:
               - name: VTGATE_GRPC_PORT
                 value: "15991"
               - name: ETCD_SERVER
-                value: "$(KB_CLUSTER_NAME)-etcd-headless"
+                value: "$(KB_CLUSTER_NAME)-vitess-headless"
               - name: ETCD_PORT
                 value: "2379"
               - name: TOPOLOGY_FLAGS

--- a/deploy/apecloud-mysql/templates/clusterdefinition.yaml
+++ b/deploy/apecloud-mysql/templates/clusterdefinition.yaml
@@ -219,7 +219,7 @@ spec:
                 readOnly: false
           - name: vttablet
             image: {{ .Values.wesqlscale.image.registry | default "docker.io" }}/{{ .Values.wesqlscale.image.repository }}:{{ .Values.wesqlscale.image.tag }}
-            imagePullPolicy: {{ default .Values.wesqlscale.image.pullPolicy "IfNotPresent" }}
+            imagePullPolicy: {{ default "IfNotPresent" .Values.wesqlscale.image.pullPolicy }}
             ports:
               - containerPort: 15100
                 name: vttabletport
@@ -365,7 +365,7 @@ spec:
       podSpec:
         containers:
           - name: etcd
-            imagePullPolicy: {{ default .Values.wesqlscale.image.pullPolicy "IfNotPresent" }}
+            imagePullPolicy: {{ default "IfNotPresent" .Values.wesqlscale.image.pullPolicy }}
             ports:
               - containerPort: 2379
                 name: etcd-client
@@ -389,7 +389,7 @@ spec:
                 exec:
                   command: ["/scripts/etcd-post-start.sh"]
           - name: vtctld
-            imagePullPolicy: {{ default .Values.wesqlscale.image.pullPolicy "IfNotPresent" }}
+            imagePullPolicy: {{ default "IfNotPresent" .Values.wesqlscale.image.pullPolicy }}
             ports:
               - containerPort: 15000
                 name: vtctld-webport
@@ -415,7 +415,7 @@ spec:
               - name: scripts
                 mountPath: /scripts 
           - name: vtconsensus
-            imagePullPolicy: {{ default .Values.wesqlscale.image.pullPolicy "IfNotPresent" }}
+            imagePullPolicy: {{ default "IfNotPresent" .Values.wesqlscale.image.pullPolicy }}
             ports:
               - containerPort: 16000
                 name: port

--- a/deploy/apecloud-mysql/templates/clusterversion.yaml
+++ b/deploy/apecloud-mysql/templates/clusterversion.yaml
@@ -19,21 +19,15 @@ spec:
     switchoverSpec:
       cmdExecutorConfig:
         image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}
-  - componentDefRef: etcd
+  - componentDefRef: vitess
     versionsContext:
       containers:
         - name: etcd
           image: {{ .Values.wesqlscale.image.registry | default "docker.io" }}/{{ .Values.wesqlscale.image.repository }}:{{ .Values.wesqlscale.image.tag }}
           imagePullPolicy: {{ default .Values.wesqlscale.image.pullPolicy "IfNotPresent" }}
-  - componentDefRef: vtctld
-    versionsContext:
-      containers:
         - name: vtctld
           image: {{ .Values.wesqlscale.image.registry | default "docker.io" }}/{{ .Values.wesqlscale.image.repository }}:{{ .Values.wesqlscale.image.tag }}
           imagePullPolicy: {{ default .Values.wesqlscale.image.pullPolicy "IfNotPresent" }}
-  - componentDefRef: vtconsensus
-    versionsContext:
-      containers:
         - name: vtconsensus
           image: {{ .Values.wesqlscale.image.registry | default "docker.io" }}/{{ .Values.wesqlscale.image.repository }}:{{ .Values.wesqlscale.image.tag }}
           imagePullPolicy: {{ default .Values.wesqlscale.image.pullPolicy "IfNotPresent" }}

--- a/deploy/apecloud-mysql/templates/clusterversion.yaml
+++ b/deploy/apecloud-mysql/templates/clusterversion.yaml
@@ -24,16 +24,16 @@ spec:
       containers:
         - name: etcd
           image: {{ .Values.wesqlscale.image.registry | default "docker.io" }}/{{ .Values.wesqlscale.image.repository }}:{{ .Values.wesqlscale.image.tag }}
-          imagePullPolicy: {{ default .Values.wesqlscale.image.pullPolicy "IfNotPresent" }}
+          imagePullPolicy: {{ default "IfNotPresent" .Values.wesqlscale.image.pullPolicy }}
         - name: vtctld
           image: {{ .Values.wesqlscale.image.registry | default "docker.io" }}/{{ .Values.wesqlscale.image.repository }}:{{ .Values.wesqlscale.image.tag }}
-          imagePullPolicy: {{ default .Values.wesqlscale.image.pullPolicy "IfNotPresent" }}
+          imagePullPolicy: {{ default "IfNotPresent" .Values.wesqlscale.image.pullPolicy }}
         - name: vtconsensus
           image: {{ .Values.wesqlscale.image.registry | default "docker.io" }}/{{ .Values.wesqlscale.image.repository }}:{{ .Values.wesqlscale.image.tag }}
-          imagePullPolicy: {{ default .Values.wesqlscale.image.pullPolicy "IfNotPresent" }}
+          imagePullPolicy: {{ default "IfNotPresent" .Values.wesqlscale.image.pullPolicy }}
   - componentDefRef: vtgate
     versionsContext:
       containers:
         - name: vtgate
           image: {{ .Values.wesqlscale.image.registry | default "docker.io" }}/{{ .Values.wesqlscale.image.repository }}:{{ .Values.wesqlscale.image.tag }}
-          imagePullPolicy: {{ default .Values.wesqlscale.image.pullPolicy "IfNotPresent" }}
+          imagePullPolicy: {{ default "IfNotPresent" .Values.wesqlscale.image.pullPolicy }}

--- a/deploy/apecloud-mysql/templates/scripts.yaml
+++ b/deploy/apecloud-mysql/templates/scripts.yaml
@@ -254,6 +254,11 @@ data:
     cell=${CELL:-'zone1'}
     export ETCDCTL_API=2
 
+    etcdctl --endpoints "http://127.0.0.1:${etcd_port}" get "/vitess/global" >/dev/null 2>&1
+    if [[ $? -eq 1 ]]; then
+      exit 0
+    fi
+
     echo "add /vitess/global"
     etcdctl --endpoints "http://127.0.0.1:${etcd_port}" mkdir /vitess/global
 


### PR DESCRIPTION
Merge etcd,vtconsensus and vtctld into one compoent named `vitess`, now the pods look like:
<img width="486" alt="image" src="https://github.com/apecloud/kubeblocks/assets/32926461/9831a826-923e-4f33-af55-4708c0c6c072">

I realized that the previous usage of the `default` function in the Helm template was incorrect. Modifying the Helm values did not successfully change the corresponding `imagePullPolicy` value. According to [this document](https://helm.sh/docs/chart_template_guide/functions_and_pipelines/#using-the-default-function), the default function: `default DEFAULT_VALUE GIVEN_VALUE`