### PR TITLE
fix: fix cluster register the same command, absolute path error and pre-check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/Shopify/sarama v1.37.2
 	github.com/StudioSol/set v1.0.0
 	github.com/apecloud/kubebench v0.0.0-20230807061913-16124b86637f
+	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/authzed/controller-idioms v0.7.0
 	github.com/aws/aws-sdk-go v1.44.257
 	github.com/benbjohnson/clock v1.3.5
@@ -143,7 +144,6 @@ require (
 	github.com/acomagu/bufpipe v1.0.4 // indirect
 	github.com/ahmetalpbalkan/go-cursor v0.0.0-20131010032410-8136607ea412 // indirect
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
-	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bhmj/xpression v0.9.1 // indirect

--- a/internal/cli/cluster/builtin_charts.go
+++ b/internal/cli/cluster/builtin_charts.go
@@ -52,7 +52,7 @@ func (e *embedConfig) loadChart() (io.ReadCloser, error) {
 	return e.chartFS.Open(fmt.Sprintf("charts/%s", e.name))
 }
 
-func (e *embedConfig) getChartFileName() string {
+func (e *embedConfig) GetChartFileName() string {
 	return e.name
 }
 
@@ -69,6 +69,10 @@ var (
 	//go:embed charts/mongodb-cluster.tgz
 	mongodbChart embed.FS
 )
+
+func IsbuiltinCharts(chart string) bool {
+	return chart == "mysql" || chart == "postgresql" || chart == "kafka" || chart == "redis" || chart == "mongodb"
+}
 
 // internal_chart registers embed chart
 

--- a/internal/cli/cluster/builtin_charts.go
+++ b/internal/cli/cluster/builtin_charts.go
@@ -52,7 +52,7 @@ func (e *embedConfig) loadChart() (io.ReadCloser, error) {
 	return e.chartFS.Open(fmt.Sprintf("charts/%s", e.name))
 }
 
-func (e *embedConfig) GetChartFileName() string {
+func (e *embedConfig) getChartFileName() string {
 	return e.name
 }
 

--- a/internal/cli/cluster/cluster_chart.go
+++ b/internal/cli/cluster/cluster_chart.go
@@ -234,7 +234,7 @@ func loadHelmChart(ci *ChartInfo, t ClusterType) error {
 	c, err := loader.LoadArchive(file)
 	if err != nil {
 		if err == gzip.ErrHeader {
-			return fmt.Errorf("file '%s' does not appear to be a valid chart file (details: %s)", cf.GetChartFileName(), err)
+			return fmt.Errorf("file '%s' does not appear to be a valid chart file (details: %s)", cf.getChartFileName(), err)
 		}
 	}
 

--- a/internal/cli/cluster/cluster_chart.go
+++ b/internal/cli/cluster/cluster_chart.go
@@ -220,6 +220,7 @@ func ValidateValues(c *ChartInfo, values map[string]interface{}) error {
 }
 
 func loadHelmChart(ci *ChartInfo, t ClusterType) error {
+	// cf references cluster config
 	cf, ok := ClusterTypeCharts[t]
 	if !ok {
 		return fmt.Errorf("failed to find the helm chart of %s", t)
@@ -233,7 +234,7 @@ func loadHelmChart(ci *ChartInfo, t ClusterType) error {
 	c, err := loader.LoadArchive(file)
 	if err != nil {
 		if err == gzip.ErrHeader {
-			return fmt.Errorf("file '%s' does not appear to be a valid chart file (details: %s)", cf.getChartFileName(), err)
+			return fmt.Errorf("file '%s' does not appear to be a valid chart file (details: %s)", cf.GetChartFileName(), err)
 		}
 	}
 

--- a/internal/cli/cluster/external_charts.go
+++ b/internal/cli/cluster/external_charts.go
@@ -146,7 +146,7 @@ func ClearCharts(c ClusterType) {
 			klog.V(2).Info(fmt.Sprintf("Warning: auto clear %s config fail due to: %s\n", c, err.Error()))
 
 		}
-		if err := os.Remove(filepath.Join(CliChartsCacheDir, ClusterTypeCharts[c].GetChartFileName())); err != nil {
+		if err := os.Remove(filepath.Join(CliChartsCacheDir, ClusterTypeCharts[c].getChartFileName())); err != nil {
 			klog.V(2).Info(fmt.Sprintf("Warning: auto clear %s config fail due to: %s\n", c, err.Error()))
 		}
 		CacheFiles = GetChartCacheFiles()
@@ -175,11 +175,11 @@ func (h *TypeInstance) PreCheck() error {
 		c, err := loader.LoadArchive(file)
 		if err != nil {
 			if err == gzip.ErrHeader {
-				return fmt.Errorf("file '%s' does not appear to be a valid chart file (details: %s)", h.GetChartFileName(), err)
+				return fmt.Errorf("file '%s' does not appear to be a valid chart file (details: %s)", h.getChartFileName(), err)
 			}
 		}
 		if c == nil {
-			return fmt.Errorf("failed to load cluster helm chart %s", h.GetChartFileName())
+			return fmt.Errorf("failed to load cluster helm chart %s", h.getChartFileName())
 		}
 		chartInfo.Chart = c
 	}
@@ -190,10 +190,10 @@ func (h *TypeInstance) PreCheck() error {
 }
 
 func (h *TypeInstance) loadChart() (io.ReadCloser, error) {
-	return os.Open(filepath.Join(CliChartsCacheDir, h.GetChartFileName()))
+	return os.Open(filepath.Join(CliChartsCacheDir, h.getChartFileName()))
 }
 
-func (h *TypeInstance) GetChartFileName() string {
+func (h *TypeInstance) getChartFileName() string {
 	return h.ChartName
 }
 
@@ -208,7 +208,7 @@ func (h *TypeInstance) register(subcmd ClusterType) error {
 	ClusterTypeCharts[subcmd] = h
 
 	for _, f := range CacheFiles {
-		if f.Name() == h.GetChartFileName() {
+		if f.Name() == h.getChartFileName() {
 			return nil
 		}
 	}

--- a/internal/cli/cluster/external_charts.go
+++ b/internal/cli/cluster/external_charts.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 
 	"gopkg.in/yaml.v2"
@@ -136,7 +135,7 @@ func ClearCharts(c ClusterType) {
 			klog.V(2).Info(fmt.Sprintf("Warning: auto clear %s config fail due to: %s\n", c, err.Error()))
 
 		}
-		if err := os.Remove(filepath.Join(CliChartsCacheDir, ClusterTypeCharts[c].getChartFileName())); err != nil {
+		if err := os.Remove(filepath.Join(CliChartsCacheDir, ClusterTypeCharts[c].GetChartFileName())); err != nil {
 			klog.V(2).Info(fmt.Sprintf("Warning: auto clear %s config fail due to: %s\n", c, err.Error()))
 		}
 		CacheFiles = GetChartCacheFiles()
@@ -148,14 +147,16 @@ type TypeInstance struct {
 	Name  ClusterType `yaml:"name"`
 	URL   string      `yaml:"helmChartUrl"`
 	Alias string      `yaml:"alias"`
+	// chartName is the filename cached locally
+	ChartName string `yaml:"chartName"`
 }
 
 func (h *TypeInstance) loadChart() (io.ReadCloser, error) {
-	return os.Open(filepath.Join(CliChartsCacheDir, h.getChartFileName()))
+	return os.Open(filepath.Join(CliChartsCacheDir, h.GetChartFileName()))
 }
 
-func (h *TypeInstance) getChartFileName() string {
-	return path.Base(h.URL)
+func (h *TypeInstance) GetChartFileName() string {
+	return h.ChartName
 }
 
 func (h *TypeInstance) getAlias() string {
@@ -169,7 +170,7 @@ func (h *TypeInstance) register(subcmd ClusterType) error {
 	ClusterTypeCharts[subcmd] = h
 
 	for _, f := range CacheFiles {
-		if f.Name() == h.getChartFileName() {
+		if f.Name() == h.GetChartFileName() {
 			return nil
 		}
 	}

--- a/internal/cli/cluster/external_charts.go
+++ b/internal/cli/cluster/external_charts.go
@@ -75,6 +75,15 @@ func (c *clusterConfig) AddConfig(add *TypeInstance) {
 	*c = append(*c, add)
 }
 
+// UpdateConfig will update the existed TypeInstance in c
+func (c *clusterConfig) UpdateConfig(update *TypeInstance) {
+	for i, instance := range *c {
+		if instance.Name == update.Name {
+			(*c)[i] = update
+		}
+	}
+}
+
 // RemoveConfig remove a ClusterType from current config
 func (c *clusterConfig) RemoveConfig(name ClusterType) bool {
 	tempList := *c

--- a/internal/cli/cluster/register.go
+++ b/internal/cli/cluster/register.go
@@ -32,8 +32,8 @@ func (t ClusterType) String() string {
 type chartLoader interface {
 	// loadChart loads the chart content during building sub-command
 	loadChart() (io.ReadCloser, error)
-	// getChartFileName returns the chart file name, include the extension
-	getChartFileName() string
+	// GetChartFileName returns the chart file name, include the extension
+	GetChartFileName() string
 	// getAlias returns the chart alias, this alias will be used as the command alias
 	getAlias() string
 	// register registers the cluster type as a sub	cmd into create cluster command

--- a/internal/cli/cluster/register.go
+++ b/internal/cli/cluster/register.go
@@ -33,7 +33,7 @@ type chartLoader interface {
 	// loadChart loads the chart content during building sub-command
 	loadChart() (io.ReadCloser, error)
 	// GetChartFileName returns the chart file name, include the extension
-	GetChartFileName() string
+	getChartFileName() string
 	// getAlias returns the chart alias, this alias will be used as the command alias
 	getAlias() string
 	// register registers the cluster type as a sub	cmd into create cluster command

--- a/internal/cli/cluster/register_test.go
+++ b/internal/cli/cluster/register_test.go
@@ -37,7 +37,7 @@ var _ = Describe("cluster register", func() {
 		}
 		Expect(mysql.register("mysql")).Should(HaveOccurred())
 		Expect(mysql.register("mysql-other")).Should(Succeed())
-		Expect(mysql.getChartFileName()).Should(Equal("apecloud-mysql-cluster.tgz"))
+		Expect(mysql.GetChartFileName()).Should(Equal("apecloud-mysql-cluster.tgz"))
 		Expect(mysql.getAlias()).Should(Equal(""))
 		chart, err := mysql.loadChart()
 		Expect(err).Should(Succeed())
@@ -48,12 +48,13 @@ var _ = Describe("cluster register", func() {
 
 	It("test external chart", func() {
 		fakeChart := &TypeInstance{
-			Name:  "fake",
-			URL:   "www.fake-chart-hub/fake.tgz",
-			Alias: "",
+			Name:      "fake",
+			URL:       "www.fake-chart-hub/fake.tgz",
+			Alias:     "",
+			ChartName: "fake.tgz",
 		}
 		Expect(fakeChart.getAlias()).Should(Equal(""))
-		Expect(fakeChart.getChartFileName()).Should(Equal("fake.tgz"))
+		Expect(fakeChart.GetChartFileName()).Should(Equal("fake.tgz"))
 		_, err := fakeChart.loadChart()
 		Expect(err).Should(HaveOccurred())
 		Expect(fakeChart.register("fake")).Should(HaveOccurred())
@@ -93,7 +94,7 @@ var _ = Describe("cluster register", func() {
 			Expect(tempCLusterConfig.WriteConfigs(tempConfigPath)).Should(Succeed())
 
 			file, _ := os.ReadFile(tempConfigPath)
-			Expect(string(file)).Should(Equal("- name: orioledb\n  helmChartUrl: https://fakeurl.com\n  alias: \"\"\n"))
+			Expect(string(file)).Should(Equal("- name: orioledb\n  helmChartUrl: https://fakeurl.com\n  alias: \"\"\n  chartName: \"\"\n"))
 		})
 
 	})

--- a/internal/cli/cluster/register_test.go
+++ b/internal/cli/cluster/register_test.go
@@ -37,7 +37,7 @@ var _ = Describe("cluster register", func() {
 		}
 		Expect(mysql.register("mysql")).Should(HaveOccurred())
 		Expect(mysql.register("mysql-other")).Should(Succeed())
-		Expect(mysql.GetChartFileName()).Should(Equal("apecloud-mysql-cluster.tgz"))
+		Expect(mysql.getChartFileName()).Should(Equal("apecloud-mysql-cluster.tgz"))
 		Expect(mysql.getAlias()).Should(Equal(""))
 		chart, err := mysql.loadChart()
 		Expect(err).Should(Succeed())
@@ -54,7 +54,7 @@ var _ = Describe("cluster register", func() {
 			ChartName: "fake.tgz",
 		}
 		Expect(fakeChart.getAlias()).Should(Equal(""))
-		Expect(fakeChart.GetChartFileName()).Should(Equal("fake.tgz"))
+		Expect(fakeChart.getChartFileName()).Should(Equal("fake.tgz"))
 		_, err := fakeChart.loadChart()
 		Expect(err).Should(HaveOccurred())
 		Expect(fakeChart.register("fake")).Should(HaveOccurred())

--- a/internal/cli/cmd/cluster/register.go
+++ b/internal/cli/cmd/cluster/register.go
@@ -157,22 +157,21 @@ func (o *registerOption) run() error {
 			return err
 		}
 	}
+	instance := &cluster.TypeInstance{
+		Name:      o.clusterType,
+		URL:       o.source,
+		Alias:     o.alias,
+		ChartName: o.cachedName,
+	}
+	if err := instance.PreCheck(); err != nil {
+		return fmt.Errorf("register helm chart pre-check failed: %s", err.Error())
+	}
 
 	if o.replace {
 		// update config
-		cluster.GlobalClusterChartConfig.UpdateConfig(&cluster.TypeInstance{
-			Name:      o.clusterType,
-			URL:       o.source,
-			Alias:     o.alias,
-			ChartName: o.cachedName,
-		})
+		cluster.GlobalClusterChartConfig.UpdateConfig(instance)
 	} else {
-		cluster.GlobalClusterChartConfig.AddConfig(&cluster.TypeInstance{
-			Name:      o.clusterType,
-			URL:       o.source,
-			Alias:     o.alias,
-			ChartName: o.cachedName,
-		})
+		cluster.GlobalClusterChartConfig.AddConfig(instance)
 	}
 
 	return cluster.GlobalClusterChartConfig.WriteConfigs(cluster.CliClusterChartConfig)

--- a/internal/cli/cmd/cluster/register.go
+++ b/internal/cli/cmd/cluster/register.go
@@ -85,6 +85,8 @@ func newRegisterCmd(f cmdutil.Factory, streams genericclioptions.IOStreams) *cob
 	}
 	cmd.Flags().StringVarP(&o.source, "source", "S", "", "Specify the cluster type chart source, support a URL or a local file path")
 	cmd.Flags().StringVar(&o.alias, "alias", "", "Set the cluster type alias")
+	cmd.Flags().BoolVar(&o.autoApprove, "auto-approve", false, "Skip interactive approval when register an existed cluster type")
+
 	_ = cmd.MarkFlagRequired("source")
 
 	return cmd

--- a/internal/cli/cmd/cluster/register.go
+++ b/internal/cli/cmd/cluster/register.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"time"
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -34,6 +35,7 @@ import (
 
 	"github.com/apecloud/kubeblocks/internal/cli/cluster"
 	"github.com/apecloud/kubeblocks/internal/cli/util/helm"
+	"github.com/apecloud/kubeblocks/internal/cli/util/prompt"
 )
 
 var clusterRegisterExample = templates.Examples(`
@@ -41,7 +43,7 @@ var clusterRegisterExample = templates.Examples(`
 	kbcli cluster register orioledb --source https://github.com/apecloud/helm-charts/releases/download/orioledb-cluster-0.6.0-beta.44/orioledb-cluster-0.6.0-beta.44.tgz
 
 	# Register a cluster type from a local path file
-	kbcli cluster register neon -S internal/cli/cluster/charts/neon-cluster.tgz
+	kbcli cluster register neon -source internal/cli/cluster/charts/neon-cluster.tgz
 `)
 
 type registerOption struct {
@@ -51,6 +53,12 @@ type registerOption struct {
 	clusterType cluster.ClusterType
 	source      string
 	alias       string
+	// cachedName is the filename cached locally
+	cachedName string
+
+	autoApprove bool
+	// replace determine whether to replace an existing chart, the default value is false
+	replace bool
 }
 
 func newRegisterOption(f cmdutil.Factory, streams genericclioptions.IOStreams) *registerOption {
@@ -87,48 +95,75 @@ func (o *registerOption) validate() error {
 	if !re.MatchString(o.clusterType.String()) {
 		return fmt.Errorf("cluster type %s is not appropriate as a subcommand", o.clusterType.String())
 	}
-
-	for key := range cluster.ClusterTypeCharts {
-		if key == o.clusterType {
-			return fmt.Errorf("cluster type %s is already existed", o.clusterType.String())
+	// stop registering if the register cluster type is the builtin cluster
+	if cluster.IsbuiltinCharts(o.clusterType.String()) {
+		return fmt.Errorf("cluster type %s is the kbcli builtin type, not allow to be changed", o.clusterType.String())
+	}
+	// double check if  the register cluster type is already existed
+	if !o.autoApprove {
+		for key := range cluster.ClusterTypeCharts {
+			if key != o.clusterType {
+				continue
+			}
+			if err := prompt.Confirm(nil, o.In, fmt.Sprintf("Your register cluster type %s is already existed", o.clusterType), "Please type 'Yes/yes' to confirm your operation and replace the cluster chart:"); err != nil {
+				return err
+			}
+			o.replace = true
 		}
 	}
 
 	if validateSource(o.source) != nil {
 		return fmt.Errorf("your entered `--source` %s, which is neither a URL nor a file that can be found locally", o.source)
 	}
+
+	o.cachedName = filepath.Base(o.source)
+	if !o.replace {
+		// if not replace. we should check the chart name whether conflict in local cache
+		// if conflicted, we add a timestamp to the cached name
+		for _, file := range cluster.CacheFiles {
+			if file.Name() == o.cachedName {
+				ext := filepath.Ext(o.cachedName)
+				timestamp := time.Now().Format("20230102150405")
+				o.cachedName = fmt.Sprintf("%s-%s.%s", o.cachedName[:len(o.cachedName)-len(ext)], timestamp, ext)
+			}
+		}
+	}
+	// todo: helm chart pre-check
+
 	return nil
 }
 
 func (o *registerOption) run() error {
-	// before download, we should check the chart name whether conflict in local cache
-	for _, file := range cluster.CacheFiles {
-		if file.Name() == filepath.Base(o.source) {
-			return fmt.Errorf("cluster type '%s' register failed due to the cluster chart's name conflict %s", o.clusterType, file.Name())
-		}
-	}
-
 	if _, err := url.ParseRequestURI(o.source); err == nil {
+
 		// source is URL
 		chartsDownloader, err := helm.NewDownloader(helm.NewConfig("default", "", "", false))
 		if err != nil {
 			return err
 		}
-		_, _, err = chartsDownloader.DownloadTo(o.source, "", cluster.CliChartsCacheDir)
+		// DownloadTo can't specify the saved name, so download it to TempDir and rename it when copy
+		tempPath, _, err := chartsDownloader.DownloadTo(o.source, "", os.TempDir())
 		if err != nil {
 			return err
 		}
+		err = copyFile(tempPath, filepath.Join(cluster.CliChartsCacheDir, o.cachedName))
+		if err != nil {
+			return err
+		}
+		_ = os.Remove(tempPath)
 	} else {
 		// source is local_path
-		if err := copyFile(o.source, filepath.Join(cluster.CliChartsCacheDir, filepath.Base(o.source))); err != nil {
+		// todo：check absolutely path error
+		if err := copyFile(o.source, filepath.Join(cluster.CliChartsCacheDir, o.cachedName)); err != nil {
 			return err
 		}
 	}
 	// update config
 	cluster.GlobalClusterChartConfig.AddConfig(&cluster.TypeInstance{
-		Name:  o.clusterType,
-		URL:   o.source,
-		Alias: o.alias,
+		Name:      o.clusterType,
+		URL:       o.source,
+		Alias:     o.alias,
+		ChartName: o.cachedName,
 	})
 	return cluster.GlobalClusterChartConfig.WriteConfigs(cluster.CliClusterChartConfig)
 }

--- a/internal/cli/cmd/cluster/register_test.go
+++ b/internal/cli/cmd/cluster/register_test.go
@@ -63,11 +63,12 @@ var _ = Describe("cluster register", func() {
 		Expect(o.validate()).Should(HaveOccurred())
 
 		o.clusterType = "mysql"
-		// already exist
+		// builtin chart
 		Expect(o.validate()).Should(HaveOccurred())
 
 		o.clusterType = "oracle"
 		Expect(o.validate()).Should(Succeed())
+
 	})
 
 	It("test validateSource", func() {


### PR DESCRIPTION
- fix #5158
- fix #5159 
- fix #5154 

In this PR, we have optimized the 'cluster register' command, primarily addressing the following points:

- [x] Implemented support for double-checking when registering duplicate commands, enabling users to update configurations with new charts. 
- [x] Fixed a bug where absolute chart paths were not functioning correctly.
- [x] Completed pre-checks for chart packages.

**Usage**:
![image](https://github.com/apecloud/kubeblocks/assets/101848970/adc44d8e-e7be-4d1c-98ee-d86a707542bf)
