### PR TITLE
fix: failed to get pods (#5141)

### DIFF
--- a/controllers/apps/configuration/parallel_upgrade_policy.go
+++ b/controllers/apps/configuration/parallel_upgrade_policy.go
@@ -20,10 +20,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package configuration
 
 import (
-	cfgcore "github.com/apecloud/kubeblocks/internal/configuration/core"
 	corev1 "k8s.io/api/core/v1"
 
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
+	cfgcore "github.com/apecloud/kubeblocks/internal/configuration/core"
 	podutil "github.com/apecloud/kubeblocks/internal/controllerutil"
 )
 
@@ -38,10 +38,14 @@ func (p *parallelUpgradePolicy) Upgrade(params reconfigureParams) (ReturnedStatu
 	var funcs RollingUpgradeFuncs
 
 	switch params.WorkloadType() {
-	case appsv1alpha1.Consensus, appsv1alpha1.Stateful, appsv1alpha1.Replication:
-		funcs = GetRSMRollingUpgradeFuncs()
 	default:
 		return makeReturnedStatus(ESNotSupport), cfgcore.MakeError("not supported component workload type[%s]", params.WorkloadType())
+	case appsv1alpha1.Consensus:
+		funcs = GetConsensusRollingUpgradeFuncs()
+	case appsv1alpha1.Stateful:
+		funcs = GetStatefulSetRollingUpgradeFuncs()
+	case appsv1alpha1.Replication:
+		funcs = GetReplicationRollingUpgradeFuncs()
 	}
 
 	pods, err := funcs.GetPodsFunc(params)

--- a/controllers/apps/configuration/parallel_upgrade_policy_test.go
+++ b/controllers/apps/configuration/parallel_upgrade_policy_test.go
@@ -66,6 +66,7 @@ var _ = Describe("Reconfigure ParallelPolicy", func() {
 					return reconfigureClient, nil
 				}),
 				withMockStatefulSet(3, nil),
+				withClusterComponent(3),
 				withConfigSpec("for_test", map[string]string{
 					"a": "b",
 				}),
@@ -94,6 +95,7 @@ var _ = Describe("Reconfigure ParallelPolicy", func() {
 					return reconfigureClient, nil
 				}),
 				withMockStatefulSet(3, nil),
+				withClusterComponent(3),
 				withConfigSpec("for_test", map[string]string{
 					"a": "b",
 				}),
@@ -133,6 +135,7 @@ var _ = Describe("Reconfigure ParallelPolicy", func() {
 					return reconfigureClient, nil
 				}),
 				withMockStatefulSet(3, nil),
+				withClusterComponent(3),
 				withConfigSpec("for_test", map[string]string{
 					"a": "b",
 				}),
@@ -174,6 +177,7 @@ var _ = Describe("Reconfigure ParallelPolicy", func() {
 					return reconfigureClient, nil
 				}),
 				withMockStatefulSet(3, nil),
+				withClusterComponent(3),
 				withConfigSpec("for_test", map[string]string{
 					"a": "b",
 				}),
@@ -203,6 +207,7 @@ var _ = Describe("Reconfigure ParallelPolicy", func() {
 				withConfigSpec("for_test", map[string]string{
 					"key": "value",
 				}),
+				withClusterComponent(2),
 				withCDComponent(appsv1alpha1.Stateless, []appsv1alpha1.ComponentConfigSpec{{
 					ComponentTemplateSpec: appsv1alpha1.ComponentTemplateSpec{
 						Name:       "for_test",

--- a/controllers/apps/configuration/rolling_upgrade_policy.go
+++ b/controllers/apps/configuration/rolling_upgrade_policy.go
@@ -56,8 +56,12 @@ func (r *rollingUpgradePolicy) Upgrade(params reconfigureParams) (ReturnedStatus
 	var funcs RollingUpgradeFuncs
 
 	switch params.WorkloadType() {
-	case appsv1alpha1.Consensus, appsv1alpha1.Replication, appsv1alpha1.Stateful:
-		funcs = GetRSMRollingUpgradeFuncs()
+	case appsv1alpha1.Consensus:
+		funcs = GetConsensusRollingUpgradeFuncs()
+	case appsv1alpha1.Replication:
+		funcs = GetReplicationRollingUpgradeFuncs()
+	case appsv1alpha1.Stateful:
+		funcs = GetStatefulSetRollingUpgradeFuncs()
 	default:
 		return makeReturnedStatus(ESNotSupport), cfgcore.MakeError("not supported component workload type[%s]", params.WorkloadType())
 	}

--- a/controllers/apps/configuration/simple_policy.go
+++ b/controllers/apps/configuration/simple_policy.go
@@ -43,8 +43,14 @@ func (s *simplePolicy) Upgrade(params reconfigureParams) (ReturnedStatus, error)
 	switch params.WorkloadType() {
 	default:
 		return makeReturnedStatus(ESNotSupport), core.MakeError("not supported component workload type:[%s]", params.WorkloadType())
-	case appsv1alpha1.Consensus, appsv1alpha1.Replication, appsv1alpha1.Stateful:
-		funcs = GetRSMRollingUpgradeFuncs()
+	case appsv1alpha1.Consensus:
+		funcs = GetConsensusRollingUpgradeFuncs()
+		compLists = fromStatefulSetObjects(params.ComponentUnits)
+	case appsv1alpha1.Stateful:
+		funcs = GetStatefulSetRollingUpgradeFuncs()
+		compLists = fromStatefulSetObjects(params.ComponentUnits)
+	case appsv1alpha1.Replication:
+		funcs = GetReplicationRollingUpgradeFuncs()
 		compLists = fromStatefulSetObjects(params.ComponentUnits)
 	case appsv1alpha1.Stateless:
 		funcs = GetDeploymentRollingUpgradeFuncs()

--- a/controllers/apps/configuration/sync_upgrade_policy.go
+++ b/controllers/apps/configuration/sync_upgrade_policy.go
@@ -59,8 +59,12 @@ func (o *syncPolicy) Upgrade(params reconfigureParams) (ReturnedStatus, error) {
 		return makeReturnedStatus(ESNotSupport), core.MakeError("not support component workload type[%s]", params.WorkloadType())
 	case appsv1alpha1.Stateless:
 		funcs = GetDeploymentRollingUpgradeFuncs()
-	case appsv1alpha1.Consensus, appsv1alpha1.Replication, appsv1alpha1.Stateful:
-		funcs = GetRSMRollingUpgradeFuncs()
+	case appsv1alpha1.Consensus:
+		funcs = GetConsensusRollingUpgradeFuncs()
+	case appsv1alpha1.Stateful:
+		funcs = GetStatefulSetRollingUpgradeFuncs()
+	case appsv1alpha1.Replication:
+		funcs = GetReplicationRollingUpgradeFuncs()
 	}
 
 	pods, err := funcs.GetPodsFunc(params)

--- a/controllers/apps/configuration/types.go
+++ b/controllers/apps/configuration/types.go
@@ -37,6 +37,9 @@ type RestartComponent func(client client.Client, ctx intctrlutil.RequestCtx, key
 type RestartContainerFunc func(pod *corev1.Pod, ctx context.Context, containerName []string, createConnFn createReconfigureClient) error
 type OnlineUpdatePodFunc func(pod *corev1.Pod, ctx context.Context, createClient createReconfigureClient, configSpec string, updatedParams map[string]string) error
 
+// Node: Distinguish between implementation and interface.
+// RollingUpgradeFuncs defines the interface, rsm is an implementation of Stateful, Replication and Consensus, not the only solution.
+
 type RollingUpgradeFuncs struct {
 	GetPodsFunc          GetPodsFunc
 	RestartContainerFunc RestartContainerFunc
@@ -44,9 +47,27 @@ type RollingUpgradeFuncs struct {
 	RestartComponent     RestartComponent
 }
 
-func GetRSMRollingUpgradeFuncs() RollingUpgradeFuncs {
+func GetConsensusRollingUpgradeFuncs() RollingUpgradeFuncs {
 	return RollingUpgradeFuncs{
-		GetPodsFunc:          getRSMPods,
+		GetPodsFunc:          getConsensusPods,
+		RestartContainerFunc: commonStopContainerWithPod,
+		OnlineUpdatePodFunc:  commonOnlineUpdateWithPod,
+		RestartComponent:     restartStatefulComponent,
+	}
+}
+
+func GetStatefulSetRollingUpgradeFuncs() RollingUpgradeFuncs {
+	return RollingUpgradeFuncs{
+		GetPodsFunc:          getStatefulSetPods,
+		RestartContainerFunc: commonStopContainerWithPod,
+		OnlineUpdatePodFunc:  commonOnlineUpdateWithPod,
+		RestartComponent:     restartStatefulComponent,
+	}
+}
+
+func GetReplicationRollingUpgradeFuncs() RollingUpgradeFuncs {
+	return RollingUpgradeFuncs{
+		GetPodsFunc:          getReplicationSetPods,
 		RestartContainerFunc: commonStopContainerWithPod,
 		OnlineUpdatePodFunc:  commonOnlineUpdateWithPod,
 		RestartComponent:     restartStatefulComponent,

--- a/internal/common/stateful_set_utils.go
+++ b/internal/common/stateful_set_utils.go
@@ -93,14 +93,19 @@ func ParseParentNameAndOrdinal(s string) (string, int32) {
 
 // GetPodListByStatefulSet gets statefulSet pod list.
 func GetPodListByStatefulSet(ctx context.Context, cli client.Client, stsObj *appsv1.StatefulSet) ([]corev1.Pod, error) {
-	podList := &corev1.PodList{}
 	selector, err := metav1.LabelSelectorAsMap(stsObj.Spec.Selector)
 	if err != nil {
 		return nil, err
 	}
+	return GetPodListByStatefulSetWithSelector(ctx, cli, stsObj, selector)
+}
+
+// GetPodListByStatefulSetWithSelector gets statefulSet pod list.
+func GetPodListByStatefulSetWithSelector(ctx context.Context, cli client.Client, stsObj *appsv1.StatefulSet, selector client.MatchingLabels) ([]corev1.Pod, error) {
+	podList := &corev1.PodList{}
 	if err := cli.List(ctx, podList,
 		&client.ListOptions{Namespace: stsObj.Namespace},
-		client.MatchingLabels(selector)); err != nil {
+		selector); err != nil {
 		return nil, err
 	}
 	var pods []corev1.Pod


### PR DESCRIPTION
Fix: [Reconfiguring processing progress status invalidation after after rsm integrated](https://github.com/apecloud/kubeblocks/issues/5141)

After rsm integrated, statefulset no longer has **_KBAppComponentLabelKey_** and **_AppInstanceLabelKey_** labels, and obtaining pods through **_commonent.GetPodListByStatefulSet_** will fail.

It may also affect other operator using this interface.