### PR TITLE
fix: fix the mismatched clusterdefiniton with cv cause buildcomponent panic 

### DIFF
--- a/internal/controller/component/component.go
+++ b/internal/controller/component/component.go
@@ -179,9 +179,7 @@ func buildComponent(reqCtx intctrlutil.RequestCtx,
 			component.PodSpec.Containers = appendOrOverrideContainerAttr(component.PodSpec.Containers, c)
 		}
 		// override component.SwitchoverSpec
-		if component.WorkloadType == appsv1alpha1.Replication || component.WorkloadType == appsv1alpha1.Consensus {
-			overrideSwitchoverSpecAttr(component.SwitchoverSpec, clusterCompVer.SwitchoverSpec)
-		}
+		overrideSwitchoverSpecAttr(component.SwitchoverSpec, clusterCompVer.SwitchoverSpec)
 	}
 
 	// handle component.PodSpec extra settings

--- a/internal/controller/component/component.go
+++ b/internal/controller/component/component.go
@@ -167,7 +167,7 @@ func buildComponent(reqCtx intctrlutil.RequestCtx,
 		ServiceAccountName:    clusterCompSpec.ServiceAccountName,
 	}
 
-	if len(clusterCompVers) > 0 && clusterCompVers[0] != nil {
+	if len(clusterCompVers) > 0 && clusterCompVers[0] != nil && (component.WorkloadType == appsv1alpha1.Replication || component.WorkloadType == appsv1alpha1.Consensus) {
 		// only accept 1st ClusterVersion override context
 		clusterCompVer := clusterCompVers[0]
 		component.ConfigTemplates = cfgcore.MergeConfigTemplates(clusterCompVer.ConfigSpecs, component.ConfigTemplates)
@@ -390,7 +390,7 @@ func GenerateConnCredential(clusterName string) string {
 
 // overrideSwitchoverSpecAttr overrides the attributes in switchoverSpec with the attributes of SwitchoverShortSpec in clusterVersion.
 func overrideSwitchoverSpecAttr(switchoverSpec *appsv1alpha1.SwitchoverSpec, cvSwitchoverSpec *appsv1alpha1.SwitchoverShortSpec) {
-	if cvSwitchoverSpec == nil || cvSwitchoverSpec.CmdExecutorConfig == nil {
+	if switchoverSpec == nil || cvSwitchoverSpec == nil || cvSwitchoverSpec.CmdExecutorConfig == nil {
 		return
 	}
 	applyCmdExecutorConfig := func(cmdExecutorConfig *appsv1alpha1.CmdExecutorConfig) {

--- a/internal/controller/component/component.go
+++ b/internal/controller/component/component.go
@@ -167,7 +167,7 @@ func buildComponent(reqCtx intctrlutil.RequestCtx,
 		ServiceAccountName:    clusterCompSpec.ServiceAccountName,
 	}
 
-	if len(clusterCompVers) > 0 && clusterCompVers[0] != nil && (component.WorkloadType == appsv1alpha1.Replication || component.WorkloadType == appsv1alpha1.Consensus) {
+	if len(clusterCompVers) > 0 && clusterCompVers[0] != nil {
 		// only accept 1st ClusterVersion override context
 		clusterCompVer := clusterCompVers[0]
 		component.ConfigTemplates = cfgcore.MergeConfigTemplates(clusterCompVer.ConfigSpecs, component.ConfigTemplates)
@@ -179,7 +179,9 @@ func buildComponent(reqCtx intctrlutil.RequestCtx,
 			component.PodSpec.Containers = appendOrOverrideContainerAttr(component.PodSpec.Containers, c)
 		}
 		// override component.SwitchoverSpec
-		overrideSwitchoverSpecAttr(component.SwitchoverSpec, clusterCompVer.SwitchoverSpec)
+		if component.WorkloadType == appsv1alpha1.Replication || component.WorkloadType == appsv1alpha1.Consensus {
+			overrideSwitchoverSpecAttr(component.SwitchoverSpec, clusterCompVer.SwitchoverSpec)
+		}
 	}
 
 	// handle component.PodSpec extra settings


### PR DESCRIPTION
- #4290
What i do:
- ~~do a `workloadtype` check before `overrideSwitchoverSpecAttr()`~~
- validate `switchoverSpec` during `overrideSwitchoverSpecAttr()`