### PR TITLE
fix: wrong backupToolName in apecloud-mysql/backuppolicytemplate.yaml

### DIFF
--- a/deploy/apecloud-mysql/templates/backuppolicytemplate.yaml
+++ b/deploy/apecloud-mysql/templates/backuppolicytemplate.yaml
@@ -46,7 +46,7 @@ spec:
         script: /scripts/binlog-collector.sh
         updateStage: post
     logfile:
-      backupToolName: wal-g-for-apecloud-mysql
+      backupToolName: apecloud-mysql-pitr-tool
       backupStatusUpdates:
       - path: manifests.backupLog
         containerName: mysql


### PR DESCRIPTION
fix #4284 