### PR TITLE
fix: rbac_templdate use wrong namespace

### DIFF
--- a/internal/controller/builder/cue/rbac_template.cue
+++ b/internal/controller/builder/cue/rbac_template.cue
@@ -17,7 +17,7 @@
 
 cluster: {
     metadata: {
-        namespace: "default"
+        namespace: string
         name:      string
     }
     spec: {


### PR DESCRIPTION

* fix https://github.com/apecloud/kubeblocks/issues/4260