### PR TITLE
feat: support to create default storage class and use it

### DIFF
--- a/apis/apps/v1alpha1/cluster_types.go
+++ b/apis/apps/v1alpha1/cluster_types.go
@@ -21,9 +21,12 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/spf13/viper"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/apecloud/kubeblocks/internal/constant"
 )
 
 // ClusterSpec defines the desired state of Cluster.
@@ -354,7 +357,7 @@ func (r PersistentVolumeClaimSpec) ToV1PersistentVolumeClaimSpec() corev1.Persis
 	return corev1.PersistentVolumeClaimSpec{
 		AccessModes:      r.AccessModes,
 		Resources:        r.Resources,
-		StorageClassName: r.StorageClassName,
+		StorageClassName: r.GetStorageClassName(viper.GetString(constant.CfgKeyDefaultStorageClass)),
 	}
 }
 

--- a/apis/apps/v1alpha1/cluster_types_test.go
+++ b/apis/apps/v1alpha1/cluster_types_test.go
@@ -22,8 +22,12 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/spf13/viper"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/yaml"
+
+	"github.com/apecloud/kubeblocks/internal/constant"
 )
 
 var _ = Describe("", func() {
@@ -52,7 +56,16 @@ var _ = Describe("", func() {
 		pvcSpec := r.ToV1PersistentVolumeClaimSpec()
 		Expect(pvcSpec.AccessModes).Should(BeEquivalentTo(r.AccessModes))
 		Expect(pvcSpec.Resources).Should(BeEquivalentTo(r.Resources))
-		Expect(pvcSpec.StorageClassName).Should(BeEquivalentTo(r.StorageClassName))
+		Expect(pvcSpec.StorageClassName).Should(BeEquivalentTo(r.GetStorageClassName(viper.GetString(constant.CfgKeyDefaultStorageClass))))
+	})
+
+	It("test ToV1PersistentVolumeClaimSpec with default storage class", func() {
+		scName := "test-sc"
+		viper.Set(constant.CfgKeyDefaultStorageClass, scName)
+		r := PersistentVolumeClaimSpec{}
+		pvcSpec := r.ToV1PersistentVolumeClaimSpec()
+		Expect(pvcSpec.StorageClassName).Should(BeEquivalentTo(&scName))
+		viper.Set(constant.CfgKeyDefaultStorageClass, "")
 	})
 
 	It("test GetStorageClassName", func() {

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -276,3 +276,38 @@ Define addon agamotto name
 {{- define "addon.agamotto.name" -}}
 {{- print "agamotto" }}
 {{- end }}
+
+{{/*
+Get cloud provider, now support aws, gcp, aliyun and tencentCloud.
+TODO: For azure, we should get provider from node.Spec.ProviderID
+*/}}
+{{- define "kubeblocks.cloudProvider" }}
+{{- $kubeVersion := .Capabilities.KubeVersion.GitVersion }}
+{{- if contains "-eks" $kubeVersion }}
+{{- "aws" -}}
+{{- else if contains "-gke" $kubeVersion }}
+{{- "gcp" -}}
+{{- else if contains "-aliyun" $kubeVersion }}
+{{- "aliyun" -}}
+{{- else if contains "-tke" $kubeVersion }}
+{{- "tencentCloud" -}}
+{{- else if contains "-aks" $kubeVersion }}
+{{- "azure" -}}
+{{- else }}
+{{- "aws" -}}
+{{- end }}
+{{- end }}
+
+{{/*
+Define default storage class name, if cloud provider is known, specify a default storage class name.
+*/}}
+{{- define "kubeblocks.defaultStorageClass" }}
+{{- $cloudProvider := (include "kubeblocks.cloudProvider" .) }}
+{{- if .Values.storageClass.name }}
+{{- .Values.storageClass.name }}
+{{- else if $cloudProvider }}
+{{- "kb-default-sc"  }}
+{{- else }}
+{{- "" }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -294,7 +294,7 @@ TODO: For azure, we should get provider from node.Spec.ProviderID
 {{- else if contains "-aks" $kubeVersion }}
 {{- "azure" -}}
 {{- else }}
-{{- "aws" -}}
+{{- "" -}}
 {{- end }}
 {{- end }}
 
@@ -303,7 +303,7 @@ Define default storage class name, if cloud provider is known, specify a default
 */}}
 {{- define "kubeblocks.defaultStorageClass" }}
 {{- $cloudProvider := (include "kubeblocks.cloudProvider" .) }}
-{{- if .Values.storageClass.name }}
+{{- if and .Values.storageClass .Values.storageClass.name }}
 {{- .Values.storageClass.name }}
 {{- else if $cloudProvider }}
 {{- "kb-default-sc"  }}

--- a/deploy/helm/templates/configmap.yaml
+++ b/deploy/helm/templates/configmap.yaml
@@ -39,3 +39,6 @@ data:
     # data plane affinity
     DATA_PLANE_AFFINITY: {{ toJson .affinity | squote }}
     {{- end }}
+
+    # the default storage class name.
+    DEFAULT_STORAGE_CLASS: {{ include "kubeblocks.defaultStorageClass" . | quote }}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -261,8 +261,6 @@ spec:
               value: "{{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.tools.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
             - name: KUBEBLOCKS_SERVICEACCOUNT_NAME
               value: {{ include "kubeblocks.serviceAccountName" . }}
-            - name: DEFAULT_STORAGE_CLASS
-              value: {{ include "kubeblocks.defaultStorageClass" . }}
             {{- if or .Values.dataProtection.enableVolumeSnapshot (index .Values "snapshot-controller" "enabled") }}
             - name: VOLUMESNAPSHOT
               value: "true"

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -261,6 +261,8 @@ spec:
               value: "{{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.tools.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
             - name: KUBEBLOCKS_SERVICEACCOUNT_NAME
               value: {{ include "kubeblocks.serviceAccountName" . }}
+            - name: DEFAULT_STORAGE_CLASS
+              value: {{ include "kubeblocks.defaultStorageClass" . }}
             {{- if or .Values.dataProtection.enableVolumeSnapshot (index .Values "snapshot-controller" "enabled") }}
             - name: VOLUMESNAPSHOT
               value: "true"

--- a/deploy/helm/templates/storageclass.yaml
+++ b/deploy/helm/templates/storageclass.yaml
@@ -1,9 +1,12 @@
-{{- if (.Capabilities.KubeVersion.GitVersion | contains "-eks") }}
+{{- $scName := (include "kubeblocks.defaultStorageClass" .) }}
+{{- if and $scName .Values.storageClass.create }}
+{{- $cloudProvider := (include "kubeblocks.cloudProvider" .) }}
+{{- if eq $cloudProvider "aws" }}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: kb-default-sc
+  name: {{ $scName }}
   labels:
     {{- include "kubeblocks.labels" . | nindent 4 }}
 allowVolumeExpansion: true
@@ -15,12 +18,12 @@ provisioner: ebs.csi.aws.com
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 ---
-{{- else if (.Capabilities.KubeVersion.GitVersion | contains "-gke") }}
+{{- else if eq $cloudProvider "gcp" }}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: kb-default-sc
+  name: {{ $scName }}
   labels:
     {{- include "kubeblocks.labels" . | nindent 4 }}
 allowVolumeExpansion: true
@@ -32,12 +35,12 @@ provisioner: pd.csi.storage.gke.io
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 ---
-{{- else if (.Capabilities.KubeVersion.GitVersion | contains "-aliyun") }}
+{{- else if eq $cloudProvider "aliyun" }}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: kb-default-sc
+  name: {{ $scName }}
   labels:
     {{- include "kubeblocks.labels" . | nindent 4 }}
 allowVolumeExpansion: true
@@ -49,12 +52,12 @@ provisioner: diskplugin.csi.alibabacloud.com
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 ---
-{{- else if (.Capabilities.KubeVersion.GitVersion | contains "-tke") }}
+{{- else if eq $cloudProvider "tencentCloud" }}
 ---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: kb-default-sc
+  name: {{ $scName }}
   labels:
     {{- include "kubeblocks.labels" . | nindent 4 }}
 parameters:
@@ -64,14 +67,14 @@ reclaimPolicy: Delete
 provisioner: com.tencent.cloud.csi.cbs
 volumeBindingMode: WaitForFirstConsumer
 ---
-{{- else if (.Capabilities.KubeVersion.GitVersion | contains "-aks") }}
+{{- else if eq $cloudProvider "azure" }}
 ---
 ## it doesn't work here because aks does not support .Capabilities.KubeVersion.GitVersion to judge the provider.
 ## refer: https://github.com/Azure/AKS/issues/3375
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: kb-default-sc
+  name: {{ $scName }}
   labels:
     {{- include "kubeblocks.labels" . | nindent 4 }}
 parameters:
@@ -83,4 +86,5 @@ provisioner: kubernetes.io/azure-disk
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 ---
+{{- end }}
 {{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -690,7 +690,8 @@ storageClass:
   ##
   name: ""
 
-  ## @param storageClass.create -- Specifies whether the storage class should be created.
+  ## @param storageClass.create -- Specifies whether the storage class should be created. If storageClass.name is not
+  ## specified or generated, this value will be ignored.
   ##
   create: true
 

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -690,8 +690,7 @@ storageClass:
   ##
   name: ""
 
-  ## @param storageClass.create -- Specifies whether the storage class should be created. If storageClass.name is not
-  ## specified, the default storage class will be used for the provisioner.
+  ## @param storageClass.create -- Specifies whether the storage class should be created.
   ##
   create: true
 

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -685,6 +685,16 @@ agamotto:
 
 ## @section KubeBlocks default storageClass Parameters for cloud provider.
 storageClass:
+  ## @param storageClass.name -- Specifies the name of the default storage class.
+  ## If name is not specified and KubeBlocks deployed in a cloud, a default name will be generated.
+  ##
+  name: ""
+
+  ## @param storageClass.create -- Specifies whether the storage class should be created. If storageClass.name is not
+  ## specified, the default storage class will be used for the provisioner.
+  ##
+  create: true
+
   mountOptions:
     - noatime
     - nobarrier

--- a/internal/constant/const.go
+++ b/internal/constant/const.go
@@ -42,6 +42,9 @@ const (
 	// data plane config key
 	CfgKeyDataPlaneTolerations = "DATA_PLANE_TOLERATIONS"
 	CfgKeyDataPlaneAffinity    = "DATA_PLANE_AFFINITY"
+
+	// storage config keys
+	CfgKeyDefaultStorageClass = "DEFAULT_STORAGE_CLASS"
 )
 
 const (


### PR DESCRIPTION
* https://github.com/apecloud/kubeblocks/issues/4212

kbcli does not support to set storageClass when create cluster again, it should use the specified storage class in KubeBlocks's config. 

So, we should support a method let user to set the default storage class. 

This PR make KubeBlocks helm chart supports to set default storage class name and `create` storage class or not. 

If `storageClass.name` is specified, created cluster will use this storage class. If `storageClass.create` is true and KubeBlocks is deployed in cloud, a storage class will be created.