### PR TITLE
chore: workload type validation rules in CD

### DIFF
--- a/apis/apps/v1alpha1/clusterdefinition_types.go
+++ b/apis/apps/v1alpha1/clusterdefinition_types.go
@@ -305,7 +305,8 @@ type ServiceRefDeclarationSpec struct {
 // ClusterComponentDefinition provides a workload component specification template,
 // with attributes that strongly work with stateful workloads and day-2 operations
 // behaviors.
-// +kubebuilder:validation:XValidation:rule="has(self.workloadType) && self.workloadType == 'Consensus' ?  has(self.consensusSpec) : !has(self.consensusSpec)",message="componentDefs.consensusSpec is required when componentDefs.workloadType is Consensus, and forbidden otherwise"
+// +kubebuilder:validation:XValidation:rule="has(self.workloadType) && self.workloadType == 'Consensus' ? (has(self.consensusSpec) || has(self.rsmSpec)) : !has(self.consensusSpec)",message="componentDefs.consensusSpec(deprecated) or componentDefs.rsmSpec(recommended) is required when componentDefs.workloadType is Consensus, and forbidden otherwise"
+// +kubebuilder:validation:XValidation:rule="has(self.workloadType) && self.workloadType == 'Replication' ? (has(self.replicationSpec) || has(self.rsmSpec)) : !has(self.replicationSpec)",message="componentDefs.replicationSpec(deprecated) or componentDefs.rsmSpec(recommended) is required when componentDefs.workloadType is Replication, and forbidden otherwise"
 type ClusterComponentDefinition struct {
 	// A component definition name, this name could be used as default name of `Cluster.spec.componentSpecs.name`,
 	// and so this name is need to conform with same validation rules as `Cluster.spec.componentSpecs.name`, that

--- a/apis/apps/v1alpha1/clusterdefinition_types.go
+++ b/apis/apps/v1alpha1/clusterdefinition_types.go
@@ -306,7 +306,6 @@ type ServiceRefDeclarationSpec struct {
 // with attributes that strongly work with stateful workloads and day-2 operations
 // behaviors.
 // +kubebuilder:validation:XValidation:rule="has(self.workloadType) && self.workloadType == 'Consensus' ? (has(self.consensusSpec) || has(self.rsmSpec)) : !has(self.consensusSpec)",message="componentDefs.consensusSpec(deprecated) or componentDefs.rsmSpec(recommended) is required when componentDefs.workloadType is Consensus, and forbidden otherwise"
-// +kubebuilder:validation:XValidation:rule="has(self.workloadType) && self.workloadType == 'Replication' ? (has(self.replicationSpec) || has(self.rsmSpec)) : !has(self.replicationSpec)",message="componentDefs.replicationSpec(deprecated) or componentDefs.rsmSpec(recommended) is required when componentDefs.workloadType is Replication, and forbidden otherwise"
 type ClusterComponentDefinition struct {
 	// A component definition name, this name could be used as default name of `Cluster.spec.componentSpecs.name`,
 	// and so this name is need to conform with same validation rules as `Cluster.spec.componentSpecs.name`, that

--- a/config/crd/bases/apps.kubeblocks.io_clusterdefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusterdefinitions.yaml
@@ -9552,10 +9552,16 @@ spec:
                   - workloadType
                   type: object
                   x-kubernetes-validations:
-                  - message: componentDefs.consensusSpec is required when componentDefs.workloadType
-                      is Consensus, and forbidden otherwise
+                  - message: componentDefs.consensusSpec(deprecated) or componentDefs.rsmSpec(recommended)
+                      is required when componentDefs.workloadType is Consensus, and
+                      forbidden otherwise
                     rule: 'has(self.workloadType) && self.workloadType == ''Consensus''
-                      ?  has(self.consensusSpec) : !has(self.consensusSpec)'
+                      ? (has(self.consensusSpec) || has(self.rsmSpec)) : !has(self.consensusSpec)'
+                  - message: componentDefs.replicationSpec(deprecated) or componentDefs.rsmSpec(recommended)
+                      is required when componentDefs.workloadType is Replication,
+                      and forbidden otherwise
+                    rule: 'has(self.workloadType) && self.workloadType == ''Replication''
+                      ? (has(self.replicationSpec) || has(self.rsmSpec)) : !has(self.replicationSpec)'
                 minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:

--- a/config/crd/bases/apps.kubeblocks.io_clusterdefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusterdefinitions.yaml
@@ -9557,11 +9557,6 @@ spec:
                       forbidden otherwise
                     rule: 'has(self.workloadType) && self.workloadType == ''Consensus''
                       ? (has(self.consensusSpec) || has(self.rsmSpec)) : !has(self.consensusSpec)'
-                  - message: componentDefs.replicationSpec(deprecated) or componentDefs.rsmSpec(recommended)
-                      is required when componentDefs.workloadType is Replication,
-                      and forbidden otherwise
-                    rule: 'has(self.workloadType) && self.workloadType == ''Replication''
-                      ? (has(self.replicationSpec) || has(self.rsmSpec)) : !has(self.replicationSpec)'
                 minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:

--- a/deploy/helm/crds/apps.kubeblocks.io_clusterdefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusterdefinitions.yaml
@@ -9552,10 +9552,16 @@ spec:
                   - workloadType
                   type: object
                   x-kubernetes-validations:
-                  - message: componentDefs.consensusSpec is required when componentDefs.workloadType
-                      is Consensus, and forbidden otherwise
+                  - message: componentDefs.consensusSpec(deprecated) or componentDefs.rsmSpec(recommended)
+                      is required when componentDefs.workloadType is Consensus, and
+                      forbidden otherwise
                     rule: 'has(self.workloadType) && self.workloadType == ''Consensus''
-                      ?  has(self.consensusSpec) : !has(self.consensusSpec)'
+                      ? (has(self.consensusSpec) || has(self.rsmSpec)) : !has(self.consensusSpec)'
+                  - message: componentDefs.replicationSpec(deprecated) or componentDefs.rsmSpec(recommended)
+                      is required when componentDefs.workloadType is Replication,
+                      and forbidden otherwise
+                    rule: 'has(self.workloadType) && self.workloadType == ''Replication''
+                      ? (has(self.replicationSpec) || has(self.rsmSpec)) : !has(self.replicationSpec)'
                 minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:

--- a/deploy/helm/crds/apps.kubeblocks.io_clusterdefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusterdefinitions.yaml
@@ -9557,11 +9557,6 @@ spec:
                       forbidden otherwise
                     rule: 'has(self.workloadType) && self.workloadType == ''Consensus''
                       ? (has(self.consensusSpec) || has(self.rsmSpec)) : !has(self.consensusSpec)'
-                  - message: componentDefs.replicationSpec(deprecated) or componentDefs.rsmSpec(recommended)
-                      is required when componentDefs.workloadType is Replication,
-                      and forbidden otherwise
-                    rule: 'has(self.workloadType) && self.workloadType == ''Replication''
-                      ? (has(self.replicationSpec) || has(self.rsmSpec)) : !has(self.replicationSpec)'
                 minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:


### PR DESCRIPTION
update outdate validation rule when `workloadType` is `Consensus`.

if `workloadType` is `Consensus`,  configuring one of `consensusSpec` or `rsmSpec` should both be ok.