### PR TITLE
chore: rename the gcs storage provider to gcs-s3comp

### DIFF
--- a/deploy/helm/templates/storageprovider/gcs-s3comp.yaml
+++ b/deploy/helm/templates/storageprovider/gcs-s3comp.yaml
@@ -1,8 +1,8 @@
-# gcs is a storage provider for [Google Cloud Storage](https://cloud.google.com/storage/).
+# gcs-s3comp is a storage provider for [Google Cloud Storage](https://cloud.google.com/storage/), by using its S3-compatible API.
 apiVersion: storage.kubeblocks.io/v1alpha1
 kind: StorageProvider
 metadata:
-  name: gcs
+  name: gcs-s3comp
   labels:
     {{- include "kubeblocks.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
Currently, the GCS storage provider is actually using the s3-compatible API instead of GCS's native API. So rename it to "gcs-s3comp" to make it more relevant.