### PR TITLE
chore: fix qdrant cluster create OOM

### DIFF
--- a/deploy/qdrant-cluster/templates/cluster.yaml
+++ b/deploy/qdrant-cluster/templates/cluster.yaml
@@ -13,7 +13,7 @@ spec:
     - name: qdrant # user-defined
       componentDefRef: qdrant # ref clusterdefinition components.name
       {{- include "kblib.componentMonitor" . | indent 6 }}
-      replicas: {{ include .Values.replicas . }}
+      replicas: {{ .Values.replicas | default 1 }}
       {{- include "kblib.componentResources" . | indent 6 }}
       {{- include "kblib.componentStorages" . | indent 6 }}
       {{- include "kblib.componentServices" . | indent 6 }}

--- a/deploy/qdrant/templates/clusterdefinition.yaml
+++ b/deploy/qdrant/templates/clusterdefinition.yaml
@@ -76,12 +76,9 @@ spec:
               - bash
               - -c
               - |
-                echo VITE_PORT=6333 >> .env
-                echo VITE_HOSTNAME=http://127.0.0.1 >> .env
-                npm run build
                 cd dist/ && serve
             ports:
-              - name: http
+              - name: web-ui
                 containerPort: 3000
           - name: qdrant
             imagePullPolicy: {{default .Values.images.pullPolicy "IfNotPresent"}}


### PR DESCRIPTION
Due to the previous npm project build during the cluster initialization process, Qdrant clusters would encounter OOM errors under the default memory settings. I have repackaged the image and conducted tests, moving the build step to the image building process.