### PR TITLE
chore: rename parameter name prefix xengine_ to smartengine_ 

### DIFF
--- a/deploy/apecloud-mysql/config/mysql8-config-constraint.cue
+++ b/deploy/apecloud-mysql/config/mysql8-config-constraint.cue
@@ -171,6 +171,9 @@
 	// smartengine enable
 	"smartengine"?: string & "0" | "1" | "OFF" | "ON"
 
+	// Deprecated: Use smartengine instead.
+	"xengine"?: string & "0" | "1" | "OFF" | "ON"
+
 	// Abort a recursive common table expression if it does more than this number of iterations.
 	cte_max_recursion_depth: int & >=0 & <=4294967295 | *1000
 

--- a/deploy/apecloud-mysql/config/mysql8-config-smartengine.tpl
+++ b/deploy/apecloud-mysql/config/mysql8-config-smartengine.tpl
@@ -170,56 +170,56 @@ ssl_key={{ $key_file }}
 {{- end }}
 
 ## xengine base config
-#default_storage_engine=xengine
+#default_storage_engine=smartengine
 default_tmp_storage_engine=innodb
-xengine=0
+smartengine=0
 
 # log_error_verbosity=3
 # binlog_format=ROW
 
 ## non classes config
 
-loose_xengine_datadir={{ $data_root }}/xengine
-loose_xengine_wal_dir={{ $data_root }}/xengine
-loose_xengine_flush_log_at_trx_commit=1
-loose_xengine_enable_2pc=1
-loose_xengine_batch_group_slot_array_size=5
-loose_xengine_batch_group_max_group_size=15
-loose_xengine_batch_group_max_leader_wait_time_us=50
-loose_xengine_block_size=16384
-loose_xengine_disable_auto_compactions=0
-loose_xengine_dump_memtable_limit_size=0
+loose_smartengine_datadir={{ $data_root }}/smartengine
+loose_smartengine_wal_dir={{ $data_root }}/smartengine
+loose_smartengine_flush_log_at_trx_commit=1
+loose_smartengine_enable_2pc=1
+loose_smartengine_batch_group_slot_array_size=5
+loose_smartengine_batch_group_max_group_size=15
+loose_smartengine_batch_group_max_leader_wait_time_us=50
+loose_smartengine_block_size=16384
+loose_smartengine_disable_auto_compactions=0
+loose_smartengine_dump_memtable_limit_size=0
 
-loose_xengine_min_write_buffer_number_to_merge=1
-loose_xengine_level0_file_num_compaction_trigger=64
-loose_xengine_level0_layer_num_compaction_trigger=2
-loose_xengine_level1_extents_major_compaction_trigger=1000
-loose_xengine_level2_usage_percent=70
-loose_xengine_flush_delete_percent=70
-loose_xengine_compaction_delete_percent=50
-loose_xengine_flush_delete_percent_trigger=700000
-loose_xengine_flush_delete_record_trigger=700000
-loose_xengine_scan_add_blocks_limit=100
+loose_smartengine_min_write_buffer_number_to_merge=1
+loose_smartengine_level0_file_num_compaction_trigger=64
+loose_smartengine_level0_layer_num_compaction_trigger=2
+loose_smartengine_level1_extents_major_compaction_trigger=1000
+loose_smartengine_level2_usage_percent=70
+loose_smartengine_flush_delete_percent=70
+loose_smartengine_compaction_delete_percent=50
+loose_smartengine_flush_delete_percent_trigger=700000
+loose_smartengine_flush_delete_record_trigger=700000
+loose_smartengine_scan_add_blocks_limit=100
 
-loose_xengine_compression_per_level=kZSTD:kZSTD:kZSTD
+loose_smartengine_compression_per_level=kZSTD:kZSTD:kZSTD
 
 
 ## classes classes config
 
 {{- if gt $phy_memory 0 }}
 {{- $phy_memory := div $phy_memory ( mul 1024 1024 ) }}
