### PR TITLE
fix: keep volumes size consistent after scale-out

### DIFF
--- a/controllers/apps/cluster_controller_test.go
+++ b/controllers/apps/cluster_controller_test.go
@@ -439,8 +439,8 @@ var _ = Describe("Cluster Controller", func() {
 		}
 	}
 
-	getPVCName := func(compName string, i int) string {
-		return fmt.Sprintf("%s-%s-%s-%d", testapps.DataVolumeName, clusterKey.Name, compName, i)
+	getPVCName := func(vctName, compName string, i int) string {
+		return fmt.Sprintf("%s-%s-%s-%d", vctName, clusterKey.Name, compName, i)
 	}
 
 	createPVC := func(clusterName, pvcName, compName string) {
@@ -450,6 +450,29 @@ var _ = Describe("Cluster Controller", func() {
 			constant.KBAppComponentLabelKey: compName,
 			constant.AppManagedByLabelKey:   constant.AppName,
 		}).CheckedCreate(&testCtx)
+	}
+
+	mockComponentPVCsBound := func(comp *appsv1alpha1.ClusterComponentSpec, replicas int, create bool) {
+		for i := 0; i < replicas; i++ {
+			for _, vct := range comp.VolumeClaimTemplates {
+				pvcKey := types.NamespacedName{
+					Namespace: clusterKey.Namespace,
+					Name:      getPVCName(vct.Name, comp.Name, i),
+				}
+				if create {
+					createPVC(clusterKey.Name, pvcKey.Name, comp.Name)
+				}
+				Eventually(testapps.CheckObjExists(&testCtx, pvcKey,
+					&corev1.PersistentVolumeClaim{}, true)).Should(Succeed())
+				Eventually(testapps.GetAndChangeObjStatus(&testCtx, pvcKey, func(pvc *corev1.PersistentVolumeClaim) {
+					pvc.Status.Phase = corev1.ClaimBound
+					if pvc.Status.Capacity == nil {
+						pvc.Status.Capacity = corev1.ResourceList{}
+					}
+					pvc.Status.Capacity[corev1.ResourceStorage] = pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+				})).Should(Succeed())
+			}
+		}
 	}
 
 	mockPodsForTest := func(cluster *appsv1alpha1.Cluster, number int) []corev1.Pod {
@@ -482,18 +505,8 @@ var _ = Describe("Cluster Controller", func() {
 	}
 
 	horizontalScaleComp := func(updatedReplicas int, comp *appsv1alpha1.ClusterComponentSpec, policy *appsv1alpha1.HorizontalScalePolicy) {
-		By("Mocking components' PVCs to bound")
-		for i := 0; i < int(comp.Replicas); i++ {
-			pvcKey := types.NamespacedName{
-				Namespace: clusterKey.Namespace,
-				Name:      getPVCName(comp.Name, i),
-			}
-			createPVC(clusterKey.Name, pvcKey.Name, comp.Name)
-			Eventually(testapps.CheckObjExists(&testCtx, pvcKey, &corev1.PersistentVolumeClaim{}, true)).Should(Succeed())
-			Expect(testapps.GetAndChangeObjStatus(&testCtx, pvcKey, func(pvc *corev1.PersistentVolumeClaim) {
-				pvc.Status.Phase = corev1.ClaimBound
-			})()).ShouldNot(HaveOccurred())
-		}
+		By("Mocking component PVCs to bound")
+		mockComponentPVCsBound(comp, int(comp.Replicas), true)
 
 		By("Checking sts replicas right")
 		stsList := testk8s.ListAndCheckStatefulSetWithComponent(&testCtx, clusterKey, comp.Name)
@@ -530,51 +543,49 @@ var _ = Describe("Cluster Controller", func() {
 			if comp.Replicas == 0 {
 				return
 			}
-			if policy == nil {
-				checkUpdatedStsReplicas()
-				return
-			}
 
-			By(fmt.Sprintf("Checking backup of component %s created", comp.Name))
-			Eventually(testapps.List(&testCtx, generics.BackupSignature,
-				client.MatchingLabels{
-					constant.AppInstanceLabelKey:    clusterKey.Name,
-					constant.KBAppComponentLabelKey: comp.Name,
-				}, client.InNamespace(clusterKey.Namespace))).Should(HaveLen(1))
+			if policy != nil {
+				By(fmt.Sprintf("Checking backup of component %s created", comp.Name))
+				Eventually(testapps.List(&testCtx, generics.BackupSignature,
+					client.MatchingLabels{
+						constant.AppInstanceLabelKey:    clusterKey.Name,
+						constant.KBAppComponentLabelKey: comp.Name,
+					}, client.InNamespace(clusterKey.Namespace))).Should(HaveLen(1))
 
-			backupKey := types.NamespacedName{Name: fmt.Sprintf("%s-%s-scaling",
-				clusterKey.Name, comp.Name),
-				Namespace: testCtx.DefaultNamespace}
-			By("Mocking backup status to completed")
-			Expect(testapps.GetAndChangeObjStatus(&testCtx, backupKey, func(backup *dataprotectionv1alpha1.Backup) {
-				backup.Status.Phase = dataprotectionv1alpha1.BackupCompleted
-				backup.Status.PersistentVolumeClaimName = "backup-data"
-				backup.Status.BackupToolName = backupToolName
-			})()).Should(Succeed())
+				backupKey := types.NamespacedName{Name: fmt.Sprintf("%s-%s-scaling",
+					clusterKey.Name, comp.Name),
+					Namespace: testCtx.DefaultNamespace}
+				By("Mocking backup status to completed")
+				Expect(testapps.GetAndChangeObjStatus(&testCtx, backupKey, func(backup *dataprotectionv1alpha1.Backup) {
+					backup.Status.Phase = dataprotectionv1alpha1.BackupCompleted
+					backup.Status.PersistentVolumeClaimName = "backup-data"
+					backup.Status.BackupToolName = backupToolName
+				})()).Should(Succeed())
 
-			if viper.GetBool("VOLUMESNAPSHOT") {
-				By("Mocking VolumeSnapshot and set it as ReadyToUse")
-				pvcName := getPVCName(comp.Name, 0)
-				volumeSnapshot := &snapshotv1.VolumeSnapshot{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      backupKey.Name,
-						Namespace: backupKey.Namespace,
-						Labels: map[string]string{
-							constant.DataProtectionLabelBackupNameKey: backupKey.Name,
-						}},
-					Spec: snapshotv1.VolumeSnapshotSpec{
-						Source: snapshotv1.VolumeSnapshotSource{
-							PersistentVolumeClaimName: &pvcName,
+				if viper.GetBool("VOLUMESNAPSHOT") {
+					By("Mocking VolumeSnapshot and set it as ReadyToUse")
+					pvcName := getPVCName(testapps.DataVolumeName, comp.Name, 0)
+					volumeSnapshot := &snapshotv1.VolumeSnapshot{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      backupKey.Name,
+							Namespace: backupKey.Namespace,
+							Labels: map[string]string{
+								constant.DataProtectionLabelBackupNameKey: backupKey.Name,
+							}},
+						Spec: snapshotv1.VolumeSnapshotSpec{
+							Source: snapshotv1.VolumeSnapshotSource{
+								PersistentVolumeClaimName: &pvcName,
+							},
 						},
-					},
+					}
+					scheme, _ := appsv1alpha1.SchemeBuilder.Build()
+					Expect(controllerruntime.SetControllerReference(clusterObj, volumeSnapshot, scheme)).Should(Succeed())
+					Expect(testCtx.CreateObj(testCtx.Ctx, volumeSnapshot)).Should(Succeed())
+					readyToUse := true
+					volumeSnapshotStatus := snapshotv1.VolumeSnapshotStatus{ReadyToUse: &readyToUse}
+					volumeSnapshot.Status = &volumeSnapshotStatus
+					Expect(k8sClient.Status().Update(testCtx.Ctx, volumeSnapshot)).Should(Succeed())
 				}
-				scheme, _ := appsv1alpha1.SchemeBuilder.Build()
-				Expect(controllerruntime.SetControllerReference(clusterObj, volumeSnapshot, scheme)).Should(Succeed())
-				Expect(testCtx.CreateObj(testCtx.Ctx, volumeSnapshot)).Should(Succeed())
-				readyToUse := true
-				volumeSnapshotStatus := snapshotv1.VolumeSnapshotStatus{ReadyToUse: &readyToUse}
-				volumeSnapshot.Status = &volumeSnapshotStatus
-				Expect(k8sClient.Status().Update(testCtx.Ctx, volumeSnapshot)).Should(Succeed())
 			}
 
 			By("Checking pvc created")
@@ -582,69 +593,74 @@ var _ = Describe("Cluster Controller", func() {
 				client.MatchingLabels{
 					constant.AppInstanceLabelKey:    clusterKey.Name,
 					constant.KBAppComponentLabelKey: comp.Name,
-				}, client.InNamespace(clusterKey.Namespace))).Should(HaveLen(updatedReplicas))
+				}, client.InNamespace(clusterKey.Namespace))).Should(HaveLen(updatedReplicas * len(comp.VolumeClaimTemplates)))
 
-			if !viper.GetBool("VOLUMESNAPSHOT") && len(viper.GetString(constant.CfgKeyBackupPVCName)) > 0 {
-				By("Checking restore job created")
-				Eventually(testapps.List(&testCtx, generics.JobSignature,
-					client.MatchingLabels{
+			if policy != nil {
+				if !viper.GetBool("VOLUMESNAPSHOT") && len(viper.GetString(constant.CfgKeyBackupPVCName)) > 0 {
+					By("Checking restore job created")
+					Eventually(testapps.List(&testCtx, generics.JobSignature,
+						client.MatchingLabels{
+							constant.AppInstanceLabelKey:    clusterKey.Name,
+							constant.KBAppComponentLabelKey: comp.Name,
+							constant.KBManagedByKey:         "cluster",
+						}, client.InNamespace(clusterKey.Namespace))).Should(HaveLen(updatedReplicas - int(comp.Replicas)))
+
+					By("Mocking job status to succeeded")
+					ml := client.MatchingLabels{
 						constant.AppInstanceLabelKey:    clusterKey.Name,
 						constant.KBAppComponentLabelKey: comp.Name,
 						constant.KBManagedByKey:         "cluster",
-					}, client.InNamespace(clusterKey.Namespace))).Should(HaveLen(updatedReplicas - int(comp.Replicas)))
-				By("Mocking job status to succeeded")
-				ml := client.MatchingLabels{
-					constant.AppInstanceLabelKey:    clusterKey.Name,
-					constant.KBAppComponentLabelKey: comp.Name,
-					constant.KBManagedByKey:         "cluster",
-				}
-				jobList := batchv1.JobList{}
-				Expect(testCtx.Cli.List(testCtx.Ctx, &jobList, ml)).Should(Succeed())
-				for _, job := range jobList.Items {
-					key := client.ObjectKeyFromObject(&job)
-					Expect(testapps.GetAndChangeObjStatus(&testCtx, key, func(job *batchv1.Job) {
-						job.Status.Succeeded = 1
-					})()).Should(Succeed())
+					}
+					jobList := batchv1.JobList{}
+					Expect(testCtx.Cli.List(testCtx.Ctx, &jobList, ml)).Should(Succeed())
+					for _, job := range jobList.Items {
+						key := client.ObjectKeyFromObject(&job)
+						Expect(testapps.GetAndChangeObjStatus(&testCtx, key, func(job *batchv1.Job) {
+							job.Status.Succeeded = 1
+						})()).Should(Succeed())
+					}
 				}
 			}
 
 			By("Mock PVCs status to bound")
-			for i := 0; i < updatedReplicas; i++ {
-				pvcKey := types.NamespacedName{
-					Namespace: clusterKey.Namespace,
-					Name:      getPVCName(comp.Name, i),
-				}
-				Eventually(testapps.CheckObjExists(&testCtx, pvcKey, &corev1.PersistentVolumeClaim{}, true)).Should(Succeed())
-				Expect(testapps.GetAndChangeObjStatus(&testCtx, pvcKey, func(pvc *corev1.PersistentVolumeClaim) {
-					pvc.Status.Phase = corev1.ClaimBound
-				})()).ShouldNot(HaveOccurred())
-			}
+			mockComponentPVCsBound(comp, updatedReplicas, false)
 
-			By("Checking backup job cleanup")
-			Eventually(testapps.List(&testCtx, generics.BackupSignature,
-				client.MatchingLabels{
-					constant.AppInstanceLabelKey:    clusterKey.Name,
-					constant.KBAppComponentLabelKey: comp.Name,
-				}, client.InNamespace(clusterKey.Namespace))).Should(HaveLen(0))
-
-			if !viper.GetBool("VOLUMESNAPSHOT") && len(viper.GetString(constant.CfgKeyBackupPVCName)) > 0 {
-				By("Checking restore job cleanup")
-				Eventually(testapps.List(&testCtx, generics.JobSignature,
+			if policy != nil {
+				By("Checking backup job cleanup")
+				Eventually(testapps.List(&testCtx, generics.BackupSignature,
 					client.MatchingLabels{
 						constant.AppInstanceLabelKey:    clusterKey.Name,
 						constant.KBAppComponentLabelKey: comp.Name,
 					}, client.InNamespace(clusterKey.Namespace))).Should(HaveLen(0))
+
+				if !viper.GetBool("VOLUMESNAPSHOT") && len(viper.GetString(constant.CfgKeyBackupPVCName)) > 0 {
+					By("Checking restore job cleanup")
+					Eventually(testapps.List(&testCtx, generics.JobSignature,
+						client.MatchingLabels{
+							constant.AppInstanceLabelKey:    clusterKey.Name,
+							constant.KBAppComponentLabelKey: comp.Name,
+						}, client.InNamespace(clusterKey.Namespace))).Should(HaveLen(0))
+				}
 			}
 
 			checkUpdatedStsReplicas()
 
-			By("Checking updated sts replicas' PVC")
-			for i := 0; i < updatedReplicas; i++ {
-				pvcKey := types.NamespacedName{
-					Namespace: clusterKey.Namespace,
-					Name:      getPVCName(comp.Name, i),
+			By("Checking updated sts replicas' PVC and size")
+			for _, vct := range comp.VolumeClaimTemplates {
+				var volumeQuantity resource.Quantity
+				for i := 0; i < updatedReplicas; i++ {
+					pvcKey := types.NamespacedName{
+						Namespace: clusterKey.Namespace,
+						Name:      getPVCName(vct.Name, comp.Name, i),
+					}
+					Eventually(testapps.CheckObj(&testCtx, pvcKey, func(g Gomega, pvc *corev1.PersistentVolumeClaim) {
+						if volumeQuantity.IsZero() {
+							volumeQuantity = pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+						}
+						Expect(pvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(volumeQuantity))
+						Expect(pvc.Status.Capacity[corev1.ResourceStorage]).To(Equal(volumeQuantity))
+					})).Should(Succeed())
 				}
-				Eventually(testapps.CheckObjExists(&testCtx, pvcKey, &corev1.PersistentVolumeClaim{}, true)).Should(Succeed())
 			}
 
 			By("Checking pod env config updated")
@@ -722,13 +738,7 @@ var _ = Describe("Cluster Controller", func() {
 		}
 	}
 
-	// @argument componentDefsWithHScalePolicy assign ClusterDefinition.spec.componentDefs[].horizontalScalePolicy for
-	// the matching names. If not provided, will set 1st ClusterDefinition.spec.componentDefs[0].horizontalScalePolicy.
-	horizontalScale := func(updatedReplicas int, policyType appsv1alpha1.HScaleDataClonePolicyType, componentDefsWithHScalePolicy ...string) {
-		cluster := &appsv1alpha1.Cluster{}
-		Expect(testCtx.Cli.Get(testCtx.Ctx, clusterKey, cluster)).Should(Succeed())
-		initialGeneration := int(cluster.Status.ObservedGeneration)
-
+	setHorizontalScalePolicy := func(policyType appsv1alpha1.HScaleDataClonePolicyType, componentDefsWithHScalePolicy ...string) {
 		By(fmt.Sprintf("Set HorizontalScalePolicy, policyType is %s", policyType))
 		Expect(testapps.GetAndChangeObj(&testCtx, client.ObjectKeyFromObject(clusterDefObj),
 			func(clusterDef *appsv1alpha1.ClusterDefinition) {
@@ -743,11 +753,17 @@ var _ = Describe("Cluster Controller", func() {
 						continue
 					}
 
+					if len(policyType) == 0 {
+						clusterDef.Spec.ComponentDefs[i].HorizontalScalePolicy = nil
+						continue
+					}
+
 					By("Checking backup policy created from backup policy template")
 					policyName := DeriveBackupPolicyName(clusterKey.Name, compDef.Name, "")
-					clusterDef.Spec.ComponentDefs[i].HorizontalScalePolicy =
-						&appsv1alpha1.HorizontalScalePolicy{Type: policyType,
-							BackupPolicyTemplateName: backupPolicyTPLName}
+					clusterDef.Spec.ComponentDefs[i].HorizontalScalePolicy = &appsv1alpha1.HorizontalScalePolicy{
+						Type:                     policyType,
+						BackupPolicyTemplateName: backupPolicyTPLName,
+					}
 
 					Eventually(testapps.CheckObjExists(&testCtx, client.ObjectKey{Name: policyName, Namespace: clusterKey.Namespace},
 						&dataprotectionv1alpha1.BackupPolicy{}, true)).Should(Succeed())
@@ -786,21 +802,20 @@ var _ = Describe("Cluster Controller", func() {
 					}
 				}
 			})()).ShouldNot(HaveOccurred())
+	}
+
+	// @argument componentDefsWithHScalePolicy assign ClusterDefinition.spec.componentDefs[].horizontalScalePolicy for
+	// the matching names. If not provided, will set 1st ClusterDefinition.spec.componentDefs[0].horizontalScalePolicy.
+	horizontalScale := func(updatedReplicas int, policyType appsv1alpha1.HScaleDataClonePolicyType, componentDefsWithHScalePolicy ...string) {
+		cluster := &appsv1alpha1.Cluster{}
+		Expect(testCtx.Cli.Get(testCtx.Ctx, clusterKey, cluster)).Should(Succeed())
+		initialGeneration := int(cluster.Status.ObservedGeneration)
+
+		setHorizontalScalePolicy(policyType, componentDefsWithHScalePolicy...)
 
 		By("Mocking all components' PVCs to bound")
 		for _, comp := range clusterObj.Spec.ComponentSpecs {
-			for i := 0; i < int(comp.Replicas); i++ {
-				pvcKey := types.NamespacedName{
-					Namespace: clusterKey.Namespace,
-					Name:      getPVCName(comp.Name, i),
-				}
-				createPVC(clusterKey.Name, pvcKey.Name, comp.Name)
-				Eventually(testapps.CheckObjExists(&testCtx, pvcKey,
-					&corev1.PersistentVolumeClaim{}, true)).Should(Succeed())
-				Eventually(testapps.GetAndChangeObjStatus(&testCtx, pvcKey, func(pvc *corev1.PersistentVolumeClaim) {
-					pvc.Status.Phase = corev1.ClaimBound
-				})).Should(Succeed())
-			}
+			mockComponentPVCsBound(&comp, int(comp.Replicas), true)
 		}
 
 		hscalePolicy := func(comp appsv1alpha1.ClusterComponentSpec) *appsv1alpha1.HorizontalScalePolicy {
@@ -824,14 +839,15 @@ var _ = Describe("Cluster Controller", func() {
 			Should(BeEquivalentTo(initialGeneration + len(clusterObj.Spec.ComponentSpecs)))
 	}
 
-	testHorizontalScale := func(compName, compDefName string, initialReplicas, updatedReplicas int32) {
-
+	testHorizontalScale := func(compName, compDefName string, initialReplicas, updatedReplicas int32,
+		dataClonePolicy appsv1alpha1.HScaleDataClonePolicyType) {
 		By("Creating a single component cluster with VolumeClaimTemplate")
 		pvcSpec := testapps.NewPVCSpec("1Gi")
 		clusterObj = testapps.NewClusterFactory(testCtx.DefaultNamespace, clusterName,
 			clusterDefObj.Name, clusterVersionObj.Name).WithRandomName().
 			AddComponent(compName, compDefName).
 			AddVolumeClaimTemplate(testapps.DataVolumeName, pvcSpec).
+			AddVolumeClaimTemplate(testapps.LogVolumeName, pvcSpec).
 			SetReplicas(initialReplicas).
 			Create(&testCtx).GetObject()
 		clusterKey = client.ObjectKeyFromObject(clusterObj)
@@ -842,10 +858,11 @@ var _ = Describe("Cluster Controller", func() {
 		// REVIEW: this test flow, wait for running phase?
 		viper.Set("VOLUMESNAPSHOT", true)
 		viper.Set(constant.CfgKeyBackupPVCName, "")
-		horizontalScale(int(updatedReplicas), appsv1alpha1.HScaleDataClonePolicyCloneVolume, compDefName)
+
+		horizontalScale(int(updatedReplicas), dataClonePolicy, compDefName)
 	}
 
-	testStorageExpansion := func(compName, compDefName string) {
+	testVolumeExpansion := func(compName, compDefName string) {
 		var (
 			storageClassName  = "sc-mock"
 			replicas          = 3
@@ -875,6 +892,7 @@ var _ = Describe("Cluster Controller", func() {
 			clusterDefObj.Name, clusterVersionObj.Name).WithRandomName().
 			AddComponent(compName, compDefName).
 			AddVolumeClaimTemplate(testapps.DataVolumeName, pvcSpec).
+			AddVolumeClaimTemplate(testapps.LogVolumeName, pvcSpec).
 			SetReplicas(int32(replicas)).
 			Create(&testCtx).GetObject()
 		clusterKey = client.ObjectKeyFromObject(clusterObj)
@@ -891,24 +909,26 @@ var _ = Describe("Cluster Controller", func() {
 
 		By("Mock PVCs in Bound Status")
 		for i := 0; i < replicas; i++ {
-			pvc := &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      getPVCName(compName, i),
-					Namespace: clusterKey.Namespace,
-					Labels: map[string]string{
-						constant.AppManagedByLabelKey:   constant.AppName,
-						constant.AppInstanceLabelKey:    clusterKey.Name,
-						constant.KBAppComponentLabelKey: compName,
-					}},
-				Spec: pvcSpec.ToV1PersistentVolumeClaimSpec(),
+			for _, vctName := range []string{testapps.DataVolumeName, testapps.LogVolumeName} {
+				pvc := &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      getPVCName(vctName, compName, i),
+						Namespace: clusterKey.Namespace,
+						Labels: map[string]string{
+							constant.AppManagedByLabelKey:   constant.AppName,
+							constant.AppInstanceLabelKey:    clusterKey.Name,
+							constant.KBAppComponentLabelKey: compName,
+						}},
+					Spec: pvcSpec.ToV1PersistentVolumeClaimSpec(),
+				}
+				Expect(testCtx.CreateObj(testCtx.Ctx, pvc)).Should(Succeed())
+				pvc.Status.Phase = corev1.ClaimBound // only bound pvc allows resize
+				if pvc.Status.Capacity == nil {
+					pvc.Status.Capacity = corev1.ResourceList{}
+				}
+				pvc.Status.Capacity[corev1.ResourceStorage] = volumeQuantity
+				Expect(k8sClient.Status().Update(testCtx.Ctx, pvc)).Should(Succeed())
 			}
-			Expect(testCtx.CreateObj(testCtx.Ctx, pvc)).Should(Succeed())
-			pvc.Status.Phase = corev1.ClaimBound // only bound pvc allows resize
-			if pvc.Status.Capacity == nil {
-				pvc.Status.Capacity = corev1.ResourceList{}
-			}
-			pvc.Status.Capacity[corev1.ResourceStorage] = volumeQuantity
-			Expect(k8sClient.Status().Update(testCtx.Ctx, pvc)).Should(Succeed())
 		}
 
 		By("mock pods/sts of component are available")
@@ -927,13 +947,17 @@ var _ = Describe("Cluster Controller", func() {
 		Eventually(testapps.GetClusterComponentPhase(&testCtx, clusterKey, compName)).Should(Equal(appsv1alpha1.RunningClusterCompPhase))
 		Eventually(testapps.GetClusterPhase(&testCtx, clusterKey)).Should(Equal(appsv1alpha1.RunningClusterPhase))
 
-		By("Updating the PVC storage size")
+		By("Updating data PVC storage size")
 		Expect(testapps.GetAndChangeObj(&testCtx, clusterKey, func(cluster *appsv1alpha1.Cluster) {
 			comp := &cluster.Spec.ComponentSpecs[0]
-			comp.VolumeClaimTemplates[0].Spec.Resources.Requests[corev1.ResourceStorage] = newVolumeQuantity
+			for i, vct := range comp.VolumeClaimTemplates {
+				if vct.Name == testapps.DataVolumeName {
+					comp.VolumeClaimTemplates[i].Spec.Resources.Requests[corev1.ResourceStorage] = newVolumeQuantity
+				}
+			}
 		})()).ShouldNot(HaveOccurred())
 
-		By("Checking the resize operation in progress")
+		By("Checking the resize operation in progress for data volume")
 		Eventually(testapps.GetClusterObservedGeneration(&testCtx, clusterKey)).Should(BeEquivalentTo(2))
 		Eventually(testapps.GetClusterComponentPhase(&testCtx, clusterKey, compName)).Should(Equal(appsv1alpha1.SpecReconcilingClusterCompPhase))
 		Eventually(testapps.GetClusterPhase(&testCtx, clusterKey)).Should(Equal(appsv1alpha1.SpecReconcilingClusterPhase))
@@ -941,18 +965,18 @@ var _ = Describe("Cluster Controller", func() {
 			pvc := &corev1.PersistentVolumeClaim{}
 			pvcKey := types.NamespacedName{
 				Namespace: clusterKey.Namespace,
-				Name:      getPVCName(compName, i),
+				Name:      getPVCName(testapps.DataVolumeName, compName, i),
 			}
 			Expect(k8sClient.Get(testCtx.Ctx, pvcKey, pvc)).Should(Succeed())
 			Expect(pvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(newVolumeQuantity))
 			Expect(pvc.Status.Capacity[corev1.ResourceStorage]).To(Equal(volumeQuantity))
 		}
 
-		By("Mock resizing of PVCs finished")
+		By("Mock resizing of data volumes finished")
 		for i := 0; i < replicas; i++ {
 			pvcKey := types.NamespacedName{
 				Namespace: clusterKey.Namespace,
-				Name:      getPVCName(compName, i),
+				Name:      getPVCName(testapps.DataVolumeName, compName, i),
 			}
 			Expect(testapps.GetAndChangeObjStatus(&testCtx, pvcKey, func(pvc *corev1.PersistentVolumeClaim) {
 				pvc.Status.Capacity[corev1.ResourceStorage] = newVolumeQuantity
@@ -964,15 +988,27 @@ var _ = Describe("Cluster Controller", func() {
 		Eventually(testapps.GetClusterComponentPhase(&testCtx, clusterKey, compName)).Should(Equal(appsv1alpha1.RunningClusterCompPhase))
 		Eventually(testapps.GetClusterPhase(&testCtx, clusterKey)).Should(Equal(appsv1alpha1.RunningClusterPhase))
 
-		By("Checking PVCs are resized")
+		By("Checking data volumes are resized")
 		for i := 0; i < replicas; i++ {
 			pvcKey := types.NamespacedName{
 				Namespace: clusterKey.Namespace,
-				Name:      getPVCName(compName, i),
+				Name:      getPVCName(testapps.DataVolumeName, compName, i),
 			}
 			Eventually(testapps.CheckObj(&testCtx, pvcKey, func(g Gomega, pvc *corev1.PersistentVolumeClaim) {
 				g.Expect(pvc.Status.Capacity[corev1.ResourceStorage]).To(Equal(newVolumeQuantity))
 			})).Should(Succeed())
+		}
+
+		By("Checking log volumes stay unchanged")
+		for i := 0; i < replicas; i++ {
+			pvc := &corev1.PersistentVolumeClaim{}
+			pvcKey := types.NamespacedName{
+				Namespace: clusterKey.Namespace,
+				Name:      getPVCName(testapps.LogVolumeName, compName, i),
+			}
+			Expect(k8sClient.Get(testCtx.Ctx, pvcKey, pvc)).Should(Succeed())
+			Expect(pvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(volumeQuantity))
+			Expect(pvc.Status.Capacity[corev1.ResourceStorage]).To(Equal(volumeQuantity))
 		}
 	}
 
@@ -1018,10 +1054,10 @@ var _ = Describe("Cluster Controller", func() {
 		By("Mock PVCs in Bound Status")
 		for i := 0; i < replicas; i++ {
 			tmpSpec := pvcSpec.ToV1PersistentVolumeClaimSpec()
-			tmpSpec.VolumeName = getPVCName(compName, i)
+			tmpSpec.VolumeName = getPVCName(testapps.DataVolumeName, compName, i)
 			pvc := &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      getPVCName(compName, i),
+					Name:      getPVCName(testapps.DataVolumeName, compName, i),
 					Namespace: clusterKey.Namespace,
 					Labels: map[string]string{
 						constant.AppInstanceLabelKey: clusterKey.Name,
@@ -1037,7 +1073,7 @@ var _ = Describe("Cluster Controller", func() {
 		for i := 0; i < replicas; i++ {
 			pv := &corev1.PersistentVolume{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      getPVCName(compName, i), // use same name as pvc
+					Name:      getPVCName(testapps.DataVolumeName, compName, i), // use same name as pvc
 					Namespace: clusterKey.Namespace,
 					Labels: map[string]string{
 						constant.AppInstanceLabelKey: clusterKey.Name,
@@ -1058,7 +1094,7 @@ var _ = Describe("Cluster Controller", func() {
 						},
 					},
 					ClaimRef: &corev1.ObjectReference{
-						Name: getPVCName(compName, i),
+						Name: getPVCName(testapps.DataVolumeName, compName, i),
 					},
 				},
 			}
@@ -1082,7 +1118,7 @@ var _ = Describe("Cluster Controller", func() {
 			pvc := &corev1.PersistentVolumeClaim{}
 			pvcKey := types.NamespacedName{
 				Namespace: clusterKey.Namespace,
-				Name:      getPVCName(compName, int(i)),
+				Name:      getPVCName(testapps.DataVolumeName, compName, int(i)),
 			}
 			Expect(k8sClient.Get(testCtx.Ctx, pvcKey, pvc)).Should(Succeed())
 			Expect(pvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(newStorageValue))
@@ -1106,7 +1142,7 @@ var _ = Describe("Cluster Controller", func() {
 				pvc := &corev1.PersistentVolumeClaim{}
 				pvcKey := types.NamespacedName{
 					Namespace: clusterKey.Namespace,
-					Name:      getPVCName(compName, int(i)),
+					Name:      getPVCName(testapps.DataVolumeName, compName, int(i)),
 				}
 				g.Expect(k8sClient.Get(testCtx.Ctx, pvcKey, pvc)).Should(Succeed())
 				g.Expect(pvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(originStorageValue))
@@ -1864,7 +1900,7 @@ var _ = Describe("Cluster Controller", func() {
 				for i := int(*sts.Spec.Replicas); i >= 0; i-- {
 					pvcKey := types.NamespacedName{
 						Namespace: clusterKey.Namespace,
-						Name:      getPVCName(compName, i),
+						Name:      getPVCName(testapps.DataVolumeName, compName, i),
 					}
 					createPVC(clusterKey.Name, pvcKey.Name, compName)
 					Eventually(testapps.CheckObjExists(&testCtx, pvcKey, &corev1.PersistentVolumeClaim{}, true)).Should(Succeed())
@@ -2189,45 +2225,54 @@ var _ = Describe("Cluster Controller", func() {
 		})
 
 		for compName, compDefName := range compNameNDef {
-			Context(fmt.Sprintf("[comp: %s] with pvc", compName), func() {
-				It("should trigger a backup process(snapshot) and create pvcs from backup for newly created replicas when horizontal scale the cluster from 1 to 3", func() {
-					testHorizontalScale(compName, compDefName, 1, 3)
-				})
-			})
-
-			Context(fmt.Sprintf("[comp: %s] with pvc and dynamic-provisioning storage class", compName), func() {
+			Context(fmt.Sprintf("[comp: %s] volume expansion", compName), func() {
 				It("should update PVC request storage size accordingly", func() {
-					testStorageExpansion(compName, compDefName)
+					testVolumeExpansion(compName, compDefName)
+				})
+
+				It("should be able to recover if volume expansion fails", func() {
+					testVolumeExpansionFailedAndRecover(compName, compDefName)
 				})
 			})
 
-			It(fmt.Sprintf("[comp: %s] should be able to recover if volume expansion fails", compName), func() {
-				testVolumeExpansionFailedAndRecover(compName, compDefName)
+			Context(fmt.Sprintf("[comp: %s] horizontal scale", compName), func() {
+				It("scale-out from 1 to 3 with backup(snapshot) policy normally", func() {
+					testHorizontalScale(compName, compDefName, 1, 3, appsv1alpha1.HScaleDataClonePolicyCloneVolume)
+				})
+
+				It("backup error at scale-out", func() {
+					testBackupError(compName, compDefName)
+				})
+
+				It("scale-out without data clone policy", func() {
+					testHorizontalScale(compName, compDefName, 1, 3, "")
+				})
+
+				It("scale-in from 3 to 1", func() {
+					testHorizontalScale(compName, compDefName, 3, 1, appsv1alpha1.HScaleDataClonePolicyCloneVolume)
+				})
+
+				It("scale-in to 0 and PVCs should not been deleted", func() {
+					testHorizontalScale(compName, compDefName, 3, 0, appsv1alpha1.HScaleDataClonePolicyCloneVolume)
+				})
+
+				It("scale-out from 0 and should work well", func() {
+					testHorizontalScale(compName, compDefName, 0, 3, appsv1alpha1.HScaleDataClonePolicyCloneVolume)
+				})
 			})
 
-			It(fmt.Sprintf("[comp: %s] should report error if backup error during horizontal scale", compName), func() {
-				testBackupError(compName, compDefName)
-			})
-
-			Context(fmt.Sprintf("[comp: %s] with horizontal scale after storage expansion", compName), func() {
-				It("should succeed with horizontal scale to 5 replicas", func() {
-					testStorageExpansion(compName, compDefName)
+			Context(fmt.Sprintf("[comp: %s] scale-out after volume expansion", compName), func() {
+				It("scale-out with data clone policy", func() {
+					testVolumeExpansion(compName, compDefName)
 					viper.Set("VOLUMESNAPSHOT", true)
 					viper.Set(constant.CfgKeyBackupPVCName, "")
 					horizontalScale(5, appsv1alpha1.HScaleDataClonePolicyCloneVolume, compDefName)
 				})
-			})
 
-			It(fmt.Sprintf("[comp: %s] and h-scale in", compName), func() {
-				testHorizontalScale(compName, compDefName, 3, 1)
-			})
-
-			It(fmt.Sprintf("[comp: %s] h-scale to 0 and pvc should not deleted", compName), func() {
-				testHorizontalScale(compName, compDefName, 3, 0)
-			})
-
-			It(fmt.Sprintf("[comp: %s] h-scale from 0 and should work", compName), func() {
-				testHorizontalScale(compName, compDefName, 0, 3)
+				It("scale-out without data clone policy", func() {
+					testVolumeExpansion(compName, compDefName)
+					horizontalScale(5, "", compDefName)
+				})
 			})
 		}
 	})

--- a/controllers/apps/components/base_stateful_hscale.go
+++ b/controllers/apps/components/base_stateful_hscale.go
@@ -112,6 +112,7 @@ func newDataClone(reqCtx intctrlutil.RequestCtx,
 			},
 		}, nil
 	}
+	// TODO: how about policy None and Snapshot?
 	return nil, nil
 }
 
@@ -310,19 +311,19 @@ func (d *dummyDataClone) clearTmpResources() ([]client.Object, error) {
 }
 
 func (d *dummyDataClone) checkBackupStatus() (backupStatus, error) {
-	return backupStatusReadyToUse, nil
+	panic("runtime error: dummyDataClone.checkBackupStatus called")
 }
 
 func (d *dummyDataClone) backup() ([]client.Object, error) {
-	return nil, nil
+	panic("runtime error: dummyDataClone.backup called")
 }
 
 func (d *dummyDataClone) checkRestoreStatus(types.NamespacedName) (backupStatus, error) {
-	return backupStatusReadyToUse, nil
+	panic("runtime error: dummyDataClone.checkRestoreStatus called")
 }
 
 func (d *dummyDataClone) restore(name types.NamespacedName) ([]client.Object, error) {
-	return nil, nil
+	panic("runtime error: dummyDataClone.restore called")
 }
 
 type snapshotDataClone struct {

--- a/controllers/apps/components/base_stateful_hscale.go
+++ b/controllers/apps/components/base_stateful_hscale.go
@@ -41,13 +41,13 @@ import (
 )
 
 type dataClone interface {
-	enabled() bool
 	// succeed check if data clone succeeded
 	succeed() (bool, error)
 	// cloneData do clone data, return objects that need to be created
 	cloneData(dataClone) ([]client.Object, error)
 	// clearTmpResources clear all the temporary resources created during data clone, return objects that need to be deleted
 	clearTmpResources() ([]client.Object, error)
+
 	checkBackupStatus() (backupStatus, error)
 	backup() ([]client.Object, error)
 	checkRestoreStatus(types.NamespacedName) (backupStatus, error)
@@ -70,11 +70,11 @@ func newDataClone(reqCtx intctrlutil.RequestCtx,
 	stsObj *appsv1.StatefulSet,
 	stsProto *appsv1.StatefulSet,
 	key types.NamespacedName) (dataClone, error) {
-	if component == nil || component.HorizontalScalePolicy == nil {
+	if component == nil {
 		return nil, nil
 	}
-	if component.HorizontalScalePolicy.Type == appsv1alpha1.HScaleDataClonePolicyCloneVolume {
-		snapshot := &snapshotDataClone{
+	if component.HorizontalScalePolicy == nil {
+		return &dummyDataClone{
 			baseDataClone{
 				reqCtx:    reqCtx,
 				cli:       cli,
@@ -84,9 +84,21 @@ func newDataClone(reqCtx intctrlutil.RequestCtx,
 				stsProto:  stsProto,
 				key:       key,
 			},
-		}
-		if snapshot.enabled() {
-			return snapshot, nil
+		}, nil
+	}
+	if component.HorizontalScalePolicy.Type == appsv1alpha1.HScaleDataClonePolicyCloneVolume {
+		if viper.GetBool("VOLUMESNAPSHOT") {
+			return &snapshotDataClone{
+				baseDataClone{
+					reqCtx:    reqCtx,
+					cli:       cli,
+					cluster:   cluster,
+					component: component,
+					stsObj:    stsObj,
+					stsProto:  stsProto,
+					key:       key,
+				},
+			}, nil
 		}
 		return &backupDataClone{
 			baseDataClone{
@@ -114,7 +126,6 @@ type baseDataClone struct {
 }
 
 func (d *baseDataClone) cloneData(realDataClone dataClone) ([]client.Object, error) {
-
 	objs := make([]client.Object, 0)
 
 	// check backup ready
@@ -136,10 +147,13 @@ func (d *baseDataClone) cloneData(realDataClone dataClone) ([]client.Object, err
 		return objs, nil
 	case backupStatusReadyToUse:
 		break
+	default:
+		panic(fmt.Sprintf("unexpected backup status: %s, clustre: %s, component: %s",
+			status, d.cluster.Name, d.component.Name))
 	}
+
 	// backup's ready, then start to check restore
-	pvcKeys := d.toCreatePVCKeys()
-	for _, pvcKey := range pvcKeys {
+	for _, pvcKey := range d.pvcKeysToRestore() {
 		restoreStatus, err := realDataClone.checkRestoreStatus(pvcKey)
 		if err != nil {
 			return nil, err
@@ -155,12 +169,19 @@ func (d *baseDataClone) cloneData(realDataClone dataClone) ([]client.Object, err
 		case backupStatusProcessing:
 		case backupStatusReadyToUse:
 			continue
-		case backupStatusFailed:
-			return nil, fmt.Errorf("restore failed")
+		default:
+			panic(fmt.Sprintf("unexpected restore status: %s, clustre: %s, component: %s",
+				status, d.cluster.Name, d.component.Name))
 		}
 	}
 
-	// restore to pvcs all ready
+	// create PVCs that do not need to restore
+	pvcObjs, err := d.createPVCs(d.excludeBackupVCTs())
+	if err != nil {
+		return nil, err
+	}
+	objs = append(objs, pvcObjs...)
+
 	return objs, nil
 }
 
@@ -174,7 +195,7 @@ func (d *baseDataClone) isPVCExists(pvcKey types.NamespacedName) (bool, error) {
 
 func (d *baseDataClone) checkAllPVCsExist() (bool, error) {
 	for i := *d.stsObj.Spec.Replicas; i < d.component.Replicas; i++ {
-		for _, vct := range d.stsObj.Spec.VolumeClaimTemplates {
+		for _, vct := range d.component.VolumeClaimTemplates {
 			pvcKey := types.NamespacedName{
 				Namespace: d.stsObj.Namespace,
 				Name:      fmt.Sprintf("%s-%s-%d", vct.Name, d.stsObj.Name, i),
@@ -192,10 +213,18 @@ func (d *baseDataClone) checkAllPVCsExist() (bool, error) {
 	return true, nil
 }
 
+func (d *baseDataClone) allVCTs() []*corev1.PersistentVolumeClaimTemplate {
+	vcts := make([]*corev1.PersistentVolumeClaimTemplate, 0)
+	for i := range d.component.VolumeClaimTemplates {
+		vcts = append(vcts, &d.component.VolumeClaimTemplates[i])
+	}
+	return vcts
+}
+
 func (d *baseDataClone) backupVCT() *corev1.PersistentVolumeClaimTemplate {
-	vcts := d.component.VolumeClaimTemplates
-	vct := vcts[0]
-	for _, tmpVct := range vcts {
+	// TODO: is it possible that component.VolumeClaimTemplates may be empty?
+	vct := d.component.VolumeClaimTemplates[0]
+	for _, tmpVct := range d.component.VolumeClaimTemplates {
 		for _, volumeType := range d.component.VolumeTypes {
 			if volumeType.Type == appsv1alpha1.VolumeTypeData && volumeType.Name == tmpVct.Name {
 				vct = tmpVct
@@ -206,20 +235,52 @@ func (d *baseDataClone) backupVCT() *corev1.PersistentVolumeClaimTemplate {
 	return &vct
 }
 
-func (d *baseDataClone) toCreatePVCKeys() []types.NamespacedName {
+func (d *baseDataClone) excludeBackupVCTs() []*corev1.PersistentVolumeClaimTemplate {
+	vcts := make([]*corev1.PersistentVolumeClaimTemplate, 0)
+	backupVCT := d.backupVCT()
+	for i := range d.component.VolumeClaimTemplates {
+		vct := &d.component.VolumeClaimTemplates[i]
+		if vct.Name != backupVCT.Name {
+			vcts = append(vcts, vct)
+		}
+	}
+	return vcts
+}
+
+func (d *baseDataClone) pvcKeysToRestore() []types.NamespacedName {
 	var pvcKeys []types.NamespacedName
-	vct := d.backupVCT()
-	for i := *d.stsObj.Spec.Replicas; i < *d.stsProto.Spec.Replicas; i++ {
+	backupVct := d.backupVCT()
+	for i := *d.stsObj.Spec.Replicas; i < d.component.Replicas; i++ {
 		pvcKey := types.NamespacedName{
 			Namespace: d.stsObj.Namespace,
-			Name: fmt.Sprintf("%s-%s-%d",
-				vct.Name,
-				d.stsObj.Name,
-				i),
+			Name:      fmt.Sprintf("%s-%s-%d", backupVct.Name, d.stsObj.Name, i),
 		}
 		pvcKeys = append(pvcKeys, pvcKey)
 	}
 	return pvcKeys
+}
+
+func (d *baseDataClone) createPVCs(vcts []*corev1.PersistentVolumeClaimTemplate) ([]client.Object, error) {
+	objs := make([]client.Object, 0)
+	for i := *d.stsObj.Spec.Replicas; i < d.component.Replicas; i++ {
+		for _, vct := range vcts {
+			pvcKey := types.NamespacedName{
+				Namespace: d.stsObj.Namespace,
+				Name:      fmt.Sprintf("%s-%s-%d", vct.Name, d.stsObj.Name, i),
+			}
+			if exist, err := d.isPVCExists(pvcKey); err != nil {
+				return nil, err
+			} else if exist {
+				continue
+			}
+			pvc, err := builder.BuildPVC(d.cluster, d.component, vct, pvcKey, "")
+			if err != nil {
+				return nil, err
+			}
+			objs = append(objs, pvc)
+		}
+	}
+	return objs, nil
 }
 
 func (d *baseDataClone) getBackupMatchingLabels() client.MatchingLabels {
@@ -230,12 +291,42 @@ func (d *baseDataClone) getBackupMatchingLabels() client.MatchingLabels {
 	}
 }
 
-type snapshotDataClone struct {
+type dummyDataClone struct {
 	baseDataClone
 }
 
-func (d *snapshotDataClone) enabled() bool {
-	return viper.GetBool("VOLUMESNAPSHOT")
+var _ dataClone = &dummyDataClone{}
+
+func (d *dummyDataClone) succeed() (bool, error) {
+	return d.checkAllPVCsExist()
+}
+
+func (d *dummyDataClone) cloneData(dataClone) ([]client.Object, error) {
+	return d.createPVCs(d.allVCTs())
+}
+
+func (d *dummyDataClone) clearTmpResources() ([]client.Object, error) {
+	return nil, nil
+}
+
+func (d *dummyDataClone) checkBackupStatus() (backupStatus, error) {
+	return backupStatusReadyToUse, nil
+}
+
+func (d *dummyDataClone) backup() ([]client.Object, error) {
+	return nil, nil
+}
+
+func (d *dummyDataClone) checkRestoreStatus(types.NamespacedName) (backupStatus, error) {
+	return backupStatusReadyToUse, nil
+}
+
+func (d *dummyDataClone) restore(name types.NamespacedName) ([]client.Object, error) {
+	return nil, nil
+}
+
+type snapshotDataClone struct {
+	baseDataClone
 }
 
 var _ dataClone = &snapshotDataClone{}
@@ -447,10 +538,6 @@ type backupDataClone struct {
 	baseDataClone
 }
 
-func (d *backupDataClone) enabled() bool {
-	return len(viper.GetString(constant.CfgKeyBackupPVCName)) > 0
-}
-
 var _ dataClone = &backupDataClone{}
 
 func (d *backupDataClone) succeed() (bool, error) {
@@ -458,8 +545,7 @@ func (d *backupDataClone) succeed() (bool, error) {
 	if err != nil || !allPVCsExist {
 		return allPVCsExist, err
 	}
-	pvcKeys := d.toCreatePVCKeys()
-	for _, pvcKey := range pvcKeys {
+	for _, pvcKey := range d.pvcKeysToRestore() {
 		restoreStatus, err := d.checkRestoreStatus(pvcKey)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
This PR will try to resolve 3 problems about scale-out:
1.  w/o h-scale policy, after a volume expansion operation, the scaled-out replicas volume size are different with old ones
2. w/ h-scale policy configured, if there are more than one volumes claimed for a component, the scale-out operation will block
3. w/ h-scale policy configured, if there are more than one volumes claimed for a component, the size of some volumes will be inconsistent