### PR TITLE
feat: kbcli backuprepo create

### DIFF
--- a/controllers/dataprotection/backuprepo_controller.go
+++ b/controllers/dataprotection/backuprepo_controller.go
@@ -25,10 +25,10 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
-	"html/template"
 	"reflect"
 	"sort"
 	"strings"
+	"text/template"
 
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -828,7 +828,7 @@ func isOwned(owner client.Object, dependent client.Object) bool {
 func randomNameForDerivedObject(repo *dpv1alpha1.BackupRepo, prefix string) string {
 	// the final name should not exceed 63 characters
 	const maxBaseNameLength = 56
-	baseName := fmt.Sprintf("%s-backuprepo-%s", prefix, repo.Name)
+	baseName := fmt.Sprintf("%s-%s", prefix, repo.Name)
 	if len(baseName) > maxBaseNameLength {
 		baseName = baseName[:maxBaseNameLength]
 	}

--- a/deploy/csi-s3/Chart.yaml
+++ b/deploy/csi-s3/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.31.3
+appVersion: 0.31.4
 description: Container Storage Interface (CSI) driver for S3 volumes
 home: https://github.com/yandex-cloud/k8s-csi-s3
 icon: https://raw.githubusercontent.com/yandex-cloud/geesefs/master/doc/geesefs.png
@@ -8,4 +8,4 @@ keywords:
 name: csi-s3
 sources:
 - https://github.com/yandex-cloud/k8s-csi-s3/deploy/helm
-version: 0.31.3
+version: 0.31.4

--- a/deploy/csi-s3/templates/driver.yaml
+++ b/deploy/csi-s3/templates/driver.yaml
@@ -1,0 +1,10 @@
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: ru.yandex.s3.csi
+spec:
+  attachRequired: false
+  podInfoOnMount: true
+  fsGroupPolicy: File # added in Kubernetes 1.19, this field is GA as of Kubernetes 1.23
+  volumeLifecycleModes: # added in Kubernetes 1.16, this field is beta
+    - Persistent

--- a/deploy/csi-s3/values.yaml
+++ b/deploy/csi-s3/values.yaml
@@ -11,7 +11,7 @@ images:
 
 storageClass:
   # Specifies whether the storage class should be created
-  create: true
+  create: false
   # storage class name
   name: "csi-s3"
   # Use a single bucket for all dynamically provisioned persistent volumes
@@ -41,7 +41,7 @@ storageClass:
 
 secret:
   # Specifies whether the secret should be created
-  create: true
+  create: false
   # S3 Access Key
   accessKey: ""
   # S3 Secret Key

--- a/deploy/helm/templates/storageprovider/minio.yaml
+++ b/deploy/helm/templates/storageprovider/minio.yaml
@@ -1,0 +1,59 @@
+apiVersion: storage.kubeblocks.io/v1alpha1
+kind: StorageProvider
+metadata:
+  name: minio
+  labels:
+    {{- include "kubeblocks.labels" . | nindent 4 }}
+spec:
+  csiDriverName: ru.yandex.s3.csi
+  csiDriverSecretTemplate: |
+    accessKeyID: {{ `{{ index .Parameters "accessKeyId" }}` }}
+    secretAccessKey: {{ `{{ index .Parameters "secretAccessKey" }}` }}
+    endpoint: {{ `{{ index .Parameters "endpoint" }}` }}
+
+  storageClassTemplate: |
+    provisioner: ru.yandex.s3.csi
+    parameters:
+      mounter: geesefs
+      # you can set mount options here, for example limit memory cache size (recommended)
+      options: {{ `{{ index .Parameters "mountOptions" }}` }}
+      bucket: {{ `{{ index .Parameters "bucket" }}` }}
+      csi.storage.k8s.io/provisioner-secret-name: {{ `{{ .CSIDriverSecretRef.Name }}` }}
+      csi.storage.k8s.io/provisioner-secret-namespace: {{ `{{ .CSIDriverSecretRef.Namespace }}` }}
+      csi.storage.k8s.io/controller-publish-secret-name: {{ `{{ .CSIDriverSecretRef.Name }}` }}
+      csi.storage.k8s.io/controller-publish-secret-namespace: {{ `{{ .CSIDriverSecretRef.Namespace }}` }}
+      csi.storage.k8s.io/node-stage-secret-name: {{ `{{ .CSIDriverSecretRef.Name }}` }}
+      csi.storage.k8s.io/node-stage-secret-namespace: {{ `{{ .CSIDriverSecretRef.Namespace }}` }}
+      csi.storage.k8s.io/node-publish-secret-name: {{ `{{ .CSIDriverSecretRef.Name }}` }}
+      csi.storage.k8s.io/node-publish-secret-namespace: {{ `{{ .CSIDriverSecretRef.Namespace }}` }}
+
+  parametersSchema:
+    openAPIV3Schema:
+      type: "object"
+      properties:
+        bucket:
+          type: string
+          description: "MinIO bucket"
+        endpoint:
+          type: string
+          description: "MinIO endpoint"
+        mountOptions:
+          type: string
+          description: "mount options for geesefs"
+          default: "--memory-limit 1000 --dir-mode 0777 --file-mode 0666"
+        accessKeyId:
+          type: string
+          description: "MinIO access key"
+        secretAccessKey:
+          type: string
+          description: "MinIO secret key"
+
+      required:
+        - bucket
+        - endpoint
+        - accessKeyId
+        - secretAccessKey
+
+    credentialFields:
+      - accessKeyId
+      - secretAccessKey

--- a/deploy/helm/templates/storageprovider/oss.yaml
+++ b/deploy/helm/templates/storageprovider/oss.yaml
@@ -1,0 +1,67 @@
+apiVersion: storage.kubeblocks.io/v1alpha1
+kind: StorageProvider
+metadata:
+  name: oss
+  labels:
+    {{- include "kubeblocks.labels" . | nindent 4 }}
+spec:
+  csiDriverName: ru.yandex.s3.csi
+  csiDriverSecretTemplate: |
+    accessKeyID: {{ `{{ index .Parameters "accessKeyId" }}` }}
+    secretAccessKey: {{ `{{ index .Parameters "secretAccessKey" }}` }}
+    {{ `{{- $region := index .Parameters "region" }}` }}
+    {{ `{{- $endpoint := index .Parameters "endpoint" }}` }}
+    {{ `{{- if not $endpoint }}` }}
+      {{ `{{- $endpoint = (printf "https://oss-%s.aliyuncs.com" $region) }}` }}
+    {{ `{{- end }}` }}
+    endpoint: {{ `{{ $endpoint }}` }}
+
+  storageClassTemplate: |
+    provisioner: ru.yandex.s3.csi
+    parameters:
+      mounter: geesefs
+      # you can set mount options here, for example limit memory cache size (recommended)
+      options: {{ `{{ printf "%s --subdomain" (index .Parameters "mountOptions") }}` }}
+      bucket: {{ `{{ index .Parameters "bucket" }}` }}
+      csi.storage.k8s.io/provisioner-secret-name: {{ `{{ .CSIDriverSecretRef.Name }}` }}
+      csi.storage.k8s.io/provisioner-secret-namespace: {{ `{{ .CSIDriverSecretRef.Namespace }}` }}
+      csi.storage.k8s.io/controller-publish-secret-name: {{ `{{ .CSIDriverSecretRef.Name }}` }}
+      csi.storage.k8s.io/controller-publish-secret-namespace: {{ `{{ .CSIDriverSecretRef.Namespace }}` }}
+      csi.storage.k8s.io/node-stage-secret-name: {{ `{{ .CSIDriverSecretRef.Name }}` }}
+      csi.storage.k8s.io/node-stage-secret-namespace: {{ `{{ .CSIDriverSecretRef.Namespace }}` }}
+      csi.storage.k8s.io/node-publish-secret-name: {{ `{{ .CSIDriverSecretRef.Name }}` }}
+      csi.storage.k8s.io/node-publish-secret-namespace: {{ `{{ .CSIDriverSecretRef.Namespace }}` }}
+
+  parametersSchema:
+    openAPIV3Schema:
+      type: "object"
+      properties:
+        region:
+          type: string
+          description: "OSS region, e.g. cn-hangzhou"
+        bucket:
+          type: string
+          description: "OSS bucket"
+        endpoint:
+          type: string
+          description: "OSS endpoint (optional)"
+        mountOptions:
+          type: string
+          description: "mount options for geesefs"
+          default: "--memory-limit 1000 --dir-mode 0777 --file-mode 0666"
+        accessKeyId:
+          type: string
+          description: "OSS access key"
+        secretAccessKey:
+          type: string
+          description: "OSS secret key"
+
+      required:
+        - bucket
+        - region
+        - accessKeyId
+        - secretAccessKey
+
+    credentialFields:
+      - accessKeyId
+      - secretAccessKey

--- a/deploy/helm/templates/storageprovider/s3.yaml
+++ b/deploy/helm/templates/storageprovider/s3.yaml
@@ -1,0 +1,71 @@
+apiVersion: storage.kubeblocks.io/v1alpha1
+kind: StorageProvider
+metadata:
+  name: s3
+  labels:
+    {{- include "kubeblocks.labels" . | nindent 4 }}
+spec:
+  csiDriverName: ru.yandex.s3.csi
+  csiDriverSecretTemplate: |
+    accessKeyID: {{ `{{ index .Parameters "accessKeyId" }}` }}
+    secretAccessKey: {{ `{{ index .Parameters "secretAccessKey" }}` }}
+    {{ `{{- $region := index .Parameters "region" }}` }}
+    {{ `{{- $endpoint := index .Parameters "endpoint" }}` }}
+    {{ `{{- if not $endpoint }}` }}
+      {{ `{{- if hasPrefix "cn-" $region }}` }}
+        {{ `{{- $endpoint = (printf "https://s3.%s.amazonaws.com.cn" $region) }}` }}
+      {{ `{{- else }}` }}
+        {{ `{{- $endpoint = (printf "https://s3.%s.amazonaws.com" $region) }}` }}
+      {{ `{{- end }}` }}
+    {{ `{{- end }}` }}
+    endpoint: {{ `{{ $endpoint }}` }}
+
+  storageClassTemplate: |
+    provisioner: ru.yandex.s3.csi
+    parameters:
+      mounter: geesefs
+      # you can set mount options here, for example limit memory cache size (recommended)
+      options: {{ `{{ printf "%s --region %s" (index .Parameters "mountOptions") (index .Parameters "region") }}` }}
+      bucket: {{ `{{ index .Parameters "bucket" }}` }}
+      csi.storage.k8s.io/provisioner-secret-name: {{ `{{ .CSIDriverSecretRef.Name }}` }}
+      csi.storage.k8s.io/provisioner-secret-namespace: {{ `{{ .CSIDriverSecretRef.Namespace }}` }}
+      csi.storage.k8s.io/controller-publish-secret-name: {{ `{{ .CSIDriverSecretRef.Name }}` }}
+      csi.storage.k8s.io/controller-publish-secret-namespace: {{ `{{ .CSIDriverSecretRef.Namespace }}` }}
+      csi.storage.k8s.io/node-stage-secret-name: {{ `{{ .CSIDriverSecretRef.Name }}` }}
+      csi.storage.k8s.io/node-stage-secret-namespace: {{ `{{ .CSIDriverSecretRef.Namespace }}` }}
+      csi.storage.k8s.io/node-publish-secret-name: {{ `{{ .CSIDriverSecretRef.Name }}` }}
+      csi.storage.k8s.io/node-publish-secret-namespace: {{ `{{ .CSIDriverSecretRef.Namespace }}` }}
+
+  parametersSchema:
+    openAPIV3Schema:
+      type: "object"
+      properties:
+        region:
+          type: string
+          description: "AWS region, e.g. us-west-1"
+        bucket:
+          type: string
+          description: "S3 bucket"
+        endpoint:
+          type: string
+          description: "S3 endpoint (optional)"
+        mountOptions:
+          type: string
+          description: "mount options for geesefs"
+          default: "--memory-limit 1000 --dir-mode 0777 --file-mode 0666"
+        accessKeyId:
+          type: string
+          description: "AWS access key"
+        secretAccessKey:
+          type: string
+          description: "AWS secret key"
+
+      required:
+        - bucket
+        - region
+        - accessKeyId
+        - secretAccessKey
+
+    credentialFields:
+      - accessKeyId
+      - secretAccessKey

--- a/docs/user_docs/cli/cli.md
+++ b/docs/user_docs/cli/cli.md
@@ -25,6 +25,13 @@ Manage alert receiver, include add, list and delete receiver.
 * [kbcli alert list-smtpserver](kbcli_alert_list-smtpserver.md)	 - List alert smtp servers config.
 
 
+## [backuprepo](kbcli_backuprepo.md)
+
+BackupRepo command.
+
+* [kbcli backuprepo create](kbcli_backuprepo_create.md)	 - Create a backup repo
+
+
 ## [bench](kbcli_bench.md)
 
 Run a benchmark.

--- a/docs/user_docs/cli/kbcli.md
+++ b/docs/user_docs/cli/kbcli.md
@@ -56,6 +56,7 @@ kbcli [flags]
 
 * [kbcli addon](kbcli_addon.md)	 - Addon command.
 * [kbcli alert](kbcli_alert.md)	 - Manage alert receiver, include add, list and delete receiver.
+* [kbcli backuprepo](kbcli_backuprepo.md)	 - BackupRepo command.
 * [kbcli bench](kbcli_bench.md)	 - Run a benchmark.
 * [kbcli builder](kbcli_builder.md)	 - builder command.
 * [kbcli class](kbcli_class.md)	 - Manage classes

--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/valyala/fasthttp v1.41.0
 	github.com/vmware-tanzu/velero v1.10.1
 	github.com/xdg-go/scram v1.1.1
+	github.com/xeipuuv/gojsonschema v1.2.0
 	go.etcd.io/etcd/client/v3 v3.5.6
 	go.etcd.io/etcd/server/v3 v3.5.6
 	go.mongodb.org/mongo-driver v1.11.1
@@ -367,7 +368,6 @@ require (
 	github.com/xdg-go/stringprep v1.0.3 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
-	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	github.com/xlab/treeprint v1.1.0 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect

--- a/internal/cli/cmd/backuprepo/backuprepo.go
+++ b/internal/cli/cmd/backuprepo/backuprepo.go
@@ -1,0 +1,40 @@
+/*
+Copyright (C) 2022-2023 ApeCloud Co., Ltd
+
+# This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package backuprepo
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+func NewBackupRepoCmd(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "backuprepo COMMAND",
+		Short: "BackupRepo command.",
+	}
+	cmd.AddCommand(
+		newCreateCommand(nil, f, streams),
+		// newUpdateCommand(f, streams), // TODO:
+		// newListCommand(f, streams), // TODO:
+		// newDescribeCmd(f, streams), // TODO:
+	)
+	return cmd
+}

--- a/internal/cli/cmd/backuprepo/backuprepo_test.go
+++ b/internal/cli/cmd/backuprepo/backuprepo_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright (C) 2022-2023 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package backuprepo
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+)
+
+var _ = Describe("backuprepo command", func() {
+	var streams genericclioptions.IOStreams
+	var tf *cmdtesting.TestFactory
+
+	BeforeEach(func() {
+		streams, _, _, _ = genericclioptions.NewTestIOStreams()
+		tf = cmdtesting.NewTestFactory()
+	})
+
+	AfterEach(func() {
+		tf.Cleanup()
+	})
+
+	It("should create backuprepo command successfully", func() {
+		cmd := NewBackupRepoCmd(tf, streams)
+		Expect(cmd).ShouldNot(BeNil())
+	})
+})

--- a/internal/cli/cmd/backuprepo/create.go
+++ b/internal/cli/cmd/backuprepo/create.go
@@ -1,0 +1,462 @@
+/*
+Copyright (C) 2022-2023 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package backuprepo
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	utilcomp "k8s.io/kubectl/pkg/util/completion"
+	"k8s.io/kubectl/pkg/util/templates"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stoewer/go-strcase"
+	"github.com/xeipuuv/gojsonschema"
+	"golang.org/x/exp/slices"
+
+	dataprotectionv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	storagev1alpha1 "github.com/apecloud/kubeblocks/apis/storage/v1alpha1"
+	"github.com/apecloud/kubeblocks/internal/cli/printer"
+	"github.com/apecloud/kubeblocks/internal/cli/types"
+	"github.com/apecloud/kubeblocks/internal/cli/util"
+	"github.com/apecloud/kubeblocks/internal/cli/util/flags"
+	"github.com/apecloud/kubeblocks/internal/constant"
+)
+
+const (
+	providerFlagName = "provider"
+)
+
+var (
+	allowedPVReclaimPolicies = []string{"Retain", "Delete"}
+)
+
+type createOptions struct {
+	genericclioptions.IOStreams
+	dynamic dynamic.Interface
+	client  kubernetes.Interface
+	factory cmdutil.Factory
+
+	storageProvider string
+	providerObject  *storagev1alpha1.StorageProvider
+	isDefault       bool
+	pvReclaimPolicy string
+	volumeCapacity  string
+	repoName        string
+	config          map[string]string
+	credential      map[string]string
+	allValues       map[string]string
+}
+
+var backupRepoCreateExamples = templates.Examples(`
+    # Create a default backup repo using S3 as the backend
+    kbcli backuprepo create \
+      --provider s3 \
+      --region us-west-1 \
+      --bucket test-kb-backup \
+      --access-key-id <ACCESS KEY> \
+      --secret-access-key <SECRET KEY> \
+      --default
+
+    # Create a non-default backup repo with a specified name
+    kbcli backuprepo create my-backup-repo \
+      --provider s3 \
+      --region us-west-1 \
+      --bucket test-kb-backup \
+      --access-key-id <ACCESS KEY> \
+      --secret-access-key <SECRET KEY>
+`)
+
+func newCreateCommand(o *createOptions, f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
+	if o == nil {
+		o = &createOptions{}
+	}
+	o.IOStreams = streams
+	cmd := &cobra.Command{
+		Use:     "create [NAME]",
+		Short:   "Create a backup repo",
+		Example: backupRepoCreateExamples,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			util.CheckErr(o.init(f))
+			err := o.parseProviderFlags(cmd, args, f)
+			if errors.Is(err, pflag.ErrHelp) {
+				return err
+			} else {
+				util.CheckErr(err)
+			}
+			util.CheckErr(o.complete(cmd))
+			util.CheckErr(o.validate(cmd))
+			util.CheckErr(o.run())
+			return nil
+		},
+		DisableFlagParsing: true,
+	}
+	cmd.Flags().StringVar(&o.storageProvider, providerFlagName, "", "Specify storage provider")
+	util.CheckErr(cmd.MarkFlagRequired(providerFlagName))
+	cmd.Flags().BoolVar(&o.isDefault, "default", false, "Specify whether to set the created backup repo as default")
+	cmd.Flags().StringVar(&o.pvReclaimPolicy, "pv-reclaim-policy", "Retain",
+		`Specify the reclaim policy for PVs created by this backup repo, the value can be "Retain" or "Delete"`)
+	cmd.Flags().StringVar(&o.volumeCapacity, "volume-capacity", "100Gi",
+		`Specify the capacity of the new created PVC"`)
+
+	// register flag completion func
+	registerFlagCompletionFunc(cmd, f)
+
+	return cmd
+}
+
+func (o *createOptions) init(f cmdutil.Factory) error {
+	var err error
+	if o.dynamic, err = f.DynamicClient(); err != nil {
+		return err
+	}
+	if o.client, err = f.KubernetesClientSet(); err != nil {
+		return err
+	}
+	o.factory = f
+	return nil
+}
+
+func flagsToValues(fs *pflag.FlagSet) map[string]string {
+	values := make(map[string]string)
+	fs.VisitAll(func(f *pflag.Flag) {
+		if f.Name == "help" {
+			return
+		}
+		val, _ := fs.GetString(f.Name)
+		values[f.Name] = val
+	})
+	return values
+}
+
+func (o *createOptions) parseProviderFlags(cmd *cobra.Command, args []string, f cmdutil.Factory) error {
+	// Since we disabled the flag parsing of the cmd, we need to parse it from args
+	tmpFlags := pflag.NewFlagSet("tmp", pflag.ContinueOnError)
+	tmpFlags.StringVar(&o.storageProvider, providerFlagName, "", "")
+	tmpFlags.BoolP("help", "h", false, "") // eat --help and -h
+	tmpFlags.ParseErrorsWhitelist.UnknownFlags = true
+	_ = tmpFlags.Parse(args)
+	if o.storageProvider == "" {
+		return fmt.Errorf("please specify the --%s flag", providerFlagName)
+	}
+
+	// Get provider info from API server
+	obj, err := o.dynamic.Resource(types.StorageProviderGVR()).Get(
+		context.Background(), o.storageProvider, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("storage provider \"%s\" is not found", o.storageProvider)
+		}
+		return err
+	}
+	provider := &storagev1alpha1.StorageProvider{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, provider)
+	if err != nil {
+		return err
+	}
+	o.providerObject = provider
+
+	// Build flags by schema
+	if provider.Spec.ParametersSchema != nil &&
+		provider.Spec.ParametersSchema.OpenAPIV3Schema != nil {
+		// Convert apiextensionsv1.JSONSchemaProps to spec.Schema
+		schemaData, err := json.Marshal(provider.Spec.ParametersSchema.OpenAPIV3Schema)
+		if err != nil {
+			return err
+		}
+		schema := &spec.Schema{}
+		if err = json.Unmarshal(schemaData, schema); err != nil {
+			return err
+		}
+		if err = flags.BuildFlagsBySchema(cmd, f, schema); err != nil {
+			return err
+		}
+	}
+
+	// Parse dynamic flags
+	cmd.DisableFlagParsing = false
+	err = cmd.ParseFlags(args)
+	if err != nil {
+		return err
+	}
+	helpFlag := cmd.Flags().Lookup("help")
+	if helpFlag != nil && helpFlag.Value.String() == "true" {
+		return pflag.ErrHelp
+	}
+	if err := cmd.ValidateRequiredFlags(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *createOptions) complete(cmd *cobra.Command) error {
+	o.config = map[string]string{}
+	o.credential = map[string]string{}
+	o.allValues = map[string]string{}
+	schema := o.providerObject.Spec.ParametersSchema
+	// Construct config and credential map from flags
+	if schema != nil && schema.OpenAPIV3Schema != nil {
+		credMap := map[string]bool{}
+		for _, x := range schema.CredentialFields {
+			credMap[x] = true
+		}
+		fromFlags := flagsToValues(cmd.LocalNonPersistentFlags())
+		for name := range schema.OpenAPIV3Schema.Properties {
+			flagName := strcase.KebabCase(name)
+			if val, ok := fromFlags[flagName]; ok {
+				o.allValues[name] = val
+				if credMap[name] {
+					o.credential[name] = val
+				} else {
+					o.config[name] = val
+				}
+			}
+		}
+	}
+	// Set repo name if specified
+	positionArgs := cmd.Flags().Args()
+	if len(positionArgs) > 0 {
+		o.repoName = positionArgs[0]
+	}
+	return nil
+}
+
+func (o *createOptions) validate(cmd *cobra.Command) error {
+	// Validate values by the json schema
+	schema := o.providerObject.Spec.ParametersSchema
+	if schema != nil && schema.OpenAPIV3Schema != nil {
+		schemaLoader := gojsonschema.NewGoLoader(schema.OpenAPIV3Schema)
+		docLoader := gojsonschema.NewGoLoader(o.allValues)
+		result, err := gojsonschema.Validate(schemaLoader, docLoader)
+		if err != nil {
+			return err
+		}
+		if !result.Valid() {
+			for _, err := range result.Errors() {
+				flagName := strcase.KebabCase(err.Field())
+				cmd.Printf("invalid value \"%v\" for \"--%s\": %s\n",
+					err.Value(), flagName, err.Description())
+			}
+			return fmt.Errorf("invalid flags")
+		}
+	}
+
+	// Validate pv reclaim policy
+	if !slices.Contains(allowedPVReclaimPolicies, o.pvReclaimPolicy) {
+		return fmt.Errorf("invalid --pv-reclaim-policy \"%s\", the value must be one of %q",
+			o.pvReclaimPolicy, allowedPVReclaimPolicies)
+	}
+
+	// Validate volume capacity
+	if _, err := resource.ParseQuantity(o.volumeCapacity); err != nil {
+		return fmt.Errorf("invalid --volume-capacity \"%s\", err: %s", o.volumeCapacity, err)
+	}
+
+	// Check if the repo already exists
+	if o.repoName != "" {
+		_, err := o.dynamic.Resource(types.BackupRepoGVR()).Get(
+			context.Background(), o.repoName, metav1.GetOptions{})
+		if err == nil {
+			return fmt.Errorf(`BackupRepo "%s" is already exists`, o.repoName)
+		}
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+
+	// Check if there are any default backup repo already exists
+	if o.isDefault {
+		list, err := o.dynamic.Resource(types.BackupRepoGVR()).List(
+			context.Background(), metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
+		for _, item := range list.Items {
+			if item.GetAnnotations()[constant.DefaultBackupRepoAnnotationKey] == "true" {
+				name := item.GetName()
+				return fmt.Errorf("there is already a default backup repo \"%s\","+
+					" please don't specify the --default flag,\n"+
+					"\tor set \"%s\" as non-default first",
+					name, name)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (o *createOptions) createCredentialSecret() (*corev1.Secret, error) {
+	// if failed to get the namespace of KubeBlocks,
+	// then create the secret in the current namespace
+	namespace, err := util.GetKubeBlocksNamespace(o.client)
+	if err != nil {
+		namespace, _, err = o.factory.ToRawKubeConfigLoader().Namespace()
+		if err != nil {
+			return nil, err
+		}
+	}
+	secretData := map[string][]byte{}
+	for k, v := range o.credential {
+		secretData[k] = []byte(v)
+	}
+	secretObj := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "kb-backuprepo-",
+			Namespace:    namespace,
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: secretData,
+	}
+	return o.client.CoreV1().Secrets(namespace).Create(
+		context.Background(), secretObj, metav1.CreateOptions{})
+}
+
+func (o *createOptions) buildBackupRepoObject(secret *corev1.Secret) (*unstructured.Unstructured, error) {
+	backupRepo := &dataprotectionv1alpha1.BackupRepo{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: fmt.Sprintf("%s/%s", types.DPAPIGroup, types.DPAPIVersion),
+			Kind:       "BackupRepo",
+		},
+		Spec: dataprotectionv1alpha1.BackupRepoSpec{
+			StorageProviderRef: o.storageProvider,
+			PVReclaimPolicy:    corev1.PersistentVolumeReclaimPolicy(o.pvReclaimPolicy),
+			VolumeCapacity:     resource.MustParse(o.volumeCapacity),
+			Config:             o.config,
+		},
+	}
+	if o.repoName != "" {
+		backupRepo.Name = o.repoName
+	} else {
+		backupRepo.GenerateName = "backuprepo-"
+	}
+	if secret != nil {
+		backupRepo.Spec.Credential = &corev1.SecretReference{
+			Name:      secret.Name,
+			Namespace: secret.Namespace,
+		}
+	}
+	if o.isDefault {
+		backupRepo.Annotations = map[string]string{
+			constant.DefaultBackupRepoAnnotationKey: "true",
+		}
+	}
+	obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(backupRepo)
+	if err != nil {
+		return nil, err
+	}
+	return &unstructured.Unstructured{Object: obj}, nil
+}
+
+func (o *createOptions) setSecretOwnership(secret *corev1.Secret, owner *unstructured.Unstructured) error {
+	old := secret.DeepCopyObject()
+	refs := secret.GetOwnerReferences()
+	refs = append(refs, metav1.OwnerReference{
+		APIVersion: owner.GetAPIVersion(),
+		Kind:       owner.GetKind(),
+		Name:       owner.GetName(),
+		UID:        owner.GetUID(),
+	})
+	secret.SetOwnerReferences(refs)
+	oldData, err := json.Marshal(old)
+	if err != nil {
+		return err
+	}
+	newData, err := json.Marshal(secret)
+	if err != nil {
+		return err
+	}
+	patchData, err := jsonpatch.CreateMergePatch(oldData, newData)
+	if err != nil {
+		return err
+	}
+	_, err = o.client.CoreV1().Secrets(secret.GetNamespace()).Patch(
+		context.Background(), secret.Name, k8stypes.MergePatchType, patchData, metav1.PatchOptions{})
+	return err
+}
+
+func (o *createOptions) run() error {
+	// create secret
+	var createdSecret *corev1.Secret
+	if len(o.credential) > 0 {
+		var err error
+		if createdSecret, err = o.createCredentialSecret(); err != nil {
+			return fmt.Errorf("create credential secret failed: %w", err)
+		}
+	}
+
+	rollbackFn := func() {
+		// rollback the created secret if the backup repo creation failed
+		if createdSecret != nil {
+			_ = o.client.CoreV1().Secrets(createdSecret.Namespace).Delete(
+				context.Background(), createdSecret.Name, metav1.DeleteOptions{})
+		}
+	}
+
+	// create backup repo
+	backupRepoObj, err := o.buildBackupRepoObject(createdSecret)
+	if err != nil {
+		rollbackFn()
+		return fmt.Errorf("build BackupRepo object failed: %w", err)
+	}
+	createdBackupRepo, err := o.dynamic.Resource(types.BackupRepoGVR()).Create(
+		context.Background(), backupRepoObj, metav1.CreateOptions{})
+	if err != nil {
+		rollbackFn()
+		return fmt.Errorf("create BackupRepo object failed: %w", err)
+	}
+
+	// set ownership of the secret to the repo object
+	if createdSecret != nil {
+		_ = o.setSecretOwnership(createdSecret, backupRepoObj)
+	}
+
+	printer.PrintLine(fmt.Sprintf("Successfully create backup repo \"%s\".", createdBackupRepo.GetName()))
+	return nil
+}
+
+func registerFlagCompletionFunc(cmd *cobra.Command, f cmdutil.Factory) {
+	util.CheckErr(cmd.RegisterFlagCompletionFunc(
+		providerFlagName,
+		func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return utilcomp.CompGetResource(f, cmd, util.GVRToString(types.StorageProviderGVR()), toComplete), cobra.ShellCompDirectiveNoFileComp
+		}))
+	util.CheckErr(cmd.RegisterFlagCompletionFunc(
+		"pv-reclaim-policy",
+		cobra.FixedCompletions(allowedPVReclaimPolicies, cobra.ShellCompDirectiveNoFileComp)))
+
+	// TODO: support completion for dynamic flags, if possible
+}

--- a/internal/cli/cmd/backuprepo/create_test.go
+++ b/internal/cli/cmd/backuprepo/create_test.go
@@ -1,0 +1,242 @@
+/*
+Copyright (C) 2022-2023 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package backuprepo
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/dynamic/fake"
+	clientfake "k8s.io/client-go/rest/fake"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+
+	"github.com/apecloud/kubeblocks/internal/cli/scheme"
+	"github.com/apecloud/kubeblocks/internal/cli/testing"
+)
+
+var _ = Describe("backuprepo create command", func() {
+	var streams genericclioptions.IOStreams
+	var tf *cmdtesting.TestFactory
+	var cmd *cobra.Command
+	var options *createOptions
+
+	BeforeEach(func() {
+		streams, _, _, _ = genericclioptions.NewTestIOStreams()
+		tf = cmdtesting.NewTestFactory().WithNamespace(testing.Namespace)
+		codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+		httpResp := func(obj runtime.Object) *http.Response {
+			return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, obj)}
+		}
+
+		tf.UnstructuredClient = &clientfake.RESTClient{
+			NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+			Client: clientfake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+				urlPrefix := "/api/v1/namespaces/" + testing.Namespace
+				if req.URL.Path == urlPrefix+"/secrets" && req.Method == http.MethodPost {
+					dec := json.NewDecoder(req.Body)
+					secret := &corev1.Secret{}
+					_ = dec.Decode(secret)
+					if secret.Name == "" && secret.GenerateName != "" {
+						secret.Name = secret.GenerateName + "123456"
+					}
+					return httpResp(secret), nil
+				}
+				if strings.HasPrefix(req.URL.Path, urlPrefix+"/secrets") && req.Method == http.MethodPatch {
+					return httpResp(&corev1.Secret{}), nil
+				}
+				mapping := map[string]*http.Response{
+					"/api/v1/secrets": httpResp(&corev1.SecretList{}),
+				}
+				return mapping[req.URL.Path], nil
+			}),
+		}
+		tf.Client = tf.UnstructuredClient
+
+		options = &createOptions{}
+		cmd = newCreateCommand(options, tf, streams)
+		err := options.init(tf)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		providerObj := testing.FakeStorageProvider("fake-s3")
+		repoObj := testing.FakeBackupRepo("test-backuprepo", false)
+		tf.FakeDynamicClient = fake.NewSimpleDynamicClient(
+			scheme.Scheme, providerObj, repoObj)
+		err = options.init(tf)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		tf.Cleanup()
+	})
+
+	Describe("parseProviderFlags", func() {
+		It("should fail if --provider is not specified", func() {
+			err := options.parseProviderFlags(cmd, []string{}, tf)
+			Expect(err).Should(MatchError(ContainSubstring("please specify the --provider flag")))
+		})
+
+		It("should fail if the specified provider is not existing", func() {
+			err := options.parseProviderFlags(cmd, []string{"--provider", "non-existent"}, tf)
+			Expect(err).Should(MatchError(ContainSubstring("storage provider \"non-existent\" is not found")))
+		})
+
+		It("should able to parse flags from the provider", func() {
+			err := options.parseProviderFlags(cmd, []string{
+				"--provider", "fake-s3",
+				"--access-key-id", "abc",
+				"--secret-access-key", "def",
+			}, tf)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("should fail to parse unknown flags", func() {
+			err := options.parseProviderFlags(cmd, []string{"--provider", "fake-s3", "--foo", "abc"}, tf)
+			Expect(err).Should(MatchError(ContainSubstring("unknown flag: --foo")))
+		})
+
+		It("should fail if required flags are not specified", func() {
+			err := options.parseProviderFlags(cmd, []string{"--provider", "fake-s3"}, tf)
+			Expect(err).Should(MatchError(ContainSubstring("required flag(s) \"access-key-id\", \"secret-access-key\" not set")))
+		})
+
+		It("should set isDefault field", func() {
+			err := options.parseProviderFlags(cmd, []string{
+				"--provider", "fake-s3", "--access-key-id", "abc", "--secret-access-key", "def", "--default",
+			}, tf)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(options.isDefault).Should(BeTrue())
+		})
+
+		It("should return ErrHelp if --help is specified", func() {
+			err := options.parseProviderFlags(cmd, []string{"--provider", "fake-s3", "--help"}, tf)
+			Expect(err).Should(MatchError(pflag.ErrHelp))
+		})
+	})
+
+	Describe("complete", func() {
+		It("should set fields in createOptions", func() {
+			err := options.parseProviderFlags(cmd, []string{
+				"test-backuprepo",
+				"--provider", "fake-s3",
+				"--access-key-id", "abc",
+				"--secret-access-key", "def",
+				"--region", "us-west-2",
+				"--bucket", "test-bucket",
+			}, tf)
+			Expect(err).ShouldNot(HaveOccurred())
+			err = options.complete(cmd)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(options.repoName).Should(Equal("test-backuprepo"))
+			Expect(options.allValues).Should(Equal(map[string]string{
+				"accessKeyId":     "abc",
+				"secretAccessKey": "def",
+				"region":          "us-west-2",
+				"bucket":          "test-bucket",
+				"endpoint":        "",
+				"mountOptions":    "",
+			}))
+			Expect(options.config).Should(Equal(map[string]string{
+				"region":       "us-west-2",
+				"bucket":       "test-bucket",
+				"endpoint":     "",
+				"mountOptions": "",
+			}))
+			Expect(options.credential).Should(Equal(map[string]string{
+				"accessKeyId":     "abc",
+				"secretAccessKey": "def",
+			}))
+		})
+	})
+
+	Describe("validate", func() {
+		BeforeEach(func() {
+			err := options.parseProviderFlags(cmd, []string{
+				"--provider", "fake-s3", "--access-key-id", "abc", "--secret-access-key", "def",
+			}, tf)
+			Expect(err).ShouldNot(HaveOccurred())
+			err = options.complete(cmd)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("should validate parameters by the json schema", func() {
+			options.allValues["region"] = "invalid-region"
+			err := options.validate(cmd)
+			Expect(err).Should(MatchError(fmt.Errorf("invalid flags")))
+		})
+		It("should validate pv reclaim policy", func() {
+			options.pvReclaimPolicy = "whatever"
+			err := options.validate(cmd)
+			Expect(err).Should(MatchError(ContainSubstring("invalid --pv-reclaim-policy")))
+		})
+		It("should validate volume capacity", func() {
+			options.volumeCapacity = "invalid"
+			err := options.validate(cmd)
+			Expect(err).Should(MatchError(ContainSubstring("invalid --volume-capacity")))
+		})
+		It("should validate the backup repo is not existing", func() {
+			options.repoName = "test-backuprepo"
+			err := options.validate(cmd)
+			Expect(err).Should(MatchError(ContainSubstring("BackupRepo \"test-backuprepo\" is already exists")))
+		})
+		It("should validate if there is a default backup repo", func() {
+			By("setting up a default backup repo")
+			providerObj := testing.FakeStorageProvider("fake-s3")
+			repoObj := testing.FakeBackupRepo("test-backuprepo", true)
+			tf.FakeDynamicClient = fake.NewSimpleDynamicClient(
+				scheme.Scheme, providerObj, repoObj)
+			err := options.init(tf)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			By("validating")
+			options.isDefault = true
+			err = options.validate(cmd)
+			Expect(err).Should(MatchError(ContainSubstring("there is already a default backup repo")))
+		})
+	})
+
+	Describe("run", func() {
+		It("should success", func() {
+			By("preparing the options")
+			err := options.parseProviderFlags(cmd, []string{
+				"--provider", "fake-s3", "--access-key-id", "abc", "--secret-access-key", "def",
+				"--region", "us-west-1", "--bucket", "test-bucket", "--default",
+			}, tf)
+			Expect(err).ShouldNot(HaveOccurred())
+			err = options.complete(cmd)
+			Expect(err).ShouldNot(HaveOccurred())
+			err = options.validate(cmd)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			By("running the command")
+			err = options.run()
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+})

--- a/internal/cli/cmd/backuprepo/suite_test.go
+++ b/internal/cli/cmd/backuprepo/suite_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright (C) 2022-2023 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package backuprepo
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestApp(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "BackupRepo Cmd Test Suite")
+}

--- a/internal/cli/cmd/cli.go
+++ b/internal/cli/cmd/cli.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/apecloud/kubeblocks/internal/cli/cmd/addon"
 	"github.com/apecloud/kubeblocks/internal/cli/cmd/alert"
+	"github.com/apecloud/kubeblocks/internal/cli/cmd/backuprepo"
 	"github.com/apecloud/kubeblocks/internal/cli/cmd/bench"
 	"github.com/apecloud/kubeblocks/internal/cli/cmd/builder"
 	"github.com/apecloud/kubeblocks/internal/cli/cmd/class"
@@ -186,6 +187,7 @@ A Command Line Interface for KubeBlocks`,
 		builder.NewBuilderCmd(f, ioStreams),
 		report.NewReportCmd(f, ioStreams),
 		infras.NewInfraCmd(ioStreams),
+		backuprepo.NewBackupRepoCmd(f, ioStreams),
 	)
 
 	filters := []string{"options"}

--- a/internal/cli/testing/fake.go
+++ b/internal/cli/testing/fake.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -40,6 +41,7 @@ import (
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
 	extensionsv1alpha1 "github.com/apecloud/kubeblocks/apis/extensions/v1alpha1"
+	storagev1alpha1 "github.com/apecloud/kubeblocks/apis/storage/v1alpha1"
 	"github.com/apecloud/kubeblocks/internal/cli/types"
 	"github.com/apecloud/kubeblocks/internal/constant"
 	testapps "github.com/apecloud/kubeblocks/internal/testutil/apps"
@@ -932,4 +934,77 @@ func FakeEventForObject(name string, namespace string, object string) *corev1.Ev
 			Name: object,
 		},
 	}
+}
+
+func FakeStorageProvider(name string) *storagev1alpha1.StorageProvider {
+	storageProvider := &storagev1alpha1.StorageProvider{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: fmt.Sprintf("%s/%s", types.StorageAPIGroup, types.StorageAPIVersion),
+			Kind:       "StorageProvider",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: storagev1alpha1.StorageProviderSpec{
+			CSIDriverName: "fake-csi-s3",
+			CSIDriverSecretTemplate: `
+accessKeyId: {{ index .Parameters "accessKeyId" }}
+secretAccessKey: {{ index .Parameters "secretAccessKey" }}
+`,
+			StorageClassTemplate: `
+bucket: {{ index .Parameters "bucket" }}
+region: {{ index .Parameters "region" }}
+endpoint: {{ index .Parameters "endpoint" }}
+mountOptions: {{ index .Parameters "mountOptions" | default "" }}
+`,
+			ParametersSchema: &storagev1alpha1.ParametersSchema{
+				OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+					Type: "object",
+					Properties: map[string]apiextensionsv1.JSONSchemaProps{
+						"accessKeyId":     {Type: "string"},
+						"secretAccessKey": {Type: "string"},
+						"bucket":          {Type: "string"},
+						"region": {
+							Type: "string",
+							Enum: []apiextensionsv1.JSON{{Raw: []byte(`""`)}, {Raw: []byte(`"us-east-1"`)}, {Raw: []byte(`"us-west-1"`)}},
+						},
+						"endpoint":     {Type: "string"},
+						"mountOptions": {Type: "string"},
+					},
+					Required: []string{
+						"accessKeyId",
+						"secretAccessKey",
+					},
+				},
+				CredentialFields: []string{
+					"accessKeyId",
+					"secretAccessKey",
+				},
+			},
+		},
+	}
+	storageProvider.SetCreationTimestamp(metav1.Now())
+	return storageProvider
+}
+
+func FakeBackupRepo(name string, isDefault bool) *dpv1alpha1.BackupRepo {
+	backupRepo := &dpv1alpha1.BackupRepo{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: fmt.Sprintf("%s/%s", types.DPAPIGroup, types.DPAPIVersion),
+			Kind:       "BackupRepo",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: dpv1alpha1.BackupRepoSpec{
+			StorageProviderRef: "fake-storage-provider",
+			PVReclaimPolicy:    "Retain",
+		},
+	}
+	if isDefault {
+		backupRepo.Annotations = map[string]string{
+			constant.DefaultBackupRepoAnnotationKey: "true",
+		}
+	}
+	return backupRepo
 }

--- a/internal/cli/types/types.go
+++ b/internal/cli/types/types.go
@@ -131,6 +131,7 @@ const (
 	ResourceBackupTools    = "backuptools"
 	ResourceRestoreJobs    = "restorejobs"
 	ResourceBackupPolicies = "backuppolicies"
+	ResourceBackupRepoes   = "backuprepoes"
 )
 
 // Extensions API group
@@ -138,6 +139,13 @@ const (
 	ExtensionsAPIGroup   = "extensions.kubeblocks.io"
 	ExtensionsAPIVersion = "v1alpha1"
 	ResourceAddons       = "addons"
+)
+
+// Storage API group
+const (
+	StorageAPIGroup          = "storage.kubeblocks.io"
+	StorageAPIVersion        = "v1alpha1"
+	ResourceStorageProviders = "storageproviders"
 )
 
 // Migration API group
@@ -234,12 +242,20 @@ func BackupToolGVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: DPAPIGroup, Version: DPAPIVersion, Resource: ResourceBackupTools}
 }
 
+func BackupRepoGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: DPAPIGroup, Version: DPAPIVersion, Resource: ResourceBackupRepoes}
+}
+
 func RestoreJobGVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: DPAPIGroup, Version: DPAPIVersion, Resource: ResourceRestoreJobs}
 }
 
 func AddonGVR() schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: ExtensionsAPIGroup, Version: ExtensionsAPIVersion, Resource: ResourceAddons}
+}
+
+func StorageProviderGVR() schema.GroupVersionResource {
+	return schema.GroupVersionResource{Group: StorageAPIGroup, Version: StorageAPIVersion, Resource: ResourceStorageProviders}
 }
 
 func ComponentResourceConstraintGVR() schema.GroupVersionResource {

--- a/internal/cli/types/types.go
+++ b/internal/cli/types/types.go
@@ -131,7 +131,7 @@ const (
 	ResourceBackupTools    = "backuptools"
 	ResourceRestoreJobs    = "restorejobs"
 	ResourceBackupPolicies = "backuppolicies"
-	ResourceBackupRepoes   = "backuprepoes"
+	ResourceBackupRepos    = "backuprepos"
 )
 
 // Extensions API group
@@ -243,7 +243,7 @@ func BackupToolGVR() schema.GroupVersionResource {
 }
 
 func BackupRepoGVR() schema.GroupVersionResource {
-	return schema.GroupVersionResource{Group: DPAPIGroup, Version: DPAPIVersion, Resource: ResourceBackupRepoes}
+	return schema.GroupVersionResource{Group: DPAPIGroup, Version: DPAPIVersion, Resource: ResourceBackupRepos}
 }
 
 func RestoreJobGVR() schema.GroupVersionResource {

--- a/internal/cli/util/flags/flags.go
+++ b/internal/cli/util/flags/flags.go
@@ -82,7 +82,22 @@ func BuildFlagsBySchema(cmd *cobra.Command, f cmdutil.Factory, schema *spec.Sche
 			return err
 		}
 	}
+
+	for _, name := range schema.Required {
+		flagName := strcase.KebabCase(name)
+		if err := cmd.MarkFlagRequired(flagName); err != nil {
+			return err
+		}
+	}
+
 	return nil
+}
+
+// castOrZero is a helper function to cast a value to a specific type.
+// If the cast fails, the zero value will be returned.
+func castOrZero[T any](v any) T {
+	cv, _ := v.(T)
+	return cv
 }
 
 func buildOneFlag(cmd *cobra.Command, f cmdutil.Factory, k string, s *spec.Schema) error {
@@ -94,13 +109,13 @@ func buildOneFlag(cmd *cobra.Command, f cmdutil.Factory, k string, s *spec.Schem
 
 	switch tpe {
 	case "string":
-		cmd.Flags().String(name, s.Default.(string), buildFlagDescription(s))
+		cmd.Flags().String(name, castOrZero[string](s.Default), buildFlagDescription(s))
 	case "integer":
-		cmd.Flags().Int(name, int(s.Default.(float64)), buildFlagDescription(s))
+		cmd.Flags().Int(name, int(castOrZero[float64](s.Default)), buildFlagDescription(s))
 	case "number":
-		cmd.Flags().Float64(name, s.Default.(float64), buildFlagDescription(s))
+		cmd.Flags().Float64(name, castOrZero[float64](s.Default), buildFlagDescription(s))
 	case "boolean":
-		cmd.Flags().Bool(name, s.Default.(bool), buildFlagDescription(s))
+		cmd.Flags().Bool(name, castOrZero[bool](s.Default), buildFlagDescription(s))
 	default:
 		return fmt.Errorf("unsupported json schema type %s", s.Type)
 	}


### PR DESCRIPTION
This PR implements the `kbcli backuprepo create` command, which is used to create BackupRepo resources, with the following behavior:

* The user needs to specify the --provider parameter, indicating which storage backend the repo uses;
* kbcli gets the spec of that StorageProvider from the API server, then dynamically builds command flags, and parses the command line parameters passed by the user;
* Then create the BackupRepo resource.

Examples:

```bash
# Create a repo backed by s3, with a random name
kbcli backuprepo create \
  --provider s3 \
  --region cn-northwest-1 \
  --bucket test-kb-backup \
  --access-key-id <ACCESS KEY> \
  --secret-access-key <SECRET KEY>

# Create a default repo backed by oss, with the specified name "my-repo"
kbcli backuprepo create my-repo \
  --provider oss \
  --region cn-hangzhou \
  --bucket test-kb-backup \
  --access-key-id <ACCESS KEY> \
  --secret-access-key <SECRET KEY> \
  --default
```

This PR also contains other changes:

* csi-s3 helm adds a CSIDriver resource (from https://github.com/yandex-cloud/k8s-csi-s3/blob/master/deploy/helm/templates/driver.yaml)
* kubeblocks helm adds a few StorageProvider resources, adapting to s3, oss and minio these 3 storage backends. Although they are all compatible with the s3 protocol, there are some subtle differences in usage, so they are handled separately. For example, s3 and oss can infer the endpoint from the region, so the user can omit the endpoint parameter; using minio requires providing the endpoint information.
* Fixed some minor issues in the BackupRepo controller

fix #3407