### PR TITLE
chore: kbcli addon list support specified name

### DIFF
--- a/internal/cli/cmd/addon/addon.go
+++ b/internal/cli/cmd/addon/addon.go
@@ -111,9 +111,11 @@ func newListCmd(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 		Use:               "list",
 		Short:             "List addons.",
 		Aliases:           []string{"ls"},
-		Args:              cli.NoArgs,
 		ValidArgsFunction: util.ResourceNameCompletionFunc(f, o.GVR),
 		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) != 0 {
+				o.Names = args
+			}
 			util.CheckErr(addonListRun(o))
 		},
 	}

--- a/internal/cli/cmd/addon/addon.go
+++ b/internal/cli/cmd/addon/addon.go
@@ -113,9 +113,7 @@ func newListCmd(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 		Aliases:           []string{"ls"},
 		ValidArgsFunction: util.ResourceNameCompletionFunc(f, o.GVR),
 		Run: func(cmd *cobra.Command, args []string) {
-			if len(args) != 0 {
-				o.Names = args
-			}
+			o.Names = args
 			util.CheckErr(addonListRun(o))
 		},
 	}


### PR DESCRIPTION
- fix: #4422

What i do:
1. reuse the `list` options to specify the `Names`