### PR TITLE
feat: cli cluster create supports 'foxlake' subcommand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,6 +302,7 @@ build-kbcli-embed-chart: helmtool create-kbcli-embed-charts-dir \
 	build-single-kbcli-embed-chart.postgresql-cluster \
 	build-single-kbcli-embed-chart.kafka-cluster \
 	build-single-kbcli-embed-chart.mongodb-cluster \
+	build-single-kbcli-embed-chart.foxlake-cluster \
 #	build-single-kbcli-embed-chart.neon-cluster
 #	build-single-kbcli-embed-chart.postgresql-cluster \
 #	build-single-kbcli-embed-chart.clickhouse-cluster \

--- a/deploy/foxlake-cluster/values.schema.json
+++ b/deploy/foxlake-cluster/values.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "version": {
+      "title": "Version",
+      "description": "Cluster version.",
+      "type": "string",
+      "default": "foxlake-0.2.0"
+    },
+    "cpu": {
+      "title": "CPU",
+      "description": "CPU cores.",
+      "type": [
+        "number",
+        "string"
+      ],
+      "default": 1,
+      "minimum": 1,
+      "maximum": 64,
+      "multipleOf": 0.5
+    },
+    "memory": {
+      "title": "Memory(Gi)",
+      "description": "Memory, the unit is Gi.",
+      "type": [
+        "number",
+        "string"
+      ],
+      "default": 2,
+      "minimum": 2,
+      "maximum": 1000
+    },
+    "storage": {
+      "title": "Storage(Gi)",
+      "description": "Storage size, the unit is Gi.",
+      "type": [
+        "number",
+        "string"
+      ],
+      "default": 20,
+      "minimum": 1,
+      "maximum": 10000
+    },
+    "storageCreate": {
+      "title": "Storage Create",
+      "description": "Specify whether a default storage will be created in FoxLake during initialization.",
+      "type": "boolean",
+      "default": false
+    },
+    "storageAccessKey": {
+      "title": "Storage Access Key",
+      "description": "Access key for the object storage service.",
+      "type": "string"
+    },
+    "storageSecretKey": {
+      "title": "Storage Secret Key",
+      "description": "Secret key for the object storage service.",
+      "type:": "string"
+    },
+    "storageEndpoint": {
+      "title": "Storage Endpoint",
+      "description": "Endpoint for the object storage service.",
+      "type": "string"
+    },
+    "storageUri": {
+      "title": "Storage URI",
+      "description": "Object Storage URI Format.",
+      "type": "string"
+    }
+  }
+}

--- a/internal/cli/cluster/builtin_charts.go
+++ b/internal/cli/cluster/builtin_charts.go
@@ -68,10 +68,12 @@ var (
 	redisChart embed.FS
 	//go:embed charts/mongodb-cluster.tgz
 	mongodbChart embed.FS
+	//go:embed charts/foxlake-cluster.tgz
+	foxlakeChart embed.FS
 )
 
 func IsbuiltinCharts(chart string) bool {
-	return chart == "mysql" || chart == "postgresql" || chart == "kafka" || chart == "redis" || chart == "mongodb"
+	return chart == "mysql" || chart == "postgresql" || chart == "kafka" || chart == "redis" || chart == "mongodb" || chart == "foxlake"
 }
 
 // internal_chart registers embed chart
@@ -120,6 +122,15 @@ func init() {
 		alias:   "",
 	}
 	if err := mongodb.register("mongodb"); err != nil {
+		fmt.Println(err.Error())
+	}
+
+	foxlake := &embedConfig{
+		chartFS: foxlakeChart,
+		name:    "foxlake-cluster.tgz",
+		alias:   "",
+	}
+	if err := foxlake.register("foxlake"); err != nil {
 		fmt.Println(err.Error())
 	}
 


### PR DESCRIPTION
resolve #4397 
User can create a foxlake cluster with default storage using the following command:
```
kbcli cluster create foxlake mycluster \
--storage-create=true \
--storage-endpoint="minio:9000" \
--storage-access-key="admin" \
--storage-secret-key="CMsg01ZvwB" \
--storage-uri="minio://foxlake/default" \
--rbac-enabled=true
```
The problem is that we create all resources under a namespace, which causes error when creating a cluster-scoped resource like "clusterrolebinding":
```
Error from server (NotFound): the server could not find the requested resource
```