### PR TITLE
chore: fix some bug and refine reconfiguring operator

### DIFF
--- a/controllers/apps/configuration/config_util.go
+++ b/controllers/apps/configuration/config_util.go
@@ -372,13 +372,17 @@ func updateConfigConstraintStatus(cli client.Client, ctx intctrlutil.RequestCtx,
 	return cli.Status().Patch(ctx.Ctx, configConstraint, patch)
 }
 
-func createConfigPatch(cfg *corev1.ConfigMap, format appsv1alpha1.CfgFileFormat, cmKeys []string) (*core.ConfigPatchInfo, bool, error) {
+func createConfigPatch(cfg *corev1.ConfigMap, formatter *appsv1alpha1.FormatterConfig, cmKeys []string) (*core.ConfigPatchInfo, bool, error) {
+	// support full update
+	if formatter == nil {
+		return nil, true, nil
+	}
 	lastConfig, err := getLastVersionConfig(cfg)
 	if err != nil {
 		return nil, false, core.WrapError(err, "failed to get last version data. config[%v]", client.ObjectKeyFromObject(cfg))
 	}
 
-	return core.CreateConfigPatch(lastConfig, cfg.Data, format, cmKeys, true)
+	return core.CreateConfigPatch(lastConfig, cfg.Data, formatter.Format, cmKeys, true)
 }
 
 func updateConfigSchema(cc *appsv1alpha1.ConfigConstraint, cli client.Client, ctx context.Context) error {

--- a/controllers/apps/configuration/reconfigure_policy.go
+++ b/controllers/apps/configuration/reconfigure_policy.go
@@ -198,7 +198,7 @@ func (receiver AutoReloadPolicy) GetPolicyName() string {
 }
 
 func NewReconfigurePolicy(cc *appsv1alpha1.ConfigConstraintSpec, cfgPatch *core.ConfigPatchInfo, policy appsv1alpha1.UpgradePolicy, restart bool) (reconfigurePolicy, error) {
-	if !cfgPatch.IsModify {
+	if cfgPatch != nil && !cfgPatch.IsModify {
 		// not walk here
 		return nil, core.MakeError("cfg not modify. [%v]", cfgPatch)
 	}

--- a/controllers/apps/configuration/reconfigurerequest_controller.go
+++ b/controllers/apps/configuration/reconfigurerequest_controller.go
@@ -108,8 +108,8 @@ func (r *ReconfigureRequestReconciler) Reconcile(ctx context.Context, req ctrl.R
 
 	tpl := &appsv1alpha1.ConfigConstraint{}
 	cfgConstraintsName, ok := config.Labels[constant.CMConfigurationConstraintsNameLabelKey]
-	if !ok || len(cfgConstraintsName) == 0 {
-		reqCtx.Log.V(1).Info("configuration without ConfigConstraints, does not support reconfiguring.")
+	if !ok || cfgConstraintsName == "" {
+		reqCtx.Log.Info("configuration without ConfigConstraints.")
 	} else {
 		if err := r.Client.Get(reqCtx.Ctx, types.NamespacedName{
 			Namespace: config.Namespace,

--- a/controllers/apps/operations/pipeline.go
+++ b/controllers/apps/operations/pipeline.go
@@ -1,0 +1,229 @@
+/*
+Copyright (C) 2022-2023 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package operations
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
+	cfgcore "github.com/apecloud/kubeblocks/internal/configuration/core"
+	intctrlutil "github.com/apecloud/kubeblocks/internal/controllerutil"
+)
+
+type reconfigureContext struct {
+	// reconfiguring request
+	config appsv1alpha1.Configuration
+
+	cli      client.Client
+	reqCtx   intctrlutil.RequestCtx
+	resource *OpsResource
+
+	clusterName   string
+	componentName string
+	configSpecs   []appsv1alpha1.ComponentConfigSpec
+}
+
+type pipeline struct {
+	err      error
+	isFailed bool
+
+	mergedConfig  map[string]string
+	configPatch   *cfgcore.ConfigPatchInfo
+	isFileUpdated bool
+
+	configMap        *corev1.ConfigMap
+	configConstraint *appsv1alpha1.ConfigConstraint
+	configSpec       *appsv1alpha1.ComponentConfigSpec
+
+	reconfigureContext
+}
+
+func (p *pipeline) wrapper(fn func() error) (ret *pipeline) {
+	ret = p
+	if ret.err != nil {
+		return
+	}
+	ret.err = fn()
+	return
+}
+
+func (p pipeline) foundConfigSpec(name string) *appsv1alpha1.ComponentConfigSpec {
+	if len(name) == 0 && len(p.configSpecs) == 1 {
+		return &p.configSpecs[0]
+	}
+	for _, configSpec := range p.configSpecs {
+		if configSpec.Name == name {
+			return &configSpec
+		}
+	}
+	return nil
+}
+
+func (p *pipeline) ValidateParameters() *pipeline {
+	validateFn := func() error {
+		configSpec := p.foundConfigSpec(p.config.Name)
+		if configSpec != nil {
+			p.configSpec = configSpec
+			return nil
+		}
+		p.isFailed = true
+		return cfgcore.MakeError(
+			"failed to reconfigure, not existed config[%s], all configs: %v",
+			p.config.Name, getConfigSpecName(p.configSpecs))
+	}
+	return p.wrapper(validateFn)
+}
+
+func (p *pipeline) ConfigMap() *pipeline {
+	cmKey := client.ObjectKey{
+		Name:      cfgcore.GetComponentCfgName(p.clusterName, p.componentName, p.configSpec.Name),
+		Namespace: p.resource.Cluster.Namespace,
+	}
+
+	return p.wrapper(func() error {
+		p.configMap = &corev1.ConfigMap{}
+		return p.cli.Get(p.reqCtx.Ctx, cmKey, p.configMap)
+	})
+}
+
+func (p *pipeline) ConfigConstraints() *pipeline {
+	validateFn := func() (err error) {
+		if !hasFileUpdate(p.config) {
+			p.isFailed = true
+			err = cfgcore.MakeError(
+				"current configSpec not support reconfigure, configSpec: %v",
+				p.configSpec.Name)
+		}
+		return
+	}
+
+	ccKey := client.ObjectKey{
+		Namespace: p.configSpec.Namespace,
+		Name:      p.configSpec.ConfigConstraintRef,
+	}
+	fetchCCFn := func() error {
+		p.configConstraint = &appsv1alpha1.ConfigConstraint{}
+		return p.cli.Get(p.reqCtx.Ctx, ccKey, p.configConstraint)
+	}
+
+	return p.wrapper(func() error {
+		if p.configSpec.ConfigConstraintRef == "" {
+			return validateFn()
+		} else {
+			return fetchCCFn()
+		}
+	})
+}
+
+func (p *pipeline) doMerge() error {
+	var err error
+	var newCfg map[string]string
+
+	cm := p.configMap
+	cc := p.configConstraint
+	config := p.config
+
+	updatedFiles := make(map[string]string, len(config.Keys))
+	updatedParams := make([]cfgcore.ParamPairs, 0, len(config.Keys))
+	for _, key := range config.Keys {
+		if key.FileContent != "" {
+			updatedFiles[key.Key] = key.FileContent
+			continue
+		}
+		if len(key.Parameters) > 0 {
+			updatedParams = append(updatedParams, cfgcore.ParamPairs{
+				Key:           key.Key,
+				UpdatedParams: fromKeyValuePair(key.Parameters)})
+		}
+	}
+
+	if newCfg, err = mergeUpdatedParams(cm.Data, updatedFiles, updatedParams, cc, *p.configSpec); err != nil {
+		p.isFailed = true
+		return err
+	}
+
+	p.mergedConfig = newCfg
+
+	// for full update
+	if cc == nil {
+		p.isFileUpdated = true
+		return nil
+	}
+
+	// for patch update
+	configPatch, restart, err := cfgcore.CreateConfigPatch(cm.Data,
+		newCfg,
+		cc.Spec.FormatterConfig.Format,
+		p.configSpec.Keys,
+		len(updatedFiles) != 0)
+	if err != nil {
+		return err
+	}
+	p.isFileUpdated = restart
+	p.configPatch = configPatch
+	return nil
+}
+
+func (p *pipeline) Merge() *pipeline {
+	return p.wrapper(p.doMerge)
+}
+
+func (p *pipeline) Sync() *pipeline {
+	return p.wrapper(func() error {
+		var cc *appsv1alpha1.ConfigConstraintSpec
+		var configSpec = *p.configSpec
+
+		if p.configConstraint != nil {
+			cc = &p.configConstraint.Spec
+		}
+		return syncConfigmap(p.configMap,
+			p.mergedConfig,
+			p.cli,
+			p.reqCtx.Ctx,
+			p.resource.OpsRequest.Name,
+			configSpec,
+			cc,
+			p.config.Policy)
+	})
+}
+
+func (p *pipeline) Complete() reconfiguringResult {
+	if p.err != nil {
+		return makeReconfiguringResult(p.err, withFailed(p.isFailed))
+	}
+
+	return makeReconfiguringResult(nil,
+		withReturned(p.mergedConfig, p.configPatch),
+		withNoFormatFilesUpdated(p.isFileUpdated))
+}
+
+func newPipeline(context reconfigureContext) *pipeline {
+	return &pipeline{reconfigureContext: context}
+}
+
+func hasFileUpdate(config appsv1alpha1.Configuration) bool {
+	for _, key := range config.Keys {
+		if key.FileContent != "" {
+			return true
+		}
+	}
+	return false
+}

--- a/controllers/apps/operations/pipeline.go
+++ b/controllers/apps/operations/pipeline.go
@@ -146,12 +146,12 @@ func (p *pipeline) doMerge() error {
 	for _, key := range config.Keys {
 		if key.FileContent != "" {
 			updatedFiles[key.Key] = key.FileContent
-			continue
 		}
 		if len(key.Parameters) > 0 {
 			updatedParams = append(updatedParams, cfgcore.ParamPairs{
 				Key:           key.Key,
-				UpdatedParams: fromKeyValuePair(key.Parameters)})
+				UpdatedParams: fromKeyValuePair(key.Parameters),
+			})
 		}
 	}
 

--- a/controllers/apps/operations/reconfigure_util.go
+++ b/controllers/apps/operations/reconfigure_util.go
@@ -79,12 +79,12 @@ func updateConfigConfigmapResource(config appsv1alpha1.Configuration,
 	for _, key := range config.Keys {
 		if key.FileContent != "" {
 			updatedFiles[key.Key] = key.FileContent
-			continue
 		}
 		if len(key.Parameters) > 0 {
 			updatedParams = append(updatedParams, core.ParamPairs{
 				Key:           key.Key,
-				UpdatedParams: fromKeyValuePair(key.Parameters)})
+				UpdatedParams: fromKeyValuePair(key.Parameters),
+			})
 		}
 	}
 

--- a/controllers/apps/operations/reconfigure_util.go
+++ b/controllers/apps/operations/reconfigure_util.go
@@ -47,6 +47,7 @@ type reconfiguringResult struct {
 
 type updateReconfigureStatus func(params []core.ParamPairs, orinalData map[string]string, formatter *appsv1alpha1.FormatterConfig) error
 
+// Deprecated: use NewPipeline instead
 // updateConfigConfigmapResource merges parameters of the config into the configmap, and verifies final configuration file.
 func updateConfigConfigmapResource(config appsv1alpha1.Configuration,
 	configSpec appsv1alpha1.ComponentConfigSpec,

--- a/controllers/apps/operations/reconfigure_util.go
+++ b/controllers/apps/operations/reconfigure_util.go
@@ -263,7 +263,7 @@ func constructReconfiguringConditions(result reconfiguringResult, resource *OpsR
 			resource.OpsRequest,
 			appsv1alpha1.ReasonReconfigureMerged,
 			configSpec.Name,
-			formatReconfiguringMessage(result.configPatch))
+			formatConfigPatchToMessage(result.configPatch, nil))
 	}
 	return appsv1alpha1.NewReconfigureRunningCondition(
 		resource.OpsRequest,
@@ -306,17 +306,13 @@ func processMergedFailed(resource *OpsResource, isInvalid bool, err error) error
 	return nil
 }
 
-func formatReconfiguringMessage(configPatch *core.ConfigPatchInfo) string {
-	if configPatch != nil {
-		return formatConfigPatchToMessage(configPatch, nil)
-	}
-	return "updated full config files."
-}
-
 func formatConfigPatchToMessage(configPatch *core.ConfigPatchInfo, execStatus *core.PolicyExecStatus) string {
 	policyName := ""
 	if execStatus != nil {
 		policyName = fmt.Sprintf("updated policy: <%s>, ", execStatus.PolicyName)
+	}
+	if configPatch == nil {
+		return fmt.Sprintf("%supdated full config files.", policyName)
 	}
 	return fmt.Sprintf("%supdated: %s, added: %s, deleted:%s",
 		policyName,

--- a/controllers/apps/operations/reconfigure_util.go
+++ b/controllers/apps/operations/reconfigure_util.go
@@ -321,17 +321,3 @@ func formatConfigPatchToMessage(configPatch *core.ConfigPatchInfo, execStatus *c
 		configPatch.AddConfig,
 		configPatch.DeleteConfig)
 }
-
-func getClusterVersionResource(cvName string, cv *appsv1alpha1.ClusterVersion, cli client.Client, ctx context.Context) error {
-	if cvName == "" {
-		return nil
-	}
-	clusterVersionKey := client.ObjectKey{
-		Namespace: "",
-		Name:      cvName,
-	}
-	if err := cli.Get(ctx, clusterVersionKey, cv); err != nil {
-		return core.WrapError(err, "failed to get clusterversion[%s]", cvName)
-	}
-	return nil
-}

--- a/internal/cli/cmd/cluster/config_edit.go
+++ b/internal/cli/cmd/cluster/config_edit.go
@@ -94,6 +94,7 @@ func (o *editConfigOptions) Run(fn func() error) error {
 		return o.runWithConfigConstraints(cfgEditContext, configSpec, fn)
 	}
 
+	o.HasPatch = false
 	o.FileContent = cfgEditContext.getEdited()
 	return fn()
 }

--- a/internal/cli/cmd/cluster/config_edit.go
+++ b/internal/cli/cmd/cluster/config_edit.go
@@ -94,6 +94,14 @@ func (o *editConfigOptions) Run(fn func() error) error {
 		return o.runWithConfigConstraints(cfgEditContext, configSpec, fn)
 	}
 
+	yes, err := o.confirmReconfigure(fmt.Sprintf(fullRestartConfirmPrompt, printer.BoldRed(o.CfgFile)))
+	if err != nil {
+		return err
+	}
+	if !yes {
+		return nil
+	}
+
 	o.HasPatch = false
 	o.FileContent = cfgEditContext.getEdited()
 	return fn()

--- a/internal/cli/cmd/cluster/config_ops_test.go
+++ b/internal/cli/cmd/cluster/config_ops_test.go
@@ -108,6 +108,7 @@ var _ = Describe("reconfigure test", func() {
 			},
 		}
 		o.KeyValues = make(map[string]*string)
+		o.HasPatch = true
 		defer ttf.Cleanup()
 
 		By("validate reconfiguring parameters")

--- a/internal/cli/cmd/cluster/errors.go
+++ b/internal/cli/cmd/cluster/errors.go
@@ -60,7 +60,7 @@ func makeConfigSpecNotExistErr(clusterName, component, configSpec string) error 
 }
 
 func makeNotFoundTemplateErr(clusterName, component string) error {
-	return cfgcore.MakeError(notFoundValidConfigTemplateErrorMessage, clusterName, component)
+	return cfgcore.MakeError(notFoundValidConfigTemplateErrorMessage, component, clusterName)
 }
 
 func makeNotFoundConfigFileErr(configFile, configSpec string, all []string) error {

--- a/internal/cli/cmd/cluster/errors.go
+++ b/internal/cli/cmd/cluster/errors.go
@@ -44,6 +44,7 @@ var (
 	notConfigSchemaPrompt         = "The config template[%s] is not defined in schema and parameter explanation info cannot be generated."
 	cue2openAPISchemaFailedPrompt = "The cue schema may not satisfy the conversion constraints of openAPISchema and parameter explanation info cannot be generated."
 	restartConfirmPrompt          = "The parameter change incurs a cluster restart, which brings the cluster down for a while. Enter to continue...\n, "
+	fullRestartConfirmPrompt      = "The config file[%s] change incurs a cluster restart, which brings the cluster down for a while. Enter to continue...\n, "
 	confirmApplyReconfigurePrompt = "Are you sure you want to apply these changes?\n"
 )
 

--- a/internal/cli/cmd/cluster/operations.go
+++ b/internal/cli/cmd/cluster/operations.go
@@ -84,6 +84,7 @@ type OperationsOptions struct {
 	CfgFile         string             `json:"cfgFile"`
 	ForceRestart    bool               `json:"forceRestart"`
 	FileContent     string             `json:"fileContent"`
+	HasPatch        bool               `json:"hasPatch"`
 
 	// VolumeExpansion options.
 	// VCTNames VolumeClaimTemplate names
@@ -112,6 +113,7 @@ func newBaseOperationsOptions(f cmdutil.Factory, streams genericclioptions.IOStr
 	o := &OperationsOptions{
 		// nil cannot be set to a map struct in CueLang, so init the map of KeyValues.
 		KeyValues:             map[string]*string{},
+		HasPatch:              true,
 		OpsType:               opsType,
 		HasComponentNamesFlag: hasComponentNamesFlag,
 		autoApprove:           false,

--- a/internal/cli/create/template/cluster_operations_template.cue
+++ b/internal/cli/create/template/cluster_operations_template.cue
@@ -35,6 +35,7 @@ options: {
 	storage:  string
 	vctNames: [...string]
 	keyValues: [string]: {string | null}
+	hasPatch:        bool
 	fileContent:     string
 	cfgTemplateName: string
 	cfgFile:         string
@@ -131,10 +132,12 @@ content: {
 						if options.fileContent != "" {
 							fileContent: options.fileContent
 						}
-						parameters: [ for k, v in options.keyValues {
-							key:   k
-							value: v
-						}]
+						if options.hasPatch {
+							parameters: [ for k, v in options.keyValues {
+								key:   k
+								value: v
+							}]
+						}
 					}]
 				}]
 			}

--- a/internal/cli/util/util.go
+++ b/internal/cli/util/util.go
@@ -461,7 +461,7 @@ func GetConfigTemplateListWithResource(cComponents []appsv1alpha1.ClusterCompone
 	if err != nil {
 		return nil, err
 	}
-	if !reloadTpl {
+	if !reloadTpl || len(configSpecs) == 1 {
 		return configSpecs, nil
 	}
 
@@ -506,10 +506,16 @@ func GetComponentsFromClusterName(key client.ObjectKey, cli dynamic.Interface) (
 
 // GetComponentsFromResource returns name of component.
 func GetComponentsFromResource(componentSpecs []appsv1alpha1.ClusterComponentSpec, clusterDefObj *appsv1alpha1.ClusterDefinition) ([]string, error) {
+	filter := func(component *appsv1alpha1.ClusterComponentDefinition) bool {
+		if component != nil && len(componentSpecs) == 1 {
+			return true
+		}
+		return enableReconfiguring(component)
+	}
 	componentNames := make([]string, 0, len(componentSpecs))
 	for _, component := range componentSpecs {
 		cdComponent := clusterDefObj.GetComponentDefByName(component.ComponentDefRef)
-		if enableReconfiguring(cdComponent) {
+		if filter(cdComponent) {
 			componentNames = append(componentNames, component.Name)
 		}
 	}


### PR DESCRIPTION
1. fix kbcli edit-config prompt typo;
2. fix a bug in the validation of file changes;
3. refine reconfiguring operation, stream programming mode to eliminate a lot of conditional judgments, and make code clearer;
```go
result := pipeline.ValidateParameters().
		ConfigMap().
		ConfigConstraints().
		Merge().
		Sync().
		Complete()

```
4. Second confirmation when the configuration file changes:
![image](https://github.com/apecloud/kubeblocks/assets/111836083/4a76711d-8a71-4a34-a622-fbbc28aac9c3)
