### PR TITLE
feat: Support Oceanbase Cluster

### DIFF
--- a/deploy/oceanbase-cluster/.helmignore
+++ b/deploy/oceanbase-cluster/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/oceanbase-cluster/Chart.yaml
+++ b/deploy/oceanbase-cluster/Chart.yaml
@@ -6,4 +6,4 @@ type: application
 
 version: 0.0.1-alpha1
 
-appVersion: "4.1.0.0"
+appVersion: "4.2.0.0-100010032023083021"

--- a/deploy/oceanbase-cluster/Chart.yaml
+++ b/deploy/oceanbase-cluster/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: oceanbase-cluster
+description: A oceanbase cluster Helm chart for KubeBlocks.
+
+type: application
+
+version: 0.0.1-alpha1
+
+appVersion: "4.1.0.0"

--- a/deploy/oceanbase-cluster/templates/NOTES.txt
+++ b/deploy/oceanbase-cluster/templates/NOTES.txt
@@ -1,0 +1,15 @@
+/*
+Copyright (c) 2023 OceanBase
+ob-operator is licensed under Mulan PSL v2.
+You can use this software according to the terms and conditions of the Mulan PSL v2.
+You may obtain a copy of Mulan PSL v2 at:
+         http://license.coscl.org.cn/MulanPSL2
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+See the Mulan PSL v2 for more details.
+*/
+
+Unlimited scalable distributed database for data-intensive transactional and real-time operational analytics workloads, with ultra-fast performance that has once achieved world records in the TPC-C benchmark test. 
+
+OceanBase has served over 400 customers across the globe and has been supporting all mission critical systems in Alipay.

--- a/deploy/oceanbase-cluster/templates/NOTES.txt
+++ b/deploy/oceanbase-cluster/templates/NOTES.txt
@@ -1,14 +1,14 @@
-/*
-Copyright (c) 2023 OceanBase
-ob-operator is licensed under Mulan PSL v2.
-You can use this software according to the terms and conditions of the Mulan PSL v2.
-You may obtain a copy of Mulan PSL v2 at:
-         http://license.coscl.org.cn/MulanPSL2
-THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
-EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
-MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
-See the Mulan PSL v2 for more details.
-*/
+/**
+ * Copyright (c) 2021 OceanBase
+ * OceanBase CE is licensed under Mulan PubL v2.
+ * You can use this software according to the terms and conditions of the Mulan PubL v2.
+ * You may obtain a copy of Mulan PubL v2 at:
+ *          http://license.coscl.org.cn/MulanPubL-2.0
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PubL v2 for more details.
+ */
 
 Unlimited scalable distributed database for data-intensive transactional and real-time operational analytics workloads, with ultra-fast performance that has once achieved world records in the TPC-C benchmark test. 
 

--- a/deploy/oceanbase-cluster/templates/_helpers.tpl
+++ b/deploy/oceanbase-cluster/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "oceanbase.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "oceanbase.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "oceanbase.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "oceanbase.labels" -}}
+helm.sh/chart: {{ include "oceanbase.chart" . }}
+{{ include "oceanbase.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "oceanbase.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "oceanbase.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "oceanbase.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "oceanbase.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/oceanbase-cluster/templates/cluster.yaml
+++ b/deploy/oceanbase-cluster/templates/cluster.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: Cluster
+metadata:
+  name: {{ include "oceanbase.fullname" . }}
+  labels: 
+    {{- include "oceanbase.labels" . | nindent 4 }}
+spec:
+  clusterDefinitionRef: oceanbase
+  clusterVersionRef: oceanbase-{{ default .Chart.AppVersion .Values.clusterVersionOverride }}
+  terminationPolicy: {{ .Values.terminationPolicy }}
+  componentSpecs:
+    - name: ob-bundle
+      componentDefRef: ob-bundle
+      serviceAccountName: {{ .Values.clusterName }}-observer-sa
+      replicas: {{ .Values.replicas | default 1 }}
+      volumeClaimTemplates:
+        {{- range $key, $val := .Values.resources.storages }}
+        - name: {{ $key }}
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: {{ $val | quote }}
+        {{- end }}

--- a/deploy/oceanbase-cluster/templates/role.yaml
+++ b/deploy/oceanbase-cluster/templates/role.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Values.clusterName }}-statefulset-reader
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+  {{- include "oceanbase.labels" . | nindent 4 }}
+rules:
+- apiGroups: ["apps"] # "" indicates the core API group
+  resources: ["statefulsets"]
+  verbs: ["get", "watch", "list"]

