### PR TITLE
chore: sync helm charts release latest

### DIFF
--- a/.github/workflows/release-sync.yml
+++ b/.github/workflows/release-sync.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   CLI_REPO: 'apecloud/kbcli'
+  HELM_CHART_REPO: 'apecloud/helm-charts'
   GITLAB_KBCLI_PROJECT_ID: 85948
   GITLAB_ACCESS_TOKEN: ${{ secrets.GITLAB_ACCESS_TOKEN }}
 
@@ -29,6 +30,14 @@ jobs:
             --type 5 \
             --tag-name $LATEST_RELEASE_TAG \
             --github-repo ${{ env.CLI_REPO }} \
+            --github-token ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          
+          HELM_CHART_LATEST_RELEASE_TAG="kubeblocks-${LATEST_RELEASE_TAG/v/}"
+          
+          bash ${{ github.workspace }}/.github/utils/utils.sh \
+            --type 5 \
+            --tag-name $HELM_CHART_LATEST_RELEASE_TAG \
+            --github-repo ${{ env.HELM_CHART_REPO }} \
             --github-token ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           
           bash ${{ github.workspace }}/.github/utils/release_gitlab.sh \


### PR DESCRIPTION
1. sync [apecloud/helm-charts](https://github.com/apecloud/helm-charts/releases/tag/kubeblocks-0.5.3) release latest version is consistent with kubeblocks