### PR TITLE
feat: kbcli bench support only cleanup, prepare or run

### DIFF
--- a/docs/user_docs/cli/kbcli_bench_pgbench.md
+++ b/docs/user_docs/cli/kbcli_bench_pgbench.md
@@ -5,14 +5,23 @@ title: kbcli bench pgbench
 Run pgbench against a PostgreSQL cluster
 
 ```
-kbcli bench pgbench [BenchmarkName] [flags]
+kbcli bench pgbench [Step] [BenchmarkName] [flags]
 ```
 
 ### Examples
 
 ```
-  # pgbench run on a cluster
+  # pgbench run on a cluster, that will exec all steps, cleanup, prepare and run
   kbcli bench pgbench mytest --cluster pgcluster --database postgres --user xxx --password xxx
+  
+  # pgbench run on a cluster with cleanup, just exec cleanup that will delete the testdata
+  kbcli bench pgbench cleanup mytest --cluster pgcluster --database postgres --user xxx --password xxx
+  
+  # pgbench run on a cluster with prepare, just exec prepare that will create the testdata
+  kbcli bench pgbench prepare mytest --cluster pgcluster --database postgres --user xxx --password xxx
+  
+  # pgbench run on a cluster with run, just exec run that will run the test
+  kbcli bench pgbench run mytest --cluster pgcluster --database postgres --user xxx --password xxx
   
   # pgbench run on a cluster with  threads and  client count
   kbcli bench sysbench mytest --cluster pgcluster --user xxx --password xxx --database xxx --clients 5 --threads 5

--- a/docs/user_docs/cli/kbcli_bench_sysbench.md
+++ b/docs/user_docs/cli/kbcli_bench_sysbench.md
@@ -5,14 +5,23 @@ title: kbcli bench sysbench
 run a SysBench benchmark
 
 ```
-kbcli bench sysbench [BenchmarkName] [flags]
+kbcli bench sysbench [Step] [BenchmarkName] [flags]
 ```
 
 ### Examples
 
 ```
-  # sysbench on a cluster
+  # sysbench on a cluster, that will exec all steps, cleanup, prepare and run
   kbcli bench sysbench mytest --cluster mycluster --user xxx --password xxx --database mydb
+  
+  # sysbench on a cluster with cleanup, just exec cleanup that will delete the testdata
+  kbcli bench sysbench cleanup mytest --cluster mycluster --user xxx --password xxx --database mydb
+  
+  # sysbench on a cluster with prepare, just exec prepare that will create the testdata
+  kbcli bench sysbench prepare mytest --cluster mycluster --user xxx --password xxx --database mydb
+  
+  # sysbench on a cluster with run, just exec run that will run the test
+  kbcli bench sysbench run mytest --cluster mycluster --user xxx --password xxx --database mydb
   
   # sysbench on a cluster with threads count
   kbcli bench sysbench mytest --cluster mycluster --user xxx --password xxx --database mydb --threads 4,8

--- a/docs/user_docs/cli/kbcli_bench_tpcc.md
+++ b/docs/user_docs/cli/kbcli_bench_tpcc.md
@@ -5,14 +5,23 @@ title: kbcli bench tpcc
 Run tpcc benchmark
 
 ```
-kbcli bench tpcc [flags]
+kbcli bench tpcc [Step] [BenchmarkName] [flags]
 ```
 
 ### Examples
 
 ```
-  # tpcc on a cluster
+  # tpcc on a cluster, that will exec all steps, cleanup, prepare and run
   kbcli bench tpcc mytest --cluster mycluster --user xxx --password xxx --database mydb
+  
+  # tpcc on a cluster with cleanup, just exec cleanup that will delete the testdata
+  kbcli bench tpcc cleanup mytest --cluster mycluster --user xxx --password xxx --database mydb
+  
+  # tpcc on a cluster with prepare, just exec prepare that will create the testdata
+  kbcli bench tpcc prepare mytest --cluster mycluster --user xxx --password xxx --database mydb
+  
+  # tpcc on a cluster with run, just exec run that will run the test
+  kbcli bench tpcc run mytest --cluster mycluster --user xxx --password xxx --database mydb
   
   # tpcc on a cluster with warehouses count, which is the overall database size scaling parameter
   kbcli bench tpcc mytest --cluster mycluster --user xxx --password xxx --database mydb --warehouses 100

--- a/docs/user_docs/cli/kbcli_bench_ycsb.md
+++ b/docs/user_docs/cli/kbcli_bench_ycsb.md
@@ -5,14 +5,23 @@ title: kbcli bench ycsb
 Run YCSB benchmark on a cluster
 
 ```
