### PR TITLE
fix: orioledb create fail by `kbcli cluster create --cluster-definition`

### DIFF
--- a/deploy/orioledb/config/etcd-serve-config.tpl
+++ b/deploy/orioledb/config/etcd-serve-config.tpl
@@ -9,7 +9,7 @@
     {{- end }}
   {{- end }}
 {{- end }}
-{{- $etcd_server := "etcd-etcd:2379" }}
+{{- $etcd_server := "" }}
 {{- if $orioledb_etcd_from_service_ref }}
   {{- if and (index $orioledb_etcd_from_service_ref.spec "endpoint") (index $orioledb_etcd_from_service_ref.spec "port") }}
      {{- $etcd_server = printf "%s:%s" $orioledb_etcd_from_service_ref.spec.endpoint.value $orioledb_etcd_from_service_ref.spec.port.value }}

--- a/deploy/orioledb/config/etcd-serve-config.tpl
+++ b/deploy/orioledb/config/etcd-serve-config.tpl
@@ -9,7 +9,7 @@
     {{- end }}
   {{- end }}
 {{- end }}
-{{- $etcd_server := "" }}
+{{- $etcd_server := "etcd-etcd:2379" }}
 {{- if $orioledb_etcd_from_service_ref }}
   {{- if and (index $orioledb_etcd_from_service_ref.spec "endpoint") (index $orioledb_etcd_from_service_ref.spec "port") }}
      {{- $etcd_server = printf "%s:%s" $orioledb_etcd_from_service_ref.spec.endpoint.value $orioledb_etcd_from_service_ref.spec.port.value }}

--- a/docs/user_docs/cli/kbcli_cluster_create.md
+++ b/docs/user_docs/cli/kbcli_cluster_create.md
@@ -84,6 +84,15 @@ kbcli cluster create [NAME] [flags]
   
   # Create a cluster with auto backup
   kbcli cluster create --cluster-definition apecloud-mysql --backup-enabled
