### PR TITLE
chore: preflight support aws us region

### DIFF
--- a/internal/cli/cmd/kubeblocks/data/eks_hostpreflight.yaml
+++ b/internal/cli/cmd/kubeblocks/data/eks_hostpreflight.yaml
@@ -36,8 +36,12 @@ spec:
         regionNames:
           - cn-northwest-1
           - cn-north-1
+          - us-east-1
+          - us-east-2
+          - us-west-1
+          - us-west-2
         outcomes:
           - warn:
-              message: k8s cluster region doesn't belong to amazon china
+              message: k8s cluster region doesn't belong to amazon china/us, you may have some unexpected behavior
           - pass:
-              message: k8s cluster region belongs to amazon china
+              message: k8s cluster region belongs to amazon china/us

--- a/internal/cli/cmd/kubeblocks/data/eks_hostpreflight.yaml
+++ b/internal/cli/cmd/kubeblocks/data/eks_hostpreflight.yaml
@@ -42,6 +42,6 @@ spec:
           - us-west-2
         outcomes:
           - warn:
-              message: k8s cluster region doesn't belong to amazon china/us, you may have some unexpected behavior
+              message: be aware of the network reachability for cluster regions that located at East-Asia
           - pass:
               message: k8s cluster region belongs to amazon china/us

--- a/internal/cli/cmd/kubeblocks/data/eks_hostpreflight.yaml
+++ b/internal/cli/cmd/kubeblocks/data/eks_hostpreflight.yaml
@@ -42,6 +42,6 @@ spec:
           - us-west-2
         outcomes:
           - warn:
-              message: be aware of the network reachability for cluster regions that located at East-Asia
+              message: k8s cluster region doesn't belong to amazon china, be aware of the network reachability for cluster regions that located at East-Asia
           - pass:
               message: k8s cluster region belongs to amazon china/us


### PR DESCRIPTION
Preflight only supports aws China region (e.g. cn-northwest-1) now. Actually, it's fine to migrate kubeblocks to aws us region,
such as us-east-1.