### PR TITLE
chore: update rw values

### DIFF
--- a/deploy/risingwave-cluster/values.schema.json
+++ b/deploy/risingwave-cluster/values.schema.json
@@ -1,0 +1,63 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "risingwave": {
+            "type": "object",
+            "properties": {
+                "metaStore": {
+                    "type": "object",
+                    "properties": {
+                        "etcd": {
+                            "type": "object",
+                            "properties": {
+                                "endpoints": {
+                                    "title": "ETCD EndPoints",
+                                    "description": "Specify ETCD cluster endpoints of the form host:port",
+                                    "type": "string",
+                                    "pattern": "^.+:\\d+$"
+                                }
+                            }
+                        }
+                    }
+                },
+                "stateStore": {
+                    "type": "object",
+                    "properties": {
+                        "s3": {
+                            "type": "object",
+                            "properties": {
+                                "authentication": {
+                                    "type": "object",
+                                    "properties": {
+                                        "accessKey": {
+                                            "$ref": "#/definitions/nonEmptyString"
+                                        },
+                                        "secretAccessKey": {
+                                            "$ref": "#/definitions/nonEmptyString"
+                                        }
+                                    }
+                                },
+                                "bucket": {
+                                    "$ref": "#/definitions/nonEmptyString"
+                                },
+                                "endpoint": {
+                                    "$ref": "#/definitions/nonEmptyString"
+                                },
+                                "region": {
+                                    "$ref": "#/definitions/nonEmptyString"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "nonEmptyString": {
+            "type": "string",
+            "minLength": 1
+        }
+    }
+}

--- a/deploy/risingwave-cluster/values.yaml
+++ b/deploy/risingwave-cluster/values.yaml
@@ -138,7 +138,7 @@ risingwave:
       ## @param risingwave.metaStore.etcd.endpoint
       ## etcd endpoint.
       ##
-      endpoints: "etcd:2379"
+      endpoints: ""
 
       ## @param risingwave.metaStore.etcd.authentication
       ## etcd authentication.


### PR DESCRIPTION
- fix #5085  
Risingwave depends on an exisited ETCD Cluster, and S3 credentials. So we add some constraints in its `values.schema.json`.