### PR TITLE
fix: kbcli kubeblocks upgrade malformed version

### DIFF
--- a/internal/cli/cmd/kubeblocks/upgrade.go
+++ b/internal/cli/cmd/kubeblocks/upgrade.go
@@ -120,7 +120,8 @@ func (o *InstallOptions) Upgrade() error {
 	}
 
 	// double check for KubeBlocks upgrade
-	if !o.autoApprove {
+	// and only check when KubeBlocks version change
+	if !o.autoApprove && o.Version != "" {
 		oldVersion, err := version.NewVersion(kbVersion)
 		if err != nil {
 			return err

--- a/internal/cli/cmd/kubeblocks/upgrade_test.go
+++ b/internal/cli/cmd/kubeblocks/upgrade_test.go
@@ -72,7 +72,7 @@ var _ = Describe("kubeblocks upgrade", func() {
 		Expect(o.Namespace).To(Equal("test"))
 	})
 
-	It("run upgrade double-check", func() {
+	It("double-check when version change", func() {
 		mockDeploy := func() *appsv1.Deployment {
 			deploy := &appsv1.Deployment{}
 			deploy.SetLabels(map[string]string{
@@ -99,6 +99,30 @@ var _ = Describe("kubeblocks upgrade", func() {
 		o.autoApprove = true
 		Expect(o.Upgrade()).Should(Succeed())
 
+	})
+
+	It("helm ValueOpts upgrade", func() {
+		mockDeploy := func() *appsv1.Deployment {
+			deploy := &appsv1.Deployment{}
+			deploy.SetLabels(map[string]string{
+				"app.kubernetes.io/name":    types.KubeBlocksChartName,
+				"app.kubernetes.io/version": "0.3.0",
+			})
+			return deploy
+		}
+
+		o := &InstallOptions{
+			Options: Options{
+				IOStreams: streams,
+				HelmCfg:   helm.NewFakeConfig(namespace),
+				Namespace: "default",
+				Client:    testing.FakeClientSet(mockDeploy()),
+				Dynamic:   testing.FakeDynamicClient(),
+			},
+			Version: "",
+		}
+		o.ValueOpts.Values = []string{"replicaCount=2"}
+		Expect(o.Upgrade()).Should(Succeed())
 	})
 
 	It("run upgrade", func() {


### PR DESCRIPTION
- fix #5208 

**What cause：**
It caused by the double-check for Kubeblocks upgrade. When the kubeblocks version not change and only upgrade the --set values , we don't need to double check the version.
![image](https://github.com/apecloud/kubeblocks/assets/101848970/646d8a4e-5f0e-4dd2-a748-de8d3fd8ee3b)
