### PR TITLE
fix: redis account not save to file as expected

### DIFF
--- a/deploy/redis/templates/clusterdefinition.yaml
+++ b/deploy/redis/templates/clusterdefinition.yaml
@@ -99,6 +99,13 @@ spec:
               - name: REDIS_ARGS
                 value: "--requirepass $(REDIS_PASSWORD)"
             command: ["/scripts/redis-start.sh"]
+            lifecycle:
+              preStop:
+                exec:
+                  command:
+                    - /bin/bash
+                    - -c
+                    - "redis-cli -a $REDIS_DEFAULT_PASSWORD acl save"
           - name: metrics
             image: {{ .Values.metrics.image.registry | default "docker.io" }}/{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}
             imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}
@@ -159,7 +166,7 @@ spec:
           - sh
           - -c
           args:
-          - "redis-cli -h $(KB_ACCOUNT_ENDPOINT) -a $REDIS_DEFAULT_PASSWORD $(KB_ACCOUNT_STATEMENT) | redis-cli -h $(KB_ACCOUNT_ENDPOINT) -a $REDIS_DEFAULT_PASSWORD acl save "
+          - "redis-cli -h $(KB_ACCOUNT_ENDPOINT) -a $REDIS_DEFAULT_PASSWORD $(KB_ACCOUNT_STATEMENT) && redis-cli -h $(KB_ACCOUNT_ENDPOINT) -a $REDIS_DEFAULT_PASSWORD acl save "
         passwordConfig:
           length: 10
           numDigits: 5

--- a/deploy/redis/templates/clusterdefinition.yaml
+++ b/deploy/redis/templates/clusterdefinition.yaml
@@ -105,7 +105,7 @@ spec:
                   command:
                     - /bin/bash
                     - -c
-                    - "redis-cli -a $REDIS_DEFAULT_PASSWORD acl save"
+                    - /scripts/redis-preStop.sh
           - name: metrics
             image: {{ .Values.metrics.image.registry | default "docker.io" }}/{{ .Values.metrics.image.repository }}:{{ .Values.metrics.image.tag }}
             imagePullPolicy: {{ .Values.metrics.image.pullPolicy | quote }}

--- a/deploy/redis/templates/scripts.yaml
+++ b/deploy/redis/templates/scripts.yaml
@@ -36,3 +36,11 @@ data:
       echo "$response"
       exit 1
     fi
+  redis-preStop.sh: |
+    #!/bin/sh
+    set -ex
+    if [ ! -z "$REDIS_DEFAULT_PASSWORD" ]; then
+      redis-cli -h 127.0.0.1 -p 6379 -a "$REDIS_DEFAULT_PASSWORD" acl save
+    else
+      redis-cli -h 127.0.0.1 -p 6379 acl save
+    fi


### PR DESCRIPTION
- fix : #3798 
Accounts are not flushed to config files as expected. So we add a `pre-Stop` hook to make sure accounts will be written back to config file.