### PR TITLE
chore: refine reconfigure reconcile code

### DIFF
--- a/controllers/apps/configuration/config_reconcile_wrapper.go
+++ b/controllers/apps/configuration/config_reconcile_wrapper.go
@@ -1,0 +1,225 @@
+/*
+Copyright (C) 2022-2023 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package configuration
+
+import (
+	"context"
+
+	appv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
+	cfgcore "github.com/apecloud/kubeblocks/internal/configuration"
+	"github.com/apecloud/kubeblocks/internal/constant"
+	"github.com/apecloud/kubeblocks/internal/generics"
+)
+
+type configSpecList []appsv1alpha1.ComponentConfigSpec
+
+type configReconcileContext struct {
+	Err    error
+	Ctx    context.Context
+	Client client.Client
+
+	Name           string
+	Component      string
+	MatchingLabels client.MatchingLabels
+	ConfigSpec     *appsv1alpha1.ComponentConfigSpec
+	ConfigMap      *corev1.ConfigMap
+
+	Cluster    *appsv1alpha1.Cluster
+	ClusterDef *appsv1alpha1.ClusterDefinition
+	ClusterVer *appsv1alpha1.ClusterVersion
+
+	Containers   []string
+	StatefulSets []appv1.StatefulSet
+	Deployments  []appv1.Deployment
+
+	ConfigConstraint    *appsv1alpha1.ConfigConstraint
+	ClusterDefComponent *appsv1alpha1.ClusterComponentDefinition
+	ClusterComponent    *appsv1alpha1.ClusterComponentSpec
+}
+
+func newConfigReconcileContext(ctx context.Context, cli client.Client, cm *corev1.ConfigMap, cc *appsv1alpha1.ConfigConstraint, componentName string, configSpecName string, matchingLabels client.MatchingLabels) *configReconcileContext {
+	return &configReconcileContext{
+		Ctx:              ctx,
+		Client:           cli,
+		ConfigMap:        cm,
+		ConfigConstraint: cc,
+		Component:        componentName,
+		Name:             configSpecName,
+		MatchingLabels:   matchingLabels,
+	}
+}
+
+func (l configSpecList) findByName(name string) *appsv1alpha1.ComponentConfigSpec {
+	for i := range l {
+		configSpec := &l[i]
+		if configSpec.Name == name {
+			return configSpec
+		}
+	}
+	return nil
+}
+
+func (c *configReconcileContext) GetRelatedObjects() error {
+	return c.cluster().
+		clusterDef().
+		clusterVer().
+		clusterComponent().
+		clusterDefComponent().
+		statefulSet().
+		deployment().
+		complete()
+}
+
+func (c *configReconcileContext) objectWrapper(fn func() error) (ret *configReconcileContext) {
+	ret = c
+	if ret.Err != nil {
+		return
+	}
+	ret.Err = fn()
+	return
+}
+
+func (c *configReconcileContext) cluster() *configReconcileContext {
+	clusterKey := client.ObjectKey{
+		Namespace: c.ConfigMap.GetNamespace(),
+		Name:      c.ConfigMap.Labels[constant.AppInstanceLabelKey],
+	}
+	return c.objectWrapper(func() error {
+		c.Cluster = &appsv1alpha1.Cluster{}
+		return c.Client.Get(c.Ctx, clusterKey, c.Cluster)
+	})
+}
+
+func (c *configReconcileContext) clusterDef() *configReconcileContext {
+	clusterDefKey := client.ObjectKey{
+		Namespace: "",
+		Name:      c.Cluster.Spec.ClusterDefRef,
+	}
+	return c.objectWrapper(func() error {
+		c.ClusterDef = &appsv1alpha1.ClusterDefinition{}
+		return c.Client.Get(c.Ctx, clusterDefKey, c.ClusterDef)
+	})
+}
+
+func (c *configReconcileContext) clusterVer() *configReconcileContext {
+	clusterVerKey := client.ObjectKey{
+		Namespace: "",
+		Name:      c.Cluster.Spec.ClusterVersionRef,
+	}
+	return c.objectWrapper(func() error {
+		if clusterVerKey.Name == "" {
+			return nil
+		}
+		c.ClusterVer = &appsv1alpha1.ClusterVersion{}
+		return c.Client.Get(c.Ctx, clusterVerKey, c.ClusterVer)
+	})
+}
+func (c *configReconcileContext) clusterDefComponent() *configReconcileContext {
+	foundFn := func() (err error) {
+		if c.ClusterComponent == nil {
+			return
+		}
+		c.ClusterDefComponent = c.ClusterDef.GetComponentDefByName(c.ClusterComponent.ComponentDefRef)
+		return
+	}
+	return c.objectWrapper(foundFn)
+}
+
+func (c *configReconcileContext) clusterComponent() *configReconcileContext {
+	return c.objectWrapper(func() (err error) {
+		c.ClusterComponent = c.Cluster.Spec.GetComponentByName(c.Component)
+		return
+	})
+}
+
+func (c *configReconcileContext) statefulSet() *configReconcileContext {
+	stsFn := func() (err error) {
+		dComp := c.ClusterDefComponent
+		if dComp == nil || dComp.WorkloadType == appsv1alpha1.Stateless {
+			return
+		}
+		c.StatefulSets, c.Containers, err = retrieveRelatedComponentsByConfigmap(
+			c.Client,
+			c.Ctx,
+			c.Name,
+			generics.StatefulSetSignature,
+			client.ObjectKeyFromObject(c.ConfigMap),
+			client.InNamespace(c.Cluster.Namespace),
+			c.MatchingLabels)
+		return
+	}
+	return c.objectWrapper(stsFn)
+}
+
+func (c *configReconcileContext) deployment() *configReconcileContext {
+	deployFn := func() (err error) {
+		dComp := c.ClusterDefComponent
+		if dComp == nil || dComp.WorkloadType != appsv1alpha1.Stateless {
+			return
+		}
+		c.Deployments, c.Containers, err = retrieveRelatedComponentsByConfigmap(
+			c.Client,
+			c.Ctx,
+			c.Name,
+			generics.DeploymentSignature,
+			client.ObjectKeyFromObject(c.ConfigMap),
+			client.InNamespace(c.Cluster.Namespace),
+			c.MatchingLabels)
+		return
+	}
+	return c.objectWrapper(deployFn)
+}
+
+func (c *configReconcileContext) complete() (err error) {
+	err = c.Err
+	if err != nil {
+		return
+	}
+
+	var configSpecs configSpecList
+	if configSpecs, err = cfgcore.GetConfigTemplatesFromComponent(
+		c.clusterComponents(),
+		c.clusterDefComponents(),
+		c.clusterVerComponents(),
+		c.Component); err != nil {
+		return
+	}
+	c.ConfigSpec = configSpecs.findByName(c.Name)
+	return
+}
+
+func (c *configReconcileContext) clusterComponents() []appsv1alpha1.ClusterComponentSpec {
+	return c.Cluster.Spec.ComponentSpecs
+}
+
+func (c *configReconcileContext) clusterDefComponents() []appsv1alpha1.ClusterComponentDefinition {
+	return c.ClusterDef.Spec.ComponentDefs
+}
+
+func (c *configReconcileContext) clusterVerComponents() []appsv1alpha1.ClusterComponentVersion {
+	if c.ClusterVer == nil {
+		return nil
+	}
+	return c.ClusterVer.Spec.ComponentVersions
+}

--- a/controllers/apps/configuration/config_related_helper.go
+++ b/controllers/apps/configuration/config_related_helper.go
@@ -1,0 +1,97 @@
+/*
+Copyright (C) 2022-2023 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package configuration
+
+import (
+	"context"
+	"reflect"
+
+	appv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	cfgcore "github.com/apecloud/kubeblocks/internal/configuration"
+	cfgutil "github.com/apecloud/kubeblocks/internal/configuration/util"
+	"github.com/apecloud/kubeblocks/internal/constant"
+	intctrlutil "github.com/apecloud/kubeblocks/internal/controllerutil"
+	"github.com/apecloud/kubeblocks/internal/generics"
+)
+
+func retrieveRelatedComponentsByConfigmap[T generics.Object, L generics.ObjList[T], PL generics.PObjList[T, L]](cli client.Client, ctx context.Context, configSpecName string, _ func(T, L), cfg client.ObjectKey, opts ...client.ListOption) ([]T, []string, error) {
+	var objList L
+	if err := cli.List(ctx, PL(&objList), opts...); err != nil {
+		return nil, nil, err
+	}
+
+	objs := make([]T, 0)
+	containers := cfgutil.NewSet()
+	configSpecKey := cfgcore.GenerateTPLUniqLabelKeyWithConfig(configSpecName)
+	items := toObjects[T, L, PL](&objList)
+	for i := range items {
+		obj := toResourceObject(&items[i])
+		if objs == nil {
+			return nil, nil, cfgcore.MakeError("failed to convert to resource object")
+		}
+		if !foundComponentConfigSpec(obj.GetAnnotations(), configSpecKey, cfg.Name) {
+			continue
+		}
+		podTemplate := transformPodTemplate(obj)
+		if podTemplate == nil {
+			continue
+		}
+		volumeMounted := intctrlutil.GetVolumeMountName(podTemplate.Spec.Volumes, cfg.Name)
+		if volumeMounted == nil {
+			continue
+		}
+		// filter config manager sidecar container
+		contains := intctrlutil.GetContainersByConfigmap(podTemplate.Spec.Containers,
+			volumeMounted.Name, func(containerName string) bool {
+				return constant.ConfigSidecarName == containerName
+			})
+		if len(contains) > 0 {
+			objs = append(objs, items[i])
+			containers.Add(contains...)
+		}
+	}
+	return objs, containers.AsSlice(), nil
+}
+
+func transformPodTemplate(obj client.Object) *corev1.PodTemplateSpec {
+	switch v := obj.(type) {
+	default:
+		return nil
+	case *appv1.StatefulSet:
+		return &v.Spec.Template
+	case *appv1.Deployment:
+		return &v.Spec.Template
+	}
+}
+
+func toObjects[T generics.Object, L generics.ObjList[T], PL generics.PObjList[T, L]](compList PL) []T {
+	return reflect.ValueOf(compList).Elem().FieldByName("Items").Interface().([]T)
+}
+
+func toResourceObject(obj any) client.Object {
+	return obj.(client.Object)
+}
+
+func foundComponentConfigSpec(annotations map[string]string, key, value string) bool {
+	return len(annotations) != 0 && annotations[key] == value
+}


### PR DESCRIPTION
reconfiguring operator:
1. reconfiguring operator depends on many resources (cluster, configmap, configstraint, clusterdefinition, clusterversion, statefulset, deployment....) , which leads to two problems:
   * resource access logic is coupled with the main reconcile logic
   * resource access exception checking is coupled with reconcile logic detection
2. lots of check functions return error, making the code difficult to understand

refator code:
1. Split the access to the dependent resources into separate module;
2. [Fluent style sdk](https://en.wikipedia.org/wiki/Fluent_interface) is used to access different resources, which reduces to check the function retuned error;
3. Use Named return values to eliminate nil and useless err variables;