### PR TITLE
fix: fix openldap VolumeExpansion ops failed

### DIFF
--- a/deploy/openldap-cluster/templates/cluster.yaml
+++ b/deploy/openldap-cluster/templates/cluster.yaml
@@ -35,7 +35,7 @@ spec:
       {{- end }}
       {{- if .Values.persistence.enabled }}
       volumeClaimTemplates:
-        - name: data # ref clusterdefinition components.containers.volumeMounts.name
+        - name: openldap # ref clusterdefinition components.containers.volumeMounts.name
           spec:
             storageClassName: {{ .Values.persistence.data.storageClassName }}
             accessModes:

--- a/deploy/openldap-cluster/values.yaml
+++ b/deploy/openldap-cluster/values.yaml
@@ -46,7 +46,7 @@ tolerations: []
 persistence:
   ## @param shard[*].persistence.enabled Enable persistence using Persistent Volume Claims
   ##
-  enabled: false
+  enabled: true
   ## `data` volume settings
   ##
   data:

--- a/deploy/openldap/templates/clusterdefinition.yaml
+++ b/deploy/openldap/templates/clusterdefinition.yaml
@@ -29,8 +29,6 @@ spec:
               - mountPath: /etc/ldap/slapd.d
                 name: openldap
                 subPath: ldap-config
-              - mountPath: /container/service/slapd/assets/config/bootstrap/ldif/custom
-                name: openldap-bootstrap
             ports:
               - containerPort: 389
                 name: ldap


### PR DESCRIPTION
Fix openldap VolumeExpansion ops failed

Modify the volumeClaimTemplates.name field of the cluster to be consistent with the volumeMounts[].name in ClusterDefinition

Close #5228 
