### PR TITLE
fix: kafka definition bugfix about conn credential and volume expand

### DIFF
--- a/deploy/kafka-cluster/templates/cluster.yaml
+++ b/deploy/kafka-cluster/templates/cluster.yaml
@@ -44,36 +44,6 @@ spec:
                 storage: {{ print $.Values.metaStorage "Gi" }}
       {{- end }}
     {{- else }}
-    - name: controller
-      componentDefRef: controller
-      tls: {{ $.Values.tlsEnable }}
-      {{- if $.Values.tlsEnable }}
-      issuer:
-        name: KubeBlocks
-      {{- end }}
-      replicas: {{ $.Values.controllerReplicas }}
-      monitor: {{ $.Values.monitorEnable }}
-      serviceAccountName: {{ include "kblib.serviceAccountName" . }}
-      {{- include "kblib.componentResources" . | indent 6 }}
-      {{- if $.Values.storageEnable }}
-      volumeClaimTemplates:
-        - name: data
-          spec:
-            storageClassName: {{ $.Values.storageClassName }}
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: {{ print $.Values.storage "Gi" }}
-        - name: metadata
-          spec:
-            storageClassName: {{ $.Values.metaStorageClassName }}
-            accessModes:
-              - ReadWriteOnce
-            resources:
-              requests:
-                storage: {{ print $.Values.metaStorage "Gi" }}
-      {{- end }}
     - name: broker
       componentDefRef: kafka-broker
       tls: {{ $.Values.tlsEnable }}
@@ -96,6 +66,28 @@ spec:
             resources:
               requests:
                 storage: {{ print $.Values.storage "Gi" }}
+        - name: metadata
+          spec:
+            storageClassName: {{ $.Values.metaStorageClassName }}
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: {{ print $.Values.metaStorage "Gi" }}
+      {{- end }}
+    - name: controller
+      componentDefRef: controller
+      tls: {{ $.Values.tlsEnable }}
+      {{- if $.Values.tlsEnable }}
+      issuer:
+        name: KubeBlocks
+      {{- end }}
+      replicas: {{ $.Values.controllerReplicas }}
+      monitor: {{ $.Values.monitorEnable }}
+      serviceAccountName: {{ include "kblib.serviceAccountName" . }}
+      {{- include "kblib.componentResources" . | indent 6 }}
+      {{- if $.Values.storageEnable }}
+      volumeClaimTemplates:
         - name: metadata
           spec:
             storageClassName: {{ $.Values.metaStorageClassName }}

--- a/deploy/kafka/templates/clusterdefinition.yaml
+++ b/deploy/kafka/templates/clusterdefinition.yaml
@@ -14,9 +14,10 @@ spec:
   type: kafka
   connectionCredential:
     superusers: "User:admin"
-    endpoint: "$(SVC_FQDN):$(SVC_PORT_kafka-ctrlr)"
+    endpoint: "$(SVC_FQDN):$(SVC_PORT_kafka-client)"
     kraftClusterID: "$(UUID_STR_B64)" 
-    sslCertPassword: "$(RANDOM_PASSWD)"
+    clientUser: "client"
+    clientPassword: "kubeblocks"
 
   componentDefs:
     # combined both controller(kraft) and broker. Ref: https://kafka.apache.org/documentation/#kraft_role
@@ -188,142 +189,6 @@ spec:
               - name: jmx-config
                 mountPath: /etc/jmx-kafka
 
