### PR TITLE
chore: Separate the registry and repository of apecloud images in helm char

### DIFF
--- a/deploy/bytebase/templates/auto-plugin.yaml
+++ b/deploy/bytebase/templates/auto-plugin.yaml
@@ -8,7 +8,7 @@ spec:
       serviceAccountName: kubeblocks
       containers:
         - name: bytebase-python-script
-          image: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/python11-tools:stable
+          image: {{ .Values.images.python.registry }}/{{ .Values.images.python.repository }}:{{ .Values.images.python.tag }}
           command:
             - /bin/sh
             - -c

--- a/deploy/bytebase/templates/statefulset.yaml
+++ b/deploy/bytebase/templates/statefulset.yaml
@@ -27,8 +27,8 @@ spec:
     spec:
       containers:
         - name: bytebase
-          image: {{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.repository }}:{{ default .Values.image.tag }}
-          imagePullPolicy: {{.Values.image.pullPolicy}}
+          image: {{ .Values.images.bytebase.registry  }}/{{ .Values.images.bytebase.repository }}:{{ .Values.images.bytebase.tag }}
+          imagePullPolicy: {{.Values.images.bytebase.pullPolicy}}
           env:
             - name: PG_URL
             {{ if $existingPgURLSecret }}

--- a/deploy/bytebase/values.yaml
+++ b/deploy/bytebase/values.yaml
@@ -1,11 +1,18 @@
 # Default values for bytebase.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-image:
-  registry: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com
-  repository: apecloud/bytebase
-  tag: beta1
-  pullPolicy: IfNotPresent
+images:
+  bytebase:
+    registry: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com
+    repository: apecloud/bytebase
+    tag: beta1
+    pullPolicy: IfNotPresent
+  python:
+    registry: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com
+    repository: apecloud/python11-tools
+    tag: stable
+    pullPolicy: ""
+
 
 bytebase:
   option:

--- a/deploy/cert-manager/templates/cert-manager.yaml
+++ b/deploy/cert-manager/templates/cert-manager.yaml
@@ -5333,8 +5333,8 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-cainjector
-          image: "infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/cert-manager-cainjector:v1.12.3"
-          imagePullPolicy: IfNotPresent
+          image: {{ .Values.images.defaultImage.registry }}/{{ .Values.images.cainjector.repository }}:{{ .Values.images.defaultImage.tag }}
+          imagePullPolicy: {{ .Values.images.defaultImage.pullPolicy }}
           args:
           - --v=2
           - --leader-election-namespace=kube-system
@@ -5390,8 +5390,8 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-controller
-          image: "infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/cert-manager-controller:v1.12.3"
-          imagePullPolicy: IfNotPresent
+          image: {{ .Values.images.defaultImage.registry }}/{{ .Values.images.controller.repository }}:{{ .Values.images.defaultImage.tag }}
+          imagePullPolicy: {{ .Values.images.defaultImage.pullPolicy }}
           args:
           - --v=2
           - --cluster-resource-namespace=$(POD_NAMESPACE)
@@ -5453,8 +5453,8 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-webhook
-          image: "infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/cert-manager-webhook:v1.12.3"
-          imagePullPolicy: IfNotPresent
+          image: {{ .Values.images.defaultImage.registry }}/{{ .Values.images.webhook.repository }}:{{ .Values.images.defaultImage.tag }}
+          imagePullPolicy:  {{ .Values.images.defaultImage.pullPolicy }}
           args:
           - --v=2
           - --secure-port=10250

--- a/deploy/cert-manager/values.yaml
+++ b/deploy/cert-manager/values.yaml
@@ -1,1 +1,13 @@
 version: "v1.12.3"
+
+images:
+  defaultImage:
+    registry: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com
+    pullPolicy: IfNotPresent
+    tag: v1.12.3
+  cainjector:
+    repository: apecloud/cert-manager-cainjector
+  controller:
+    repository: apecloud/cert-manager-controller
+  webhook:
+    repository: apecloud/cert-manager-webhook

--- a/deploy/csi-s3/manifest.yaml
+++ b/deploy/csi-s3/manifest.yaml
@@ -4,10 +4,10 @@ helm_chart:
 requirements:
   k8s_version: ">=1.13"
 images:
