### PR TITLE
chore: kafka bugfix & support jvm setting

### DIFF
--- a/deploy/helm/templates/addons/migration-addon.yaml
+++ b/deploy/helm/templates/addons/migration-addon.yaml
@@ -23,7 +23,7 @@ spec:
 
     installOptions:
       {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
-      version: 0.1.0
+      version: 0.1.1
       {{- end }}
 
     valuesMapping:

--- a/deploy/helm/templates/addons/migration-addon.yaml
+++ b/deploy/helm/templates/addons/migration-addon.yaml
@@ -18,7 +18,7 @@ spec:
     {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}
     chartLocationURL: {{ .Values.addonChartLocationBase }}/dt-platform
     {{- else }}
-    chartLocationURL: {{ .Values.addonChartLocationBase }}/dt-platform-0.1.0.tgz
+    chartLocationURL: {{ .Values.addonChartLocationBase }}/dt-platform-0.1.1-test.1.tgz
     {{- end }}
 
     installOptions:

--- a/deploy/kafka-cluster/templates/cluster.yaml
+++ b/deploy/kafka-cluster/templates/cluster.yaml
@@ -26,14 +26,23 @@ spec:
       {{- include "kblib.componentServices" . | indent 6 }}
       {{- if $.Values.storageEnable }}
       volumeClaimTemplates:
-        - name: data 
+        - name: data
           spec:
+            storageClassName: {{ $.Values.storageClassName }}
             accessModes:
               - ReadWriteOnce
             resources:
               requests:
                 storage: {{ print $.Values.storage "Gi" }}
-        {{- end }}
+        - name: metadata
+          spec:
+            storageClassName: {{ $.Values.metaStorageClassName }}
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: {{ print $.Values.metaStorage "Gi" }}
+      {{- end }}
     {{- else }}
     - name: controller
       componentDefRef: controller
@@ -50,11 +59,20 @@ spec:
       volumeClaimTemplates:
         - name: data
           spec:
+            storageClassName: {{ $.Values.storageClassName }}
             accessModes:
               - ReadWriteOnce
             resources:
               requests:
                 storage: {{ print $.Values.storage "Gi" }}
+        - name: metadata
+          spec:
+            storageClassName: {{ $.Values.metaStorageClassName }}
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: {{ print $.Values.metaStorage "Gi" }}
       {{- end }}
     - name: broker
       componentDefRef: kafka-broker
@@ -70,15 +88,24 @@ spec:
       {{- include "kblib.componentServices" . | indent 6 }}
       {{- if $.Values.storageEnable }}
       volumeClaimTemplates:
-        - name: data 
+        - name: data
           spec:
+            storageClassName: {{ $.Values.storageClassName }}
             accessModes:
               - ReadWriteOnce
             resources:
               requests:
                 storage: {{ print $.Values.storage "Gi" }}
-        {{- end }}
+        - name: metadata
+          spec:
+            storageClassName: {{ $.Values.metaStorageClassName }}
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: {{ print $.Values.metaStorage "Gi" }}
       {{- end }}
+    {{- end }}
     {{- if .Values.monitorEnable }}
     - name: metrics-exp
       componentDefRef: kafka-exporter

--- a/deploy/kafka-cluster/templates/cluster.yaml
+++ b/deploy/kafka-cluster/templates/cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "kblib.clusterName" . }}
   labels: {{ include "kblib.clusterLabels" . | nindent 4 }}
   annotations:
-    "kubeblocks.io/extra-env": '{"KB_KAFKA_ENABLE_SASL":"{{ $.Values.saslEnable }}"}'
+    "kubeblocks.io/extra-env": '{"KB_KAFKA_ENABLE_SASL":"{{ $.Values.saslEnable }}","KB_KAFKA_BROKER_HEAP":"{{ $.Values.brokerHeap }}","KB_KAFKA_CONTROLLER_HEAP":"{{ $.Values.controllerHeap }}"}'
 spec:
   clusterDefinitionRef: kafka # ref clusterdefinition.name
   clusterVersionRef: {{ .Values.version }}
@@ -26,27 +26,13 @@ spec:
       {{- include "kblib.componentServices" . | indent 6 }}
       {{- if $.Values.storageEnable }}
       volumeClaimTemplates:
-        - name: metadata 
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: {{ print $.Values.metaStorage "Gi" }}
         - name: data 
           spec:
             accessModes:
               - ReadWriteOnce
             resources:
               requests:
-                storage: {{ print $.Values.dataStorage "Gi" }}
-        - name: log 
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: {{ print $.Values.logStorage "Gi" }}
+                storage: {{ print $.Values.storage "Gi" }}
         {{- end }}
     {{- else }}
     - name: controller
@@ -62,20 +48,13 @@ spec:
       {{- include "kblib.componentResources" . | indent 6 }}
       {{- if $.Values.storageEnable }}
       volumeClaimTemplates:
-        - name: metadata 
+        - name: data
           spec:
             accessModes:
               - ReadWriteOnce
             resources:
               requests:
-                storage: {{ print $.Values.metaStorage "Gi" }}
-        - name: log
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: {{ print $.Values.logStorage "Gi" }}
+                storage: {{ print $.Values.storage "Gi" }}
       {{- end }}
     - name: broker
       componentDefRef: kafka-broker
@@ -97,14 +76,7 @@ spec:
               - ReadWriteOnce
             resources:
               requests:
-                storage: {{ print $.Values.metaStorage "Gi" }}
-        - name: log
-          spec:
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: {{ print $.Values.logStorage "Gi" }}
+                storage: {{ print $.Values.storage "Gi" }}
         {{- end }}
       {{- end }}
     {{- if .Values.monitorEnable }}

--- a/deploy/kafka-cluster/values.schema.json
+++ b/deploy/kafka-cluster/values.schema.json
@@ -30,6 +30,12 @@
       "type": "boolean",
       "default": false
     },
+    "storageEnable": {
+      "title": "StorageEnable",
+      "description": "Enable storage for Kafka.",
+      "type": "boolean",
+      "default": false
+    },
     "storage": {
       "title": "Storage(Gi)",
       "description": "Data Storage size, the unit is Gi.",
@@ -40,6 +46,29 @@
       "default": 10,
       "minimum": 1,
       "maximum": 10000
+    },
+    "storageClass": {
+      "title": "StorageClass",
+      "description": "The StorageClass for Kafka Data Storage.",
+      "type": "string",
+      "default": ""
+    },
+    "metaStorage": {
+      "title": "MetaStorage(Gi)",
+      "description": "Metadata Storage size, the unit is Gi.",
+      "type": [
+        "number",
+        "string"
+      ],
+      "default": 5,
+      "minimum": 1,
+      "maximum": 10000
+    },
+    "metaStorageClass": {
+      "title": "MetaStorageClass",
+      "description": "The StorageClass for Kafka Metadata Storage.",
+      "type": "string",
+      "default": ""
     },
     "replicas": {
       "title": "Replicas",
@@ -86,7 +115,7 @@
         "number",
         "string"
       ],
-      "default": 1,
+      "default": 0.5,
       "minimum": 0.5,
       "maximum": 64,
       "multipleOf": 0.5
@@ -98,7 +127,7 @@
         "number",
         "string"
       ],
-      "default": 1,
+      "default": 0.5,
       "minimum": 0.5,
       "maximum": 1000
     },

--- a/deploy/kafka-cluster/values.schema.json
+++ b/deploy/kafka-cluster/values.schema.json
@@ -18,12 +18,6 @@
         "separated"
       ]
     },
-    "tlsEnable": {
-      "title": "TlsEnable",
-      "description": "Enable TLS for Kafka.",
-      "type": "boolean",
-      "default": false
-    },
     "saslEnable": {
       "title": "SaslEnable",
       "description": "Enable authentication using SASL/PLAIN for Kafka.",
@@ -36,25 +30,8 @@
       "type": "boolean",
       "default": false
     },
