### PR TITLE
chore: check containers.volumeMounts and containers.envFrom (#4421)

### DIFF
--- a/controllers/apps/configuration/config_related_helper.go
+++ b/controllers/apps/configuration/config_related_helper.go
@@ -63,7 +63,8 @@ func retrieveRelatedComponentsByConfigmap[T generics.Object, L generics.ObjList[
 		}
 		// filter config manager sidecar container
 		contains := intctrlutil.GetContainersByConfigmap(podTemplate.Spec.Containers,
-			volumeMounted.Name, func(containerName string) bool {
+			volumeMounted.Name, core.GenerateEnvFromName(cfg.Name),
+			func(containerName string) bool {
 				return constant.ConfigSidecarName == containerName
 			})
 		if len(contains) > 0 {

--- a/controllers/apps/configuration/config_util.go
+++ b/controllers/apps/configuration/config_util.go
@@ -325,6 +325,9 @@ func validateConfigTemplate(cli client.Client, ctx intctrlutil.RequestCtx, confi
 			logger.Error(err, "failed to get config template cm object!")
 			return nil, err
 		}
+		if configSpec.VolumeName == "" && len(configSpec.AsEnvFrom) == 0 {
+			return nil, core.MakeError("config template volume name and envFrom is empty!")
+		}
 		if configSpec.ConfigConstraintRef == "" {
 			return nil, nil
 		}

--- a/internal/configuration/core/type.go
+++ b/internal/configuration/core/type.go
@@ -21,6 +21,7 @@ package core
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/StudioSol/set"
 	"github.com/go-logr/logr"
@@ -171,4 +172,9 @@ func getInstanceCfgCMName(objName, tplName string) string {
 // GetComponentCfgName is similar to getInstanceCfgCMName, while without statefulSet object.
 func GetComponentCfgName(clusterName, componentName, tplName string) string {
 	return getInstanceCfgCMName(fmt.Sprintf("%s-%s", clusterName, componentName), tplName)
+}
+
+// GenerateEnvFromName generates env configmap name
+func GenerateEnvFromName(originName string) string {
+	return strings.Join([]string{originName, "envfrom"}, "-")
 }

--- a/internal/controller/plan/envfrom_utils.go
+++ b/internal/controller/plan/envfrom_utils.go
@@ -21,7 +21,6 @@ package plan
 
 import (
 	"context"
-	"strings"
 
 	"github.com/spf13/cast"
 	corev1 "k8s.io/api/core/v1"
@@ -129,7 +128,7 @@ func fetchConfigmap(localObjs []client.Object, cmName, namespace string, cli cli
 
 func createEnvFromConfigmap(cluster *appsv1alpha1.Cluster, componentName string, template appsv1alpha1.ComponentConfigSpec, originKey client.ObjectKey, envMap map[string]string, ctx context.Context, cli client.Client) (*corev1.ConfigMap, error) {
 	cmKey := client.ObjectKey{
-		Name:      generateEnvFromName(originKey.Name),
+		Name:      core.GenerateEnvFromName(originKey.Name),
 		Namespace: originKey.Namespace,
 	}
 	cm := &corev1.ConfigMap{}
@@ -219,7 +218,7 @@ func SyncEnvConfigmap(configSpec appsv1alpha1.ComponentConfigSpec, cmObj *corev1
 
 func updateEnvFromConfigmap(origObj client.ObjectKey, envMap map[string]string, cli client.Client, ctx context.Context) error {
 	cmKey := client.ObjectKey{
-		Name:      generateEnvFromName(origObj.Name),
+		Name:      core.GenerateEnvFromName(origObj.Name),
 		Namespace: origObj.Namespace,
 	}
 	cm := &corev1.ConfigMap{}
@@ -232,8 +231,4 @@ func updateEnvFromConfigmap(origObj client.ObjectKey, envMap map[string]string, 
 		return err
 	}
 	return nil
-}
-
-func generateEnvFromName(originName string) string {
-	return strings.Join([]string{originName, "envfrom"}, "-")
 }

--- a/internal/controller/plan/envfrom_utils_test.go
+++ b/internal/controller/plan/envfrom_utils_test.go
@@ -122,7 +122,7 @@ var _ = Describe("ConfigEnvFrom test", func() {
 			configSpec.Keys = []string{"env-config"}
 
 			cmObj := origCMObject.DeepCopy()
-			cmObj.SetName(generateEnvFromName(origCMObject.Name))
+			cmObj.SetName(core.GenerateEnvFromName(origCMObject.Name))
 			k8sMockClient.MockGetMethod(testutil.WithGetReturned(testutil.WithConstructSimpleGetResult([]client.Object{
 				cmObj,
 				configConstraint,
@@ -141,7 +141,7 @@ var _ = Describe("ConfigEnvFrom test", func() {
 
 			configSpec.AsEnvFrom = nil
 			cmObj := origCMObject.DeepCopy()
-			cmObj.SetName(generateEnvFromName(origCMObject.Name))
+			cmObj.SetName(core.GenerateEnvFromName(origCMObject.Name))
 			k8sMockClient.MockGetMethod(testutil.WithGetReturned(testutil.WithConstructSimpleGetResult([]client.Object{
 				cmObj,
 				configConstraint,

--- a/internal/controller/plan/prepare_test.go
+++ b/internal/controller/plan/prepare_test.go
@@ -384,7 +384,7 @@ var _ = Describe("Cluster Controller", func() {
 				Expect(reflect.TypeOf(resources[i]).String()).Should(ContainSubstring(v), fmt.Sprintf("failed at idx %d", i))
 				if isStatefulSet(v) {
 					sts := resources[i].(*appsv1.StatefulSet)
-					Expect(checkEnvFrom(&sts.Spec.Template.Spec.Containers[0], generateEnvFromName(cfgcore.GetComponentCfgName(cluster.Name, component.Name, configSpecName)))).Should(BeTrue())
+					Expect(checkEnvFrom(&sts.Spec.Template.Spec.Containers[0], cfgcore.GenerateEnvFromName(cfgcore.GetComponentCfgName(cluster.Name, component.Name, configSpecName)))).Should(BeTrue())
 				}
 			}
 		})

--- a/internal/controllerutil/pod_utils.go
+++ b/internal/controllerutil/pod_utils.go
@@ -86,7 +86,7 @@ func GetContainerByConfigSpec(podSpec *corev1.PodSpec, configs []appsv1alpha1.Co
 // GetPodContainerWithVolumeMount searches for containers mounting the volume
 func GetPodContainerWithVolumeMount(podSpec *corev1.PodSpec, volumeName string) []*corev1.Container {
 	containers := podSpec.Containers
-	if len(containers) == 0 {
+	if len(containers) == 0 || volumeName == "" {
 		return nil
 	}
 	return getContainerWithVolumeMount(containers, volumeName)

--- a/internal/controllerutil/pod_utils_test.go
+++ b/internal/controllerutil/pod_utils_test.go
@@ -571,7 +571,7 @@ var _ = Describe("pod utils", func() {
 					envFrom:    "test-config-env",
 					filters: []containerNameFilter{
 						func(name string) bool {
-							return name == "mysql"
+							return false
 						},
 					},
 				},

--- a/internal/controllerutil/volume_util.go
+++ b/internal/controllerutil/volume_util.go
@@ -68,6 +68,9 @@ func CreateOrUpdatePodVolumes(podSpec *corev1.PodSpec, volumes map[string]appsv1
 	// Update PodTemplate Volumes
 	for _, cmName := range volumeKeys {
 		templateSpec := volumes[cmName]
+		if templateSpec.VolumeName == "" {
+			continue
+		}
 		if podVolumes, err = CreateOrUpdateVolume(podVolumes, templateSpec.VolumeName, func(volumeName string) corev1.Volume {
 			return corev1.Volume{
 				Name: volumeName,


### PR DESCRIPTION
The current configuration operator assumes that the configmap is mounted, and the configmap associated with envFrom will not be reconcile.