### PR TITLE
fix: SyncEnvConfigmap panic for configuration controller (#5243)

### DIFF
--- a/controllers/apps/configuration/configuration_controller.go
+++ b/controllers/apps/configuration/configuration_controller.go
@@ -202,6 +202,7 @@ func isReconcileStatus(phase appsv1alpha1.ConfigurationPhase) bool {
 	return phase == appsv1alpha1.CRunningPhase ||
 		phase == appsv1alpha1.CInitPhase ||
 		phase == appsv1alpha1.CPendingPhase ||
+		phase == appsv1alpha1.CFailedPhase ||
 		phase == appsv1alpha1.CMergedPhase ||
 		phase == appsv1alpha1.CMergeFailedPhase ||
 		phase == appsv1alpha1.CUpgradingPhase ||

--- a/internal/controller/configuration/pipeline.go
+++ b/internal/controller/configuration/pipeline.go
@@ -379,7 +379,7 @@ func (p *updatePipeline) UpdateConfigVersion(revision string) *updatePipeline {
 
 func (p *updatePipeline) Sync() *updatePipeline {
 	return p.Wrap(func() error {
-		if p.ConfigConstraintObj != nil {
+		if p.ConfigConstraintObj != nil && !p.isDone() {
 			if err := SyncEnvConfigmap(*p.configSpec, p.newCM, &p.ConfigConstraintObj.Spec, p.Client, p.Context); err != nil {
 				return err
 			}


### PR DESCRIPTION
fix: [create pulsar cluster failed and lead to kubeblocks CrashLoopBackOff](#5243)