### PR TITLE
fix: make mysql-scale cluster 'enabled-all-logs' work properly

### DIFF
--- a/deploy/apecloud-mysql-cluster/templates/_helpers.tpl
+++ b/deploy/apecloud-mysql-cluster/templates/_helpers.tpl
@@ -15,7 +15,9 @@ The minimum proxy cpu cores is 0.5 and the maximum cpu cores is 64.
 - name: vtcontroller
   componentDefRef: vtcontroller # ref clusterdefinition componentDefs.name
   enabledLogs:
-    - log
+    - error
+    - warning
+    - info
   volumeClaimTemplates:
     - name: data
       spec:

--- a/deploy/apecloud-mysql/config/mysql-scale-vtconsensus-config-constraint.cue
+++ b/deploy/apecloud-mysql/config/mysql-scale-vtconsensus-config-constraint.cue
@@ -17,14 +17,14 @@
 
 #VtConsensusParameter: {
 
+	// Enable or disable logs. (default true)
+	enable_logs: bool
+
 	// Refresh interval to load tablets. (default 10s)
 	refresh_interval: =~"[-+]?([0-9]*(\\.[0-9]*)?[a-z]+)+$"
 
 	// Time to wait for a diagnose and repair operation. (default 3s)
 	scan_repair_timeout: =~"[-+]?([0-9]*(\\.[0-9]*)?[a-z]+)+$"
-
-	// Enable or disable logs. (default true)
-	enable_logs: bool
 
 	...
 }

--- a/deploy/apecloud-mysql/config/mysql-scale-vtconsensus-config-constraint.cue
+++ b/deploy/apecloud-mysql/config/mysql-scale-vtconsensus-config-constraint.cue
@@ -23,6 +23,9 @@
 	// Time to wait for a diagnose and repair operation. (default 3s)
 	scan_repair_timeout: =~"[-+]?([0-9]*(\\.[0-9]*)?[a-z]+)+$"
 
+	// Enable or disable logs. (default true)
+	enable_logs: bool
+
 	...
 }
 

--- a/deploy/apecloud-mysql/config/mysql-scale-vtconsensus-config.tpl
+++ b/deploy/apecloud-mysql/config/mysql-scale-vtconsensus-config.tpl
@@ -1,3 +1,9 @@
 [vtconsensus]
 refresh_interval=1s
 scan_repair_timeout=1s
+
+{{ block "logsBlock" . }}
+{{- if hasKey $.component "enabledLogs" }}
+enable_logs=true
+{{- end }}
+{{ end }}

--- a/deploy/apecloud-mysql/config/mysql-scale-vtgate-config-constraint.cue
+++ b/deploy/apecloud-mysql/config/mysql-scale-vtgate-config-constraint.cue
@@ -68,6 +68,21 @@
 	// Tablet refresh interval. (default 1m0s)
 	tablet_refresh_interval: =~"[-+]?([0-9]*(\\.[0-9]*)?[a-z]+)+$"
 
+    //Which auth server implementation to use. Options: none, static, mysqlbased. (default "none")
+    mysql_auth_server_impl: string &"none" | "static" | "mysqlbased"
+
+    //JSON File to read the users/passwords from, need set mysql_auth_server_impl to static.
+    mysql_auth_server_static_file: string
+
+    //Path to ssl key for mysql server plugin SSL
+    mysql_server_ssl_key: string
+
+    //Path to the ssl cert for mysql server plugin SSL
+    mysql_server_ssl_cert: string
+
+    //Reject insecure connections but only if mysql_server_ssl_cert and mysql_server_ssl_key are provided.(default "false")
+    mysql_server_require_secure_transport: bool
+
 	...
 }
 

--- a/deploy/apecloud-mysql/config/mysql-scale-vtgate-config-constraint.cue
+++ b/deploy/apecloud-mysql/config/mysql-scale-vtgate-config-constraint.cue
@@ -29,8 +29,14 @@
 	// Duration for how long a request should be buffered at most. (default 10s)
 	buffer_window: =~"[-+]?([0-9]*(\\.[0-9]*)?[a-z]+)+$"
 
-	// Enable buffering (stalling) of primary traffic during failovers.
+	// Enable buffering (stalling) of primary traffic during failovers. (default false)
 	enable_buffer: bool
