### PR TITLE
chore: update postgresql image pgvector version to v0.5.0

### DIFF
--- a/deploy/postgresql/templates/clusterversion.yaml
+++ b/deploy/postgresql/templates/clusterversion.yaml
@@ -61,18 +61,18 @@ spec:
       versionsContext:
         initContainers:
           - name: pg-init-container
-            image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:12.14.1
+            image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:12.14.1-pgvector-v0.5.0
         containers:
           - name: postgresql
-            image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:12.14.1
+            image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:12.14.1-pgvector-v0.5.0
           - name: pgbouncer
             image: {{ .Values.pgbouncer.image.registry | default "docker.io" }}/{{ .Values.pgbouncer.image.repository }}:{{ .Values.pgbouncer.image.tag }}
       systemAccountSpec:
         cmdExecutorConfig:
-          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:12.14.1
+          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:12.14.1-pgvector-v0.5.0
       switchoverSpec:
         cmdExecutorConfig:
-          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:12.14.1
+          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:12.14.1-pgvector-v0.5.0
 
 ---
 apiVersion: apps.kubeblocks.io/v1alpha1
@@ -105,18 +105,18 @@ spec:
       versionsContext:
         initContainers:
           - name: pg-init-container
-            image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:12.15.0
+            image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:12.15.0-pgvector-v0.5.0
         containers:
           - name: postgresql
-            image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:12.15.0
+            image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:12.15.0-pgvector-v0.5.0
           - name: pgbouncer
             image: {{ .Values.pgbouncer.image.registry | default "docker.io" }}/{{ .Values.pgbouncer.image.repository }}:{{ .Values.pgbouncer.image.tag }}
       systemAccountSpec:
         cmdExecutorConfig:
-          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:12.15.0
+          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:12.15.0-pgvector-v0.5.0
       switchoverSpec:
         cmdExecutorConfig:
-          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:12.15.0
+          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:12.15.0-pgvector-v0.5.0
 
 ---
 apiVersion: apps.kubeblocks.io/v1alpha1
@@ -134,18 +134,18 @@ spec:
       versionsContext:
         initContainers:
           - name: pg-init-container
-            image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:14.8.0
+            image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:14.8.0-pgvector-v0.5.0
         containers:
           - name: postgresql
-            image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:14.8.0
+            image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:14.8.0-pgvector-v0.5.0
           - name: pgbouncer
             image: {{ .Values.pgbouncer.image.registry | default "docker.io" }}/{{ .Values.pgbouncer.image.repository }}:{{ .Values.pgbouncer.image.tag }}
       systemAccountSpec:
         cmdExecutorConfig:
-          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:14.8.0
+          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:14.8.0-pgvector-v0.5.0
       switchoverSpec:
         cmdExecutorConfig:
-          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:14.8.0
+          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:14.8.0-pgvector-v0.5.0
 
 ---
 # Adding backward compatibility for clusterVersion 12.14.0, which will be removed in subsequent iterative versions.
@@ -183,15 +183,15 @@ spec:
       versionsContext:
         initContainers:
           - name: pg-init-container
-            image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:12.14.0
+            image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:12.14.0-pgvector-v0.5.0
         containers:
           - name: postgresql
-            image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:12.14.0
+            image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:12.14.0-pgvector-v0.5.0
           - name: pgbouncer
             image: {{ .Values.pgbouncer.image.registry | default "docker.io" }}/{{ .Values.pgbouncer.image.repository }}:{{ .Values.pgbouncer.image.tag }}
       systemAccountSpec:
         cmdExecutorConfig:
-          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:12.14.0
+          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:12.14.0-pgvector-v0.5.0
       switchoverSpec:
         cmdExecutorConfig:
-          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:12.14.0
+          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:12.14.0-pgvector-v0.5.0

--- a/deploy/postgresql/values.yaml
+++ b/deploy/postgresql/values.yaml
@@ -11,7 +11,7 @@
 image:
   registry: registry.cn-hangzhou.aliyuncs.com
   repository: apecloud/spilo
-  tag: 14.7.2
+  tag: 14.7.2-pgvector-v0.5.0
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION

![img_v2_80485631-aaf0-4cc2-bfe7-819253532a5g](https://github.com/apecloud/kubeblocks/assets/12824920/4e2e9601-911b-484d-9b94-b91fc98fdb8d)

Pgvector v0.5.0 new feature:  HNSW

![img_v2_0904662f-b06a-46dd-86ff-bd6952875f6g](https://github.com/apecloud/kubeblocks/assets/12824920/f7135351-d1da-4931-a329-70c0690ac95f)
