### PR TITLE
chore: removed configconstraint dependence on configspec.name, using env TOOLS_SCRIPTS_PATH

### DIFF
--- a/deploy/pulsar/templates/configconstraints.yaml
+++ b/deploy/pulsar/templates/configconstraints.yaml
@@ -69,7 +69,7 @@ spec:
         # imagePullPolicy: "{{ template "pulsar.imagePullPolicy" (dict "image" .Values.images.pulsarTools "root" .) }}"
       - name: init-pulsar-client-config
         command:
-          - "/opt/kb-tools/reload/broker-config/install-pulsar-client-config.sh"
+          - "$(TOOLS_SCRIPTS_PATH)/install-pulsar-client-config.sh"
 
 ---
 apiVersion: apps.kubeblocks.io/v1alpha1

--- a/internal/configuration/config_manager/builder.go
+++ b/internal/configuration/config_manager/builder.go
@@ -41,11 +41,10 @@ import (
 )
 
 const (
-	configTemplateName   = "reload.yaml"
-	scriptVolumePrefix   = "cm-script-"
-	configVolumePrefix   = "cm-config-"
-	kbScriptVolumePath   = "/opt/kb-tools/reload"
-	kbConfigVolumePath   = "/opt/kb-tools/config"
+	configTemplateName = "reload.yaml"
+	scriptVolumePrefix = "cm-script-"
+	configVolumePrefix = "cm-config-"
+
 	scriptConfigField    = "scripts"
 	formatterConfigField = "formatterConfig"
 
@@ -53,6 +52,14 @@ const (
 	configManagerConfig           = "config-manager.yaml"
 	configManagerConfigMountPoint = "/opt/config-manager"
 	configManagerCMPrefix         = "sidecar-"
+)
+
+const (
+	KBScriptVolumePath = "/opt/kb-tools/reload"
+	KBConfigVolumePath = "/opt/kb-tools/config"
+
+	KBTOOLSScriptsPathEnv  = "TOOLS_SCRIPTS_PATH"
+	KBConfigManagerPathEnv = "TOOLS_PATH"
 )
 
 const KBConfigSpecLazyRenderedYamlFile = "lazy-rendered-config.yaml"
@@ -401,7 +408,7 @@ func checkAndUpdateReloadYaml(data map[string]string, reloadConfig string, forma
 }
 
 func buildCfgManagerScripts(options appsv1alpha1.ScriptConfig, manager *CfgManagerBuildParams, cli client.Client, ctx context.Context, configSpec appsv1alpha1.ComponentConfigSpec) error {
-	mountPoint := filepath.Join(kbScriptVolumePath, configSpec.Name)
+	mountPoint := filepath.Join(KBScriptVolumePath, configSpec.Name)
 	referenceCMKey := client.ObjectKey{
 		Namespace: options.Namespace,
 		Name:      options.ScriptConfigMapRef,
@@ -418,11 +425,11 @@ func buildCfgManagerScripts(options appsv1alpha1.ScriptConfig, manager *CfgManag
 }
 
 func GetConfigMountPoint(configSpec appsv1alpha1.ComponentConfigSpec) string {
-	return filepath.Join(kbConfigVolumePath, configSpec.Name)
+	return filepath.Join(KBConfigVolumePath, configSpec.Name)
 }
 
 func GetScriptsMountPoint(configSpec appsv1alpha1.ComponentConfigSpec) string {
-	return filepath.Join(kbScriptVolumePath, configSpec.Name)
+	return filepath.Join(KBScriptVolumePath, configSpec.Name)
 }
 
 func GetScriptsVolumeName(configSpec appsv1alpha1.ComponentConfigSpec) string {

--- a/internal/controller/builder/builder.go
+++ b/internal/controller/builder/builder.go
@@ -25,6 +25,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -725,7 +726,7 @@ func BuildRestoreJob(cluster *appsv1alpha1.Cluster, synthesizedComponent *compon
 	return job, nil
 }
 
-func BuildCfgManagerToolsContainer(sidecarRenderedParam *cfgcm.CfgManagerBuildParams, component *component.SynthesizedComponent, toolsMetas []appsv1alpha1.ToolConfig) ([]corev1.Container, error) {
+func BuildCfgManagerToolsContainer(sidecarRenderedParam *cfgcm.CfgManagerBuildParams, component *component.SynthesizedComponent, toolsMetas []appsv1alpha1.ToolConfig, toolsMap map[string]cfgcm.ConfigSpecMeta) ([]corev1.Container, error) {
 	toolContainers := make([]corev1.Container, 0, len(toolsMetas))
 	for _, toolConfig := range toolsMetas {
 		toolContainer := corev1.Container{
@@ -740,12 +741,23 @@ func BuildCfgManagerToolsContainer(sidecarRenderedParam *cfgcm.CfgManagerBuildPa
 		toolContainers = append(toolContainers, toolContainer)
 	}
 	for i := range toolContainers {
-		if err := injectEnvs(sidecarRenderedParam.Cluster, component, sidecarRenderedParam.EnvConfigName, &toolContainers[i]); err != nil {
+		container := &toolContainers[i]
+		if err := injectEnvs(sidecarRenderedParam.Cluster, component, sidecarRenderedParam.EnvConfigName, container); err != nil {
 			return nil, err
 		}
 		injectZeroResourcesLimitsIfEmpty(&toolContainers[i])
+		if meta, ok := toolsMap[container.Name]; ok {
+			setToolsScriptsPath(container, meta)
+		}
 	}
 	return toolContainers, nil
+}
+
+func setToolsScriptsPath(container *corev1.Container, meta cfgcm.ConfigSpecMeta) {
+	container.Env = append(container.Env, corev1.EnvVar{
+		Name:  cfgcm.KBTOOLSScriptsPathEnv,
+		Value: filepath.Join(cfgcm.KBScriptVolumePath, meta.ConfigSpec.Name),
+	})
 }
 
 func BuildVolumeSnapshotClass(name string, driver string) (*snapshotv1.VolumeSnapshotClass, error) {

--- a/internal/controller/builder/builder.go
+++ b/internal/controller/builder/builder.go
@@ -745,7 +745,7 @@ func BuildCfgManagerToolsContainer(sidecarRenderedParam *cfgcm.CfgManagerBuildPa
 		if err := injectEnvs(sidecarRenderedParam.Cluster, component, sidecarRenderedParam.EnvConfigName, container); err != nil {
 			return nil, err
 		}
-		injectZeroResourcesLimitsIfEmpty(&toolContainers[i])
+		injectZeroResourcesLimitsIfEmpty(container)
 		if meta, ok := toolsMap[container.Name]; ok {
 			setToolsScriptsPath(container, meta)
 		}

--- a/internal/controller/builder/builder_test.go
+++ b/internal/controller/builder/builder_test.go
@@ -512,7 +512,7 @@ var _ = Describe("builder", func() {
 				{Name: "test-tool", Image: "test-image", Command: []string{"sh"}},
 			}
 
-			obj, err := BuildCfgManagerToolsContainer(cfgManagerParams, synthesizedComponent, toolContainers)
+			obj, err := BuildCfgManagerToolsContainer(cfgManagerParams, synthesizedComponent, toolContainers, map[string]cfgcm.ConfigSpecMeta{})
 			Expect(err).Should(BeNil())
 			Expect(obj).ShouldNot(BeEmpty())
 		})

--- a/internal/controller/plan/prepare.go
+++ b/internal/controller/plan/prepare.go
@@ -200,7 +200,7 @@ func updateEnvPath(container *corev1.Container, params *cfgcm.CfgManagerBuildPar
 	}
 	if len(scriptPath) != 0 {
 		container.Env = append(container.Env, corev1.EnvVar{
-			Name:  "TOOLS_PATH",
+			Name:  cfgcm.KBConfigManagerPathEnv,
 			Value: strings.Join(scriptPath, ":"),
 		})
 	}

--- a/internal/controller/plan/tool_image_builder.go
+++ b/internal/controller/plan/tool_image_builder.go
@@ -25,7 +25,6 @@ import (
 
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
 	cfgcm "github.com/apecloud/kubeblocks/internal/configuration/config_manager"
-	cfgutil "github.com/apecloud/kubeblocks/internal/configuration/util"
 	"github.com/apecloud/kubeblocks/internal/constant"
 	"github.com/apecloud/kubeblocks/internal/controller/builder"
 	"github.com/apecloud/kubeblocks/internal/controller/component"
@@ -46,16 +45,16 @@ func buildConfigToolsContainer(cfgManagerParams *cfgcm.CfgManagerBuildParams, po
 
 	// construct config manager tools volume
 	toolContainers := make([]appsv1alpha1.ToolConfig, 0)
-	toolSets := cfgutil.NewSet()
+	toolsMap := make(map[string]cfgcm.ConfigSpecMeta)
 	for _, buildParam := range cfgManagerParams.ConfigSpecsBuildParams {
 		if buildParam.ToolsImageSpec == nil {
 			continue
 		}
 		for _, toolConfig := range buildParam.ToolsImageSpec.ToolConfigs {
-			if !toolSets.InArray(toolConfig.Name) {
+			if _, ok := toolsMap[toolConfig.Name]; !ok {
 				replaceToolsImageHolder(&toolConfig, podSpec, buildParam.ConfigSpec.VolumeName)
 				toolContainers = append(toolContainers, toolConfig)
-				toolSets.Add(toolConfig.Name)
+				toolsMap[toolConfig.Name] = buildParam
 			}
 		}
 		buildToolsVolumeMount(cfgManagerParams, podSpec, buildParam.ConfigSpec.VolumeName, buildParam.ToolsImageSpec.MountPoint)
@@ -67,7 +66,7 @@ func buildConfigToolsContainer(cfgManagerParams *cfgcm.CfgManagerBuildParams, po
 		return nil
 	}
 
-	containers, err := builder.BuildCfgManagerToolsContainer(cfgManagerParams, comp, toolContainers)
+	containers, err := builder.BuildCfgManagerToolsContainer(cfgManagerParams, comp, toolContainers, toolsMap)
 	if err == nil {
 		cfgManagerParams.ToolsContainers = containers
 	}


### PR DESCRIPTION
configconstraint dependence on configspec.name:

old:
```
toolsImageSpec:
  mountPoint: /kb/tools
  toolConfigs:
    - name: init-pulsar-client-config
      command:
        - "/opt/kb-tools/reload/broker-config/install-pulsar-client-config.sh"
```

new:
```
toolsImageSpec:
  mountPoint: /kb/tools
  toolConfigs:
    - name: init-pulsar-client-config
      command:
        - "$(TOOLS_SCRIPTS_PATH)/install-pulsar-client-config.sh"
```