### PR TITLE
fix: supply the docker error info when playground init locally failed

### DIFF
--- a/internal/cli/util/version.go
+++ b/internal/cli/util/version.go
@@ -133,7 +133,11 @@ func GetDockerVersion() (*gv.Version, error) {
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil || stderr.String() != "" {
-		return nil, fmt.Errorf("failed to get the docker version by executing \"docker info --format {{.ServerVersion}}\": %s", stderr.String())
+		var errMsg = stderr.String()
+		if errMsg == "" {
+			errMsg = err.Error()
+		}
+		return nil, fmt.Errorf("failed to get the docker version by executing \"docker info --format {{.ServerVersion}}\": %s", errMsg)
 	}
 	return gv.NewVersion(strings.TrimSpace(string(out)))
 }

--- a/internal/cli/util/version.go
+++ b/internal/cli/util/version.go
@@ -133,7 +133,7 @@ func GetDockerVersion() (*gv.Version, error) {
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil || stderr.String() != "" {
-		var errMsg = stderr.String()
+		errMsg := stderr.String()
 		if errMsg == "" {
 			errMsg = err.Error()
 		}

--- a/internal/cli/util/version.go
+++ b/internal/cli/util/version.go
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package util
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os/exec"
@@ -128,9 +129,11 @@ func GetKubeBlocksDeploy(client kubernetes.Interface) (*appsv1.Deployment, error
 func GetDockerVersion() (*gv.Version, error) {
 	// exec cmd to get output from docker info --format '{{.ServerVersion}}'
 	cmd := exec.Command("docker", "info", "--format", "{{.ServerVersion}}")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
 	out, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get the docker version by executing \"docker info --format {{.ServerVersion}}\": %s", err)
+	if err != nil || stderr.String() != "" {
+		return nil, fmt.Errorf("failed to get the docker version by executing \"docker info --format {{.ServerVersion}}\": %s", stderr.String())
 	}
 	return gv.NewVersion(strings.TrimSpace(string(out)))
 }

--- a/internal/cli/util/version.go
+++ b/internal/cli/util/version.go
@@ -130,7 +130,7 @@ func GetDockerVersion() (*gv.Version, error) {
 	cmd := exec.Command("docker", "info", "--format", "{{.ServerVersion}}")
 	out, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("playground init failed locally due to the absence of the Docker service")
+		return nil, fmt.Errorf("failed to get the docker version by executing \"docker info --format {{.ServerVersion}}\": %s", err)
 	}
 	return gv.NewVersion(strings.TrimSpace(string(out)))
 }

--- a/internal/cli/util/version.go
+++ b/internal/cli/util/version.go
@@ -130,7 +130,7 @@ func GetDockerVersion() (*gv.Version, error) {
 	cmd := exec.Command("docker", "info", "--format", "{{.ServerVersion}}")
 	out, err := cmd.Output()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("playground init failed locally due to the absence of the Docker service")
 	}
 	return gv.NewVersion(strings.TrimSpace(string(out)))
 }


### PR DESCRIPTION
- fix #5314 