### PR TITLE
fix: fix jupyter-hub enable fail in GKE

### DIFF
--- a/deploy/helm/templates/addons/jupyterhub-addon.yaml
+++ b/deploy/helm/templates/addons/jupyterhub-addon.yaml
@@ -14,8 +14,7 @@ spec:
   type: Helm
 
   helm:
-    #  chartLocationURL: https://jihulab.com/api/v4/projects/85949/packages/helm/stable/charts/jupyterhub-0.1.0.tgz
-    chartLocationURL: https://jupyterhub.github.io/helm-chart/jupyterhub-3.0.2-0.dev.git.6297.h3f5cb91f.tgz
+    chartLocationURL: https://jihulab.com/api/v4/projects/85949/packages/helm/stable/charts/jupyterhub-0.1.0.tgz
     installValues:
       setValues:
         - proxy.service.type=ClusterIP


### PR DESCRIPTION
- fix: #4932

Jupyter-hub officail helm chart url https://jupyterhub.github.io/helm-chart/jupyterhub-3.0.2.tgz is not attachable in GKE.
So we use our mirror url for jupyter-hub.

Jupyter-notebooks seems already running in my test and not need to fix.