### PR TITLE
fix: improve frontend and configmap for greptimedb

### DIFF
--- a/deploy/greptimedb-cluster/Chart.yaml
+++ b/deploy/greptimedb-cluster/Chart.yaml
@@ -4,6 +4,6 @@ description: A greptimedb cluster Helm chart for KubeBlocks.
 
 type: application
 
-version: 0.1.0-beta.0
+version: 0.1.0-beta.1
 
 appVersion: "0.3.2"

--- a/deploy/greptimedb/Chart.yaml
+++ b/deploy/greptimedb/Chart.yaml
@@ -3,7 +3,7 @@ name: greptimedb
 description: GreptimeDB Cluster Helm Chart for KubeBlocks.
 
 # This is the chart version
-version: 0.1.0-beta.0
+version: 0.1.0-beta.1
 
 # This is the version number of greptimedb
 appVersion: "0.3.2"

--- a/deploy/greptimedb/templates/clusterdefinition.yaml
+++ b/deploy/greptimedb/templates/clusterdefinition.yaml
@@ -19,6 +19,10 @@ spec:
       characterType: greptimedb
       probes:
       configSpecs:
+        - name: greptimedb-frontend
+          templateRef: greptimedb-frontend
+          volumeName: frontend-config
+          namespace: {{ .Release.Namespace }}
       service:
         ports:
           - name: http
@@ -87,7 +91,7 @@ spec:
             terminationMessagePolicy: File
             volumeMounts:
               - mountPath: /etc/greptimedb
-                name: config
+                name: frontend-config
             args:
               - frontend
               - start
@@ -120,17 +124,17 @@ spec:
         terminationGracePeriodSeconds: 10
         dnsPolicy: ClusterFirst
         restartPolicy: Always
-        volumes:
-          - configMap:
-              defaultMode: 420
-              name: greptimedb-frontend
-            name: config
+
     - name: datanode
       workloadType: Stateful
       characterType: greptimedb
       probes:
       logConfigs:
       configSpecs:
+        - name: greptimedb-datanode
+          templateRef: greptimedb-datanode
+          volumeName: datanode-config
+          namespace: {{ .Release.Namespace }}
       service:
         ports:
           - name: http
@@ -226,21 +230,22 @@ spec:
               - mountPath: /etc/greptimedb
                 name: config
               - mountPath: /etc/greptimedb-init
-                name: init-config
+                name: datanode-config
         serviceAccountName: greptimedb-cluster
         terminationGracePeriodSeconds: 10
         volumes:
           - emptyDir: {}
             name: config
-          - configMap:
-              defaultMode: 420
-              name: greptimedb-datanode
-            name: init-config
+
     - name: meta
       workloadType: Stateless
       characterType: greptimedb
       probes:
       configSpecs:
+        - name: greptimedb-meta
+          templateRef: greptimedb-meta
+          volumeName: meta-config
+          namespace: {{ .Release.Namespace }}
       service:
         ports:
           - name: grpc
@@ -298,7 +303,7 @@ spec:
                 name: http
             volumeMounts:
               - mountPath: /etc/greptimedb
-                name: config
+                name: meta-config
             args:
               - metasrv
               - start
@@ -319,11 +324,7 @@ spec:
         terminationGracePeriodSeconds: 10
         dnsPolicy: ClusterFirst
         restartPolicy: Always
-        volumes:
-          - configMap:
-              defaultMode: 420
-              name: greptimedb-meta
-            name: config
+
     - name: etcd
       workloadType: Consensus
       characterType: etcd

--- a/deploy/greptimedb/templates/clusterdefinition.yaml
+++ b/deploy/greptimedb/templates/clusterdefinition.yaml
@@ -43,7 +43,25 @@ spec:
             - name: GREPTIMEDB_META_SVC
               valueFrom:
                 type: ServiceRef
+        - &datanodeRef
+          componentDefName: datanode
+          componentRefEnv:
+            - name: GREPTIMEDB_DATANODE_SVC
+              valueFrom:
+                type: ServiceRef
       podSpec:
+        initContainers:
+          - name: wait-datanode
+            image: busybox:1.28
+            imagePullPolicy: {{default .Values.images.pullPolicy "IfNotPresent"}}
+            command:
+              - bin/sh
+              - -c
+              - |
+                until nslookup $(GREPTIMEDB_DATANODE_SVC)-headless.$(KB_NAMESPACE).svc{{ .Values.clusterDomain }}; do
+                  # frontend requires at least one datanode is ready
+                  echo "waiting for datanode"; sleep 2;
+                done;
         containers:
           - name: frontend
             imagePullPolicy: {{default .Values.images.pullPolicy "IfNotPresent"}}
@@ -65,16 +83,6 @@ spec:
               periodSeconds: 10
               successThreshold: 1
               timeoutSeconds: 3
-            startupProbe:
-              failureThreshold: 15
-              httpGet:
-                path: /health
-                port: 4000
-                scheme: HTTP
-              initialDelaySeconds: 30
-              periodSeconds: 10
-              successThreshold: 1
-              timeoutSeconds: 3
             terminationMessagePath: /dev/termination-log
             terminationMessagePolicy: File
             volumeMounts:
@@ -84,7 +92,7 @@ spec:
               - frontend
               - start
               - --metasrv-addr
-              - $(GREPTIMEDB_META_SVC)-headless.$(KB_NAMESPACE).svc{{ .Values.clusterDomain }}:3002
+              - $(GREPTIMEDB_META_SVC).$(KB_NAMESPACE).svc{{ .Values.clusterDomain }}:3002
               - --http-addr
               - 0.0.0.0:4000
               - --grpc-addr
@@ -155,16 +163,6 @@ spec:
               periodSeconds: 10
               successThreshold: 1
               timeoutSeconds: 3
-            startupProbe:
-              failureThreshold: 15
-              httpGet:
-                path: /health
-                port: 4000
-                scheme: HTTP
-              initialDelaySeconds: 20
-              periodSeconds: 10
-              successThreshold: 1
-              timeoutSeconds: 3
             terminationMessagePath: /dev/termination-log
             terminationMessagePolicy: File
             volumeMounts:
@@ -181,13 +179,24 @@ spec:
               - datanode
               - start
               - --metasrv-addr
-              - $(GREPTIMEDB_META_SVC)-headless.$(KB_NAMESPACE).svc{{ .Values.clusterDomain }}:3002
+              - $(GREPTIMEDB_META_SVC).$(KB_NAMESPACE).svc{{ .Values.clusterDomain }}:3002
               - --http-addr
               - 0.0.0.0:4000
               - --config-file
               - /etc/greptimedb/config.toml
         dnsPolicy: ClusterFirst
         initContainers:
+          - name: wait-meta
+            image: busybox:1.28
+            imagePullPolicy: {{default .Values.images.pullPolicy "IfNotPresent"}}
+            command:
+              - bin/sh
+              - -c
+              - |
+                until nslookup $(GREPTIMEDB_META_SVC)-headless.$(KB_NAMESPACE).svc{{ .Values.clusterDomain }}; do
+                  # datanode requires at least one meta is ready
+                  echo "waiting for meta"; sleep 2;
+                done;
           - name: initializer
             args:
               - --config-path
@@ -248,6 +257,17 @@ spec:
               valueFrom:
                 type: ServiceRef
       podSpec:
+        initContainers:
+          - name: wait-etcd
+            image: busybox:1.28
+            imagePullPolicy: {{default .Values.images.pullPolicy "IfNotPresent"}}
+            command:
+              - bin/sh
+              - -c
+              - |
+                until nslookup $(GREPTIMEDB_ETCD_SVC)-headless.$(KB_NAMESPACE).svc{{ .Values.clusterDomain }}; do
+                  echo "waiting for etcd"; sleep 2;
+                done;
         containers:
           - name: meta
             imagePullPolicy: {{default .Values.images.pullPolicy "IfNotPresent"}}
@@ -269,18 +289,13 @@ spec:
               periodSeconds: 10
               successThreshold: 1
               timeoutSeconds: 3