+
+	// Enable or disable logs. (default true)
+	enable_logs: bool
+
+	// Enable or disable query log. (default true)
+	enable_query_log: bool
 
 	// At startup, the tabletGateway will wait up to this duration to get at least one tablet per keyspace/shard/tablet type. (default 30s)
 	gateway_initial_tablet_timeout: =~"[-+]?([0-9]*(\\.[0-9]*)?[a-z]+)+$"
@@ -61,12 +67,6 @@
 
 	// Tablet refresh interval. (default 1m0s)
 	tablet_refresh_interval: =~"[-+]?([0-9]*(\\.[0-9]*)?[a-z]+)+$"
-
-	// Enable or disable logs. (default true)
-	enable_logs: bool
-
-	// Enable or disable query log. (default true)
-	enable_query_log: bool
 
 	...
 }

--- a/deploy/apecloud-mysql/config/mysql-scale-vtgate-config-constraint.cue
+++ b/deploy/apecloud-mysql/config/mysql-scale-vtgate-config-constraint.cue
@@ -62,6 +62,12 @@
 	// Tablet refresh interval. (default 1m0s)
 	tablet_refresh_interval: =~"[-+]?([0-9]*(\\.[0-9]*)?[a-z]+)+$"
 
+	// Enable or disable logs. (default true)
+	enable_logs: bool
+
+	// Enable or disable query log. (default true)
+	enable_query_log: bool
+
 	...
 }
 

--- a/deploy/apecloud-mysql/config/mysql-scale-vtgate-config.tpl
+++ b/deploy/apecloud-mysql/config/mysql-scale-vtgate-config.tpl
@@ -14,3 +14,12 @@ buffer_size=10000
 buffer_window=30s
 buffer_max_failover_duration=60s
 buffer_min_time_between_failovers=60s
+
+{{ block "logsBlock" . }}
+{{- if hasKey $.component "enabledLogs" }}
+enable_logs=true
+{{- if mustHas "queryLog" $.component.enabledLogs }}
+enable_query_log=true
+{{- end }}
+{{- end }}
+{{ end }}

--- a/deploy/apecloud-mysql/config/mysql-scale-vtgate-config.tpl
+++ b/deploy/apecloud-mysql/config/mysql-scale-vtgate-config.tpl
@@ -14,6 +14,11 @@ buffer_size=10000
 buffer_window=30s
 buffer_max_failover_duration=60s
 buffer_min_time_between_failovers=60s
+mysql_auth_server_impl=none
+mysql_server_require_secure_transport=false
+mysql_auth_server_static_file=
+mysql_server_ssl_key=
+mysql_server_ssl_cert=
 
 {{ block "logsBlock" . }}
 {{- if hasKey $.component "enabledLogs" }}

--- a/deploy/apecloud-mysql/config/mysql-scale-vttablet-config-constraint.cue
+++ b/deploy/apecloud-mysql/config/mysql-scale-vttablet-config-constraint.cue
@@ -20,6 +20,12 @@
 	// Connection timeout to mysqld in milliseconds. (0 for no timeout, default 500)
 	db_connect_timeout_ms: int & >=0
 
+	// Enable or disable logs. (default true)
+	enable_logs: bool
+
+	// Enable or disable query log. (default true)
+	enable_query_log: bool
+
 	// Interval between health checks. (default 20s)
 	health_check_interval: =~"[-+]?([0-9]*(\\.[0-9]*)?[a-z]+)+$"
 
@@ -31,12 +37,6 @@
 
 	// Table acl config mode. Valid values are: simple, mysqlbased. (default simple)
 	table_acl_config_mode: string & "simple" | "mysqlbased"
-
-	// Enable or disable logs. (default true)
-	enable_logs: bool
-
-	// Enable or disable query log. (default true)
-	enable_query_log: bool
 
 	...
 }

--- a/deploy/apecloud-mysql/config/mysql-scale-vttablet-config-constraint.cue
+++ b/deploy/apecloud-mysql/config/mysql-scale-vttablet-config-constraint.cue
@@ -29,8 +29,14 @@
 	// Delay between retries of updates to keep the tablet and its shard record in sync. (default 30s)
 	shard_sync_retry_delay: =~"[-+]?([0-9]*(\\.[0-9]*)?[a-z]+)+$"
 
