### PR TITLE
chore: add clusters read privilege for nyancat

### DIFF
--- a/deploy/nyancat/templates/clusterrole.yaml
+++ b/deploy/nyancat/templates/clusterrole.yaml
@@ -7,4 +7,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["services", "pods", "secrets"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps.kubeblocks.io"]
+    resources: ["clusters"]
+    verbs: ["get", "list", "watch"]


### PR DESCRIPTION
Nyancat need clusters read privilege to get & list clusters by KubeBlocks clientset.

<img width="836" alt="image" src="https://github.com/apecloud/kubeblocks/assets/4293867/34e23408-aa7e-48eb-9438-c08fc5adccc7">
