### PR TITLE
chore: make csi-s3 compatible with the huawei cloud

### DIFF
--- a/deploy/csi-s3/templates/attacher.yaml
+++ b/deploy/csi-s3/templates/attacher.yaml
@@ -93,14 +93,14 @@ spec:
             - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS
-              value: /var/lib/kubelet/plugins/ru.yandex.s3.csi/csi.sock
+              value: {{ .Values.kubeletPath }}/plugins/ru.yandex.s3.csi/csi.sock
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/kubelet/plugins/ru.yandex.s3.csi
+              mountPath: {{ .Values.kubeletPath }}/plugins/ru.yandex.s3.csi
       volumes:
         - name: socket-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/ru.yandex.s3.csi
+            path: {{ .Values.kubeletPath }}/plugins/ru.yandex.s3.csi
             type: DirectoryOrCreate
 {{- end -}}

--- a/deploy/csi-s3/templates/csi-s3.yaml
+++ b/deploy/csi-s3/templates/csi-s3.yaml
@@ -71,7 +71,7 @@ spec:
             - name: ADDRESS
               value: /csi/csi.sock
             - name: DRIVER_REG_SOCK_PATH
-              value: /var/lib/kubelet/plugins/ru.yandex.s3.csi/csi.sock
+              value: {{ .Values.kubeletPath }}/plugins/ru.yandex.s3.csi/csi.sock
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -104,22 +104,22 @@ spec:
             - name: plugin-dir
               mountPath: /csi
             - name: pods-mount-dir
-              mountPath: /var/lib/kubelet/pods
+              mountPath: {{ .Values.kubeletPath }}/pods
               mountPropagation: "Bidirectional"
             - name: fuse-device
               mountPath: /dev/fuse
       volumes:
         - name: registration-dir
           hostPath:
-            path: /var/lib/kubelet/plugins_registry/
+            path: {{ .Values.kubeletPath }}/plugins_registry/
             type: DirectoryOrCreate
         - name: plugin-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/ru.yandex.s3.csi
+            path: {{ .Values.kubeletPath }}/plugins/ru.yandex.s3.csi
             type: DirectoryOrCreate
         - name: pods-mount-dir
           hostPath:
-            path: /var/lib/kubelet/pods
+            path: {{ .Values.kubeletPath }}/pods
             type: Directory
         - name: fuse-device
           hostPath:

--- a/deploy/csi-s3/templates/provisioner.yaml
+++ b/deploy/csi-s3/templates/provisioner.yaml
@@ -86,11 +86,11 @@ spec:
             - "--v=4"
           env:
             - name: ADDRESS
-              value: /var/lib/kubelet/plugins/ru.yandex.s3.csi/csi.sock
+              value: {{ .Values.kubeletPath }}/plugins/ru.yandex.s3.csi/csi.sock
           imagePullPolicy: "IfNotPresent"
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/kubelet/plugins/ru.yandex.s3.csi
+              mountPath: {{ .Values.kubeletPath }}/plugins/ru.yandex.s3.csi
         - name: csi-s3
           image: {{ .Values.images.csi }}
           imagePullPolicy: IfNotPresent
@@ -100,14 +100,14 @@ spec:
             - "--v=4"
           env:
             - name: CSI_ENDPOINT
-              value: unix:///var/lib/kubelet/plugins/ru.yandex.s3.csi/csi.sock
+              value: unix://{{ .Values.kubeletPath }}/kubelet/plugins/ru.yandex.s3.csi/csi.sock
             - name: NODE_ID
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
           volumeMounts:
             - name: socket-dir
-              mountPath: /var/lib/kubelet/plugins/ru.yandex.s3.csi
+              mountPath: {{ .Values.kubeletPath }}/kubelet/plugins/ru.yandex.s3.csi
       volumes:
         - name: socket-dir
           emptyDir: {}

--- a/deploy/csi-s3/values.yaml
+++ b/deploy/csi-s3/values.yaml
@@ -76,3 +76,6 @@ csiName: s3
 
 # Check if this CSI has been installed multiple times. if true, only install storageClass and secret.
 multiCSI: false
+
+# kubelet path in the host
+kubeletPath: /var/lib/kubelet

--- a/deploy/helm/templates/addons/csi-s3-addon.yaml
+++ b/deploy/helm/templates/addons/csi-s3-addon.yaml
@@ -27,6 +27,12 @@ spec:
         - name: {{ include "kubeblocks.fullname" . }}-cloud-provider
           key: csi-s3
 
+      {{- $cloudProvider := (include "kubeblocks.cloudProvider" .) }}
+      {{- if eq $cloudProvider "huaweiCloud" }}
+      setValues:
+        - kubeletPath=/mnt/paas/kubernetes/kubelet
+      {{- end }}
+
     valuesMapping:
       jsonMap:
         tolerations: tolerations


### PR DESCRIPTION
The kubelet path in huawei cloud is changed to /mnt/paas/kubernetes/kubelet instead of /var/lib/kubelet. This causes csi-s3 stop working in huawei cloud.

This PR makes the kubelet path configurable, and adapts the value for huawei cloud.