### PR TITLE
fix: change `ApeCloud-MySQL` affinity template

### DIFF
--- a/.github/workflows/cicd-pull-request.yml
+++ b/.github/workflows/cicd-pull-request.yml
@@ -174,13 +174,13 @@ jobs:
     name: check helm
     needs: trigger-mode
     if: contains(needs.trigger-mode.outputs.trigger-mode, '[deploy]')
-    uses: apecloud/apecloud-cd/.github/workflows/release-charts-check.yml@v0.1.8
+    uses: apecloud/apecloud-cd/.github/workflows/release-charts-check.yml@v0.1.9
     with:
       MAKE_OPS: "bump-chart-ver"
       VERSION: "v0.6.0-check"
       CHART_NAME: "kubeblocks"
       CHART_DIR: "deploy/helm"
-      APECD_REF: "v0.1.8"
+      APECD_REF: "v0.1.9"
     secrets: inherit
 
   check-kbcli:

--- a/deploy/apecloud-mysql-cluster/values.yaml
+++ b/deploy/apecloud-mysql-cluster/values.yaml
@@ -38,3 +38,7 @@ storage: 20
 ## if mode is raftGroup, proxyEnabled can be true or false
 ##
 proxyEnabled: false
+
+## customized default values to override kblib chart's values
+extra:
+  podAntiAffinity: Required

--- a/deploy/kblib/templates/_schedule.tpl
+++ b/deploy/kblib/templates/_schedule.tpl
@@ -3,9 +3,9 @@ Define cluster affinity
 */}}
 {{- define "kblib.affinity" }}
 affinity:
-  podAntiAffinity: Preferred
-  {{- if eq .Values.extra.availabilityPolicy "zone" }}
+  podAntiAffinity: {{ .Values.extra.podAntiAffinity }}
   topologyKeys:
+  {{- if eq .Values.extra.availabilityPolicy "zone" }}
     - topology.kubernetes.io/zone
   {{- else if eq .Values.extra.availabilityPolicy "node" }}
     - kubernetes.io/hostname

--- a/deploy/kblib/values.schema.json
+++ b/deploy/kblib/values.schema.json
@@ -26,7 +26,7 @@
       "title": "Availability Policy",
       "description": "The availability policy of cluster.",
       "type": "string",
-      "default": "none",
+      "default": "node",
       "enum": [
         "none",
         "node",

--- a/deploy/kblib/values.yaml
+++ b/deploy/kblib/values.yaml
@@ -9,7 +9,11 @@ terminationPolicy: Delete
 
 ## @param availablePolicy
 ##
-availabilityPolicy: none
+availabilityPolicy: node
+
+## @param podAntiAffinity
+##
+podAntiAffinity: Preferred
 
 ## @param tenancy dedicated or shared
 ##


### PR DESCRIPTION
fix #3020 

- make `node` as the default topologyKey
- make `podAntiAffinity: Required` for ApeCloud-MySQL

<img width="2259" alt="image" src="https://github.com/apecloud/kubeblocks/assets/4293867/0e77f05b-f0cb-40fa-995b-3cfb50b7f445">