--- a/deploy/oceanbase-cluster/templates/rolebinding.yaml
+++ b/deploy/oceanbase-cluster/templates/rolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Values.clusterName }}-read-statefulsets
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+  {{- include "oceanbase.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.clusterName }}-observer-sa 
+- kind: ServiceAccount
+  name: kb-{{ .Values.clusterName }}
+roleRef:
+  kind: Role
+  name: {{ .Values.clusterName }}-statefulset-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/oceanbase-cluster/templates/serviceaccount.yaml
+++ b/deploy/oceanbase-cluster/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.clusterName }}-observer-sa
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+  {{- include "oceanbase.labels" . | nindent 4 }}

--- a/deploy/oceanbase-cluster/values.yaml
+++ b/deploy/oceanbase-cluster/values.yaml
@@ -20,4 +20,3 @@ resources:
     data-file: 50Gi
     data-log: 50Gi
     log: 20Gi
-    monitor-conf: 2Gi

--- a/deploy/oceanbase-cluster/values.yaml
+++ b/deploy/oceanbase-cluster/values.yaml
@@ -1,0 +1,23 @@
+# Default values for oceanbase-cluster.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+
+nameOverride: ""
+fullnameOverride: ""
+clusterVersionOverride: "4.2.0.0-100010032023083021"
+
+terminationPolicy: "Delete"
+
+clusterName: obcluster
+
+replicas: 3
+
+resources:
+  cpu: 2.2
+  memory: 11Gi
+  storages:
+    data-file: 50Gi
+    data-log: 50Gi
+    log: 20Gi
+    monitor-conf: 2Gi

--- a/deploy/oceanbase/.helmignore
+++ b/deploy/oceanbase/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/oceanbase/Chart.yaml
+++ b/deploy/oceanbase/Chart.yaml
@@ -6,4 +6,4 @@ type: application
 
 version: 0.0.1-alpha1
 
-appVersion: "4.1.0.0"
+appVersion: "4.2.0.0-100010032023083021"

--- a/deploy/oceanbase/Chart.yaml
+++ b/deploy/oceanbase/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: oceanbase
+description: "Unlimited scalable distributed database for data-intensive transactional and real-time operational analytics workloads, with ultra-fast performance that has once achieved world records in the TPC-C benchmark test. OceanBase has served over 400 customers across the globe and has been supporting all mission critical systems in Alipay."
+
+type: application
+
+version: 0.0.1-alpha1
+
+appVersion: "4.1.0.0"

--- a/deploy/oceanbase/templates/NOTES.txt
+++ b/deploy/oceanbase/templates/NOTES.txt
@@ -1,0 +1,15 @@
+/*
+Copyright (c) 2023 OceanBase
+ob-operator is licensed under Mulan PSL v2.
+You can use this software according to the terms and conditions of the Mulan PSL v2.
+You may obtain a copy of Mulan PSL v2 at:
+         http://license.coscl.org.cn/MulanPSL2
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+See the Mulan PSL v2 for more details.
+*/
+
+Unlimited scalable distributed database for data-intensive transactional and real-time operational analytics workloads, with ultra-fast performance that has once achieved world records in the TPC-C benchmark test. 
+
+OceanBase has served over 400 customers across the globe and has been supporting all mission critical systems in Alipay.

--- a/deploy/oceanbase/templates/NOTES.txt
+++ b/deploy/oceanbase/templates/NOTES.txt
@@ -1,14 +1,14 @@
-/*
-Copyright (c) 2023 OceanBase
-ob-operator is licensed under Mulan PSL v2.
-You can use this software according to the terms and conditions of the Mulan PSL v2.
-You may obtain a copy of Mulan PSL v2 at:
-         http://license.coscl.org.cn/MulanPSL2
-THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
-EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
-MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
-See the Mulan PSL v2 for more details.
-*/
+/**
+ * Copyright (c) 2021 OceanBase
+ * OceanBase CE is licensed under Mulan PubL v2.
+ * You can use this software according to the terms and conditions of the Mulan PubL v2.
+ * You may obtain a copy of Mulan PubL v2 at:
+ *          http://license.coscl.org.cn/MulanPubL-2.0
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PubL v2 for more details.
+ */
 
 Unlimited scalable distributed database for data-intensive transactional and real-time operational analytics workloads, with ultra-fast performance that has once achieved world records in the TPC-C benchmark test. 
 

