### PR TITLE
fix: failed to create cluster with --set-file

### DIFF
--- a/internal/cli/cmd/cluster/create.go
+++ b/internal/cli/cmd/cluster/create.go
@@ -583,7 +583,8 @@ func (o *CreateOptions) buildComponents(clusterCompSpecs []appsv1alpha1.ClusterC
 		for _, setComp := range setsCompSpecs {
 			setsCompSpecsMap[setComp.Name] = setComp
 		}
-		for _, comp := range clusterCompSpecs {
+		for index := range clusterCompSpecs {
+			comp := clusterCompSpecs[index]
 			overrideComponentBySets(&comp, setsCompSpecsMap[comp.Name], compSets[comp.Name])
 			compSpecs = append(compSpecs, &comp)
 		}


### PR DESCRIPTION
error: The Cluster "redis-cluster" is invalid: spec.componentSpecs[1]: Duplicate value: map[string]interface {}{"name":"redis-sentinel"}