-kbcli bench ycsb [BenchmarkName] [flags]
+kbcli bench ycsb [Step] [BenchmarkName] [flags]
 ```
 
 ### Examples
 
 ```
-  # ycsb on a cluster
+  # ycsb on a cluster, that will exec all steps, cleanup, prepare and run
   kbcli bench ycsb mytest --cluster mycluster --user xxx --password xxx --database mydb
+  
+  # ycsb on a cluster with cleanup, just exec cleanup that will delete the testdata
+  kbcli bench ycsb cleanup mytest --cluster mycluster --user xxx --password xxx --database mydb
+  
+  # ycsb on a cluster with prepare, just exec prepare that will create the testdata
+  kbcli bench ycsb prepare mytest --cluster mycluster --user xxx --password xxx --database mydb
+  
+  # ycsb on a cluster with run, just exec run that will run the test
+  kbcli bench ycsb run mytest --cluster mycluster --user xxx --password xxx --database mydb
   
   # ycsb on a cluster with threads count
   kbcli bench ycsb mytest --cluster mycluster --user xxx --password xxx --database mydb --threads 4,8

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/Shopify/sarama v1.30.0
 	github.com/StudioSol/set v1.0.0
-	github.com/apecloud/kubebench v0.0.0-20230731014958-be57f3087497
+	github.com/apecloud/kubebench v0.0.0-20230804055724-8f3c1c83ec7c
 	github.com/authzed/controller-idioms v0.7.0
 	github.com/aws/aws-sdk-go v1.44.180
 	github.com/benbjohnson/clock v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -326,8 +326,8 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuW
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/antlr/antlr4/runtime/Go/antlr v1.4.10 h1:yL7+Jz0jTC6yykIK/Wh74gnTJnrGr5AyrNMXuA0gves=
 github.com/antlr/antlr4/runtime/Go/antlr v1.4.10/go.mod h1:F7bn7fEU90QkQ3tnmaTx3LTKLEDqnwWODIYppRQ5hnY=
-github.com/apecloud/kubebench v0.0.0-20230731014958-be57f3087497 h1:zob/yGtcRPMcqHWM43oXOpbYn3bbg+bXf3f9iHcKHLI=
-github.com/apecloud/kubebench v0.0.0-20230731014958-be57f3087497/go.mod h1:pk7XhTJO9+AVE0mGUGb0WfU8ME9o4s3nClyuWATMQAQ=
+github.com/apecloud/kubebench v0.0.0-20230804055724-8f3c1c83ec7c h1:0DlKW7JMY4Z7EDTII/5OFxQ2dKU4V6x9OhQe+qRGYe4=
+github.com/apecloud/kubebench v0.0.0-20230804055724-8f3c1c83ec7c/go.mod h1:pk7XhTJO9+AVE0mGUGb0WfU8ME9o4s3nClyuWATMQAQ=
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkEghdlcqw7yxLeM89kiTRPUo=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/internal/cli/cmd/bench/bench.go
+++ b/internal/cli/cmd/bench/bench.go
@@ -335,3 +335,27 @@ func validateBenchmarkExist(factory cmdutil.Factory, streams genericclioptions.I
 	}
 	return nil
 }
