### PR TITLE
chore: upload gitlab asset error retry

### DIFF
--- a/.github/utils/release_gitlab.sh
+++ b/.github/utils/release_gitlab.sh
@@ -180,8 +180,14 @@ create_release() {
 
 upload_asset() {
     request_url=$API_URL/$PROJECT_ID/packages/generic/$PACKAGE_NAME/$TAG_NAME/
-
-    gitlab_api_curl $request_url --upload-file $ASSET_PATH
+    for i in {1..10}; do
+        ret_msg=$(gitlab_api_curl $request_url --upload-file $ASSET_PATH)
+        echo "return message:$ret_msg"
+        if [[ "$ret_msg" == *"201 Created"* ]]; then
+            break
+        fi
+        sleep 1
+    done
 }
 
 download_asset() {


### PR DESCRIPTION
fix upload gitlab asset  {"message":"500 Internal Server Error"} retry
![image](https://github.com/apecloud/kubeblocks/assets/109708205/8c03982d-c546-41b2-b957-099cbc78b3b2)
