### PR TITLE
feat: replace to stateful deploy kind for pgsql wal archive

### DIFF
--- a/controllers/dataprotection/backuppolicy_controller.go
+++ b/controllers/dataprotection/backuppolicy_controller.go
@@ -353,8 +353,8 @@ func (r *BackupPolicyReconciler) reconcileForStatefulSetKind(
 	if cronExpression != "" && slices.Contains([]dataprotectionv1alpha1.BackupPhase{
 		dataprotectionv1alpha1.BackupCompleted, dataprotectionv1alpha1.BackupFailed},
 		backup.Status.Phase) {
-		// if schedule is enabled and backup already is completed, update phase to running
-		backup.Status.Phase = dataprotectionv1alpha1.BackupRunning
+		// if schedule is enabled and backup already is completed, update phase to New
+		backup.Status.Phase = dataprotectionv1alpha1.BackupNew
 		backup.Status.FailureReason = ""
 		return r.Client.Status().Patch(ctx, backup, patch)
 	}
@@ -558,6 +558,9 @@ func (r *BackupPolicyReconciler) handleLogfilePolicy(
 		var cronExpression string
 		if schedule != nil && schedule.Enable {
 			cronExpression = schedule.CronExpression
+		}
+		if err := r.reconfigure(reqCtx, backupPolicy, logfile.BasePolicy, dataprotectionv1alpha1.BackupTypeLogFile); err != nil {
+			return err
 		}
 		return r.reconcileForStatefulSetKind(reqCtx.Ctx, backupPolicy, dataprotectionv1alpha1.BackupTypeLogFile, cronExpression)
 	}

--- a/controllers/dataprotection/utils.go
+++ b/controllers/dataprotection/utils.go
@@ -94,6 +94,10 @@ func getClusterLabelKeys() []string {
 	return []string{constant.AppInstanceLabelKey, constant.KBAppComponentLabelKey}
 }
 
+func excludeLabelsForWorkload() []string {
+	return []string{constant.KBAppComponentLabelKey}
+}
+
 func buildAutoCreationAnnotations(backupPolicyName string) map[string]string {
 	return map[string]string{
 		dataProtectionAnnotationCreateByPolicyKey: "true",
@@ -116,7 +120,7 @@ func buildBackupWorkloadsLabels(backup *dataprotectionv1alpha1.Backup) map[strin
 	if labels == nil {
 		labels = map[string]string{}
 	} else {
-		for _, v := range getClusterLabelKeys() {
+		for _, v := range excludeLabelsForWorkload() {
 			delete(labels, v)
 		}
 	}

--- a/deploy/mongodb/dataprotection/pitr-backup.sh
+++ b/deploy/mongodb/dataprotection/pitr-backup.sh
@@ -9,8 +9,6 @@ export MONGODB_URI="mongodb://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:27017/?authSo
 export WALG_FILE_PREFIX=${BACKUP_DIR}
 export OPLOG_ARCHIVE_TIMEOUT_INTERVAL=${ARCHIVE_INTERVAL}
 export OPLOG_ARCHIVE_AFTER_SIZE=${ARCHIVE_AFTER_SIZE}
-# retention time
-export OPLOG_PITR_DISCOVERY_INTERVAL=168h
 retryTimes=0
 purgeCounter=0
 wal_g_pid=0
@@ -45,8 +43,7 @@ check_oplog_push_process(){
   fi
 }
 
-# write the startTime and stopTime to backup.info file
-dump_start_and_stop_time() {
+save_backup_status() {
    TOTAL_SIZE=$(du -shx ${BACKUP_DIR}|awk '{print $1}')
    OLDEST_FILE=$(ls -t ${BACKUP_DIR}/oplog_005 | tail -n 1) && OLDEST_FILE=${OLDEST_FILE#*_} && LOG_START_TIME=${OLDEST_FILE%%.*}
    LATEST_FILE=$(ls -t ${BACKUP_DIR}/oplog_005 | head -n 1) && LATEST_FILE=${LATEST_FILE##*_} && LOG_STOP_TIME=${LATEST_FILE%%.*}
@@ -78,7 +75,7 @@ while true; do
   check_oplog_push_process
   sleep 1
   if [ -d ${BACKUP_DIR}/oplog_005 ];then
-    dump_start_and_stop_time
+    save_backup_status
     # purge the expired oplog
     purge_expired_files
   fi

--- a/deploy/postgresql/dataprotection/pitr-backup.sh
+++ b/deploy/postgresql/dataprotection/pitr-backup.sh
@@ -1,47 +1,126 @@
 #!/bin/bash
-set -e;
-# clean up expired logfiles
-if [ ! -z ${LOGFILE_TTL_SECOND} ];then
-  retention_day=$((${LOGFILE_TTL_SECOND}/86400))
-  EXPIRED_INCR_LOG=${BACKUP_DIR}/$(date -d"${retention_day} day ago" +%Y%m%d);
-  if [ -d ${EXPIRED_INCR_LOG} ]; then
-    rm -rf ${EXPIRED_INCR_LOG};
-  fi
-fi
-
 export PGPASSWORD=${DB_PASSWORD}
 PSQL="psql -h ${DB_HOST} -U ${DB_USER} -d postgres"
-LAST_TRANS=$(pg_waldump $(${PSQL} -Atc "select pg_walfile_name(pg_current_wal_lsn())") --rmgr=Transaction 2>/dev/null |tail -n 1)
-if [ "${LAST_TRANS}" != "" ] && [ "$(find ${LOG_DIR}/archive_status/ -name '*.ready')" = "" ]; then
-  echo "switch wal file"
-  ${PSQL} -c "select pg_switch_wal()"
-  for i in $(seq 1 60); do
-    echo "waiting wal ready ..."
-    if [ "$(find ${LOG_DIR}/archive_status/ -name '*.ready')" != "" ]; then break; fi
-    sleep 1
-  done
+last_switch_wal_time=$(date +%s)
+last_purge_time=$(date +%s)
+STOP_TIME=
+switch_wal_interval=300
+
+if [[ ${SWITCH_WAL_INTERVAL_SECONDS} =~ ^[0-9]+$ ]];then
+  switch_wal_interval=${SWITCH_WAL_INTERVAL_SECONDS}
 fi
 
-STOP_TIME=""
-TODAY_INCR_LOG=${BACKUP_DIR}/$(date +%Y%m%d);
-mkdir -p ${TODAY_INCR_LOG};
-cd ${LOG_DIR}
-for i in $(ls -tr ./archive_status/*.ready); do
-  wal_ready_name="${i##*/}"
-  wal_name=${wal_ready_name%.*}
-  echo "uploading ${wal_name}";
-  LOG_STOP_TIME=$(pg_waldump ${wal_name} --rmgr=Transaction 2>/dev/null |tail -n 1|awk -F ' COMMIT ' '{print $2}'|awk -F ';' '{print $1}')
-  if [[ ! -z $LOG_STOP_TIME ]];then
-    STOP_TIME=$(date -d "${LOG_STOP_TIME}" -u '+%Y-%m-%dT%H:%M:%SZ')
-  fi
-  gzip -kqc ${wal_name} > ${TODAY_INCR_LOG}/${wal_name}.gz;
-  mv -f ${i} ./archive_status/${wal_name}.done;
-done
-echo "done."
-sync;
-TOTAL_SIZE=$(du -shx ${BACKUP_DIR}|awk '{print $1}')
-if [[ -z $STOP_TIME ]];then
-  echo "{\"totalSize\":\"$TOTAL_SIZE\",\"manifests\":{\"backupTool\":{\"uploadTotalSize\":\"${TOTAL_SIZE}\"}}}" > ${BACKUP_DIR}/backup.info
-else
-  echo "{\"totalSize\":\"$TOTAL_SIZE\",\"manifests\":{\"backupLog\":{\"stopTime\":\"${STOP_TIME}\"},\"backupTool\":{\"uploadTotalSize\":\"${TOTAL_SIZE}\"}}}" > ${BACKUP_DIR}/backup.info
+backup_in_secondary=
+if [ "${DP_POD_ROLE}" == "primary" ]; then
+   backup_in_secondary=f
+elif [ "${DP_POD_ROLE}" == "secondary" ]; then
+   backup_in_secondary=t
 fi
+
+function log() {
+    msg=$1
+    local curr_date=$(date -u '+%Y-%m-%d %H:%M:%S')
+    echo "${curr_date} INFO: $msg"
+}
+
+function purge_expired_files() {
+    # clean up expired logfiles, interval is 60s
+    local curr_time=$(date +%s)
+    local diff_time=$((${curr_time}-${last_purge_time}))
+    if [[ -z ${LOGFILE_TTL_SECOND} || ${diff_time} -lt 60 ]]; then
+       return
+    fi
+    retention_day=$((${LOGFILE_TTL_SECOND}/86400))
+    EXPIRED_INCR_LOG=${BACKUP_DIR}/$(date -d"${retention_day} day ago" +%Y%m%d);
+    if [ -d ${EXPIRED_INCR_LOG} ]; then
+      rm -rf ${EXPIRED_INCR_LOG};
+    fi
+    last_purge_time=${curr_time}
+}
+
+function switch_wal_log() {
+    local curr_time=$(date +%s)
+    local diff_time=$((${curr_time}-${last_switch_wal_time}))
+    if [[ ${diff_time} -lt ${switch_wal_interval} ]]; then
+       return
+    fi
+    LAST_TRANS=$(pg_waldump $(${PSQL} -Atc "select pg_walfile_name(pg_current_wal_lsn())") --rmgr=Transaction 2>/dev/null |tail -n 1)
+    if [ "${LAST_TRANS}" != "" ] && [ "$(find ${LOG_DIR}/archive_status/ -name '*.ready')" = "" ]; then
+      log "start to switch wal file"
+      ${PSQL} -c "select pg_switch_wal()"
+      for i in $(seq 1 60); do
+        if [ "$(find ${LOG_DIR}/archive_status/ -name '*.ready')" != "" ]; then
+          log "switch wal file successfully"
+          break;
+        fi
+        sleep 1
+      done
+    fi
+    last_switch_wal_time=${curr_time}
+}
+
+function upload_wal_log() {
+    TODAY_INCR_LOG=${BACKUP_DIR}/$(date +%Y%m%d);
+    mkdir -p ${TODAY_INCR_LOG};
+    cd ${LOG_DIR}
+    for i in $(ls -tr ./archive_status/ | grep .ready); do
+      wal_name=${i%.*}
+      LOG_STOP_TIME=$(pg_waldump ${wal_name} --rmgr=Transaction 2>/dev/null |tail -n 1|awk -F ' COMMIT ' '{print $2}'|awk -F ';' '{print $1}')
+      if [[ ! -z $LOG_STOP_TIME ]];then
+        STOP_TIME=$(date -d "${LOG_STOP_TIME}" -u '+%Y-%m-%dT%H:%M:%SZ')
+      fi
+      if [ -f ${wal_name} ]; then
+        log "upload ${wal_name}"
+        gzip -kqc ${wal_name} > ${TODAY_INCR_LOG}/${wal_name}.gz;
+        mv -f ./archive_status/${i} ./archive_status/${wal_name}.done;
+      fi
+    done
+}
+
+function save_backup_status() {
+    TOTAL_SIZE=$(du -shx ${BACKUP_DIR}|awk '{print $1}')
+    if [[ -z ${STOP_TIME} ]];then
+      echo "{\"totalSize\":\"${TOTAL_SIZE}\",\"manifests\":{\"backupTool\":{\"uploadTotalSize\":\"${TOTAL_SIZE}\"}}}" > ${BACKUP_DIR}/backup.info
+    else
+      echo "{\"totalSize\":\"${TOTAL_SIZE}\",\"manifests\":{\"backupLog\":{\"stopTime\":\"${STOP_TIME}\"},\"backupTool\":{\"uploadTotalSize\":\"${TOTAL_SIZE}\"}}}" > ${BACKUP_DIR}/backup.info
+    fi
+}
+
+function check_pg_process() {
+    is_ok=false
+    for ((i=1;i<4;i++));do
+      is_secondary=$(${PSQL} -Atc "select pg_is_in_recovery()")
+      if [[ $? -eq 0  && (-z ${backup_in_secondary} || "${backup_in_secondary}" == "${is_secondary}") ]]; then
+        is_ok=true
+        break
+      fi
+      echo "Waring: target backup pod is not OK, target role: ${DP_POD_ROLE}, pg_is_in_recovery: ${is_secondary}, retry detection!"
+      sleep 1
+    done
+    if [[ ${is_ok} == "false" ]];then
+      echo "ERROR: target backup pod is not OK, target role: ${DP_POD_ROLE}, pg_is_in_recovery: ${is_secondary}!"
+      exit 1
+    fi
+}
+
+# trap term signal
+trap "echo 'Terminating...' && sync && exit 0" TERM
+log "start to archive wal logs"
+while true; do
+
+  # check if pg process is ok
+  check_pg_process
+
+  # switch wal log
+  switch_wal_log
+
+  # upload wal log
+  upload_wal_log
+
+  # save backup status which will be updated to `backup` CR by the sidecar
+  save_backup_status
+
+  # purge the expired wal logs
+  purge_expired_files
+  sleep ${DP_INTERVAL_SECONDS}
+done

--- a/deploy/postgresql/templates/backuptool-pitr.yaml
+++ b/deploy/postgresql/templates/backuptool-pitr.yaml
@@ -7,7 +7,7 @@ metadata:
     {{- include "postgresql.labels" . | nindent 4 }}
   name: postgres-pitr
 spec:
-  deployKind: job
+  deployKind: statefulSet
   env:
     - name: VOLUME_DATA_DIR
       value: /home/postgres/pgdata
@@ -23,6 +23,13 @@ spec:
       value: 2006-01-02 15:04:05 MST
     - name: LOG_DIR
       value: $(VOLUME_DATA_DIR)/pgroot/data/pg_wal
+    - name: DP_POD_ROLE
+      # TODO input by backup policy
+      value: primary
+    - name: DP_INTERVAL_SECONDS
+      value: "10"
+    - name: SWITCH_WAL_INTERVAL_SECONDS
+      value: "300"
   image: ""
   logical:
     restoreCommands:


### PR DESCRIPTION
Currently, PGSQL and Apecloud mysql use cronjob to regularly archive logs, which may pose the following risks:

1. If there are a large number of clusters and job scheduling is carried out simultaneously, it may cause significant pressure on the API server.
2. the minimum timing unit for cronjob is at the minute level, which poses a high risk of data loss