### PR TITLE
feat: Integrate PolarDB-X into KubeBlocks.

### DIFF
--- a/deploy/polardbx-cluster/.helmignore
+++ b/deploy/polardbx-cluster/.helmignore
@@ -1,0 +1,24 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+*.lock

--- a/deploy/polardbx-cluster/Chart.yaml
+++ b/deploy/polardbx-cluster/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: polardbx-cluster
+description: PolarDB-X Cluster Helm Chart for KubeBlocks.
+
+type: application
+version: 0.1.0
+appVersion: v1.4.1
+
+keywords:
+- polardbx
+- database
+- distributed
+- cloud-native
+
+home: https://polardbx.com/home
+
+maintainers:
+- name: Vettal Wu
+  email: vettal.wd@alibaba-inc.com

--- a/deploy/polardbx-cluster/templates/NOTES.txt
+++ b/deploy/polardbx-cluster/templates/NOTES.txt
@@ -1,0 +1,14 @@
+Thanks for installing PolarDB-X using KubeBlocks!
+
+1. Run the following command to create your first PolarDB-X cluster:
+
+```
+kbcli cluster create pxc --cluster-definition polardbx
+```
+
+2. Port-forward service to localhost and connect to PolarDB-X cluster:
+
+```
+kubectl port-forward svc/pxc-cn 3306:3306
+mysql -h127.0.0.1 -upolardbx_root
+```

