### PR TITLE
chore: Optimizing wal log parameters for small-size instances, e.g: Sealos instances

### DIFF
--- a/internal/cli/cmd/builder/template/util.go
+++ b/internal/cli/cmd/builder/template/util.go
@@ -21,6 +21,7 @@ package template
 
 import (
 	"reflect"
+	"strings"
 
 	"github.com/sethvargo/go-password/password"
 	"helm.sh/helm/v3/pkg/cli/values"
@@ -59,8 +60,12 @@ func mockClusterObject(clusterDefObj *appsv1alpha1.ClusterDefinition, renderedOp
 		factory.AddComponent(component.CharacterType+"-"+RandomString(3), component.Name)
 		factory.SetReplicas(renderedOpts.Replicas)
 		if renderedOpts.DataVolumeName != "" {
-			pvcSpec := testapps.NewPVCSpec("10Gi")
-			factory.AddVolumeClaimTemplate(renderedOpts.DataVolumeName, pvcSpec)
+			fields := strings.SplitN(renderedOpts.DataVolumeName, ":", 2)
+			if len(fields) == 1 {
+				fields = append(fields, "10Gi")
+			}
+			pvcSpec := testapps.NewPVCSpec(fields[1])
+			factory.AddVolumeClaimTemplate(fields[0], pvcSpec)
 		}
 		if renderedOpts.CPU != "" || renderedOpts.Memory != "" {
 			factory.SetResources(fromResource(renderedOpts))

--- a/internal/controller/plan/builtin_functions.go
+++ b/internal/controller/plan/builtin_functions.go
@@ -254,7 +254,7 @@ func getPortByName(args interface{}, portName string) (interface{}, error) {
 	return nil, nil
 }
 
-// getComponentPVCSizeByName get pvc size by name
+// getComponentPVCSizeByName gets pvc size by name
 func getComponentPVCSizeByName(args interface{}, pvcName string) (int64, error) {
 	component, err := fromJSONObject[component.SynthesizedComponent](args)
 	if err != nil {
@@ -268,7 +268,7 @@ func getComponentPVCSizeByName(args interface{}, pvcName string) (int64, error) 
 	return -1, nil
 }
 
-// getPVCSize get pvc size by name
+// getPVCSize gets pvc size by name
 func getPVCSize(args interface{}) (int64, error) {
 	pvcTemp, err := fromJSONObject[corev1.PersistentVolumeClaimTemplate](args)
 	if err != nil {

--- a/internal/controller/plan/builtin_functions.go
+++ b/internal/controller/plan/builtin_functions.go
@@ -61,7 +61,7 @@ func fromJSONObject[T any](args interface{}) (*T, error) {
 	return &container, nil
 }
 
-func fromJSONArray[T corev1.Container | corev1.Volume](args interface{}) ([]T, error) {
+func fromJSONArray[T corev1.Container | corev1.Volume | corev1.PersistentVolumeClaimTemplate](args interface{}) ([]T, error) {
 	b, err := json.Marshal(args)
 	if err != nil {
 		return nil, err
@@ -254,6 +254,29 @@ func getPortByName(args interface{}, portName string) (interface{}, error) {
 	return nil, nil
 }
 
+// getComponentPVCSizeByName get pvc size by name
+func getComponentPVCSizeByName(args interface{}, pvcName string) (int64, error) {
+	component, err := fromJSONObject[component.SynthesizedComponent](args)
+	if err != nil {
+		return -1, err
+	}
+	for _, v := range component.VolumeClaimTemplates {
+		if v.Name == pvcName {
+			return intctrlutil.GetStorageSizeFromPersistentVolume(v), nil
+		}
+	}
+	return -1, nil
+}
+
+// getPVCSize get pvc size by name
+func getPVCSize(args interface{}) (int64, error) {
+	pvcTemp, err := fromJSONObject[corev1.PersistentVolumeClaimTemplate](args)
+	if err != nil {
+		return -1, err
+	}
+	return intctrlutil.GetStorageSizeFromPersistentVolume(*pvcTemp), nil
+}
+
 // getCAFile gets CA file
 func getCAFile() string {
 	return builder.MountPath + "/" + builder.CAName
@@ -280,6 +303,8 @@ func BuiltInCustomFunctions(c *configTemplateBuilder, component *component.Synth
 		builtInGetArgFunctionName:                    getArgByName,
 		builtInGetContainerFunctionName:              getPodContainerByName,
 		builtInGetContainerCPUFunctionName:           getContainerCPU,
+		builtInGetPVCSizeByNameFunctionName:          getComponentPVCSizeByName,
+		builtInGetPVCSizeFunctionName:                getPVCSize,
 		builtInGetContainerMemoryFunctionName:        getContainerMemory,
 		builtInGetContainerRequestMemoryFunctionName: getContainerRequestMemory,
 		builtInGetCAFile:                             getCAFile,

--- a/internal/controller/plan/config_template.go
+++ b/internal/controller/plan/config_template.go
@@ -55,6 +55,8 @@ const (
 	builtInGetPortFunctionName                   = "getPortByName"
 	builtInGetContainerFunctionName              = "getContainerByName"
 	builtInGetContainerCPUFunctionName           = "getContainerCPU"
+	builtInGetPVCSizeByNameFunctionName          = "getComponentPVCSizeByName"
+	builtInGetPVCSizeFunctionName                = "getPVCSize"
 	builtInGetContainerMemoryFunctionName        = "getContainerMemory"
 	builtInGetContainerRequestMemoryFunctionName = "getContainerRequestMemory"
 

--- a/internal/controller/plan/config_template_test.go
+++ b/internal/controller/plan/config_template_test.go
@@ -159,6 +159,20 @@ single_thread_memory = 294912
 			Name:           "replicasets",
 			CompDefName:    "replicasets",
 			Replicas:       5,
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaimTemplate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "data",
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("10Gi"),
+							},
+						},
+					},
+				},
+			},
 		}
 		cfgTemplate = []appsv1alpha1.ComponentConfigSpec{{
 			ComponentTemplateSpec: appsv1alpha1.ComponentTemplateSpec{
@@ -234,6 +248,8 @@ single_thread_memory = 294912
 				"invalid_pvc":       "{{ getPVCByName $.podSpec.volumes \"invalid\" }}",
 				"invalid_memory":    "{{ getContainerMemory ( index $.podSpec.containers 1 ) }}",
 				"cluster_domain":    "{{- $.clusterDomain }}",
+				"pvc_size":          "{{- getComponentPVCSizeByName $.component \"data\" }}",
+				"pvc_size2":         "{{- getPVCSize ( index $.component.volumeClaimTemplates 0 ) }}",
 			})
 
 			Expect(err).Should(BeNil())
@@ -262,6 +278,8 @@ single_thread_memory = 294912
 			Expect(rendered["invalid_resource"]).Should(BeEquivalentTo(""))
 			Expect(rendered["invalid_memory"]).Should(BeEquivalentTo("0"))
 			Expect(rendered["cluster_domain"]).Should(BeEquivalentTo("test-domain"))
+			Expect(rendered["pvc_size"]).Should(BeEquivalentTo("10737418240"))
+			Expect(rendered["pvc_size2"]).Should(BeEquivalentTo("10737418240"))
 		})
 
 		It("test array null check", func() {

--- a/internal/controllerutil/pod_utils.go
+++ b/internal/controllerutil/pod_utils.go
@@ -214,6 +214,15 @@ func GetRequestMemorySize(container corev1.Container) int64 {
 	return 0
 }
 
+// GetStorageSizeFromPersistentVolume gets content of Resources.Requests.storage
+func GetStorageSizeFromPersistentVolume(pvc corev1.PersistentVolumeClaimTemplate) int64 {
+	requests := pvc.Spec.Resources.Requests
+	if val, ok := (requests)[corev1.ResourceStorage]; ok {
+		return val.Value()
+	}
+	return -1
+}
+
 // PodIsReady checks if pod is ready
 func PodIsReady(pod *corev1.Pod) bool {
 	if pod.Status.Conditions == nil {


### PR DESCRIPTION
sealos data disk is very small(e.g: 1Gi), but wal log takes up 800MB+, causing the disk to be full! 

new rule：
When the disk size is below 5G, the wal log limit is set to 256MB.