### PR TITLE
fix: kbcli bench return proper message when kubebench is not enabled

### DIFF
--- a/internal/cli/cmd/bench/bench.go
+++ b/internal/cli/cmd/bench/bench.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/docker/cli/cli"
 	"github.com/spf13/cobra"
@@ -180,6 +181,12 @@ func newDeleteCmd(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra
 }
 
 func (o *benchListOption) run() error {
+	defer func() {
+		if err := recover(); err != nil {
+			fmt.Fprintf(o.Out, "it's seems that kubebech is not running, please run `kbcli addon enable kubebech` to install it or check the kubebech pod status.\n")
+		}
+	}()
+
 	var infos []*resource.Info
 	for _, gvr := range benchGVRList {
 		bench := list.NewListOptions(o.Factory, o.IOStreams, gvr)
@@ -188,6 +195,10 @@ func (o *benchListOption) run() error {
 		bench.LabelSelector = o.LabelSelector
 		result, err := bench.Run()
 		if err != nil {
+			if strings.Contains(err.Error(), "the server doesn't have a resource type") {
+				fmt.Fprintf(o.Out, "kubebech is not installed, please run `kbcli addon enable kubebech` to install it.\n")
+				return nil
+			}
 			return err
 		}
 

--- a/internal/cli/cmd/bench/bench.go
+++ b/internal/cli/cmd/bench/bench.go
@@ -183,7 +183,7 @@ func newDeleteCmd(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra
 func (o *benchListOption) run() error {
 	defer func() {
 		if err := recover(); err != nil {
-			fmt.Fprintf(o.Out, "it's seems that kubebech is not running, please run `kbcli addon enable kubebech` to install it or check the kubebech pod status.\n")
+			fmt.Fprintf(o.Out, "it seems that kubebench is not running, please run `kbcli addon enable kubebench` to install it or check the kubebench pod status.\n")
 		}
 	}()
 
@@ -196,7 +196,7 @@ func (o *benchListOption) run() error {
 		result, err := bench.Run()
 		if err != nil {
 			if strings.Contains(err.Error(), "the server doesn't have a resource type") {
-				fmt.Fprintf(o.Out, "kubebech is not installed, please run `kbcli addon enable kubebech` to install it.\n")
+				fmt.Fprintf(o.Out, "kubebench is not installed, please run `kbcli addon enable kubebench` to install it.\n")
 				return nil
 			}
 			return err


### PR DESCRIPTION
<img width="1111" alt="image" src="https://github.com/apecloud/kubeblocks/assets/49025948/8fac564e-4425-4b67-a5b0-629c79aca829">
