### PR TITLE
feat: add the --show-password flag to control the display of passwords.

### DIFF
--- a/docs/user_docs/cli/kbcli_cluster_connect.md
+++ b/docs/user_docs/cli/kbcli_cluster_connect.md
@@ -23,14 +23,17 @@ kbcli cluster connect (NAME | -i INSTANCE-NAME) [flags]
   # connect to a specified component
   kbcli cluster connect mycluster --component mycomponent
   
-  # show cli connection example
+  # show cli connection example with password mask
   kbcli cluster connect mycluster --show-example --client=cli
   
-  # show java connection example
+  # show java connection example with password mask
   kbcli cluster connect mycluster --show-example --client=java
   
-  # show all connection examples
+  # show all connection examples with password mask
   kbcli cluster connect mycluster --show-example
+  
+  # show cli connection examples with real password
+  kbcli cluster connect mycluster --show-example --client=cli --show-password
 ```
 
 ### Options

--- a/docs/user_docs/cli/kbcli_cluster_connect.md
+++ b/docs/user_docs/cli/kbcli_cluster_connect.md
@@ -42,6 +42,7 @@ kbcli cluster connect (NAME | -i INSTANCE-NAME) [flags]
   -h, --help               help for connect
   -i, --instance string    The instance name to connect.
       --show-example       Show how to connect to cluster/instance from different clients.
+      --show-password      Show password in example.
 ```
 
 ### Options inherited from parent commands

--- a/internal/cli/cmd/cluster/connect.go
+++ b/internal/cli/cmd/cluster/connect.go
@@ -66,13 +66,16 @@ var connectExample = templates.Examples(`
 		# show all connection examples
 		kbcli cluster connect mycluster --show-example`)
 
+const passwordMask = "******"
+
 type ConnectOptions struct {
 	clusterName   string
 	componentName string
 
-	clientType  string
-	showExample bool
-	engine      engine.ClusterCommands
+	clientType   string
+	showExample  bool
+	showPassword bool
+	engine       engine.ClusterCommands
 
 	privateEndPoint bool
 	svc             *corev1.Service
@@ -109,6 +112,8 @@ func NewConnectCmd(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobr
 	cmd.Flags().StringVarP(&o.PodName, "instance", "i", "", "The instance name to connect.")
 	flags.AddComponentsFlag(f, cmd, false, &o.componentName, "The component to connect. If not specified, pick up the first one.")
 	cmd.Flags().BoolVar(&o.showExample, "show-example", false, "Show how to connect to cluster/instance from different clients.")
+	cmd.Flags().BoolVar(&o.showPassword, "show-password", false, "Show password in example.")
+
 	cmd.Flags().StringVar(&o.clientType, "client", "", "Which client connection example should be output, only valid if --show-example is true.")
 
 	cmd.Flags().StringVar(&o.userName, "as-user", "", "Connect to cluster as user")
@@ -355,7 +360,9 @@ func (o *ConnectOptions) getConnectionInfo() (*engine.ConnectionInfo, error) {
 	if info.User, info.Password, err = getUserAndPassword(objs.ClusterDef, objs.Secrets); err != nil {
 		return nil, err
 	}
-
+	if !o.showPassword {
+		info.Password = passwordMask
+	}
 	// get host and port, use external endpoints first, if external endpoints are empty,
 	// use internal endpoints
 

--- a/internal/cli/cmd/cluster/connect.go
+++ b/internal/cli/cmd/cluster/connect.go
@@ -57,14 +57,17 @@ var connectExample = templates.Examples(`
 		# connect to a specified component
 		kbcli cluster connect mycluster --component mycomponent
 
-		# show cli connection example
+		# show cli connection example with password mask
 		kbcli cluster connect mycluster --show-example --client=cli
 
-		# show java connection example
+		# show java connection example with password mask
 		kbcli cluster connect mycluster --show-example --client=java
 
-		# show all connection examples
-		kbcli cluster connect mycluster --show-example`)
+		# show all connection examples with password mask
+		kbcli cluster connect mycluster --show-example 
+
+		# show cli connection examples with real password 
+		kbcli cluster connect mycluster --show-example --client=cli --show-password`)
 
 const passwordMask = "******"
 

--- a/internal/cli/cmd/cluster/connect_test.go
+++ b/internal/cli/cmd/cluster/connect_test.go
@@ -135,7 +135,7 @@ var _ = Describe("connection", func() {
 		Expect(o.runShowExample()).Should(Succeed())
 	})
 
-	It("getUserAndPassword", func() {
+	Context("getConnectionInfo", func() {
 		const (
 			user     = "test-user"
 			password = "test-password"
@@ -148,10 +148,25 @@ var _ = Describe("connection", func() {
 		}
 		secretList := &corev1.SecretList{}
 		secretList.Items = []corev1.Secret{secret}
-		u, p, err := getUserAndPassword(testing.FakeClusterDef(), secretList)
-		Expect(err).Should(Succeed())
-		Expect(u).Should(Equal(user))
-		Expect(p).Should(Equal(password))
+		It("getUserAndPassword", func() {
+			u, p, err := getUserAndPassword(testing.FakeClusterDef(), secretList)
+			Expect(err).Should(Succeed())
+			Expect(u).Should(Equal(user))
+			Expect(p).Should(Equal(password))
+		})
+
+		It("--show-password", func() {
+			o := &ConnectOptions{ExecOptions: exec.NewExecOptions(tf, streams)}
+			Expect(o.validate([]string{clusterName})).Should(Succeed())
+			Expect(o.complete()).Should(Succeed())
+			info, err := o.getConnectionInfo()
+			Expect(err).Should(Succeed())
+			Expect(info.Password).Should(Equal(passwordMask))
+			o.showPassword = true
+			info, err = o.getConnectionInfo()
+			Expect(err).Should(Succeed())
+			Expect(info.Password).Should(Equal(password))
+		})
 	})
 })
 


### PR DESCRIPTION
- fix: #4455 

What i do:
1. add the `--show-password` flag for `getConnectionInfo`. If `--show-password` is false, the info.password will be replaced by a password mask "******"
2. fix the UTs

Example:
![image](https://github.com/apecloud/kubeblocks/assets/101848970/a6c1263e-31cd-46b0-8de9-31e5a0a9068f)
![image](https://github.com/apecloud/kubeblocks/assets/101848970/fef383a8-311a-4943-97cc-3cd06d0a6b06)
