### PR TITLE
fix: support using the password of the original cluster for recovery

### DIFF
--- a/apis/dataprotection/v1alpha1/backuppolicy_types.go
+++ b/apis/dataprotection/v1alpha1/backuppolicy_types.go
@@ -110,7 +110,7 @@ type ConnectionCredential struct {
 
 	// passwordKey specifies the map key of the password in the connection credential secret.
 	// this password will be saved in the backup annotation for full backup.
-	// you can use the environment variable DP_ENCRYPTION_KEY to specify encrypted key.
+	// you can use the environment variable DP_ENCRYPTION_KEY to specify encryption key.
 	// +kubebuilder:default=password
 	PasswordKey string `json:"passwordKey,omitempty"`
 

--- a/apis/dataprotection/v1alpha1/backuppolicy_types.go
+++ b/apis/dataprotection/v1alpha1/backuppolicy_types.go
@@ -109,8 +109,8 @@ type ConnectionCredential struct {
 	UsernameKey string `json:"usernameKey,omitempty"`
 
 	// passwordKey specifies the map key of the password in the connection credential secret.
-	// this password will be saved in the backup annotation for full backup.
-	// you can use the environment variable DP_ENCRYPTION_KEY to specify encryption key.
+	// This password will be saved in the backup annotation for full backup.
+	// You can use the environment variable DP_ENCRYPTION_KEY to specify encryption key.
 	// +kubebuilder:default=password
 	PasswordKey string `json:"passwordKey,omitempty"`
 

--- a/apis/dataprotection/v1alpha1/backuppolicy_types.go
+++ b/apis/dataprotection/v1alpha1/backuppolicy_types.go
@@ -109,6 +109,8 @@ type ConnectionCredential struct {
 	UsernameKey string `json:"usernameKey,omitempty"`
 
 	// passwordKey specifies the map key of the password in the connection credential secret.
+	// this password will be saved in the backup annotation for full backup.
+	// you can use the environment variable DP_ENCRYPTION_KEY to specify encrypted key.
 	// +kubebuilder:default=password
 	PasswordKey string `json:"passwordKey,omitempty"`
 

--- a/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -335,8 +335,8 @@ spec:
                       passwordKey:
                         default: password
                         description: passwordKey specifies the map key of the password
-                          in the connection credential secret. this password will
-                          be saved in the backup annotation for full backup. you can
+                          in the connection credential secret. This password will
+                          be saved in the backup annotation for full backup. You can
                           use the environment variable DP_ENCRYPTION_KEY to specify
                           encryption key.
                         type: string

--- a/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -335,7 +335,10 @@ spec:
                       passwordKey:
                         default: password
                         description: passwordKey specifies the map key of the password
-                          in the connection credential secret.
+                          in the connection credential secret. this password will
+                          be saved in the backup annotation for full backup. you can
+                          use the environment variable DP_ENCRYPTION_KEY to specify
+                          encrypted key.
                         type: string
                       portKey:
                         description: portKey specifies the map key of the port in

--- a/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -338,7 +338,7 @@ spec:
                           in the connection credential secret. this password will
                           be saved in the backup annotation for full backup. you can
                           use the environment variable DP_ENCRYPTION_KEY to specify
-                          encrypted key.
+                          encryption key.
                         type: string
                       portKey:
                         description: portKey specifies the map key of the port in

--- a/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
@@ -538,8 +538,8 @@ spec:
                       passwordKey:
                         default: password
                         description: passwordKey specifies the map key of the password
-                          in the connection credential secret. this password will
-                          be saved in the backup annotation for full backup. you can
+                          in the connection credential secret. This password will
+                          be saved in the backup annotation for full backup. You can
                           use the environment variable DP_ENCRYPTION_KEY to specify
                           encryption key.
                         type: string

--- a/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
@@ -541,7 +541,7 @@ spec:
                           in the connection credential secret. this password will
                           be saved in the backup annotation for full backup. you can
                           use the environment variable DP_ENCRYPTION_KEY to specify
-                          encrypted key.
+                          encryption key.
                         type: string
                       portKey:
                         description: portKey specifies the map key of the port in

--- a/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
@@ -538,7 +538,10 @@ spec:
                       passwordKey:
                         default: password
                         description: passwordKey specifies the map key of the password
-                          in the connection credential secret.
+                          in the connection credential secret. this password will
+                          be saved in the backup annotation for full backup. you can
+                          use the environment variable DP_ENCRYPTION_KEY to specify
+                          encrypted key.
                         type: string
                       portKey:
                         description: portKey specifies the map key of the port in

--- a/config/crd/bases/dataprotection.kubeblocks.io_restores.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_restores.yaml
@@ -2030,7 +2030,7 @@ spec:
                           in the connection credential secret. this password will
                           be saved in the backup annotation for full backup. you can
                           use the environment variable DP_ENCRYPTION_KEY to specify
-                          encrypted key.
+                          encryption key.
                         type: string
                       portKey:
                         description: portKey specifies the map key of the port in

--- a/config/crd/bases/dataprotection.kubeblocks.io_restores.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_restores.yaml
@@ -2027,7 +2027,10 @@ spec:
                       passwordKey:
                         default: password
                         description: passwordKey specifies the map key of the password
-                          in the connection credential secret.
+                          in the connection credential secret. this password will
+                          be saved in the backup annotation for full backup. you can
+                          use the environment variable DP_ENCRYPTION_KEY to specify
+                          encrypted key.
                         type: string
                       portKey:
                         description: portKey specifies the map key of the port in

--- a/config/crd/bases/dataprotection.kubeblocks.io_restores.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_restores.yaml
@@ -2027,8 +2027,8 @@ spec:
                       passwordKey:
                         default: password
                         description: passwordKey specifies the map key of the password
-                          in the connection credential secret. this password will
-                          be saved in the backup annotation for full backup. you can
+                          in the connection credential secret. This password will
+                          be saved in the backup annotation for full backup. You can
                           use the environment variable DP_ENCRYPTION_KEY to specify
                           encryption key.
                         type: string

--- a/controllers/dataprotection/backup_controller_test.go
+++ b/controllers/dataprotection/backup_controller_test.go
@@ -66,7 +66,7 @@ var _ = Describe("Backup Controller test", func() {
 		// job to delete the backup between the ClearResources function delete
 		// the job and get the job list, resulting the ClearResources panic.
 		Eventually(testapps.List(&testCtx, generics.BackupSignature, inNS)).Should(HaveLen(0))
-
+		testapps.ClearResources(&testCtx, generics.SecretSignature, inNS, ml)
 		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.BackupPolicySignature, true, inNS)
 		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.JobSignature, true, inNS)
 		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.PersistentVolumeClaimSignature, true, inNS)
@@ -143,6 +143,7 @@ var _ = Describe("Backup Controller test", func() {
 					g.Expect(fetched.Status.PersistentVolumeClaimName).Should(Equal(repoPVCName))
 					g.Expect(fetched.Status.Path).Should(Equal(dpbackup.BuildBackupPath(fetched, backupPolicy.Spec.PathPrefix)))
 					g.Expect(fetched.Status.Phase).Should(Equal(dpv1alpha1.BackupPhaseRunning))
+					g.Expect(fetched.Annotations[dptypes.ConnectionPasswordKey]).ShouldNot(BeEmpty())
 				})).Should(Succeed())
 
 				By("check backup job's nodeName equals pod's nodeName")

--- a/controllers/dataprotection/backuppolicy_controller_test.go
+++ b/controllers/dataprotection/backuppolicy_controller_test.go
@@ -25,7 +25,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	intctrlutil "github.com/apecloud/kubeblocks/pkg/generics"
+	"github.com/apecloud/kubeblocks/pkg/generics"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
 	testdp "github.com/apecloud/kubeblocks/pkg/testutil/dataprotection"
 )
