### PR TITLE
fix: component.BuildComponent painc when configuration.spec.ComponentName donot exist in the cluster.spec.componentSpecs

### DIFF
--- a/controllers/apps/configuration/configuration_controller.go
+++ b/controllers/apps/configuration/configuration_controller.go
@@ -21,6 +21,7 @@ package configuration
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -102,11 +103,26 @@ func (r *ConfigurationReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "failed to get related object.")
 	}
 
+	if fetcherTask.ClusterComObj == nil || fetcherTask.ClusterDefComObj == nil {
+		return r.failWithInvalidComponent(configuration, reqCtx)
+	}
+
 	if err := r.runTasks(reqCtx, configuration, fetcherTask, tasks); err != nil {
 		return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "failed to run configuration reconcile task.")
 	}
 	if !isAllReady(configuration) {
 		return intctrlutil.RequeueAfter(reconcileInterval, reqCtx.Log, "")
+	}
+	return intctrlutil.Reconciled()
+}
+
+func (r *ConfigurationReconciler) failWithInvalidComponent(configuration *appsv1alpha1.Configuration, reqCtx intctrlutil.RequestCtx) (ctrl.Result, error) {
+	msg := fmt.Sprintf("not found cluster component or cluster definition component: [%s]", configuration.Spec.ComponentName)
+	reqCtx.Log.Error(fmt.Errorf(msg), "")
+	patch := client.MergeFrom(configuration.DeepCopy())
+	configuration.Status.Message = msg
+	if err := r.Client.Status().Patch(reqCtx.Ctx, configuration, patch); err != nil {
+		return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "failed to update configuration status.")
 	}
 	return intctrlutil.Reconciled()
 }
@@ -140,8 +156,8 @@ func (r *ConfigurationReconciler) runTasks(
 		return err
 	}
 
-	revision := strconv.FormatInt(configuration.GetGeneration(), 10)
 	patch := client.MergeFrom(configuration.DeepCopy())
+	revision := strconv.FormatInt(configuration.GetGeneration(), 10)
 	for _, task := range tasks {
 		if err := task.Do(fetcher, synthesizedComp, revision); err != nil {
 			task.Status.Phase = appsv1alpha1.CMergeFailedPhase
@@ -158,6 +174,7 @@ func (r *ConfigurationReconciler) runTasks(
 		}
 	}
 
+	configuration.Status.Message = ""
 	if len(errs) > 0 {
 		configuration.Status.Message = utilerrors.NewAggregate(errs).Error()
 	}

--- a/controllers/apps/configuration/configuration_controller_test.go
+++ b/controllers/apps/configuration/configuration_controller_test.go
@@ -90,6 +90,29 @@ var _ = Describe("Configuration Controller", func() {
 				g.Expect(itemStatus.Phase).Should(BeEquivalentTo(appsv1alpha1.CFinishedPhase))
 			}, time.Second*60, time.Second*1).Should(Succeed())
 		})
+
+		It("Invalid component test", func() {
+			_, _, clusterObj, clusterVersionObj, synthesizedComp := mockReconcileResource()
+
+			cfgKey := client.ObjectKey{
+				Name:      core.GenerateComponentConfigurationName(clusterName, "invalid-component"),
+				Namespace: testCtx.DefaultNamespace,
+			}
+
+			Expect(initConfiguration(&intctrlutil.ResourceCtx{
+				Client:        k8sClient,
+				Context:       ctx,
+				Namespace:     testCtx.DefaultNamespace,
+				ClusterName:   clusterName,
+				ComponentName: "invalid-component",
+			}, synthesizedComp, clusterObj, clusterVersionObj)).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				cfg := &appsv1alpha1.Configuration{}
+				g.Expect(k8sClient.Get(ctx, cfgKey, cfg)).Should(Succeed())
+				g.Expect(cfg.Status.Message).Should(ContainSubstring("not found cluster component"))
+			}, time.Second*60, time.Second*1).Should(Succeed())
+		})
 	})
 
 })


### PR DESCRIPTION
fix: [panic in configuration_controller.go](#5269)