-  - full: images.attacher
-  - full: images.registrar
-  - full: images.provisioner
-  - full: images.csi
+  - full: "images.defaultImage.registry/images.attacher.repository:images.attacher.tag"
+  - full: "images.defaultImage.registry/images.registrar.repository:images.registrar.tag"
+  - full: "images.defaultImage.registry/images.attacher.provisioner:images.provisioner.tag"
+  - full: "images.defaultImage.registry/images.csi:images.csi.tag"
 user_values:
   - name: storageClass.create
     title:

--- a/deploy/csi-s3/templates/_helpers.tpl
+++ b/deploy/csi-s3/templates/_helpers.tpl
@@ -40,3 +40,17 @@ Expand the mountOptions of the storageClass.
   {{- .Values.storageClass.mountOptions }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create full image name
+*/}}
+{{- define "csi-s3.imageFullName" -}}
+{{- printf "%s/%s:%s" ( .image.registry | default .root.Values.images.defaultImage.registry ) ( .image.repository ) ( .image.tag ) -}}
+{{- end -}}
+
+{{/*
+Create image pull policy
+*/}}
+{{- define "csi-s3.imagePullPolicy" -}}
+{{- printf "%s" ( .image.pullPolicy | default .root.Values.images.defaultImage.pullPolicy | default "IfNotPresent" ) -}}
+{{- end -}}

--- a/deploy/csi-s3/templates/attacher.yaml
+++ b/deploy/csi-s3/templates/attacher.yaml
@@ -87,14 +87,14 @@ spec:
       {{- end }}
       containers:
         - name: csi-attacher
-          image: {{ .Values.images.attacher }}
+          image: "{{ template "csi-s3.imageFullName" (dict "image" .Values.images.attacher "root" .) }}"
           args:
             - "--v=4"
             - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS
               value: {{ .Values.kubeletPath }}/plugins/ru.yandex.s3.csi/csi.sock
-          imagePullPolicy: "IfNotPresent"
+          imagePullPolicy: "{{ template "csi-s3.imagePullPolicy" (dict "image" .Values.images.attacher "root" .) }}"
           volumeMounts:
             - name: socket-dir
               mountPath: {{ .Values.kubeletPath }}/plugins/ru.yandex.s3.csi

--- a/deploy/csi-s3/templates/csi-s3.yaml
+++ b/deploy/csi-s3/templates/csi-s3.yaml
@@ -62,7 +62,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: driver-registrar
-          image: {{ .Values.images.registrar }}
+          image: "{{ template "csi-s3.imageFullName" (dict "image" .Values.images.registrar "root" .) }}"
           args:
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
             - "--v=4"
@@ -87,8 +87,8 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: {{ .Values.images.csi }}
-          imagePullPolicy: IfNotPresent
+          image: "{{ template "csi-s3.imageFullName" (dict "image" .Values.images.csi "root" .) }}"
+          imagePullPolicy: "{{ template "csi-s3.imagePullPolicy" (dict "image" .Values.images.csi "root" .) }}"
           args:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodeid=$(NODE_ID)"

--- a/deploy/csi-s3/templates/provisioner.yaml
+++ b/deploy/csi-s3/templates/provisioner.yaml
@@ -80,20 +80,20 @@ spec:
       {{- end }}
       containers:
         - name: csi-provisioner
-          image: {{ .Values.images.provisioner }}
+          image: "{{ template "csi-s3.imageFullName" (dict "image" .Values.images.provisioner "root" .) }}"
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=4"
           env:
             - name: ADDRESS
               value: {{ .Values.kubeletPath }}/plugins/ru.yandex.s3.csi/csi.sock
-          imagePullPolicy: "IfNotPresent"
+          imagePullPolicy: "{{ template "csi-s3.imagePullPolicy" (dict "image" .Values.images.provisioner "root" .) }}"
           volumeMounts:
             - name: socket-dir
               mountPath: {{ .Values.kubeletPath }}/plugins/ru.yandex.s3.csi
         - name: csi-s3
-          image: {{ .Values.images.csi }}
-          imagePullPolicy: IfNotPresent
+          image: "{{ template "csi-s3.imageFullName" (dict "image" .Values.images.csi "root" .) }}"
+          imagePullPolicy: "{{ template "csi-s3.imagePullPolicy" (dict "image" .Values.images.csi "root" .) }}"
           args:
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodeid=$(NODE_ID)"

