### PR TITLE
fix: split the wesql-scale configuration to avoid confusion and add table_acl_config_mode config item

### DIFF
--- a/deploy/apecloud-mysql-cluster/templates/_helpers.tpl
+++ b/deploy/apecloud-mysql-cluster/templates/_helpers.tpl
@@ -16,6 +16,8 @@ The proxy cpu cores is 1/6 of the cluster total cpu cores.
 {{- end }}
 - name: vtcontroller
   componentDefRef: vtcontroller # ref clusterdefinition componentDefs.name
+  enabledLogs:
+    - log
   volumeClaimTemplates:
     - name: data
       spec:

--- a/deploy/apecloud-mysql-cluster/templates/_helpers.tpl
+++ b/deploy/apecloud-mysql-cluster/templates/_helpers.tpl
@@ -32,6 +32,11 @@ The proxy cpu cores is 1/6 of the cluster total cpu cores.
 - name: vtgate
   componentDefRef: vtgate # ref clusterdefinition componentDefs.name
   replicas: 1
+  enabledLogs:
+    - error
+    - warning
+    - info
+    - queryLog
   resources:
     requests:
       cpu: {{ $proxyCPU }}

--- a/deploy/apecloud-mysql/config/mysql-scale-vtconsensus-config.tpl
+++ b/deploy/apecloud-mysql/config/mysql-scale-vtconsensus-config.tpl
@@ -1,0 +1,3 @@
+[vtconsensus]
+refresh_interval=1s
+scan_repair_timeout=1s

--- a/deploy/apecloud-mysql/config/mysql-scale-vtgate-config.tpl
+++ b/deploy/apecloud-mysql/config/mysql-scale-vtgate-config.tpl
@@ -1,11 +1,3 @@
-[vttablet]
-health_check_interval=1s
-shard_sync_retry_delay=1s
-remote_operation_timeout=1s
-db_connect_timeout_ms=500
-[vtconsensus]
-refresh_interval=1s
-scan_repair_timeout=1s
 [vtgate]
 gateway_initial_tablet_timeout=30s
 healthcheck_timeout=2s

--- a/deploy/apecloud-mysql/config/mysql-scale-vttablet-config-constraint.cue
+++ b/deploy/apecloud-mysql/config/mysql-scale-vttablet-config-constraint.cue
@@ -29,6 +29,9 @@
 	// Delay between retries of updates to keep the tablet and its shard record in sync. (default 30s)
 	shard_sync_retry_delay: =~"[-+]?([0-9]*(\\.[0-9]*)?[a-z]+)+$"
 
+	// table acl config mode. Valid values are: simple, mysqlbased. (default simple)
+	table_acl_config_mode: string & "simple" | "mysqlbased"
+
 	...
 }
 

--- a/deploy/apecloud-mysql/config/mysql-scale-vttablet-config.tpl
+++ b/deploy/apecloud-mysql/config/mysql-scale-vttablet-config.tpl
@@ -1,0 +1,6 @@
+[vttablet]
+health_check_interval=1s
+shard_sync_retry_delay=1s
+remote_operation_timeout=1s
+db_connect_timeout_ms=500
+table_acl_config_mode=simple

--- a/deploy/apecloud-mysql/templates/clusterdefinition.yaml
+++ b/deploy/apecloud-mysql/templates/clusterdefinition.yaml
@@ -355,6 +355,11 @@ spec:
           constraintRef: mysql-scale-vtconsensus-config-constraints
           volumeName: mysql-scale-config
           namespace: {{ .Release.Namespace }}
+      logConfigs:
+        {{- range $name,$pattern := .Values.etcdLogConfigs }}
+        - name: {{ $name }}
+          filePathPattern: {{ $pattern }}
+        {{- end }}
       service:
         ports:
           - name: etcd-port

--- a/deploy/apecloud-mysql/templates/clusterdefinition.yaml
+++ b/deploy/apecloud-mysql/templates/clusterdefinition.yaml
@@ -42,8 +42,8 @@ spec:
           namespace: {{ .Release.Namespace }}
           volumeName: agamotto-configuration
           defaultMode: 0777
-        - name: mysql-scale-config
-          templateRef: mysql-scale-config-template
+        - name: vttablet-config
+          templateRef: vttablet-config-template
           constraintRef: mysql-scale-vttablet-config-constraints
           volumeName: mysql-scale-config
           namespace: {{ .Release.Namespace }}
@@ -350,8 +350,8 @@ spec:
           volumeName: scripts
           defaultMode: 493
       configSpecs:
-        - name: mysql-scale-config
-          templateRef: mysql-scale-config-template
+        - name: vtconsensus-config
+          templateRef: vtconsensus-config-template
           constraintRef: mysql-scale-vtconsensus-config-constraints
           volumeName: mysql-scale-config
           namespace: {{ .Release.Namespace }}