-	// table acl config mode. Valid values are: simple, mysqlbased. (default simple)
+	// Table acl config mode. Valid values are: simple, mysqlbased. (default simple)
 	table_acl_config_mode: string & "simple" | "mysqlbased"
+
+	// Enable or disable logs. (default true)
+	enable_logs: bool
+
+	// Enable or disable query log. (default true)
+	enable_query_log: bool
 
 	...
 }

--- a/deploy/apecloud-mysql/config/mysql-scale-vttablet-config-constraint.cue
+++ b/deploy/apecloud-mysql/config/mysql-scale-vttablet-config-constraint.cue
@@ -38,6 +38,18 @@
 	// Table acl config mode. Valid values are: simple, mysqlbased. (default simple)
 	table_acl_config_mode: string & "simple" | "mysqlbased"
 
+    // path to table access checker config file (json file);
+	table_acl_config: string
+
+	// Ticker to reload ACLs. Duration flag, format e.g.: 30s. Default: 30s
+	table_acl_config_reload_interval: =~"[-+]?([0-9]*(\\.[0-9]*)?[a-z]+)+$"
+
+    // only allow queries that pass table acl checks if true
+	queryserver_config_strict_table_acl: bool
+
+    // if this flag is true, vttablet will fail to start if a valid tableacl config does not exist
+    enforce_tableacl_config: bool
+
 	...
 }
 

--- a/deploy/apecloud-mysql/config/mysql-scale-vttablet-config.tpl
+++ b/deploy/apecloud-mysql/config/mysql-scale-vttablet-config.tpl
@@ -6,3 +6,7 @@ db_connect_timeout_ms=500
 table_acl_config_mode=simple
 enable_logs=true
 enable_query_log=true
+table_acl_config=
+queryserver_config_strict_table_acl=false
+table_acl_config_reload_interval=30s
+enforce_tableacl_config=false

--- a/deploy/apecloud-mysql/config/mysql-scale-vttablet-config.tpl
+++ b/deploy/apecloud-mysql/config/mysql-scale-vttablet-config.tpl
@@ -4,3 +4,5 @@ shard_sync_retry_delay=1s
 remote_operation_timeout=1s
 db_connect_timeout_ms=500
 table_acl_config_mode=simple
+enable_logs=true
+enable_query_log=true

--- a/deploy/apecloud-mysql/templates/clusterdefinition.yaml
+++ b/deploy/apecloud-mysql/templates/clusterdefinition.yaml
@@ -263,6 +263,8 @@ spec:
                 mountPath: /scripts
               - name: mysql-scale-config
                 mountPath: /conf
+              - name: data
+                mountPath: /vtdataroot
         volumes:
           - name: log-data
             hostPath:
@@ -407,6 +409,8 @@ spec:
                 mountPath: /scripts
               - name: mysql-scale-config
                 mountPath: /conf
+              - name: data
+                mountPath: /vtdataroot
           - name: etcd
             imagePullPolicy: {{ default "IfNotPresent" .Values.wesqlscale.image.pullPolicy }}
             ports:
@@ -428,7 +432,7 @@ spec:
               - name: scripts
                 mountPath: /scripts
               - name: data
-                mountPath: /vtdataroot/etcd
+                mountPath: /vtdataroot
             lifecycle:
               postStart:
                 exec:
@@ -459,6 +463,8 @@ spec:
             volumeMounts:
               - name: scripts
                 mountPath: /scripts
+              - name: data
+                mountPath: /vtdataroot
     - name: vtgate
       characterType: mysql
       workloadType: Stateless

--- a/deploy/apecloud-mysql/templates/clusterdefinition.yaml
+++ b/deploy/apecloud-mysql/templates/clusterdefinition.yaml
@@ -356,7 +356,7 @@ spec:
           volumeName: mysql-scale-config
           namespace: {{ .Release.Namespace }}
       logConfigs:
-        {{- range $name,$pattern := .Values.etcdLogConfigs }}
+        {{- range $name,$pattern := .Values.vtconsensusLogConfigs }}
         - name: {{ $name }}
           filePathPattern: {{ $pattern }}
         {{- end }}
@@ -373,6 +373,40 @@ spec:
             targetPort: vtctld-grpcport
       podSpec:
         containers:
+          - name: vtconsensus
+            imagePullPolicy: {{ default "IfNotPresent" .Values.wesqlscale.image.pullPolicy }}
+            ports:
+              - containerPort: 16000
+                name: port
+            env:
+              - name: CELL
+                value: {{ .Values.wesqlscale.cell | default "zone1" | quote }}
+              - name: MYSQL_ROOT_USER
+                valueFrom:
+                  secretKeyRef:
+                    name: $(CONN_CREDENTIAL_SECRET_NAME)
+                    key: username
+                    optional: false
+              - name: MYSQL_ROOT_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: $(CONN_CREDENTIAL_SECRET_NAME)
+                    key: password
+                    optional: false
+              - name: VTCONSENSUS_PORT
+                value: "16000"
+              - name: ETCD_SERVER
+                value: "localhost"
+              - name: ETCD_PORT
+                value: "2379"
+              - name: TOPOLOGY_FLAGS
+                value: "--topo_implementation etcd2 --topo_global_server_address $(ETCD_SERVER):$(ETCD_PORT) --topo_global_root /vitess/global"
+            command: ["/scripts/vtconsensus.sh"]
+            volumeMounts:
+              - name: scripts
+                mountPath: /scripts
+              - name: mysql-scale-config
+                mountPath: /conf
           - name: etcd
             imagePullPolicy: {{ default "IfNotPresent" .Values.wesqlscale.image.pullPolicy }}
             ports:
@@ -425,40 +459,6 @@ spec:
             volumeMounts:
               - name: scripts
                 mountPath: /scripts
-          - name: vtconsensus
-            imagePullPolicy: {{ default "IfNotPresent" .Values.wesqlscale.image.pullPolicy }}
-            ports:
-              - containerPort: 16000
-                name: port
-            env:
-              - name: CELL
-                value: {{ .Values.wesqlscale.cell | default "zone1" | quote }}
-              - name: MYSQL_ROOT_USER
-                valueFrom:
-                  secretKeyRef:
-                    name: $(CONN_CREDENTIAL_SECRET_NAME)
-                    key: username
-                    optional: false
-              - name: MYSQL_ROOT_PASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    name: $(CONN_CREDENTIAL_SECRET_NAME)
-                    key: password
-                    optional: false
-              - name: VTCONSENSUS_PORT
-                value: "16000"
-              - name: ETCD_SERVER
-                value: "localhost"
-              - name: ETCD_PORT
-                value: "2379"
-              - name: TOPOLOGY_FLAGS
-                value: "--topo_implementation etcd2 --topo_global_server_address $(ETCD_SERVER):$(ETCD_PORT) --topo_global_root /vitess/global"
-            command: ["/scripts/vtconsensus.sh"]
-            volumeMounts:
-              - name: scripts
-                mountPath: /scripts
-              - name: mysql-scale-config
-                mountPath: /conf
     - name: vtgate
       characterType: mysql
       workloadType: Stateless

--- a/deploy/apecloud-mysql/templates/scripts.yaml
+++ b/deploy/apecloud-mysql/templates/scripts.yaml
@@ -245,7 +245,11 @@ data:
     --pid_file $VTDATAROOT/vttablet.pid \
     --vtctld_addr http://$vtctld_host:$vtctld_web_port/ \
     --table-acl-config-mode=$table_acl_config_mode \
-    --disable_active_reparents
+    --disable_active_reparents \
+    $(if [ -n "$table_acl_config" ]; then echo "--table-acl-config $table_acl_config"; fi) \
+    $(if [ "$queryserver_config_strict_table_acl" == "true" ]; then echo "--queryserver-config-strict-table-acl"; fi) \
+    $(if [ "$enforce_tableacl_config" == "true" ]; then echo "--enforce-tableacl-config"; fi) \
+    --table-acl-config-reload-interval $table_acl_config_reload_interval
     EOF
   etcd.sh: |-
     #!/bin/bash
@@ -367,7 +371,6 @@ data:
       --tablet_refresh_interval $tablet_refresh_interval \
       --service_map 'grpc-vtgateservice' \
       --pid_file $VTDATAROOT/vtgate.pid \