@@ -41,10 +41,11 @@ var _ = Describe("BackupPolicy Controller test", func() {
 		ml := client.HasLabels{testCtx.TestObjLabelKey}
 
 		// non-namespaced
-		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, intctrlutil.ActionSetSignature, true, ml)
+		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.ActionSetSignature, true, ml)
 
 		// namespaced
-		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, intctrlutil.BackupPolicySignature, true, inNS)
+		testapps.ClearResources(&testCtx, generics.SecretSignature, inNS, ml)
+		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.BackupPolicySignature, true, inNS)
 	}
 
 	BeforeEach(func() {

--- a/controllers/dataprotection/backuprepo_controller_test.go
+++ b/controllers/dataprotection/backuprepo_controller_test.go
@@ -38,7 +38,7 @@ import (
 	storagev1alpha1 "github.com/apecloud/kubeblocks/apis/storage/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
-	intctrlutil "github.com/apecloud/kubeblocks/pkg/generics"
+	"github.com/apecloud/kubeblocks/pkg/generics"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
 	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
@@ -55,21 +55,21 @@ var _ = Describe("BackupRepo controller", func() {
 		By("clean resources")
 		// non-namespaced
 		ml := client.HasLabels{testCtx.TestObjLabelKey}
-		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, intctrlutil.BackupRepoSignature, true, ml)
-		testapps.ClearResources(&testCtx, intctrlutil.StorageProviderSignature, ml)
-		testapps.ClearResources(&testCtx, intctrlutil.CSIDriverSignature, ml)
+		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.BackupRepoSignature, true, ml)
+		testapps.ClearResources(&testCtx, generics.StorageProviderSignature, ml)
+		testapps.ClearResources(&testCtx, generics.CSIDriverSignature, ml)
 
 		// namespaced
 		inNS := client.InNamespace(viper.GetString(constant.CfgKeyCtrlrMgrNS))
-		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, intctrlutil.BackupSignature, true, inNS, ml)
-		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, intctrlutil.PersistentVolumeClaimSignature, true, inNS, ml)
-		testapps.ClearResources(&testCtx, intctrlutil.StorageClassSignature, inNS, ml)
-		testapps.ClearResources(&testCtx, intctrlutil.SecretSignature, inNS, ml)
+		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.BackupSignature, true, inNS, ml)
+		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.PersistentVolumeClaimSignature, true, inNS, ml)
+		testapps.ClearResources(&testCtx, generics.StorageClassSignature, inNS, ml)
+		testapps.ClearResources(&testCtx, generics.SecretSignature, inNS, ml)
 
 		// namespace2
 		inNS2 := client.InNamespace(namespace2)
