### PR TITLE
fix: failed to update with --enable-all-logs (#4672)

### DIFF
--- a/internal/cli/cmd/cluster/update.go
+++ b/internal/cli/cmd/cluster/update.go
@@ -320,6 +320,9 @@ func (o *updateOptions) reconfigureLogVariables(c *appsv1alpha1.Cluster, cd *app
 		if keyName, logTPL, err = findLogsBlockTPL(configTemplate.Data); err != nil {
 			return err
 		}
+		if logTPL == nil {
+			return nil
+		}
 		if err = logTPL.Execute(&buf, logValue); err != nil {
 			return err
 		}
@@ -400,8 +403,9 @@ func findLogsBlockTPL(confData map[string]string) (string, *template.Template, e
 		if logTPL != nil {
 			return key, logTPL, nil
 		}
+		return "", nil, errors.New("no logs config template found")
 	}
-	return "", nil, errors.New("no logs config template found")
+	return "", nil, nil
 }
 
 func buildLogsTPLValues(compSpec *appsv1alpha1.ClusterComponentSpec) (*gotemplate.TplValues, error) {

--- a/internal/cli/cmd/cluster/update_test.go
+++ b/internal/cli/cmd/cluster/update_test.go
@@ -232,10 +232,12 @@ general_log_file=/data/mysql/log/mysqld.log
 				confData    map[string]string
 				keyName     string
 				expectedErr bool
+				expectedNil bool
 			}{{
 				confData:    nil,
 				keyName:     "",
-				expectedErr: true,
+				expectedErr: false,
+				expectedNil: true,
 			}, {
 				confData: map[string]string{
 					"test.cnf": "test",
@@ -257,7 +259,9 @@ general_log_file=/data/mysql/log/mysqld.log
 					Expect(err).Should(HaveOccurred())
 				} else {
 					Expect(key).Should(Equal(test.keyName))
-					Expect(tpl).ShouldNot(BeNil())
+					if !test.expectedNil {
+						Expect(tpl).ShouldNot(BeNil())
+					}
 					Expect(err).ShouldNot(HaveOccurred())
 				}
 			}


### PR DESCRIPTION
Should not fail if there is no logBlock in the component configuration，e.g: vttablet 
