### PR TITLE
feat: verify the parameters are allowed to be modified (#4804)

### DIFF
--- a/internal/cli/cmd/cluster/config_edit.go
+++ b/internal/cli/cmd/cluster/config_edit.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/cmd/util/editor"
@@ -119,6 +120,14 @@ func (o *editConfigOptions) Run(fn func(info *cfgcore.ConfigPatchInfo, cc *appsv
 	dynamicUpdated, err := cfgcore.IsUpdateDynamicParameters(&configConstraint.Spec, configPatch)
 	if err != nil {
 		return nil
+	}
+
+	// check immutable parameters
+	if len(configConstraint.Spec.ImmutableParameters) > 0 {
+		params := cfgcore.GenerateVisualizedParamsList(configPatch, formatterConfig, nil)
+		if err = util.ValidateParametersModified2(sets.KeySet(fromKeyValuesToMap(params, o.CfgFile)), configConstraint.Spec); err != nil {
+			return err
+		}
 	}
 
 	confirmPrompt := confirmApplyReconfigurePrompt

--- a/internal/cli/cmd/cluster/config_ops.go
+++ b/internal/cli/cmd/cluster/config_ops.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/templates"
@@ -98,6 +99,9 @@ func (o *configOpsOptions) Validate() error {
 		return nil
 	}
 	if err := o.validateConfigParams(o.wrapper.ConfigTemplateSpec()); err != nil {
+		return err
+	}
+	if err := util.ValidateParametersModified(o.wrapper.ConfigTemplateSpec(), sets.KeySet(o.KeyValues), o.Dynamic); err != nil {
 		return err
 	}
 	o.printConfigureTips()

--- a/internal/cli/util/util.go
+++ b/internal/cli/util/util.go
@@ -42,7 +42,6 @@ import (
 	"text/template"
 	"time"
 
-	cfgutil "github.com/apecloud/kubeblocks/internal/configuration/util"
 	"github.com/fatih/color"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -75,6 +74,7 @@ import (
 	"github.com/apecloud/kubeblocks/internal/cli/testing"
 	"github.com/apecloud/kubeblocks/internal/cli/types"
 	cfgcore "github.com/apecloud/kubeblocks/internal/configuration"
+	cfgutil "github.com/apecloud/kubeblocks/internal/configuration/util"
 	"github.com/apecloud/kubeblocks/internal/constant"
 )
 

--- a/internal/configuration/reconfigure_util.go
+++ b/internal/configuration/reconfigure_util.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"reflect"
 
-	"github.com/StudioSol/set"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -104,11 +103,11 @@ func IsUpdateDynamicParameters(cc *appsv1alpha1.ConfigConstraintSpec, cfg *Confi
 	if err != nil {
 		return false, err
 	}
-	updateParams := set.NewLinkedHashSetString(params...)
+	updateParams := util.NewSet(params...)
 
 	// if ConfigConstraint has StaticParameters, check updated parameter
 	if len(cc.StaticParameters) > 0 {
-		staticParams := set.NewLinkedHashSetString(cc.StaticParameters...)
+		staticParams := util.NewSet(cc.StaticParameters...)
 		union := util.Union(staticParams, updateParams)
 		if union.Length() > 0 {
 			return false, nil
@@ -121,7 +120,7 @@ func IsUpdateDynamicParameters(cc *appsv1alpha1.ConfigConstraintSpec, cfg *Confi
 
 	// if ConfigConstraint has DynamicParameter, and all updated params are dynamic
 	if len(cc.DynamicParameters) > 0 {
-		dynamicParams := set.NewLinkedHashSetString(cc.DynamicParameters...)
+		dynamicParams := util.NewSet(cc.DynamicParameters...)
 		diff := util.Difference(updateParams, dynamicParams)
 		return diff.Length() == 0, nil
 	}


### PR DESCRIPTION
Some parameters, such as datadir, that are not allowed to be modified, which may cause the engine to fail to restart.

This feature depends on configconstraints.spec.**_immutableParameters_**.