-loose_xengine_write_buffer_size={{ min ( max 32 ( mulf $phy_memory 0.01 ) ) 256 | int | mul 1024 1024 }}
-loose_xengine_db_write_buffer_size={{ mulf $phy_memory 0.3 | int | mul 1024 1024 }}
-loose_xengine_db_total_write_buffer_size={{ mulf $phy_memory 0.3 | int | mul 1024 1024 }}
-loose_xengine_block_cache_size={{ mulf $phy_memory 0.3 | int | mul 1024 1024 }}
-loose_xengine_row_cache_size={{ mulf $phy_memory 0.1 | int | mul 1024 1024 }}
-loose_xengine_max_total_wal_size={{ min ( mulf $phy_memory 0.3 ) ( mul 12 1024 ) | int | mul 1024 1024 }}
+loose_smartengine_write_buffer_size={{ min ( max 32 ( mulf $phy_memory 0.01 ) ) 256 | int | mul 1024 1024 }}
+loose_smartengine_db_write_buffer_size={{ mulf $phy_memory 0.3 | int | mul 1024 1024 }}
+loose_smartengine_db_total_write_buffer_size={{ mulf $phy_memory 0.3 | int | mul 1024 1024 }}
+loose_smartengine_block_cache_size={{ mulf $phy_memory 0.3 | int | mul 1024 1024 }}
+loose_smartengine_row_cache_size={{ mulf $phy_memory 0.1 | int | mul 1024 1024 }}
+loose_smartengine_max_total_wal_size={{ min ( mulf $phy_memory 0.3 ) ( mul 12 1024 ) | int | mul 1024 1024 }}
 {{- end }}
 
 {{- if gt $phy_cpu 0 }}
-loose_xengine_max_background_flushes={{ max 1 ( min ( div $phy_cpu 2 ) 8 ) | int }}
-loose_xengine_base_background_compactions={{ max 1 ( min ( div $phy_cpu 2 ) 8 ) | int }}
-loose_xengine_max_background_compactions={{ max 1 (min ( div $phy_cpu 2 ) 12 ) | int }}
+loose_smartengine_max_background_flushes={{ max 1 ( min ( div $phy_cpu 2 ) 8 ) | int }}
+loose_smartengine_base_background_compactions={{ max 1 ( min ( div $phy_cpu 2 ) 8 ) | int }}
+loose_smartengine_max_background_compactions={{ max 1 (min ( div $phy_cpu 2 ) 12 ) | int }}
 {{- end }}
 
 

--- a/deploy/apecloud-mysql/config/mysql8-config-smartengine.tpl
+++ b/deploy/apecloud-mysql/config/mysql8-config-smartengine.tpl
@@ -169,7 +169,7 @@ ssl_cert={{ $cert_file }}
 ssl_key={{ $key_file }}
 {{- end }}
 
-## xengine base config
+## smartengine base config
 #default_storage_engine=smartengine
 default_tmp_storage_engine=innodb
 smartengine=0

--- a/deploy/apecloud-mysql/templates/clusterversion.yaml
+++ b/deploy/apecloud-mysql/templates/clusterversion.yaml
@@ -2,6 +2,8 @@ apiVersion: apps.kubeblocks.io/v1alpha1
 kind: ClusterVersion
 metadata:
   name: ac-mysql-{{ default .Chart.AppVersion .Values.clusterVersionOverride }}
+  annotations:
+    kubeblocks.io/is-default-cluster-version: "false"
   labels:
     {{- include "apecloud-mysql.labels" . | nindent 4 }}
 spec:
@@ -43,6 +45,8 @@ apiVersion: apps.kubeblocks.io/v1alpha1
 kind: ClusterVersion
 metadata:
   name: ac-mysql-smartengine-{{ default .Chart.AppVersion .Values.clusterVersionOverride }}
+  annotations:
+    kubeblocks.io/is-default-cluster-version: "true"
   labels:
     {{- include "apecloud-mysql.labels" . | nindent 4 }}
 spec:

--- a/deploy/apecloud-mysql/templates/clusterversion.yaml
+++ b/deploy/apecloud-mysql/templates/clusterversion.yaml
@@ -37,3 +37,50 @@ spec:
         - name: vtgate
           image: {{ .Values.wesqlscale.image.registry | default "docker.io" }}/{{ .Values.wesqlscale.image.repository }}:{{ .Values.wesqlscale.image.tag }}
           imagePullPolicy: {{ default "IfNotPresent" .Values.wesqlscale.image.pullPolicy }}
+---
+
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: ClusterVersion
+metadata:
+  name: ac-mysql-smartengine-{{ default .Chart.AppVersion .Values.clusterVersionOverride }}
+  labels:
+    {{- include "apecloud-mysql.labels" . | nindent 4 }}
+spec:
+  clusterDefinitionRef: apecloud-mysql
+  componentVersions:
+    - componentDefRef: mysql
+      configSpecs:
+        - name: mysql-consensusset-config
+          templateRef: mysql8.0-smartengine-config-template
+          constraintRef: mysql8.0-config-constraints
+          volumeName: mysql-config
+          namespace: {{ .Release.Namespace }}
+      versionsContext:
+        containers:
+          - name: mysql
+            image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.smartEngineTag }}
+            imagePullPolicy: {{ default .Values.image.pullPolicy "IfNotPresent" }}
+      systemAccountSpec:
+        cmdExecutorConfig:
+          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.smartEngineTag }}
+      switchoverSpec:
+        cmdExecutorConfig:
+          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ .Values.image.smartEngineTag }}
+    - componentDefRef: vtcontroller
+      versionsContext:
+        containers:
+          - name: etcd
+            image: {{ .Values.wesqlscale.image.registry | default "docker.io" }}/{{ .Values.wesqlscale.image.repository }}:{{ .Values.wesqlscale.image.tag }}
+            imagePullPolicy: {{ default "IfNotPresent" .Values.wesqlscale.image.pullPolicy }}
+          - name: vtctld
+            image: {{ .Values.wesqlscale.image.registry | default "docker.io" }}/{{ .Values.wesqlscale.image.repository }}:{{ .Values.wesqlscale.image.tag }}
+            imagePullPolicy: {{ default "IfNotPresent" .Values.wesqlscale.image.pullPolicy }}
+          - name: vtconsensus
+            image: {{ .Values.wesqlscale.image.registry | default "docker.io" }}/{{ .Values.wesqlscale.image.repository }}:{{ .Values.wesqlscale.image.tag }}
+            imagePullPolicy: {{ default "IfNotPresent" .Values.wesqlscale.image.pullPolicy }}
+    - componentDefRef: vtgate
+      versionsContext:
+        containers:
+          - name: vtgate
+            image: {{ .Values.wesqlscale.image.registry | default "docker.io" }}/{{ .Values.wesqlscale.image.repository }}:{{ .Values.wesqlscale.image.tag }}
+            imagePullPolicy: {{ default "IfNotPresent" .Values.wesqlscale.image.pullPolicy }}

--- a/deploy/apecloud-mysql/templates/configmap.yaml
+++ b/deploy/apecloud-mysql/templates/configmap.yaml
@@ -12,6 +12,16 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  name: mysql8.0-smartengine-config-template
+  labels:
+   {{- include "apecloud-mysql.labels" . | nindent 4 }}
+data:
+  my.cnf: |-
+   {{- .Files.Get "config/mysql8-config-smartengine.tpl" | nindent 4 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
   name: vtgate-config-template
   labels:
     {{- include "apecloud-mysql.labels" . | nindent 4 }}

--- a/deploy/apecloud-mysql/values.yaml
+++ b/deploy/apecloud-mysql/values.yaml
@@ -8,6 +8,7 @@ image:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: 8.0.30-5.alpha9.20230606.gf80d546.9
+  smartEngineTag: 8.0.30-5.alpha10.20230725.g8d05885.10
 
 ## MySQL Cluster parameters
 cluster:


### PR DESCRIPTION
Add new clusterversion for apecloud-mysql, When kubeblocks is upgraded(0.5 --> 0.6), it will not affect the old mysql engine.