-    # controller(kraft) Ref: https://kafka.apache.org/documentation/#kraft_role
-    - name: controller
-      description: |-
-        Kafka controller that act as controllers (kraft) only server.
-      workloadType: Stateful # Consensus
-      characterType: kafka
-      probes:
-      monitor:
-        builtIn: false
-        exporterConfig:
-          scrapePath: /metrics
-          scrapePort: 5556
-      configSpecs:
-        - name: kafka-configuration-tpl
-          constraintRef: {{ include "kafka.name" . }}-cc
-          templateRef: {{ include "kafka.name" . }}-configuration-tpl
-          volumeName: kafka-config
-          namespace: {{ .Release.Namespace }}
-        - name: kafka-jmx-configuration-tpl
-          templateRef: {{ include "kafka.name" . }}-jmx-configuration-tpl
-          volumeName: jmx-config
-          namespace: {{ .Release.Namespace }}
-      scriptSpecs:
-        - name: kafka-scripts-tpl
-          templateRef: {{ include "kafka.name" . }}-scripts-tpl
-          volumeName: scripts
-          namespace: {{ .Release.Namespace }}
-          defaultMode: 0755
-      service:
-        ports:
-          - name: kafka-ctrlr
-            targetPort: kafka-ctrlr
-            port: 9093
-          - name: metrics
-            targetPort: metrics
-            port: 5556
-      podSpec:
-        securityContext:
-          fsGroup: 1001
-        containers:
-          - name: kafka
-            command:
-              - /scripts/kafka-server-setup.sh
-            env:
-              - name: BITNAMI_DEBUG
-                value: {{ .Values.debugEnabled | quote }}
-              - name: MY_POD_IP
-                value: "$(KB_PODIP)"
-                # value: "$(KB_POD_IP)"
-              - name: MY_POD_NAME
-                value: "$(KB_POD_NAME)"
-              - name: KAFKA_ENABLE_KRAFT
-                value: "yes"
-              - name: KAFKA_CFG_PROCESS_ROLES
-                value: "controller"
-              - name: KAFKA_CFG_CONTROLLER_LISTENER_NAMES # required for KRaft
-                value: "CONTROLLER"
-              - name: KAFKA_CFG_LISTENERS # required for KRaft
-                value: "CONTROLLER://:9093"
-              - name: KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP
-                value: "CONTROLLER:PLAINTEXT"
-              - name: ALLOW_PLAINTEXT_LISTENER
-                value: "yes"
-              - name: JMX_PORT
-                value: "5555"
-              - name: KAFKA_VOLUME_DIR
-                value: "/bitnami/kafka"
-              - name: KAFKA_CFG_METADATA_LOG_DIR
-                value: "/bitnami/kafka/metadata"
-              - name: KAFKA_LOG_DIR
-                value: "/bitnami/kafka/data"
-              - name: KAFKA_HEAP_OPTS
-                #value: "-Xmx1024m -Xms1024m"
-                value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
-              - name: SERVER_PROP_FILE
-                value: /scripts/server.properties
-              - name: KAFKA_CFG_SUPER_USERS
-                valueFrom:
-                  secretKeyRef:
-                    name: $(CONN_CREDENTIAL_SECRET_NAME)
-                    key: superusers
-                    optional: false
-              - name: KAFKA_KRAFT_CLUSTER_ID
-                valueFrom:
-                  secretKeyRef:
-                    name: $(CONN_CREDENTIAL_SECRET_NAME)
-                    key: kraftClusterID
-                    optional: false
-            ports:
-              - name: kafka-ctrlr
-                containerPort: 9093
-            livenessProbe:
-              failureThreshold: 3
-              initialDelaySeconds: 10
-              periodSeconds: 10
-              successThreshold: 1
-              timeoutSeconds: 5
-              tcpSocket:
-                port: kafka-ctrlr
-            startupProbe:
-              failureThreshold: 30
-              initialDelaySeconds: 5
-              periodSeconds: 10
-              successThreshold: 1
-              timeoutSeconds: 5
-              tcpSocket:
-                port: kafka-ctrlr
-            volumeMounts:
-              - name: metadata
-                mountPath: /bitnami/kafka
-              - name: kafka-config
-                mountPath: /scripts/server.properties
-                subPath: server.properties
-              - name: scripts
-                mountPath: /scripts/kafka-server-setup.sh
-                subPath: kafka-server-setup.sh
-              - name: scripts
-                mountPath: /opt/bitnami/scripts/kafka-env.sh
-                subPath: kafka-env.sh
-          - name: jmx-exporter
-            command:
-              - java
-            args:
-              - -XX:MaxRAMPercentage=100
-              - -XshowSettings:vm
-              - -jar
-              - jmx_prometheus_httpserver.jar
-              - "5556"
-              - /etc/jmx-kafka/jmx-kafka-prometheus.yml
-            ports:
-              - name: metrics
-                containerPort: 5556
-            volumeMounts:
-              - name: jmx-config
-                mountPath: /etc/jmx-kafka
-
     - name: kafka-broker
       description: |-
         Kafka broker.
@@ -466,6 +331,142 @@ spec:
               - name: tools
                 mountPath: /tools/server-jaas.properties
                 subPath: server-jaas.properties