+
+// parseStepAndName parses the step and name from the given arguments and name prefix.
+// If no arguments are provided, it sets the step to "all" and generates a random name with the given prefix.
+// If the first argument is "all", "cleanup", "prepare", or "run", it sets the step to the argument value.
+// If a second argument is provided, it sets the name to the argument value.
+// If the first argument is not a valid step value, it sets the name to the first argument value.
+// Returns the step and name as strings.
+func parseStepAndName(args []string, namePrefix string) (step, name string) {
+	step = "all"
+	name = fmt.Sprintf("%s-%s", namePrefix, util.RandRFC1123String(6))
+
+	if len(args) > 0 {
+		switch args[0] {
+		case "all", "cleanup", "prepare", "run":
+			step = args[0]
+			if len(args) > 1 {
+				name = args[1]
+			}
+		default:
+			name = args[0]
+		}
+	}
+	return
+}

--- a/internal/cli/cmd/bench/pgbench.go
+++ b/internal/cli/cmd/bench/pgbench.go
@@ -37,7 +37,6 @@ import (
 
 	"github.com/apecloud/kubeblocks/internal/cli/cluster"
 	"github.com/apecloud/kubeblocks/internal/cli/types"
-	"github.com/apecloud/kubeblocks/internal/cli/util"
 )
 
 const (
@@ -45,8 +44,17 @@ const (
 )
 
 var pgbenchExample = templates.Examples(`
-# pgbench run on a cluster
+# pgbench run on a cluster, that will exec all steps, cleanup, prepare and run
 kbcli bench pgbench mytest --cluster pgcluster --database postgres --user xxx --password xxx
+
+# pgbench run on a cluster with cleanup, just exec cleanup that will delete the testdata
+kbcli bench pgbench cleanup mytest --cluster pgcluster --database postgres --user xxx --password xxx
+
+# pgbench run on a cluster with prepare, just exec prepare that will create the testdata
+kbcli bench pgbench prepare mytest --cluster pgcluster --database postgres --user xxx --password xxx
+
+# pgbench run on a cluster with run, just exec run that will run the test
+kbcli bench pgbench run mytest --cluster pgcluster --database postgres --user xxx --password xxx
 
 # pgbench run on a cluster with  threads and  client count
 kbcli bench sysbench mytest --cluster pgcluster --user xxx --password xxx --database xxx --clients 5 --threads 5
@@ -74,6 +82,7 @@ type PgBenchOptions struct {
 	Transactions int      // specify the number of transactions per client
 	Duration     int      // specify the duration of benchmark test in seconds
 	Select       bool     // specify to run SELECT-only transactions
+	Step         string   // specify the benchmark step, exec all, cleanup, prepare or run
 	ExtraArgs    []string // specify extra arguments for pgbench
 
 	BenchBaseOptions
@@ -88,7 +97,7 @@ func NewPgBenchCmd(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobr
 	}
 
 	cmd := &cobra.Command{
-		Use:     "pgbench [BenchmarkName]",
+		Use:     "pgbench [Step] [BenchmarkName]",
 		Short:   "Run pgbench against a PostgreSQL cluster",
 		Example: pgbenchExample,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -117,13 +126,7 @@ func (o *PgBenchOptions) Complete(args []string) error {
 	var host string
 	var port int
 
-	// use the first argument as the name of the benchmark
-	if len(args) > 0 {
-		o.name = args[0]
-	}
-	if o.name == "" {
-		o.name = fmt.Sprintf("pgbench-%s", util.RandRFC1123String(6))
-	}
+	o.Step, o.name = parseStepAndName(args, "pgbench")
 
 	if o.ClusterName != "" {
 		o.namespace, _, err = o.factory.ToRawKubeConfigLoader().Namespace()
@@ -219,6 +222,7 @@ func (o *PgBenchOptions) Run() error {
 			SelectOnly:   o.Select,
 			Transactions: o.Transactions,
 			Duration:     o.Duration,
+			Step:         o.Step,
 			Target: v1alpha1.PgbenchTarget{
 				Host:     o.Host,
 				Port:     o.Port,

--- a/internal/cli/cmd/bench/sysbench.go
+++ b/internal/cli/cmd/bench/sysbench.go
@@ -37,7 +37,6 @@ import (
 
 	"github.com/apecloud/kubeblocks/internal/cli/cluster"
 	"github.com/apecloud/kubeblocks/internal/cli/types"
-	"github.com/apecloud/kubeblocks/internal/cli/util"
 )
 
 var (
@@ -48,8 +47,17 @@ var (
 )
 
 var sysbenchExample = templates.Examples(`
-		# sysbench on a cluster
+		# sysbench on a cluster, that will exec all steps, cleanup, prepare and run
 		kbcli bench sysbench mytest --cluster mycluster --user xxx --password xxx --database mydb
+
+		# sysbench on a cluster with cleanup, just exec cleanup that will delete the testdata
+		kbcli bench sysbench cleanup mytest --cluster mycluster --user xxx --password xxx --database mydb
+
+		# sysbench on a cluster with prepare, just exec prepare that will create the testdata
+		kbcli bench sysbench prepare mytest --cluster mycluster --user xxx --password xxx --database mydb
+
+		# sysbench on a cluster with run, just exec run that will run the test
+		kbcli bench sysbench run mytest --cluster mycluster --user xxx --password xxx --database mydb
 
 		# sysbench on a cluster with threads count
 		kbcli bench sysbench mytest --cluster mycluster --user xxx --password xxx --database mydb --threads 4,8
@@ -79,6 +87,7 @@ type SysBenchOptions struct {
 	ExtraArgs    []string
 	ReadPercent  int
 	WritePercent int
+	Step         string
 
 	BenchBaseOptions
 	*cluster.ClusterObjects     `json:"-"`
@@ -92,7 +101,7 @@ func NewSysBenchCmd(f cmdutil.Factory, streams genericclioptions.IOStreams) *cob
 	}
 
 	cmd := &cobra.Command{
-		Use:     "sysbench [BenchmarkName]",
+		Use:     "sysbench [Step] [BenchmarkName]",
 		Short:   "run a SysBench benchmark",
 		Example: sysbenchExample,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -122,13 +131,7 @@ func (o *SysBenchOptions) Complete(args []string) error {
 	var host string
 	var port int
 
-	// use the first argument as the name of the benchmark
-	if len(args) > 0 {
-		o.name = args[0]
-	}
-	if o.name == "" {
-		o.name = fmt.Sprintf("sysbench-%s", util.RandRFC1123String(6))
-	}
+	o.Step, o.name = parseStepAndName(args, "sysbench")
 
 	if o.ClusterName != "" {
 		o.namespace, _, err = o.factory.ToRawKubeConfigLoader().Namespace()
@@ -260,6 +263,7 @@ func (o *SysBenchOptions) Run() error {
 			Threads:   o.Threads,
 			Types:     o.Type,
 			Duration:  o.Duration,
+			Step:      o.Step,
 			ExtraArgs: o.ExtraArgs,
 			Target: v1alpha1.SysbenchTarget{
 				Driver:   o.Driver,


### PR DESCRIPTION
just run the sysbench benchmark
<img width="1235" alt="image" src="https://github.com/apecloud/kubeblocks/assets/49025948/30e3a92d-fa9a-41e6-873b-1988e37c4d9c">

just prepare the sysbench testdata
<img width="1267" alt="image" src="https://github.com/apecloud/kubeblocks/assets/49025948/2053dff6-ac41-439d-a131-7f6afd8d5252">

just cleanup the sysbench testdata
<img width="1334" alt="image" src="https://github.com/apecloud/kubeblocks/assets/49025948/6bf92447-0cdd-40db-820d-46989c093a76">

just run the tpcc benchmark
<img width="1250" alt="image" src="https://github.com/apecloud/kubeblocks/assets/49025948/ab2b1301-f7bf-4877-8c23-cb695f47f98d">
