### PR TITLE
fix: limit 1 replica at mysql point-in-time recovery

### DIFF
--- a/internal/cli/cmd/cluster/create.go
+++ b/internal/cli/cmd/cluster/create.go
@@ -333,6 +333,12 @@ func fillClusterInfoFromBackup(o *CreateOptions, cls **appsv1alpha1.Cluster) err
 	if err != nil {
 		return err
 	}
+	// HACK/TODO: apecloud-mysql pitr only support one replica for PITR.
+	if backupCluster.Spec.ClusterDefRef == "apecloud-mysql" && o.RestoreTime != "" {
+		for _, c := range backupCluster.Spec.ComponentSpecs {
+			c.Replicas = 1
+		}
+	}
 	curCluster := *cls
 	if curCluster == nil {
 		curCluster = backupCluster
@@ -375,10 +381,20 @@ func setBackup(o *CreateOptions, components []map[string]interface{}) error {
 	return nil
 }
 
-func setRestoreTime(o *CreateOptions) error {
+func setRestoreTime(o *CreateOptions, components []map[string]interface{}) error {
 	if o.RestoreTime == "" || o.SourceCluster == "" {
 		return nil
 	}
+
+	// HACK/TODO: apecloud-mysql pitr only support one replica for PITR.
+	if o.ClusterDefRef == "apecloud-mysql" {
+		for _, c := range components {
+			if c["replicas"].(int64) > 1 {
+				return fmt.Errorf("apecloud-mysql only support one replica for point-in-time recovery")
+			}
+		}
+	}
+
 	if o.Annotations == nil {
 		o.Annotations = map[string]string{}
 	}
@@ -482,7 +498,7 @@ func (o *CreateOptions) Complete() error {
 	if err = setBackup(o, components); err != nil {
 		return err
 	}
-	if err = setRestoreTime(o); err != nil {
+	if err = setRestoreTime(o, components); err != nil {
 		return err
 	}
 	o.ComponentSpecs = components
@@ -525,17 +541,51 @@ func (o *CreateOptions) buildComponents(clusterCompSpecs []appsv1alpha1.ClusterC
 		return nil, err
 	}
 
-	if clusterCompSpecs != nil {
-		for _, comp := range clusterCompSpecs {
-			compSpecs = append(compSpecs, &comp)
+	compSets, err := buildCompSetsMap(o.Values, cd)
+	if err != nil {
+		return nil, err
+	}
+	overrideComponentBySets := func(comp, setComp *appsv1alpha1.ClusterComponentSpec, setValues map[setKey]string) {
+		for k := range setValues {
+			switch k {
+			case keyReplicas:
+				comp.Replicas = setComp.Replicas
+			case keyCPU:
+				comp.Resources.Requests[corev1.ResourceCPU] = setComp.Resources.Requests[corev1.ResourceCPU]
+				comp.Resources.Limits[corev1.ResourceCPU] = setComp.Resources.Limits[corev1.ResourceCPU]
+			case keyClass:
+				comp.ClassDefRef = setComp.ClassDefRef
+			case keyMemory:
+				comp.Resources.Requests[corev1.ResourceMemory] = setComp.Resources.Requests[corev1.ResourceMemory]
+				comp.Resources.Limits[corev1.ResourceMemory] = setComp.Resources.Limits[corev1.ResourceMemory]
+			case keyStorage:
+				if len(comp.VolumeClaimTemplates) > 0 && len(setComp.VolumeClaimTemplates) > 0 {
+					comp.VolumeClaimTemplates[0].Spec.Resources.Requests = setComp.VolumeClaimTemplates[0].Spec.Resources.Requests
+				}
+			case keyStorageClass:
+				if len(comp.VolumeClaimTemplates) > 0 && len(setComp.VolumeClaimTemplates) > 0 {
+					comp.VolumeClaimTemplates[0].Spec.StorageClassName = setComp.VolumeClaimTemplates[0].Spec.StorageClassName
+				}
+			case keySwitchPolicy:
+				comp.SwitchPolicy = setComp.SwitchPolicy
+			}
 		}
-	} else {
-		// build components from set values or environment variables
-		compSets, err := buildCompSetsMap(o.Values, cd)
+	}
+
+	if clusterCompSpecs != nil {
+		setsCompSpecs, err := buildClusterComp(cd, compSets, clsMgr)
 		if err != nil {
 			return nil, err
 		}
-
+		setsCompSpecsMap := map[string]*appsv1alpha1.ClusterComponentSpec{}
+		for _, setComp := range setsCompSpecs {
+			setsCompSpecsMap[setComp.Name] = setComp
+		}
+		for _, comp := range clusterCompSpecs {
+			overrideComponentBySets(&comp, setsCompSpecsMap[comp.Name], compSets[comp.Name])
+			compSpecs = append(compSpecs, &comp)
+		}
+	} else {
 		compSpecs, err = buildClusterComp(cd, compSets, clsMgr)
 		if err != nil {
 			return nil, err

--- a/internal/cli/cmd/cluster/create.go
+++ b/internal/cli/cmd/cluster/create.go
@@ -142,6 +142,7 @@ var clusterCreateExample = templates.Examples(`
 const (
 	CueTemplateName = "cluster_template.cue"
 	monitorKey      = "monitor"
+	apeCloudMysql   = "apecloud-mysql"
 )
 
 type setKey string
@@ -334,7 +335,7 @@ func fillClusterInfoFromBackup(o *CreateOptions, cls **appsv1alpha1.Cluster) err
 		return err
 	}
 	// HACK/TODO: apecloud-mysql pitr only support one replica for PITR.
-	if backupCluster.Spec.ClusterDefRef == "apecloud-mysql" && o.RestoreTime != "" {
+	if backupCluster.Spec.ClusterDefRef == apeCloudMysql && o.RestoreTime != "" {
 		for _, c := range backupCluster.Spec.ComponentSpecs {
 			c.Replicas = 1
 		}
@@ -387,7 +388,7 @@ func setRestoreTime(o *CreateOptions, components []map[string]interface{}) error
 	}
 
 	// HACK/TODO: apecloud-mysql pitr only support one replica for PITR.
-	if o.ClusterDefRef == "apecloud-mysql" {
+	if o.ClusterDefRef == apeCloudMysql {
 		for _, c := range components {
 			if c["replicas"].(int64) > 1 {
 				return fmt.Errorf("apecloud-mysql only support one replica for point-in-time recovery")
@@ -921,7 +922,7 @@ func buildClusterComp(cd *appsv1alpha1.ClusterDefinition, setsMap map[string]map
 		// HACK: for apecloud-mysql cluster definition, if setsMap is empty, user
 		// does not specify any set, so we only build the first component.
 		// TODO(ldm): remove this hack and use helm chart to render the cluster.
-		if i > 0 && len(sets) == 0 && cd.Name == "apecloud-mysql" {
+		if i > 0 && len(sets) == 0 && cd.Name == apeCloudMysql {
 			continue
 		}
 

--- a/internal/cli/cmd/cluster/create_test.go
+++ b/internal/cli/cmd/cluster/create_test.go
@@ -430,8 +430,13 @@ var _ = Describe("create", func() {
 		o.Namespace = testing.Namespace
 		o.RestoreTime = "Jun 16,2023 18:57:01 UTC+0800"
 		o.SourceCluster = testing.ClusterName
+		components := []map[string]interface{}{
+			{
+				"name": testing.ClusterName,
+			},
+		}
 		By("test setRestoreTime")
-		Expect(setRestoreTime(o)).Should(Succeed())
+		Expect(setRestoreTime(o, components)).Should(Succeed())
 	})
 
 	It("test fillClusterMetadataFromBackup", func() {

--- a/internal/cli/cmd/cluster/dataprotection.go
+++ b/internal/cli/cmd/cluster/dataprotection.go
@@ -523,6 +523,10 @@ func (o *CreateRestoreOptions) runPITR() error {
 			constant.RestoreFromSrcClusterAnnotationKey: o.SourceCluster,
 		},
 	}
+	// HACK/TODO: apecloud-mysql pitr only support one replica for PITR.
+	if clusterObj.Spec.ClusterDefRef == "apecloud-mysql" {
+		clusterObj.Spec.ComponentSpecs[0].Replicas = 1
+	}
 	return o.createCluster(clusterObj)
 }
 


### PR DESCRIPTION
- PITR limit 1 replica for apecloud mysql in kbcli.(mysql kernel will support multi replicas in the next few days.)
- fix kbcli doesn't work when created from backup config via `--set`