### PR TITLE
fix: solving the problem of private image pulling

### DIFF
--- a/controllers/apps/components/utils.go
+++ b/controllers/apps/components/utils.go
@@ -645,7 +645,12 @@ func updateKubeBlocksToolsImage(pc *corev1.Container) {
 func getImageName(image string) string {
 	subs := strings.Split(image, ":")
 	if len(subs) != 2 {
-		return ""
+		if len(subs) == 3 {
+			lastIndex := strings.LastIndex(image, ":")
+			return image[:lastIndex]
+		} else {
+			return ""
+		}
 	}
 	return subs[0]
 }

--- a/controllers/apps/components/utils.go
+++ b/controllers/apps/components/utils.go
@@ -644,15 +644,15 @@ func updateKubeBlocksToolsImage(pc *corev1.Container) {
 
 func getImageName(image string) string {
 	subs := strings.Split(image, ":")
-	if len(subs) != 2 {
-		if len(subs) == 3 {
-			lastIndex := strings.LastIndex(image, ":")
-			return image[:lastIndex]
-		} else {
-			return ""
-		}
+	switch len(subs) {
+	case 2:
+		return subs[0]
+	case 3:
+		lastIndex := strings.LastIndex(image, ":")
+		return image[:lastIndex]
+	default:
+		return ""
 	}
-	return subs[0]
 }
 
 // getCustomLabelSupportKind returns the kinds that support custom label.


### PR DESCRIPTION
My K8S cluster and image repository deploy in private network enviroment. K8S cluster can not pull image from public network. I need to parse image named as  xxx.xxx.xxx:port/imagename:tag in a private image repo.When I vertically scale the redis/mysql cluster, the image is replaced by  "KUBEBLOCKS_TOOLS_IMAGE".