### PR TITLE
fix: cli created cluster without expected public service

### DIFF
--- a/deploy/kblib/templates/_helper.tpl
+++ b/deploy/kblib/templates/_helper.tpl
@@ -4,13 +4,13 @@ TODO: For azure, we should get provider from node.Spec.ProviderID
 */}}
 {{- define "kblib.cloudProvider" }}
 {{- $kubeVersion := .Capabilities.KubeVersion.GitVersion }}
-{{- if contains $kubeVersion "eks" }}
+{{- if contains "eks" $kubeVersion }}
 {{- "aws" -}}
-{{- else if contains $kubeVersion "gke" }}
+{{- else if contains "gke" $kubeVersion }}
 {{- "gcp" -}}
-{{- else if contains $kubeVersion "aliyun" }}
+{{- else if contains "aliyun" $kubeVersion }}
 {{- "aliyun" -}}
-{{- else if contains $kubeVersion "tke" }}
+{{- else if contains "tke" $kubeVersion }}
 {{- "tencentCloud" -}}
 {{- else }}
 {{- "" -}}

--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -263,7 +263,7 @@ make run-delve GO_PACKAGE=./cmd/manager/main.go
 ```shell
 make test-delve TEST_PACKAGES=./controllers/apps/...
 ```
-> Unlike `go test` supports multiple packages, `Delve` needs a single executable to work, it only support single package.
+> Unlike `go test` supports multiple packages, `Delve` needs a single executable to work, it only supports single package.
 
 #### Change debug server port
 You can change debug server port for `make run-delve` and `make test-delve`.

--- a/docs/user_docs/cli/kbcli_cluster_create_kafka.md
+++ b/docs/user_docs/cli/kbcli_cluster_create_kafka.md
@@ -21,7 +21,7 @@ kbcli cluster create kafka NAME [flags]
 ### Options
 
 ```
-      --availability-policy string   The availability policy of cluster. Legal values [none, node, zone]. (default "none")
+      --availability-policy string   The availability policy of cluster. Legal values [none, node, zone]. (default "node")
       --broker-replicas int          The number of Kafka broker replicas for separated mode. Value range [1, 100]. (default 1)
       --controller-replicas int      The number of Kafka controller replicas for separated mode. Legal values [1, 3, 5]. (default 1)
       --cpu float                    CPU cores. Value range [0.5, 64]. (default 1)

--- a/docs/user_docs/cli/kbcli_cluster_create_mongodb.md
+++ b/docs/user_docs/cli/kbcli_cluster_create_mongodb.md
@@ -21,7 +21,7 @@ kbcli cluster create mongodb NAME [flags]
 ### Options
 
 ```
-      --availability-policy string   The availability policy of cluster. Legal values [none, node, zone]. (default "none")
+      --availability-policy string   The availability policy of cluster. Legal values [none, node, zone]. (default "node")
       --cpu float                    CPU cores. Value range [0.5, 64]. (default 1)
   -h, --help                         help for mongodb
       --host-network-accessible      Specify whether the cluster can be accessed from within the VPC.

--- a/docs/user_docs/cli/kbcli_cluster_create_mysql.md
+++ b/docs/user_docs/cli/kbcli_cluster_create_mysql.md
@@ -21,7 +21,7 @@ kbcli cluster create mysql NAME [flags]
 ### Options
 
 ```
-      --availability-policy string   The availability policy of cluster. Legal values [none, node, zone]. (default "none")
+      --availability-policy string   The availability policy of cluster. Legal values [none, node, zone]. (default "node")
       --cpu float                    CPU cores. Value range [0.5, 64]. (default 1)
   -h, --help                         help for mysql
       --host-network-accessible      Specify whether the cluster can be accessed from within the VPC.

--- a/docs/user_docs/cli/kbcli_cluster_create_postgresql.md
+++ b/docs/user_docs/cli/kbcli_cluster_create_postgresql.md
@@ -21,7 +21,7 @@ kbcli cluster create postgresql NAME [flags]
 ### Options
 
 ```
-      --availability-policy string   The availability policy of cluster. Legal values [none, node, zone]. (default "none")
+      --availability-policy string   The availability policy of cluster. Legal values [none, node, zone]. (default "node")
       --cpu float                    CPU cores. Value range [0.5, 64]. (default 1)
   -h, --help                         help for postgresql
       --host-network-accessible      Specify whether the cluster can be accessed from within the VPC.

