### PR TITLE
fix: fix orioledb restart fail due to the invalid permissions

### DIFF
--- a/deploy/orioledb/templates/scripts.yaml
+++ b/deploy/orioledb/templates/scripts.yaml
@@ -119,10 +119,14 @@ data:
   init.sql: |
     CREATE EXTENSION pg_stat_statements;
   setup.sh: |
-    mkdir -p /home/postgres/pgdata/conf
-    chmod 777 -R /home/postgres/pgdata
-    cp /home/postgres/conf/postgresql.conf /home/postgres/pgdata/conf
-    chmod 777 -R /home/postgres/pgdata/conf
+    if [ -d "/home/postgres/pgdata/conf" ]; then
+      chmod 750 /home/postgres/pgdata/pgroot/data
+    else
+      mkdir -p /home/postgres/pgdata/conf
+      chmod 777 -R /home/postgres/pgdata
+      cp /home/postgres/conf/postgresql.conf /home/postgres/pgdata/conf
+      chmod 777 -R /home/postgres/pgdata/conf
+    fi
     source /dependency/conf
 
 {{/*    chmod 750 -R /home/postgres/pgdata*/}}


### PR DESCRIPTION
- fix #5485 

Add the new logic for container restarting.
![image](https://github.com/apecloud/kubeblocks/assets/101848970/3534b31c-bc4f-4061-90db-0b205b1d6bc3)
![image](https://github.com/apecloud/kubeblocks/assets/101848970/462ece61-9c21-4de8-b742-cac438afde7b)