@@ -463,9 +463,14 @@ spec:
           namespace: {{ .Release.Namespace }}
           volumeName: scripts
           defaultMode: 493
+      logConfigs:
+        {{- range $name,$pattern := .Values.vtgateLogConfigs }}
+        - name: {{ $name }}
+          filePathPattern: {{ $pattern }}
+        {{- end }}
       configSpecs:
-        - name: mysql-scale-config
-          templateRef: mysql-scale-config-template
+        - name: vtgate-config
+          templateRef: vtgate-config-template
           constraintRef: mysql-scale-vtgate-config-constraints
           volumeName: mysql-scale-config
           namespace: {{ .Release.Namespace }}

--- a/deploy/apecloud-mysql/templates/configmap.yaml
+++ b/deploy/apecloud-mysql/templates/configmap.yaml
@@ -12,12 +12,32 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: mysql-scale-config-template
+  name: vtgate-config-template
   labels:
     {{- include "apecloud-mysql.labels" . | nindent 4 }}
 data:
-  wesql-scale.cnf: |-
-    {{- .Files.Get "config/mysql-scale-config.tpl" | nindent 4 }}
+  vtgate.cnf: |-
+    {{- .Files.Get "config/mysql-scale-vtgate-config.tpl" | nindent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vtconsensus-config-template
+  labels:
+    {{- include "apecloud-mysql.labels" . | nindent 4 }}
+data:
+  vtconsensus.cnf: |-
+    {{- .Files.Get "config/mysql-scale-vtconsensus-config.tpl" | nindent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: vttablet-config-template
+  labels:
+    {{- include "apecloud-mysql.labels" . | nindent 4 }}
+data:
+  vttablet.cnf: |-
+    {{- .Files.Get "config/mysql-scale-vttablet-config.tpl" | nindent 4 }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/deploy/apecloud-mysql/templates/scripts.yaml
+++ b/deploy/apecloud-mysql/templates/scripts.yaml
@@ -256,7 +256,7 @@ data:
 
     etcd --enable-v2=true --data-dir "${VTDATAROOT}/etcd/"  \
       --listen-client-urls "http://0.0.0.0:${etcd_port}" \
-      --advertise-client-urls "http://0.0.0.0:${etcd_port}"
+      --advertise-client-urls "http://0.0.0.0:${etcd_port}" 2>&1 | tee "${VTDATAROOT}/etcd.log"
   etcd-post-start.sh: |-
     #!/bin/bash
     etcd_port=${ETCD_PORT:-'2379'}

--- a/deploy/apecloud-mysql/templates/scripts.yaml
+++ b/deploy/apecloud-mysql/templates/scripts.yaml
@@ -17,7 +17,7 @@ data:
     #!/bin/bash
     function set_config_variables(){
       echo "set config variables [$1]"
-      config_file="/conf/wesql-scale.cnf"
+      config_file="/conf/$1.cnf"
       config_content=$(sed -n '/\['$1'\]/,/\[/ { /\['$1'\]/d; /\[/q; p; }' $config_file)
       while read line
       do
@@ -242,6 +242,7 @@ data:
     --service_map 'grpc-queryservice,grpc-tabletmanager,grpc-updatestream' \
     --pid_file $VTDATAROOT/vttablet.pid \
     --vtctld_addr http://$vtctld_host:$vtctld_web_port/ \
+    --table-acl-config-mode=$table_acl_config_mode \
     --disable_active_reparents
     EOF
   etcd.sh: |-

--- a/deploy/apecloud-mysql/values.yaml
+++ b/deploy/apecloud-mysql/values.yaml
@@ -63,6 +63,12 @@ logConfigs:
   slow: /data/mysql/log/mysqld-slowquery.log
   general: /data/mysql/log/mysqld.log
 
+vtgateLogConfigs:
+  error: /vtdataroot/vtgate.ERROR
+  warning: /vtdataroot/vtgate.WARNING
+  info: /vtdataroot/vtgate.INFO
+  queryLog: /vtdataroot/vtgate_querylog.txt
+
 roleProbe:
   failureThreshold: 2
   periodSeconds: 1

--- a/deploy/apecloud-mysql/values.yaml
+++ b/deploy/apecloud-mysql/values.yaml
@@ -69,6 +69,9 @@ vtgateLogConfigs:
   info: /vtdataroot/vtgate.INFO
   queryLog: /vtdataroot/vtgate_querylog.txt
 
+etcdLogConfigs:
+  log: /vtdataroot/etcd.log
+
 roleProbe:
   failureThreshold: 2
   periodSeconds: 1


### PR DESCRIPTION
* We found that the default configuration of table_acl_config_mode is set to "mysqlbased," which can cause issue #4289. Added a configurable item `table_acl_config_mode` and setting it to "simple" can address this problem temporarily.

* To avoid confusion when users use configuration and execute `kbcli cluster describe-config --show-detail`, the configuration tpl files of the wesql-scale related components are split.

* Add some missing logConfigs.