### PR TITLE
fix: reconfiguring parameters labels not exist (#5517)

### DIFF
--- a/controllers/apps/operations/pipeline.go
+++ b/controllers/apps/operations/pipeline.go
@@ -163,6 +163,10 @@ func (p *pipeline) doMergeImpl(parameters appsv1alpha1.ConfigurationItem) error 
 				return cfgcore.MakeError("not allowed to update file content: %s", key.Key)
 			}
 			updateParameters(item, key.Key, key.Parameters)
+			p.updatedParameters = append(p.updatedParameters, cfgcore.ParamPairs{
+				Key:           key.Key,
+				UpdatedParams: fromKeyValuePair(key.Parameters),
+			})
 			continue
 		}
 		if key.FileContent != "" {
@@ -196,8 +200,16 @@ func (p *pipeline) createUpdatePatch(item *appsv1alpha1.ConfigurationItemDetail,
 }
 
 func updateFileContent(item *appsv1alpha1.ConfigurationItemDetail, key string, content string) {
+	params, ok := item.ConfigFileParams[key]
+	if !ok {
+		item.ConfigFileParams[key] = appsv1alpha1.ConfigParams{
+			Content: &content,
+		}
+		return
+	}
 	item.ConfigFileParams[key] = appsv1alpha1.ConfigParams{
-		Content: &content,
+		Parameters: params.Parameters,
+		Content:    &content,
 	}
 }
 
@@ -206,9 +218,30 @@ func updateParameters(item *appsv1alpha1.ConfigurationItemDetail, key string, pa
 	for _, parameter := range parameters {
 		updatedParams[parameter.Key] = parameter.Value
 	}
-	item.ConfigFileParams[key] = appsv1alpha1.ConfigParams{
-		Parameters: updatedParams,
+
+	params, ok := item.ConfigFileParams[key]
+	if !ok {
+		item.ConfigFileParams[key] = appsv1alpha1.ConfigParams{
+			Parameters: updatedParams,
+		}
+		return
 	}
+
+	item.ConfigFileParams[key] = appsv1alpha1.ConfigParams{
+		Content:    params.Content,
+		Parameters: mergeMaps(params.Parameters, updatedParams),
+	}
+}
+
+func mergeMaps(m1 map[string]*string, m2 map[string]*string) map[string]*string {
+	merged := make(map[string]*string)
+	for key, value := range m1 {
+		merged[key] = value
+	}
+	for key, value := range m2 {
+		merged[key] = value
+	}
+	return merged
 }
 
 func (p *pipeline) doMerge() error {

--- a/pkg/configuration/core/config_util.go
+++ b/pkg/configuration/core/config_util.go
@@ -22,6 +22,7 @@ package core
 import (
 	"context"
 	"regexp"
+	"strings"
 
 	"github.com/spf13/cast"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -41,7 +42,7 @@ const pattern = `^[a-z0-9A-Z]([a-zA-Z0-9\.\-\_]*[a-zA-Z0-9])?$`
 var regxPattern = regexp.MustCompile(pattern)
 
 func FromValueToString(val interface{}) string {
-	str := cast.ToString(val)
+	str := strings.Trim(cast.ToString(val), ` '"`)
 	if regxPattern.MatchString(str) {
 		return str
 	}


### PR DESCRIPTION
related issue: [[BUG] reconfiguring parameters labels not exist after refactoring the configuration module](#5517)