+  
+  # Create a cluster with default component having multiple storage volumes
+  kbcli cluster create --cluster-definition oceanbase --pvc name=data-file,size=50Gi --pvc name=data-log,size=50Gi --pvc name=log,size=20Gi
+  
+  # Create a cluster with specifying a component having multiple storage volumes
+  kbcli cluster create --cluster-definition pulsar --pvc type=bookies,name=ledgers,size=20Gi --pvc type=bookies,name=journal,size=20Gi
+  
+  # Create a cluster with using a service reference to another KubeBlocks cluster
+  cluster create --cluster-definition pulsar --service-reference name=pulsarZookeeper,cluster=zookeeper,namespace=default
 ```
 
 ### Options
@@ -110,6 +119,7 @@ kbcli cluster create [NAME] [flags]
       --pvc stringArray                        Set the cluster detail persistent volume claim, each '--pvc' corresponds to a component, and will override the simple configurations about storage by --set (e.g. --pvc type=mysql,name=data,mode=ReadWriteOnce,size=20Gi --pvc type=mysql,name=log,mode=ReadWriteOnce,size=1Gi)
       --rbac-enabled                           Specify whether rbac resources will be created by kbcli, otherwise KubeBlocks server will try to create rbac resources
       --restore-to-time string                 Set a time for point in time recovery
+      --service-reference stringArray          Set the other KubeBlocks cluster dependencies, each '--service-reference' corresponds to a cluster service. (e.g --service-reference name=pulsarZookeeper,cluster=zookeeper,namespace=default)
       --set stringArray                        Set the cluster resource including cpu, memory, replicas and storage, each set corresponds to a component.(e.g. --set cpu=1,memory=1Gi,replicas=3,storage=20Gi or --set class=general-1c1g)
   -f, --set-file string                        Use yaml file, URL, or stdin to set the cluster resource
       --tenancy string                         Tenancy options, one of: (SharedNode, DedicatedNode) (default "SharedNode")

--- a/internal/cli/cluster/helper.go
+++ b/internal/cli/cluster/helper.go
@@ -431,3 +431,26 @@ func GetConfigConstraintByName(dynamic dynamic.Interface, name string) (*appsv1a
 	}
 	return ccObj, nil
 }
+
+func GetServiceRefs(cd *appsv1alpha1.ClusterDefinition) []string {
+	var serviceRefs []string
+	for _, compDef := range cd.Spec.ComponentDefs {
+		if compDef.ServiceRefDeclarations == nil {
+			continue
+		}
+
+		for _, ref := range compDef.ServiceRefDeclarations {
+			serviceRefs = append(serviceRefs, ref.Name)
+		}
+	}
+	return serviceRefs
+}
+
+// GetDefaultServiceRef will return the ServiceRefDeclarations in cluster-definition when the cluster-definition contains only one ServiceRefDeclaration
+func GetDefaultServiceRef(cd *appsv1alpha1.ClusterDefinition) (string, error) {
+	serviceRefs := GetServiceRefs(cd)
+	if len(serviceRefs) != 1 {
+		return "", fmt.Errorf("failed to get the cluster default service reference name")
+	}
+	return serviceRefs[0], nil
+}

--- a/internal/cli/cluster/helper_test.go
+++ b/internal/cli/cluster/helper_test.go
@@ -125,4 +125,25 @@ var _ = Describe("helper", func() {
 		Expect(err).Should(Succeed())
 		Expect(cm).ShouldNot(BeNil())
 	})
+
+	It("get all ServiceRefs from cluster-definition", func() {
+		Expect(GetServiceRefs(testing.FakeClusterDef())).Should(Equal([]string{testing.ServiceRefName}))
+	})
+
+	It("get default ServiceRef from cluster-definition", func() {
+		cd := testing.FakeClusterDef()
+		ref, err := GetDefaultServiceRef(cd)
+		Expect(ref).Should(Equal(testing.ServiceRefName))
+		Expect(err).Should(Succeed())
+
+		deepCopyCD := cd.DeepCopy()
+		deepCopyCD.Spec.ComponentDefs[0].ServiceRefDeclarations = append(deepCopyCD.Spec.ComponentDefs[0].ServiceRefDeclarations, testing.FakeServiceRef("other-serviceRef"))
+		_, err = GetDefaultServiceRef(deepCopyCD)
+		Expect(err).Should(HaveOccurred())
+
+		deepCopyCD = cd.DeepCopy()
+		deepCopyCD.Spec.ComponentDefs[0].ServiceRefDeclarations = nil
+		_, err = GetDefaultServiceRef(deepCopyCD)
+		Expect(err).Should(HaveOccurred())
+	})
 })

--- a/internal/cli/cmd/cluster/create_test.go
+++ b/internal/cli/cmd/cluster/create_test.go
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package cluster
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -758,4 +759,98 @@ var _ = Describe("create", func() {
 
 	})
 
+	It("test getServiceRefs", func() {
+		testCase := []struct {
+			input    []string
+			success  bool
+			expected []map[serviceRefKey]string
+		}{
+			{
+				[]string{fmt.Sprintf("name=%s,cluster=mysql,namespace=default", testing.ServiceRefName)},
+				true,
+				[]map[serviceRefKey]string{
+					{
+						serviceRefKeyName:      testing.ServiceRefName,
+						serviceRefKeyCluster:   "mysql",
+						serviceRefKeyNamespace: "default",
+					},
+				},
+			},
+			{
+				[]string{"name=invalid,cluster=mysql,namespace=default"},
+				false,
+				nil,
+			},
+			{
+				[]string{"invalidKey=test"},
+				false,
+				nil,
+			},
+		}
+		for i := range testCase {
+			refs, err := getServiceRefs(testCase[i].input, testing.FakeClusterDef())
+			if testCase[i].success {
+				Expect(err).Should(Succeed())
+				Expect(refs).Should(Equal(testCase[i].expected))
+			} else {
+				Expect(err).Should(HaveOccurred())
+			}
+		}
+
+	})
+
+	It("test build ServiceRefs for ClusterComponentSpec", func() {
+		testCase := []struct {
+			input    []string
+			before   []*appsv1alpha1.ClusterComponentSpec
+			cd       *appsv1alpha1.ClusterDefinition
+			success  bool
+			expected []*appsv1alpha1.ClusterComponentSpec
+		}{
+			{[]string{fmt.Sprintf("name=%s,cluster=%s,namespace=%s", testing.ServiceRefName, testing.ClusterName, testing.Namespace)},
+				[]*appsv1alpha1.ClusterComponentSpec{
+					{
+						Name: testing.ComponentDefName,
+					},
+				},
+				testing.FakeClusterDef(),
+				true,
+				[]*appsv1alpha1.ClusterComponentSpec{
+					{
+						Name: testing.ComponentDefName,
+						ServiceRefs: []appsv1alpha1.ServiceRef{
+							{Name: testing.ServiceRefName, Cluster: testing.ClusterName, Namespace: testing.Namespace},
+						},
+					},
+				},
+			}, {[]string{fmt.Sprintf("name=%s,cluster=%s,namespace=%s", testing.ServiceRefName, testing.ClusterName, testing.Namespace)},
+				[]*appsv1alpha1.ClusterComponentSpec{
+					{
+						Name: testing.ComponentDefName,
+					},
+				},
+				testing.FakeClusterDef(),
+				true,
+				[]*appsv1alpha1.ClusterComponentSpec{
+					{
+						Name: testing.ComponentDefName,
+						ServiceRefs: []appsv1alpha1.ServiceRef{
+							{Name: testing.ServiceRefName, Cluster: testing.ClusterName, Namespace: testing.Namespace},
+						},
+					},
+				},
+			},
+		}
+
+		for i := range testCase {
+			compSpec, err := buildServiceRefs(testCase[i].input, testCase[i].cd, testCase[i].before)
+			if testCase[i].success {
+				Expect(err).Should(Succeed())
+				Expect(compSpec).Should(Equal(testCase[i].expected))
+			} else {
+				Expect(err).Should(HaveOccurred())
+			}
+		}
+
+	})
 })

--- a/internal/cli/testing/fake.go
+++ b/internal/cli/testing/fake.go
@@ -60,6 +60,7 @@ const (
 	SecretName         = "fake-secret-conn-credential"
 	StorageClassName   = "fake-storage-class"
 	PVCName            = "fake-pvc"
+	ServiceRefName     = "fake-serviceRef"
 
 	KubeBlocksRepoName  = "fake-kubeblocks-repo"
 	KubeBlocksChartName = "fake-kubeblocks"
@@ -299,6 +300,9 @@ func FakeClusterDef() *appsv1alpha1.ClusterDefinition {
 					},
 					ConfigConstraintRef: "mysql8.0-config-constraints",
 				},
+			},
+			ServiceRefDeclarations: []appsv1alpha1.ServiceRefDeclaration{
+				FakeServiceRef(ServiceRefName),
 			},
 		},
 		{
@@ -1077,4 +1081,16 @@ func FakeClusterList() *appsv1alpha1.ClusterList {
 	}
 	clusters.Items = append(clusters.Items, *FakeCluster(ClusterName, Namespace))
 	return clusters
+}
+
+func FakeServiceRef(serviceRefName string) appsv1alpha1.ServiceRefDeclaration {
+	return appsv1alpha1.ServiceRefDeclaration{
+		Name: serviceRefName,
+		ServiceRefDeclarationSpecs: []appsv1alpha1.ServiceRefDeclarationSpec{
+			{
+				ServiceKind:    "mysql",
+				ServiceVersion: "8.0.\\d{1,2}$",
+			},
+		},
+	}
 }


### PR DESCRIPTION
- fix #5419 

Now orioledb cluters use the `serviceRefDeclarations` to reference tothe etcd service in order to meet the requirement of being able to use any etcd cluster as a dependency for their Patroni.

In this PR we support `kbcli cluster create --cluster-definition XX` to specify cluster service reference with flag `--service-reference`

Example:
![image](https://github.com/apecloud/kubeblocks/assets/101848970/a6bab89f-a2e9-4af6-b504-27e1b4758dcb)
![image](https://github.com/apecloud/kubeblocks/assets/101848970/9215fa45-327c-4673-aa75-1fb7ced22fa6)
![image](https://github.com/apecloud/kubeblocks/assets/101848970/769844b7-7309-4ee7-b1f3-c97f56bd03f9)

Todo:
`--service-reference` we shuold specify the **serviceRef** name which be declared in cluster-definition. For users, it can be challenging to guess which serviceRefs are defined in a cluster-definition.
We **Next** will support `kbcli cluster list-serviceRef [cd-name] ` to list all  serviceRefs declared in a cluster-definition.

- More info see: https://github.com/apecloud/kubeblocks/pull/5237