--- a/deploy/csi-s3/values.yaml
+++ b/deploy/csi-s3/values.yaml
@@ -1,13 +1,32 @@
 ---
 images:
+  defaultImage:
+    registry: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com
+    pullPolicy: IfNotPresent
   # Source: quay.io/k8scsi/csi-attacher:v3.0.1
-  attacher: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/csi-attacher:v3.4.0
+  attacher:
+    registry: ""
+    repository: apecloud/csi-attacher
+    tag: v3.4.0
+    pullPolicy: ""
   # Source: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
-  registrar: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/csi-node-driver-registrar:v2.5.1
+  registrar:
+    registry: ""
+    repository: apecloud/csi-node-driver-registrar
+    tag: v2.5.1
+    pullPolicy: ""
   # Source: quay.io/k8scsi/csi-provisioner:v2.1.0
-  provisioner: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/csi-provisioner:v3.1.0
+  provisioner:
+    registry: ""
+    repository: apecloud/csi-provisioner
+    tag: v3.1.0
+    pullPolicy: ""
   # Main image
-  csi: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/csi-s3-driver:0.31.3
+  csi:
+    registry: ""
+    repository: apecloud/csi-s3-driver
+    tag: 0.31.3
+    pullPolicy: ""
 
 storageClass:
   # Specifies whether the storage class should be created

--- a/deploy/neon-cluster/templates/vm-compute-node-deploy.yaml
+++ b/deploy/neon-cluster/templates/vm-compute-node-deploy.yaml
@@ -26,9 +26,9 @@ spec:
     memorySlotSize: 1Gi
     memorySlots: { min: 1, use: 1, max: 5 }
     rootDisk:
-      image: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pg14-disk-test:test
+      image: {{ .Values.images.pg14.registry }}/{{ .Values.images.pg14.repository }}:{{ .Values.images.pg14.tag }}
       size: 12Gi
-      imagePullPolicy: IfNotPresent
+      imagePullPolicy: {{ .Values.images.pg14.pullPolicy }}
     command: 
       - /bin/bash
       - -c

--- a/deploy/neon-cluster/values.yaml
+++ b/deploy/neon-cluster/values.yaml
@@ -3,6 +3,13 @@ version: latest
 storageClassName: ""
 terminationPolicy: Delete
 
+images:
+  pg14:
+    registry: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com
+    repository: apecloud/pg14-disk-test
+    tag: test
+    pullPolicy: IfNotPresent
+
 storagebroker:
   replicas: 1
   resources:

--- a/deploy/pulsar/templates/_helpers.tpl
+++ b/deploy/pulsar/templates/_helpers.tpl
@@ -45,7 +45,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Create full image name
 */}}
 {{- define "pulsar.imageFullName" -}}
