### PR TITLE
chore: supply AIGC demo in Jupyter addon

### DIFF
--- a/deploy/jupyter-notebook/values.yaml
+++ b/deploy/jupyter-notebook/values.yaml
@@ -9,7 +9,7 @@ image:
   repository: apecloud/jupyter-notebook-llm
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: beta1
+  tag: beta2
 
 fullnameOverride: ""
 


### PR DESCRIPTION
Rebuild Jupyter image and supply the default `docs-QA-assistantor.ipynb` deom in the `/work` directory.
![image](https://github.com/apecloud/kubeblocks/assets/101848970/7e4e760c-1663-44e0-b13a-35fcd52c8398)
