### PR TITLE
chore: auto cherry-pick workflow

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -16,6 +16,6 @@ jobs:
           fetch-depth: 0
 
       - name: Automatic Cherry Pick
-        uses: vendoo/gha-cherry-pick@v1
+        uses: apecloud/gha-cherry-pick@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -1,0 +1,21 @@
+name: CHERRY-PICK
+on:
+  issue_comment:
+    types: [created]
+
+
+jobs:
+  cherry-pick:
+    name: Cherry Pick
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/cherry-pick')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Automatic Cherry Pick
+        uses: vendoo/gha-cherry-pick@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
resolve #3758 
cherry-pick preconditions:
1. PR is merged.
2. The target branch exists and has no conflict.
3. The target branch is not a protected branch.
```
Usage:
 /cherry-pick release-0.6
```
cherry-pick success
![image](https://github.com/apecloud/kubeblocks/assets/109708205/dc85705d-a4dd-412d-8588-392f7011b43d)

cherry-pick error
![image](https://github.com/apecloud/kubeblocks/assets/109708205/23f2e033-8069-4132-812a-fe0681145886)