-{{- printf "%s:%s" ( .image.repository | default .root.Values.defaultPulsarImage.repository ) ( .image.tag | default .root.Values.defaultPulsarImage.tag | default .root.Chart.AppVersion ) -}}
+{{- printf "%s/%s:%s" ( .image.registry | default .root.Values.defaultPulsarImage.registry ) ( .image.repository | default .root.Values.defaultPulsarImage.repository ) ( .image.tag | default .root.Values.defaultPulsarImage.tag | default .root.Chart.AppVersion ) -}}
 {{- end -}}
 
 {{/*

--- a/deploy/pulsar/templates/clusterdefinition-zookeeper.yaml
+++ b/deploy/pulsar/templates/clusterdefinition-zookeeper.yaml
@@ -113,7 +113,7 @@ spec:
               - name: zookeeper-config-env
                 mountPath: /opt/pulsar/none
           - name: metrics
-            image: {{ .Values.images.metrics.repository }}:{{ .Values.images.metrics.tag }}
+            image: {{ .Values.images.metrics.registry }}/{{ .Values.images.metrics.repository }}:{{ .Values.images.metrics.tag }}
             imagePullPolicy: {{ default "IfNotPresent" .Values.images.metrics.pullPolicy }}
             securityContext:
               runAsNonRoot: false

--- a/deploy/pulsar/templates/clusterdefinition.yaml
+++ b/deploy/pulsar/templates/clusterdefinition.yaml
@@ -213,7 +213,7 @@ spec:
             - name: pulsar-client-config
               mountPath: /opt/pulsar/client-conf
           - name: metrics
-            image: {{ .Values.images.metrics.repository }}:{{ .Values.images.metrics.tag }}
+            image: {{ .Values.images.metrics.registry }}/{{ .Values.images.metrics.repository }}:{{ .Values.images.metrics.tag }}
             imagePullPolicy: {{ default "IfNotPresent" .Values.images.metrics.pullPolicy }}
             securityContext:
               runAsNonRoot: false
@@ -386,7 +386,7 @@ spec:
               - name: pulsar-proxy-config
                 mountPath: /opt/pulsar/conf
           - name: metrics
-            image: {{ .Values.images.metrics.repository }}:{{ .Values.images.metrics.tag }}
+            image: {{ .Values.images.metrics.registry }}/{{ .Values.images.metrics.repository }}:{{ .Values.images.metrics.tag }}
             imagePullPolicy: {{ default "IfNotPresent" .Values.images.metrics.pullPolicy }}
             securityContext:
               runAsNonRoot: false
@@ -542,7 +542,7 @@ spec:
               - name: pulsar-bookies-config
                 mountPath: /opt/pulsar/conf
           - name: metrics
-            image: {{ .Values.images.metrics.repository }}:{{ .Values.images.metrics.tag }}
+            image: {{ .Values.images.metrics.registry }}/{{ .Values.images.metrics.repository }}:{{ .Values.images.metrics.tag }}
             imagePullPolicy: {{ default "IfNotPresent" .Values.images.metrics.pullPolicy }}
             securityContext:
               runAsNonRoot: false
@@ -676,7 +676,7 @@ spec:
             - name: recovery-config-env
               mountPath: /opt/pulsar/none
           - name: metrics
-            image: {{ .Values.images.metrics.repository }}:{{ .Values.images.metrics.tag }}
+            image: {{ .Values.images.metrics.registry }}/{{ .Values.images.metrics.repository }}:{{ .Values.images.metrics.tag }}
             imagePullPolicy: {{ default "IfNotPresent" .Values.images.metrics.pullPolicy }}
             securityContext:
               runAsNonRoot: false
@@ -810,7 +810,7 @@ spec:
               - name: zookeeper-config-env
                 mountPath: /opt/pulsar/none
           - name: metrics
-            image: {{ .Values.images.metrics.repository }}:{{ .Values.images.metrics.tag }}
+            image: {{ .Values.images.metrics.registry }}/{{ .Values.images.metrics.repository }}:{{ .Values.images.metrics.tag }}
             imagePullPolicy: {{ default "IfNotPresent" .Values.images.metrics.pullPolicy }}
             securityContext:
               runAsNonRoot: false

--- a/deploy/pulsar/values.yaml
+++ b/deploy/pulsar/values.yaml
@@ -17,7 +17,8 @@ debugEnabled: false
 ## Default Pulsar image
 ##
 defaultPulsarImage:
-  repository: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar
+  registry: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com
+  repository: apecloud/pulsar
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag:
@@ -34,7 +35,8 @@ images:
   zookeeper:
     # Zookeeper component is used for metadata, shouldn't need update following tag value for common 
     # upgrade scenario
-    repository: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsar
+    registry: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com
+    repository: apecloud/pulsar
     pullPolicy: IfNotPresent
     tag: 2.11.2
 
@@ -49,12 +51,14 @@ images:
     tag: ""
 
   pulsarTools:
-    repository: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/pulsartools
+    registry: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com
+    repository: apecloud/pulsartools
     pullPolicy: ""
     tag: "2.11"
 
   metrics:
-    repository: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/agamotto
+    registry: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com
+    repository: apecloud/agamotto
     pullPolicy: IfNotPresent
     tag: 0.1.2-beta.2
 


### PR DESCRIPTION
- fix: #4915 

all of modifications  are tested by: 
`helm template --debug xxx `

for example:  pulsar.yaml 
![1698070374090](https://github.com/apecloud/kubeblocks/assets/7733385/88044dfc-b4c8-4465-b5f6-5e2dab3ceaac)


