### PR TITLE
fix: postgresql/redis cluster hscale ops status is incorrect

### DIFF
--- a/controllers/apps/components/base.go
+++ b/controllers/apps/components/base.go
@@ -311,7 +311,6 @@ func (c *componentBase) StatusWorkload(reqCtx intctrlutil.RequestCtx, cli client
 	isRunning, err := c.ComponentSet.IsRunning(reqCtx.Ctx, obj)
 	if err != nil {
 		return err
-
 	}
 
 	var podsReady *bool
@@ -326,10 +325,9 @@ func (c *componentBase) StatusWorkload(reqCtx intctrlutil.RequestCtx, cli client
 	hasFailedPodTimedOut := false
 	timedOutPodStatusMessage := appsv1alpha1.ComponentMessageMap{}
 	var delayedRequeueError error
-	clusterGenerationFromWorkload := obj.GetAnnotations()[constant.KubeBlocksGenerationKey]
+	isLatestWorkload := obj.GetAnnotations()[constant.KubeBlocksGenerationKey] == strconv.FormatInt(c.Cluster.Generation, 10)
 	// check if it is the latest obj after cluster does updates.
-	if !isRunning && !appsv1alpha1.ComponentPodsAreReady(podsReady) &&
-		clusterGenerationFromWorkload == strconv.FormatInt(c.Cluster.Generation, 10) {
+	if !isRunning && !appsv1alpha1.ComponentPodsAreReady(podsReady) && isLatestWorkload {
 		var requeueAfter time.Duration
 		if hasFailedPodTimedOut, timedOutPodStatusMessage, requeueAfter = hasFailedAndTimedOutPod(pods); requeueAfter != 0 {
 			delayedRequeueError = intctrlutil.NewDelayedRequeueError(requeueAfter, "requeue for workload status to reconcile.")

--- a/internal/controller/graph/dag.go
+++ b/internal/controller/graph/dag.go
@@ -145,11 +145,11 @@ func (d *DAG) AddConnectRoot(v Vertex) bool {
 }
 
 // WalkTopoOrder walks the DAG 'd' in topology order
-func (d *DAG) WalkTopoOrder(walkFunc WalkFunc) error {
+func (d *DAG) WalkTopoOrder(walkFunc WalkFunc, less func(v1, v2 Vertex) bool) error {
 	if err := d.validate(); err != nil {
 		return err
 	}
-	orders := d.topologicalOrder(false, nil)
+	orders := d.topologicalOrder(false, less)
 	for _, v := range orders {
 		if err := walkFunc(v); err != nil {
 			return err
@@ -159,11 +159,11 @@ func (d *DAG) WalkTopoOrder(walkFunc WalkFunc) error {
 }
 
 // WalkReverseTopoOrder walks the DAG 'd' in reverse topology order
-func (d *DAG) WalkReverseTopoOrder(walkFunc WalkFunc) error {
+func (d *DAG) WalkReverseTopoOrder(walkFunc WalkFunc, less func(v1, v2 Vertex) bool) error {
 	if err := d.validate(); err != nil {
 		return err
 	}
-	orders := d.topologicalOrder(true, nil)
+	orders := d.topologicalOrder(true, less)
 	for _, v := range orders {
 		if err := walkFunc(v); err != nil {
 			return err
@@ -267,13 +267,13 @@ func (d *DAG) Merge(subDag *DAG) {
 }
 
 // String returns a string representation of the DAG in topology order
-func (d *DAG) String() string {
+func (d *DAG) String(less func(v1, v2 Vertex) bool) string {
 	str := "|"
 	walkFunc := func(v Vertex) error {
 		str += fmt.Sprintf("->%v", v)
 		return nil
 	}
-	if err := d.WalkReverseTopoOrder(walkFunc); err != nil {
+	if err := d.WalkReverseTopoOrder(walkFunc, less); err != nil {
 		return "->err"
 	}
 	return str

--- a/internal/controller/graph/dag_test.go
+++ b/internal/controller/graph/dag_test.go
@@ -160,7 +160,7 @@ func TestWalkTopoOrder(t *testing.T) {
 		walkOrder = append(walkOrder, v.(int))
 		return nil
 	}
-	if err := dag.WalkReverseTopoOrder(walkFunc); err != nil {
+	if err := dag.WalkReverseTopoOrder(walkFunc, nil); err != nil {
 		t.Error(err)
 	}
 	for i := range expected {
@@ -171,7 +171,7 @@ func TestWalkTopoOrder(t *testing.T) {
 
 	expected = []int{8, 7, 2, 3, 0, 6, 9, 11, 12, 10, 1, 5, 4}
 	walkOrder = make([]int, 0, len(expected))
-	if err := dag.WalkTopoOrder(walkFunc); err != nil {
+	if err := dag.WalkTopoOrder(walkFunc, nil); err != nil {
 		t.Error(err)
 	}
 	for i := range expected {
@@ -329,7 +329,7 @@ func TestMerge(t *testing.T) {
 
 func TestString(t *testing.T) {
 	dag := newTestDAG()
-	str := dag.String()
+	str := dag.String(nil)
 	expectedOrder := []string{"|", "4", "5", "1", "10", "12", "11", "9", "6", "0", "3", "2", "7", "8"}
 	expectedStr := strings.Join(expectedOrder, "->")
 	if str != expectedStr {

--- a/internal/controller/rsm/plan_builder.go
+++ b/internal/controller/rsm/plan_builder.go
@@ -100,7 +100,7 @@ func (b *PlanBuilder) Build() (graph.Plan, error) {
 // Plan implementation
 
 func (p *Plan) Execute() error {
-	return p.dag.WalkReverseTopoOrder(p.walkFunc)
+	return p.dag.WalkReverseTopoOrder(p.walkFunc, nil)
 }
 
 // Do the real works


### PR DESCRIPTION
now, updating CR uses the `client.Update` interface, and there may be errors when the CR version number is not the latest. When performing an hscale, the workload object will be updated very early. If the update of other objects fails, then entering the coordination again will not lead to the logic of compPhase to `Updating`, but rather to the logic of `upRunning`, changing the cluster status to Abnormal/Failed