-      --mysql_auth_server_impl none \
       --read_write_splitting_policy $read_write_splitting_policy  \
       --read_write_splitting_ratio $read_write_splitting_ratio  \
       --read_after_write_consistency $read_after_write_consistency \
@@ -376,7 +379,12 @@ data:
       --buffer_size $buffer_size \
       --buffer_window $buffer_window \
       --buffer_max_failover_duration $buffer_max_failover_duration \
-      --buffer_min_time_between_failovers $buffer_min_time_between_failovers
+      --buffer_min_time_between_failovers $buffer_min_time_between_failovers \
+      $(if [ "$mysql_server_require_secure_transport" == "true" ]; then echo "--mysql_server_require_secure_transport"; fi) \
+      $(if [ -n "$mysql_server_ssl_cert" ]; then echo "--mysql_server_ssl_cert $mysql_server_ssl_cert"; fi) \
+      $(if [ -n "$mysql_server_ssl_key" ]; then echo "--mysql_server_ssl_key $mysql_server_ssl_key"; fi) \
+      $(if [ -n "$mysql_auth_server_static_file" ]; then echo "--mysql_auth_server_static_file $mysql_auth_server_static_file"; fi) \
+    --mysql_auth_server_impl $mysql_auth_server_impl
     EOF
   binlog-collector.sh: |-
     #!/bin/bash

--- a/deploy/apecloud-mysql/templates/scripts.yaml
+++ b/deploy/apecloud-mysql/templates/scripts.yaml
@@ -211,7 +211,9 @@ data:
 
     echo "starting vttablet for $alias..."
 
+    VTDATAROOT=$VTDATAROOT/vttablet
     su vitess <<EOF
+    mkdir -p $VTDATAROOT
     exec vttablet \
     $topology_fags \
     --alsologtostderr \
@@ -294,7 +296,9 @@ data:
     vtctld_web_port=${VTCTLD_WEB_PORT:-'15000'}
     topology_fags=${TOPOLOGY_FLAGS:-'--topo_implementation etcd2 --topo_global_server_address 127.0.0.1:2379 --topo_global_root /vitess/global'}
 
+    VTDATAROOT=$VTDATAROOT/vtctld
     su vitess <<EOF
+    mkdir -p $VTDATAROOT
     exec vtctld \
     $topology_fags \
     --alsologtostderr \
@@ -318,7 +322,9 @@ data:
     vtconsensusport=${VTCONSENSUS_PORT:-'16000'}
     topology_fags=${TOPOLOGY_FLAGS:-'--topo_implementation etcd2 --topo_global_server_address 127.0.0.1:2379 --topo_global_root /vitess/global'}
 
+    VTDATAROOT=$VTDATAROOT/vtconsensus
     su vitess <<EOF
+    mkdir -p $VTDATAROOT
     exec vtconsensus \
       $topology_fags \
       --alsologtostderr \

--- a/deploy/apecloud-mysql/templates/scripts.yaml
+++ b/deploy/apecloud-mysql/templates/scripts.yaml
@@ -24,7 +24,7 @@ data:
         if [[ $line =~ ^[a-zA-Z_][a-zA-Z0-9_]*=[a-zA-Z0-9_.]*$ ]]; then
           echo $line
           eval "export $line"
