### PR TITLE
chore: make lorry role probe timeout configurable

### DIFF
--- a/deploy/mongodb/values.yaml
+++ b/deploy/mongodb/values.yaml
@@ -20,7 +20,7 @@ fullnameOverride: ""
 roleProbe:
   failureThreshold: 3
   periodSeconds: 2
-  timeoutSeconds: 1
+  timeoutSeconds: 2
 
 ## Authentication parameters
 ##

--- a/internal/controller/rsm/transformer_object_generation.go
+++ b/internal/controller/rsm/transformer_object_generation.go
@@ -444,6 +444,13 @@ func injectRoleProbeAgentContainer(rsm workloads.ReplicatedStateMachine, templat
 			Value: string(roleProbe.RoleUpdateMechanism),
 		})
 
+	// inject role probe timeout env
+	env = append(env,
+		corev1.EnvVar{
+			Name:  roleProbeTimeoutVarName,
+			Value: strconv.Itoa(int(roleProbe.TimeoutSeconds)),
+		})
+
 	// lorry related envs
 	env = append(env,
 		corev1.EnvVar{

--- a/internal/controller/rsm/types.go
+++ b/internal/controller/rsm/types.go
@@ -89,6 +89,7 @@ const (
 	leaderHostVarName             = "KB_RSM_LEADER_HOST"
 	targetHostVarName             = "KB_RSM_TARGET_HOST"
 	RoleUpdateMechanismVarName    = "KB_RSM_ROLE_UPDATE_MECHANISM"
+	roleProbeTimeoutVarName       = "KB_RSM_ROLE_PROBE_TIMEOUT"
 	directAPIServerEventFieldPath = "spec.containers{sqlchannel}"
 	readinessProbeEventFieldPath  = "spec.containers{" + roleProbeContainerName + "}"
 	legacyEventFieldPath          = "spec.containers{kb-checkrole}"

--- a/lorry/binding/base.go
+++ b/lorry/binding/base.go
@@ -217,8 +217,12 @@ func (ops *BaseOperations) CheckRoleOps(ctx context.Context, req *ProbeRequest, 
 		return opsRes, nil
 	}
 
-	// sql exec timeout needs to be less than httpget's timeout which by default 1s.
-	ctx1, cancel := context.WithTimeout(ctx, 999*time.Millisecond)
+	timeoutSeconds := defaultRoleProbeTimeoutSeconds
+	if viper.IsSet(roleProbeTimeoutVarName) {
+		timeoutSeconds = viper.GetInt(roleProbeTimeoutVarName)
+	}
+	timeout := time.Duration(timeoutSeconds) * (800 * time.Millisecond)
+	ctx1, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	role, err := ops.GetRole(ctx1, req, resp)
 	if err != nil {

--- a/lorry/binding/base.go
+++ b/lorry/binding/base.go
@@ -221,6 +221,8 @@ func (ops *BaseOperations) CheckRoleOps(ctx context.Context, req *ProbeRequest, 
 	if viper.IsSet(roleProbeTimeoutVarName) {
 		timeoutSeconds = viper.GetInt(roleProbeTimeoutVarName)
 	}
+	// lorry utilizes the pod readiness probe to trigger role probe and 'timeoutSeconds' is directly copied from the 'probe.timeoutSeconds' field of pod.
+	// here we give 80% of the total time to role probe job and leave the remaining 20% to kubelet to handle the readiness probe related tasks.
 	timeout := time.Duration(timeoutSeconds) * (800 * time.Millisecond)
 	ctx1, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()

--- a/lorry/binding/types.go
+++ b/lorry/binding/types.go
@@ -49,8 +49,10 @@ const (
 	roleEventReportFrequency          = int(1 / roleEventRecordQPS)
 	defaultFailedEventReportFrequency = 1800
 	defaultRoleDetectionThreshold     = 300
+	defaultRoleProbeTimeoutSeconds    = 2
 
 	rsmRoleUpdateMechanismVarName = "KB_RSM_ROLE_UPDATE_MECHANISM"
+	roleProbeTimeoutVarName       = "KB_RSM_ROLE_PROBE_TIMEOUT"
 )
 
 const (


### PR DESCRIPTION
current role probe timeout is hard coded with value of 1s, which is not enough for some engines' role probe job.
this pr makes lorry role probe timeout configurable.