### PR TITLE
chore: adjust milestone setting rules

### DIFF
--- a/.github/workflows/milestone-set.yaml
+++ b/.github/workflows/milestone-set.yaml
@@ -4,32 +4,30 @@ on:
   workflow_dispatch:
   issues:
     types:
-      - opened
       - closed
   pull_request_target:
     types:
-      - opened
       - closed
 
 
 jobs:
   issue-milestone:
     if: ${{ github.event_name == 'issues' }}
-    uses: apecloud/apecloud-cd/.github/workflows/issue-milestone.yml@v0.1.31
+    uses: apecloud/apecloud-cd/.github/workflows/issue-milestone.yml@v0.1.32
     with:
-      APECD_REF: "v0.1.31"
+      APECD_REF: "v0.1.32"
     secrets: inherit
     
   pr-milestone:
     if: ${{ github.event_name  == 'pull_request_target' }}
-    uses: apecloud/apecloud-cd/.github/workflows/pull-request-milestone.yml@v0.1.31
+    uses: apecloud/apecloud-cd/.github/workflows/pull-request-milestone.yml@v0.1.32
     with:
-      APECD_REF: "v0.1.31"
+      APECD_REF: "v0.1.32"
     secrets: inherit
 
   move_milestone:
     if: ${{ github.event_name  == 'workflow_dispatch' }}
-    uses: apecloud/apecloud-cd/.github/workflows/milestone-move.yml@v0.1.31
+    uses: apecloud/apecloud-cd/.github/workflows/milestone-move.yml@v0.1.32
     with:
-      APECD_REF: "v0.1.31"
+      APECD_REF: "v0.1.32"
     secrets: inherit

--- a/.github/workflows/milestoneclose.yml
+++ b/.github/workflows/milestoneclose.yml
@@ -13,9 +13,9 @@ env:
 
 jobs:
   move_milestone:
-    uses: apecloud/apecloud-cd/.github/workflows/milestone-move.yml@v0.1.31
+    uses: apecloud/apecloud-cd/.github/workflows/milestone-move.yml@v0.1.32
     with:
-      APECD_REF: "v0.1.31"
+      APECD_REF: "v0.1.32"
     secrets: inherit
 
   move_issues:


### PR DESCRIPTION
1. Milestone is empty when issue/pr open and can be set manually.
2. If close issue/pr milestone is empty, set default milsestone.
3. When milsestone is closed, if issue/pr has a milestone, it will be moved to the next milestone. If not, it will remain empty.
ref: https://github.com/apecloud/apecloud-cd/pull/132/files