### PR TITLE
feat: add auto signup and KB clusters auto injection to Bytebase

### DIFF
--- a/deploy/bytebase/Chart.yaml
+++ b/deploy/bytebase/Chart.yaml
@@ -15,4 +15,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.0
+version: 0.4.0

--- a/deploy/bytebase/templates/auto-plugin.yaml
+++ b/deploy/bytebase/templates/auto-plugin.yaml
@@ -7,8 +7,8 @@ spec:
     spec:
       serviceAccountName: kubeblocks
       containers:
-        - name: python-script
-          image: python:3.11-alpine3.18
+        - name: bytebase-python-script
+          image: registry.cn-hangzhou.aliyuncs.com/apecloud/python11-tools:stable
           command:
             - /bin/sh
             - -c

--- a/deploy/bytebase/templates/auto-plugin.yaml
+++ b/deploy/bytebase/templates/auto-plugin.yaml
@@ -1,0 +1,29 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: python-job
+spec:
+  template:
+    spec:
+      serviceAccountName: kubeblocks
+      containers:
+        - name: python-script
+          image: python:3.11-alpine3.18
+          command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /home/script
+              cp /script/* /home/script
+              chmod 777 /home/script/*
+              cd /home/script
+              ./init.sh
+          volumeMounts:
+            - name: script
+              mountPath: /script
+      restartPolicy: OnFailure
+      volumes:
+        - name: script
+          configMap:
+            name: bb-setup-script
+  backoffLimit: 3

--- a/deploy/bytebase/templates/script.yaml
+++ b/deploy/bytebase/templates/script.yaml
@@ -8,7 +8,8 @@ data:
     set -e
 
     URL="${BYTEBASE_ENTRYPOINT_PORT_8080_TCP_ADDR}:${BYTEBASE_ENTRYPOINT_PORT_8080_TCP_PORT}"
-    echo URL
+    sleep 10 # wait bytebase start up
+    echo $URL
     retry_count=0
     MAX_RETRIES=300
     while [ $retry_count -lt $MAX_RETRIES ]; do

--- a/deploy/bytebase/templates/script.yaml
+++ b/deploy/bytebase/templates/script.yaml
@@ -21,7 +21,7 @@ data:
     else
     echo "Response code is $response_code. Waiting..."
     retry_count=$((retry_count + 1))
-    sleep 1  # 等待一秒后再次轮询
+    sleep 1
     fi
     done
 
@@ -61,31 +61,37 @@ data:
             port = os.getenv("BYTEBASE_ENTRYPOINT_PORT_8080_TCP_PORT")
         client = Client(f"{url}:{port}", "v1")
 
-        signup = {
-            "state": "ACTIVE",
+        code = client.login({
             "email": "admin@example.com",
-            "title": "kubeblocks",
-            "user_type": "USER",
-            "password": "admin",
-            "service_key": "",
-            "mfa_enabled": False
-        }
+            "password": "admin"
+        })
+        if code != 200:
+            print("login failed, signup first...")
+            signup = {
+                "state": "ACTIVE",
+                "email": "admin@example.com",
+                "title": "kubeblocks",
+                "user_type": "USER",
+                "password": "admin",
+                "service_key": "",
+                "mfa_enabled": False
+            }
 
-        res = client.signup(signup)
-        print("signup result: ", res[0], res[1])
+            res = client.signup(signup)
+            print("signup result: ", res[0], res[1])
 
         res, code = client.get_environment()
         if code != 200:
-          # create a new environment
-          new_environment = {
-              "uid": "kubeblocks",
-              "name": "environments/kubeblocks",
-              "title": "kubeblocks",
-              "state": API.StateActive,
-              "tier": API.TierUnprotected
-          }
-          res = client.create_environment(new_environment)
-          print(res)
+            # create a new environment
+            new_environment = {
+                "uid": "kubeblocks",
+                "name": "environments/kubeblocks",
+                "title": "kubeblocks",
+                "state": API.StateActive,
+                "tier": API.TierUnprotected
+            }
+            res = client.create_environment(new_environment)
+            print(res)
 
         # inject cluster
         for info in clusters:
@@ -96,27 +102,27 @@ data:
                 name = s.metadata.owner_references[0].name
                 code, date = client.get_instance(name)
                 if code != 200:
-                  username = base64.b64decode(s.data["username"]).decode("utf-8")
-                  password = base64.b64decode(s.data["password"]).decode("utf-8")
-                  host = base64.b64decode(s.data["host"]).decode("utf-8")
-                  port = base64.b64decode(s.data["port"]).decode("utf-8")
-                  new_instance = {
-                      "name": name,
-                      "title": name,
-                      "state": API.StateActive,
-                      "engine": engine_type,
-                      "dataSources": [{
-                          # "title": "",
-                          "type": API.ADMIN,
-                          "username": username,
-                          "password": password,
-                          "host": host,
-                          "port": port,
-                      }],
-                      "environment": "environments/kubeblocks",
-                  }
-                  res = client.create_instance(new_instance)
-                  print(res)
+                    username = base64.b64decode(s.data["username"]).decode("utf-8")
+                    password = base64.b64decode(s.data["password"]).decode("utf-8")
+                    host = base64.b64decode(s.data["host"]).decode("utf-8")
+                    port = base64.b64decode(s.data["port"]).decode("utf-8")
+                    new_instance = {
+                        "name": name,
+                        "title": name,
+                        "state": API.StateActive,
+                        "engine": engine_type,
+                        "dataSources": [{
+                            # "title": "",
+                            "type": API.ADMIN,
+                            "username": username,
+                            "password": password,
+                            "host": host,
+                            "port": port,
+                        }],
+                        "environment": "environments/kubeblocks",
+                    }
+                    res = client.create_instance(new_instance)
+                    print(res)
 
 
   bytebase_api.py: |
@@ -175,7 +181,6 @@ data:
             url = f"{self.url}/{self.version}/auth/login"
 
             response = requests.post(url, data=rb, headers=headers)
-            response.raise_for_status()
 
             accessToken = response.headers.get("Grpc-Metadata-Bytebase-Access-Token")
             refreshToken = response.headers.get("Grpc-Metadata-Bytebase-Refresh-Token")

--- a/deploy/bytebase/templates/script.yaml
+++ b/deploy/bytebase/templates/script.yaml
@@ -1,0 +1,266 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: bb-setup-script
+data:
+  init.sh: |
+    set -o errexit
+    set -e
+
+
+    pip install requests kubernetes
+    URL="${BYTEBASE_ENTRYPOINT_PORT_8080_TCP_ADDR}:${BYTEBASE_ENTRYPOINT_PORT_8080_TCP_PORT}"
+    echo URL
+    retry_count=0
+    MAX_RETRIES=300
+    while [ $retry_count -lt $MAX_RETRIES ]; do
+    response_headers=$(wget --server-response --spider -nv  ${URL}  2>&1)
+    response_code=$(echo "$response_headers" | awk '/HTTP/{print $2}')
+    if [ "$response_code" -eq "200" ]; then
+    echo "Response code is 200. Exiting..."
+    break
+    else
+    echo "Response code is $response_code. Waiting..."
+    retry_count=$((retry_count + 1))
+    sleep 1  # 等待一秒后再次轮询
+    fi
+    done
+
+    if [ $retry_count -eq $MAX_RETRIES ]; then
+    echo "Max retries reached. Exiting..."
+    exit
+    fi
+
+    python main.py "http://${BYTEBASE_ENTRYPOINT_PORT_8080_TCP_ADDR}" ${BYTEBASE_ENTRYPOINT_PORT_8080_TCP_PORT}
+
+  main.py: |
+    import os
+    import sys
+    import base64
+    from kubernetes import client, config
+    from client import Client
+    import bytebase_api as API
+
+    if __name__ == '__main__':
+        config.load_incluster_config()
+        # config.load_config()
+        v1 = client.CoreV1Api()
+        namespace = os.getenv("KB_NAMESPACE") or "default"
+
+        # clusters contain the cluster label and the corresponding engine type.
+        clusters = [
+            ['app.kubernetes.io/name=apecloud-mysql', API.MYSQL],
+            ['app.kubernetes.io/name=postgresql', API.POSTGRES],
+            ['app.kubernetes.io/name=mongodb', API.MONGODB],
+            ['app.kubernetes.io/name=redis', API.REDIS]
+        ]
+        url = sys.argv[1] or os.getenv("BYTEBASE_ENTRYPOINT_PORT_8080_TCP_ADDR")
+        # url = os.getenv("BYTEBASE_ENTRYPOINT_PORT_8080_TCP_ADDR") or ""  # exit("get bytebase address failed")
+        port = sys.argv[2] or os.getenv("BYTEBASE_ENTRYPOINT_PORT_8080_TCP_PORT")  # exit("get bytebase port failed")
+        client = Client(f"{url}:{port}", "v1")
+
+        # client = Client("http://localhost:18080", "v1")
+
+        signup = {
+            "state": "ACTIVE",
+            "email": "admin@example.com",
+            "title": "kubeblocks",
+            "user_type": "USER",
+            "password": "admin",
+            "service_key": "",
+            "mfa_enabled": False
+        }
+
+        res = client.signup(signup)
+        print("signup result: ", res[0], res[1])
+        #
+        # create a new environment
+        new_environment = {
+            "uid": "kubeblocks",
+            "name": "environments/kubeblocks",
+            "title": "kubeblocks",
+            "state": API.StateActive,
+            "tier": API.TierUnprotected
+        }
+        res = client.create_environment(new_environment)
+        print(res)
+
+        # get service
+        for info in clusters:
+            label = info[0]
+            engine_type = info[1]
+            # services = v1.list_namespaced_service(namespace=namespace, label_selector=label)
+            secrets = v1.list_namespaced_secret(namespace="", label_selector=label)
+            for s in secrets.items:
+                # print(s.data["host"], s.data["port"], s.data["username"], s.data["password"])
+                # print(base64.b64decode(s.data["host"]).decode("utf-8"),
+                #       base64.b64decode(s.data["port"]).decode("utf-8"),
+                #       base64.b64decode(s.data["username"]).decode("utf-8"),
+                #       base64.b64decode(s.data["password"]).decode("utf-8"),
+                #       s.metadata.owner_references[0].name)
+                name = s.metadata.owner_references[0].name
+                username = base64.b64decode(s.data["username"]).decode("utf-8")
+                password = base64.b64decode(s.data["password"]).decode("utf-8")
+                host = base64.b64decode(s.data["host"]).decode("utf-8")
+                port = base64.b64decode(s.data["port"]).decode("utf-8")
+                new_instance = {
+                    "name": name,
+                    "title": name,
+                    "state": API.StateActive,
+                    "engine": engine_type,
+                    "dataSources": [{
+                        # "title": "",
+                        "type": API.ADMIN,
+                        "username": username,
+                        "password": password,
+                        "host": host,
+                        "port": port,
+                    }],
+                    "environment": "environments/kubeblocks",
+                }
+                res = client.create_instance(new_instance)
+                print(res)
+
+
+  bytebase_api.py: |
+    # Engine Type
+    ENGINE_UNSPECIFIED = 0
+    CLICKHOUSE = 1
+    MYSQL = 2
+    POSTGRES = 3
+    SNOWFLAKE = 4
+    SQLITE = 5
+    TIDB = 6
+    MONGODB = 7
+    REDIS = 8
+    ORACLE = 9
+    SPANNER = 10
+    MSSQL = 11
+    REDSHIFT = 12
+    MARIADB = 13
+    OCEANBASE = 14
+    DM = 15
+    RISINGWAVE = 16
+
+    # DataSourceType
+    DATA_SOURCE_UNSPECIFIED = 0
+    ADMIN = 1
+    READ_ONLY = 2
+
+    # Environment And Instance State
+    StateActive = "ACTIVE"
+    StateDeleted = "DELETED"
+
+    # Environment Tier
+    TierProtected = 1
+    TierUnprotected = 2
+
+  client.py: |
+    import json
+    import requests
+
+    class Client:
+        def __init__(self, url, version):
+            self.url = url  # url should contain the protocol and port eg: "http://localhost:18080"
+            self.version = version
+            self.loginCookie = None
+
+            self.email = ""
+            self.password = ""
+
+        def login(self, auth):
+            if auth['email'] == '' or auth['password'] == '':
+                return 0, ValueError("define username and password")
+
+            auth['web'] = True
+            rb = json.dumps(auth).encode('utf-8')
+            headers = {'Content-Type': 'application/json'}
+            url = f"{self.url}/{self.version}/auth/login"
+
+            response = requests.post(url, data=rb, headers=headers)
+            response.raise_for_status()
+
+            accessToken = response.headers.get("Grpc-Metadata-Bytebase-Access-Token")
+            refreshToken = response.headers.get("Grpc-Metadata-Bytebase-Refresh-Token")
+            user = response.headers.get("Grpc-Metadata-Bytebase-User")
+
+            self.loginCookie = {
+                'AccessToken': accessToken,
+                'RefreshToken': refreshToken,
+                'User': user
+            }
+
+            return response.status_code, None
+
+        def signup(self, data):
+            if data['email'] == '' or data['password'] == '':
+                return 0, ValueError("the username and password cannot be empty")
+
+            url = f"{self.url}/{self.version}/users"
+            response = requests.post(url, json=data)
+            # response.raise_for_status()
+            # print(response)
+            self.email = data['email']
+            self.password = data['password']
+            return response.status_code, response.text
+
+        def get_environment(self, environment_name="kubeblocks"):
+            self.login({
+                'email': self.email,
+                'password': self.password
+            })
+            url = f"{self.url}/{self.version}/environments/{environment_name}"
+            headers = {'Authorization': f"Bearer {self.loginCookie['AccessToken']}"}
+            response = requests.get(url, headers=headers)
+            response.raise_for_status()
+            res_data = json.loads(response.text)
+            return res_data
+
+        def create_environment(self, environment):
+            self.login({
+                'email': self.email,
+                'password': self.password
+            })
+            url = f"{self.url}/{self.version}/environments?environment_id=kubeblocks"  # create a new enviroment named kubeblokcs
+            headers = {'Authorization': f"Bearer {self.loginCookie['AccessToken']}"}
+            response = requests.post(url, json=environment, headers=headers)
+            response.raise_for_status()
+            res_data = json.loads(response.text)
+            return res_data
+
+        def get_instance(self, name="test-sample-instance"):
+            self.login({
+                'email': self.email,
+                'password': self.password
+            })
+            # url = f"{self.url}/{self.version}/environments/{environment_name}"
+
+            instance_name = f"instances/{name}"
+            url = f"{self.url}/{self.version}/{instance_name}"
+            # self.client.head()
+            headers = {'Authorization': f"Bearer {self.loginCookie['AccessToken']}"}
+            response = requests.get(url, headers=headers)
+            response.raise_for_status()
+
+            if response.status_code == 404:
+                raise Exception("Instance not found")
+            elif response.status_code > 250:
+                raise Exception(f"Error fetching instance, status code: {response.status_code}")
+
+            res_data = json.loads(response.text)
+            return res_data
+
+        def create_instance(self, instance):
+            self.login({
+                'email': self.email,
+                'password': self.password
+            })
+            instance_id = instance["name"]
+            headers = {'Authorization': f"Bearer {self.loginCookie['AccessToken']}"}
+            url = f"{self.url}/{self.version}/instances?instance_id=f{instance_id}"
+            # instanceId = instance.get("title")
+            # url = f"{self.url}/{self.version}/environments/101/instances?instanceId={instanceId}"
+            response = requests.post(url, headers=headers, json=instance)
+            response.raise_for_status()
+            res_data = json.loads(response.text)
+            return res_data

--- a/deploy/bytebase/templates/script.yaml
+++ b/deploy/bytebase/templates/script.yaml
@@ -7,8 +7,6 @@ data:
     set -o errexit
     set -e
 
-
-    pip install requests kubernetes
     URL="${BYTEBASE_ENTRYPOINT_PORT_8080_TCP_ADDR}:${BYTEBASE_ENTRYPOINT_PORT_8080_TCP_PORT}"
     echo URL
     retry_count=0
@@ -45,7 +43,7 @@ data:
         config.load_incluster_config()
         # config.load_config()
         v1 = client.CoreV1Api()
-        namespace = os.getenv("KB_NAMESPACE") or "default"
+        # namespace = os.getenv("KB_NAMESPACE") or "default"
 
         # clusters contain the cluster label and the corresponding engine type.
         clusters = [
@@ -54,12 +52,13 @@ data:
             ['app.kubernetes.io/name=mongodb', API.MONGODB],
             ['app.kubernetes.io/name=redis', API.REDIS]
         ]
-        url = sys.argv[1] or os.getenv("BYTEBASE_ENTRYPOINT_PORT_8080_TCP_ADDR")
-        # url = os.getenv("BYTEBASE_ENTRYPOINT_PORT_8080_TCP_ADDR") or ""  # exit("get bytebase address failed")
-        port = sys.argv[2] or os.getenv("BYTEBASE_ENTRYPOINT_PORT_8080_TCP_PORT")  # exit("get bytebase port failed")
+        if len(sys.argv) >= 3:
+            url = sys.argv[1]
+            port = sys.argv[2]  # exit("get bytebase port failed")
+        else:
+            url = os.getenv("BYTEBASE_ENTRYPOINT_PORT_8080_TCP_ADDR")
+            port = os.getenv("BYTEBASE_ENTRYPOINT_PORT_8080_TCP_PORT")
         client = Client(f"{url}:{port}", "v1")
-
-        # client = Client("http://localhost:18080", "v1")
 
         signup = {
             "state": "ACTIVE",
@@ -73,53 +72,50 @@ data:
 
         res = client.signup(signup)
         print("signup result: ", res[0], res[1])
-        #
-        # create a new environment
-        new_environment = {
-            "uid": "kubeblocks",
-            "name": "environments/kubeblocks",
-            "title": "kubeblocks",
-            "state": API.StateActive,
-            "tier": API.TierUnprotected
-        }
-        res = client.create_environment(new_environment)
-        print(res)
 
-        # get service
+        res, code = client.get_environment()
+        if code != 200:
+          # create a new environment
+          new_environment = {
+              "uid": "kubeblocks",
+              "name": "environments/kubeblocks",
+              "title": "kubeblocks",
+              "state": API.StateActive,
+              "tier": API.TierUnprotected
+          }
+          res = client.create_environment(new_environment)
+          print(res)
+
+        # inject cluster
         for info in clusters:
             label = info[0]
             engine_type = info[1]
-            # services = v1.list_namespaced_service(namespace=namespace, label_selector=label)
             secrets = v1.list_namespaced_secret(namespace="", label_selector=label)
             for s in secrets.items:
-                # print(s.data["host"], s.data["port"], s.data["username"], s.data["password"])
-                # print(base64.b64decode(s.data["host"]).decode("utf-8"),
-                #       base64.b64decode(s.data["port"]).decode("utf-8"),
-                #       base64.b64decode(s.data["username"]).decode("utf-8"),
-                #       base64.b64decode(s.data["password"]).decode("utf-8"),
-                #       s.metadata.owner_references[0].name)
                 name = s.metadata.owner_references[0].name
-                username = base64.b64decode(s.data["username"]).decode("utf-8")
-                password = base64.b64decode(s.data["password"]).decode("utf-8")
-                host = base64.b64decode(s.data["host"]).decode("utf-8")
-                port = base64.b64decode(s.data["port"]).decode("utf-8")
-                new_instance = {
-                    "name": name,
-                    "title": name,
-                    "state": API.StateActive,
-                    "engine": engine_type,
-                    "dataSources": [{
-                        # "title": "",
-                        "type": API.ADMIN,
-                        "username": username,
-                        "password": password,
-                        "host": host,
-                        "port": port,
-                    }],
-                    "environment": "environments/kubeblocks",
-                }
-                res = client.create_instance(new_instance)
-                print(res)
+                code, date = client.get_instance(name)
+                if code != 200:
+                  username = base64.b64decode(s.data["username"]).decode("utf-8")
+                  password = base64.b64decode(s.data["password"]).decode("utf-8")
+                  host = base64.b64decode(s.data["host"]).decode("utf-8")
+                  port = base64.b64decode(s.data["port"]).decode("utf-8")
+                  new_instance = {
+                      "name": name,
+                      "title": name,
+                      "state": API.StateActive,
+                      "engine": engine_type,
+                      "dataSources": [{
+                          # "title": "",
+                          "type": API.ADMIN,
+                          "username": username,
+                          "password": password,
+                          "host": host,
+                          "port": port,
+                      }],
+                      "environment": "environments/kubeblocks",
+                  }
+                  res = client.create_instance(new_instance)
+                  print(res)
 
 
   bytebase_api.py: |
@@ -212,9 +208,8 @@ data:
             url = f"{self.url}/{self.version}/environments/{environment_name}"
             headers = {'Authorization': f"Bearer {self.loginCookie['AccessToken']}"}
             response = requests.get(url, headers=headers)
-            response.raise_for_status()
             res_data = json.loads(response.text)
-            return res_data
+            return res_data, response.status_code
 
         def create_environment(self, environment):
             self.login({
@@ -233,22 +228,12 @@ data:
                 'email': self.email,
                 'password': self.password
             })
-            # url = f"{self.url}/{self.version}/environments/{environment_name}"
-
             instance_name = f"instances/{name}"
             url = f"{self.url}/{self.version}/{instance_name}"
-            # self.client.head()
             headers = {'Authorization': f"Bearer {self.loginCookie['AccessToken']}"}
             response = requests.get(url, headers=headers)
-            response.raise_for_status()
-
-            if response.status_code == 404:
-                raise Exception("Instance not found")
-            elif response.status_code > 250:
-                raise Exception(f"Error fetching instance, status code: {response.status_code}")
-
             res_data = json.loads(response.text)
-            return res_data
+            return response.status_code, res_data
 
         def create_instance(self, instance):
             self.login({
@@ -257,9 +242,7 @@ data:
             })
             instance_id = instance["name"]
             headers = {'Authorization': f"Bearer {self.loginCookie['AccessToken']}"}
-            url = f"{self.url}/{self.version}/instances?instance_id=f{instance_id}"
-            # instanceId = instance.get("title")
-            # url = f"{self.url}/{self.version}/environments/101/instances?instanceId={instanceId}"
+            url = f"{self.url}/{self.version}/instances?instance_id={instance_id}"
             response = requests.post(url, headers=headers, json=instance)
             response.raise_for_status()
             res_data = json.loads(response.text)

--- a/deploy/helm/templates/addons/bytebase-addon.yaml
+++ b/deploy/helm/templates/addons/bytebase-addon.yaml
@@ -16,7 +16,6 @@ spec:
   helm:
     # use the ApeCloud's chart repository since Bytebase's image doesn't currently support ARM64
     chartLocationURL: https://jihulab.com/api/v4/projects/85949/packages/helm/stable/charts/bytebase-0.4.0.tgz
-    # chartLocationURL: https://github.com/apecloud/helm-charts/releases/download/bytebase-0.1.0/bytebase-0.1.0.tgz
   installable:
     autoInstall: false
 

--- a/deploy/helm/templates/addons/bytebase-addon.yaml
+++ b/deploy/helm/templates/addons/bytebase-addon.yaml
@@ -15,7 +15,7 @@ spec:
 
   helm:
     # use the ApeCloud's chart repository since Bytebase's image doesn't currently support ARM64
-    chartLocationURL: https://jihulab.com/api/v4/projects/85949/packages/helm/stable/charts/bytebase-0.3.0.tgz
+    chartLocationURL: https://jihulab.com/api/v4/projects/85949/packages/helm/stable/charts/bytebase-0.4.0.tgz
     # chartLocationURL: https://github.com/apecloud/helm-charts/releases/download/bytebase-0.1.0/bytebase-0.1.0.tgz
   installable:
     autoInstall: false


### PR DESCRIPTION
- do more to fix : https://github.com/apecloud/kubeblocks/issues/4636


The more integrated Bytebase we can use now! When we enable bytebase addon, we can use the email `admin@example.com` and password `admin` to login and all the clusters created by Kubeblocks will already added into Bytebase in the `kubeblocks` enviroment.

What i do:
Add a k8s `job` when bytebase start up and it will perform a series of actions, including user registration, environment creation, and instance creation by invoking the Bytebase API.
And it's easy to reach auto injection for new clusters in KB after Bytebase addon enabled. Just change the `job` to a `CronJob`.

usage:
1.  `kbcli addon enble bytebase`
2.  `kbcli dashboard open bytebase`
3. login by email: `admin@example.com` and  password: `admin`
![image](https://github.com/apecloud/kubeblocks/assets/101848970/4b217c03-23ba-45c2-b259-4c0dfb78dbf1)
![image](https://github.com/apecloud/kubeblocks/assets/101848970/12561c7c-e9fc-4827-a1b2-c48dc5e95af4)
