### PR TITLE
fix: fix kbcli create cluster when test kb locally

### DIFF
--- a/internal/cli/cmd/cluster/create.go
+++ b/internal/cli/cmd/cluster/create.go
@@ -1193,10 +1193,7 @@ func getStorageClasses(dynamic dynamic.Interface) (map[string]struct{}, bool, er
 		return allStorageClasses, existedDefault, nil
 	}
 	existedDefault, err = validateDefaultSCInConfig(dynamic)
-	if err != nil {
-		return allStorageClasses, existedDefault, err
-	}
-	return allStorageClasses, existedDefault, nil
+	return allStorageClasses, existedDefault, err
 }
 
 // validateClusterVersion checks the existence of declared cluster version,

--- a/internal/cli/cmd/cluster/create.go
+++ b/internal/cli/cmd/cluster/create.go
@@ -1189,11 +1189,14 @@ func getStorageClasses(dynamic dynamic.Interface) (map[string]struct{}, bool, er
 		}
 	}
 	// for cloud k8s we will check the kubeblocks-manager-config
-	defaultInConfig, err := validateDefaultSCInConfig(dynamic)
+	if existedDefault {
+		return allStorageClasses, existedDefault, nil
+	}
+	existedDefault, err = validateDefaultSCInConfig(dynamic)
 	if err != nil {
 		return allStorageClasses, existedDefault, err
 	}
-	return allStorageClasses, existedDefault || defaultInConfig, nil
+	return allStorageClasses, existedDefault, nil
 }
 
 // validateClusterVersion checks the existence of declared cluster version,


### PR DESCRIPTION
- fix:#4412
What i do:
fix the check default **storageclass** logic: when we check if there are already default **storageclass** in `k8s`, we will not check the `kubeblocks` **configmap**.