### PR TITLE
doc: fix  the capitalization issue

### DIFF
--- a/docs/user_docs/installation/install-kbcli.md
+++ b/docs/user_docs/installation/install-kbcli.md
@@ -19,10 +19,10 @@ For Windows users, PowerShell version should be 5.0 or higher.
 
 ## Install kbcli
 
-kbcli now supports MacOS, Windows, and Linux.
+kbcli now supports macOS, Windows, and Linux.
 
 <Tabs>
-<TabItem value="MacOS" label="MacOS" default>
+<TabItem value="macOS" label="macOS" default>
 
 You can install kbcli with `curl` or `brew`.
 


### PR DESCRIPTION
as titled

The correct way to write the name of Apple's operating system for Mac computers is "macOS", with a lowercase "m" and an uppercase "C".