### PR TITLE
feat: support volume populator for restore

### DIFF
--- a/apis/dataprotection/v1alpha1/backuppolicy_types.go
+++ b/apis/dataprotection/v1alpha1/backuppolicy_types.go
@@ -100,19 +100,17 @@ const (
 // target database cluster.
 type ConnectionCredential struct {
 	// secretName refers to the Secret object that contains the connection credential.
-	// +kube:validation:Required
+	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
 	SecretName string `json:"secretName"`
 
 	// usernameKey specifies the map key of the user in the connection credential secret.
-	// +kubebuilder:validation:Required
 	// +kubebuilder:default=username
-	UsernameKey string `json:"usernameKey"`
+	UsernameKey string `json:"usernameKey,omitempty"`
 
 	// passwordKey specifies the map key of the password in the connection credential secret.
-	// +kubebuilder:validation:Required
 	// +kubebuilder:default=password
-	PasswordKey string `json:"passwordKey"`
+	PasswordKey string `json:"passwordKey,omitempty"`
 
 	// hostKey specifies the map key of the host in the connection credential secret.
 	// +kubebuilder:default=host

--- a/apis/dataprotection/v1alpha1/types.go
+++ b/apis/dataprotection/v1alpha1/types.go
@@ -179,16 +179,16 @@ func (r RetentionPeriod) nextNumber(input string) (num int, rest string, err err
 	return num, rest, nil
 }
 
-// RestorePhase The current phase. Valid values are Running, Completed, Failed, Deleting.
+// RestorePhase The current phase. Valid values are Running, Completed, Failed, AsDataSource.
 // +enum
-// +kubebuilder:validation:Enum={Running,Completed,Failed,Deleting}
+// +kubebuilder:validation:Enum={Running,Completed,Failed,AsDataSource}
 type RestorePhase string
 
 const (
-	RestorePhaseRunning   RestorePhase = "Running"
-	RestorePhaseCompleted RestorePhase = "Completed"
-	RestorePhaseFailed    RestorePhase = "Failed"
-	RestorePhaseDeleting  RestorePhase = "Deleting"
+	RestorePhaseRunning      RestorePhase = "Running"
+	RestorePhaseCompleted    RestorePhase = "Completed"
+	RestorePhaseFailed       RestorePhase = "Failed"
+	RestorePhaseAsDataSource RestorePhase = "AsDataSource"
 )
 
 // RestoreActionStatus the status of restore action.

--- a/cmd/dataprotection/main.go
+++ b/cmd/dataprotection/main.go
@@ -225,6 +225,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = (&dpcontrollers.VolumePopulatorReconciler{
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("volume-populator-controller"),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "VolumePopulator")
+		os.Exit(1)
+	}
+
 	if err = (&dpcontrollers.BackupPolicyReconciler{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),

--- a/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -354,9 +354,7 @@ spec:
                           in the connection credential secret.
                         type: string
                     required:
-                    - passwordKey
                     - secretName
-                    - usernameKey
                     type: object
                   podSelector:
                     description: podSelector is used to find the target pod. The volumes

--- a/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
@@ -549,9 +549,7 @@ spec:
                           in the connection credential secret.
                         type: string
                     required:
-                    - passwordKey
                     - secretName
-                    - usernameKey
                     type: object
                   podSelector:
                     description: podSelector is used to find the target pod. The volumes

--- a/config/crd/bases/dataprotection.kubeblocks.io_restores.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_restores.yaml
@@ -2046,9 +2046,7 @@ spec:
                           in the connection credential secret.
                         type: string
                     required:
-                    - passwordKey
                     - secretName
-                    - usernameKey
                     type: object
                   execAction:
                     description: configuration for exec action.
@@ -2504,12 +2502,12 @@ spec:
                 type: string
               phase:
                 description: RestorePhase The current phase. Valid values are Running,
-                  Completed, Failed, Deleting.
+                  Completed, Failed, AsDataSource.
                 enum:
                 - Running
                 - Completed
                 - Failed
-                - Deleting
+                - AsDataSource
                 type: string
               startTimestamp:
                 description: Date/time when the restore started being processed.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -443,6 +443,8 @@ rules:
   - persistentvolumeclaims/status
   verbs:
   - get
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:

--- a/controllers/apps/cluster_controller_test.go
+++ b/controllers/apps/cluster_controller_test.go
@@ -624,7 +624,7 @@ var _ = Describe("Cluster Controller", func() {
 				Expect(testapps.GetAndChangeObjStatus(&testCtx, backupKey, func(backup *dpv1alpha1.Backup) {
 					backup.Status.Phase = dpv1alpha1.BackupPhaseCompleted
 					backup.Status.PersistentVolumeClaimName = "backup-data"
-					testdp.MockBackupStatusMethod(backup, testapps.DataVolumeName)
+					testdp.MockBackupStatusMethod(backup, testdp.BackupMethodName, testapps.DataVolumeName, testdp.ActionSetName)
 				})()).Should(Succeed())
 
 				if testk8s.IsMockVolumeSnapshotEnabled(&testCtx, storageClassName) {
@@ -2324,7 +2324,7 @@ var _ = Describe("Cluster Controller", func() {
 			Eventually(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKeyFromObject(backup), func(backup *dpv1alpha1.Backup) {
 				backup.Status.PersistentVolumeClaimName = "backup-pvc"
 				backup.Status.Phase = dpv1alpha1.BackupPhaseCompleted
-				testdp.MockBackupStatusMethod(backup, testapps.DataVolumeName)
+				testdp.MockBackupStatusMethod(backup, testdp.BackupMethodName, testapps.DataVolumeName, testdp.ActionSetName)
 			})).Should(Succeed())
 
 			By("creating cluster with backup")

--- a/controllers/apps/opsrequest_controller_test.go
+++ b/controllers/apps/opsrequest_controller_test.go
@@ -500,7 +500,7 @@ var _ = Describe("OpsRequest Controller", func() {
 			backup := &dpv1alpha1.Backup{}
 			Expect(k8sClient.Get(testCtx.Ctx, backupKey, backup)).Should(Succeed())
 			backup.Status.Phase = dpv1alpha1.BackupPhaseCompleted
-			testdp.MockBackupStatusMethod(backup, testapps.DataVolumeName)
+			testdp.MockBackupStatusMethod(backup, testdp.BackupMethodName, testapps.DataVolumeName, testdp.ActionSetName)
 			Expect(k8sClient.Status().Update(testCtx.Ctx, backup)).Should(Succeed())
 			Eventually(testapps.CheckObj(&testCtx, clusterKey, func(g Gomega, cluster *appsv1alpha1.Cluster) {
 				g.Expect(cluster.Status.Components[mysqlCompName].Phase).Should(Equal(appsv1alpha1.UpdatingClusterCompPhase))

--- a/controllers/dataprotection/suite_test.go
+++ b/controllers/dataprotection/suite_test.go
@@ -179,6 +179,13 @@ var _ = BeforeSuite(func() {
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
+	err = (&VolumePopulatorReconciler{
+		Client:   k8sManager.GetClient(),
+		Scheme:   k8sManager.GetScheme(),
+		Recorder: k8sManager.GetEventRecorderFor("volume-populate-controller"),
+	}).SetupWithManager(k8sManager)
+	Expect(err).ToNot(HaveOccurred())
+
 	testCtx = testutil.NewDefaultTestContext(ctx, k8sClient, testEnv)
 
 	go func() {

--- a/controllers/dataprotection/types.go
+++ b/controllers/dataprotection/types.go
@@ -91,9 +91,6 @@ const (
 const (
 	populatePodPrefix = "kb-populate"
 
-	// context keys
-	nodeNameKey = "nodeName"
-
 	// annotation keys
 	annSelectedNode = "volume.kubernetes.io/selected-node"
 	annPopulateFrom = "dataprotections.kubeblocks.io/populate-from"
@@ -104,10 +101,11 @@ const (
 	reasonVolumePopulateFailed  = "VolumePopulateFailed"
 
 	// pvc condition type and reason
+	reasonPopulatingFailed     = "Failed"
+	reasonPopulatingProcessing = "Processing"
+	reasonPopulatingSucceed    = "Succeed"
+
 	PersistentVolumeClaimPopulating corev1.PersistentVolumeClaimConditionType = "Populating"
-	reasonPopulatingFailed                                                    = "Failed"
-	reasonPopulatingProcessing                                                = "Processing"
-	reasonPopulatingSucceed                                                   = "Succeed"
 )
 
 var reconcileInterval = time.Second

--- a/controllers/dataprotection/types.go
+++ b/controllers/dataprotection/types.go
@@ -23,6 +23,8 @@ import (
 	"runtime"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	viper "github.com/apecloud/kubeblocks/internal/viperx"
 )
 
@@ -83,6 +85,29 @@ const (
 	ReasonHaveResidualPVCs          = "HaveResidualPVCs"
 	ReasonDerivedObjectsDeleted     = "DerivedObjectsDeleted"
 	ReasonUnknownError              = "UnknownError"
+)
+
+// constant  for volume populator
+const (
+	populatePodPrefix = "kb-populate"
+
+	// context keys
+	nodeNameKey = "nodeName"
+
+	// annotation keys
+	annSelectedNode = "volume.kubernetes.io/selected-node"
+	annPopulateFrom = "dataprotections.kubeblocks.io/populate-from"
+
+	// event reason
+	reasonStartToVolumePopulate = "StartToVolumePopulate"
+	reasonVolumePopulateSucceed = "VolumePopulateSucceed"
+	reasonVolumePopulateFailed  = "VolumePopulateFailed"
+
+	// pvc condition type and reason
+	PersistentVolumeClaimPopulating corev1.PersistentVolumeClaimConditionType = "Populating"
+	reasonPopulatingFailed                                                    = "Failed"
+	reasonPopulatingProcessing                                                = "Processing"
+	reasonPopulatingSucceed                                                   = "Succeed"
 )
 
 var reconcileInterval = time.Second

--- a/controllers/dataprotection/utils.go
+++ b/controllers/dataprotection/utils.go
@@ -299,3 +299,9 @@ func fromFlattenName(flatten string) (name string, namespace string) {
 	}
 	return
 }
+
+// restore functions
+
+func getPopulatePVCName(pvcUID types.UID) string {
+	return fmt.Sprintf("%s-%s", populatePodPrefix, pvcUID)
+}

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -140,7 +140,7 @@ func (r *VolumePopulatorReconciler) populate(reqCtx intctrlutil.RequestCtx, pvc 
 	if err != nil || wait {
 		return err
 	}
-	// Make sure the PVC finalizer is gone
+	// Make sure the PVC finalizer is present
 	if !slices.Contains(pvc.Finalizers, dptypes.DataProtectionFinalizerName) {
 		pvcPatch := client.MergeFrom(pvc.DeepCopy())
 		controllerutil.AddFinalizer(pvc, dptypes.DataProtectionFinalizerName)

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -109,7 +109,7 @@ func (r *VolumePopulatorReconciler) matchToPopulate(pvc *corev1.PersistentVolume
 	if dataSourceRef.APIGroup != nil {
 		apiGroup = *dataSourceRef.APIGroup
 	}
-	if dptypes.DataprotectionApiGroup != apiGroup || dptypes.RestoreKind != dataSourceRef.Kind || "" == dataSourceRef.Name {
+	if apiGroup != dptypes.DataprotectionAPIGroup || dataSourceRef.Kind != dptypes.RestoreKind || dataSourceRef.Name == "" {
 		// Ignore PVCs that aren't for this populator to handle
 		return false, nil
 	}

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -1,0 +1,416 @@
+/*
+Copyright (C) 2022-2023 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package dataprotection
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"golang.org/x/exp/slices"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/component-helpers/storage/volume"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	"github.com/apecloud/kubeblocks/internal/constant"
+	intctrlutil "github.com/apecloud/kubeblocks/internal/controllerutil"
+	dprestore "github.com/apecloud/kubeblocks/internal/dataprotection/restore"
+	dptypes "github.com/apecloud/kubeblocks/internal/dataprotection/types"
+	"github.com/apecloud/kubeblocks/internal/dataprotection/utils"
+)
+
+// VolumePopulatorReconciler reconciles a Restore object
+type VolumePopulatorReconciler struct {
+	client.Client
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+}
+
+// +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims/finalizers,verbs=update
+// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.11.0/pkg/reconcile
+func (r *VolumePopulatorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	reqCtx := intctrlutil.RequestCtx{
+		Ctx:      ctx,
+		Req:      req,
+		Log:      log.FromContext(ctx).WithValues("volume-populator", req.NamespacedName),
+		Recorder: r.Recorder,
+	}
+
+	// Get pvc
+	pvc := &corev1.PersistentVolumeClaim{}
+	if err := r.Client.Get(reqCtx.Ctx, reqCtx.Req.NamespacedName, pvc); err != nil {
+		return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "")
+	}
+
+	if err := r.syncPVC(reqCtx, pvc); err != nil {
+		if intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal) {
+			r.Recorder.Event(pvc, corev1.EventTypeWarning, reasonVolumePopulateFailed, err.Error())
+			if patchErr := r.updatePVCConditions(reqCtx, pvc, reasonPopulatingFailed, err.Error()); patchErr != nil {
+				return intctrlutil.RequeueWithError(patchErr, reqCtx.Log, "")
+			}
+			return intctrlutil.Reconciled()
+		}
+		return intctrlutil.RequeueWithError(err, reqCtx.Log, "")
+	}
+	return intctrlutil.Reconciled()
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *VolumePopulatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.PersistentVolumeClaim{}).
+		Owns(&batchv1.Job{}).
+		Complete(r)
+}
+
+func (r *VolumePopulatorReconciler) matchToPopulate(pvc *corev1.PersistentVolumeClaim) (bool, error) {
+	dataSourceRef := pvc.Spec.DataSourceRef
+	if dataSourceRef == nil {
+		// Ignore PVCs without a datasource
+		return false, nil
+	}
+	apiGroup := ""
+	if dataSourceRef.APIGroup != nil {
+		apiGroup = *dataSourceRef.APIGroup
+	}
+	if dptypes.DataprotectionApiGroup != apiGroup || dptypes.RestoreKind != dataSourceRef.Kind || "" == dataSourceRef.Name {
+		// Ignore PVCs that aren't for this populator to handle
+		return false, nil
+	}
+	if dataSourceRef.Namespace != nil && *dataSourceRef.Namespace != pvc.Namespace {
+		message := fmt.Sprintf(`custom resource of restore "%s" should be in the same namespace as the persistentVolumeClaim's namespace.`, *dataSourceRef.Namespace)
+		return false, intctrlutil.NewFatalError(message)
+	}
+	return true, nil
+}
+
+func (r *VolumePopulatorReconciler) syncPVC(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim) error {
+	matched, err := r.matchToPopulate(pvc)
+	if err != nil {
+		return err
+	}
+	if !matched {
+		return nil
+	}
+	// if pvc has not bound pv, populate it.
+	if pvc.Spec.VolumeName == "" {
+		return r.populate(reqCtx, pvc)
+	}
+	return r.cleanup(reqCtx, pvc)
+}
+
+func (r *VolumePopulatorReconciler) populate(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim) error {
+	wait, nodeName, err := r.waitForPVCSelectedNode(reqCtx, pvc)
+	if err != nil || wait {
+		return err
+	}
+	// Make sure the PVC finalizer is gone
+	if !slices.Contains(pvc.Finalizers, dptypes.DataProtectionFinalizerName) {
+		pvcPatch := client.MergeFrom(pvc.DeepCopy())
+		controllerutil.AddFinalizer(pvc, dptypes.DataProtectionFinalizerName)
+		if err = r.Client.Patch(reqCtx.Ctx, pvc, pvcPatch); err != nil {
+			return err
+		}
+	}
+	if err = r.updatePVCConditions(reqCtx, pvc, reasonPopulatingProcessing, "Populator started"); err != nil {
+		return err
+	}
+
+	restore, err := r.getRestoreCR(reqCtx, pvc, nodeName)
+	if err != nil {
+		return err
+	}
+
+	restoreMgr := dprestore.NewRestoreManager(restore, r.Recorder, r.Scheme)
+	if err = dprestore.ValidateAndInitRestoreMGR(reqCtx, r.Client, r.Recorder, restoreMgr); err != nil {
+		return err
+	}
+
+	var populatePVC *corev1.PersistentVolumeClaim
+	for i, v := range restoreMgr.PrepareDataBackupSets {
+		if populatePVC == nil {
+			populatePVC, err = r.getPopulatePVC(reqCtx, pvc, v,
+				restore.Spec.PrepareDataConfig.DataSourceRef.VolumeSource, nodeName)
+			if err != nil {
+				return err
+			}
+		}
+
+		// 1. build populate job
+		job, err := restoreMgr.BuildVolumePopulateJob(v, populatePVC, i)
+		if err != nil {
+			return err
+		}
+		if job == nil {
+			continue
+		}
+
+		// 2. create job
+		jobs, err := restoreMgr.CreateJobsIfNotExist(reqCtx, r.Client, pvc, []*batchv1.Job{job})
+		if err != nil {
+			return err
+		}
+
+		// 3. check if jobs are finished.
+		isCompleted, err := dprestore.CheckJobDone(jobs[0])
+		if !isCompleted {
+			return nil
+		}
+		if err != nil {
+			return intctrlutil.NewFatalError(err.Error())
+		}
+	}
+	// 4. if jobs are succeed, rebind the pvc and pv
+	if err = r.rebindPVCAndPV(reqCtx, populatePVC, pvc); err != nil {
+		return err
+	}
+	if err = r.updatePVCConditions(reqCtx, pvc, reasonPopulatingSucceed, "Populator finished"); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *VolumePopulatorReconciler) cleanup(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim) error {
+	if slices.Contains(pvc.Finalizers, dptypes.DataProtectionFinalizerName) {
+		pvcPatch := client.MergeFrom(pvc.DeepCopy())
+		controllerutil.RemoveFinalizer(pvc, dptypes.DataProtectionFinalizerName)
+		if err := r.Client.Patch(reqCtx.Ctx, pvc, pvcPatch); err != nil {
+			return err
+		}
+	}
+
+	jobs := &batchv1.JobList{}
+	if err := r.Client.List(reqCtx.Ctx, jobs,
+		client.InNamespace(pvc.Namespace), client.MatchingLabels(map[string]string{
+			dprestore.DataProtectionLabelPopulatePVCKey: getPopulatePVCName(pvc.UID),
+		})); err != nil {
+		return err
+	}
+
+	for i := range jobs.Items {
+		job := &jobs.Items[i]
+		if controllerutil.ContainsFinalizer(job, dptypes.DataProtectionFinalizerName) {
+			patch := client.MergeFrom(job.DeepCopy())
+			controllerutil.RemoveFinalizer(job, dptypes.DataProtectionFinalizerName)
+			if err := r.Patch(reqCtx.Ctx, job, patch); err != nil {
+				return err
+			}
+		}
+		if !job.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if err := intctrlutil.BackgroundDeleteObject(r.Client, reqCtx.Ctx, job); err != nil {
+			return err
+		}
+	}
+
+	populatePVC := &corev1.PersistentVolumeClaim{}
+	if err := r.Client.Get(reqCtx.Ctx, types.NamespacedName{Name: getPopulatePVCName(pvc.UID),
+		Namespace: pvc.Namespace}, populatePVC); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+	return r.Client.Delete(reqCtx.Ctx, populatePVC)
+}
+
+func (r *VolumePopulatorReconciler) checkIntreeStorageClass(pvc *corev1.PersistentVolumeClaim, sc *storagev1.StorageClass) error {
+	if !strings.HasPrefix(sc.Provisioner, "kubernetes.io/") {
+		// This is not an in-tree StorageClass
+		return nil
+	}
+
+	if pvc.Annotations != nil {
+		if migrated := pvc.Annotations[volume.AnnMigratedTo]; migrated != "" {
+			// The PVC is migrated to CSI
+			return nil
+		}
+	}
+	// The SC is in-tree & PVC is not migrated
+	return intctrlutil.NewFatalError(fmt.Sprintf("in-tree volume volume plugin %q cannot use volume populator", sc.Provisioner))
+}
+
+func (r *VolumePopulatorReconciler) waitForPVCSelectedNode(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim) (bool, string, error) {
+	var nodeName string
+	if pvc.Spec.StorageClassName != nil {
+		storageClassName := *pvc.Spec.StorageClassName
+		storageClass := &storagev1.StorageClass{}
+		if err := r.Client.Get(reqCtx.Ctx, types.NamespacedName{Name: storageClassName}, storageClass); err != nil {
+			return false, nodeName, err
+		}
+
+		if err := r.checkIntreeStorageClass(pvc, storageClass); err != nil {
+			return false, nodeName, err
+		}
+		if storageClass.VolumeBindingMode != nil && storagev1.VolumeBindingWaitForFirstConsumer == *storageClass.VolumeBindingMode {
+			nodeName = pvc.Annotations[annSelectedNode]
+			if nodeName == "" {
+				// Wait for the PVC to get a node name before continuing
+				return true, nodeName, nil
+			}
+		}
+	}
+	return false, nodeName, nil
+}
+
+func (r *VolumePopulatorReconciler) getPopulatePVC(reqCtx intctrlutil.RequestCtx,
+	pvc *corev1.PersistentVolumeClaim,
+	backupSet dprestore.BackupActionSet,
+	volumeSource,
+	nodeName string) (*corev1.PersistentVolumeClaim, error) {
+	populatePVCName := getPopulatePVCName(pvc.UID)
+	populatePVC := &corev1.PersistentVolumeClaim{}
+	if err := r.Client.Get(reqCtx.Ctx, types.NamespacedName{Name: populatePVCName,
+		Namespace: pvc.Namespace}, populatePVC); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, err
+		}
+		// create populate pvc
+		populatePVC = &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      populatePVCName,
+				Namespace: pvc.Namespace,
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes:      pvc.Spec.AccessModes,
+				Resources:        pvc.Spec.Resources,
+				StorageClassName: pvc.Spec.StorageClassName,
+				VolumeMode:       pvc.Spec.VolumeMode,
+			},
+		}
+		if nodeName != "" {
+			populatePVC.Annotations = map[string]string{
+				annSelectedNode: pvc.Annotations[annSelectedNode],
+			}
+		}
+		if backupSet.UseVolumeSnapshot {
+			// restore from volume snapshot.
+			populatePVC.Spec.DataSourceRef = &corev1.TypedObjectReference{
+				Name:     utils.GetBackupVolumeSnapshotName(backupSet.Backup.Name, volumeSource),
+				Kind:     constant.VolumeSnapshotKind,
+				APIGroup: &dprestore.VolumeSnapshotGroup,
+			}
+		}
+		if err = r.Client.Create(reqCtx.Ctx, populatePVC); err != nil && !apierrors.IsAlreadyExists(err) {
+			return nil, err
+		}
+	}
+	return populatePVC, nil
+}
+
+func (r *VolumePopulatorReconciler) getRestoreCR(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim, nodeName string) (*dpv1alpha1.Restore, error) {
+	restore := &dpv1alpha1.Restore{}
+	if err := r.Client.Get(reqCtx.Ctx, types.NamespacedName{Name: pvc.Spec.DataSourceRef.Name,
+		Namespace: pvc.Namespace}, restore); err != nil {
+		return nil, err
+	}
+	if restore.Spec.PrepareDataConfig == nil || restore.Spec.PrepareDataConfig.DataSourceRef == nil {
+		return nil, intctrlutil.NewFatalError(fmt.Sprintf(`spec.prepareDataConfig.datasourceRef of restore "%s" can not be empty`, restore.Name))
+	}
+	restore.Spec.PrepareDataConfig.SchedulingSpec = dpv1alpha1.SchedulingSpec{
+		Tolerations: []corev1.Toleration{
+			{Operator: corev1.TolerationOpExists},
+		},
+	}
+	if nodeName != "" {
+		restore.Spec.PrepareDataConfig.SchedulingSpec.NodeSelector = map[string]string{
+			corev1.LabelHostname: nodeName,
+		}
+	}
+	return restore, nil
+}
+
+func (r *VolumePopulatorReconciler) rebindPVCAndPV(reqCtx intctrlutil.RequestCtx, populatePVC, pvc *corev1.PersistentVolumeClaim) error {
+	pv := &corev1.PersistentVolume{}
+	if err := r.Client.Get(reqCtx.Ctx, types.NamespacedName{Name: populatePVC.Spec.VolumeName, Namespace: pvc.Namespace}, pv); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		// We'll get called again later when the PV exists
+		return nil
+	}
+	// Examine the claimref for the PV and see if it's bound to the correct PVC
+	claimRef := pv.Spec.ClaimRef
+	if claimRef.Name == pvc.Name && claimRef.Namespace == pvc.Namespace && claimRef.UID == pvc.UID {
+		return nil
+	}
+	// Make new PV with strategic patch values to perform the PV rebind
+	patchPV := client.MergeFrom(pv.DeepCopy())
+	pv.Spec.ClaimRef = &corev1.ObjectReference{
+		Namespace:       pvc.Namespace,
+		Name:            pvc.Name,
+		UID:             pvc.UID,
+		ResourceVersion: pvc.ResourceVersion,
+	}
+	if pv.Annotations == nil {
+		pv.Annotations = map[string]string{}
+	}
+	pv.Annotations[annPopulateFrom] = pvc.Spec.DataSourceRef.Name
+	return r.Client.Patch(reqCtx.Ctx, pv, patchPV)
+}
+
+func (r *VolumePopulatorReconciler) updatePVCConditions(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim, reason, message string) error {
+	progressCondition := corev1.PersistentVolumeClaimCondition{
+		Type:               PersistentVolumeClaimPopulating,
+		Status:             corev1.ConditionTrue,
+		LastTransitionTime: metav1.Now(),
+		Reason:             reason,
+		Message:            message,
+	}
+	pvcPatch := client.MergeFrom(pvc.DeepCopy())
+	var existPopulating bool
+	for i, v := range pvc.Status.Conditions {
+		if v.Type != PersistentVolumeClaimPopulating {
+			continue
+		}
+		if reason == v.Reason {
+			return nil
+		}
+		existPopulating = true
+		pvc.Status.Conditions[i] = progressCondition
+	}
+	if !existPopulating {
+		pvc.Status.Conditions = append(pvc.Status.Conditions, progressCondition)
+	}
+	switch reason {
+	case reasonPopulatingProcessing:
+		r.Recorder.Event(pvc, corev1.EventTypeNormal, reasonStartToVolumePopulate, message)
+	case reasonPopulatingSucceed:
+		r.Recorder.Event(pvc, corev1.EventTypeNormal, reasonVolumePopulateSucceed, message)
+	}
+	return r.Client.Status().Patch(reqCtx.Ctx, pvc, pvcPatch)
+}

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Volume Populator Controller test", func() {
 				testCtx.DefaultNamespace, pvcName, testdp.ClusterName, testdp.ComponentName, testdp.DataVolumeName).
 				SetStorage(storageSize).
 				SetStorageClass(testdp.StorageClassName).
-				SetDataSourceRef(dptypes.DataprotectionApiGroup, dptypes.RestoreKind, restore.Name).
+				SetDataSourceRef(dptypes.DataprotectionAPIGroup, dptypes.RestoreKind, restore.Name).
 				Create(&testCtx).GetObject()
 			return pvc
 		}

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -1,0 +1,270 @@
+/*
+Copyright (C) 2022-2023 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package dataprotection
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	dprestore "github.com/apecloud/kubeblocks/internal/dataprotection/restore"
+	dptypes "github.com/apecloud/kubeblocks/internal/dataprotection/types"
+	"github.com/apecloud/kubeblocks/internal/generics"
+	testapps "github.com/apecloud/kubeblocks/internal/testutil/apps"
+	testdp "github.com/apecloud/kubeblocks/internal/testutil/dataprotection"
+)
+
+var _ = Describe("Volume Populator Controller test", func() {
+	cleanEnv := func() {
+		// must wait till resources deleted and no longer existed before the testcases start,
+		// otherwise if later it needs to create some new resource objects with the same name,
+		// in race conditions, it will find the existence of old objects, resulting failure to
+		// create the new objects.
+		By("clean resources")
+
+		// delete rest mocked objects
+		inNS := client.InNamespace(testCtx.DefaultNamespace)
+		ml := client.HasLabels{testCtx.TestObjLabelKey}
+
+		// namespaced
+		testapps.ClearResources(&testCtx, generics.PodSignature, inNS, ml)
+		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.BackupSignature, true, inNS)
+
+		// wait all backup to be deleted, otherwise the controller maybe create
+		// job to delete the backup between the ClearResources function delete
+		// the job and get the job list, resulting the ClearResources panic.
+		Eventually(testapps.List(&testCtx, generics.BackupSignature, inNS)).Should(HaveLen(0))
+
+		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.RestoreSignature, true, inNS)
+		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.JobSignature, true, inNS)
+		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.PersistentVolumeClaimSignature, true, inNS)
+
+		// non-namespaced
+		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.ActionSetSignature, true, ml)
+		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.StorageClassSignature, true, ml)
+		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.PersistentVolumeSignature, true, ml)
+	}
+
+	BeforeEach(func() {
+		cleanEnv()
+	})
+
+	AfterEach(func() {
+		cleanEnv()
+	})
+
+	When("volume populator controller test", func() {
+		var (
+			actionSet   *dpv1alpha1.ActionSet
+			pvcName     = "data-mysql-mysql-0"
+			storageSize = "20Gi"
+			// intreeProvisioner = "kubernetes.io/no-provisioner"
+			csiProvisioner = "csi.test.io/provisioner"
+		)
+
+		createStorageClass := func(volumeBinding storagev1.VolumeBindingMode) *storagev1.StorageClass {
+			storageClass := &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: testdp.StorageClassName,
+				},
+				Provisioner:       csiProvisioner,
+				VolumeBindingMode: &volumeBinding,
+			}
+			Expect(testCtx.CreateObj(testCtx.Ctx, storageClass)).Should(Succeed())
+			return storageClass
+		}
+
+		BeforeEach(func() {
+			By("create actionSet")
+			actionSet = testdp.NewFakeActionSet(&testCtx)
+		})
+
+		initResources := func(volumeBinding storagev1.VolumeBindingMode, useVolumeSnapshotBackup, mockBackupCompleted bool) *corev1.PersistentVolumeClaim {
+			By("create storageClass")
+			createStorageClass(volumeBinding)
+
+			By("create backup")
+			backup := testdp.NewFakeBackup(&testCtx, nil)
+			// wait for backup is failed by backup controller.
+			// it will be failed if the backupPolicy is not created.
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(backup), func(g Gomega, tmpBackup *dpv1alpha1.Backup) {
+				g.Expect(tmpBackup.Status.Phase).Should(Equal(dpv1alpha1.BackupPhaseFailed))
+			})).Should(Succeed())
+
+			if mockBackupCompleted {
+				// then mock backup to completed
+				backupMethodName := testdp.BackupMethodName
+				if useVolumeSnapshotBackup {
+					backupMethodName = testdp.VSBackupMethodName
+				}
+				Expect(testapps.ChangeObjStatus(&testCtx, backup, func() {
+					backup.Status.Phase = dpv1alpha1.BackupPhaseCompleted
+					testdp.MockBackupStatusMethod(backup, backupMethodName, testdp.DataVolumeName, actionSet.Name)
+				})).Should(Succeed())
+			}
+
+			By("create restore ")
+			restore := testdp.NewRestoreactory(testCtx.DefaultNamespace, testdp.RestoreName).
+				SetBackup(backup.Name, testCtx.DefaultNamespace).
+				SetDataSourceRef(testdp.DataVolumeName, testdp.DataVolumeMountPath).
+				Create(&testCtx).GetObject()
+
+			By("create PVC and set spec.dataSourceRef to restore")
+			pvc := testapps.NewPersistentVolumeClaimFactory(
+				testCtx.DefaultNamespace, pvcName, testdp.ClusterName, testdp.ComponentName, testdp.DataVolumeName).
+				SetStorage(storageSize).
+				SetStorageClass(testdp.StorageClassName).
+				SetDataSourceRef(dptypes.DataprotectionApiGroup, dptypes.RestoreKind, restore.Name).
+				Create(&testCtx).GetObject()
+			return pvc
+		}
+
+		mockPV := func(populatePVCName string) *corev1.PersistentVolume {
+			pv := &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-pv",
+				},
+				Spec: corev1.PersistentVolumeSpec{
+					StorageClassName: testdp.StorageClassName,
+					AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+					Capacity: map[corev1.ResourceName]resource.Quantity{
+						corev1.ResourceStorage: resource.MustParse(storageSize),
+					},
+					ClaimRef: &corev1.ObjectReference{
+						Namespace: testCtx.DefaultNamespace,
+						Name:      populatePVCName,
+					},
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							Driver:       "kubernetes.io",
+							VolumeHandle: "test-volume-handle",
+						},
+					},
+				},
+			}
+			Expect(testCtx.Create(ctx, pv)).Should(Succeed())
+			populatePVC := &corev1.PersistentVolumeClaim{}
+			// bind pv
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: populatePVCName, Namespace: testCtx.DefaultNamespace}, populatePVC)).Should(Succeed())
+			Expect(testapps.ChangeObj(&testCtx, populatePVC, func(c *corev1.PersistentVolumeClaim) {
+				c.Spec.VolumeName = pv.Name
+			})).Should(Succeed())
+			return pv
+		}
+
+		testVolumePopulate := func(volumeBinding storagev1.VolumeBindingMode, useVolumeSnapshotBackup bool) {
+			pvc := initResources(volumeBinding, useVolumeSnapshotBackup, true)
+
+			pvcKey := client.ObjectKeyFromObject(pvc)
+			if volumeBinding == storagev1.VolumeBindingWaitForFirstConsumer {
+				By("wait for pvc has selected the node")
+				Eventually(testapps.CheckObj(&testCtx, pvcKey, func(g Gomega, tmpPVC *corev1.PersistentVolumeClaim) {
+					g.Expect(len(tmpPVC.Status.Conditions)).Should(Equal(0))
+				})).Should(Succeed())
+			}
+
+			By("mock pvc has selected the node")
+			Expect(testapps.ChangeObj(&testCtx, pvc, func(claim *corev1.PersistentVolumeClaim) {
+				if claim.Annotations == nil {
+					claim.Annotations = map[string]string{}
+				}
+				claim.Annotations[annSelectedNode] = "test-node"
+			})).Should(Succeed())
+			Eventually(testapps.CheckObj(&testCtx, pvcKey, func(g Gomega, tmpPVC *corev1.PersistentVolumeClaim) {
+				g.Expect(len(tmpPVC.Status.Conditions)).Should(Equal(1))
+				g.Expect(tmpPVC.Status.Conditions[0].Type).Should(Equal(PersistentVolumeClaimPopulating))
+			})).Should(Succeed())
+
+			By("expect for populate pvc created")
+			populatePVCName := getPopulatePVCName(pvc.UID)
+			populatePVC := &corev1.PersistentVolumeClaim{}
+			Eventually(testapps.CheckObjExists(&testCtx, types.NamespacedName{Namespace: testCtx.DefaultNamespace,
+				Name: populatePVCName}, populatePVC, true))
+
+			By("expect for job created")
+			Eventually(testapps.List(&testCtx, generics.JobSignature,
+				client.MatchingLabels{dprestore.DataProtectionLabelPopulatePVCKey: populatePVCName},
+				client.InNamespace(testCtx.DefaultNamespace))).Should(HaveLen(1))
+
+			By("mock to create pv and bind to populate pvc")
+			pv := mockPV(populatePVCName)
+
+			By("mock job to succeed")
+			jobList := &batchv1.JobList{}
+			Expect(k8sClient.List(ctx, jobList,
+				client.MatchingLabels{dprestore.DataProtectionLabelPopulatePVCKey: getPopulatePVCName(pvc.UID)},
+				client.InNamespace(testCtx.DefaultNamespace))).Should(Succeed())
+			testdp.ReplaceK8sJobStatus(&testCtx, client.ObjectKeyFromObject(&jobList.Items[0]), batchv1.JobComplete)
+
+			By("expect for pvc has been populated")
+			Eventually(testapps.CheckObj(&testCtx, pvcKey, func(g Gomega, tmpPVC *corev1.PersistentVolumeClaim) {
+				g.Expect(tmpPVC.Status.Conditions[0].Reason).Should(Equal(reasonPopulatingSucceed))
+			})).Should(Succeed())
+
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(pv), func(g Gomega, tmpPV *corev1.PersistentVolume) {
+				g.Expect(tmpPV.Spec.ClaimRef.Name).Should(Equal(pvc.Name))
+				g.Expect(tmpPV.Spec.ClaimRef.UID).Should(Equal(pvc.UID))
+			})).Should(Succeed())
+
+			// mock pvc.spec.volumeName
+			Expect(testapps.ChangeObj(&testCtx, pvc, func(claim *corev1.PersistentVolumeClaim) {
+				claim.Spec.VolumeName = pv.Name
+			})).Should(Succeed())
+
+			By("expect for resources are cleaned up")
+			Eventually(testapps.List(&testCtx, generics.JobSignature,
+				client.MatchingLabels{dprestore.DataProtectionLabelPopulatePVCKey: populatePVCName},
+				client.InNamespace(testCtx.DefaultNamespace))).Should(HaveLen(0))
+			Eventually(testapps.CheckObjExists(&testCtx, types.NamespacedName{Namespace: testCtx.DefaultNamespace,
+				Name: populatePVCName}, populatePVC, false))
+		}
+
+		Context("test volume populator", func() {
+			It("test VolumePopulator when volumeBinding of storageClass is WaitForFirstConsumer", func() {
+				testVolumePopulate(storagev1.VolumeBindingWaitForFirstConsumer, false)
+			})
+
+			It("test VolumePopulator when volumeBinding of storageClass is Immediate", func() {
+				testVolumePopulate(storagev1.VolumeBindingImmediate, false)
+			})
+
+			It("test VolumePopulator when backup uses volume snapshot", func() {
+				testVolumePopulate(storagev1.VolumeBindingWaitForFirstConsumer, true)
+			})
+
+			It("test VolumePopulator when it fails", func() {
+				pvc := initResources(storagev1.VolumeBindingImmediate, false, false)
+				Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(pvc), func(g Gomega, tmpPVC *corev1.PersistentVolumeClaim) {
+					g.Expect(len(tmpPVC.Status.Conditions)).Should(Equal(1))
+					g.Expect(tmpPVC.Status.Conditions[0].Reason).Should(Equal(reasonPopulatingFailed))
+				})).Should(Succeed())
+
+			})
+
+		})
+	})
+})

--- a/deploy/helm/config/rbac/role.yaml
+++ b/deploy/helm/config/rbac/role.yaml
@@ -443,6 +443,8 @@ rules:
   - persistentvolumeclaims/status
   verbs:
   - get
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -354,9 +354,7 @@ spec:
                           in the connection credential secret.
                         type: string
                     required:
-                    - passwordKey
                     - secretName
-                    - usernameKey
                     type: object
                   podSelector:
                     description: podSelector is used to find the target pod. The volumes

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
@@ -549,9 +549,7 @@ spec:
                           in the connection credential secret.
                         type: string
                     required:
-                    - passwordKey
                     - secretName
-                    - usernameKey
                     type: object
                   podSelector:
                     description: podSelector is used to find the target pod. The volumes

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_restores.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_restores.yaml
@@ -2046,9 +2046,7 @@ spec:
                           in the connection credential secret.
                         type: string
                     required:
-                    - passwordKey
                     - secretName
-                    - usernameKey
                     type: object
                   execAction:
                     description: configuration for exec action.
@@ -2504,12 +2502,12 @@ spec:
                 type: string
               phase:
                 description: RestorePhase The current phase. Valid values are Running,
-                  Completed, Failed, Deleting.
+                  Completed, Failed, AsDataSource.
                 enum:
                 - Running
                 - Completed
                 - Failed
-                - Deleting
+                - AsDataSource
                 type: string
               startTimestamp:
                 description: Date/time when the restore started being processed.

--- a/docs/user_docs/cli/kbcli_cluster_backup.md
+++ b/docs/user_docs/cli/kbcli_cluster_backup.md
@@ -30,7 +30,7 @@ kbcli cluster backup NAME [flags]
 
 ```
   -h, --help            help for backup
-      --method string   Backup method that defined in backup policy
+      --method string   Backup method that defined in backup policy (required)
       --name string     Backup name
       --policy string   Backup policy name, this flag will be ignored when backup-type is snapshot
 ```

--- a/docs/user_docs/cli/kbcli_cluster_restore.md
+++ b/docs/user_docs/cli/kbcli_cluster_restore.md
@@ -15,8 +15,8 @@ kbcli cluster restore [flags]
   kbcli cluster restore new-cluster-name --backup backup-name
   
   # restore a new cluster from point in time
-  kbcli cluster restore new-cluster-name --restore-to-time "Apr 13,2023 18:40:35 UTC+0800" --source-cluster mycluster
-  kbcli cluster restore new-cluster-name --restore-to-time "2023-04-13T18:40:35+08:00" --source-cluster mycluster
+  kbcli cluster restore new-cluster-name --restore-to-time "Apr 13,2023 18:40:35 UTC+0800" --backup logfile-backup
+  kbcli cluster restore new-cluster-name --restore-to-time "2023-04-13T18:40:35+08:00" --backup logfile-backup
 ```
 
 ### Options

--- a/go.mod
+++ b/go.mod
@@ -108,6 +108,7 @@ require (
 	k8s.io/client-go v0.28.2
 	k8s.io/code-generator v0.28.2
 	k8s.io/component-base v0.28.2
+	k8s.io/component-helpers v0.28.2
 	k8s.io/cri-api v0.27.1
 	k8s.io/gengo v0.0.0-20230829151522-9cce18d56c01
 	k8s.io/klog v1.0.0
@@ -407,7 +408,6 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiserver v0.28.1 // indirect
-	k8s.io/component-helpers v0.28.2 // indirect
 	oras.land/oras-go v1.2.4 // indirect
 	periph.io/x/host/v3 v3.8.0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/internal/cli/cmd/cluster/dataprotection.go
+++ b/internal/cli/cmd/cluster/dataprotection.go
@@ -91,7 +91,7 @@ var (
 
 		# create a datafile backup
 		# backup all files under the data directory and save them to the specified storage, only full backup is supported now.
-		kbcli cluster backup mycluster --type datafile
+		kbcli cluster backup mycluster --type datafile 
 
 		# create a backup with specified backup policy
 		kbcli cluster backup mycluster --policy <backup-policy-name>
@@ -109,8 +109,8 @@ var (
 		kbcli cluster restore new-cluster-name --backup backup-name
 
 		# restore a new cluster from point in time
-		kbcli cluster restore new-cluster-name --restore-to-time "Apr 13,2023 18:40:35 UTC+0800" --source-cluster mycluster
-        kbcli cluster restore new-cluster-name --restore-to-time "2023-04-13T18:40:35+08:00" --source-cluster mycluster
+		kbcli cluster restore new-cluster-name --restore-to-time "Apr 13,2023 18:40:35 UTC+0800" --backup logfile-backup
+        kbcli cluster restore new-cluster-name --restore-to-time "2023-04-13T18:40:35+08:00" --backup logfile-backup
 	`)
 	describeBackupExample = templates.Examples(`
 		# describe a backup
@@ -264,7 +264,7 @@ func NewCreateBackupCmd(f cmdutil.Factory, streams genericclioptions.IOStreams) 
 		},
 	}
 
-	cmd.Flags().StringVar(&o.BackupMethod, "method", "", "Backup method that defined in backup policy")
+	cmd.Flags().StringVar(&o.BackupMethod, "method", "", "Backup method that defined in backup policy (required)")
 	cmd.Flags().StringVar(&o.BackupName, "name", "", "Backup name")
 	cmd.Flags().StringVar(&o.BackupPolicy, "policy", "", "Backup policy name, this flag will be ignored when backup-type is snapshot")
 

--- a/internal/controller/plan/restore_test.go
+++ b/internal/controller/plan/restore_test.go
@@ -210,7 +210,7 @@ var _ = Describe("PITR Functions", func() {
 				CompletionTimestamp:       baseStopTime,
 				PersistentVolumeClaimName: remotePVC.Name,
 			}
-			testdp.MockBackupStatusMethod(backup, testapps.DataVolumeName)
+			testdp.MockBackupStatusMethod(backup, testdp.VSBackupMethodName, testapps.DataVolumeName, testdp.ActionSetName)
 			patchBackupStatus(backup.Status, client.ObjectKeyFromObject(backup))
 		})
 

--- a/internal/dataprotection/restore/builder.go
+++ b/internal/dataprotection/restore/builder.go
@@ -51,6 +51,8 @@ type restoreJobBuilder struct {
 	command              []string
 	tolerations          []corev1.Toleration
 	nodeSelector         map[string]string
+	jobName              string
+	labels               map[string]string
 }
 
 func newRestoreJobBuilder(restore *dpv1alpha1.Restore, backupSet BackupActionSet, stage dpv1alpha1.RestoreStage) *restoreJobBuilder {
@@ -60,16 +62,18 @@ func newRestoreJobBuilder(restore *dpv1alpha1.Restore, backupSet BackupActionSet
 		stage:              stage,
 		commonVolumes:      []corev1.Volume{},
 		commonVolumeMounts: []corev1.VolumeMount{},
+		labels:             BuildRestoreLabels(restore.Name),
 	}
 }
 
 func (r *restoreJobBuilder) buildPVCVolumeAndMount(
-	claim dpv1alpha1.RestoreVolumeClaim,
+	claim dpv1alpha1.VolumeConfig,
+	claimName,
 	identifier string) (*corev1.Volume, *corev1.VolumeMount, error) {
-	volumeName := fmt.Sprintf("%s-%s", identifier, claim.Name)
+	volumeName := fmt.Sprintf("%s-%s", identifier, claimName)
 	volume := &corev1.Volume{
 		Name:         volumeName,
-		VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: claim.Name}},
+		VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: claimName}},
 	}
 	volumeMount := &corev1.VolumeMount{Name: volumeName}
 	if claim.MountPath != "" {
@@ -154,6 +158,16 @@ func (r *restoreJobBuilder) setNodeNameToNodeSelector(nodeName string) *restoreJ
 	r.nodeSelector = map[string]string{
 		corev1.LabelHostname: nodeName,
 	}
+	return r
+}
+
+func (r *restoreJobBuilder) setJobName(jobName string) *restoreJobBuilder {
+	r.jobName = jobName
+	return r
+}
+
+func (r *restoreJobBuilder) addLabel(key, value string) *restoreJobBuilder {
+	r.labels[key] = value
 	return r
 }
 
@@ -246,11 +260,14 @@ func (r *restoreJobBuilder) builderRestoreJobName(jobIndex int) string {
 
 // build the restore job by this builder.
 func (r *restoreJobBuilder) build(jobIndex int) *batchv1.Job {
+	if r.jobName == "" {
+		r.jobName = r.builderRestoreJobName(jobIndex)
+	}
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      r.builderRestoreJobName(jobIndex),
+			Name:      r.jobName,
 			Namespace: r.restore.Namespace,
-			Labels:    BuildRestoreLabels(r.restore.Name),
+			Labels:    r.labels,
 		},
 	}
 	podSpec := job.Spec.Template.Spec
@@ -259,7 +276,7 @@ func (r *restoreJobBuilder) build(jobIndex int) *batchv1.Job {
 	podSpec.SecurityContext = &corev1.PodSecurityContext{
 		RunAsUser: &runUser,
 	}
-	podSpec.RestartPolicy = corev1.RestartPolicyOnFailure
+	podSpec.RestartPolicy = corev1.RestartPolicyNever
 	if r.stage == dpv1alpha1.PrepareData {
 		// set scheduling spec
 		schedulingSpec := r.restore.Spec.PrepareDataConfig.SchedulingSpec

--- a/internal/dataprotection/restore/types.go
+++ b/internal/dataprotection/restore/types.go
@@ -19,7 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 package restore
 
-var volumeSnapshotGroup = "snapshot.storage.k8s.io"
+var VolumeSnapshotGroup = "snapshot.storage.k8s.io"
 
 // Restore condition constants
 const (
@@ -44,7 +44,8 @@ const (
 
 // labels key
 const (
-	DataProtectionLabelRestoreKey = "dataprotection.kubeblocks.io/restore"
+	DataProtectionLabelRestoreKey     = "dataprotection.kubeblocks.io/restore"
+	DataProtectionLabelPopulatePVCKey = "dataprotection.kubeblocks.io/populate-pvc"
 )
 
 // env name for restore

--- a/internal/dataprotection/types/constant.go
+++ b/internal/dataprotection/types/constant.go
@@ -97,3 +97,8 @@ const (
 	// DPBackupStopTime backup stop time
 	DPBackupStopTime = "BACKUP_STOP_TIME" // backup stop time
 )
+
+const (
+	RestoreKind            = "Restore"
+	DataprotectionApiGroup = "dataprotection.kubeblocks.io"
+)

--- a/internal/dataprotection/types/constant.go
+++ b/internal/dataprotection/types/constant.go
@@ -100,5 +100,5 @@ const (
 
 const (
 	RestoreKind            = "Restore"
-	DataprotectionApiGroup = "dataprotection.kubeblocks.io"
+	DataprotectionAPIGroup = "dataprotection.kubeblocks.io"
 )

--- a/internal/dataprotection/utils/envvar.go
+++ b/internal/dataprotection/utils/envvar.go
@@ -39,12 +39,16 @@ func BuildEnvByCredential(pod *corev1.Pod, credential *dpv1alpha1.ConnectionCred
 	} else {
 		hostEnv = buildEnvBySecretKey(dptypes.DPDBHost, credential.SecretName, credential.HostKey)
 	}
-	envVars = append(envVars,
-		buildEnvBySecretKey(dptypes.DPDBUser, credential.SecretName, credential.UsernameKey),
-		buildEnvBySecretKey(dptypes.DPDBPassword, credential.SecretName, credential.PasswordKey),
-		buildEnvBySecretKey(dptypes.DPDBPort, credential.SecretName, credential.PortKey),
-		hostEnv,
-	)
+	envVars = append(envVars, hostEnv)
+	if credential.PasswordKey != "" {
+		envVars = append(envVars, buildEnvBySecretKey(dptypes.DPDBPassword, credential.SecretName, credential.PasswordKey))
+	}
+	if credential.UsernameKey != "" {
+		envVars = append(envVars, buildEnvBySecretKey(dptypes.DPDBUser, credential.SecretName, credential.UsernameKey))
+	}
+	if credential.PortKey != "" {
+		envVars = append(envVars, buildEnvBySecretKey(dptypes.DPDBPort, credential.SecretName, credential.PortKey))
+	}
 	return envVars
 }
 

--- a/internal/generics/type.go
+++ b/internal/generics/type.go
@@ -65,6 +65,8 @@ var SecretSignature = func(_ corev1.Secret, _ *corev1.Secret, _ corev1.SecretLis
 var ServiceSignature = func(_ corev1.Service, _ *corev1.Service, _ corev1.ServiceList, _ *corev1.ServiceList) {}
 var PersistentVolumeClaimSignature = func(_ corev1.PersistentVolumeClaim, _ *corev1.PersistentVolumeClaim, _ corev1.PersistentVolumeClaimList, _ *corev1.PersistentVolumeClaimList) {
 }
+var PersistentVolumeSignature = func(_ corev1.PersistentVolume, _ *corev1.PersistentVolume, _ corev1.PersistentVolumeList, _ *corev1.PersistentVolumeList) {
+}
 var PodSignature = func(_ corev1.Pod, _ *corev1.Pod, _ corev1.PodList, _ *corev1.PodList) {}
 var EventSignature = func(_ corev1.Event, _ *corev1.Event, _ corev1.EventList, _ *corev1.EventList) {}
 var ConfigMapSignature = func(_ corev1.ConfigMap, _ *corev1.ConfigMap, _ corev1.ConfigMapList, _ *corev1.ConfigMapList) {}

--- a/internal/testutil/apps/pvc_factoy.go
+++ b/internal/testutil/apps/pvc_factoy.go
@@ -75,3 +75,12 @@ func (factory *MockPersistentVolumeClaimFactory) SetAnnotations(annotations map[
 	factory.Get().Annotations = annotations
 	return factory
 }
+
+func (factory *MockPersistentVolumeClaimFactory) SetDataSourceRef(apiGroup, kind, name string) *MockPersistentVolumeClaimFactory {
+	factory.Get().Spec.DataSourceRef = &corev1.TypedObjectReference{
+		Name:     name,
+		APIGroup: &apiGroup,
+		Kind:     kind,
+	}
+	return factory
+}

--- a/internal/testutil/dataprotection/backup_utils.go
+++ b/internal/testutil/dataprotection/backup_utils.go
@@ -29,7 +29,6 @@ import (
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
 	storagev1alpha1 "github.com/apecloud/kubeblocks/apis/storage/v1alpha1"
 	"github.com/apecloud/kubeblocks/internal/constant"
-	"github.com/apecloud/kubeblocks/internal/dataprotection/utils"
 	"github.com/apecloud/kubeblocks/internal/dataprotection/utils/boolptr"
 	"github.com/apecloud/kubeblocks/internal/testutil"
 	testapps "github.com/apecloud/kubeblocks/internal/testutil/apps"
@@ -204,15 +203,15 @@ func EnableBackupSchedule(testCtx *testutil.TestContext,
 	})).Should(Succeed())
 }
 
-func MockBackupStatusMethod(backup *dpv1alpha1.Backup, targetVolume string) {
-	snapshot := utils.VolumeSnapshotEnabled()
-	backupMethod := BackupMethodName
-	if snapshot {
-		backupMethod = VSBackupMethodName
+func MockBackupStatusMethod(backup *dpv1alpha1.Backup, backupMethodName, targetVolume, actionSetName string) {
+	var snapshot bool
+	if backupMethodName == VSBackupMethodName {
+		snapshot = true
 	}
 	backup.Status.BackupMethod = &dpv1alpha1.BackupMethod{
-		Name:            backupMethod,
+		Name:            backupMethodName,
 		SnapshotVolumes: &snapshot,
+		ActionSetName:   actionSetName,
 		TargetVolumes: &dpv1alpha1.TargetVolumeInfo{
 			Volumes: []string{targetVolume},
 			VolumeMounts: []corev1.VolumeMount{

--- a/internal/testutil/dataprotection/constant.go
+++ b/internal/testutil/dataprotection/constant.go
@@ -48,3 +48,9 @@ const (
 
 	KBToolImage = "apecloud/kubeblocks-tool:latest"
 )
+
+// Restore
+const (
+	RestoreName       = "test-restore"
+	MysqlTemplateName = "data-mysql-mysql"
+)

--- a/internal/testutil/dataprotection/restore_factory.go
+++ b/internal/testutil/dataprotection/restore_factory.go
@@ -1,0 +1,112 @@
+/*
+Copyright (C) 2022-2023 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package dataprotection
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	testapps "github.com/apecloud/kubeblocks/internal/testutil/apps"
+)
+
+type MockRestoreFactory struct {
+	testapps.BaseFactory[dpv1alpha1.Restore, *dpv1alpha1.Restore, MockRestoreFactory]
+}
+
+func NewRestoreactory(namespace, name string) *MockRestoreFactory {
+	f := &MockRestoreFactory{}
+	f.Init(namespace, name,
+		&dpv1alpha1.Restore{
+			Spec: dpv1alpha1.RestoreSpec{},
+		}, f)
+	return f
+}
+
+func (f *MockRestoreFactory) SetBackup(name, namespace string) *MockRestoreFactory {
+	f.Get().Spec.Backup = dpv1alpha1.BackupRef{
+		Name:      name,
+		Namespace: namespace,
+	}
+	return f
+}
+
+func (f *MockRestoreFactory) SetRestoreTime(restoreTime string) *MockRestoreFactory {
+	f.Get().Spec.RestoreTime = restoreTime
+	return f
+}
+
+func (f *MockRestoreFactory) SetLabels(labels map[string]string) *MockRestoreFactory {
+	f.Get().SetLabels(labels)
+	return f
+}
+
+func (f *MockRestoreFactory) AddEnv(env corev1.EnvVar) *MockRestoreFactory {
+	f.Get().Spec.Env = append(f.Get().Spec.Env, env)
+	return f
+}
+
+func (f *MockRestoreFactory) SetDataSourceRef(volumeSource, mountPath string) *MockRestoreFactory {
+	prepareDataConfig := f.Get().Spec.PrepareDataConfig
+	if prepareDataConfig == nil {
+		prepareDataConfig = &dpv1alpha1.PrepareDataConfig{
+			VolumeClaimManagementPolicy: dpv1alpha1.ParallelManagementPolicy,
+		}
+	}
+	prepareDataConfig.DataSourceRef = &dpv1alpha1.VolumeConfig{
+		VolumeSource: volumeSource,
+		MountPath:    mountPath,
+	}
+	f.Get().Spec.PrepareDataConfig = prepareDataConfig
+	return f
+}
+
+func (f *MockRestoreFactory) SetVolumeClaimsTemplate(templateName, volumeSource, mountPath, storageClass string, replicas, startingIndex int32) *MockRestoreFactory {
+	prepareDataConfig := f.Get().Spec.PrepareDataConfig
+	if prepareDataConfig == nil {
+		prepareDataConfig = &dpv1alpha1.PrepareDataConfig{}
+	}
+	prepareDataConfig.RestoreVolumeClaimsTemplate = &dpv1alpha1.RestoreVolumeClaimsTemplate{
+		Replicas:      replicas,
+		StartingIndex: startingIndex,
+		Templates: []dpv1alpha1.RestoreVolumeClaim{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: templateName,
+				},
+				VolumeConfig: dpv1alpha1.VolumeConfig{
+					VolumeSource: volumeSource,
+					MountPath:    mountPath,
+				},
+				VolumeClaimSpec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: &storageClass,
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("20Gi"),
+						},
+					},
+					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				},
+			},
+		},
+	}
+	return f
+}


### PR DESCRIPTION
user can restore a new pvc or rebuild pvc by volume populator controller, the steps of `rebuild` are as follows:
1.  create restore CR with the backup
```
apiVersion: dataprotection.kubeblocks.io/v1alpha1
kind: Restore
metadata:
 name: restore-ljj4n
spec:
  backup:
    name: backup-default-wesql-20231009161516
  prepareDataConfig:
    dataSourceRef:
      volumeSource: data
```
2. delete the old pvc and create a same pvc which refer the restore
```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  labels:
    app.kubernetes.io/instance: wesql
    app.kubernetes.io/managed-by: kubeblocks
    app.kubernetes.io/name: apecloud-mysql
    apps.kubeblocks.io/component-name: mysql
    apps.kubeblocks.io/vct-name: data
    kubeblocks.io/volume-type: data
  name: data-wesql-mysql-0
  namespace: default
spec:
  accessModes:
  - ReadWriteOnce
  dataSourceRef:
    apiGroup: dataprotection.kubeblocks.io
    kind: Restore
    name: restore-ljj4n
  resources:
    requests:
      storage: 20Gi
  storageClassName: standard
  volumeMode: Filesystem
```
3. delete the pod which refer the old pvc.
4. wait for rebuilding the pod and ready