### PR TITLE
docs: fix typo in mongodb example doc

### DIFF
--- a/docs/user_docs/kubeblocks-for-mongodb/cluster-management/scale-for-apecloud-mongodb.md
+++ b/docs/user_docs/kubeblocks-for-mongodb/cluster-management/scale-for-apecloud-mongodb.md
@@ -39,13 +39,13 @@ kbcli cluster list mongodb-cluster
       ***Example***
 
       ```bash
-      kbcli cluster vscale mongodb-cluster --component-names=mongodb --cpu=500m --memory=500Mi
+      kbcli cluster vscale mongodb-cluster --components=mongodb --cpu=500m --memory=500Mi
       >
       OpsRequest mongodb-cluster-verticalscaling-thglk created successfully, you can view the progress:
              kbcli cluster describe-ops mongodb-cluster-verticalscaling-thglk -n default
       ```
 
-   - `--component-names` describes the component name ready for vertical scaling.
+   - `--components` describes the component name ready for vertical scaling.
    - `--memory` describes the requested and limited size of the component memory.
    - `--cpu` describes the requested and limited size of the component CPU.
 


### PR DESCRIPTION
fix #5355