--- a/deploy/polardbx-cluster/templates/_helpers.tpl
+++ b/deploy/polardbx-cluster/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "polardbx.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "polardbx.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "polardbx.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "polardbx.labels" -}}
+helm.sh/chart: {{ include "polardbx.chart" . }}
+{{ include "polardbx.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "polardbx.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "polardbx.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "polardbx.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "polardbx.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/polardbx-cluster/templates/cluster.yaml
+++ b/deploy/polardbx-cluster/templates/cluster.yaml
@@ -1,0 +1,99 @@
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: Cluster
+metadata:
+  name: {{ include "polardbx.name" . }}
+  labels:
+    {{ include "polardbx.labels" . | nindent 4 }}
+spec:
+  clusterDefinitionRef: polardbx
+  clusterVersionRef: polardbx-{{ default .Chart.AppVersion .Values.clusterVersionOverride }}
+  terminationPolicy: {{ .Values.polardbx.terminationPolicy }}
+  componentSpecs:
+    - componentDefRef: gms
+      name: gms
+      replicas: {{ .Values.gms.replicas }}
+      {{- with  .Values.gms.resources }}
+      resources:
+        {{- with .limits }}
+        limits:
+          cpu: {{ .cpu | quote }}
+          memory: {{ .memory | quote }}
+        {{- end }}
+        {{- with .requests }}
+        requests:
+          cpu: {{ .cpu | quote }}
+          memory: {{ .memory | quote }}
+        {{- end }}
+      {{- end }}
+      {{- if .Values.gms.persistence.enabled }}
+      volumeClaimTemplates:
+        - name: data   # ref clusterdefinition components.containers.volumeMounts.name
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: {{ .Values.gms.persistence.data.size }}
+      {{- end }}
+    {{- $i := 0 }}
+    {{- range .Values.dn }}
+    - componentDefRef: dn
+      name: dn-{{ $i }}
+      replicas: {{ .replicas }}
+      {{- with  .resources }}
+      resources:
+        {{- with .limits }}
+        limits:
+          cpu: {{ .cpu | quote }}
+          memory: {{ .memory | quote }}
+        {{- end }}
+        {{- with .requests }}
+        requests:
+          cpu: {{ .cpu | quote }}
+          memory: {{ .memory | quote }}
+        {{- end }}
+      {{- end }}
+      {{- if .persistence.enabled }}
+      volumeClaimTemplates:
+        - name: data   # ref clusterdefinition components.containers.volumeMounts.name
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage:  {{ .persistence.data.size }}
+      {{- end }}
+    {{- end }}
+    {{- $i = add1 $i }}
+    - componentDefRef: cn
+      name: cn
+      replicas: {{ .Values.cn.replicas }}
+      {{- with  .Values.cn.resources }}
+      resources:
+        {{- with .limits }}
+        limits:
+          cpu: {{ .cpu | quote }}
+          memory: {{ .memory | quote }}
+        {{- end }}
+        {{- with .requests }}
+        requests:
+          cpu: {{ .cpu | quote }}
+          memory: {{ .memory | quote }}
+        {{- end }}
+      {{- end }}
+    - componentDefRef: cdc
+      name: cdc
+      replicas: {{ .Values.cdc.replicas }}
+      {{- with  .Values.cn.resources }}
+      resources:
+        {{- with .limits }}
+        limits:
+          cpu: {{ .cpu | quote }}
+          memory: {{ .memory | quote }}
+        {{- end }}
+        {{- with .requests }}
+        requests:
+          cpu: {{ .cpu | quote }}
+          memory: {{ .memory | quote }}
+        {{- end }}
+      {{- end }}

--- a/deploy/polardbx-cluster/values.yaml
+++ b/deploy/polardbx-cluster/values.yaml
@@ -1,0 +1,110 @@
+## cluster settings for polardbx cluster
+nameOverride: pxc
+polardbx:
+  ## @param polardbx.terminationPolicy, temination policy for polardbx cluster
+  terminationPolicy: WipeOut
+
+gms:
+  ## @param gms.replicas data replicas of gms instance
+  ## Default value is 3, which means a paxos group: leader, follower, follower
+  replicas: 3
+
+  ## @param gms.resources
+  ## resource management for gms component
+  ## more info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+  resources:
+    requests:
+      cpu: "1"
+      memory: "1Gi"
+    limits:
+      cpu: "1"
+      memory: "1Gi"
+
+
+  ## Enable persistence using Persistent Volume Claims
+  ## ref: https://kubernetes.io/docs/user-guide/persistent-volumes/
+  ##
+  persistence:
+    ## @param shard[*].persistence.enabled Enable persistence using Persistent Volume Claims
+    ##
+    enabled: true
+    ## `data` volume settings
+    ##
+    data:
+      ## @param shard[*].persistence.data.storageClassName Storage class of backing PVC
+      ## If defined, storageClassName: <storageClass>
+      ## If set to "-", storageClassName: "", which disables dynamic provisioning
+      ## If undefined (the default) or set to null, no storageClassName spec is
+      ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+      ##   GKE, AWS & OpenStack)
+      ##
+      storageClassName:
+      ## @param shard[*].persistence.size Size of data volume
+      ##
+      size: 20Gi
+
+dn:
+  -
+    ## @param dn[*].replicas data replicas of each DN instance
+    ## Default value is 3, which means a paxos group: leader, follower, follower
+    replicas: 3
+    ## @param dn[*].resources
+    ## resource management for dn component
+    ## more info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+    resources:
+      requests:
+        cpu: "1"
+        memory: "1Gi"
+      limits:
+        cpu: "1"
+        memory: "1Gi"
+
+    ## Enable persistence using Persistent Volume Claims
+    ## ref: https://kubernetes.io/docs/user-guide/persistent-volumes/
+    ##
+    persistence:
+      ## @param shard[*].persistence.enabled Enable persistence using Persistent Volume Claims
+      ##
+      enabled: true
+      ## `data` volume settings
+      ##
+      data:
+        ## @param shard[*].persistence.data.storageClassName Storage class of backing PVC
+        ## If defined, storageClassName: <storageClass>
+        ## If set to "-", storageClassName: "", which disables dynamic provisioning
+        ## If undefined (the default) or set to null, no storageClassName spec is
+        ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+        ##   GKE, AWS & OpenStack)
+        ##
+        storageClassName:
+        ## @param shard[*].persistence.size Size of data volume
+        ##
+        size: 20Gi
+
+cn:
+  ## @param cn.replicas number of polardb-x cn nodes
+  replicas: 2
+  ## @param cn.resources
+  ## resource management for cn component
+  ## more info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+  resources:
+    requests:
+      cpu: "1"
+      memory: "1Gi"
+    limits:
+      cpu: "1"
+      memory: "1Gi"
+
+cdc:
+  ## @param cdc.replicas number of polardb-x cdc nodes
+  replicas: 2
+  ## @param cdc.resources
+  ## resource management for cdc component
+  ## more info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+  resources:
+    requests:
+      cpu: "1"
+      memory: "1Gi"
+    limits:
+      cpu: "1"
+      memory: "1Gi"

--- a/deploy/polardbx/.helmignore
+++ b/deploy/polardbx/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/polardbx/Chart.yaml
+++ b/deploy/polardbx/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: polardbx-cluster
+description: PolarDB-X Cluster Helm Chart for KubeBlocks.
+
+type: application
+version: 0.1.0
+appVersion: v1.4.1
+
+keywords:
+  - polardbx
+  - database
+  - distributed
+  - cloud-native
+
+home: https://polardbx.com/home
+
+maintainers:
+  - name: Vettal Wu
+    email: vettal.wd@alibaba-inc.com

--- a/deploy/polardbx/dashboards/polardbx-overview.json
+++ b/deploy/polardbx/dashboards/polardbx-overview.json
@@ -1,0 +1,4626 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 7,
+        "x": 0,
+        "y": 1
+      },
+      "id": 15,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.2.4",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(irate(polardbx_stats_request_count_total{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"}[1m]))",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Logical",
+          "queryType": "randomWalk",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(irate(polardbx_stats_physical_request_count_total{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"}[1m]))",
+          "hide": true,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Physical",
+          "refId": "B"
+        }
+      ],
+      "title": "QPS (Logical)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 7,
+        "x": 7,
+        "y": 1
+      },
+      "id": 10,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "text": {}
+      },
+      "pluginVersion": "9.2.4",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(irate(polardbx_stats_request_count_total{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"}[1m]))",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "QPS (Logical)",
+          "queryType": "randomWalk",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(irate(polardbx_stats_physical_request_count_total{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"}[1m]))",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "QPS (Physical)",
+          "refId": "B"
+        }
+      ],
+      "title": "QPS",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 14,
+        "y": 1
+      },
+      "id": 40,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.2.4",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(polardbx_stats_best_effort_transaction_count_total{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"}[1m])) +\n\nsum(rate(polardbx_stats_xa_transaction_count_total{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"}[1m])) +\n\nsum(rate(polardbx_stats_tso_transaction_count_total{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"}[1m])) ",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Errors",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "TPS",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 19,
+        "y": 1
+      },
+      "id": 14,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "text": {}
+      },
+      "pluginVersion": "9.2.4",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(polardbx_stats_active_connections{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"})",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Connections",
+          "queryType": "randomWalk",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(polardbx_stats_running_count{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"})",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Threads (Running)",
+          "refId": "B"
+        }
+      ],
+      "title": "Connections/Threads",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "dark-yellow",
+                "value": 20
+              },
+              {
+                "color": "dark-orange",
+                "value": 50
+              },
+              {
+                "color": "dark-red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 7,
+        "x": 0,
+        "y": 5
+      },
+      "id": 16,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.2.4",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(delta(polardbx_stats_request_time_cost_total{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"}[1m])) / (sum(delta (polardbx_stats_request_count_total{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"}[1m])) + 1) / 1000",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Logical",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Response Time (Logical)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "light-yellow",
+                "value": 20
+              },
+              {
+                "color": "dark-orange",
+                "value": 50
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 7,
+        "x": 7,
+        "y": 5
+      },
+      "id": 12,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "text": {}
+      },
+      "pluginVersion": "9.2.4",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(delta(polardbx_stats_request_time_cost_total{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"}[1m])) / (sum(delta (polardbx_stats_request_count_total{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"}[1m])) + 1) / 1000",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "RT (Logical)",
+          "queryType": "randomWalk",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(delta(polardbx_stats_physical_request_time_cost_total{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"}[1m])) / (sum(delta (polardbx_stats_physical_request_count_total{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"}[1m])) + 1) / 1000",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "RT (Physical)",
+          "refId": "B"
+        }
+      ],
+      "title": "Response Time",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 15
+              },
+              {
+                "color": "red",
+                "value": 30
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 5,
+        "x": 14,
+        "y": 5
+      },
+      "id": 18,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.2.4",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(polardbx_stats_error_count_total{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"}[1m]))",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Errors",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Errors",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "align": "center",
+            "displayMode": "auto",
+            "filterable": false,
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CPU %"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "gradient-gauge"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MEM %"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "gradient-gauge"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MEM"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              },
+              {
+                "id": "custom.width",
+                "value": 162
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "MEM (Limit)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Pod"
+            },
+            "properties": [
+              {
+                "id": "custom.filterable",
+                "value": true
+              },
+              {
+                "id": "custom.width",
+                "value": 215
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Network (Recv)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "auto"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Network (Sent)"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "node"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 205
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Host"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "Node Dashboard",
+                    "url": "./d/fa49a4706d07a042595b664c87fb33ea/nodes?orgId=1&var-datasource=$datasource&var-instance=${__value.text}"
+                  }
+                ]
+              },
+              {
+                "id": "custom.width",
+                "value": 221
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Pod"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "Pod Dashboard",
+                    "url": "./d/6581e46e4e5c7ba40a07646395ef7b23/k8s-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=${__value.text}"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CPU"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 92
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "CPU (Limit)"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 107
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 96,
+      "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "frameIndex": 0,
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "CPU"
+          }
+        ]
+      },
+      "pluginVersion": "9.2.4",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum by (app_kubernetes_io_instance, pod, app_kubernetes_io_component, apps_kubeblocks_io_component_name) (mysql_up{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\", app_kubernetes_io_component=\"gms\"})\nor\nsum by (app_kubernetes_io_instance, pod, app_kubernetes_io_component, apps_kubeblocks_io_component_name) (polardbx_up{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"})\nor \nsum by (app_kubernetes_io_instance, pod, app_kubernetes_io_component, apps_kubeblocks_io_component_name) (mysql_up{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\", app_kubernetes_io_component=\"dn\"})\nor \nsum by (app_kubernetes_io_instance, pod, app_kubernetes_io_component, apps_kubeblocks_io_component_name) (polardbx_cdc_up{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"})\n",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{ pod }}",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "title": "Topology",
+      "transformations": [
+        {
+          "id": "seriesToColumns",
+          "options": {
+            "byField": "pod"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true,
+              "Time 4": true,
+              "Time 5": true,
+              "Time 6": true,
+              "Time 7": true,
+              "Time 8": true,
+              "Time 9": true,
+              "Value": true,
+              "Value #A": true
+            },
+            "indexByName": {
+              "Time": 2,
+              "Value": 5,
+              "app_kubernetes_io_component": 1,
+              "app_kubernetes_io_instance": 0,
+              "apps_kubeblocks_io_component_name": 3,
+              "pod": 4
+            },
+            "renameByName": {
+              "Value #B": "CPU",
+              "Value #C": "CPU (Limit)",
+              "Value #D": "CPU %",
+              "Value #E": "MEM",
+              "Value #F": "MEM (Limit)",
+              "Value #G": "MEM %",
+              "Value #H": "Network (Recv)",
+              "Value #I": "Network (Sent)",
+              "app_kubernetes_io_component": "role",
+              "app_kubernetes_io_instance": "instance",
+              "apps_kubeblocks_io_component_name": "component_name",
+              "node": "Host",
+              "pod": "pod"
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Pod"
+              }
+            ]
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 19
+      },
+      "id": 42,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Global Meta Service",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 20
+      },
+      "id": 86,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_queries{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"gms\", namespace=\"$namespace\"}[1m]))",
+          "interval": "",
+          "legendFormat": "qps (physical)",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "QPS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 20
+      },
+      "id": 87,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(mysql_global_status_threads_connected{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"gms\", namespace=\"$namespace\"})",
+          "interval": "",
+          "legendFormat": "connections",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(mysql_global_status_threads_running{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"gms\", namespace=\"$namespace\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "threads",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Connections/Threads",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 20
+      },
+      "id": 88,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(mysql_global_status_innodb_buffer_pool_bytes_data{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"gms\", namespace=\"$namespace\"})",
+          "interval": "",
+          "legendFormat": "buffer pool size",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Buffer Pool Size (Total)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 20
+      },
+      "id": 89,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(mysql_global_status_innodb_buffer_pool_bytes_data{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"gms\", namespace=\"$namespace\"}) by (xstore_name)",
+          "interval": "",
+          "legendFormat": "{{ xstore_name }}",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Buffer Pool Size (GMS)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 10,
+              "type": "log"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 28
+      },
+      "id": 90,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(mysql_global_status_buffer_pool_dirty_pages{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"gms\", namespace=\"$namespace\"})",
+          "interval": "",
+          "legendFormat": "dirty",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_buffer_pool_page_changes_total{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"gms\", namespace=\"$namespace\"}[10m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "flush",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Buffer Pool Dirty/Flush (Total)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 28
+      },
+      "id": 91,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(mysql_global_status_innodb_row_lock_current_waits{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"gms\", namespace=\"$namespace\"})",
+          "interval": "",
+          "legendFormat": "current wait",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Row Lock Current Wait (Total)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 28
+      },
+      "id": 92,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_innodb_buffer_pool_read_requests{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"gms\", namespace=\"$namespace\"}[1m]))",
+          "interval": "",
+          "legendFormat": "reads",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_innodb_buffer_pool_write_requests{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"gms\", namespace=\"$namespace\"}[1m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "writes",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Logical Reads/Writes (Total)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 28
+      },
+      "id": 93,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_innodb_log_writes{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"gms\",  namespace=\"$namespace\"}[1m]))",
+          "interval": "",
+          "legendFormat": "log writes",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_innodb_data_reads{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"gms\", namespace=\"$namespace\"}[1m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "data reads",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_innodb_data_fsyncs{polardbx_name=\"$polardbx\", polardbx_role=\"dn\", xstore_role=\"leader\", namespace=\"$namespace\"}[1m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "data fsyncs",
+          "queryType": "randomWalk",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_innodb_os_log_fsyncs{polardbx_name=\"$polardbx\", polardbx_role=\"dn\", xstore_role=\"leader\", namespace=\"$namespace\"}[1m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "log fsyncs",
+          "queryType": "randomWalk",
+          "refId": "D"
+        }
+      ],
+      "title": "IOPS (Total)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 36
+      },
+      "id": 94,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_innodb_data_written{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"gms\", namespace=\"$namespace\"}[1m]))",
+          "interval": "",
+          "legendFormat": "data written/s",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_innodb_data_read{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"gms\", namespace=\"$namespace\"}[1m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "data read/s",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_innodb_os_log_written{polardbx_name=\"$polardbx\", polardbx_role=\"dn\", xstore_role=\"leader\", namespace=\"$namespace\"}[1m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "log writtern/s",
+          "queryType": "randomWalk",
+          "refId": "C"
+        }
+      ],
+      "title": "IO Throughput (Total)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 36
+      },
+      "id": 95,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_bytes_received{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"gms\", namespace=\"$namespace\"}[1m]))",
+          "interval": "",
+          "legendFormat": "received/s",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_bytes_sent{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"gms\", namespace=\"$namespace\"}[1m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "sent/s",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Network (Total)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "id": 4,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Compute Node",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 45
+      },
+      "id": 28,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(polardbx_stats_request_count_total{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"}[1m]))",
+          "interval": "",
+          "legendFormat": "qps (logical)",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(polardbx_stats_physical_request_count_total{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"}[1m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "qps (physical)",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "QPS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 45
+      },
+      "id": 29,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(delta(polardbx_stats_request_time_cost_total{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"}[1m])) / (sum(delta (polardbx_stats_request_count_total{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"}[1m])) + 1) / 1000",
+          "interval": "",
+          "legendFormat": "rt (logical)",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(delta(polardbx_stats_physical_request_time_cost_total{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"}[30s])) / (sum(delta (polardbx_stats_physical_request_count_total{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"}[30s])) + 1) / 1000",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "rt (physical)",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Response Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 45
+      },
+      "id": 30,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(polardbx_stats_active_connections{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"})",
+          "interval": "",
+          "legendFormat": "connections",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(polardbx_stats_running_count{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "threads (running)",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Connections / Threads",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ns"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "A"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "right"
+              },
+              {
+                "id": "custom.axisLabel",
+                "value": "count"
+              },
+              {
+                "id": "unit",
+                "value": "short"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.gradientMode",
+                "value": "none"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "custom.axisPlacement",
+                "value": "left"
+              },
+              {
+                "id": "unit",
+                "value": "ns"
+              },
+              {
+                "id": "custom.axisLabel",
+                "value": "time"
+              },
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.gradientMode",
+                "value": "none"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 45
+      },
+      "id": 31,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(idelta(polardbx_jvmstats_gc_collector_invocation_count{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"}[1m])) by (type)",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "count - {{ type }}",
+          "queryType": "randomWalk",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(idelta(polardbx_jvmstats_gc_collector_time_total{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"}[1m]) / (idelta(polardbx_jvmstats_gc_collector_invocation_count{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"}[1m]) + 1)) by (type)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "time - {{ type }}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "GC",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 53
+      },
+      "id": 32,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(polardbx_stc_connection_error_count_total{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"}[1m]))",
+          "interval": "",
+          "legendFormat": "connection error",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Connection Error",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 53
+      },
+      "id": 39,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(polardbx_stats_best_effort_transaction_count_total{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"}[1m]))",
+          "interval": "",
+          "legendFormat": "best effort",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(polardbx_stats_xa_transaction_count_total{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\"}[1m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "xa",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "sum(rate(polardbx_stats_tso_transaction_count_total{polardbx_name=\"$polardbx\", namespace=\"$namespace\"}[1m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "tso",
+          "queryType": "randomWalk",
+          "refId": "C"
+        }
+      ],
+      "title": "Transactions",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "µs"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 53
+      },
+      "id": 33,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "topk(5, sum by (schema) (\n    label_replace(\n      rate(polardbx_stc_request_time_cost_total{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\", appname!~\"__.*__@.*|information_schema@.*|polardbx@.*\"}[1m]),\n      \"schema\",\n      \"$1\",\n      \"appname\",\n      \"(.*)@.*\"\n    )\n  )\n) by (schema)",
+          "interval": "",
+          "legendFormat": "{{ schema }}",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Processing Time (Top 5)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 53
+      },
+      "id": 34,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "topk(5, sum by (schema) (\n    label_replace(\n      rate(polardbx_stc_active_physical_connection_count{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\", appname!~\"__.*__@.*|information_schema@.*|polardbx@.*\"}[1m]),\n      \"schema\",\n      \"$1\",\n      \"appname\",\n      \"(.*)@.*\"\n    )\n  )\n) by (schema)",
+          "interval": "",
+          "legendFormat": "active - {{ schema }}",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "topk(5, sum by (schema) (\n    label_replace(\n      rate(polardbx_stc_pooling_physical_connection_count{polardbx_name=\"$polardbx\", namespace=\"$namespace\", appname!~\"__.*__@.*|information_schema@.*|polardbx@.*\"}[1m]),\n      \"schema\",\n      \"$1\",\n      \"appname\",\n      \"(.*)@.*\"\n    )\n  )\n) by (schema)",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "pooling - {{ schema }}",
+          "refId": "B"
+        }
+      ],
+      "title": "Physical Connection (Top 5)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 61
+      },
+      "id": 6,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Data Node",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 62
+      },
+      "id": 55,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_queries{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"dn\", namespace=\"$namespace\"}[1m]))",
+          "interval": "",
+          "legendFormat": "qps (physical)",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "QPS",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 62
+      },
+      "id": 56,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(mysql_global_status_threads_connected{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"dn\", namespace=\"$namespace\"})",
+          "interval": "",
+          "legendFormat": "connections",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(mysql_global_status_threads_running{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"dn\", namespace=\"$namespace\"})",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "threads",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Connections/Threads",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 62
+      },
+      "id": 57,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(mysql_global_status_innodb_buffer_pool_bytes_data{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"dn\", namespace=\"$namespace\"})",
+          "interval": "",
+          "legendFormat": "buffer pool size",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Buffer Pool Size (Total)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 62
+      },
+      "id": 58,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(mysql_global_status_innodb_buffer_pool_bytes_data{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"dn\", namespace=\"$namespace\"}) by (xstore_name)",
+          "interval": "",
+          "legendFormat": "{{ xstore_name }}",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Buffer Pool Size (DN)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 10,
+              "type": "log"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 70
+      },
+      "id": 59,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(mysql_global_status_buffer_pool_dirty_pages{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"dn\", namespace=\"$namespace\"})",
+          "interval": "",
+          "legendFormat": "dirty",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_buffer_pool_page_changes_total{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"dn\", namespace=\"$namespace\"}[10m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "flush",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Buffer Pool Dirty/Flush (Total)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 70
+      },
+      "id": 60,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(mysql_global_status_innodb_row_lock_current_waits{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"dn\", namespace=\"$namespace\"})",
+          "interval": "",
+          "legendFormat": "current wait",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Row Lock Current Wait (Total)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 70
+      },
+      "id": 61,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_innodb_buffer_pool_read_requests{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"dn\", namespace=\"$namespace\"}[1m]))",
+          "interval": "",
+          "legendFormat": "reads",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_innodb_buffer_pool_write_requests{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"dn\", namespace=\"$namespace\"}[1m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "writes",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Logical Reads/Writes (Total)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 70
+      },
+      "id": 62,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_innodb_log_writes{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"dn\",  namespace=\"$namespace\"}[1m]))",
+          "interval": "",
+          "legendFormat": "log writes",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_innodb_data_reads{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"dn\", namespace=\"$namespace\"}[1m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "data reads",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_innodb_data_fsyncs{polardbx_name=\"$polardbx\", polardbx_role=\"dn\", xstore_role=\"leader\", namespace=\"$namespace\"}[1m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "data fsyncs",
+          "queryType": "randomWalk",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_innodb_os_log_fsyncs{polardbx_name=\"$polardbx\", polardbx_role=\"dn\", xstore_role=\"leader\", namespace=\"$namespace\"}[1m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "log fsyncs",
+          "queryType": "randomWalk",
+          "refId": "D"
+        }
+      ],
+      "title": "IOPS (Total)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 78
+      },
+      "id": 63,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_innodb_data_written{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"dn\", namespace=\"$namespace\"}[1m]))",
+          "interval": "",
+          "legendFormat": "data written/s",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_innodb_data_read{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"dn\", namespace=\"$namespace\"}[1m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "data read/s",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_innodb_os_log_written{polardbx_name=\"$polardbx\", polardbx_role=\"dn\", xstore_role=\"leader\", namespace=\"$namespace\"}[1m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "log writtern/s",
+          "queryType": "randomWalk",
+          "refId": "C"
+        }
+      ],
+      "title": "IO Throughput (Total)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 78
+      },
+      "id": 64,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_bytes_received{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"dn\", namespace=\"$namespace\"}[1m]))",
+          "interval": "",
+          "legendFormat": "received/s",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_bytes_sent{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"dn\", namespace=\"$namespace\"}[1m]))",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "sent/s",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Network (Total)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 78
+      },
+      "id": 65,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_commands_total{polapp_kubernetes_io_instanceardbx_name=\"$polardbx\", app_kubernetes_io_component=\"dn\", namespace=\"$namespace\", command=~\"xa_.*\"}[1m])) by (command)",
+          "interval": "",
+          "legendFormat": "{{ command }}",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "XA Transactions (Total)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 78
+      },
+      "id": 66,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "sum(rate(mysql_global_status_commands_total{app_kubernetes_io_instance=\"$polardbx\", app_kubernetes_io_component=\"dn\", namespace=\"$namespace\", command=~\"begin|commit|rollback\"}[1m])) by (command)",
+          "interval": "",
+          "legendFormat": "{{ command }}",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Transactions (Total)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 86
+      },
+      "id": 68,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "CDC Node",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 87
+      },
+      "id": 76,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "polardbx_cdc_dumper_delay_in_millisecond{namespace=\"$namespace\"}\n* on(namespace,pod)\ngroup_left() polardbx_cdc_up{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\", app_kubernetes_io_component=\"cdc\"}",
+          "interval": "",
+          "legendFormat": "{{ pod }}",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Delay(ms)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "opacity",
+            "hideFrom": {
+              "graph": false,
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 87
+      },
+      "id": 77,
+      "options": {
+        "graph": {},
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "7.5.3",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "polardbx_cdc_dumper_jvm_heap_usage{namespace=\"$namespace\"}\n* on(namespace,pod)\ngroup_left() polardbx_cdc_up{app_kubernetes_io_instance=\"$polardbx\", namespace=\"$namespace\", app_kubernetes_io_component=\"cdc\"}",
+          "interval": "",
+          "legendFormat": "{{ pod }}",
+          "queryType": "randomWalk",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Dumper Heap Usage",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "10s",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "isNone": true,
+          "selected": false,
+          "text": "None",
+          "value": ""
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(kube_pod_info, cluster)",
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(kube_pod_info, cluster)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "default",
+          "value": "default"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(polardbx_up, namespace)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": {
+          "query": "label_values(polardbx_up, namespace)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "/^(?!kube\\-system|.*\\-operator\\-system|monitoring|loki)/",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "pxc-v4",
+          "value": "pxc-v4"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(polardbx_up{namespace=\"$namespace\"}, app_kubernetes_io_instance)",
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "polardbx",
+        "options": [],
+        "query": {
+          "query": "label_values(polardbx_up{namespace=\"$namespace\"}, app_kubernetes_io_instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "PolarDB-X Overview",
+  "uid": "EByXvnuGk",
+  "version": 2,
+  "weekStart": ""
+}

--- a/deploy/polardbx/scripts/gms-init.sql
+++ b/deploy/polardbx/scripts/gms-init.sql
@@ -1,0 +1,153 @@
+CREATE DATABASE IF NOT EXISTS polardbx_meta_db;
+USE polardbx_meta_db;
+
+CREATE TABLE IF NOT EXISTS server_info (
+  id BIGINT(11) NOT NULL auto_increment,
+  gmt_created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  gmt_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP on UPDATE CURRENT_TIMESTAMP,
+  inst_id VARCHAR(128) NOT NULL,
+  inst_type INT(11) NOT NULL,
+  ip VARCHAR(128) NOT NULL,
+  port INT(11) NOT NULL,
+  htap_port INT(11) NOT NULL,
+  mgr_port INT(11) NOT NULL,
+  mpp_port INT(11) NOT NULL,
+  status INT(11) NOT NULL,
+  region_id VARCHAR(128) DEFAULT NULL,
+  azone_id VARCHAR(128) DEFAULT NULL,
+  idc_id VARCHAR(128) DEFAULT NULL,
+  cpu_core INT(11) DEFAULT NULL,
+  mem_size INT(11) DEFAULT NULL,
+  extras text DEFAULT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_inst_id_addr (inst_id, ip, port),
+  INDEX idx_inst_id_status (inst_id, status)
+) engine = innodb DEFAULT charset = utf8;
+
+CREATE TABLE IF NOT EXISTS storage_info (
+  id BIGINT(11) NOT NULL auto_increment,
+  gmt_created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  gmt_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP on UPDATE CURRENT_TIMESTAMP,
+  inst_id VARCHAR(128) NOT NULL,
+  storage_inst_id VARCHAR(128) NOT NULL,
+  storage_master_inst_id VARCHAR(128) NOT NULL,
+  ip VARCHAR(128) NOT NULL,
+  port INT(11) NOT NULL comment 'port for mysql',
+  xport INT(11) DEFAULT NULL comment 'port for x-protocol',
+  user VARCHAR(128) NOT NULL,
+  passwd_enc text NOT NULL,
+  storage_type INT(11) NOT NULL comment '0:x-cluster, 1:mysql, 2:polardb',
+  inst_kind INT(11) NOT NULL comment '0:master, 1:slave, 2:metadb',
+  status INT(11) NOT NULL comment '0:storage ready, 1:storage not_ready',
+  region_id VARCHAR(128) DEFAULT NULL,
+  azone_id VARCHAR(128) DEFAULT NULL,
+  idc_id VARCHAR(128) DEFAULT NULL,
+  max_conn INT(11) NOT NULL,
+  cpu_core INT(11) DEFAULT NULL,
+  mem_size INT(11) DEFAULT NULL comment 'mem unit: MB',
+  is_vip INT(11) DEFAULT NULL COMMENT '0:ip is NOT vip, 1:ip is vip',
+  extras text DEFAULT NULL COMMENT 'reserve for extra info',
+  PRIMARY KEY (id),
+  INDEX idx_inst_id_status (inst_id, status),
+  UNIQUE KEY uk_inst_id_addr (storage_inst_id, ip, port, inst_kind)
+) engine = innodb DEFAULT charset = utf8;
+
+CREATE TABLE if not exists user_priv (
+  id bigint(11) NOT NULL AUTO_INCREMENT,
+  gmt_created timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  gmt_modified timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  user_name char(32) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  host char(60) COLLATE utf8_unicode_ci NOT NULL DEFAULT '',
+  password char(100) COLLATE utf8_unicode_ci NOT NULL,
+  select_priv tinyint(1) NOT NULL DEFAULT '0',
+  insert_priv tinyint(1) NOT NULL DEFAULT '0',
+  update_priv tinyint(1) NOT NULL DEFAULT '0',
+  delete_priv tinyint(1) NOT NULL DEFAULT '0',
+  create_priv tinyint(1) NOT NULL DEFAULT '0',
+  drop_priv tinyint(1) NOT NULL DEFAULT '0',
+  grant_priv tinyint(1) NOT NULL DEFAULT '0',
+  index_priv tinyint(1) NOT NULL DEFAULT '0',
+  alter_priv tinyint(1) NOT NULL DEFAULT '0',
+  show_view_priv int(11) NOT NULL DEFAULT '0',
+  create_view_priv int(11) NOT NULL DEFAULT '0',
+  create_user_priv int(11) NOT NULL DEFAULT '0',
+  meta_db_priv int(11) NOT NULL DEFAULT '0',
+  PRIMARY KEY (id),
+  UNIQUE KEY uk (user_name, host)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8 COLLATE = utf8_unicode_ci COMMENT = 'Users and global privileges';
+
+CREATE TABLE IF NOT EXISTS quarantine_config (
+  id BIGINT(11) NOT NULL auto_increment,
+  gmt_created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  gmt_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP on UPDATE CURRENT_TIMESTAMP,
+  inst_id VARCHAR(100) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
+  group_name VARCHAR(200) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
+  net_work_type VARCHAR(100) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
+  security_ip_type VARCHAR(100) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
+  security_ips text CHARACTER SET utf8 COLLATE utf8_unicode_ci,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk (inst_id, group_name)
+) engine = innodb DEFAULT charset = utf8 comment = 'Quarantine config';
+
+
+CREATE TABLE IF NOT EXISTS config_listener (
+  id bigint(11) NOT NULL AUTO_INCREMENT,
+  gmt_created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  gmt_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  data_id varchar(200) NOT NULL,
+  status int NOT NULL COMMENT '0:normal, 1:removed',
+  op_version bigint NOT NULL,
+  extras varchar(1024) DEFAULT NULL,
+  PRIMARY KEY (id),
+  INDEX idx_modify_ts (gmt_modified),
+  INDEX idx_status (status),
+  UNIQUE KEY uk_data_id (data_id)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8;
+
+create table if not exists inst_config (
+  id bigint(11) NOT NULL AUTO_INCREMENT,
+  gmt_created timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  gmt_modified timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  inst_id varchar(128) NOT NULL,
+  param_key varchar(128) NOT NULL,
+  param_val varchar(1024) NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uk_inst_id_key (inst_id, param_key)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8;
+
+CREATE TABLE IF NOT EXISTS polardbx_extra (
+  id BIGINT(11) NOT NULL auto_increment,
+  inst_id VARCHAR(128) NOT NULL,
+  name VARCHAR(128) NOT NULL,
+  type VARCHAR(10) NOT NULL,
+  comment VARCHAR(256) NOT NULL,
+  status INT(4) NOT NULL,
+  gmt_created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  gmt_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP on
+             UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE uk_inst_id_name_type (inst_id, name, type)
+) engine = innodb DEFAULT charset = utf8 COLLATE = utf8_unicode_ci comment = 'extra table for polardbx manager';
+
+CREATE TABLE IF NOT EXISTS schema_change (
+    id           BIGINT(11)      NOT NULL AUTO_INCREMENT,
+    table_name   varchar(64)     NOT NULL,
+    version      int unsigned    NOT NULL,
+    gmt_created  timestamp       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    gmt_modified timestamp       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY table_name (table_name)
+    )   ENGINE = innodb DEFAULT CHARSET=utf8;
+
+CREATE TABLE IF NOT EXISTS k8s_topology (
+    id BIGINT(11) NOT NULL AUTO_INCREMENT,
+    uid VARCHAR(128) NOT NULL,
+    name VARCHAR(128) NOT NULL,
+    type VARCHAR(10) NOT NULL,
+    gmt_created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    gmt_modified TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY(uid),
+    UNIQUE KEY(name, type)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8 COLLATE = utf8_unicode_ci COMMENT = 'PolarDBX K8s Topology';
+

--- a/deploy/polardbx/scripts/gms-metadata.tpl
+++ b/deploy/polardbx/scripts/gms-metadata.tpl
@@ -1,0 +1,23 @@
+USE polardbx_meta_db;
+
+INSERT IGNORE INTO schema_change(table_name, version) VALUES('user_priv', 1);
+INSERT IGNORE INTO quarantine_config VALUES (NULL, NOW(), NOW(), '$KB_CLUSTER_NAME', 'default', NULL, NULL, '0.0.0.0/0');
+
+INSERT IGNORE INTO config_listener (id, gmt_created, gmt_modified, data_id, status, op_version, extras) VALUES (NULL, NOW(), NOW(), 'polardbx.server.info.$KB_CLUSTER_NAME', 0, 0, NULL);
+INSERT IGNORE INTO config_listener (id, gmt_created, gmt_modified, data_id, status, op_version, extras) VALUES (NULL, NOW(), NOW(), 'polardbx.storage.info.$KB_CLUSTER_NAME', 0, 0, NULL);
+INSERT IGNORE INTO config_listener (id, gmt_created, gmt_modified, data_id, status, op_version, extras) VALUES (NULL, NOW(), NOW(), 'polardbx.inst.config.$KB_CLUSTER_NAME', 0, 0, NULL);
+INSERT IGNORE INTO config_listener (id, gmt_created, gmt_modified, data_id, status, op_version, extras) VALUES (NULL, NOW(), NOW(), 'polardbx.quarantine.config.$KB_CLUSTER_NAME', 0, 0, NULL);
+INSERT IGNORE INTO config_listener (id, gmt_created, gmt_modified, data_id, status, op_version, extras) VALUES (NULL, NOW(), NOW(), 'polardbx.privilege.info', 0, 0, NULL);
+
+INSERT IGNORE INTO inst_config (inst_id, param_key,param_val) values ('$KB_CLUSTER_NAME','CONN_POOL_XPROTO_META_DB_PORT','0');
+INSERT IGNORE INTO inst_config (inst_id, param_key,param_val) values ('$KB_CLUSTER_NAME','CDC_STARTUP_MODE','1');
+INSERT IGNORE INTO inst_config (inst_id, param_key,param_val) values ('$KB_CLUSTER_NAME','CONN_POOL_MAX_POOL_SIZE','500');
+INSERT IGNORE INTO inst_config (inst_id, param_key,param_val) values ('$KB_CLUSTER_NAME','MAX_PREPARED_STMT_COUNT','500000');
+
+INSERT IGNORE INTO storage_info (id, gmt_created, gmt_modified, inst_id, storage_inst_id, storage_master_inst_id,ip, port, xport, user, passwd_enc, storage_type, inst_kind, status, region_id, azone_id, idc_id, max_conn, cpu_core, mem_size, is_vip, extras)
+    VALUES (NULL, NOW(), NOW(), '$KB_CLUSTER_NAME', '$GMS_SVC_NAME', '$GMS_SVC_NAME', '$GMS_HOST', '3306', '31600', '$metaDbUser', '$ENC_PASSWORD', '3', '2', '0', NULL, NULL, NULL, 10000, 4,  34359738368 , '0', '');
+
+INSERT IGNORE INTO user_priv (id, gmt_created, gmt_modified, user_name, host, password, select_priv, insert_priv, update_priv, delete_priv, create_priv, drop_priv, grant_priv, index_priv, alter_priv, show_view_priv, create_view_priv, create_user_priv, meta_db_priv)
+    VALUES (NULL, now(), now(), '$metaDbUser', '%', '$SHA1_ENC_PASSWORD', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1', '1');
+
+UPDATE config_listener SET op_version = op_version + 1 WHERE data_id = 'polardbx.privilege.info';

--- a/deploy/polardbx/scripts/metadb-setup.tpl
+++ b/deploy/polardbx/scripts/metadb-setup.tpl
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+until mysql -h$GMS_SVC_NAME -P$GMS_SVC_PORT -u$metaDbUser -p$metaDbNonEncPasswd -e 'select 1'; do
+    sleep 1;
+    echo "wait gms ready"
+done
+
+function generate_dn_init_sql() {
+    echo "$DN_HEADLESS_SVC_NAME" | tr ',' '\n' | while IFS= read -r item
+    do
+      DN_HOSTNAME=$item
+      DN_NAME=$(echo "$DN_HOSTNAME" | cut -d'.' -f2 | sed s/-headless//)
+      dn_init_sql="INSERT IGNORE INTO storage_info (id, gmt_created, gmt_modified, inst_id, storage_inst_id, storage_master_inst_id,ip, port, xport, user, passwd_enc, storage_type, inst_kind, status, region_id, azone_id, idc_id, max_conn, cpu_core, mem_size, is_vip, extras)
+      VALUES (NULL, NOW(), NOW(), '$KB_CLUSTER_NAME', '$DN_NAME', '$DN_NAME', '$DN_HOSTNAME', '3306', '31600', '$metaDbUser', '$ENC_PASSWORD', '3', '0', '0', NULL, NULL, NULL, 10000, 4,  34359738368 , '0', '');"
+      echo $dn_init_sql >> /scripts/gms-init-metadata.sql
+    done
+    echo "UPDATE config_listener SET op_version = op_version + 1 WHERE data_id = 'polardbx.storage.info.$KB_CLUSTER_NAME'" >> /scripts/gms-init-metadata.sql
+}
+
+ENC_PASSWORD=$(echo -n "$metaDbNonEncPasswd" | openssl enc -aes-128-ecb -K "$(printf "%s" "$dnPasswordKey" | od -An -tx1 | tr -d " \n")" -base64)
+SHA1_ENC_PASSWORD=$(echo -n "$metaDbNonEncPasswd" | sha1sum | cut -d ' ' -f1)
+echo "export metaDbPasswd=$ENC_PASSWORD" >> /shared/env.sh
+
+SOURCE_CMD="mysql -h$GMS_SVC_NAME -P$GMS_SVC_PORT -u$metaDbUser -p$metaDbNonEncPasswd -e 'source /scripts/gms-init.sql'"
+eval $SOURCE_CMD
+
+GMS_HOST=$GMS_SVC_NAME"."$KB_NAMESPACE".svc.cluster.local"
+
+eval "gms_metadata_sql=\"$(cat /scripts/gms-metadata.tpl)\""
+
+echo $gms_metadata_sql > /scripts/gms-init-metadata.sql
+generate_dn_init_sql
+
+cat /scripts/gms-init-metadata.sql
+
+eval "mysql -h$GMS_SVC_NAME -P$GMS_SVC_PORT -u$metaDbUser -p$metaDbNonEncPasswd -e 'source /scripts/gms-init-metadata.sql'"
+

--- a/deploy/polardbx/scripts/xstore-post-start.tpl
+++ b/deploy/polardbx/scripts/xstore-post-start.tpl
@@ -1,0 +1,24 @@
+#!/bin/sh
+# usage: xstore-post-start.sh type_name
+# type_name: component.type, in uppercase.
+
+TYPE_NAME=$1
+
+# setup shared-channel.json
+SHARED_CHANNEL_JSON='{"nodes": ['
+
+i=0
+while [ $i -lt $(eval echo \$KB_"$TYPE_NAME"_N) ]; do
+  hostname=$(eval echo \$KB_"$TYPE_NAME"_"$i"_HOSTNAME)
+  pod=$(echo "$hostname" | cut -d'.' -f1)
+
+  NODE_OBJECT=$(printf '{"pod": "%s", "host": "%s", "port": 11306, "role": "candidate", "node_name": "%s" }' "$pod" "$hostname" "$pod")
+  SHARED_CHANNEL_JSON+="$NODE_OBJECT,"
+  i=$(( i + 1))
+done
+
+SHARED_CHANNEL_JSON=${SHARED_CHANNEL_JSON%,}
+SHARED_CHANNEL_JSON+=']}'
+
+mkdir -p /data/shared/
+echo $SHARED_CHANNEL_JSON > /data/shared/shared-channel.json

--- a/deploy/polardbx/scripts/xstore-setup.tpl
+++ b/deploy/polardbx/scripts/xstore-setup.tpl
@@ -1,0 +1,17 @@
+#!/bin/sh
+# usage: xstore-setup.sh
+# setup root account for xstore and run entrypoint
+
+function setup_account() {
+    until myc -e 'select 1'; do
+        sleep 1;
+        echo "wait mysql ready"
+    done
+    echo "mysql is ok"
+    myc -e "SET sql_log_bin=OFF;SET force_revise=ON;CREATE USER IF NOT EXISTS $KB_SERVICE_USER IDENTIFIED BY '$KB_SERVICE_PASSWORD';GRANT ALL PRIVILEGES ON *.* TO $KB_SERVICE_USER;ALTER USER $KB_SERVICE_USER IDENTIFIED BY '$KB_SERVICE_PASSWORD';"
+
+}
+
+
+setup_account &
+/tools/xstore/current/venv/bin/python3 /tools/xstore/current/entrypoint.py

--- a/deploy/polardbx/templates/NOTES.txt
+++ b/deploy/polardbx/templates/NOTES.txt
@@ -1,0 +1,14 @@
+Thanks for installing PolarDB-X using KubeBlocks!
+
+1. Run the following command to create your first PolarDB-X cluster:
+
+```
+kbcli cluster create pxc --cluster-definition polardbx
+```
+
+2. Port-forward service to localhost and connect to PolarDB-X cluster:
+
+```
+kubectl port-forward svc/pxc-cn 3306:3306
+mysql -h127.0.0.1 -upolardbx_root
+```

--- a/deploy/polardbx/templates/_helpers.tpl
+++ b/deploy/polardbx/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "polardbx.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "polardbx.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "polardbx.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "polardbx.labels" -}}
+helm.sh/chart: {{ include "polardbx.chart" . }}
+{{ include "polardbx.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "polardbx.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "polardbx.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "polardbx.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "polardbx.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/polardbx/templates/clusterDefintion.yaml
+++ b/deploy/polardbx/templates/clusterDefintion.yaml
@@ -1,0 +1,694 @@
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: ClusterDefinition
+metadata:
+  name: polardbx
+  labels:
+    {{- include "polardbx.labels" . | nindent 4 }}
+spec:
+  connectionCredential:
+    username: "polardbx_root"
+    password: "$(RANDOM_PASSWD)"
+    endpoint: "$(SVC_FQDN):$(SVC_PORT_polardbx)"
+    host: "$(SVC_FQDN)"
+    port: "$(SVC_PORT_polardbx)"
+    metaDbPasswd: "$(RANDOM_PASSWD)"
+  componentDefs:
+    - name: gms
+      scriptSpecs:
+        - name: polardbx-scripts
+          templateRef: polardbx-scripts
+          volumeName: scripts
+          namespace: {{ .Release.Namespace }}
+          defaultMode: 0555
+      workloadType: Consensus
+      characterType: polardbx
+      consensusSpec:
+        leader:
+          name: "leader"
+          accessMode: ReadWrite
+        followers:
+          - name: "follower"
+            accessMode: Readonly
+        updateStrategy: Parallel
+      probes:
+        roleProbe:
+          failureThreshold: {{ .Values.roleProbe.failureThreshold }}
+          periodSeconds: {{ .Values.roleProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.roleProbe.timeoutSeconds }}
+      service:
+        ports:
+          - name: mysql
+            port: 3306
+            targetPort: 3306
+          - name: metrics
+            port: 9104
+            targetPort: 9104
+      monitor:
+        builtIn: false
+        exporterConfig:
+          scrapePort: 9104
+          scrapePath: "/metrics"
+      podSpec:
+        volumes: &xstoreVolumes
+          - hostPath:
+              path: /data/cache/tools/xstore
+              type: Directory
+            name: xstore-tools
+          - downwardAPI:
+              defaultMode: 420
+              items:
+                - fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.labels
+                  path: labels
+                - fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.annotations
+                  path: annotations
+                - fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.annotations['runmode']
+                  path: runmode
+                - fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.name
+                  path: name
+                - fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+                  path: namespace
+            name: podinfo
+        initContainers: &xsotreInitContainers
+          - name: tools-updater
+            command: ["/bin/ash"]
+            args: ["-c", "./hack/update.sh /target"]
+            env:
+              - name: NODE_NAME
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: spec.nodeName
+            volumeMounts:
+              - name: xstore-tools
+                mountPath: /target
+        containers:
+          - name: engine
+            command: ["/scripts/xstore-setup.sh"]
+            lifecycle:
+              postStart:
+                exec:
+                  command:
+                    - /scripts/xstore-post-start.sh
+                    - GMS
+            env: &xstoreEngineEnv
+              - name: LANG
+                value: en_US.utf8
+              - name: LC_ALL
+                value: en_US.utf8
+              - name: ENGINE
+                value: galaxy
+              - name: ENGINE_HOME
+                value: /opt/galaxy_engine
+              - name: NODE_ROLE
+                value: candidate
+              - name: NODE_IP
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: status.hostIP
+              - name: NODE_NAME
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: spec.nodeName
+              - name: POD_IP
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: status.podIP
+              - name: POD_NAME
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.name
+              - name: LIMITS_CPU
+                valueFrom:
+                  resourceFieldRef:
+                    containerName: engine
+                    resource: limits.cpu
+                    divisor: "1m"
+              - name: LIMITS_MEM
+                valueFrom:
+                  resourceFieldRef:
+                    containerName: engine
+                    resource: limits.memory
+              - name: PORT_MYSQL
+                value: "3306"
+              - name: PORT_PAXOS
+                value: "11306"
+              - name: PORT_POLARX
+                value: "31600"
+              - name: KB_SERVICE_USER
+                value: "polardbx_root"
+              - name: KB_SERVICE_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: $(CONN_CREDENTIAL_SECRET_NAME)
+                    key: password
+                    optional: false
+              - name: RSM_COMPATIBILITY_MODE
+                value: "true"
+            ports: &xstoreEnginePorts
+              - name: mysql
+                containerPort: 3306
+              - name: paxos
+                containerPort: 11306
+              - name: polarx
+                containerPort: 31600
+            startupProbe:
+              failureThreshold: 60
+              tcpSocket:
+                port: mysql
+              initialDelaySeconds: 5
+              periodSeconds: 10
+              successThreshold: 1
+              timeoutSeconds: 30
+            volumeMounts: &xstoreEngineVolumeMounts
+              - name: data
+                mountPath: /data/mysql
+              - name: data-log
+                mountPath: /data-log/mysql
+              - name: xstore-tools
+                mountPath: /tools/xstore
+              - name: scripts
+                mountPath: /scripts/xstore-post-start.sh
+                subPath: xstore-post-start.sh
+              - name: scripts
+                mountPath: /scripts/xstore-setup.sh
+                subPath: xstore-setup.sh
+              - name: podinfo
+                mountPath: /etc/podinfo
+          - name: exporter
+            imagePullPolicy: IfNotPresent
+            ports:
+              - name: metrics
+                containerPort: 9104
+                protocol: TCP
+            env:
+              - name: "MYSQL_MONITOR_USER"
+                valueFrom:
+                  secretKeyRef:
+                    name: $(CONN_CREDENTIAL_SECRET_NAME)
+                    key: username
+              - name: "MYSQL_MONITOR_PASSWORD"
+                valueFrom:
+                  secretKeyRef:
+                    name: $(CONN_CREDENTIAL_SECRET_NAME)
+                    key: password
+              - name: "DATA_SOURCE_NAME"
+                value: "$(MYSQL_MONITOR_USER):$(MYSQL_MONITOR_PASSWORD)@(localhost:3306)/"
+    - name: dn
+      scriptSpecs:
+        - name: polardbx-scripts
+          templateRef: polardbx-scripts
+          volumeName: scripts
+          namespace: {{ .Release.Namespace }}
+          defaultMode: 0555
+      workloadType: Consensus
+      characterType: polardbx
+      componentDefRef:
+        - &gmsRef
+          componentDefName: gms
+          componentRefEnv:
+            - name: GMS_SVC_PORT
+              valueFrom:
+                type: FieldRef
+                fieldPath: $.componentDef.service.ports[?(@.name == "mysql")].port
+            - name: GMS_SVC_NAME
+              valueFrom:
+                type: ServiceRef
+      consensusSpec:
+        leader:
+          name: "leader"
+          accessMode: ReadWrite
+        followers:
+          - name: "follower"
+            accessMode: Readonly
+        updateStrategy: Parallel
+      probes:
+        roleProbe:
+          failureThreshold: {{ .Values.roleProbe.failureThreshold }}
+          periodSeconds: {{ .Values.roleProbe.periodSeconds }}
+          timeoutSeconds: {{ .Values.roleProbe.timeoutSeconds }}
+      service:
+        ports:
+          - name: mysql
+            port: 3306
+            targetPort: 3306
+      monitor:
+        builtIn: false
+        exporterConfig:
+          scrapePort: 9104
+          scrapePath: "/metrics"
+      podSpec:
+        volumes: *xstoreVolumes
+        initContainers: *xsotreInitContainers
+        containers:
+          - name: engine
+            command: [ "/scripts/xstore-setup.sh" ]
+            lifecycle:
+              postStart:
+                exec:
+                  command:
+                    - /scripts/xstore-post-start.sh
+                    - DN
+            env: *xstoreEngineEnv
+            ports: *xstoreEnginePorts
+            startupProbe:
+              failureThreshold: 60
+              tcpSocket:
+                port: mysql
+              initialDelaySeconds: 20
+              periodSeconds: 10
+              successThreshold: 1
+              timeoutSeconds: 30
+            volumeMounts: *xstoreEngineVolumeMounts
+          - name: exporter
+            imagePullPolicy: IfNotPresent
+            ports:
+              - name: metrics
+                containerPort: 9104
+                protocol: TCP
+            env:
+              - name: "MYSQL_MONITOR_USER"
+                valueFrom:
+                  secretKeyRef:
+                    name: $(CONN_CREDENTIAL_SECRET_NAME)
+                    key: username
+              - name: "MYSQL_MONITOR_PASSWORD"
+                valueFrom:
+                  secretKeyRef:
+                    name: $(CONN_CREDENTIAL_SECRET_NAME)
+                    key: password
+              - name: "DATA_SOURCE_NAME"
+                value: "$(MYSQL_MONITOR_USER):$(MYSQL_MONITOR_PASSWORD)@(localhost:3306)/"
+    - name: cn
+      scriptSpecs:
+        - name: polardbx-scripts
+          templateRef: polardbx-scripts
+          volumeName: scripts
+          namespace: {{ .Release.Namespace }}
+          defaultMode: 0555
+      workloadType: Stateless
+      characterType: mysql
+      componentDefRef:
+        - *gmsRef
+        - componentDefName: dn
+          componentRefEnv:
+            - name: DN_SVC_PORT
+              valueFrom:
+                type: FieldRef
+                fieldPath: $.componentDef.service.ports[?(@.name == "mysql")].port
+            - name: DN_HEADLESS_SVC_NAME
+              valueFrom:
+                type: HeadlessServiceRef
+                format: $(POD_FQDN){{ .Values.clusterDomain }}
+                joinWith: ","
+      service:
+        ports:
+          - name: mysql
+            port: 3306
+            targetPort: 3306
+          - name: metrics
+            port: 9104
+            targetPort: 9104
+      monitor:
+        builtIn: false
+        exporterConfig:
+          scrapePort: 9104
+          scrapePath: "/metrics"
+      podSpec:
+        shareProcessNamespace: true  # For jmx collector
+        volumes:
+          - name: shared
+            emptyDir: {}
+        initContainers:
+          - name: metadb-init
+            command: ["/scripts/metadb-setup.sh"]
+            env:
+            - name: metaDbAddr
+              value: "$(GMS_SVC_NAME):$(GMS_SVC_PORT)"
+            - name: metaDbName
+              value: "polardbx_meta_db"
+            - name: metaDbUser
+              valueFrom:
+                secretKeyRef:
+                  name: $(CONN_CREDENTIAL_SECRET_NAME)
+                  key: username
+                  optional: false
+            - name: metaDbNonEncPasswd
+              valueFrom:
+                secretKeyRef:
+                  name: $(CONN_CREDENTIAL_SECRET_NAME)
+                  key: password
+                  optional: false
+            - name: dnPasswordKey
+              value: "$(metaDbNonEncPasswd)$(metaDbNonEncPasswd)"
+            - name: switchCloud
+              value: aliyun
+            - name: metaDbConn
+              value: "mysql -h$(GMS_SVC_NAME) -P3306 -u$(metaDbUser) -p$(metaDbNonEncPasswd) -D$(metaDbName)"
+            volumeMounts:
+              - name: scripts
+                mountPath: /scripts/metadb-setup.sh
+                subPath: metadb-setup.sh
+              - name: scripts
+                mountPath: /scripts/gms-init.sql
+                subPath: gms-init.sql
+              - name: scripts
+                mountPath: /scripts/gms-metadata.tpl
+                subPath: gms-metadata.tpl
+              - name: shared
+                mountPath: /shared
+          - name: init
+            command: [ "sh" ]
+            args: [ "-c", 'source /shared/env.sh && /polardbx-init' ]
+            env: &cnEngineEnv
+              - name: POD_ID
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.name
+              - name: POD_IP
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: status.podIP
+              - name: HOST_IP
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: status.hostIP
+              - name: NODE_NAME
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: spec.nodeName
+              - name: metaDbAddr
+                value: "$(GMS_SVC_NAME):$(GMS_SVC_PORT)"
+              - name: metaDbName
+                value: "polardbx_meta_db"
+              - name: metaDbUser
+                valueFrom:
+                  secretKeyRef:
+                    name: $(CONN_CREDENTIAL_SECRET_NAME)
+                    key: username
+                    optional: false
+              - name: metaDbNonEncPasswd
+                valueFrom:
+                  secretKeyRef:
+                    name: $(CONN_CREDENTIAL_SECRET_NAME)
+                    key: password
+                    optional: false
+              - name: switchCloud
+                value: aliyun
+              - name: metaDbConn
+                value: "mysql -h$(GMS_SVC_NAME) -P3306 -u$(metaDbUser) -p$(metaDbPasswd) -D$(metaDbName)"
+              - name: dnPasswordKey
+                value: "$(metaDbNonEncPasswd)$(metaDbNonEncPasswd)"
+              - name: metaDbXprotoPort
+                value: "0"
+              - name: storageDbXprotoPort
+                value: "0"
+              - name: instanceId
+                value: "$(KB_CLUSTER_NAME)"
+              - name: instanceType
+                value: "0"
+              - name: serverPort
+                value: "3306"
+              - name: mgrPort
+                value: "3406"
+              - name: mppPort
+                value: "3506"
+              - name: htapPort
+                value: "3606"
+              - name: logPort
+                value: "8507"
+              - name: ins_id
+                value: dummy
+              - name: polarx_dummy_log_port
+                value: "$(logPort)"
+              - name: polarx_dummy_ssh_port
+                value: "-1"
+              - name: cpuCore
+                valueFrom:
+                  resourceFieldRef:
+                    containerName: engine
+                    resource: limits.cpu
+              - name: memSize
+                valueFrom:
+                  resourceFieldRef:
+                    containerName: engine
+                    resource: limits.memory
+              - name: cpu_cores
+                valueFrom:
+                  resourceFieldRef:
+                    containerName: engine
+                    resource: limits.cpu
+              - name: memory
+                valueFrom:
+                  resourceFieldRef:
+                    containerName: engine
+                    resource: limits.memory
+              - name: galaxyXProtocol
+                value: "1"
+              - name: processorHandler
+                value: "1"
+              - name: processors
+                value: "1"
+              - name: serverExecutor
+                value: "1024"
+              - name: TDDL_OPTS
+                value: -Dpod.id=$(POD_ID) -XX:+UnlockExperimentalVMOptions -XX:+UseWisp2 -Dio.grpc.netty.shaded.io.netty.transport.noNative=true
+                  -Dio.netty.transport.noNative=true -DinstanceVersion=8.0.3
+            volumeMounts:
+              - name: shared
+                mountPath: /shared
+        containers:
+          - name: engine
+            command:
+              - /bin/bash
+              - -c
+            args:
+              - "source /shared/env.sh && /home/admin/entrypoint.sh 20"
+            env: *cnEngineEnv
+            ports:
+              - containerPort: 3306
+                name: mysql
+                protocol: TCP
+              - containerPort: 3406
+                name: mgr
+                protocol: TCP
+              - containerPort: 3506
+                name: mpp
+                protocol: TCP
+              - containerPort: 3606
+                name: htap
+                protocol: TCP
+              - containerPort: 8507
+                name: log
+                protocol: TCP
+            startupProbe:
+              failureThreshold: 60
+              tcpSocket:
+                port: mysql
+              initialDelaySeconds: 5
+              periodSeconds: 10
+              successThreshold: 1
+              timeoutSeconds: 30
+            livenessProbe:
+              failureThreshold: 60
+              tcpSocket:
+                port: mysql
+              initialDelaySeconds: 5
+              periodSeconds: 10
+              successThreshold: 1
+              timeoutSeconds: 30
+            readinessProbe:
+              failureThreshold: 60
+              tcpSocket:
+                port: mysql
+              initialDelaySeconds: 5
+              periodSeconds: 10
+              successThreshold: 1
+              timeoutSeconds: 30
+            volumeMounts:
+              - name: tmp
+                mountPath: /tmp
+              - name: polardbx-log
+                mountPath: /home/admin/drds-server/logs
+              - name: polardbx-spill
+                mountPath: /home/admin/drds-server/spill
+              - name: shared
+                mountPath: /shared
+          - name: exporter
+            args:
+             - -collectors.process
+             - -collectors.jvm
+             - -target.type=CN
+             - -target.port=3406
+             - -web.listen-addr=:9104
+             - -web.metrics-path=/metrics
+            env:
+              - name: GOMAXPROCS
+                value: "1"
+            ports:
+              - containerPort: 9104
+                name: metrics
+                protocol: TCP
+            volumeMounts:
+              - name: tmp
+                mountPath: /tmp
+    - name: cdc
+      scriptSpecs:
+        - name: polardbx-scripts
+          templateRef: polardbx-scripts
+          volumeName: scripts
+          namespace: {{ .Release.Namespace }}
+          defaultMode: 0555
+      workloadType: Stateless
+      characterType: mysql
+      componentDefRef:
+        - *gmsRef
+        - componentDefName: cn
+          componentRefEnv:
+            - name: CN_SVC_PORT
+              valueFrom:
+                type: FieldRef
+                fieldPath: $.componentDef.service.ports[?(@.name == "mysql")].port
+            - name: CN_SVC_NAME
+              valueFrom:
+                type: ServiceRef
+      service:
+        ports:
+          - name: mysql
+            port: 3306
+            targetPort: 3306
+          - name: metrics
+            port: 9104
+            targetPort: 9104
+      monitor:
+        builtIn: false
+        exporterConfig:
+          scrapePort: 9104
+          scrapePath: "/metrics"
+      podSpec:
+        initContainers:
+          - name: wait-cn-ready
+            command:
+              - bin/sh
+              - -c
+              - |
+                until mysql -h$CN_SVC_NAME -P$CN_SVC_PORT -u$polarx_username -p$polarx_password -e 'select 1'; do
+                  sleep 1;
+                  echo "cn is not ready"
+                done
+            env:
+              - name: polarx_username
+                valueFrom:
+                  secretKeyRef:
+                    name: $(CONN_CREDENTIAL_SECRET_NAME)
+                    key: username
+                    optional: false
+              - name: polarx_password
+                valueFrom:
+                  secretKeyRef:
+                    name: $(CONN_CREDENTIAL_SECRET_NAME)
+                    key: password
+                    optional: false
+        containers:
+          - name: engine
+            env:
+              - name: switchCloud
+                value: aliyun
+              - name: cluster_id
+                value: "$(KB_CLUSTER_NAME)"
+              - name: ins_id
+                valueFrom:
+                  fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.name
+              - name: daemonPort
+                value: "3300"
+              - name: common_ports
+                value: '{"cdc1_port":"3009","cdc3_port":"3011","cdc2_port":"3010","cdc6_port":"3014","cdc5_port":"3013","cdc4_port":"3012"}'
+              - name: metaDb_url
+                value: "jdbc:mysql://$(GMS_SVC_NAME):$(GMS_SVC_PORT)/polardbx_meta_db?useSSL=false"
+              - name: polarx_url
+                value: "jdbc:mysql://$(CN_SVC_NAME):$(CN_SVC_PORT)/__cdc__?useSSL=false"
+              - name: metaDb_username
+                valueFrom:
+                  secretKeyRef:
+                    name: $(CONN_CREDENTIAL_SECRET_NAME)
+                    key: username
+                    optional: false
+              - name: metaDb_password
+                valueFrom:
+                  secretKeyRef:
+                    name: $(CONN_CREDENTIAL_SECRET_NAME)
+                    key: password
+                    optional: false
+              - name: polarx_username
+                valueFrom:
+                  secretKeyRef:
+                    name: $(CONN_CREDENTIAL_SECRET_NAME)
+                    key: username
+                    optional: false
+              - name: polarx_password
+                valueFrom:
+                  secretKeyRef:
+                    name: $(CONN_CREDENTIAL_SECRET_NAME)
+                    key: password
+                    optional: false
+              - name: metaDbNonEncPasswd
+                valueFrom:
+                  secretKeyRef:
+                    name: $(CONN_CREDENTIAL_SECRET_NAME)
+                    key: password
+                    optional: false
+              - name: dnPasswordKey
+                value: "$(metaDbNonEncPasswd)$(metaDbNonEncPasswd)"
+              - name: cpu_cores
+                valueFrom:
+                  resourceFieldRef:
+                    containerName: engine
+                    resource: limits.cpu
+              - name: mem_size
+                valueFrom:
+                  resourceFieldRef:
+                    containerName: engine
+                    resource: limits.memory
+                    divisor: "1M"
+              - name: disk_size
+                value: "10240"
+              - name: disk_quota
+                value: "10240"
+            volumeMounts:
+              - name: binlog
+                mountPath: /home/admin/binlog
+              - name: log
+                mountPath: /home/admin/logs
+          - name: exporter
+            args:
+              - -web.listen-addr=:9104
+              - -web.metrics-path=/metrics
+              - -target.port=3007
+              - -target.type=CDC
+            env:
+              - name: GOMAXPROCS
+                value: "1"
+            ports:
+              - containerPort: 9104
+                name: metrics
+                protocol: TCP
+

--- a/deploy/polardbx/templates/clusterVersion.yaml
+++ b/deploy/polardbx/templates/clusterVersion.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps.kubeblocks.io/v1alpha1
+kind: ClusterVersion
+metadata:
+  name: polardbx-{{ default .Chart.AppVersion .Values.clusterVersionOverride }}
+  labels:
+    {{- include "polardbx.labels" . | nindent 4 }}
+spec:
+  clusterDefinitionRef: polardbx
+  componentVersions:
+    - componentDefRef: gms
+      versionsContext:
+        containers:
+          - name: engine
+            image: {{ .Values.images.polardbx.repository }}/{{ .Values.images.polardbx.dn.name}}:{{.Values.images.polardbx.dn.tag}}
+            imagePullPolicy: {{ default "IfNotPresent" .Values.images.polardbx.pullPolicy }}
+          - name: exporter
+            image: {{ .Values.images.prom.repository }}/{{ .Values.images.prom.mysqld_exporter.name}}:{{.Values.images.prom.mysqld_exporter.tag}}
+            imagePullPolicy: {{ default "IfNotPresent" .Values.images.prom.pullPolicy }}
+        initContainers:
+          - name: tools-updater
+            image: {{ .Values.images.polardbx.repository }}/{{ .Values.images.polardbx.toolsUpdater.name }}:{{.Values.images.polardbx.toolsUpdater.tag}}
+            imagePullPolicy: {{ default "IfNotPresent" .Values.images.polardbx.pullPolicy }}
+    - componentDefRef: dn
+      versionsContext:
+        containers:
+          - name: engine
+            image: {{ .Values.images.polardbx.repository }}/{{ .Values.images.polardbx.dn.name}}:{{.Values.images.polardbx.dn.tag}}
+            imagePullPolicy: {{ default "IfNotPresent" .Values.images.polardbx.pullPolicy }}
+          - name: exporter
+            image: {{ .Values.images.prom.repository }}/{{ .Values.images.prom.mysqld_exporter.name}}:{{.Values.images.prom.mysqld_exporter.tag}}
+            imagePullPolicy: {{ default "IfNotPresent" .Values.images.prom.pullPolicy }}
+        initContainers:
+          - name: tools-updater
+            image: {{ .Values.images.polardbx.repository }}/{{ .Values.images.polardbx.toolsUpdater.name }}:{{.Values.images.polardbx.toolsUpdater.tag}}
+            imagePullPolicy: {{ default "IfNotPresent" .Values.images.polardbx.pullPolicy }}
+    - componentDefRef: cn
+      versionsContext:
+        containers:
+          - name: engine
+            image: {{ .Values.images.polardbx.repository }}/{{ .Values.images.polardbx.cn.name}}:{{.Values.images.polardbx.cn.tag}}
+            imagePullPolicy: {{ default "IfNotPresent" .Values.images.polardbx.pullPolicy }}
+          - name: exporter
+            image: {{ .Values.images.polardbx.repository }}/{{ .Values.images.polardbx.exporter.name}}:{{.Values.images.polardbx.exporter.tag}}
+            imagePullPolicy: {{ default "IfNotPresent" .Values.images.polardbx.pullPolicy }}
+        initContainers:
+          - name: init
+            image: {{ .Values.images.polardbx.repository }}/{{ .Values.images.polardbx.init.name }}:{{.Values.images.polardbx.init.tag}}
+            imagePullPolicy: {{ default "IfNotPresent" .Values.images.polardbx.pullPolicy }}
+          - name: metadb-init
+            image:  {{ .Values.images.mysql.repository }}:{{ .Values.images.mysql.tag }}
+            imagePullPolicy: {{ default "IfNotPresent" .Values.images.mysql.pullPolicy }}
+    - componentDefRef: cdc
+      versionsContext:
+        containers:
+          - name: engine
+            image: {{ .Values.images.polardbx.repository }}/{{ .Values.images.polardbx.cdc.name}}:{{.Values.images.polardbx.cdc.tag}}
+            imagePullPolicy: {{ default "IfNotPresent" .Values.images.polardbx.pullPolicy }}
+          - name: exporter
+            image: {{ .Values.images.polardbx.repository }}/{{ .Values.images.polardbx.exporter.name}}:{{.Values.images.polardbx.exporter.tag}}
+            imagePullPolicy: {{ default "IfNotPresent" .Values.images.polardbx.pullPolicy }}
+        initContainers:
+          - name: wait-cn-ready
+            image: {{ .Values.images.mysql.repository }}:{{ .Values.images.mysql.tag }}
+            imagePullPolicy: {{ default "IfNotPresent" .Values.images.mysql.pullPolicy }}

--- a/deploy/polardbx/templates/configmap-dashboards.yaml
+++ b/deploy/polardbx/templates/configmap-dashboards.yaml
@@ -1,0 +1,19 @@
+{{- $files := .Files.Glob "dashboards/*.json" }}
+{{- if $files }}
+apiVersion: v1
+kind: ConfigMapList
+items:
+{{- range $path, $fileContents := $files }}
+{{- $dashboardName := regexReplaceAll "(^.*/)(.*)\\.json$" $path "${2}" }}
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: {{ printf "grafana-%s" $dashboardName | trunc 63 | trimSuffix "-" }}
+    labels:
+      grafana_dashboard: "1"
+      app: {{ template "polardbx.name" $ }}-grafana
+{{ include "polardbx.labels" $ | indent 6 }}
+  data:
+    {{ $dashboardName }}.json: {{ $.Files.Get $path | toJson }}
+{{- end }}
+{{- end }}

--- a/deploy/polardbx/templates/scriptstemplate.yaml
+++ b/deploy/polardbx/templates/scriptstemplate.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: polardbx-scripts
+  labels:
+    {{- include "polardbx.labels" . | nindent 4 }}
+data:
+  xstore-post-start.sh: |-
+    {{- .Files.Get "scripts/xstore-post-start.tpl" | nindent 4 }}
+  xstore-setup.sh: |-
+    {{- .Files.Get "scripts/xstore-setup.tpl" | nindent 4 }}
+  gms-init.sql: |-
+    {{- .Files.Get "scripts/gms-init.sql" | nindent 4 }}
+  gms-metadata.tpl: |-
+    {{- .Files.Get "scripts/gms-metadata.tpl" | nindent 4 }}
+  metadb-setup.sh: |-
+    {{- .Files.Get "scripts/metadb-setup.tpl" | nindent 4 }}

--- a/deploy/polardbx/values.yaml
+++ b/deploy/polardbx/values.yaml
@@ -1,0 +1,61 @@
+# Default values for PolarDB-X.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+clusterVersionOverride: ""
+
+roleProbe:
+  failureThreshold: 2
+  periodSeconds: 1
+  timeoutSeconds: 1
+
+# Related image configurations.
+images:
+  polardbx:
+    pullPolicy: IfNotPresent
+    # Repo of polardbx default images. Default is polardbx.
+    repository: polardbx
+
+    # Images for xstore(DN) tools updater.
+    toolsUpdater:
+      name: xstore-tools
+      tag: latest
+
+    # Image for DN engine
+    dn:
+      name: polardbx-engine-2.0
+      tag: latest
+
+    # Image for CN engine
+    cn:
+      name: polardbx-sql
+      tag: latest
+
+    # Image for CN initialization
+    init:
+      name: polardbx-init
+      tag: latest
+
+    # Image for CN engine
+    cdc:
+      name: polardbx-cdc
+      tag: latest
+
+    # Image for CN&CDC exporter
+    exporter:
+      name: polardbx-exporter
+      tag: latest
+
+  # Tool image settings for gms initialization
+  mysql:
+    repository: mysql
+    pullPolicy: IfNotPresent
+    tag: "8.0.30"
+
+  # Images for DN exporter
+  prom:
+    repository: prom
+    pullPolicy: IfNotPresent
+    mysqld_exporter:
+      name: mysqld-exporter
+      tag: v0.14.0


### PR DESCRIPTION
- to #5244 

KubeBlocks is an interesting project that helps developers and platform engineers manage database workloads on K8s. [PolarDB-X](https://github.com/polardb/polardbx-sql) is an open-source, cloud native, distributed Database. In this PR, I have made the efforts to integrate PolarDB-X into KubeBlocks.

Functions implemented now:

* Create PolarDB-X cluster.
* Scale Up/Down of CN or CDC.
* Scale In/Out of CN or CDC.
* Stop or Restart PolarDB-X cluster.
* Metrics Export and Grafana/Prometheus Integration.


## Quick Start with PolarDB-X

1. Install PolarDB-X cluster defination.
```
helm install polardbx ./deploy/polardbx
```

2. Create PolarDB-X Cluster. There are two options:

Opt1：Create PolarDB-X by kbcli:

```
kbcli cluster create pxc --cluster-definition polardbx
```


Opt2: Install polardbx-cluster helm chart, which will create a PolarDB-X cluster named `pxc`:

```
helm install polardbx-cluster ./deploy/polardbx-cluster
```

3. Wait all pods ready, then you can connect PolarDB-X.

```
kubectl port-forward svc/pxc-cn 3306:3306
mysql -h127.0.0.1 -upolardbx_root
```

## Related issue

PolarDB-X differs slightly from other databases and the data node consensus role can not be detected directly by lorry container at the start. Thanks for the support from the KubeBlocks community in implementing this feature. Here is the related issue:

* #5063 
