### PR TITLE
fix: inconsistent generated plural

### DIFF
--- a/apis/dataprotection/v1alpha1/backuprepo_types.go
+++ b/apis/dataprotection/v1alpha1/backuprepo_types.go
@@ -82,7 +82,7 @@ type BackupRepoStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:categories={kubeblocks},scope=Cluster
 
-// BackupRepo is the Schema for the backuprepoes API
+// BackupRepo is the Schema for the backuprepos API
 type BackupRepo struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/dataprotection/v1alpha1/backuprepo_types.go
+++ b/apis/dataprotection/v1alpha1/backuprepo_types.go
@@ -80,7 +80,7 @@ type BackupRepoStatus struct {
 // +k8s:openapi-gen=true
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:categories={kubeblocks},scope=Cluster
+// +kubebuilder:resource:path=backuprepos,categories={kubeblocks},scope=Cluster
 
 // BackupRepo is the Schema for the backuprepos API
 type BackupRepo struct {

--- a/config/crd/bases/dataprotection.kubeblocks.io_backuprepos.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backuprepos.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
-  name: backuprepoes.dataprotection.kubeblocks.io
+  name: backuprepos.dataprotection.kubeblocks.io
 spec:
   group: dataprotection.kubeblocks.io
   names:
@@ -13,14 +13,14 @@ spec:
     - kubeblocks
     kind: BackupRepo
     listKind: BackupRepoList
-    plural: backuprepoes
+    plural: backuprepos
     singular: backuprepo
   scope: Cluster
   versions:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: BackupRepo is the Schema for the backuprepoes API
+        description: BackupRepo is the Schema for the backuprepos API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -17,7 +17,7 @@ resources:
 - bases/apps.kubeblocks.io_componentclassdefinitions.yaml
 - bases/workloads.kubeblocks.io_replicatedstatemachines.yaml
 - bases/storage.kubeblocks.io_storageproviders.yaml
-- bases/dataprotection.kubeblocks.io_backuprepoes.yaml
+- bases/dataprotection.kubeblocks.io_backuprepos.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:
@@ -41,7 +41,7 @@ patchesStrategicMerge:
 #- patches/webhook_in_componentclassdefinitions.yaml
 #- patches/webhook_in_replicatedstatemachines.yaml
 #- patches/webhook_in_storageproviders.yaml
-#- patches/webhook_in_backuprepoes.yaml
+#- patches/webhook_in_backuprepos.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
@@ -64,7 +64,7 @@ patchesStrategicMerge:
 #- patches/cainjection_in_componentclassdefinitions.yaml
 #- patches/cainjection_in_replicatedstatemachines.yaml
 #- patches/cainjection_in_storageproviders.yaml
-#- patches/cainjection_in_backuprepoes.yaml
+#- patches/cainjection_in_backuprepos.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/config/crd/patches/cainjection_in_dataprotection_backuprepos.yaml
+++ b/config/crd/patches/cainjection_in_dataprotection_backuprepos.yaml
@@ -4,4 +4,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: backuprepoes.dataprotection.kubeblocks.io
+  name: backuprepos.dataprotection.kubeblocks.io

--- a/config/crd/patches/webhook_in_dataprotection_backuprepos.yaml
+++ b/config/crd/patches/webhook_in_dataprotection_backuprepos.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: backuprepoes.dataprotection.kubeblocks.io
+  name: backuprepos.dataprotection.kubeblocks.io
 spec:
   conversion:
     strategy: Webhook

--- a/config/rbac/dataprotection_backuprepo_editor_role.yaml
+++ b/config/rbac/dataprotection_backuprepo_editor_role.yaml
@@ -1,4 +1,4 @@
-# permissions for end users to edit backuprepoes.
+# permissions for end users to edit backuprepos.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -14,7 +14,7 @@ rules:
 - apiGroups:
   - dataprotection.kubeblocks.io
   resources:
-  - backuprepoes
+  - backuprepos
   verbs:
   - create
   - delete
@@ -26,6 +26,6 @@ rules:
 - apiGroups:
   - dataprotection.kubeblocks.io
   resources:
-  - backuprepoes/status
+  - backuprepos/status
   verbs:
   - get

--- a/config/rbac/dataprotection_backuprepo_viewer_role.yaml
+++ b/config/rbac/dataprotection_backuprepo_viewer_role.yaml
@@ -1,4 +1,4 @@
-# permissions for end users to view backuprepoes.
+# permissions for end users to view backuprepos.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -14,7 +14,7 @@ rules:
 - apiGroups:
   - dataprotection.kubeblocks.io
   resources:
-  - backuprepoes
+  - backuprepos
   verbs:
   - get
   - list
@@ -22,6 +22,6 @@ rules:
 - apiGroups:
   - dataprotection.kubeblocks.io
   resources:
-  - backuprepoes/status
+  - backuprepos/status
   verbs:
   - get

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -545,7 +545,7 @@ rules:
 - apiGroups:
   - dataprotection.kubeblocks.io
   resources:
-  - backuprepoes
+  - backuprepos
   verbs:
   - create
   - delete
@@ -557,13 +557,13 @@ rules:
 - apiGroups:
   - dataprotection.kubeblocks.io
   resources:
-  - backuprepoes/finalizers
+  - backuprepos/finalizers
   verbs:
   - update
 - apiGroups:
   - dataprotection.kubeblocks.io
   resources:
-  - backuprepoes/status
+  - backuprepos/status
   verbs:
   - get
   - patch

--- a/controllers/dataprotection/backuprepo_controller.go
+++ b/controllers/dataprotection/backuprepo_controller.go
@@ -67,9 +67,9 @@ type BackupRepoReconciler struct {
 }
 
 // full access on BackupRepos
-// +kubebuilder:rbac:groups=dataprotection.kubeblocks.io,resources=backuprepoes,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=dataprotection.kubeblocks.io,resources=backuprepoes/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=dataprotection.kubeblocks.io,resources=backuprepoes/finalizers,verbs=update
+// +kubebuilder:rbac:groups=dataprotection.kubeblocks.io,resources=backuprepos,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=dataprotection.kubeblocks.io,resources=backuprepos/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=dataprotection.kubeblocks.io,resources=backuprepos/finalizers,verbs=update
 
 // watch StorageProviders
 // +kubebuilder:rbac:groups=storage.kubeblocks.io,resources=storageproviders,verbs=get;list;watch

--- a/deploy/helm/config/rbac/role.yaml
+++ b/deploy/helm/config/rbac/role.yaml
@@ -545,7 +545,7 @@ rules:
 - apiGroups:
   - dataprotection.kubeblocks.io
   resources:
-  - backuprepoes
+  - backuprepos
   verbs:
   - create
   - delete
@@ -557,13 +557,13 @@ rules:
 - apiGroups:
   - dataprotection.kubeblocks.io
   resources:
-  - backuprepoes/finalizers
+  - backuprepos/finalizers
   verbs:
   - update
 - apiGroups:
   - dataprotection.kubeblocks.io
   resources:
-  - backuprepoes/status
+  - backuprepos/status
   verbs:
   - get
   - patch

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backuprepos.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backuprepos.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.0
   creationTimestamp: null
-  name: backuprepoes.dataprotection.kubeblocks.io
+  name: backuprepos.dataprotection.kubeblocks.io
 spec:
   group: dataprotection.kubeblocks.io
   names:
@@ -13,14 +13,14 @@ spec:
     - kubeblocks
     kind: BackupRepo
     listKind: BackupRepoList
-    plural: backuprepoes
+    plural: backuprepos
     singular: backuprepo
   scope: Cluster
   versions:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: BackupRepo is the Schema for the backuprepoes API
+        description: BackupRepo is the Schema for the backuprepos API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/docs/user_docs/api-reference/backup.md
+++ b/docs/user_docs/api-reference/backup.md
@@ -280,7 +280,7 @@ BackupPolicyStatus
 <h3 id="dataprotection.kubeblocks.io/v1alpha1.BackupRepo">BackupRepo
 </h3>
 <div>
-<p>BackupRepo is the Schema for the backuprepoes API</p><br />
+<p>BackupRepo is the Schema for the backuprepos API</p><br />
 </div>
 <table>
 <thead>


### PR DESCRIPTION
For the BackupRepo resource, the plural names generated by kubebuilder and client-gen are inconsistent: kubebuilder uses “backuprepoes”, while client-gen uses “backuprepos”, which causes the generated client to fail to operate the BackupRepo resource (such as FakeDynamicClient). Since no convenient method was found to control the generation of client-gen, the plural name in the CRD was manually modified to use “backuprepos” uniformly.

fix #4251 