### PR TITLE
feat: cli plugin adapt the change of  block index repository

### DIFF
--- a/internal/cli/cmd/plugin/types.go
+++ b/internal/cli/cmd/plugin/types.go
@@ -67,6 +67,9 @@ func (p *Paths) IndexPluginsPath(name string) []string {
 	if _, err := os.Stat(filepath.Join(p.IndexPath(name), "krew-plugins")); err == nil {
 		result = append(result, filepath.Join(p.IndexPath(name), "krew-plugins"))
 	}
+	if _, err := os.Stat(filepath.Join(p.IndexPath(name), "cli-plugins")); err == nil {
+		result = append(result, filepath.Join(p.IndexPath(name), "cli-plugins"))
+	}
 	return result
 }
 


### PR DESCRIPTION
the [block-index](https://github.com/apecloud/block-index) rename the dir `plugins` to `cli-plugins`. Therefore, the plugin cmd also need to check the cli-plugins dir.