### PR TITLE
fix: get cd and cv from backup if creating cluster by backup

### DIFF
--- a/internal/cli/cmd/cluster/create.go
+++ b/internal/cli/cmd/cluster/create.go
@@ -227,8 +227,6 @@ func NewCreateCmd(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra
 	cmd.PersistentFlags().StringVar(&o.DryRun, "dry-run", "none", `Must be "client", or "server". If with client strategy, only print the object that would be sent, and no data is actually sent. If with server strategy, submit the server-side request, but no data is persistent.`)
 	cmd.PersistentFlags().Lookup("dry-run").NoOptDefVal = "unchanged"
 
-	// add required
-	_ = cmd.MarkFlagRequired("cluster-definition")
 	// add updatable flags
 	o.UpdatableFlags.addFlags(cmd)
 
@@ -353,6 +351,9 @@ func fillClusterInfoFromBackup(o *CreateOptions, cls **appsv1alpha1.Cluster) err
 		return fmt.Errorf("specified cluster version does not match from backup(expect: %s, actual: %s),"+
 			" please check", backupCluster.Spec.ClusterVersionRef, o.ClusterVersionRef)
 	}
+
+	o.ClusterDefRef = curCluster.Spec.ClusterDefRef
+	o.ClusterVersionRef = curCluster.Spec.ClusterVersionRef
 
 	*cls = curCluster
 	return nil


### PR DESCRIPTION

* fix https://github.com/apecloud/kubeblocks/issues/4610