-            startupProbe:
-              failureThreshold: 15
-              httpGet:
-                path: /health
-                port: 4000
-                scheme: HTTP
-              initialDelaySeconds: 10
-              periodSeconds: 10
-              successThreshold: 1
-              timeoutSeconds: 3
             terminationMessagePath: /dev/termination-log
             terminationMessagePolicy: File
+            ports:
+              - containerPort: 3002
+                name: grpc
+              - containerPort: 4000
+                name: http
             volumeMounts:
               - mountPath: /etc/greptimedb
                 name: config
@@ -297,6 +312,9 @@ spec:
               - $(GREPTIMEDB_ETCD_SVC)-headless.$(KB_NAMESPACE).svc{{ .Values.clusterDomain }}:2379
               - --config-file
               - /etc/greptimedb/config.toml
+            env:
+              - name: GREPTIMEDB_METASRV__DISABLE_REGION_FAILOVER
+                value: {{ .Values.meta.disableRegionFailover | quote}}
         serviceAccountName: greptimedb-cluster
         terminationGracePeriodSeconds: 10
         dnsPolicy: ClusterFirst
@@ -356,13 +374,13 @@ spec:
                 DOMAIN=$KB_NAMESPACE".svc{{ .Values.clusterDomain }}"
                 i=0
                 while [ $i -lt $KB_REPLICA_COUNT ]; do
-                	if [ $i -ne 0 ]; then
-                		PEERS="$PEERS,";
-                	fi;
-                	host=$(eval echo \$KB_"$i"_HOSTNAME)
+                  if [ $i -ne 0 ]; then
+                    PEERS="$PEERS,";
+                  fi;
+                  host=$(eval echo \$KB_"$i"_HOSTNAME)
                   host=$host"."$DOMAIN
                   hostname=${KB_CLUSTER_COMP_NAME}-${i}
-                	PEERS="$PEERS$hostname=http://$host:2380"
+                  PEERS="$PEERS$hostname=http://$host:2380"
                   i=$(( i + 1 ))
                 done
                 MY_PEER=$KB_POD_FQDN{{ .Values.clusterDomain }}

--- a/deploy/greptimedb/templates/clusterdefinition.yaml
+++ b/deploy/greptimedb/templates/clusterdefinition.yaml
@@ -62,7 +62,7 @@ spec:
               - bin/sh
               - -c
               - |
-                until nslookup $(GREPTIMEDB_DATANODE_SVC)-headless.$(KB_NAMESPACE).svc{{ .Values.clusterDomain }}; do
+                until nslookup ${GREPTIMEDB_DATANODE_SVC}-headless.${KB_NAMESPACE}.svc{{ .Values.clusterDomain }}; do
                   # frontend requires at least one datanode is ready
                   echo "waiting for datanode"; sleep 2;
                 done;
@@ -197,7 +197,7 @@ spec:
               - bin/sh
               - -c
               - |
-                until nslookup $(GREPTIMEDB_META_SVC)-headless.$(KB_NAMESPACE).svc{{ .Values.clusterDomain }}; do
+                until nslookup ${GREPTIMEDB_META_SVC}-headless.${KB_NAMESPACE}.svc{{ .Values.clusterDomain }}; do
                   # datanode requires at least one meta is ready
                   echo "waiting for meta"; sleep 2;
                 done;
@@ -270,7 +270,7 @@ spec:
               - bin/sh
               - -c
               - |
-                until nslookup $(GREPTIMEDB_ETCD_SVC)-headless.$(KB_NAMESPACE).svc{{ .Values.clusterDomain }}; do
+                until nslookup ${GREPTIMEDB_ETCD_SVC}-headless.${KB_NAMESPACE}.svc{{ .Values.clusterDomain }}; do
                   echo "waiting for etcd"; sleep 2;
                 done;
         containers:

--- a/deploy/greptimedb/values.yaml
+++ b/deploy/greptimedb/values.yaml
@@ -18,3 +18,8 @@ images:
   etcd:
     repository: docker.io/greptime/etcd
     tag: v3.5.5
+
+## @param metasrv config
+##
+meta:
+  disableRegionFailover: true


### PR DESCRIPTION
Fixes #4827 

- add a env for meta to fix the inner bug for greptimedb
- add init containers for components to refine startup order
- using `configSpec` to mount configmap