-		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, intctrlutil.BackupSignature, true, inNS2, ml)
-		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, intctrlutil.PersistentVolumeClaimSignature, true, inNS2, ml)
+		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.BackupSignature, true, inNS2, ml)
+		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.PersistentVolumeClaimSignature, true, inNS2, ml)
 
 		// delete namespace2
 		Eventually(func(g Gomega) {

--- a/controllers/dataprotection/backupschedule_controller_test.go
+++ b/controllers/dataprotection/backupschedule_controller_test.go
@@ -63,6 +63,7 @@ var _ = Describe("Backup Schedule Controller", func() {
 		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.JobSignature, true, inNS)
 		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.PersistentVolumeClaimSignature, true, inNS)
 		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.CronJobSignature, true, inNS)
+		testapps.ClearResources(&testCtx, generics.SecretSignature, inNS, ml)
 
 		// non-namespaced
 		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.ActionSetSignature, true, ml)

--- a/controllers/dataprotection/gc_controller_test.go
+++ b/controllers/dataprotection/gc_controller_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Data Protection Garbage Collection Controller", func() {
 
 		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.JobSignature, true, inNS)
 		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.PersistentVolumeClaimSignature, true, inNS)
-
+		testapps.ClearResources(&testCtx, generics.SecretSignature, inNS, ml)
 		// non-namespaced
 		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.ActionSetSignature, true, ml)
 		testapps.ClearResources(&testCtx, generics.StorageClassSignature, ml)

--- a/controllers/dataprotection/restore_controller_test.go
+++ b/controllers/dataprotection/restore_controller_test.go
@@ -66,6 +66,7 @@ var _ = Describe("Restore Controller test", func() {
 		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.JobSignature, true, inNS)
 		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.RestoreSignature, true, inNS)
 		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.PersistentVolumeClaimSignature, true, inNS)
+		testapps.ClearResources(&testCtx, generics.SecretSignature, inNS, ml)
 
 		// non-namespaced
 		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.ActionSetSignature, true, ml)

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -335,8 +335,8 @@ spec:
                       passwordKey:
                         default: password
                         description: passwordKey specifies the map key of the password
-                          in the connection credential secret. this password will
-                          be saved in the backup annotation for full backup. you can
+                          in the connection credential secret. This password will
+                          be saved in the backup annotation for full backup. You can
                           use the environment variable DP_ENCRYPTION_KEY to specify
                           encryption key.
                         type: string

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -335,7 +335,10 @@ spec:
                       passwordKey:
                         default: password
                         description: passwordKey specifies the map key of the password
-                          in the connection credential secret.
+                          in the connection credential secret. this password will
+                          be saved in the backup annotation for full backup. you can
+                          use the environment variable DP_ENCRYPTION_KEY to specify
+                          encrypted key.
                         type: string
                       portKey:
                         description: portKey specifies the map key of the port in

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -338,7 +338,7 @@ spec:
                           in the connection credential secret. this password will
                           be saved in the backup annotation for full backup. you can
                           use the environment variable DP_ENCRYPTION_KEY to specify
-                          encrypted key.
+                          encryption key.
                         type: string
                       portKey:
                         description: portKey specifies the map key of the port in

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
@@ -538,8 +538,8 @@ spec:
                       passwordKey:
                         default: password
                         description: passwordKey specifies the map key of the password
-                          in the connection credential secret. this password will
-                          be saved in the backup annotation for full backup. you can
+                          in the connection credential secret. This password will
+                          be saved in the backup annotation for full backup. You can
                           use the environment variable DP_ENCRYPTION_KEY to specify
                           encryption key.
                         type: string

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
@@ -541,7 +541,7 @@ spec:
                           in the connection credential secret. this password will
                           be saved in the backup annotation for full backup. you can
                           use the environment variable DP_ENCRYPTION_KEY to specify
-                          encrypted key.
+                          encryption key.
                         type: string
                       portKey:
                         description: portKey specifies the map key of the port in

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
@@ -538,7 +538,10 @@ spec:
                       passwordKey:
                         default: password
                         description: passwordKey specifies the map key of the password