+          - name: jmx-exporter
+            command:
+              - java
+            args:
+              - -XX:MaxRAMPercentage=100
+              - -XshowSettings:vm
+              - -jar
+              - jmx_prometheus_httpserver.jar
+              - "5556"
+              - /etc/jmx-kafka/jmx-kafka-prometheus.yml
+            ports:
+              - name: metrics
+                containerPort: 5556
+            volumeMounts:
+              - name: jmx-config
+                mountPath: /etc/jmx-kafka
+
+    # controller(kraft) Ref: https://kafka.apache.org/documentation/#kraft_role
+    - name: controller
+      description: |-
+        Kafka controller that act as controllers (kraft) only server.
+      workloadType: Stateful # Consensus
+      characterType: kafka
+      probes:
+      monitor:
+        builtIn: false
+        exporterConfig:
+          scrapePath: /metrics
+          scrapePort: 5556
+      configSpecs:
+        - name: kafka-configuration-tpl
+          constraintRef: {{ include "kafka.name" . }}-cc
+          templateRef: {{ include "kafka.name" . }}-configuration-tpl
+          volumeName: kafka-config
+          namespace: {{ .Release.Namespace }}
+        - name: kafka-jmx-configuration-tpl
+          templateRef: {{ include "kafka.name" . }}-jmx-configuration-tpl
+          volumeName: jmx-config
+          namespace: {{ .Release.Namespace }}
+      scriptSpecs:
+        - name: kafka-scripts-tpl
+          templateRef: {{ include "kafka.name" . }}-scripts-tpl
+          volumeName: scripts
+          namespace: {{ .Release.Namespace }}
+          defaultMode: 0755
+      service:
+        ports:
+          - name: kafka-ctrlr
+            targetPort: kafka-ctrlr
+            port: 9093
+          - name: metrics
+            targetPort: metrics
+            port: 5556
+      podSpec:
+        securityContext:
+          fsGroup: 1001
+        containers:
+          - name: kafka
+            command:
+              - /scripts/kafka-server-setup.sh
+            env:
+              - name: BITNAMI_DEBUG
+                value: {{ .Values.debugEnabled | quote }}
+              - name: MY_POD_IP
+                value: "$(KB_PODIP)"
+                # value: "$(KB_POD_IP)"
+              - name: MY_POD_NAME
+                value: "$(KB_POD_NAME)"
+              - name: KAFKA_ENABLE_KRAFT
+                value: "yes"
+              - name: KAFKA_CFG_PROCESS_ROLES
+                value: "controller"
+              - name: KAFKA_CFG_CONTROLLER_LISTENER_NAMES # required for KRaft
+                value: "CONTROLLER"
+              - name: KAFKA_CFG_LISTENERS # required for KRaft
+                value: "CONTROLLER://:9093"
+              - name: KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP
+                value: "CONTROLLER:PLAINTEXT"
+              - name: ALLOW_PLAINTEXT_LISTENER
+                value: "yes"
+              - name: JMX_PORT
+                value: "5555"
+              - name: KAFKA_VOLUME_DIR
+                value: "/bitnami/kafka"
+              - name: KAFKA_CFG_METADATA_LOG_DIR
+                value: "/bitnami/kafka/metadata"
+              - name: KAFKA_LOG_DIR
+                value: "/bitnami/kafka/data"
+              - name: KAFKA_HEAP_OPTS
+                #value: "-Xmx1024m -Xms1024m"
+                value: "-XshowSettings:vm -XX:MaxRAMPercentage=100 -Ddepth=64"
+              - name: SERVER_PROP_FILE
+                value: /scripts/server.properties
+              - name: KAFKA_CFG_SUPER_USERS
+                valueFrom:
+                  secretKeyRef:
+                    name: $(CONN_CREDENTIAL_SECRET_NAME)
+                    key: superusers
+                    optional: false
+              - name: KAFKA_KRAFT_CLUSTER_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: $(CONN_CREDENTIAL_SECRET_NAME)
+                    key: kraftClusterID
+                    optional: false
+            ports:
+              - name: kafka-ctrlr
+                containerPort: 9093
+            livenessProbe:
+              failureThreshold: 3
+              initialDelaySeconds: 10
+              periodSeconds: 10
+              successThreshold: 1
+              timeoutSeconds: 5
+              tcpSocket:
+                port: kafka-ctrlr
+            startupProbe:
+              failureThreshold: 30
+              initialDelaySeconds: 5
+              periodSeconds: 10
+              successThreshold: 1
+              timeoutSeconds: 5
+              tcpSocket:
+                port: kafka-ctrlr
+            volumeMounts:
+              - name: metadata
+                mountPath: /bitnami/kafka
+              - name: kafka-config
+                mountPath: /scripts/server.properties
+                subPath: server.properties
+              - name: scripts
+                mountPath: /scripts/kafka-server-setup.sh
+                subPath: kafka-server-setup.sh
+              - name: scripts
+                mountPath: /opt/bitnami/scripts/kafka-env.sh
+                subPath: kafka-env.sh
           - name: jmx-exporter
             command:
               - java


### PR DESCRIPTION
for https://github.com/apecloud/kubeblocks/issues/4573:
- make sure the content in the connection credential secret is correct
- adjust the order of the controller and broker components in the definition in the separated mode to ensure that the component that needs to expose the service is at the first

for https://github.com/apecloud/kubeblocks/issues/4436: 
- remove useless volumeClaimTemplates configuration in kafka cluster definition