### PR TITLE
fix: create snapshot failed on GKE

### DIFF
--- a/deploy/helm/templates/dataprotection.yaml
+++ b/deploy/helm/templates/dataprotection.yaml
@@ -80,7 +80,10 @@ spec:
             - name: VOLUMESNAPSHOT
               value: "true"
             {{- end }}
-            {{- if .Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1beta1" }}
+            {{- if .Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1" }}
+            - name: VOLUMESNAPSHOT_API_BETA
+              value: "false"
+            {{- else if .Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1beta1" }}
             - name: VOLUMESNAPSHOT_API_BETA
               value: "true"
             {{- end }}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -89,7 +89,10 @@ spec:
             - name: VOLUMESNAPSHOT
               value: "true"
             {{- end }}
-            {{- if .Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1beta1" }}
+            {{- if .Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1" }}
+            - name: VOLUMESNAPSHOT_API_BETA
+              value: "false"
+            {{- else if .Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1beta1" }}
             - name: VOLUMESNAPSHOT_API_BETA
               value: "true"
             {{- end }}


### PR DESCRIPTION
The latest version of GKE has added snapshot validating webhook, which will be intercepted if created using v1beta1 version