### PR TITLE
fix: distinguish ops for kbcli confirm

### DIFF
--- a/internal/cli/cmd/accounts/delete.go
+++ b/internal/cli/cmd/accounts/delete.go
@@ -56,7 +56,7 @@ func (o *DeleteUserOptions) Validate(args []string) error {
 	if o.AutoApprove {
 		return nil
 	}
-	if err := prompt.Confirm([]string{o.info.UserName}, o.In, false); err != nil {
+	if err := prompt.Confirm([]string{o.info.UserName}, o.In, ""); err != nil {
 		return err
 	}
 	return nil

--- a/internal/cli/cmd/accounts/delete.go
+++ b/internal/cli/cmd/accounts/delete.go
@@ -20,11 +20,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package accounts
 
 import (
+	"github.com/apecloud/kubeblocks/internal/cli/util/prompt"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 
-	"github.com/apecloud/kubeblocks/internal/cli/delete"
 	channelutil "github.com/apecloud/kubeblocks/internal/sqlchannel/util"
 )
 
@@ -56,7 +56,7 @@ func (o *DeleteUserOptions) Validate(args []string) error {
 	if o.AutoApprove {
 		return nil
 	}
-	if err := delete.Confirm([]string{o.info.UserName}, o.In, false); err != nil {
+	if err := prompt.Confirm([]string{o.info.UserName}, o.In, false); err != nil {
 		return err
 	}
 	return nil

--- a/internal/cli/cmd/accounts/delete.go
+++ b/internal/cli/cmd/accounts/delete.go
@@ -56,7 +56,7 @@ func (o *DeleteUserOptions) Validate(args []string) error {
 	if o.AutoApprove {
 		return nil
 	}
-	if err := delete.Confirm([]string{o.info.UserName}, o.In); err != nil {
+	if err := delete.Confirm([]string{o.info.UserName}, o.In, false); err != nil {
 		return err
 	}
 	return nil

--- a/internal/cli/cmd/cluster/operations.go
+++ b/internal/cli/cmd/cluster/operations.go
@@ -338,7 +338,7 @@ func (o *OperationsOptions) Validate() error {
 		}
 	}
 	if !o.autoApprove && o.DryRun == "none" {
-		return prompt.Confirm([]string{o.Name}, o.In, false)
+		return prompt.Confirm([]string{o.Name}, o.In, "")
 	}
 	return nil
 }
@@ -776,7 +776,7 @@ func cancelOps(o *OperationsOptions) error {
 		return fmt.Errorf("opsRequest type: %s not support cancel action", opsRequest.Spec.Type)
 	}
 	if !o.autoApprove {
-		if err := prompt.Confirm([]string{o.Name}, o.In, false); err != nil {
+		if err := prompt.Confirm([]string{o.Name}, o.In, ""); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/cmd/cluster/operations.go
+++ b/internal/cli/cmd/cluster/operations.go
@@ -338,7 +338,7 @@ func (o *OperationsOptions) Validate() error {
 		}
 	}
 	if !o.autoApprove && o.DryRun == "none" {
-		return delete.Confirm([]string{o.Name}, o.In)
+		return delete.Confirm([]string{o.Name}, o.In, false)
 	}
 	return nil
 }
@@ -776,7 +776,7 @@ func cancelOps(o *OperationsOptions) error {
 		return fmt.Errorf("opsRequest type: %s not support cancel action", opsRequest.Spec.Type)
 	}
 	if !o.autoApprove {
-		if err := delete.Confirm([]string{o.Name}, o.In); err != nil {
+		if err := delete.Confirm([]string{o.Name}, o.In, false); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/cmd/cluster/operations.go
+++ b/internal/cli/cmd/cluster/operations.go
@@ -43,11 +43,11 @@ import (
 	"github.com/apecloud/kubeblocks/internal/class"
 	"github.com/apecloud/kubeblocks/internal/cli/cluster"
 	"github.com/apecloud/kubeblocks/internal/cli/create"
-	"github.com/apecloud/kubeblocks/internal/cli/delete"
 	"github.com/apecloud/kubeblocks/internal/cli/printer"
 	"github.com/apecloud/kubeblocks/internal/cli/types"
 	"github.com/apecloud/kubeblocks/internal/cli/util"
 	"github.com/apecloud/kubeblocks/internal/cli/util/flags"
+	"github.com/apecloud/kubeblocks/internal/cli/util/prompt"
 	"github.com/apecloud/kubeblocks/internal/constant"
 )
 
@@ -338,7 +338,7 @@ func (o *OperationsOptions) Validate() error {
 		}
 	}
 	if !o.autoApprove && o.DryRun == "none" {
-		return delete.Confirm([]string{o.Name}, o.In, false)
+		return prompt.Confirm([]string{o.Name}, o.In, false)
 	}
 	return nil
 }
@@ -776,7 +776,7 @@ func cancelOps(o *OperationsOptions) error {
 		return fmt.Errorf("opsRequest type: %s not support cancel action", opsRequest.Spec.Type)
 	}
 	if !o.autoApprove {
-		if err := delete.Confirm([]string{o.Name}, o.In, false); err != nil {
+		if err := prompt.Confirm([]string{o.Name}, o.In, false); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/delete/delete.go
+++ b/internal/cli/delete/delete.go
@@ -21,6 +21,7 @@ package delete
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,6 +31,7 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 
+	"github.com/apecloud/kubeblocks/internal/cli/printer"
 	"github.com/apecloud/kubeblocks/internal/cli/util"
 	"github.com/apecloud/kubeblocks/internal/cli/util/prompt"
 )
@@ -152,7 +154,7 @@ func (o *DeleteOptions) complete() error {
 		if len(names) == 0 {
 			names = o.Names
 		}
-		if err = prompt.Confirm(names, o.In, len(o.LabelSelector) != 0); err != nil {
+		if err = prompt.Confirm(names, o.In, fmt.Sprintf("These clusters will be deleted:[%s]\n", printer.BoldRed(strings.Join(names, " ")))); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/delete/delete.go
+++ b/internal/cli/delete/delete.go
@@ -154,7 +154,7 @@ func (o *DeleteOptions) complete() error {
 		if len(names) == 0 {
 			names = o.Names
 		}
-		if err = prompt.Confirm(names, o.In, fmt.Sprintf("Clusters to be deleted:[%s]", printer.BoldRed(strings.Join(names, " ")))); err != nil {
+		if err = prompt.Confirm(names, o.In, fmt.Sprintf("%s to be deleted:[%s]", o.GVR.Resource, printer.BoldRed(strings.Join(names, " ")))); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/delete/delete.go
+++ b/internal/cli/delete/delete.go
@@ -157,7 +157,7 @@ func (o *DeleteOptions) complete() error {
 		if len(names) == 0 {
 			names = o.Names
 		}
-		if err = Confirm(names, o.In); err != nil {
+		if err = Confirm(names, o.In, len(o.LabelSelector) != 0); err != nil {
 			return err
 		}
 	}
@@ -241,12 +241,17 @@ func (o *DeleteOptions) postDeleteResource(object runtime.Object) error {
 	return nil
 }
 
-// Confirm let user double-check what to delete
-func Confirm(names []string, in io.Reader) error {
+// Confirm let user double-check for the cluster ops
+// if ops is not DEFAULT, it will output the details information for confirmation
+func Confirm(names []string, in io.Reader, isLabelSelector bool) error {
 	if len(names) == 0 {
 		return nil
 	}
-	fmt.Printf("These clusters will be deleted:[%s]\n", printer.BoldRed(strings.Join(names, " ")))
+	// if the resources were selected by label, user don't know their names we should give a prompt
+	// and only delete for cluster may use it
+	if isLabelSelector {
+		fmt.Printf("These clusters will be deleted:[%s]\n", printer.BoldRed(strings.Join(names, " ")))
+	}
 	// '\n' in NewPrompt will break the output
 	_, err := prompt.NewPrompt("Please type the name again(separate with white space when more than one):",
 		func(entered string) error {

--- a/internal/cli/delete/delete.go
+++ b/internal/cli/delete/delete.go
@@ -154,7 +154,7 @@ func (o *DeleteOptions) complete() error {
 		if len(names) == 0 {
 			names = o.Names
 		}
-		if err = prompt.Confirm(names, o.In, fmt.Sprintf("These clusters will be deleted:[%s]\n", printer.BoldRed(strings.Join(names, " ")))); err != nil {
+		if err = prompt.Confirm(names, o.In, fmt.Sprintf("Clusters to be deleted:[%s]", printer.BoldRed(strings.Join(names, " ")))); err != nil {
 			return err
 		}
 	}

--- a/internal/cli/delete/delete.go
+++ b/internal/cli/delete/delete.go
@@ -242,7 +242,7 @@ func (o *DeleteOptions) postDeleteResource(object runtime.Object) error {
 }
 
 // Confirm let user double-check for the cluster ops
-// if ops is not DEFAULT, it will output the details information for confirmation
+// if isLabelSelector is true, it will output the details information for confirmation
 func Confirm(names []string, in io.Reader, isLabelSelector bool) error {
 	if len(names) == 0 {
 		return nil

--- a/internal/cli/util/prompt/prompt.go
+++ b/internal/cli/util/prompt/prompt.go
@@ -27,8 +27,6 @@ import (
 
 	"github.com/manifoldco/promptui"
 	"golang.org/x/exp/slices"
-
-	"github.com/apecloud/kubeblocks/internal/cli/printer"
 )
 
 func NewPrompt(label string, validate promptui.ValidateFunc, in io.Reader) *promptui.Prompt {
@@ -58,14 +56,14 @@ func NewPrompt(label string, validate promptui.ValidateFunc, in io.Reader) *prom
 
 // Confirm let user double-check for the cluster ops
 // if isLabelSelector is true, it will output the details information for confirmation
-func Confirm(names []string, in io.Reader, isLabelSelector bool) error {
+func Confirm(names []string, in io.Reader, customMessage string) error {
 	if len(names) == 0 {
 		return nil
 	}
 	// if the resources were selected by label, user don't know their names we should give a prompt
 	// and only delete for cluster may use it
-	if isLabelSelector {
-		fmt.Printf("These clusters will be deleted:[%s]\n", printer.BoldRed(strings.Join(names, " ")))
+	if len(customMessage) != 0 {
+		fmt.Printf("%s", customMessage)
 	}
 	// '\n' in NewPrompt will break the output
 	_, err := NewPrompt("Please type the name again(separate with white space when more than one):",

--- a/internal/cli/util/prompt/prompt.go
+++ b/internal/cli/util/prompt/prompt.go
@@ -55,17 +55,14 @@ func NewPrompt(label string, validate promptui.ValidateFunc, in io.Reader) *prom
 }
 
 // Confirm let user double-check for the cluster ops
-// if isLabelSelector is true, it will output the details information for confirmation
+// use customMessage to display more information
 func Confirm(names []string, in io.Reader, customMessage string) error {
 	if len(names) == 0 {
 		return nil
 	}
-	// if the resources were selected by label, user don't know their names we should give a prompt
-	// and only delete for cluster may use it
 	if len(customMessage) != 0 {
-		fmt.Printf("%s", customMessage)
+		fmt.Println(customMessage)
 	}
-	// '\n' in NewPrompt will break the output
 	_, err := NewPrompt("Please type the name again(separate with white space when more than one):",
 		func(entered string) error {
 			enteredNames := strings.Split(entered, " ")


### PR DESCRIPTION
- fix: https://github.com/apecloud/kubeblocks/issues/4665

What i do:
distinguish ops for kbcli confirm between `cluster delete` by labelSelector and other ops that use `Confirm()`

Example:
![image](https://github.com/apecloud/kubeblocks/assets/101848970/78ac17af-9d8e-47fa-ac74-97f4d7804ede)
![image](https://github.com/apecloud/kubeblocks/assets/101848970/de6fdda6-8261-462f-afa5-ee94c938cd63)
![image](https://github.com/apecloud/kubeblocks/assets/101848970/e149fbae-550a-4557-a168-a749cc2466cf)
![image](https://github.com/apecloud/kubeblocks/assets/101848970/be41dcb4-7b25-4c94-bc95-1e1e6f4f0e2f)
