### PR TITLE
fix: new verision jupyter addon will can't load the demo

### DIFF
--- a/deploy/jupyter-notebook/templates/deployment.yaml
+++ b/deploy/jupyter-notebook/templates/deployment.yaml
@@ -14,6 +14,18 @@ spec:
       labels:
         {{- include "jupyter.selectorLabels" . | nindent 8 }}
     spec:
+      initContainers:
+        - name: init-container
+          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ default .Values.image.tag }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              cp /tmp/docs-QA-assistantor.ipynb /home/jovyan/work
+              chmod 777 /home/jovyan/work/docs-QA-assistantor.ipynb
+          volumeMounts:
+            - name: data-volume
+              mountPath: /home/jovyan/work
       containers:
         - name: {{ .Chart.Name }}
           image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ default .Values.image.tag }}

--- a/deploy/jupyter-notebook/values.yaml
+++ b/deploy/jupyter-notebook/values.yaml
@@ -9,7 +9,7 @@ image:
   repository: apecloud/jupyter-notebook-llm
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: beta1
+  tag: beta2
 
 fullnameOverride: ""
 


### PR DESCRIPTION
- fix #5576 
In beta2 the jupyter version and some Python pip libraries have been updated. It causes error when run the demo.
And due to the PVC in jupyter-addon, the demo hasn't been mounted onto the deployment.

so i :
1. rebuild the beta2 image from version beta1.
2. add init-container.