### PR TITLE
fix: failed to update statefulSet for rsm component when reconfiguring

### DIFF
--- a/controllers/apps/configuration/config_reconcile_wrapper.go
+++ b/controllers/apps/configuration/config_reconcile_wrapper.go
@@ -197,9 +197,7 @@ func (c *configReconcileContext) rsm() *configReconcileContext {
 		// fix uid mismatch bug: convert rsm to sts
 		for _, rsm := range c.RSMList {
 			var stsObject appv1.StatefulSet
-			sts := components.ConvertRSMToSTS(&rsm)
-			err = c.Client.Get(c.Ctx, client.ObjectKeyFromObject(sts), &stsObject)
-			if err != nil {
+			if err = c.Client.Get(c.Ctx, client.ObjectKeyFromObject(components.ConvertRSMToSTS(&rsm)), &stsObject); err != nil {
 				return
 			}
 			c.StatefulSets = append(c.StatefulSets, stsObject)

--- a/controllers/apps/configuration/reconfigurerequest_controller.go
+++ b/controllers/apps/configuration/reconfigurerequest_controller.go
@@ -36,7 +36,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
-	"github.com/apecloud/kubeblocks/controllers/apps/components"
 	cfgcm "github.com/apecloud/kubeblocks/internal/configuration/config_manager"
 	"github.com/apecloud/kubeblocks/internal/configuration/core"
 	"github.com/apecloud/kubeblocks/internal/constant"
@@ -191,19 +190,11 @@ func (r *ReconfigureRequestReconciler) sync(reqCtx intctrlutil.RequestCtx, confi
 			"related component does not have any configSpecs, skip reconfigure")
 		return intctrlutil.Reconciled()
 	}
-	if len(reconcileContext.StatefulSets) == 0 && len(reconcileContext.Deployments) == 0 && len(reconcileContext.RSMList) == 0 {
+	if len(reconcileContext.StatefulSets) == 0 && len(reconcileContext.Deployments) == 0 {
 		reqCtx.Recorder.Eventf(config,
 			corev1.EventTypeWarning, appsv1alpha1.ReasonReconfigureFailed,
 			"the configmap is not used by any container, skip reconfigure")
 		return intctrlutil.Reconciled()
-	}
-	// TODO(free6om): configuration controller needs workload type to do the config reloading job.
-	// it's a rather hacky way converting rsm to sts to make configuration controller works as usual.
-	// should make configuration controller recognizing rsm.
-	if len(reconcileContext.RSMList) > 0 {
-		for _, rsm := range reconcileContext.RSMList {
-			reconcileContext.StatefulSets = append(reconcileContext.StatefulSets, *components.ConvertRSMToSTS(&rsm))
-		}
 	}
 
 	return r.performUpgrade(reconfigureParams{


### PR DESCRIPTION
1. fix update bug;
2. the rsm related logic is in the configReconcileContext.rsm, Configuration reconcile does not depend on rsm.