-                          in the connection credential secret.
+                          in the connection credential secret. this password will
+                          be saved in the backup annotation for full backup. you can
+                          use the environment variable DP_ENCRYPTION_KEY to specify
+                          encrypted key.
                         type: string
                       portKey:
                         description: portKey specifies the map key of the port in

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_restores.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_restores.yaml
@@ -2030,7 +2030,7 @@ spec:
                           in the connection credential secret. this password will
                           be saved in the backup annotation for full backup. you can
                           use the environment variable DP_ENCRYPTION_KEY to specify
-                          encrypted key.
+                          encryption key.
                         type: string
                       portKey:
                         description: portKey specifies the map key of the port in

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_restores.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_restores.yaml
@@ -2027,7 +2027,10 @@ spec:
                       passwordKey:
                         default: password
                         description: passwordKey specifies the map key of the password
-                          in the connection credential secret.
+                          in the connection credential secret. this password will
+                          be saved in the backup annotation for full backup. you can
+                          use the environment variable DP_ENCRYPTION_KEY to specify
+                          encrypted key.
                         type: string
                       portKey:
                         description: portKey specifies the map key of the port in

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_restores.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_restores.yaml
@@ -2027,8 +2027,8 @@ spec:
                       passwordKey:
                         default: password
                         description: passwordKey specifies the map key of the password
-                          in the connection credential secret. this password will
-                          be saved in the backup annotation for full backup. you can
+                          in the connection credential secret. This password will
+                          be saved in the backup annotation for full backup. You can
                           use the environment variable DP_ENCRYPTION_KEY to specify
                           encryption key.
                         type: string

--- a/deploy/helm/templates/dataprotection.yaml
+++ b/deploy/helm/templates/dataprotection.yaml
@@ -87,6 +87,11 @@ spec:
             - name: ENABLE_WEBHOOKS
               value: "true"
             {{- end }}
+            - name: DP_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kubeblocks.fullname" . }}-secret
+                  key: dataProtectionEncryptionKey
             - name: DATASAFED_IMAGE
               value: "{{ .Values.dataProtection.image.registry | default "docker.io" }}/{{ .Values.dataProtection.image.datasafed.repository }}:{{ .Values.dataProtection.image.datasafed.tag | default "latest" }}"
           {{- with .Values.securityContext }}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -112,6 +112,11 @@ spec:
             - name: RECOVER_VOLUME_EXPANSION_FAILURE
               value: "true"
             {{- end }}
+            - name: DP_ENCRYPTION_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kubeblocks.fullname" . }}-secret
+                  key: dataProtectionEncryptionKey
             - name: KUBE_PROVIDER
               value: {{ .Values.provider | quote }}
           {{- with .Values.securityContext }}

--- a/deploy/helm/templates/rbac/cluster_pod_required_role.yaml
+++ b/deploy/helm/templates/rbac/cluster_pod_required_role.yaml
@@ -124,10 +124,6 @@ rules:
   - backups
   verbs:
   - create
