### PR TITLE
chore: add printcolumn annotations to BackupRepo CRD

### DIFF
--- a/apis/dataprotection/v1alpha1/backuprepo_types.go
+++ b/apis/dataprotection/v1alpha1/backuprepo_types.go
@@ -49,30 +49,34 @@ type BackupRepoSpec struct {
 
 // BackupRepoStatus defines the observed state of BackupRepo
 type BackupRepoStatus struct {
-	// Storage provider reconciliation phases. Valid values are PreChecking, Failed, Ready, Deleting.
+	// Backup repo reconciliation phases. Valid values are PreChecking, Failed, Ready, Deleting.
 	// +kubebuilder:validation:Enum={PreChecking,Failed,Ready,Deleting}
 	// +optional
 	Phase BackupRepoPhase `json:"phase,omitempty"`
 
-	// Describes the current state of the repo.
+	// conditions describes the current state of the repo.
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
-	// ObservedGeneration is the latest generation observed by the controller.
+	// observedGeneration is the latest generation observed by the controller.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
-	// GeneratedCSIDriverSecret references the generated secret used by the CSI driver.
+	// generatedCSIDriverSecret references the generated secret used by the CSI driver.
 	// +optional
 	GeneratedCSIDriverSecret *corev1.SecretReference `json:"generatedCSIDriverSecret,omitempty"`
 
-	// GeneratedStorageClassName indicates the generated storage class name.
+	// generatedStorageClassName indicates the generated storage class name.
 	// +optional
 	GeneratedStorageClassName string `json:"generatedStorageClassName,omitempty"`
 
-	// BackupPVCName is the name of the PVC used to store backup data.
+	// backupPVCName is the name of the PVC used to store backup data.
 	// +optional
 	BackupPVCName string `json:"backupPVCName,omitempty"`
+
+	// isDefault indicates whether this backup repo is the default one.
+	// +optional
+	IsDefault bool `json:"isDefault,omitempty"`
 }
 
 // +genclient
@@ -81,6 +85,10 @@ type BackupRepoStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=backuprepos,categories={kubeblocks},scope=Cluster
+// +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.phase"
+// +kubebuilder:printcolumn:name="STORAGEPROVIDER",type="string",JSONPath=".spec.storageProviderRef"
+// +kubebuilder:printcolumn:name="DEFAULT",type="boolean",JSONPath=`.status.isDefault`
+// +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 
 // BackupRepo is the Schema for the backuprepos API
 type BackupRepo struct {

--- a/config/crd/bases/dataprotection.kubeblocks.io_backuprepos.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backuprepos.yaml
@@ -17,7 +17,20 @@ spec:
     singular: backuprepo
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: STATUS
+      type: string
+    - jsonPath: .spec.storageProviderRef
+      name: STORAGEPROVIDER
+      type: string
+    - jsonPath: .status.isDefault
+      name: DEFAULT
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: BackupRepo is the Schema for the backuprepos API
@@ -84,11 +97,11 @@ spec:
             description: BackupRepoStatus defines the observed state of BackupRepo
             properties:
               backupPVCName:
-                description: BackupPVCName is the name of the PVC used to store backup
+                description: backupPVCName is the name of the PVC used to store backup
                   data.
                 type: string
               conditions:
-                description: Describes the current state of the repo.
+                description: conditions describes the current state of the repo.
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -157,7 +170,7 @@ spec:
                   type: object
                 type: array
               generatedCSIDriverSecret:
-                description: GeneratedCSIDriverSecret references the generated secret
+                description: generatedCSIDriverSecret references the generated secret
                   used by the CSI driver.
                 properties:
                   name:
@@ -170,11 +183,15 @@ spec:
                     type: string
                 type: object
               generatedStorageClassName:
-                description: GeneratedStorageClassName indicates the generated storage
+                description: generatedStorageClassName indicates the generated storage
                   class name.
                 type: string
+              isDefault:
+                description: isDefault indicates whether this backup repo is the default
+                  one.
+                type: boolean
               observedGeneration:
-                description: ObservedGeneration is the latest generation observed
+                description: observedGeneration is the latest generation observed
                   by the controller.
                 format: int64
                 type: integer
@@ -190,8 +207,8 @@ spec:
                   - Failed
                   - Ready
                   - Deleting
-                description: Storage provider reconciliation phases. Valid values
-                  are PreChecking, Failed, Ready, Deleting.
+                description: Backup repo reconciliation phases. Valid values are PreChecking,
+                  Failed, Ready, Deleting.
                 type: string
             type: object
         type: object

--- a/controllers/dataprotection/backuprepo_controller_test.go
+++ b/controllers/dataprotection/backuprepo_controller_test.go
@@ -622,5 +622,27 @@ parameters:
 				g.Expect(apierrors.IsNotFound(err)).Should(BeTrue())
 			}).Should(Succeed())
 		})