-    "storageEnable": {
-      "title": "StorageEnable",
-      "description": "Enable storage for Kafka meta/data/log.",
-      "type": "boolean",
-      "default": false
-    },
-    "metaStorage": {
-      "title": "MetaStorage(Gi)",
-      "description": "Meta Storage size, the unit is Gi.",
-      "type": [
-        "number",
-        "string"
-      ],
-      "default": 5,
-      "minimum": 1,
-      "maximum": 10000
-    },
-    "dataStorage": {
-      "title": "DataStorage(Gi)",
+    "storage": {
+      "title": "Storage(Gi)",
       "description": "Data Storage size, the unit is Gi.",
       "type": [
         "number",
@@ -64,20 +41,9 @@
       "minimum": 1,
       "maximum": 10000
     },
-    "logStorage": {
-      "title": "LogStorage(Gi)",
-      "description": "Log Storage size, the unit is Gi.",
-      "type": [
-        "number",
-        "string"
-      ],
-      "default": 2,
-      "minimum": 1,
-      "maximum": 10000
-    },
     "replicas": {
       "title": "Replicas",
-      "description": "The number of Kafka replicas for combined mode.",
+      "description": "The number of Kafka broker replicas for combined mode.",
       "type": "integer",
       "default": 1,
       "enum": [
@@ -135,6 +101,18 @@
       "default": 1,
       "minimum": 0.5,
       "maximum": 1000
+    },
+    "brokerHeap": {
+      "title": "BrokerHeap",
+      "description": "Kafka broker's jvm heap setting.",
+      "type": "string",
+      "default": "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
+    },
+    "controllerHeap": {
+      "title": "ControllerHeap",
+      "description": "Kafka controller's jvm heap setting for separated mode",
+      "type": "string",
+      "default": "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
     }
   }
 }

--- a/deploy/kafka-cluster/values.yaml
+++ b/deploy/kafka-cluster/values.yaml
@@ -23,7 +23,7 @@ cpu: 0.5
 
 ## @param memory, the unit is Gi
 ##
-memory: 1
+memory: 0.5
 
 ## @param requests.cpu if not set, use cpu
 ## @param requests.memory, if not set, use memory
@@ -32,10 +32,17 @@ requests:
 #  cpu:
 #  memory:
 
-storageEnable: true
+storageEnable: false
+
+storageClassName:
 
 ## kafka data storage setting,the unit is Gi
 storage: 10
+
+## kafka metaadata storage setting,the unit is Gi
+metaStorage: 5
+
+metaStorageClassName:
 
 ## kafka replicas for combined mode
 replicas: 1

--- a/deploy/kafka-cluster/values.yaml
+++ b/deploy/kafka-cluster/values.yaml
@@ -34,14 +34,8 @@ requests:
 
 storageEnable: true
 
-## kafka metaadata storage setting,the unit is Gi
-metaStorage: 5
-
 ## kafka data storage setting,the unit is Gi
-dataStorage: 10
-
-## kafka log storage setting,the unit is Gi
-logStorage: 2
+storage: 10
 
 ## kafka replicas for combined mode
 replicas: 1
@@ -57,3 +51,11 @@ controllerReplicas: 1
 ## kafka monitor component replicas
 ## only effective when monitorEnable=true
 monitorReplicas: 1
+
+## kafka broker's jvm heap setting
+brokerHeap: -XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64
+
+## kafka broker's jvm heap setting
+## only effective when clusterMode='separated'
+controllerHeap: -XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64
+

--- a/deploy/kafka/scripts/kafka-server-setup.sh.tpl
+++ b/deploy/kafka/scripts/kafka-server-setup.sh.tpl
@@ -1,57 +1,60 @@
 #!/bin/bash
 
+# TLS setting
 {{- if $.component.tls }}
-# override TLS and auth settings
-export KAFKA_TLS_TYPE="PEM"
-echo "KAFKA_TLS_TYPE=$KAFKA_TLS_TYPE"
-export KAFKA_CFG_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM=""
-echo "KAFKA_CFG_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM=$KAFKA_CFG_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM"
-export KAFKA_CERTIFICATE_PASSWORD=""
-echo "KAFKA_CERTIFICATE_PASSWORD=$KAFKA_CERTIFICATE_PASSWORD"
-export KAFKA_TLS_CLIENT_AUTH=none
-echo "KAFKA_TLS_CLIENT_AUTH=$KAFKA_TLS_CLIENT_AUTH"
+  # override TLS and auth settings
+  export KAFKA_TLS_TYPE="PEM"
+  echo "[tls]KAFKA_TLS_TYPE=$KAFKA_TLS_TYPE"
+  export KAFKA_CFG_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM=""
+  echo "[tls]KAFKA_CFG_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM=$KAFKA_CFG_SSL_ENDPOINT_IDENTIFICATION_ALGORITHM"
+  export KAFKA_CERTIFICATE_PASSWORD=""
+  echo "[tls]KAFKA_CERTIFICATE_PASSWORD=$KAFKA_CERTIFICATE_PASSWORD"
+  export KAFKA_TLS_CLIENT_AUTH=none
+  echo "[tls]KAFKA_TLS_CLIENT_AUTH=$KAFKA_TLS_CLIENT_AUTH"
 
-# override TLS protocol
-export KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT,CLIENT:SSL
-echo "KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=$KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP"
-# Todo: enable encrypted transmission inside the service
-#export KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:SSL,INTERNAL:SSL,CLIENT:SSL
-#export KAFKA_CFG_SECURITY_INTER_BROKER_PROTOCOL=SSL
-#echo "KAFKA_CFG_SECURITY_INTER_BROKER_PROTOCOL=SSL"
+  # override TLS protocol
+  export KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT,CLIENT:SSL
+  echo "KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=$KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP"
+  # Todo: enable encrypted transmission inside the service
+  #export KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:SSL,INTERNAL:SSL,CLIENT:SSL
+  #export KAFKA_CFG_SECURITY_INTER_BROKER_PROTOCOL=SSL
+  #echo "KAFKA_CFG_SECURITY_INTER_BROKER_PROTOCOL=SSL"
 
-mkdir -p /opt/bitnami/kafka/config/certs
-PEM_CA="$KB_TLS_CERT_PATH/ca.crt"
-PEM_CERT="$KB_TLS_CERT_PATH/tls.crt"
-PEM_KEY="$KB_TLS_CERT_PATH/tls.key"
-if [[ -f "$PEM_CERT" ]] && [[ -f "$PEM_KEY" ]]; then
-    CERT_DIR="/opt/bitnami/kafka/config/certs"
-    PEM_CA_LOCATION="${CERT_DIR}/kafka.truststore.pem"
-    PEM_CERT_LOCATION="${CERT_DIR}/kafka.keystore.pem"
-        if [[ -f "$PEM_CA" ]]; then
-            cp "$PEM_CA" "$PEM_CA_LOCATION"
-            cp "$PEM_CERT" "$PEM_CERT_LOCATION"
-        else
-            echo "PEM_CA not provided, and auth.tls.pemChainIncluded was not true. One of these values must be set when using PEM type for TLS."
-            exit 1
-        fi
+  mkdir -p /opt/bitnami/kafka/config/certs
+  PEM_CA="$KB_TLS_CERT_PATH/ca.crt"
+  PEM_CERT="$KB_TLS_CERT_PATH/tls.crt"
+  PEM_KEY="$KB_TLS_CERT_PATH/tls.key"
+  if [[ -f "$PEM_CERT" ]] && [[ -f "$PEM_KEY" ]]; then
+      CERT_DIR="/opt/bitnami/kafka/config/certs"
+      PEM_CA_LOCATION="${CERT_DIR}/kafka.truststore.pem"
+      PEM_CERT_LOCATION="${CERT_DIR}/kafka.keystore.pem"
+          if [[ -f "$PEM_CA" ]]; then
+              cp "$PEM_CA" "$PEM_CA_LOCATION"
+              cp "$PEM_CERT" "$PEM_CERT_LOCATION"
+          else
+              echo "[tls]PEM_CA not provided, and auth.tls.pemChainIncluded was not true. One of these values must be set when using PEM type for TLS."
+              exit 1
+          fi
 
-    # Ensure the key used PEM format with PKCS#8
-    openssl pkcs8 -topk8 -nocrypt -in "$PEM_KEY" > "${CERT_DIR}/kafka.keystore.key"
-    # combined the certificate and private-key for client use
-    cat ${CERT_DIR}/kafka.keystore.key ${PEM_CERT_LOCATION} > ${CERT_DIR}/client.combined.key
-else
-    echo "Couldn't find the expected PEM files! They are mandatory when encryption via TLS is enabled."
-    exit 1
-fi
-export KAFKA_TLS_TRUSTSTORE_FILE="/opt/bitnami/kafka/config/certs/kafka.truststore.pem"
-echo "KAFKA_TLS_TRUSTSTORE_FILE=$KAFKA_TLS_TRUSTSTORE_FILE"
-echo "ssl.endpoint.identification.algorithm=" >> /opt/bitnami/kafka/config/kraft/server.properties
-echo "ssl.endpoint.identification.algorithm=" >> /opt/bitnami/kafka/config/server.properties
+      # Ensure the key used PEM format with PKCS#8
+      openssl pkcs8 -topk8 -nocrypt -in "$PEM_KEY" > "${CERT_DIR}/kafka.keystore.key"
+      # combined the certificate and private-key for client use
+      cat ${CERT_DIR}/kafka.keystore.key ${PEM_CERT_LOCATION} > ${CERT_DIR}/client.combined.key
+  else
+      echo "[tls]Couldn't find the expected PEM files! They are mandatory when encryption via TLS is enabled."
+      exit 1
+  fi
+  export KAFKA_TLS_TRUSTSTORE_FILE="/opt/bitnami/kafka/config/certs/kafka.truststore.pem"
+  echo "[tls]KAFKA_TLS_TRUSTSTORE_FILE=$KAFKA_TLS_TRUSTSTORE_FILE"
+  echo "[tls]ssl.endpoint.identification.algorithm=" >> /opt/bitnami/kafka/config/kraft/server.properties
+  echo "[tls]ssl.endpoint.identification.algorithm=" >> /opt/bitnami/kafka/config/server.properties
 {{- end }}
 
+# cfg setting with props
 # convert server.properties to 'export KAFKA_CFG_{prop}' env variables
 SERVER_PROP_PATH=${SERVER_PROP_PATH:-/bitnami/kafka/config/server.properties}
 SERVER_PROP_FILE=${SERVER_PROP_FILE:-server.properties}
+
 if [[ -f "$SERVER_PROP_FILE" ]]; then
     IFS='='
     while read -r line; do
@@ -70,7 +73,7 @@ if [[ -f "$SERVER_PROP_FILE" ]]; then
         env_suffix=`eval echo "${env_suffix}"`
         env_value=`eval echo "${kv[1]}"`
         export KAFKA_CFG_${env_suffix}="${env_value}"
-        echo "export KAFKA_CFG_${env_suffix}=${env_value}"
+        echo "[cfg]export KAFKA_CFG_${env_suffix}=${env_value}"
     done <$SERVER_PROP_FILE
     unset IFS
 fi
@@ -80,14 +83,14 @@ if [[ "true" == "$KB_KAFKA_ENABLE_SASL" ]]; then
   # bitnami default jaas setting: /opt/bitnami/kafka/config/kafka_jaas.conf
   if [[ "${KB_KAFKA_SASL_CONFIG_PATH}" ]]; then
     cp ${KB_KAFKA_SASL_CONFIG_PATH} /opt/bitnami/kafka/config/kafka_jaas.conf
-    echo "do: cp ${KB_KAFKA_SASL_CONFIG_PATH} /opt/bitnami/kafka/config/kafka_jaas.conf "
+    echo "[sasl]do: cp ${KB_KAFKA_SASL_CONFIG_PATH} /opt/bitnami/kafka/config/kafka_jaas.conf "
   fi
   export KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,INTERNAL:SASL_PLAINTEXT,CLIENT:SASL_PLAINTEXT
-  echo "KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=$KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP"
+  echo "[sasl]KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=$KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP"
   export KAFKA_CFG_SASL_ENABLED_MECHANISMS="PLAIN"
-  echo "export KAFKA_CFG_SASL_ENABLED_MECHANISMS=${KAFKA_CFG_SASL_ENABLED_MECHANISMS}"
+  echo "[sasl]export KAFKA_CFG_SASL_ENABLED_MECHANISMS=${KAFKA_CFG_SASL_ENABLED_MECHANISMS}"
   export KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL="PLAIN"
-  echo "export KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL=${KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL}"
+  echo "[sasl]export KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL=${KAFKA_CFG_SASL_MECHANISM_INTER_BROKER_PROTOCOL}"
 fi
 
 if [[ -n "$KAFKA_KRAFT_CLUSTER_ID" ]]; then
@@ -101,6 +104,13 @@ fi
 {{- $clusterName := $.cluster.metadata.name }}
 {{- $namespace := $.cluster.metadata.namespace }}
 
+# jvm setting
+if [[ -n "$KB_KAFKA_BROKER_HEAP" ]]; then
+  export KAFKA_HEAP_OPTS=${KB_KAFKA_BROKER_HEAP}
+  echo "[jvm][KB_KAFKA_BROKER_HEAP]export KAFKA_HEAP_OPTS=${KB_KAFKA_BROKER_HEAP}"
+fi
+
+# cfg setting
 if [[ "broker" = "$KAFKA_CFG_PROCESS_ROLES" ]]; then
     # override node.id setting
     # increments based on a specified base to avoid conflicts with controller settings
@@ -109,7 +119,7 @@ if [[ "broker" = "$KAFKA_CFG_PROCESS_ROLES" ]]; then
     BROKER_NODE_ID=$(( $INDEX + $BROKER_MIN_NODE_ID ))
     export KAFKA_CFG_NODE_ID="$BROKER_NODE_ID"
     export KAFKA_CFG_BROKER_ID="$BROKER_NODE_ID"
-    echo "KAFKA_CFG_NODE_ID=$KAFKA_CFG_NODE_ID"
+    echo "[cfg]KAFKA_CFG_NODE_ID=$KAFKA_CFG_NODE_ID"
     # generate KAFKA_CFG_CONTROLLER_QUORUM_VOTERS for broker if not a combine-cluster
     {{- $voters := "" }}
     {{- range $i, $c := $.cluster.spec.componentSpecs }}
@@ -124,21 +134,25 @@ if [[ "broker" = "$KAFKA_CFG_PROCESS_ROLES" ]]; then
       {{- end }}
     {{- end }}
     export KAFKA_CFG_CONTROLLER_QUORUM_VOTERS={{ $voters }}
-    echo "export KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=$KAFKA_CFG_CONTROLLER_QUORUM_VOTERS,for kafka-broker."
+    echo "[cfg]export KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=$KAFKA_CFG_CONTROLLER_QUORUM_VOTERS,for kafka-broker."
 
     # deleting this information can reacquire the controller members when the broker restarts,
     # and avoid the mismatch between the controller in the quorum-state and the actual controller in the case of a controller scale,
     # which will cause the broker to fail to start
     if [ -f "$KAFKA_CFG_METADATA_LOG_DIR/__cluster_metadata-0/quorum-state" ]; then
-      echo "Removing quorum-state file when restart."
+      echo "[action]Removing quorum-state file when restart."
       rm -f "$KAFKA_CFG_METADATA_LOG_DIR/__cluster_metadata-0/quorum-state"
     fi
 else
+    if [[ "controller" = "$KAFKA_CFG_PROCESS_ROLES" ]] && [[ -n "$KB_KAFKA_CONTROLLER_HEAP" ]]; then
+      export KAFKA_HEAP_OPTS=${KB_KAFKA_CONTROLLER_HEAP}
+      echo "[jvm][KB_KAFKA_CONTROLLER_HEAP]export KAFKA_HEAP_OPTS=${KB_KAFKA_CONTROLLER_HEAP}"
+    fi
     # generate node.id
     ID="${KB_POD_NAME#${KB_CLUSTER_COMP_NAME}-}"
     export KAFKA_CFG_NODE_ID="$((ID + 0))"
     export KAFKA_CFG_BROKER_ID="$((ID + 0))"
-    echo "KAFKA_CFG_NODE_ID=$KAFKA_CFG_NODE_ID"
+    echo "[cfg]KAFKA_CFG_NODE_ID=$KAFKA_CFG_NODE_ID"
     # generate KAFKA_CFG_CONTROLLER_QUORUM_VOTERS if is a combine-cluster or controller
     {{- $replicas := $.component.replicas | int }}
     {{- $voters := "" }}
@@ -149,7 +163,7 @@ else
     {{- end }}
     {{- $voters = trimPrefix "," $voters }}
     export KAFKA_CFG_CONTROLLER_QUORUM_VOTERS={{ $voters }}
-    echo "export KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=$KAFKA_CFG_CONTROLLER_QUORUM_VOTERS,for kafka-server."
+    echo "[cfg]export KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=$KAFKA_CFG_CONTROLLER_QUORUM_VOTERS,for kafka-server."
 fi
 
 exec /entrypoint.sh /run.sh

--- a/deploy/kafka/templates/clusterdefinition.yaml
+++ b/deploy/kafka/templates/clusterdefinition.yaml
@@ -108,7 +108,7 @@ spec:
               - name: KAFKA_CFG_METADATA_LOG_DIR
                 value: "/bitnami/kafka/metadata"
               - name: KAFKA_LOG_DIR
-                value: "/opt/bitnami/kafka/logs"
+                value: "/bitnami/kafka/logs"
               - name: KAFKA_HEAP_OPTS
                 #value: "-Xmx1024m -Xms1024m"
                 value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
@@ -154,12 +154,8 @@ spec:
               tcpSocket:
                 port: kafka-ctrlr
             volumeMounts:
-              - name: metadadata
-                mountPath: /bitnami/kafka/metadata
               - name: data
                 mountPath: /bitnami/kafka
-              - name: logs
-                mountPath: /opt/bitnami/kafka/logs
               - name: scripts
                 mountPath: /scripts/kafka-server-setup.sh
                 subPath: kafka-server-setup.sh
@@ -260,7 +256,7 @@ spec:
               - name: KAFKA_CFG_METADATA_LOG_DIR
                 value: "/bitnami/kafka/metadata"
               - name: KAFKA_LOG_DIR
-                value: "/opt/bitnami/kafka/logs"
+                value: "/bitnami/kafka/logs"
               - name: KAFKA_HEAP_OPTS
                 #value: "-Xmx1024m -Xms1024m"
                 value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
@@ -298,12 +294,8 @@ spec:
               tcpSocket:
                 port: kafka-ctrlr
             volumeMounts:
-              - name: metadadata
-                mountPath: /bitnami/kafka/metadata
-              # - name: data
-              #   mountPath: /bitnami/kafka
-              - name: logs
-                mountPath: /opt/bitnami/kafka/logs
+              - name: data
+                mountPath: /bitnami/kafka
               - name: kafka-config
                 mountPath: /scripts/server.properties
                 subPath: server.properties
@@ -410,7 +402,7 @@ spec:
               - name: KAFKA_CFG_METADATA_LOG_DIR
                 value: "/bitnami/kafka/metadata"
               - name: KAFKA_LOG_DIR
-                value: "/opt/bitnami/kafka/logs"
+                value: "/bitnami/kafka/logs"
               - name: KAFKA_HEAP_OPTS
                 #value: "-Xmx1024m -Xms1024m"
                 value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
@@ -458,8 +450,6 @@ spec:
             volumeMounts:
               - name: data
                 mountPath: /bitnami/kafka
-              - name: logs
-                mountPath: /opt/bitnami/kafka/logs
               - name: scripts
                 mountPath: /scripts/kafka-server-setup.sh
                 subPath: kafka-server-setup.sh

--- a/deploy/kafka/templates/clusterdefinition.yaml
+++ b/deploy/kafka/templates/clusterdefinition.yaml
@@ -108,7 +108,7 @@ spec:
               - name: KAFKA_CFG_METADATA_LOG_DIR
                 value: "/bitnami/kafka/metadata"
               - name: KAFKA_LOG_DIR
-                value: "/bitnami/kafka/logs"
+                value: "/bitnami/kafka/data"
               - name: KAFKA_HEAP_OPTS
                 #value: "-Xmx1024m -Xms1024m"
                 value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
@@ -156,6 +156,8 @@ spec:
             volumeMounts:
               - name: data
                 mountPath: /bitnami/kafka
+              - name: metadata
+                mountPath: /bitnami/kafka/metadata
               - name: scripts
                 mountPath: /scripts/kafka-server-setup.sh
                 subPath: kafka-server-setup.sh
@@ -256,7 +258,7 @@ spec:
               - name: KAFKA_CFG_METADATA_LOG_DIR
                 value: "/bitnami/kafka/metadata"
               - name: KAFKA_LOG_DIR
-                value: "/bitnami/kafka/logs"
+                value: "/bitnami/kafka/data"
               - name: KAFKA_HEAP_OPTS
                 #value: "-Xmx1024m -Xms1024m"
                 value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
@@ -294,7 +296,7 @@ spec:
               tcpSocket:
                 port: kafka-ctrlr
             volumeMounts:
-              - name: data
+              - name: metadata
                 mountPath: /bitnami/kafka
               - name: kafka-config
                 mountPath: /scripts/server.properties
@@ -402,7 +404,7 @@ spec:
               - name: KAFKA_CFG_METADATA_LOG_DIR
                 value: "/bitnami/kafka/metadata"
               - name: KAFKA_LOG_DIR
-                value: "/bitnami/kafka/logs"
+                value: "/bitnami/kafka/data"
               - name: KAFKA_HEAP_OPTS
                 #value: "-Xmx1024m -Xms1024m"
                 value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
@@ -450,6 +452,8 @@ spec:
             volumeMounts:
               - name: data
                 mountPath: /bitnami/kafka
+              - name: metadata
+                mountPath: /bitnami/kafka/metadata
               - name: scripts
                 mountPath: /scripts/kafka-server-setup.sh
                 subPath: kafka-server-setup.sh


### PR DESCRIPTION
# changes
1. add: support kafka jvm heap setting
2. fix: kafka data storage is not work
3. change some storage setting with kafka
4. change kbcli kafka resource setting default value

# kbcli setting
`kbt cluster create kafka -h
Create a kafka cluster.

Examples:
  \# Create a cluster with the default values
  kbcli cluster create kafka

  \# Create a cluster with the specified cpu, memory and storage
  kbcli cluster create kafka --cpu 1 --memory 2 --storage 10

Options:
    --availability-policy='none':
	The availability policy of cluster. Legal values [none, node, zone].

    --broker-heap='-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64':
	Kafka broker's jvm heap setting.

    --broker-replicas=1:
	The number of Kafka broker replicas for separated mode.

    --controller-heap='-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64':
	Kafka controller's jvm heap setting for separated mode

    --controller-replicas=1:
	The number of Kafka controller replicas for separated mode. Legal values [1,3,5].

    --cpu=0.5:
	CPU cores.

    --host-network-accessible=false:
	Specify whether the cluster can be accessed from within the VPC.

    --memory=0.5:
	Memory, the unit is Gi.

    --meta-storage=5:
	Metadata Storage size, the unit is Gi.

    --meta-storage-class='':
	The StorageClass for Kafka Metadata Storage.

    --mode='combined':
	Mode for Kafka kraft cluster, 'combined' is combined Kafka controller and broker,'separated' is broker and
	controller running independently. Legal values [combined, separated].

    --monitor-enable=false:
	Enable monitor for Kafka.

    --monitor-replicas=1:
	The number of Kafka monitor replicas.

    --monitoring-interval=0:
	The monitoring interval of cluster, 0 is disabled, the unit is second.

    --publicly-accessible=false:
	Specify whether the cluster can be accessed from the public internet.

    --replicas=1:
	The number of Kafka broker replicas for combined mode. Legal values [1,3,5].

    --sasl-enable=false:
	Enable authentication using SASL/PLAIN for Kafka.

    --storage=10:
	Data Storage size, the unit is Gi.

    --storage-class='':
	The StorageClass for Kafka Data Storage.

    --storage-enable=false:
	Enable storage for Kafka.

    --tenancy='SharedNode':
	The tenancy of cluster. Legal values [SharedNode, DedicatedNode].

    --termination-policy='Delete':
	The termination policy of cluster. Legal values [DoNotTerminate, Halt, Delete, WipeOut].

    --version='':
	Cluster version.

Usage:
  kbcli cluster create kafka NAME [flags] [options]

Use "kbcli options" for a list of global command-line options (applies to all commands).`