-  - get
-  - list
-  - update
-  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deploy/helm/templates/secret.yaml
+++ b/deploy/helm/templates/secret.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kubeblocks.fullname" . }}-secret
+  labels:
+    {{- include "kubeblocks.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- if .Values.dataProtection.encryptionKey }}
+  dataProtectionEncryptionKey: {{ .Values.dataProtection.encryptionKey }}
+  {{- else }}
+  dataProtectionEncryptionKey: {{ include "kubeblocks.fullname" . }}-dp-aes256
+  {{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -308,12 +308,11 @@ admissionWebhooks:
 dataProtection:
   enabled: true
   enableVolumeSnapshot: false
-  backupPVCName: ""
-  backupPVCInitCapacity: ""
-  backupPVCStorageClassName: ""
-  backupPVCCreatePolicy: ""
-  backupPVConfigMapName: ""
-  backupPVConfigMapNamespace: ""
+  # customizing the encryption key is strongly recommended.
+  # if you do not specify a custom key, the default key will be used.
+  # using the default key can potentially lead to the exposure of database passwords
+  # if 'get/list' role of the backup CR are compromised.
+  encryptionKey: ""
 
   image:
     registry: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com

--- a/pkg/cli/cmd/cluster/create.go
+++ b/pkg/cli/cmd/cluster/create.go
@@ -336,10 +336,16 @@ func getRestoreFromBackupAnnotation(backup *dpv1alpha1.Backup, volumeRestorePoli
 	volumeRestorePolicyString := fmt.Sprintf(`"%s":"%s"`, constant.VolumeRestorePolicyKeyForRestore, volumeRestorePolicy)
 	var restoreTimeString string
 	if restoreTime != "" {
-		restoreTimeString = fmt.Sprintf(`",%s":"%s"`, constant.RestoreTimeKeyForRestore, restoreTime)
+		restoreTimeString = fmt.Sprintf(`,"%s":"%s"`, constant.RestoreTimeKeyForRestore, restoreTime)
 	}
 
-	restoreFromBackupAnnotation := fmt.Sprintf(`{"%s":{%s,%s,%s%s}}`, componentName, backupNameString, backupNamespaceString, volumeRestorePolicyString, restoreTimeString)
+	var passwordString string
+	connectionPassword := backup.Annotations[dptypes.ConnectionPasswordKey]
+	if connectionPassword != "" {
+		passwordString = fmt.Sprintf(`,"%s":"%s"`, constant.ConnectionPassword, connectionPassword)
+	}
+
+	restoreFromBackupAnnotation := fmt.Sprintf(`{"%s":{%s,%s,%s%s%s}}`, componentName, backupNameString, backupNamespaceString, volumeRestorePolicyString, restoreTimeString, passwordString)
 	return restoreFromBackupAnnotation, nil
 }
 

--- a/pkg/cli/cmd/cluster/dataprotection_test.go
+++ b/pkg/cli/cmd/cluster/dataprotection_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/cli/types"
 	"github.com/apecloud/kubeblocks/pkg/cli/util"
 	"github.com/apecloud/kubeblocks/pkg/constant"
+	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 )
 
 var _ = Describe("DataProtection", func() {
@@ -279,6 +280,9 @@ var _ = Describe("DataProtection", func() {
 		newClusterObj := &appsv1alpha1.Cluster{}
 		Expect(cluster.GetK8SClientObject(tf.FakeDynamicClient, newClusterObj, types.ClusterGVR(), testing.Namespace, newClusterName)).Should(Succeed())
 		Expect(clusterObj.Spec.ComponentSpecs[0].Replicas).Should(Equal(int32(1)))
+		// check if cluster contains the annotation for restoring
+		Expect(newClusterObj.Annotations[constant.RestoreFromBackupAnnotationKey]).Should(ContainSubstring(constant.ConnectionPassword))
+		Expect(newClusterObj.Annotations[constant.RestoreFromBackupAnnotationKey]).Should(ContainSubstring(constant.BackupNamespaceKeyForRestore))
 		By("restore new cluster from source cluster which is deleted")
 		// mock cluster is not lived in kubernetes
 		mockBackupInfo(tf.FakeDynamicClient, backupName, "deleted-cluster", nil, "")
@@ -440,6 +444,7 @@ func mockBackupInfo(dynamic dynamic.Interface, backupName, clusterName string, t
 				"name": backupName,
 				"annotations": map[string]any{
 					constant.ClusterSnapshotAnnotationKey: clusterString,
+					dptypes.ConnectionPasswordKey:         "test-password",
 				},
 				"labels": map[string]any{
 					constant.AppInstanceLabelKey:    clusterName,

--- a/pkg/constant/const.go
+++ b/pkg/constant/const.go
@@ -40,6 +40,9 @@ const (
 
 	// storage config keys
 	CfgKeyDefaultStorageClass = "DEFAULT_STORAGE_CLASS"
+
+	// customized encryption key for encrypting the password of connection credential.
+	CfgKeyDPEncryptionKey = "DP_ENCRYPTION_KEY"
 )
 
 const (
@@ -298,4 +301,5 @@ const (
 	BackupNamespaceKeyForRestore     = "namespace"
 	VolumeRestorePolicyKeyForRestore = "volumeRestorePolicy"
 	RestoreTimeKeyForRestore         = "restoreTime"
+	ConnectionPassword               = "connectionPassword"
 )

--- a/pkg/controller/factory/builder.go
+++ b/pkg/controller/factory/builder.go
@@ -50,6 +50,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/rsm"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
 
 const (
@@ -636,6 +637,30 @@ func BuildConnCredential(clusterDefinition *appsv1alpha1.ClusterDefinition, clus
 		}
 	}
 
+	// get restore password if exists during recovery.
+	getRestorePassword := func() string {
+		valueString := cluster.Annotations[constant.RestoreFromBackupAnnotationKey]
+		if len(valueString) == 0 {
+			return ""
+		}
+		backupMap := map[string]map[string]string{}
+		err := json.Unmarshal([]byte(valueString), &backupMap)
+		if err != nil {
+			return ""
+		}
+		backupSource, ok := backupMap[component.Name]
+		if !ok {
+			return ""
+		}
+		password, ok := backupSource[constant.ConnectionPassword]
+		if !ok {
+			return ""
+		}
+		e := intctrlutil.NewEncryptor(viper.GetString(constant.CfgKeyDPEncryptionKey))
+		password, _ = e.Decrypt([]byte(password))
+		return password
+	}
+
 	// TODO: do JIT value generation for lower CPU resources
 	// 1st pass replace variables
 	uuidVal := uuid.New()
@@ -644,8 +669,15 @@ func BuildConnCredential(clusterDefinition *appsv1alpha1.ClusterDefinition, clus
 	uuidB64 := base64.RawStdEncoding.EncodeToString(uuidBytes)
 	uuidStrB64 := base64.RawStdEncoding.EncodeToString([]byte(strings.ReplaceAll(uuidStr, "-", "")))
 	uuidHex := hex.EncodeToString(uuidBytes)
+	randomPassword := randomString(8)
+	restorePassword := getRestorePassword()
+	// check if a connection password is specified during recovery.
+	// if exists, replace the random password
+	if restorePassword != "" {
+		randomPassword = restorePassword
+	}
 	m := map[string]string{
-		"$(RANDOM_PASSWD)":        randomString(8),
+		"$(RANDOM_PASSWD)":        randomPassword,
 		"$(UUID)":                 uuidStr,
 		"$(UUID_B64)":             uuidB64,
 		"$(UUID_STR_B64)":         uuidStrB64,

--- a/pkg/controller/factory/builder_test.go
+++ b/pkg/controller/factory/builder_test.go
@@ -238,6 +238,23 @@ var _ = Describe("builder", func() {
 
 		})
 
+		It("builds Conn. Credential during restoring from backup", func() {
+			originalPassword := "test-passw0rd"
+			encryptionKey := "encryptionKey"
+			viper.Set(constant.CfgKeyDPEncryptionKey, encryptionKey)
+			var (
+				clusterDefObj                             = testapps.NewClusterDefFactoryWithConnCredential("conn-cred").GetObject()
+				clusterDef, cluster, synthesizedComponent = newClusterObjs(clusterDefObj)
+			)
+			e := intctrlutil.NewEncryptor(encryptionKey)
+			ciphertext, _ := e.Encrypt([]byte(originalPassword))
+			cluster.Annotations[constant.RestoreFromBackupAnnotationKey] = fmt.Sprintf(`{"%s":{"%s":"%s"}}`,
+				synthesizedComponent.Name, constant.ConnectionPassword, ciphertext)
+			credential := BuildConnCredential(clusterDef, cluster, synthesizedComponent)
+			Expect(credential).ShouldNot(BeNil())
+			Expect(credential.StringData["RANDOM_PASSWD"]).Should(Equal(originalPassword))
+		})
+
 		It("builds StatefulSet correctly", func() {
 			reqCtx := newReqCtx()
 			_, cluster, synthesizedComponent := newClusterObjs(nil)

--- a/pkg/controllerutil/encryption.go
+++ b/pkg/controllerutil/encryption.go
@@ -1,0 +1,105 @@
+/*
+Copyright (C) 2022-2023 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package controllerutil
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io"
+
+	"golang.org/x/crypto/hkdf"
+)
+
+const purposeEncryptionKey = "encryption"
+
+type encryptor struct {
+	encryptionKey     []byte
+	encryptionHashKey []byte
+	gcm               cipher.AEAD
+}
+
+func NewEncryptor(encryptionKey string) *encryptor {
+	return &encryptor{
+		encryptionKey: []byte(encryptionKey),
+	}
+}
+
+func (e *encryptor) deriveKey() {
+	key := make([]byte, 32)
+	k := hkdf.New(sha256.New, e.encryptionKey, []byte(purposeEncryptionKey), nil)
+	io.ReadFull(k, key)
+	e.encryptionHashKey = key
+}
+
+func (e *encryptor) init() error {
+	e.deriveKey()
+	block, err := aes.NewCipher(e.encryptionHashKey)
+	if err != nil {
+		return err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return err
+	}
+	e.gcm = gcm
+	return nil
+}
+
+// Encrypt encrypts the plaintext by secretKey by nonce string.
+func (e *encryptor) Encrypt(plaintext []byte) (string, error) {
+	if err := e.init(); err != nil {
+		return "", err
+	}
+	nonce := make([]byte, e.gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+	ciphertext := e.gcm.Seal(nil, nonce, plaintext, e.encryptionHashKey)
+	// append nonce to ciphertext for decrypt
+	ciphertext = append(nonce, ciphertext...)
+	return base64.StdEncoding.EncodeToString(ciphertext), nil
+}
+
+// Decrypt decrypts the ciphertext by secretKey.
+func (e *encryptor) Decrypt(ciphertext []byte) (string, error) {
+	ciphertext, err := base64.StdEncoding.DecodeString(string(ciphertext))
+	if err != nil {
+		return "", err
+	}
+	if err = e.init(); err != nil {
+		return "", err
+	}
+	// fetch nonce from secret key
+	nonceSize := e.gcm.NonceSize()
+	if len(ciphertext) < nonceSize {
+		return "", fmt.Errorf("ciphertext is too short")
+	}
+	nonce := ciphertext[:nonceSize]
+	ciphertext = ciphertext[nonceSize:]
+	plaintext, err := e.gcm.Open(nil, nonce, ciphertext, e.encryptionHashKey)
+	if err != nil {
+		return "", err
+	}
+	return string(plaintext), nil
+}

--- a/pkg/controllerutil/encryption.go
+++ b/pkg/controllerutil/encryption.go
@@ -48,7 +48,7 @@ func NewEncryptor(encryptionKey string) *encryptor {
 func (e *encryptor) deriveKey() {
 	key := make([]byte, 32)
 	k := hkdf.New(sha256.New, e.encryptionKey, []byte(purposeEncryptionKey), nil)
-	io.ReadFull(k, key)
+	_, _ = io.ReadFull(k, key)
 	e.encryptionHashKey = key
 }
 

--- a/pkg/controllerutil/encryption_test.go
+++ b/pkg/controllerutil/encryption_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright (C) 2022-2023 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package controllerutil
+
+import (
+	"testing"
+)
+
+func TestEncryptor(t *testing.T) {
+	secretKey := "dp-aes-test"
+	e := NewEncryptor(secretKey)
+	plaintexts := []string{"password1", "test-password", "passwr0d", "$2@dsR^T"}
+	for _, v := range plaintexts {
+		ciphertext, err := e.Encrypt([]byte(v))
+		if err != nil {
+			t.Error(err.Error())
+		}
+		plaintext, err := e.Decrypt([]byte(ciphertext))
+		if err != nil {
+			t.Error(err.Error())
+		}
+		if plaintext != v {
+			t.Errorf("encrypt/decrypt value is incorrect for %s", v)
+		}
+	}
+}

--- a/pkg/dataprotection/restore/utils.go
+++ b/pkg/dataprotection/restore/utils.go
@@ -38,6 +38,7 @@ import (
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	dperrors "github.com/apecloud/kubeblocks/pkg/dataprotection/errors"
 	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
+	"github.com/apecloud/kubeblocks/pkg/dataprotection/utils"
 )
 
 func SetRestoreCondition(restore *dpv1alpha1.Restore, status metav1.ConditionStatus, conditionType, reason, message string) {
@@ -219,12 +220,7 @@ func ValidateAndInitRestoreMGR(reqCtx intctrlutil.RequestCtx,
 	// TODO: check if there is permission for cross namespace recovery.
 
 	// check if the backup is completed exclude continuous backup.
-	var backupType dpv1alpha1.BackupType
-	if backupSet.ActionSet != nil {
-		backupType = backupSet.ActionSet.Spec.BackupType
-	} else if backupSet.UseVolumeSnapshot {
-		backupType = dpv1alpha1.BackupTypeFull
-	}
+	backupType := utils.GetBackupType(backupSet.ActionSet, &backupSet.UseVolumeSnapshot)
 	if backupType != dpv1alpha1.BackupTypeContinuous && backupSet.Backup.Status.Phase != dpv1alpha1.BackupPhaseCompleted {
 		err = intctrlutil.NewFatalError(fmt.Sprintf(`phase of backup "%s" is not completed`, backupName))
 		return err

--- a/pkg/dataprotection/types/constant.go
+++ b/pkg/dataprotection/types/constant.go
@@ -66,6 +66,8 @@ const (
 	AutoBackupLabelKey = "dataprotection.kubeblocks.io/autobackup"
 	// BackupTargetPodLabelKey specifies the backup target pod label key.
 	BackupTargetPodLabelKey = "dataprotection.kubeblocks.io/target-pod-name"
+	// ConnectionPasswordKey specifies the password of the connection credential.
+	ConnectionPasswordKey = "dataprotection.kubeblocks.io/connection-password"
 )
 
 // env names
@@ -96,10 +98,11 @@ const (
 	DPTimeFormat = "DP_TIME_FORMAT"
 	// DPBackupStopTime backup stop time
 	DPBackupStopTime = "DP_BACKUP_STOP_TIME" // backup stop time
-	// DPDatasafedLocalBackendPath force datasafed to use local backend with the path
-	DPDatasafedLocalBackendPath = "DP_DATASAFED_LOCAL_BACKEND_PATH"
 	// DPDatasafedBinPath the path containing the datasafed binary
 	DPDatasafedBinPath = "DP_DATASAFED_BIN_PATH"
+	// DPDatasafedLocalBackendPath force datasafed to use local backend with the path
+	// NOTE: do not add 'DP_' for this constant, it is the datasafed built-in environment.
+	DPDatasafedLocalBackendPath = "DATASAFED_LOCAL_BACKEND_PATH"
 )
 
 const (

--- a/pkg/dataprotection/utils/utils.go
+++ b/pkg/dataprotection/utils/utils.go
@@ -37,6 +37,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
+	"github.com/apecloud/kubeblocks/pkg/dataprotection/utils/boolptr"
 	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
 
@@ -196,4 +197,13 @@ func CovertEnvToMap(env []corev1.EnvVar) map[string]string {
 		envMap[v.Name] = v.Value
 	}
 	return envMap
+}
+
+func GetBackupType(actionSet *dpv1alpha1.ActionSet, useSnapshot *bool) dpv1alpha1.BackupType {
+	if actionSet != nil {
+		return actionSet.Spec.BackupType
+	} else if boolptr.IsSetToTrue(useSnapshot) {
+		return dpv1alpha1.BackupTypeFull
+	}
+	return ""
 }

--- a/pkg/testutil/apps/clusterdef_factory.go
+++ b/pkg/testutil/apps/clusterdef_factory.go
@@ -38,6 +38,21 @@ type MockClusterDefFactory struct {
 	BaseFactory[appsv1alpha1.ClusterDefinition, *appsv1alpha1.ClusterDefinition, MockClusterDefFactory]
 }
 
+func getDefaultConnectionCredential() map[string]string {
+	return map[string]string{
+		"username":          "root",
+		"SVC_FQDN":          "$(SVC_FQDN)",
+		"HEADLESS_SVC_FQDN": "$(HEADLESS_SVC_FQDN)",
+		"RANDOM_PASSWD":     "$(RANDOM_PASSWD)",
+		"tcpEndpoint":       "tcp:$(SVC_FQDN):$(SVC_PORT_mysql)",
+		"paxosEndpoint":     "paxos:$(SVC_FQDN):$(SVC_PORT_paxos)",
+		"UUID":              "$(UUID)",
+		"UUID_B64":          "$(UUID_B64)",
+		"UUID_STR_B64":      "$(UUID_STR_B64)",
+		"UUID_HEX":          "$(UUID_HEX)",
+	}
+}
+
 func NewClusterDefFactory(name string) *MockClusterDefFactory {
 	f := &MockClusterDefFactory{}
 	f.Init("", name,
@@ -46,14 +61,14 @@ func NewClusterDefFactory(name string) *MockClusterDefFactory {
 				ComponentDefs: []appsv1alpha1.ClusterComponentDefinition{},
 			},
 		}, f)
-	f.SetConnectionCredential(defaultConnectionCredential, nil)
+	f.SetConnectionCredential(getDefaultConnectionCredential(), nil)
 	return f
 }
 
 func NewClusterDefFactoryWithConnCredential(name string) *MockClusterDefFactory {
 	f := NewClusterDefFactory(name)
 	f.AddComponentDef(StatefulMySQLComponent, "conn-cred")
-	f.SetConnectionCredential(defaultConnectionCredential, &defaultSvcSpec)
+	f.SetConnectionCredential(getDefaultConnectionCredential(), &defaultSvcSpec)
 	return f
 }
 

--- a/pkg/testutil/apps/constant.go
+++ b/pkg/testutil/apps/constant.go
@@ -99,19 +99,6 @@ var (
 		},
 	}
 
-	defaultConnectionCredential = map[string]string{
-		"username":          "root",
-		"SVC_FQDN":          "$(SVC_FQDN)",
-		"HEADLESS_SVC_FQDN": "$(HEADLESS_SVC_FQDN)",
-		"RANDOM_PASSWD":     "$(RANDOM_PASSWD)",
-		"tcpEndpoint":       "tcp:$(SVC_FQDN):$(SVC_PORT_mysql)",
-		"paxosEndpoint":     "paxos:$(SVC_FQDN):$(SVC_PORT_paxos)",
-		"UUID":              "$(UUID)",
-		"UUID_B64":          "$(UUID_B64)",
-		"UUID_STR_B64":      "$(UUID_STR_B64)",
-		"UUID_HEX":          "$(UUID_HEX)",
-	}
-
 	// defaultSvc value are corresponding to defaultMySQLContainer.Ports name mapping and
 	// corresponding to defaultConnectionCredential variable placeholder
 	defaultSvcSpec = appsv1alpha1.ServiceSpec{

--- a/pkg/testutil/dataprotection/backup_utils.go
+++ b/pkg/testutil/dataprotection/backup_utils.go
@@ -62,6 +62,17 @@ func NewFakeBackupPolicy(testCtx *testutil.TestContext,
 		SetBackupMethodVolumes([]string{DataVolumeName}).
 		Apply(change).
 		Create(testCtx).GetObject()
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ClusterName,
+			Namespace: testCtx.DefaultNamespace,
+		},
+		StringData: map[string]string{
+			"password": "test-passw0rd",
+		},
+	}
+	Expect(testCtx.CreateObj(testCtx.Ctx, secret)).Should(Succeed())
 	Eventually(testapps.CheckObj(testCtx, client.ObjectKeyFromObject(bp),
 		func(g Gomega, bp *dpv1alpha1.BackupPolicy) {
 			g.Expect(bp.Status.Phase).Should(BeEquivalentTo(dpv1alpha1.AvailablePhase))


### PR DESCRIPTION
In previous versions, a special password processing script needed to be run during startup for reinitializing the generated password.

In this pull request, we are encrypting the database connection password using AES and storing it in the annotation of the `backup`. This allows the original password to be recovered from this annotation during the restore process. 

**It's important to note that if the AES key is not specified, it will use a default value, which could pose security risks.**

We strongly recommend specifying a custom key during cluster installation or upgrade. 

` kbcli kubeblocks upgrade/install --set dataProtection.encryptionKey="your secret key"`

Additionally, it's crucial to avoid granting Backup `get` and `list` permissions without careful consideration.


fix https://github.com/apecloud/kubeblocks/issues/4753 https://github.com/apecloud/kubeblocks/issues/4612