+
+		It("should update backupRepo.status.isDefault", func() {
+			By("making the repo default")
+			Eventually(testapps.GetAndChangeObj(&testCtx, repoKey, func(repo *dpv1alpha1.BackupRepo) {
+				repo.Annotations = map[string]string{
+					constant.DefaultBackupRepoAnnotationKey: trueVal,
+				}
+			})).Should(Succeed())
+			By("checking the repo is default")
+			Eventually(testapps.CheckObj(&testCtx, repoKey, func(g Gomega, repo *dpv1alpha1.BackupRepo) {
+				g.Expect(repo.Status.IsDefault).Should(BeTrue())
+			})).Should(Succeed())
+
+			By("making the repo non default")
+			Eventually(testapps.GetAndChangeObj(&testCtx, repoKey, func(repo *dpv1alpha1.BackupRepo) {
+				repo.Annotations = nil
+			})).Should(Succeed())
+			By("checking the repo is not default")
+			Eventually(testapps.CheckObj(&testCtx, repoKey, func(g Gomega, repo *dpv1alpha1.BackupRepo) {
+				g.Expect(repo.Status.IsDefault).Should(BeFalse())
+			})).Should(Succeed())
+		})
 	})
 })

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backuprepos.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backuprepos.yaml
@@ -17,7 +17,20 @@ spec:
     singular: backuprepo
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: STATUS
+      type: string
+    - jsonPath: .spec.storageProviderRef
+      name: STORAGEPROVIDER
+      type: string
+    - jsonPath: .status.isDefault
+      name: DEFAULT
+      type: boolean
+    - jsonPath: .metadata.creationTimestamp
+      name: AGE
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: BackupRepo is the Schema for the backuprepos API
@@ -84,11 +97,11 @@ spec:
             description: BackupRepoStatus defines the observed state of BackupRepo
             properties:
               backupPVCName:
-                description: BackupPVCName is the name of the PVC used to store backup
+                description: backupPVCName is the name of the PVC used to store backup
                   data.
                 type: string
               conditions:
-                description: Describes the current state of the repo.
+                description: conditions describes the current state of the repo.
                 items:
                   description: "Condition contains details for one aspect of the current
                     state of this API Resource. --- This struct is intended for direct
@@ -157,7 +170,7 @@ spec:
                   type: object
                 type: array
               generatedCSIDriverSecret:
-                description: GeneratedCSIDriverSecret references the generated secret
+                description: generatedCSIDriverSecret references the generated secret
                   used by the CSI driver.
                 properties:
                   name:
@@ -170,11 +183,15 @@ spec:
                     type: string
                 type: object
               generatedStorageClassName:
-                description: GeneratedStorageClassName indicates the generated storage
+                description: generatedStorageClassName indicates the generated storage
                   class name.
                 type: string
+              isDefault:
+                description: isDefault indicates whether this backup repo is the default
+                  one.
+                type: boolean
               observedGeneration:
-                description: ObservedGeneration is the latest generation observed
+                description: observedGeneration is the latest generation observed
                   by the controller.
                 format: int64
                 type: integer
@@ -190,8 +207,8 @@ spec:
                   - Failed
                   - Ready
                   - Deleting
-                description: Storage provider reconciliation phases. Valid values
-                  are PreChecking, Failed, Ready, Deleting.
+                description: Backup repo reconciliation phases. Valid values are PreChecking,
+                  Failed, Ready, Deleting.
                 type: string
             type: object
         type: object


### PR DESCRIPTION
`kubectl get backuprepo` will print out more information.

```bash
% kg backuprepo
NAME                    STATUS   STORAGEPROVIDER   DEFAULT   AGE
backuprepo-jg2mb        Ready    oss                         21s
kubeblocks-backuprepo   Ready    s3                true      3d
```