### PR TITLE
chore: workaround of goland code inspector bug which fails to infer generic pointer type

### DIFF
--- a/controllers/apps/components/utils.go
+++ b/controllers/apps/components/utils.go
@@ -54,7 +54,7 @@ var (
 )
 
 func listObjWithLabelsInNamespace[T generics.Object, PT generics.PObject[T], L generics.ObjList[T], PL generics.PObjList[T, L]](
-	ctx context.Context, cli client.Client, _ func(T, L), namespace string, labels client.MatchingLabels) ([]PT, error) {
+	ctx context.Context, cli client.Client, _ func(T, PT, L, PL), namespace string, labels client.MatchingLabels) ([]PT, error) {
 	var objList L
 	if err := cli.List(ctx, PL(&objList), labels, client.InNamespace(namespace)); err != nil {
 		return nil, err

--- a/controllers/apps/configuration/config_related_helper.go
+++ b/controllers/apps/configuration/config_related_helper.go
@@ -35,7 +35,7 @@ import (
 	"github.com/apecloud/kubeblocks/internal/generics"
 )
 
-func retrieveRelatedComponentsByConfigmap[T generics.Object, L generics.ObjList[T], PL generics.PObjList[T, L]](cli client.Client, ctx context.Context, configSpecName string, _ func(T, L), cfg client.ObjectKey, opts ...client.ListOption) ([]T, []string, error) {
+func retrieveRelatedComponentsByConfigmap[T generics.Object, PT generics.PObject[T], L generics.ObjList[T], PL generics.PObjList[T, L]](cli client.Client, ctx context.Context, configSpecName string, _ func(T, PT, L, PL), cfg client.ObjectKey, opts ...client.ListOption) ([]T, []string, error) {
 	var objList L
 	if err := cli.List(ctx, PL(&objList), opts...); err != nil {
 		return nil, nil, err

--- a/internal/cli/cmd/builder/template/k8s_resource.go
+++ b/internal/cli/cmd/builder/template/k8s_resource.go
@@ -32,8 +32,8 @@ import (
 
 type MatchResourceFunc func(object client.Object) bool
 
-func CustomizedObjFromYaml[T generics.Object, PT generics.PObject[T], L generics.ObjList[T]](filePath string, signature func(T, L)) (PT, error) {
-	objList, err := CustomizedObjectListFromYaml[T, PT, L](filePath, signature)
+func CustomizedObjFromYaml[T generics.Object, PT generics.PObject[T], L generics.ObjList[T], PL generics.PObjList[T, L]](filePath string, signature func(T, PT, L, PL)) (PT, error) {
+	objList, err := CustomizedObjectListFromYaml[T, PT, L, PL](filePath, signature)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func CustomizedObjFromYaml[T generics.Object, PT generics.PObject[T], L generics
 	return objList[0], nil
 }
 
-func CustomizedObjectListFromYaml[T generics.Object, PT generics.PObject[T], L generics.ObjList[T]](yamlfile string, signature func(T, L)) ([]PT, error) {
+func CustomizedObjectListFromYaml[T generics.Object, PT generics.PObject[T], L generics.ObjList[T], PL generics.PObjList[T, L]](yamlfile string, signature func(T, PT, L, PL)) ([]PT, error) {
 	objBytes, err := os.ReadFile(yamlfile)
 	if err != nil {
 		return nil, err
@@ -58,12 +58,12 @@ func CustomizedObjectListFromYaml[T generics.Object, PT generics.PObject[T], L g
 		if err != nil {
 			return nil, err
 		}
-		objList = append(objList, CreateTypedObjectFromYamlByte[T, PT, L](doc, signature))
+		objList = append(objList, CreateTypedObjectFromYamlByte[T, PT, L, PL](doc, signature))
 	}
 	return objList, nil
 }
 
-func CreateTypedObjectFromYamlByte[T generics.Object, PT generics.PObject[T], L generics.ObjList[T]](yamlBytes []byte, _ func(T, L)) PT {
+func CreateTypedObjectFromYamlByte[T generics.Object, PT generics.PObject[T], L generics.ObjList[T], PL generics.PObjList[T, L]](yamlBytes []byte, _ func(T, PT, L, PL)) PT {
 	var obj PT
 	if err := yaml.Unmarshal(yamlBytes, &obj); err != nil {
 		return nil
@@ -71,7 +71,7 @@ func CreateTypedObjectFromYamlByte[T generics.Object, PT generics.PObject[T], L 
 	return obj
 }
 
-func GetTypedResourceObjectBySignature[T generics.Object, PT generics.PObject[T], L generics.ObjList[T]](objects []client.Object, _ func(T, L), matchers ...MatchResourceFunc) PT {
+func GetTypedResourceObjectBySignature[T generics.Object, PT generics.PObject[T], L generics.ObjList[T], PL generics.PObjList[T, L]](objects []client.Object, _ func(T, PT, L, PL), matchers ...MatchResourceFunc) PT {
 	for _, object := range objects {
 		obj, ok := object.(PT)
 		if !ok {

--- a/internal/generics/type.go
+++ b/internal/generics/type.go
@@ -58,59 +58,74 @@ type PObjList[T Object, L ObjList[T]] interface {
 }
 
 // signature is used as an argument passed to generic functions for type deduction.
+// Goland IDE 2023.2.1 and 2023.2.2 code inspector has a bug to infer pointer type like PObject and PObjList from Object and ObjectList.
+// To workaround this bug, we also pass the pointer type to generic functions in signature.
 
-var SecretSignature = func(_ corev1.Secret, _ corev1.SecretList) {}
-var ServiceSignature = func(_ corev1.Service, _ corev1.ServiceList) {}
-var PersistentVolumeClaimSignature = func(_ corev1.PersistentVolumeClaim, _ corev1.PersistentVolumeClaimList) {}
-var PodSignature = func(_ corev1.Pod, _ corev1.PodList) {}
-var EventSignature = func(_ corev1.Event, _ corev1.EventList) {}
-var ConfigMapSignature = func(_ corev1.ConfigMap, _ corev1.ConfigMapList) {}
-var EndpointsSignature = func(_ corev1.Endpoints, _ corev1.EndpointsList) {}
+var SecretSignature = func(_ corev1.Secret, _ *corev1.Secret, _ corev1.SecretList, _ *corev1.SecretList) {}
+var ServiceSignature = func(_ corev1.Service, _ *corev1.Service, _ corev1.ServiceList, _ *corev1.ServiceList) {}
+var PersistentVolumeClaimSignature = func(_ corev1.PersistentVolumeClaim, _ *corev1.PersistentVolumeClaim, _ corev1.PersistentVolumeClaimList, _ *corev1.PersistentVolumeClaimList) {
+}
+var PodSignature = func(_ corev1.Pod, _ *corev1.Pod, _ corev1.PodList, _ *corev1.PodList) {}
+var EventSignature = func(_ corev1.Event, _ *corev1.Event, _ corev1.EventList, _ *corev1.EventList) {}
+var ConfigMapSignature = func(_ corev1.ConfigMap, _ *corev1.ConfigMap, _ corev1.ConfigMapList, _ *corev1.ConfigMapList) {}
+var EndpointsSignature = func(_ corev1.Endpoints, _ *corev1.Endpoints, _ corev1.EndpointsList, _ *corev1.EndpointsList) {}
 
-var RSMSignature = func(_ workloads.ReplicatedStateMachine, _ workloads.ReplicatedStateMachineList) {}
-var StatefulSetSignature = func(A appsv1.StatefulSet, B appsv1.StatefulSetList) {}
-var DeploymentSignature = func(_ appsv1.Deployment, _ appsv1.DeploymentList) {}
-var ReplicaSetSignature = func(_ appsv1.ReplicaSet, _ appsv1.ReplicaSetList) {}
+var RSMSignature = func(_ workloads.ReplicatedStateMachine, _ *workloads.ReplicatedStateMachine, _ workloads.ReplicatedStateMachineList, _ *workloads.ReplicatedStateMachineList) {
+}
+var StatefulSetSignature = func(_ appsv1.StatefulSet, _ *appsv1.StatefulSet, _ appsv1.StatefulSetList, _ *appsv1.StatefulSetList) {
+}
+var DeploymentSignature = func(_ appsv1.Deployment, _ *appsv1.Deployment, _ appsv1.DeploymentList, _ *appsv1.DeploymentList) {}
+var ReplicaSetSignature = func(_ appsv1.ReplicaSet, _ *appsv1.ReplicaSet, _ appsv1.ReplicaSetList, _ *appsv1.ReplicaSetList) {}
 
-var JobSignature = func(_ batchv1.Job, _ batchv1.JobList) {}
-var CronJobSignature = func(_ batchv1.CronJob, _ batchv1.CronJobList) {}
+var JobSignature = func(_ batchv1.Job, _ *batchv1.Job, _ batchv1.JobList, _ *batchv1.JobList) {}
+var CronJobSignature = func(_ batchv1.CronJob, _ *batchv1.CronJob, _ batchv1.CronJobList, _ *batchv1.CronJobList) {}
 
-var PodDisruptionBudgetSignature = func(_ policyv1.PodDisruptionBudget, _ policyv1.PodDisruptionBudgetList) {
+var PodDisruptionBudgetSignature = func(_ policyv1.PodDisruptionBudget, _ *policyv1.PodDisruptionBudget, _ policyv1.PodDisruptionBudgetList, _ *policyv1.PodDisruptionBudgetList) {
 }
 
-var StorageClassSignature = func(_ storagev1.StorageClass, _ storagev1.StorageClassList) {}
-var CSIDriverSignature = func(_ storagev1.CSIDriver, _ storagev1.CSIDriverList) {}
-
-var VolumeSnapshotSignature = func(_ snapshotv1.VolumeSnapshot, _ snapshotv1.VolumeSnapshotList) {}
-
-var ClusterSignature = func(_ appsv1alpha1.Cluster, _ appsv1alpha1.ClusterList) {}
-var ClusterVersionSignature = func(_ appsv1alpha1.ClusterVersion, _ appsv1alpha1.ClusterVersionList) {}
-var ClusterDefinitionSignature = func(_ appsv1alpha1.ClusterDefinition, _ appsv1alpha1.ClusterDefinitionList) {
+var StorageClassSignature = func(_ storagev1.StorageClass, _ *storagev1.StorageClass, _ storagev1.StorageClassList, _ *storagev1.StorageClassList) {
 }
-var OpsRequestSignature = func(_ appsv1alpha1.OpsRequest, _ appsv1alpha1.OpsRequestList) {}
-var ConfigConstraintSignature = func(_ appsv1alpha1.ConfigConstraint, _ appsv1alpha1.ConfigConstraintList) {
+var CSIDriverSignature = func(_ storagev1.CSIDriver, _ *storagev1.CSIDriver, _ storagev1.CSIDriverList, _ *storagev1.CSIDriverList) {
 }
 
-var BackupPolicyTemplateSignature = func(_ appsv1alpha1.BackupPolicyTemplate, _ appsv1alpha1.BackupPolicyTemplateList) {
+var VolumeSnapshotSignature = func(_ snapshotv1.VolumeSnapshot, _ *snapshotv1.VolumeSnapshot, _ snapshotv1.VolumeSnapshotList, _ *snapshotv1.VolumeSnapshotList) {
 }
-var BackupPolicySignature = func(_ dataprotectionv1alpha1.BackupPolicy, _ dataprotectionv1alpha1.BackupPolicyList) {
-}
-var BackupSignature = func(_ dataprotectionv1alpha1.Backup, _ dataprotectionv1alpha1.BackupList) {
-}
-var BackupToolSignature = func(_ dataprotectionv1alpha1.BackupTool, _ dataprotectionv1alpha1.BackupToolList) {
-}
-var RestoreJobSignature = func(_ dataprotectionv1alpha1.RestoreJob, _ dataprotectionv1alpha1.RestoreJobList) {
-}
-var BackupRepoSignature = func(_ dataprotectionv1alpha1.BackupRepo, _ dataprotectionv1alpha1.BackupRepoList) {
-}
-var AddonSignature = func(_ extensionsv1alpha1.Addon, _ extensionsv1alpha1.AddonList) {
-}
-var ComponentResourceConstraintSignature = func(_ appsv1alpha1.ComponentResourceConstraint, _ appsv1alpha1.ComponentResourceConstraintList) {}
-var ComponentClassDefinitionSignature = func(_ appsv1alpha1.ComponentClassDefinition, _ appsv1alpha1.ComponentClassDefinitionList) {}
 
-var StorageProviderSignature = func(_ storagev1alpha1.StorageProvider, _ storagev1alpha1.StorageProviderList) {}
+var ClusterSignature = func(_ appsv1alpha1.Cluster, _ *appsv1alpha1.Cluster, _ appsv1alpha1.ClusterList, _ *appsv1alpha1.ClusterList) {
+}
+var ClusterVersionSignature = func(_ appsv1alpha1.ClusterVersion, _ *appsv1alpha1.ClusterVersion, _ appsv1alpha1.ClusterVersionList, _ *appsv1alpha1.ClusterVersionList) {
+}
+var ClusterDefinitionSignature = func(_ appsv1alpha1.ClusterDefinition, _ *appsv1alpha1.ClusterDefinition, _ appsv1alpha1.ClusterDefinitionList, _ *appsv1alpha1.ClusterDefinitionList) {
+}
+var OpsRequestSignature = func(_ appsv1alpha1.OpsRequest, _ *appsv1alpha1.OpsRequest, _ appsv1alpha1.OpsRequestList, _ *appsv1alpha1.OpsRequestList) {
+}
+var ConfigConstraintSignature = func(_ appsv1alpha1.ConfigConstraint, _ *appsv1alpha1.ConfigConstraint, _ appsv1alpha1.ConfigConstraintList, _ *appsv1alpha1.ConfigConstraintList) {
+}
 
-var ConfigurationSignature = func(_ appsv1alpha1.Configuration, _ appsv1alpha1.ConfigurationList) {}
+var BackupPolicyTemplateSignature = func(_ appsv1alpha1.BackupPolicyTemplate, _ *appsv1alpha1.BackupPolicyTemplate, _ appsv1alpha1.BackupPolicyTemplateList, _ *appsv1alpha1.BackupPolicyTemplateList) {
+}
+var BackupPolicySignature = func(_ dataprotectionv1alpha1.BackupPolicy, _ *dataprotectionv1alpha1.BackupPolicy, _ dataprotectionv1alpha1.BackupPolicyList, _ *dataprotectionv1alpha1.BackupPolicyList) {
+}
+var BackupSignature = func(_ dataprotectionv1alpha1.Backup, _ *dataprotectionv1alpha1.Backup, _ dataprotectionv1alpha1.BackupList, _ *dataprotectionv1alpha1.BackupList) {
+}
+var BackupToolSignature = func(_ dataprotectionv1alpha1.BackupTool, _ *dataprotectionv1alpha1.BackupTool, _ dataprotectionv1alpha1.BackupToolList, _ *dataprotectionv1alpha1.BackupToolList) {
+}
+var RestoreJobSignature = func(_ dataprotectionv1alpha1.RestoreJob, _ *dataprotectionv1alpha1.RestoreJob, _ dataprotectionv1alpha1.RestoreJobList, _ *dataprotectionv1alpha1.RestoreJobList) {
+}
+var BackupRepoSignature = func(_ dataprotectionv1alpha1.BackupRepo, _ *dataprotectionv1alpha1.BackupRepo, _ dataprotectionv1alpha1.BackupRepoList, _ *dataprotectionv1alpha1.BackupRepoList) {
+}
+var AddonSignature = func(_ extensionsv1alpha1.Addon, _ *extensionsv1alpha1.Addon, _ extensionsv1alpha1.AddonList, _ *extensionsv1alpha1.AddonList) {
+}
+var ComponentResourceConstraintSignature = func(_ appsv1alpha1.ComponentResourceConstraint, _ *appsv1alpha1.ComponentResourceConstraint, _ appsv1alpha1.ComponentResourceConstraintList, _ *appsv1alpha1.ComponentResourceConstraintList) {
+}
+var ComponentClassDefinitionSignature = func(_ appsv1alpha1.ComponentClassDefinition, _ *appsv1alpha1.ComponentClassDefinition, _ appsv1alpha1.ComponentClassDefinitionList, _ *appsv1alpha1.ComponentClassDefinitionList) {
+}
+
+var StorageProviderSignature = func(_ storagev1alpha1.StorageProvider, _ *storagev1alpha1.StorageProvider, _ storagev1alpha1.StorageProviderList, _ *storagev1alpha1.StorageProviderList) {
+}
+
+var ConfigurationSignature = func(_ appsv1alpha1.Configuration, _ *appsv1alpha1.Configuration, _ appsv1alpha1.ConfigurationList, _ *appsv1alpha1.ConfigurationList) {
+}
 
 func ToGVK(object client.Object) schema.GroupVersionKind {
 	t := reflect.TypeOf(object)

--- a/internal/testutil/apps/common_util.go
+++ b/internal/testutil/apps/common_util.go
@@ -154,7 +154,7 @@ func CheckObj[T intctrlutil.Object, PT intctrlutil.PObject[T]](testCtx *testutil
 
 func List[T intctrlutil.Object, PT intctrlutil.PObject[T],
 	L intctrlutil.ObjList[T], PL intctrlutil.PObjList[T, L]](
-	testCtx *testutil.TestContext, _ func(T, L), opt ...client.ListOption) func(gomega.Gomega) []T {
+	testCtx *testutil.TestContext, _ func(T, PT, L, PL), opt ...client.ListOption) func(gomega.Gomega) []T {
 	return func(g gomega.Gomega) []T {
 		var objList L
 		g.Expect(testCtx.Cli.List(testCtx.Ctx, PL(&objList), opt...)).To(gomega.Succeed())
@@ -290,7 +290,7 @@ func DeleteObject[T intctrlutil.Object, PT intctrlutil.PObject[T]](
 // ClearResources clears all resources of the given type T satisfying the input ListOptions.
 func ClearResources[T intctrlutil.Object, PT intctrlutil.PObject[T],
 	L intctrlutil.ObjList[T], PL intctrlutil.PObjList[T, L]](
-	testCtx *testutil.TestContext, funcSig func(T, L), opts ...client.DeleteAllOfOption) {
+	testCtx *testutil.TestContext, funcSig func(T, PT, L, PL), opts ...client.DeleteAllOfOption) {
 	ClearResourcesWithRemoveFinalizerOption[T, PT, L, PL](testCtx, funcSig, false, opts...)
 }
 
@@ -298,7 +298,7 @@ func ClearResources[T intctrlutil.Object, PT intctrlutil.PObject[T],
 // removeFinalizer specifier, and satisfying the input ListOptions.
 func ClearResourcesWithRemoveFinalizerOption[T intctrlutil.Object, PT intctrlutil.PObject[T],
 	L intctrlutil.ObjList[T], PL intctrlutil.PObjList[T, L]](
-	testCtx *testutil.TestContext, _ func(T, L), removeFinalizer bool, opts ...client.DeleteAllOfOption) {
+	testCtx *testutil.TestContext, _ func(T, PT, L, PL), removeFinalizer bool, opts ...client.DeleteAllOfOption) {
 	var (
 		obj     T
 		objList L


### PR DESCRIPTION
Goland IDE 2023.2.1 and 2023.2.2 code inspector has a bug to infer generic pointer type like PObject and PObjList from Object and ObjectList, reported by those issues:
- https://youtrack.jetbrains.com/issue/GO-15335/Error-when-infer-generic-type-with-pointers
- https://youtrack.jetbrains.com/issue/GO-15306/False-error-when-using-pointer-method
- https://youtrack.jetbrains.com/issue/GO-15285/Incorrect-type-error-calling-a-generic-function-with-generic-interfaces-using-type-constraints

However, we don't know when this bug shall be fixed, to workaround this bug, we pass the pointer type that could be inferred to generic functions in signature explicitly.