--- a/docs/user_docs/cli/kbcli_cluster_create_redis.md
+++ b/docs/user_docs/cli/kbcli_cluster_create_redis.md
@@ -21,7 +21,7 @@ kbcli cluster create redis NAME [flags]
 ### Options
 
 ```
-      --availability-policy string   The availability policy of cluster. Legal values [none, node, zone]. (default "none")
+      --availability-policy string   The availability policy of cluster. Legal values [none, node, zone]. (default "node")
       --cpu float                    CPU cores. Value range [0.5, 64]. (default 1)
   -h, --help                         help for redis
       --host-network-accessible      Specify whether the cluster can be accessed from within the VPC.

--- a/internal/cli/cluster/cluster_chart.go
+++ b/internal/cli/cluster/cluster_chart.go
@@ -32,6 +32,7 @@ import (
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
+	"helm.sh/helm/v3/pkg/chartutil"
 	"helm.sh/helm/v3/pkg/releaseutil"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/kube-openapi/pkg/validation/spec"
@@ -120,14 +121,24 @@ func BuildChartInfo(t ClusterType) (*ChartInfo, error) {
 }
 
 // GetManifests gets the cluster manifests
-func GetManifests(c *chart.Chart, namespace, name string, values map[string]interface{}) (map[string]string, error) {
+func GetManifests(c *chart.Chart, namespace, name string, kubeVersion string, values map[string]interface{}) (map[string]string, error) {
 	// get the helm chart manifest
-	actionCfg, err := helm.NewActionConfig(helm.NewFakeConfig(namespace))
+	actionCfg, err := helm.NewActionConfig(helm.NewConfig(namespace, "", "", false))
 	if err != nil {
 		return nil, err
 	}
 	actionCfg.Log = func(format string, v ...interface{}) {
 		fmt.Printf(format, v...)
+	}
+
+	// Parse Kubernetes version to fit the helm action config.
+	//
+	// We must set a valid Kubernetes version to render the manifests, otherwise
+	// helm will use a fake one that will cause the .Capabilities.KubeVersion.GitVersion
+	// return the fake version that is not expected.
+	v, err := chartutil.ParseKubeVersion(kubeVersion)
+	if err != nil {
+		return nil, err
 	}
 
 	client := action.NewInstall(actionCfg)
@@ -136,6 +147,7 @@ func GetManifests(c *chart.Chart, namespace, name string, values map[string]inte
 	client.ClientOnly = true
 	client.ReleaseName = name
 	client.Namespace = namespace
+	client.KubeVersion = v
 
 	rel, err := client.Run(c, values)
 	if err != nil {

--- a/internal/cli/cluster/cluster_chart.go
+++ b/internal/cli/cluster/cluster_chart.go
@@ -121,7 +121,7 @@ func BuildChartInfo(t ClusterType) (*ChartInfo, error) {
 }
 
 // GetManifests gets the cluster manifests
-func GetManifests(c *chart.Chart, namespace, name string, kubeVersion string, values map[string]interface{}) (map[string]string, error) {
+func GetManifests(c *chart.Chart, namespace, name, kubeVersion string, values map[string]interface{}) (map[string]string, error) {
 	// get the helm chart manifest
 	actionCfg, err := helm.NewActionConfig(helm.NewConfig(namespace, "", "", false))
 	if err != nil {

--- a/internal/cli/cluster/cluster_chart_test.go
+++ b/internal/cli/cluster/cluster_chart_test.go
@@ -29,6 +29,7 @@ var _ = Describe("cluster engine", func() {
 		clusterType = "mysql"
 		name        = "test-cluster"
 		namespace   = "test-namespace"
+		kubeVersion = "v99.99.0"
 	)
 
 	It("get and validate engine helm chart", func() {
@@ -46,7 +47,7 @@ var _ = Describe("cluster engine", func() {
 		Expect(c.SubChartName).ShouldNot(BeEmpty())
 
 		By("get manifests")
-		manifests, err := GetManifests(c.Chart, namespace, name, nil)
+		manifests, err := GetManifests(c.Chart, namespace, name, kubeVersion, nil)
 		Expect(err).Should(Succeed())
 		Expect(manifests).ShouldNot(BeEmpty())
 

--- a/internal/cli/cmd/cluster/create_subcmds.go
+++ b/internal/cli/cmd/cluster/create_subcmds.go
@@ -122,8 +122,14 @@ func (o *createSubCmdsOptions) run() error {
 	// move values that belong to sub chart to sub map
 	values := buildHelmValues(o.chartInfo, o.values)
 
+	// get Kubernetes version
+	kubeVersion, err := util.GetK8sVersion(o.Client.Discovery())
+	if err != nil || kubeVersion == "" {
+		return fmt.Errorf("failed to get Kubernetes version %s", err)
+	}
+
 	// get cluster manifests
-	manifests, err := cluster.GetManifests(o.chartInfo.Chart, o.Namespace, o.Name, values)
+	manifests, err := cluster.GetManifests(o.chartInfo.Chart, o.Namespace, o.Name, kubeVersion, values)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/cmd/cluster/create_subcmds.go
+++ b/internal/cli/cmd/cluster/create_subcmds.go
@@ -125,7 +125,7 @@ func (o *createSubCmdsOptions) run() error {
 	// get Kubernetes version
 	kubeVersion, err := util.GetK8sVersion(o.Client.Discovery())
 	if err != nil || kubeVersion == "" {
-		return fmt.Errorf("failed to get Kubernetes version %s", err)
+		return fmt.Errorf("failed to get Kubernetes version %v", err)
 	}
 
 	// get cluster manifests

--- a/internal/cli/cmd/cluster/create_subcmds_test.go
+++ b/internal/cli/cmd/cluster/create_subcmds_test.go
@@ -24,15 +24,16 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/spf13/cobra"
 
+	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/cli-runtime/pkg/resource"
-	"k8s.io/client-go/kubernetes/scheme"
-
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/resource"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/kubernetes/scheme"
 	clientfake "k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 
@@ -63,6 +64,7 @@ var _ = Describe("create cluster by cluster type", func() {
 			}
 			tf.Client = tf.UnstructuredClient
 			tf.FakeDynamicClient = testing.FakeDynamicClient(data)
+			tf.WithDiscoveryClient(cmdtesting.NewFakeCachedDiscoveryClient())
 			return tf
 		}
 	)
@@ -115,6 +117,9 @@ var _ = Describe("create cluster by cluster type", func() {
 
 		By("run")
 		o.DryRun = "client"
+		o.Client = testing.FakeClientSet()
+		fakeDiscovery, _ := o.Client.Discovery().(*fakediscovery.FakeDiscovery)
+		fakeDiscovery.FakedServerVersion = &version.Info{Major: "1", Minor: "27", GitVersion: "v1.27.0"}
 		Expect(o.run()).Should(Succeed())
 	})
 })


### PR DESCRIPTION
* fix #4199

```shell
$ kb cluster create mysql --publicly-accessible=true --dry-run
apiVersion: apps.kubeblocks.io/v1alpha1
kind: Cluster
metadata:
  labels:
    app.kubernetes.io/instance: tea51
    app.kubernetes.io/version: 8.0.30
    helm.sh/chart: apecloud-mysql-cluster-0.5.0-alpha.0
  name: tea51
  namespace: default
spec:
  affinity:
    podAntiAffinity: Required
    tenancy: SharedNode
    topologyKeys:
    - kubernetes.io/hostname
  clusterDefinitionRef: apecloud-mysql
  clusterVersionRef: ac-mysql-8.0.30
  componentSpecs:
  - componentDefRef: mysql
    enabledLogs:
    - slow
    - error
    monitor: false
    name: mysql
    replicas: 1
    resources:
      limits:
        cpu: "1"
        memory: 1Gi
      requests:
        cpu: "1"
        memory: 1Gi
    serviceAccountName: kb-sa-tea51
    services:
    - annotations:
        service.beta.kubernetes.io/aws-load-balancer-internal: "false"
        service.beta.kubernetes.io/aws-load-balancer-type: nlb
      name: public
      serviceType: LoadBalancer
    volumeClaimTemplates:
    - name: data
      spec:
        accessModes:
        - ReadWriteOnce
        resources:
          requests:
            storage: 20Gi
  terminationPolicy: Delete

```