-        elif ! [[ $line =~ ^[[:space:]]*# ]]; then 
+        elif ! [[ -z $line  || $line =~ ^[[:space:]]*# ]]; then 
           echo "bad format: $line"
         fi
       done <<< "$(echo -e "$config_content")"

--- a/deploy/apecloud-mysql/templates/scripts.yaml
+++ b/deploy/apecloud-mysql/templates/scripts.yaml
@@ -215,8 +215,8 @@ data:
     exec vttablet \
     $topology_fags \
     --alsologtostderr \
-    --log_dir $VTDATAROOT \
-    --log_queries_to_file $VTDATAROOT/$tablet_logfile \
+    $(if [ "$enable_logs" == "true" ]; then echo "--log_dir $VTDATAROOT"; fi) \
+    $(if [ "$enable_query_log" == "true" ]; then echo "--log_queries_to_file $VTDATAROOT/$tablet_logfile"; fi) \
     --tablet-path $alias \
     --tablet_hostname "$tablet_hostname" \
     --init_tablet_type $tablet_type \
@@ -324,7 +324,7 @@ data:
       --alsologtostderr \
       --refresh_interval $refresh_interval \
       --scan_repair_timeout $scan_repair_timeout \
-      --log_dir ${VTDATAROOT} \
+      $(if [ "$enable_logs" == "true" ]; then echo "--log_dir $VTDATAROOT"; fi) \
       --db_username "$MYSQL_ROOT_USER" \
       --db_password "$MYSQL_ROOT_PASSWORD"
     EOF
@@ -349,8 +349,8 @@ data:
       --srv_topo_timeout $srv_topo_timeout \
       --grpc_keepalive_time $grpc_keepalive_time \
       --grpc_keepalive_timeout $grpc_keepalive_timeout \
-      --log_dir $VTDATAROOT \
-      --log_queries_to_file $VTDATAROOT/vtgate_querylog.txt \
+      $(if [ "$enable_logs" == "true" ]; then echo "--log_dir $VTDATAROOT"; fi) \
+      $(if [ "$enable_query_log" == "true" ]; then echo "--log_queries_to_file $VTDATAROOT/vtgate_querylog.txt"; fi) \
       --port $web_port \
       --grpc_port $grpc_port \
       --mysql_server_port $mysql_server_port \

--- a/deploy/apecloud-mysql/values.yaml
+++ b/deploy/apecloud-mysql/values.yaml
@@ -70,9 +70,9 @@ vtgateLogConfigs:
   queryLog: /vtdataroot/vtgate_querylog.txt
 
 vtconsensusLogConfigs:
-  error: /vtdataroot/vtconsensus.ERROR
-  warning: /vtdataroot/vtconsensus.WARNING
-  info: /vtdataroot/vtconsensus.INFO
+  error: /vtdataroot/vtconsensus/vtconsensus.ERROR
+  warning: /vtdataroot/vtconsensus/vtconsensus.WARNING
+  info: /vtdataroot/vtconsensus/vtconsensus.INFO
 
 roleProbe:
   failureThreshold: 2

--- a/deploy/apecloud-mysql/values.yaml
+++ b/deploy/apecloud-mysql/values.yaml
@@ -69,8 +69,10 @@ vtgateLogConfigs:
   info: /vtdataroot/vtgate.INFO
   queryLog: /vtdataroot/vtgate_querylog.txt
 
-etcdLogConfigs:
-  log: /vtdataroot/etcd.log
+vtconsensusLogConfigs:
+  error: /vtdataroot/vtconsensus.ERROR
+  warning: /vtdataroot/vtconsensus.WARNING
+  info: /vtdataroot/vtconsensus.INFO
 
 roleProbe:
   failureThreshold: 2

--- a/internal/cli/cmd/cluster/update.go
+++ b/internal/cli/cmd/cluster/update.go
@@ -322,6 +322,7 @@ func (o *updateOptions) reconfigureLogVariables(c *appsv1alpha1.Cluster, cd *app
 		if logValue, err = buildLogsTPLValues(&compSpec); err != nil {
 			return err
 		}
+		buf.Reset()
 		if err = logTPL.Execute(&buf, logValue); err != nil {
 			return err
 		}


### PR DESCRIPTION
* fix #4398 
  Add two configuration items: `enable_logs` and `enable_query_log`, to the 'logsBlocks' for wesql-scale related components.
Reset buffer before tpl.Execute in the reconfigureLogVariables function to avoid confusion when dealing with multiple components.
  
  ![image](https://github.com/apecloud/kubeblocks/assets/32926461/ffb43a7c-7e4a-41b2-b2d5-f5ed248ee65e)

* replace etcd with vtconsensus as the default container for vtcontroller.
  
  ![image](https://github.com/apecloud/kubeblocks/assets/32926461/6fa3920a-ae64-418b-9fa8-2502bda09519)

* persistent wesql-scale related components' log files in pv except vtgate, as it's a stateless component. Ignore vtgate temporary until the newest log collection workaround is available
  ![image](https://github.com/apecloud/kubeblocks/assets/32926461/68e4e7b4-5e8c-43bd-8bd9-2c986dd8d480)
  ![image](https://github.com/apecloud/kubeblocks/assets/32926461/e54a31b4-d2bd-4a3a-b998-1d25746d7bfb)