--- a/deploy/oceanbase/templates/_helpers.tpl
+++ b/deploy/oceanbase/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "oceanbase.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "oceanbase.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "oceanbase.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "oceanbase.labels" -}}
+helm.sh/chart: {{ include "oceanbase.chart" . }}
+{{ include "oceanbase.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "oceanbase.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "oceanbase.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "oceanbase.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "oceanbase.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/oceanbase/templates/clusterdefinition.yaml
+++ b/deploy/oceanbase/templates/clusterdefinition.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   connectionCredential:
     username: root
-    # password: "$(RANDOM_PASSWD)"
     password: ""
     endpoint: "$(SVC_FQDN):$(SVC_PORT_sql)"
     host: "$(SVC_FQDN)"
@@ -38,14 +37,6 @@ spec:
               - containerPort: 2882
                 name: rpc
                 protocol: TCP
-            # readinessProbe:
-            #   failureThreshold: 10
-            #   initialDelaySeconds: 5
-            #   periodSeconds: 2
-            #   successThreshold: 1
-            #   tcpSocket:
-            #     port: 2881
-            #   timeoutSeconds: 1
             resources:
               limits:
                 cpu: "2"
@@ -73,46 +64,3 @@ spec:
                   secretKeyRef:
                     name: $(CONN_CREDENTIAL_SECRET_NAME)
                     key: password
-          - name: obagent-container
-            env:
-              - name: OB_MONITOR_STATUS
-                value: active
-              - name: CLUSTER_NAME
-                value: obcluster
-              - name: CLUSTER_ID
-                value: "1"
-              - name: MONITOR_USER
-                value: monitor
-              - name: MONITOR_PASSWORD
-                value: {{ .Values.monitorPassword | quote }}
-            ports:
-              - containerPort: 8088
-                name: http
-                protocol: TCP
-              - containerPort: 8089
-                name: pprof
-                protocol: TCP
-            readinessProbe:
-              failureThreshold: 3
-              httpGet:
-                path: /metrics/stat
-                port: 8088
-                scheme: HTTP
-              initialDelaySeconds: 5
-              periodSeconds: 2
-              successThreshold: 1
-              timeoutSeconds: 1
-            resources:
-              limits:
-                cpu: 200m
-                memory: 1Gi
-              requests:
-                cpu: 200m
-                memory: 1Gi
-            volumeMounts:
-              - mountPath: /home/admin/obagent/conf
-                name: monitor-conf
-            workingDir: /home/admin/obagent
-
-
-

--- a/deploy/oceanbase/templates/clusterdefinition.yaml
+++ b/deploy/oceanbase/templates/clusterdefinition.yaml
@@ -1,0 +1,118 @@
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: ClusterDefinition
+metadata:
+  name: oceanbase
+  labels:
+    {{- include "oceanbase.labels" . | nindent 4 }}
+spec:
+  connectionCredential:
+    username: root
+    # password: "$(RANDOM_PASSWD)"
+    password: ""
+    endpoint: "$(SVC_FQDN):$(SVC_PORT_sql)"
+    host: "$(SVC_FQDN)"
+    port: "$(SVC_PORT_sql)"
+  componentDefs:
+    - name: ob-bundle
+      characterType: oceanbase
+      workloadType: Stateful
+      service:
+        ports:
+          - name: sql
+            port: 2881
+            targetPort: 2881
+          - name: rpc
+            port: 2882
+            targetPort: 2882
+      podSpec:
+        containers:
+          - name: observer-container
+            command:
+              - bash
+              - -c
+              - "./scripts/entrypoint.sh"
+            ports:
+              - containerPort: 2881
+                name: sql
+                protocol: TCP
+              - containerPort: 2882
+                name: rpc
+                protocol: TCP
+            # readinessProbe:
+            #   failureThreshold: 10
+            #   initialDelaySeconds: 5
+            #   periodSeconds: 2
+            #   successThreshold: 1
+            #   tcpSocket:
+            #     port: 2881
+            #   timeoutSeconds: 1
+            resources:
+              limits:
+                cpu: "2"
+                memory: 10Gi
+              requests:
+                cpu: "2"
+                memory: 10Gi
+            volumeMounts:
+              - mountPath: /home/admin/data-file
+                name: data-file
+              - mountPath: /home/admin/data-log
+                name: data-log
+              - mountPath: /home/admin/log
+                name: log
+            workingDir: /home/admin/oceanbase
+            env:
+              - name: LD_LIBRARY_PATH
+                value: /home/admin/oceanbase/lib
+              - name: ZONE_COUNT
+                value: {{ .Values.zoneCount | quote }}
+              - name: CLUSTER_NAME
+                value: "$(KB_CLUSTER_COMP_NAME)"
+              - name: DB_ROOT_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: $(CONN_CREDENTIAL_SECRET_NAME)
+                    key: password
+          - name: obagent-container
+            env:
+              - name: OB_MONITOR_STATUS
+                value: active
+              - name: CLUSTER_NAME
+                value: obcluster
+              - name: CLUSTER_ID
+                value: "1"
+              - name: MONITOR_USER
+                value: monitor
+              - name: MONITOR_PASSWORD
+                value: {{ .Values.monitorPassword | quote }}
+            ports:
+              - containerPort: 8088
+                name: http
+                protocol: TCP
+              - containerPort: 8089
+                name: pprof
+                protocol: TCP
+            readinessProbe:
+              failureThreshold: 3
+              httpGet:
+                path: /metrics/stat
+                port: 8088
+                scheme: HTTP
+              initialDelaySeconds: 5
+              periodSeconds: 2
+              successThreshold: 1
+              timeoutSeconds: 1
+            resources:
+              limits:
+                cpu: 200m
+                memory: 1Gi
+              requests:
+                cpu: 200m
+                memory: 1Gi
+            volumeMounts:
+              - mountPath: /home/admin/obagent/conf
+                name: monitor-conf
+            workingDir: /home/admin/obagent
+
+
+

--- a/deploy/oceanbase/templates/clusterversion.yaml
+++ b/deploy/oceanbase/templates/clusterversion.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: ClusterVersion
+metadata:
+  name: oceanbase-{{ default .Chart.AppVersion .Values.clusterVersionOverride }}
+  labels:
+    {{- include "oceanbase.labels" . | nindent 4 }}
+spec:
+  clusterDefinitionRef: oceanbase
+  componentVersions:
+  - componentDefRef: ob-bundle
+    versionsContext:
+      containers:
+      - name: observer-container
+        image: {{ .Values.images.registry | default "docker.io" }}/{{ .Values.images.observer.repository }}:{{ .Values.images.observer.tag }}
+        imagePullPolicy: {{ default .Values.images.pullPolicy "IfNotPresent" }}
+      - name: obagent-container
+        image: {{ .Values.images.registry | default "docker.io" }}/{{ .Values.images.obagent.repository }}:{{ .Values.images.obagent.tag }}
+        imagePullPolicy: {{ default .Values.images.pullPolicy "IfNotPresent" }}

--- a/deploy/oceanbase/templates/clusterversion.yaml
+++ b/deploy/oceanbase/templates/clusterversion.yaml
@@ -13,6 +13,3 @@ spec:
       - name: observer-container
         image: {{ .Values.images.registry | default "docker.io" }}/{{ .Values.images.observer.repository }}:{{ .Values.images.observer.tag }}
         imagePullPolicy: {{ default .Values.images.pullPolicy "IfNotPresent" }}
-      - name: obagent-container
-        image: {{ .Values.images.registry | default "docker.io" }}/{{ .Values.images.obagent.repository }}:{{ .Values.images.obagent.tag }}
-        imagePullPolicy: {{ default .Values.images.pullPolicy "IfNotPresent" }}

--- a/deploy/oceanbase/values.yaml
+++ b/deploy/oceanbase/values.yaml
@@ -8,12 +8,8 @@ images:
   observer:
     repository: oceanbase-chart
     tag: 4.2.0.0-100010032023083021
-  obagent:
-    repository: obagent
-    tag: 1.2.1-snapshot
 
 zoneCount: 3
-monitorPassword: "demo"
 
 nameOverride: ""
 fullnameOverride: ""

--- a/deploy/oceanbase/values.yaml
+++ b/deploy/oceanbase/values.yaml
@@ -1,0 +1,20 @@
+# Default values for oceanbase.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+images:
+  registry: oceanbasedev
+  pullPolicy: IfNotPresent
+  observer:
+    repository: oceanbase-chart
+    tag: 4.2.0.0-100010032023083021
+  obagent:
+    repository: obagent
+    tag: 1.2.1-snapshot
+
+zoneCount: 3
+monitorPassword: "demo"
+
+nameOverride: ""
+fullnameOverride: ""
+clusterVersionOverride: "4.2.0.0-100010032023083021"

--- a/internal/cli/create/template/cluster_template.cue
+++ b/internal/cli/create/template/cluster_template.cue
@@ -50,7 +50,7 @@ content: {
 			nodeLabels:      options.nodeLabels
 			tenancy:         options.tenancy
 		}
-		backup: options.backupConfig
+		backup:            options.backupConfig
 		tolerations:       options.tolerations
 		componentSpecs:    options.componentSpecs
 		terminationPolicy: options.terminationPolicy

--- a/lorry/engine/oceanbase.go
+++ b/lorry/engine/oceanbase.go
@@ -1,0 +1,93 @@
+/*
+Copyright (C) 2022-2023 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package engine
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ ClusterCommands = &oceanbase{}
+
+type oceanbase struct {
+	info     EngineInfo
+	examples map[ClientType]buildConnectExample
+}
+
+func newOceanbase() *oceanbase {
+	return &oceanbase{
+		info: EngineInfo{
+			Client: "mysql",
+		},
+		examples: map[ClientType]buildConnectExample{
+			CLI: func(info *ConnectionInfo) string {
+				return fmt.Sprintf(`# oceanbase client connection example
+mysql -h %s -P %s -u %s
+`, info.Host, info.Port, info.User)
+			},
+		},
+	}
+}
+
+func (r *oceanbase) ConnectCommand(connectInfo *AuthInfo) []string {
+	userName := "root"
+	userPass := ""
+
+	if connectInfo != nil {
+		userName = connectInfo.UserName
+		userPass = connectInfo.UserPasswd
+	}
+
+	var obCmd []string
+
+	if userPass != "" {
+		obCmd = []string{fmt.Sprintf("%s -P2881 -u%s -A -p%s", r.info.Client, userName, userPass)}
+	} else {
+		obCmd = []string{fmt.Sprintf("%s -P2881 -u%s -A", r.info.Client, userName)}
+	}
+
+	return []string{"bash", "-c", strings.Join(obCmd, " ")}
+}
+
+func (r *oceanbase) Container() string {
+	return r.info.Container
+}
+
+func (r *oceanbase) ConnectExample(info *ConnectionInfo, client string) string {
+	return buildExample(info, client, r.examples)
+}
+
+func (r *oceanbase) ExecuteCommand(scripts []string) ([]string, []corev1.EnvVar, error) {
+	cmd := []string{}
+	cmd = append(cmd, "/bin/bash", "-c", "-ex")
+	if envVarMap[password] == "" {
+		cmd = append(cmd, fmt.Sprintf("%s -P2881 -u%s -e %s", r.info.Client, envVarMap[user], strconv.Quote(strings.Join(scripts, " "))))
+	} else {
+		cmd = append(cmd, fmt.Sprintf("%s -P2881 -u%s -p%s -e %s", r.info.Client,
+			fmt.Sprintf("$%s", envVarMap[user]),
+			fmt.Sprintf("$%s", envVarMap[password]),
+			strconv.Quote(strings.Join(scripts, " "))))
+	}
+
+	return cmd, nil, nil
+}


### PR DESCRIPTION
- fix #5122 
Support Oceanbase Cluster

Features:
1. Ad-hoc cluster bootstrap 
2. Dynamically scale in and out
3. Instance crash recovery

DO NOT SUPPORT:
1. Modify zone count when cluster is running
2. Upgrade OB image version on the fly
3. Monitor system running status