### PR TITLE
feat: pre-check the BackupRepo by running a real job

### DIFF
--- a/cmd/dataprotection/main.go
+++ b/cmd/dataprotection/main.go
@@ -254,9 +254,10 @@ func main() {
 	}
 
 	if err = (&dpcontrollers.BackupRepoReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor("backup-repo-controller"),
+		Client:     mgr.GetClient(),
+		Scheme:     mgr.GetScheme(),
+		Recorder:   mgr.GetEventRecorderFor("backup-repo-controller"),
+		RestConfig: mgr.GetConfig(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "BackupRepo")
 		os.Exit(1)

--- a/controllers/dataprotection/backuprepo_controller.go
+++ b/controllers/dataprotection/backuprepo_controller.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/go-logr/logr"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -55,9 +56,45 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
+	"github.com/apecloud/kubeblocks/pkg/dataprotection/utils"
 	"github.com/apecloud/kubeblocks/pkg/generics"
 	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
+
+type reconcileContext struct {
+	intctrlutil.RequestCtx
+	repo       *dpv1alpha1.BackupRepo
+	provider   *storagev1alpha1.StorageProvider
+	Parameters map[string]string
+	renderCtx  renderContext
+	digest     string
+}
+
+func (r *reconcileContext) getDigest() string {
+	if r.digest != "" {
+		return r.digest
+	}
+	content := ""
+	content += stableSerializeMap(r.Parameters)
+	content += r.provider.Spec.StorageClassTemplate
+	content += r.provider.Spec.PersistentVolumeClaimTemplate
+	content += r.provider.Spec.CSIDriverSecretTemplate
+	content += r.provider.Spec.DatasafedConfigTemplate
+	r.digest = md5Digest(content)
+	return r.digest
+}
+
+func (r *reconcileContext) digestChanged() bool {
+	return !r.hasSameDigest(r.repo)
+}
+
+func (r *reconcileContext) hasSameDigest(obj client.Object) bool {
+	return obj.GetAnnotations()[dataProtectionBackupRepoDigestAnnotationKey] == r.getDigest()
+}
+
+func (r *reconcileContext) preCheckResourceName() string {
+	return cutName(fmt.Sprintf("pre-check-%s-%s", r.repo.UID[:8], r.repo.Name))
+}
 
 // BackupRepoReconciler reconciles a BackupRepo object
 type BackupRepoReconciler struct {
@@ -85,6 +122,12 @@ type BackupRepoReconciler struct {
 
 // create or delete PVCs
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
+
+// create or delete Secrets
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
+
+// create or delete Jobs
+// +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -139,12 +182,18 @@ func (r *BackupRepoReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return checkedRequeueWithError(err, reqCtx.Log, "check parameters failed")
 	}
 
-	renderCtx := renderContext{
+	reconCtx := &reconcileContext{
+		RequestCtx: reqCtx,
+		repo:       repo,
+		provider:   provider,
 		Parameters: parameters,
+		renderCtx: renderContext{
+			Parameters: parameters,
+		},
 	}
 
 	// create StorageClass and Secret for the CSI driver
-	err = r.createStorageClassAndSecret(reqCtx, renderCtx, repo, provider)
+	err = r.createStorageClassAndSecret(reconCtx)
 	if err != nil {
 		_ = r.updateStatus(reqCtx, repo)
 		return checkedRequeueWithError(err, reqCtx.Log,
@@ -152,25 +201,21 @@ func (r *BackupRepoReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	// check PVC template
-	err = r.checkPVCTemplate(reqCtx, renderCtx, repo, provider)
+	err = r.checkPVCTemplate(reconCtx)
 	if err != nil {
 		_ = r.updateStatus(reqCtx, repo)
 		return checkedRequeueWithError(err, reqCtx.Log,
 			"failed to check PVC template")
 	}
 
-	// check tool config
-	err = r.checkAndUpdateToolConfig(reqCtx, renderCtx, repo, provider)
-	if err != nil {
-		_ = r.updateStatus(reqCtx, repo)
-		return checkedRequeueWithError(err, reqCtx.Log,
-			"failed to check tool config")
+	// pre-check the repo by running a real job
+	if repo.Status.Phase != dpv1alpha1.BackupRepoDeleting {
+		err = r.preCheckRepo(reconCtx)
+		if err != nil {
+			_ = r.updateStatus(reqCtx, repo)
+			return checkedRequeueWithError(err, reqCtx.Log, "failed to pre-check")
+		}
 	}
-
-	// TODO: implement pre-check logic
-	//  1. try to create a PVC and observe its status
-	//  2. create a pre-check job, mount with the PVC and check job status
-	//  3. pre-check again if the secret object for CSI got updated
 
 	// update status phase to ready if all conditions are met
 	if err = r.updateStatus(reqCtx, repo); err != nil {
@@ -178,9 +223,37 @@ func (r *BackupRepoReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			"failed to update BackupRepo status")
 	}
 
-	// check associated backups, to create PVC in their namespaces
+	if cond := meta.FindStatusCondition(repo.Status.Conditions, ConditionTypePreCheckPassed); cond != nil {
+		if cond.Status != metav1.ConditionUnknown {
+			// clear pre-check resources if pre-check job is finished
+			if err := r.removePreCheckResources(reconCtx); err != nil {
+				return checkedRequeueWithError(err, reqCtx.Log,
+					"failed to remove pre-check resources")
+			}
+			// update the digest annotation when the job is done
+			if reconCtx.digestChanged() {
+				err := updateAnnotations(reconCtx.Ctx, r.Client, repo, map[string]string{
+					dataProtectionBackupRepoDigestAnnotationKey:     reconCtx.getDigest(),
+					dataProtectionNeedUpdateToolConfigAnnotationKey: trueVal,
+				})
+				if err != nil {
+					return checkedRequeueWithError(err, reqCtx.Log,
+						"failed to update digest annotation")
+				}
+			}
+		}
+	}
+
 	if repo.Status.Phase == dpv1alpha1.BackupRepoReady {
-		if err = r.prepareForAssociatedBackups(reqCtx, renderCtx, repo, provider); err != nil {
+		// update tool config if needed
+		err = r.updateToolConfigSecrets(reconCtx)
+		if err != nil {
+			return checkedRequeueWithError(err, reqCtx.Log,
+				"failed to update tool config secrets")
+		}
+
+		// check associated backups, to create PVC in their namespaces
+		if err = r.prepareForAssociatedBackups(reconCtx); err != nil {
 			return checkedRequeueWithError(err, reqCtx.Log,
 				"check associated backups failed")
 		}
@@ -194,12 +267,17 @@ func (r *BackupRepoReconciler) updateStatus(reqCtx intctrlutil.RequestCtx, repo 
 	// not allow to transit to other phase if it is deleting
 	if repo.Status.Phase != dpv1alpha1.BackupRepoDeleting {
 		phase := dpv1alpha1.BackupRepoFailed
-		if meta.IsStatusConditionTrue(repo.Status.Conditions, ConditionTypeStorageProviderReady) &&
+		basicCheckingPassed := meta.IsStatusConditionTrue(repo.Status.Conditions, ConditionTypeStorageProviderReady) &&
 			meta.IsStatusConditionTrue(repo.Status.Conditions, ConditionTypeParametersChecked) &&
 			meta.IsStatusConditionTrue(repo.Status.Conditions, ConditionTypeStorageClassCreated) &&
-			meta.IsStatusConditionTrue(repo.Status.Conditions, ConditionTypePVCTemplateChecked) &&
-			meta.IsStatusConditionTrue(repo.Status.Conditions, ConditionTypeToolConfigChecked) {
-			phase = dpv1alpha1.BackupRepoReady
+			meta.IsStatusConditionTrue(repo.Status.Conditions, ConditionTypePVCTemplateChecked)
+		if basicCheckingPassed {
+			cond := meta.FindStatusCondition(repo.Status.Conditions, ConditionTypePreCheckPassed)
+			if cond != nil && cond.Status == metav1.ConditionTrue {
+				phase = dpv1alpha1.BackupRepoReady
+			} else if cond != nil && cond.Status == metav1.ConditionUnknown {
+				phase = dpv1alpha1.BackupRepoPreChecking
+			}
 		}
 		repo.Status.Phase = phase
 	}
@@ -224,15 +302,21 @@ func (r *BackupRepoReconciler) updateStatus(reqCtx intctrlutil.RequestCtx, repo 
 	return nil
 }
 
-func (r *BackupRepoReconciler) updateConditionInDefer(reqCtx intctrlutil.RequestCtx, repo *dpv1alpha1.BackupRepo,
-	condType string, reason string, err *error) {
+func (r *BackupRepoReconciler) updateConditionInDefer(ctx context.Context, repo *dpv1alpha1.BackupRepo,
+	condType string, reason string, statusPtr *metav1.ConditionStatus, messagePtr *string, err *error) {
 	status := metav1.ConditionTrue
 	message := ""
 	if *err != nil {
 		status = metav1.ConditionFalse
 		message = (*err).Error()
 	}
-	updateErr := updateCondition(reqCtx.Ctx, r.Client, repo, condType, status, reason, message)
+	if statusPtr != nil {
+		status = *statusPtr
+	}
+	if messagePtr != nil {
+		message = *messagePtr
+	}
+	updateErr := updateCondition(ctx, r.Client, repo, condType, status, reason, message)
 	if *err == nil {
 		*err = updateErr
 	}
@@ -242,7 +326,7 @@ func (r *BackupRepoReconciler) checkStorageProvider(
 	reqCtx intctrlutil.RequestCtx, repo *dpv1alpha1.BackupRepo) (provider *storagev1alpha1.StorageProvider, err error) {
 	reason := ReasonUnknownError
 	defer func() {
-		r.updateConditionInDefer(reqCtx, repo, ConditionTypeStorageProviderReady, reason, &err)
+		r.updateConditionInDefer(reqCtx.Ctx, repo, ConditionTypeStorageProviderReady, reason, nil, nil, &err)
 	}()
 
 	// get storage provider object
@@ -287,7 +371,7 @@ func (r *BackupRepoReconciler) checkParameters(reqCtx intctrlutil.RequestCtx,
 	repo *dpv1alpha1.BackupRepo) (parameters map[string]string, err error) {
 	reason := ReasonUnknownError
 	defer func() {
-		r.updateConditionInDefer(reqCtx, repo, ConditionTypeParametersChecked, reason, &err)
+		r.updateConditionInDefer(reqCtx.Ctx, repo, ConditionTypeParametersChecked, reason, nil, nil, &err)
 	}()
 
 	// collect parameters for rendering templates
@@ -303,51 +387,50 @@ func (r *BackupRepoReconciler) checkParameters(reqCtx intctrlutil.RequestCtx,
 	return parameters, nil
 }
 
-func (r *BackupRepoReconciler) createStorageClassAndSecret(reqCtx intctrlutil.RequestCtx,
-	renderCtx renderContext, repo *dpv1alpha1.BackupRepo, provider *storagev1alpha1.StorageProvider) (err error) {
+func (r *BackupRepoReconciler) createStorageClassAndSecret(reconCtx *reconcileContext) (err error) {
 
 	reason := ReasonUnknownError
 	defer func() {
-		r.updateConditionInDefer(reqCtx, repo, ConditionTypeStorageClassCreated, reason, &err)
+		r.updateConditionInDefer(reconCtx.Ctx, reconCtx.repo, ConditionTypeStorageClassCreated, reason, nil, nil, &err)
 	}()
 
-	oldRepo := repo.DeepCopy()
+	oldRepo := reconCtx.repo.DeepCopy()
 
 	// create secret for the CSI driver if it's not exist,
 	// or update the secret if the template or values are updated
-	if provider.Spec.CSIDriverSecretTemplate != "" {
-		if repo.Status.GeneratedCSIDriverSecret == nil {
-			repo.Status.GeneratedCSIDriverSecret = &corev1.SecretReference{
-				Name:      randomNameForDerivedObject(repo, "secret"),
+	if reconCtx.provider.Spec.CSIDriverSecretTemplate != "" {
+		if reconCtx.repo.Status.GeneratedCSIDriverSecret == nil {
+			reconCtx.repo.Status.GeneratedCSIDriverSecret = &corev1.SecretReference{
+				Name:      randomNameForDerivedObject(reconCtx.repo, "secret"),
 				Namespace: viper.GetString(constant.CfgKeyCtrlrMgrNS),
 			}
 		}
-		renderCtx.CSIDriverSecretRef = *repo.Status.GeneratedCSIDriverSecret
+		reconCtx.renderCtx.CSIDriverSecretRef = *reconCtx.repo.Status.GeneratedCSIDriverSecret
 		// create or update the secret for CSI
-		if _, err = r.createOrUpdateSecretForCSIDriver(reqCtx, renderCtx, repo, provider); err != nil {
+		if _, err = r.createOrUpdateSecretForCSIDriver(reconCtx); err != nil {
 			reason = ReasonPrepareCSISecretFailed
 			return err
 		}
 	}
 
-	if provider.Spec.StorageClassTemplate != "" {
+	if reconCtx.provider.Spec.StorageClassTemplate != "" {
 		// create storage class if it's not exist
-		if repo.Status.GeneratedStorageClassName == "" {
-			repo.Status.GeneratedStorageClassName = randomNameForDerivedObject(repo, "sc")
+		if reconCtx.repo.Status.GeneratedStorageClassName == "" {
+			reconCtx.repo.Status.GeneratedStorageClassName = randomNameForDerivedObject(reconCtx.repo, "sc")
 		}
-		if _, err = r.createStorageClass(reqCtx, renderCtx, repo, provider); err != nil {
+		if _, err = r.createStorageClass(reconCtx); err != nil {
 			reason = ReasonPrepareStorageClassFailed
 			return err
 		}
 	}
 
-	if !meta.IsStatusConditionTrue(repo.Status.Conditions, ConditionTypeStorageClassCreated) {
-		setCondition(repo, ConditionTypeStorageClassCreated,
+	if !meta.IsStatusConditionTrue(reconCtx.repo.Status.Conditions, ConditionTypeStorageClassCreated) {
+		setCondition(reconCtx.repo, ConditionTypeStorageClassCreated,
 			metav1.ConditionTrue, ReasonStorageClassCreated, "")
 	}
 
-	if !reflect.DeepEqual(oldRepo.Status, repo.Status) {
-		err := r.Client.Status().Patch(reqCtx.Ctx, repo, client.MergeFrom(oldRepo))
+	if !reflect.DeepEqual(oldRepo.Status, reconCtx.repo.Status) {
+		err := r.Client.Status().Patch(reconCtx.Ctx, reconCtx.repo, client.MergeFrom(oldRepo))
 		if err != nil {
 			return fmt.Errorf("failed to patch backup repo: %w", err)
 		}
@@ -357,24 +440,20 @@ func (r *BackupRepoReconciler) createStorageClassAndSecret(reqCtx intctrlutil.Re
 }
 
 func (r *BackupRepoReconciler) createOrUpdateSecretForCSIDriver(
-	reqCtx intctrlutil.RequestCtx, renderCtx renderContext,
-	repo *dpv1alpha1.BackupRepo, provider *storagev1alpha1.StorageProvider) (created bool, err error) {
+	reconCtx *reconcileContext) (created bool, err error) {
 
 	secret := &corev1.Secret{}
-	secret.Name = repo.Status.GeneratedCSIDriverSecret.Name
-	secret.Namespace = repo.Status.GeneratedCSIDriverSecret.Namespace
+	secret.Name = reconCtx.repo.Status.GeneratedCSIDriverSecret.Name
+	secret.Namespace = reconCtx.repo.Status.GeneratedCSIDriverSecret.Namespace
 
-	templateMd5 := md5Digest(provider.Spec.CSIDriverSecretTemplate)
-	parametersMd5 := renderCtx.Md5OfParameters()
 	shouldUpdateFunc := func() bool {
-		tmplMd5InSecret := secret.Annotations[dataProtectionSecretTemplateMD5AnnotationKey]
-		paramMd5InSecret := secret.Annotations[dataProtectionTemplateValuesMD5AnnotationKey]
-		return templateMd5 != tmplMd5InSecret || parametersMd5 != paramMd5InSecret
+		oldDigest := secret.Annotations[dataProtectionBackupRepoDigestAnnotationKey]
+		return oldDigest != reconCtx.getDigest()
 	}
 
-	return createOrUpdateObject(reqCtx.Ctx, r.Client, secret, func() error {
+	return createOrUpdateObject(reconCtx.Ctx, r.Client, secret, func() error {
 		// render secret template
-		content, err := renderTemplate("secret", provider.Spec.CSIDriverSecretTemplate, renderCtx)
+		content, err := renderTemplate("secret", reconCtx.provider.Spec.CSIDriverSecretTemplate, reconCtx.renderCtx)
 		if err != nil {
 			return fmt.Errorf("failed to render secret template: %w", err)
 		}
@@ -392,15 +471,14 @@ func (r *BackupRepoReconciler) createOrUpdateSecretForCSIDriver(
 		if secret.Labels == nil {
 			secret.Labels = make(map[string]string)
 		}
-		secret.Labels[dataProtectionBackupRepoKey] = repo.Name
+		secret.Labels[dataProtectionBackupRepoKey] = reconCtx.repo.Name
 
 		if secret.Annotations == nil {
 			secret.Annotations = make(map[string]string)
 		}
-		secret.Annotations[dataProtectionSecretTemplateMD5AnnotationKey] = templateMd5
-		secret.Annotations[dataProtectionTemplateValuesMD5AnnotationKey] = parametersMd5
+		secret.Annotations[dataProtectionBackupRepoDigestAnnotationKey] = reconCtx.getDigest()
 
-		if err := controllerutil.SetControllerReference(repo, secret, r.Scheme); err != nil {
+		if err := controllerutil.SetControllerReference(reconCtx.repo, secret, r.Scheme); err != nil {
 			return fmt.Errorf("failed to set controller reference: %w", err)
 		}
 		return nil
@@ -408,15 +486,14 @@ func (r *BackupRepoReconciler) createOrUpdateSecretForCSIDriver(
 }
 
 func (r *BackupRepoReconciler) createStorageClass(
-	reqCtx intctrlutil.RequestCtx, renderCtx renderContext,
-	repo *dpv1alpha1.BackupRepo, provider *storagev1alpha1.StorageProvider) (created bool, err error) {
+	reconCtx *reconcileContext) (created bool, err error) {
 
 	storageClass := &storagev1.StorageClass{}
-	storageClass.Name = repo.Status.GeneratedStorageClassName
-	return createObjectIfNotExist(reqCtx.Ctx, r.Client, storageClass,
+	storageClass.Name = reconCtx.repo.Status.GeneratedStorageClassName
+	return createObjectIfNotExist(reconCtx.Ctx, r.Client, storageClass,
 		func() error {
 			// render storage class template
-			content, err := renderTemplate("sc", provider.Spec.StorageClassTemplate, renderCtx)
+			content, err := renderTemplate("sc", reconCtx.provider.Spec.StorageClassTemplate, reconCtx.renderCtx)
 			if err != nil {
 				return fmt.Errorf("failed to render storage class template: %w", err)
 			}
@@ -426,81 +503,58 @@ func (r *BackupRepoReconciler) createStorageClass(
 
 			// create storage class object
 			storageClass.Labels = map[string]string{
-				dataProtectionBackupRepoKey: repo.Name,
+				dataProtectionBackupRepoKey: reconCtx.repo.Name,
 			}
 			bindingMode := storagev1.VolumeBindingImmediate
 			storageClass.VolumeBindingMode = &bindingMode
-			if repo.Spec.PVReclaimPolicy != "" {
-				storageClass.ReclaimPolicy = &repo.Spec.PVReclaimPolicy
+			if reconCtx.repo.Spec.PVReclaimPolicy != "" {
+				storageClass.ReclaimPolicy = &reconCtx.repo.Spec.PVReclaimPolicy
 			}
-			if err := controllerutil.SetControllerReference(repo, storageClass, r.Scheme); err != nil {
+			if err := controllerutil.SetControllerReference(reconCtx.repo, storageClass, r.Scheme); err != nil {
 				return fmt.Errorf("failed to set owner reference: %w", err)
 			}
 			return nil
 		})
 }
 
-func (r *BackupRepoReconciler) checkPVCTemplate(reqCtx intctrlutil.RequestCtx,
-	renderCtx renderContext, repo *dpv1alpha1.BackupRepo, provider *storagev1alpha1.StorageProvider) (err error) {
-
+func (r *BackupRepoReconciler) checkPVCTemplate(reconCtx *reconcileContext) (err error) {
 	reason := ReasonUnknownError
 	defer func() {
-		r.updateConditionInDefer(reqCtx, repo, ConditionTypePVCTemplateChecked, reason, &err)
+		r.updateConditionInDefer(reconCtx.Ctx, reconCtx.repo, ConditionTypePVCTemplateChecked, reason, nil, nil, &err)
 	}()
 
-	if !repo.AccessByMount() || provider.Spec.PersistentVolumeClaimTemplate == "" {
+	if !reconCtx.repo.AccessByMount() || reconCtx.provider.Spec.PersistentVolumeClaimTemplate == "" {
+		reason = ReasonSkipped
 		return nil
 	}
-	checkedTemplateMd5 := repo.Annotations[dataProtectionPVCTemplateMD5MD5AnnotationKey]
-	checkedParametersMd5 := repo.Annotations[dataProtectionTemplateValuesMD5AnnotationKey]
-	currentTemplateMd5 := md5Digest(provider.Spec.PersistentVolumeClaimTemplate)
-	currentParametersMd5 := renderCtx.Md5OfParameters()
-	if checkedTemplateMd5 != currentTemplateMd5 || checkedParametersMd5 != currentParametersMd5 {
+	if reconCtx.digestChanged() {
 		pvc := &corev1.PersistentVolumeClaim{}
-		err := r.constructPVCByTemplate(renderCtx, pvc, repo, provider.Spec.PersistentVolumeClaimTemplate)
+		err := r.constructPVCByTemplate(reconCtx, pvc, reconCtx.provider.Spec.PersistentVolumeClaimTemplate)
 		if err != nil {
 			reason = ReasonBadPVCTemplate
 			return err
 		}
 	}
-	if err = updateAnnotations(reqCtx.Ctx, r.Client, repo, map[string]string{
-		dataProtectionPVCTemplateMD5MD5AnnotationKey: currentTemplateMd5,
-		dataProtectionTemplateValuesMD5AnnotationKey: currentParametersMd5,
-	}); err != nil {
-		return err
-	}
 	reason = ReasonPVCTemplateChecked
 	return nil
 }
 
-func (r *BackupRepoReconciler) checkAndUpdateToolConfig(reqCtx intctrlutil.RequestCtx,
-	renderCtx renderContext, repo *dpv1alpha1.BackupRepo, provider *storagev1alpha1.StorageProvider) (err error) {
-
-	reason := ReasonUnknownError
-	defer func() {
-		r.updateConditionInDefer(reqCtx, repo, ConditionTypeToolConfigChecked, reason, &err)
-	}()
-
-	if !repo.AccessByTool() {
+func (r *BackupRepoReconciler) updateToolConfigSecrets(reconCtx *reconcileContext) (err error) {
+	if !reconCtx.repo.AccessByTool() {
 		return nil
 	}
-	checkedTemplateMd5 := repo.Annotations[dataProtectionToolConfigTemplateMD5MD5AnnotationKey]
-	checkedParametersMd5 := repo.Annotations[dataProtectionTemplateValuesMD5AnnotationKey]
-	currentTemplateMd5 := md5Digest(provider.Spec.DatasafedConfigTemplate)
-	currentParametersMd5 := renderCtx.Md5OfParameters()
-	if !(checkedTemplateMd5 != currentTemplateMd5 || checkedParametersMd5 != currentParametersMd5) {
+	if reconCtx.repo.Annotations[dataProtectionNeedUpdateToolConfigAnnotationKey] != trueVal {
 		return nil
 	}
-	// check tool config template
-	content, err := renderTemplate("tool-config", provider.Spec.DatasafedConfigTemplate, renderCtx)
+	// render tool config template
+	content, err := renderTemplate("tool-config", reconCtx.provider.Spec.DatasafedConfigTemplate, reconCtx.renderCtx)
 	if err != nil {
-		reason = ReasonBadToolConfigTemplate
 		return err
 	}
 	// update existing tool config secrets
 	secretList := &corev1.SecretList{}
-	err = r.Client.List(reqCtx.Ctx, secretList, client.MatchingLabels{
-		dataProtectionBackupRepoKey:   repo.Name,
+	err = r.Client.List(reconCtx.Ctx, secretList, client.MatchingLabels{
+		dataProtectionBackupRepoKey:   reconCtx.repo.Name,
 		dataProtectionIsToolConfigKey: trueVal,
 	})
 	if err != nil {
@@ -508,9 +562,8 @@ func (r *BackupRepoReconciler) checkAndUpdateToolConfig(reqCtx intctrlutil.Reque
 	}
 	for idx := range secretList.Items {
 		secret := &secretList.Items[idx]
-		tmplMd5InSecret := secret.Annotations[dataProtectionToolConfigTemplateMD5MD5AnnotationKey]
-		paramMd5InSecret := secret.Annotations[dataProtectionTemplateValuesMD5AnnotationKey]
-		if tmplMd5InSecret == currentTemplateMd5 && paramMd5InSecret == currentParametersMd5 {
+		oldDigest := secret.Annotations[dataProtectionBackupRepoDigestAnnotationKey]
+		if oldDigest == reconCtx.getDigest() {
 			continue
 		}
 		patch := client.MergeFrom(secret.DeepCopy())
@@ -518,30 +571,211 @@ func (r *BackupRepoReconciler) checkAndUpdateToolConfig(reqCtx intctrlutil.Reque
 		if secret.Annotations == nil {
 			secret.Annotations = make(map[string]string)
 		}
-		secret.Annotations[dataProtectionToolConfigTemplateMD5MD5AnnotationKey] = currentTemplateMd5
-		secret.Annotations[dataProtectionTemplateValuesMD5AnnotationKey] = currentParametersMd5
-		if err = r.Client.Patch(reqCtx.Ctx, secret, patch); err != nil {
+		secret.Annotations[dataProtectionBackupRepoDigestAnnotationKey] = reconCtx.getDigest()
+		if err = r.Client.Patch(reconCtx.Ctx, secret, patch); err != nil {
 			return err
 		}
 	}
 
-	if err = updateAnnotations(reqCtx.Ctx, r.Client, repo, map[string]string{
-		dataProtectionToolConfigTemplateMD5MD5AnnotationKey: currentTemplateMd5,
-		dataProtectionTemplateValuesMD5AnnotationKey:        currentParametersMd5,
-	}); err != nil {
+	return updateAnnotations(reconCtx.Ctx, r.Client, reconCtx.repo, map[string]string{
+		dataProtectionNeedUpdateToolConfigAnnotationKey: "false",
+	})
+}
+
+func (r *BackupRepoReconciler) preCheckRepo(reconCtx *reconcileContext) (err error) {
+	if !reconCtx.digestChanged() {
+		return nil
+	}
+	status := metav1.ConditionUnknown
+	reason := ReasonUnknownError
+	message := ""
+	defer func() {
+		if message == "" && err != nil {
+			message = err.Error()
+		}
+		r.updateConditionInDefer(reconCtx.Ctx, reconCtx.repo, ConditionTypePreCheckPassed, reason, &status, &message, &err)
+	}()
+	var job *batchv1.Job
+	switch {
+	case reconCtx.repo.AccessByMount():
+		job, err = r.runPreCheckJobForMounting(reconCtx)
+	case reconCtx.repo.AccessByTool():
+		job, err = r.runPreCheckJobForTool(reconCtx)
+	default:
+		err = fmt.Errorf("unknown access method: %s", reconCtx.repo.Spec.AccessMethod)
+	}
+	if err != nil {
 		return err
 	}
-	reason = ReasonToolConfigChecked
+
+	finished, jobStatus, failureReason := utils.IsJobFinished(job)
+	if !finished {
+		// wait job to finish
+		return newDependencyError("wait job to finish")
+	}
+
+	if jobStatus == batchv1.JobFailed {
+		status = metav1.ConditionFalse
+		reason = ReasonPreCheckFailed
+		// TODO: collect the failure reason from the PVC or the log
+		message = fmt.Sprintf("pre-check failed: %s", failureReason)
+	} else {
+		status = metav1.ConditionTrue
+		reason = ReasonPreCheckPassed
+	}
 	return nil
 }
 
-func (r *BackupRepoReconciler) constructPVCByTemplate(
-	renderCtx renderContext, pvc *corev1.PersistentVolumeClaim,
-	repo *dpv1alpha1.BackupRepo, tmpl string) error {
-	// fill render values
-	renderCtx.GeneratedStorageClassName = repo.Status.GeneratedStorageClassName
+func (r *BackupRepoReconciler) removePreCheckResources(reconCtx *reconcileContext) error {
+	objects := []client.Object{
+		&batchv1.Job{},
+		&corev1.PersistentVolumeClaim{},
+		&corev1.Secret{},
+	}
+	name := reconCtx.preCheckResourceName()
+	namespace := viper.GetString(constant.CfgKeyCtrlrMgrNS)
+	objKey := client.ObjectKey{Name: name, Namespace: namespace}
+	for _, obj := range objects {
+		err := r.Client.Get(reconCtx.Ctx, objKey, obj)
+		if err == nil {
+			err = intctrlutil.BackgroundDeleteObject(r.Client, reconCtx.Ctx, obj)
+		}
+		if err == nil || apierrors.IsNotFound(err) {
+			continue
+		}
+		return err
+	}
+	return nil
+}
 
-	content, err := renderTemplate("pvc", tmpl, renderCtx)
+func (r *BackupRepoReconciler) runPreCheckJobForMounting(reconCtx *reconcileContext) (job *batchv1.Job, err error) {
+	namespace := viper.GetString(constant.CfgKeyCtrlrMgrNS)
+	// create PVC
+	pvcName := reconCtx.preCheckResourceName()
+	pvc, err := r.createRepoPVC(reconCtx, pvcName, namespace, map[string]string{
+		dataProtectionBackupRepoDigestAnnotationKey: reconCtx.getDigest(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	// run pre-check job
+	job = &batchv1.Job{}
+	job.Name = reconCtx.preCheckResourceName()
+	job.Namespace = namespace
+	_, err = createObjectIfNotExist(reconCtx.Ctx, r.Client, job, func() error {
+		job.Spec = batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					Containers: []corev1.Container{{
+						Name:            "pre-check",
+						Image:           viper.GetString(constant.KBToolsImage),
+						ImagePullPolicy: corev1.PullPolicy(viper.GetString(constant.KBImagePullPolicy)),
+						Command: []string{
+							"bash", "-c", `set -ex; echo "pre-check" > /backup/precheck.txt; sync`,
+						},
+						VolumeMounts: []corev1.VolumeMount{{
+							Name:      "backup-pvc",
+							MountPath: "/backup",
+						}},
+					}},
+					Volumes: []corev1.Volume{{
+						Name: "backup-pvc",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: pvcName,
+							},
+						},
+					}},
+				},
+			},
+		}
+		job.Labels = map[string]string{
+			dataProtectionBackupRepoKey: reconCtx.repo.Name,
+		}
+		job.Annotations = map[string]string{
+			dataProtectionBackupRepoDigestAnnotationKey: reconCtx.getDigest(),
+		}
+		return controllerutil.SetControllerReference(reconCtx.repo, job, r.Scheme)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// these resources were created for the old generation of the backupRepo,
+	// so remove them and then retry.
+	if !reconCtx.hasSameDigest(pvc) || !reconCtx.hasSameDigest(job) {
+		err = r.removePreCheckResources(reconCtx)
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("pre-check job or PVC digest not match, try again")
+	}
+	return job, nil
+}
+
+func (r *BackupRepoReconciler) runPreCheckJobForTool(reconCtx *reconcileContext) (job *batchv1.Job, err error) {
+	namespace := viper.GetString(constant.CfgKeyCtrlrMgrNS)
+	// create tool config
+	secretName := reconCtx.preCheckResourceName()
+	secret, err := r.createToolConfigSecret(reconCtx, secretName, namespace, map[string]string{
+		dataProtectionBackupRepoDigestAnnotationKey: reconCtx.getDigest(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	// run pre-check job
+	job = &batchv1.Job{}
+	job.Name = reconCtx.preCheckResourceName()
+	job.Namespace = namespace
+	_, err = createObjectIfNotExist(reconCtx.Ctx, r.Client, job, func() error {
+		job.Spec = batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					Containers: []corev1.Container{{
+						Name:            "pre-check",
+						Image:           viper.GetString(constant.KBToolsImage),
+						ImagePullPolicy: corev1.PullPolicy(viper.GetString(constant.KBImagePullPolicy)),
+						Command: []string{
+							"bash", "-c",
+							`
+set -ex
+export PATH="$PATH:$DP_DATASAFED_BIN_PATH"
+echo "pre-check" | datasafed push - /precheck.txt`,
+						},
+					}},
+				},
+			},
+		}
+		job.Labels = map[string]string{
+			dataProtectionBackupRepoKey: reconCtx.repo.Name,
+		}
+		job.Annotations = map[string]string{
+			dataProtectionBackupRepoDigestAnnotationKey: reconCtx.getDigest(),
+		}
+		utils.InjectDatasafedWithConfig(&job.Spec.Template.Spec, secretName, "")
+		return controllerutil.SetControllerReference(reconCtx.repo, job, r.Scheme)
+	})
+
+	// these resources were created for the old generation of the backupRepo,
+	// so remove them and then retry.
+	if !reconCtx.hasSameDigest(secret) || !reconCtx.hasSameDigest(job) {
+		err = r.removePreCheckResources(reconCtx)
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("pre-check job or tool config secret digest not match, try again")
+	}
+	return job, nil
+}
+
+func (r *BackupRepoReconciler) constructPVCByTemplate(
+	reconCtx *reconcileContext, pvc *corev1.PersistentVolumeClaim, tmpl string) error {
+	// fill render values
+	reconCtx.renderCtx.GeneratedStorageClassName = reconCtx.repo.Status.GeneratedStorageClassName
+
+	content, err := renderTemplate("pvc", tmpl, reconCtx.renderCtx)
 	if err != nil {
 		return fmt.Errorf("failed to render PVC template: %w", err)
 	}
@@ -552,7 +786,7 @@ func (r *BackupRepoReconciler) constructPVCByTemplate(
 }
 
 func (r *BackupRepoReconciler) listAssociatedBackups(
-	reqCtx intctrlutil.RequestCtx, repo *dpv1alpha1.BackupRepo, extraSelector map[string]string) ([]*dpv1alpha1.Backup, error) {
+	ctx context.Context, repo *dpv1alpha1.BackupRepo, extraSelector map[string]string) ([]*dpv1alpha1.Backup, error) {
 	// list backups associated with the repo
 	backupList := &dpv1alpha1.BackupList{}
 	selectors := client.MatchingLabels{
@@ -561,7 +795,7 @@ func (r *BackupRepoReconciler) listAssociatedBackups(
 	for k, v := range extraSelector {
 		selectors[k] = v
 	}
-	err := r.Client.List(reqCtx.Ctx, backupList, selectors)
+	err := r.Client.List(ctx, backupList, selectors)
 	var filtered []*dpv1alpha1.Backup
 	for idx := range backupList.Items {
 		backup := &backupList.Items[idx]
@@ -573,11 +807,8 @@ func (r *BackupRepoReconciler) listAssociatedBackups(
 	return filtered, err
 }
 
-func (r *BackupRepoReconciler) prepareForAssociatedBackups(
-	reqCtx intctrlutil.RequestCtx, renderCtx renderContext,
-	repo *dpv1alpha1.BackupRepo, provider *storagev1alpha1.StorageProvider) error {
-
-	backups, err := r.listAssociatedBackups(reqCtx, repo, map[string]string{
+func (r *BackupRepoReconciler) prepareForAssociatedBackups(reconCtx *reconcileContext) error {
+	backups, err := r.listAssociatedBackups(reconCtx.Ctx, reconCtx.repo, map[string]string{
 		dataProtectionWaitRepoPreparationKey: trueVal,
 	})
 	if err != nil {
@@ -587,27 +818,27 @@ func (r *BackupRepoReconciler) prepareForAssociatedBackups(
 	var retErr error
 	for _, backup := range backups {
 		switch {
-		case repo.AccessByMount():
-			if err := r.checkOrCreatePVC(reqCtx, renderCtx, repo, provider, backup.Namespace); err != nil {
-				reqCtx.Log.Error(err, "failed to check or create PVC", "namespace", backup.Namespace)
+		case reconCtx.repo.AccessByMount():
+			if _, err := r.createRepoPVC(reconCtx, reconCtx.repo.Status.BackupPVCName, backup.Namespace, nil); err != nil {
+				reconCtx.Log.Error(err, "failed to check or create PVC", "namespace", backup.Namespace)
 				retErr = err
 				continue
 			}
-		case repo.AccessByTool():
-			if err := r.checkOrCreateToolConfigSecret(reqCtx, renderCtx, repo, provider, backup.Namespace); err != nil {
-				reqCtx.Log.Error(err, "failed to check or create tool config secret", "namespace", backup.Namespace)
+		case reconCtx.repo.AccessByTool():
+			if _, err := r.createToolConfigSecret(reconCtx, reconCtx.repo.Status.ToolConfigSecretName, backup.Namespace, nil); err != nil {
+				reconCtx.Log.Error(err, "failed to check or create tool config secret", "namespace", backup.Namespace)
 				retErr = err
 				continue
 			}
 		default:
-			retErr = fmt.Errorf("unknown access method: %s", repo.Spec.AccessMethod)
+			retErr = fmt.Errorf("unknown access method: %s", reconCtx.repo.Spec.AccessMethod)
 		}
 
 		if backup.Labels[dataProtectionWaitRepoPreparationKey] != "" {
 			patch := client.MergeFrom(backup.DeepCopy())
 			delete(backup.Labels, dataProtectionWaitRepoPreparationKey)
-			if err = r.Client.Patch(reqCtx.Ctx, backup, patch); err != nil {
-				reqCtx.Log.Error(err, "failed to patch backup",
+			if err = r.Client.Patch(reconCtx.Ctx, backup, patch); err != nil {
+				reconCtx.Log.Error(err, "failed to patch backup",
 					"backup", client.ObjectKeyFromObject(backup))
 				retErr = err
 				continue
@@ -617,27 +848,26 @@ func (r *BackupRepoReconciler) prepareForAssociatedBackups(
 	return retErr
 }
 
-func (r *BackupRepoReconciler) checkOrCreatePVC(
-	reqCtx intctrlutil.RequestCtx, renderCtx renderContext,
-	repo *dpv1alpha1.BackupRepo, provider *storagev1alpha1.StorageProvider, namespace string) error {
+func (r *BackupRepoReconciler) createRepoPVC(reconCtx *reconcileContext,
+	name, namespace string, extraAnnos map[string]string) (*corev1.PersistentVolumeClaim, error) {
 
 	pvc := &corev1.PersistentVolumeClaim{}
-	pvc.Name = repo.Status.BackupPVCName
+	pvc.Name = name
 	pvc.Namespace = namespace
-	_, err := createObjectIfNotExist(reqCtx.Ctx, r.Client, pvc,
+	_, err := createObjectIfNotExist(reconCtx.Ctx, r.Client, pvc,
 		func() error {
-			if provider.Spec.PersistentVolumeClaimTemplate != "" {
+			if reconCtx.provider.Spec.PersistentVolumeClaimTemplate != "" {
 				// construct the PVC object by rendering the template
-				err := r.constructPVCByTemplate(renderCtx, pvc, repo, provider.Spec.PersistentVolumeClaimTemplate)
+				err := r.constructPVCByTemplate(reconCtx, pvc, reconCtx.provider.Spec.PersistentVolumeClaimTemplate)
 				if err != nil {
 					return err
 				}
 				// overwrite PVC name and namespace
-				pvc.Name = repo.Status.BackupPVCName
+				pvc.Name = name
 				pvc.Namespace = namespace
 			} else {
 				// set storage class name to PVC, other fields will be set with default value later
-				storageClassName := repo.Status.GeneratedStorageClassName
+				storageClassName := reconCtx.repo.Status.GeneratedStorageClassName
 				pvc.Spec = corev1.PersistentVolumeClaimSpec{
 					StorageClassName: &storageClassName,
 				}
@@ -646,7 +876,14 @@ func (r *BackupRepoReconciler) checkOrCreatePVC(
 			if pvc.Labels == nil {
 				pvc.Labels = make(map[string]string)
 			}
-			pvc.Labels[dataProtectionBackupRepoKey] = repo.Name
+			pvc.Labels[dataProtectionBackupRepoKey] = reconCtx.repo.Name
+			// extra annotations
+			if pvc.Annotations == nil {
+				pvc.Annotations = make(map[string]string)
+			}
+			for k, v := range extraAnnos {
+				pvc.Annotations[k] = v
+			}
 			// set default values if not set
 			if len(pvc.Spec.AccessModes) == 0 {
 				pvc.Spec.AccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}
@@ -660,15 +897,15 @@ func (r *BackupRepoReconciler) checkOrCreatePVC(
 			}
 			// note: pvc.Spec.Resources.Requests.Storage() never returns nil
 			if pvc.Spec.Resources.Requests.Storage().IsZero() {
-				pvc.Spec.Resources.Requests[corev1.ResourceStorage] = repo.Spec.VolumeCapacity
+				pvc.Spec.Resources.Requests[corev1.ResourceStorage] = reconCtx.repo.Spec.VolumeCapacity
 			}
-			if err := controllerutil.SetControllerReference(repo, pvc, r.Scheme); err != nil {
+			if err := controllerutil.SetControllerReference(reconCtx.repo, pvc, r.Scheme); err != nil {
 				return fmt.Errorf("failed to set owner reference: %w", err)
 			}
 			return nil
 		})
 
-	return err
+	return pvc, err
 }
 
 func constructToolConfigSecret(secret *corev1.Secret, content string) {
@@ -677,16 +914,15 @@ func constructToolConfigSecret(secret *corev1.Secret, content string) {
 	}
 }
 
-func (r *BackupRepoReconciler) checkOrCreateToolConfigSecret(
-	reqCtx intctrlutil.RequestCtx, renderCtx renderContext,
-	repo *dpv1alpha1.BackupRepo, provider *storagev1alpha1.StorageProvider, namespace string) error {
+func (r *BackupRepoReconciler) createToolConfigSecret(reconCtx *reconcileContext,
+	name, namespace string, extraAnnos map[string]string) (*corev1.Secret, error) {
 
 	secret := &corev1.Secret{}
-	secret.Name = repo.Status.ToolConfigSecretName
+	secret.Name = name
 	secret.Namespace = namespace
-	_, err := createObjectIfNotExist(reqCtx.Ctx, r.Client, secret,
+	_, err := createObjectIfNotExist(reconCtx.Ctx, r.Client, secret,
 		func() error {
-			content, err := renderTemplate("tool-config", provider.Spec.DatasafedConfigTemplate, renderCtx)
+			content, err := renderTemplate("tool-config", reconCtx.provider.Spec.DatasafedConfigTemplate, reconCtx.renderCtx)
 			if err != nil {
 				return fmt.Errorf("failed to render tool config template: %w", err)
 			}
@@ -694,20 +930,22 @@ func (r *BackupRepoReconciler) checkOrCreateToolConfigSecret(
 
 			// add a referencing label
 			secret.Labels = map[string]string{
-				dataProtectionBackupRepoKey:   repo.Name,
+				dataProtectionBackupRepoKey:   reconCtx.repo.Name,
 				dataProtectionIsToolConfigKey: trueVal,
 			}
 			secret.Annotations = map[string]string{
-				dataProtectionTemplateValuesMD5AnnotationKey:        renderCtx.Md5OfParameters(),
-				dataProtectionToolConfigTemplateMD5MD5AnnotationKey: md5Digest(provider.Spec.DatasafedConfigTemplate),
+				dataProtectionBackupRepoDigestAnnotationKey: reconCtx.getDigest(),
 			}
-			if err := controllerutil.SetControllerReference(repo, secret, r.Scheme); err != nil {
+			for k, v := range extraAnnos {
+				secret.Annotations[k] = v
+			}
+			if err := controllerutil.SetControllerReference(reconCtx.repo, secret, r.Scheme); err != nil {
 				return fmt.Errorf("failed to set owner reference: %w", err)
 			}
 			return nil
 		})
 
-	return err
+	return secret, err
 }
 
 func (r *BackupRepoReconciler) collectParameters(
@@ -747,7 +985,7 @@ func (r *BackupRepoReconciler) deleteExternalResources(
 	// TODO: block deletion if any BackupPolicy is referencing to this repo
 
 	// check if the repo is still being used by any backup
-	if backups, err := r.listAssociatedBackups(reqCtx, repo, nil); err != nil {
+	if backups, err := r.listAssociatedBackups(reqCtx.Ctx, repo, nil); err != nil {
 		return err
 	} else if len(backups) > 0 {
 		_ = updateCondition(reqCtx.Ctx, r.Client, repo, ConditionTypeDerivedObjectsDeleted,
@@ -756,10 +994,15 @@ func (r *BackupRepoReconciler) deleteExternalResources(
 		return fmt.Errorf("some backups still refer to this repo")
 	}
 
-	// delete PVCs
-	if clear, err := r.deletePVCs(reqCtx, repo); err != nil {
+	// delete pre-check jobs
+	if err := r.deleteJobs(reqCtx, repo); err != nil {
 		return err
-	} else if !clear {
+	}
+
+	// delete PVCs
+	if cleared, err := r.deletePVCs(reqCtx, repo); err != nil {
+		return err
+	} else if !cleared {
 		_ = updateCondition(reqCtx.Ctx, r.Client, repo, ConditionTypeDerivedObjectsDeleted,
 			metav1.ConditionFalse, ReasonHaveResidualPVCs,
 			"maybe the derived PVCs are still in use")
@@ -790,7 +1033,28 @@ func (r *BackupRepoReconciler) deleteExternalResources(
 	return nil
 }
 
-func (r *BackupRepoReconciler) deletePVCs(reqCtx intctrlutil.RequestCtx, repo *dpv1alpha1.BackupRepo) (clear bool, err error) {
+func (r *BackupRepoReconciler) deleteJobs(reqCtx intctrlutil.RequestCtx, repo *dpv1alpha1.BackupRepo) error {
+	jobList := &batchv1.JobList{}
+	if err := r.Client.List(reqCtx.Ctx, jobList,
+		client.MatchingLabels(map[string]string{
+			dataProtectionBackupRepoKey: repo.Name,
+		})); err != nil {
+		return fmt.Errorf("failed to list Jobs: %w", err)
+	}
+
+	for _, job := range jobList.Items {
+		if !isOwned(repo, &job) {
+			continue
+		}
+		reqCtx.Log.Info("deleting job", "name", job.Name, "namespace", job.Namespace)
+		if err := intctrlutil.BackgroundDeleteObject(r.Client, reqCtx.Ctx, &job); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *BackupRepoReconciler) deletePVCs(reqCtx intctrlutil.RequestCtx, repo *dpv1alpha1.BackupRepo) (cleared bool, err error) {
 	pvcList := &corev1.PersistentVolumeClaimList{}
 	if err := r.Client.List(reqCtx.Ctx, pvcList,
 		client.MatchingLabels(map[string]string{
@@ -809,18 +1073,18 @@ func (r *BackupRepoReconciler) deletePVCs(reqCtx intctrlutil.RequestCtx, repo *d
 		}
 	}
 	// make sure all derived PVCs are deleted
-	clear = true
+	cleared = true
 	for _, pvc := range pvcList.Items {
 		if !isOwned(repo, &pvc) {
 			continue
 		}
 		err = r.Client.Get(reqCtx.Ctx, client.ObjectKeyFromObject(&pvc), &corev1.PersistentVolumeClaim{})
 		if !apierrors.IsNotFound(err) {
-			clear = false
+			cleared = false
 			break
 		}
 	}
-	return clear, nil
+	return cleared, nil
 }
 
 func (r *BackupRepoReconciler) deleteStorageClasses(reqCtx intctrlutil.RequestCtx, repo *dpv1alpha1.BackupRepo) error {
@@ -920,6 +1184,7 @@ func (r *BackupRepoReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.mapSecretToRepos)).
 		Owns(&storagev1.StorageClass{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
+		Owns(&batchv1.Job{}).
 		Complete(r)
 }
 
@@ -957,15 +1222,6 @@ type renderContext struct {
 	Parameters                map[string]string
 	CSIDriverSecretRef        corev1.SecretReference
 	GeneratedStorageClassName string
-
-	md5OfParameters string
-}
-
-func (r *renderContext) Md5OfParameters() string {
-	if r.md5OfParameters == "" {
-		r.md5OfParameters = md5Digest(stableSerializeMap(r.Parameters))
-	}
-	return r.md5OfParameters
 }
 
 func renderTemplate(name, tpl string, rCtx renderContext) (string, error) {
@@ -1116,4 +1372,11 @@ func randomNameForDerivedObject(repo *dpv1alpha1.BackupRepo, prefix string) stri
 		baseName = baseName[:maxBaseNameLength]
 	}
 	return baseName + "-" + rand.String(6)
+}
+
+func cutName(name string) string {
+	if len(name) > 63 {
+		return name[:63]
+	}
+	return name
 }

--- a/controllers/dataprotection/backuprepo_controller.go
+++ b/controllers/dataprotection/backuprepo_controller.go
@@ -809,6 +809,9 @@ echo "pre-check" | datasafed push - /precheck.txt`,
 		utils.InjectDatasafedWithConfig(&job.Spec.Template.Spec, secretName, "")
 		return controllerutil.SetControllerReference(reconCtx.repo, job, r.Scheme)
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	// these resources were created for the old generation of the backupRepo,
 	// so remove them and then retry.
@@ -922,8 +925,7 @@ func (r *BackupRepoReconciler) collectFailedPodLogs(ctx context.Context,
 		return "", err
 	}
 	for _, pod := range podList.Items {
-		switch pod.Status.Phase {
-		case corev1.PodFailed:
+		if pod.Status.Phase == corev1.PodFailed {
 			currOpts := &corev1.PodLogOptions{
 				Container: containerName,
 			}

--- a/controllers/dataprotection/suite_test.go
+++ b/controllers/dataprotection/suite_test.go
@@ -176,9 +176,10 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&BackupRepoReconciler{
-		Client:   k8sManager.GetClient(),
-		Scheme:   k8sManager.GetScheme(),
-		Recorder: k8sManager.GetEventRecorderFor("backup-repo-controller"),
+		Client:     k8sManager.GetClient(),
+		Scheme:     k8sManager.GetScheme(),
+		Recorder:   k8sManager.GetEventRecorderFor("backup-repo-controller"),
+		RestConfig: k8sManager.GetConfig(),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/controllers/dataprotection/suite_test.go
+++ b/controllers/dataprotection/suite_test.go
@@ -82,6 +82,7 @@ var _ = BeforeSuite(func() {
 
 	ctx, cancel = context.WithCancel(context.TODO())
 
+	viper.SetDefault(constant.CfgKeyCtrlrMgrNS, "default")
 	viper.SetDefault(constant.KBToolsImage, "apecloud/kubeblocks:latest")
 	fmt.Printf("config settings: %v\n", viper.AllSettings())
 

--- a/controllers/dataprotection/types.go
+++ b/controllers/dataprotection/types.go
@@ -73,6 +73,7 @@ const (
 	ReasonDerivedObjectsDeleted     = "DerivedObjectsDeleted"
 	ReasonPreCheckPassed            = "PreCheckPassed"
 	ReasonPreCheckFailed            = "PreCheckFailed"
+	ReasonDigestChanged             = "DigestChanged"
 	ReasonUnknownError              = "UnknownError"
 	ReasonSkipped                   = "Skipped"
 )

--- a/controllers/dataprotection/types.go
+++ b/controllers/dataprotection/types.go
@@ -42,10 +42,8 @@ const (
 	dataProtectionIsToolConfigKey        = "dataprotection.kubeblocks.io/is-tool-config"
 
 	// annotation keys
-	dataProtectionSecretTemplateMD5AnnotationKey        = "dataprotection.kubeblocks.io/secret-template-md5"
-	dataProtectionTemplateValuesMD5AnnotationKey        = "dataprotection.kubeblocks.io/template-values-md5"
-	dataProtectionPVCTemplateMD5MD5AnnotationKey        = "dataprotection.kubeblocks.io/pvc-template-md5"
-	dataProtectionToolConfigTemplateMD5MD5AnnotationKey = "dataprotection.kubeblocks.io/tool-config-template-md5"
+	dataProtectionBackupRepoDigestAnnotationKey     = "dataprotection.kubeblocks.io/backup-repo-digest"
+	dataProtectionNeedUpdateToolConfigAnnotationKey = "dataprotection.kubeblocks.io/need-update-tool-config"
 )
 
 // condition constants
@@ -55,8 +53,8 @@ const (
 	ConditionTypeParametersChecked     = "ParametersChecked"
 	ConditionTypeStorageClassCreated   = "StorageClassCreated"
 	ConditionTypePVCTemplateChecked    = "PVCTemplateChecked"
-	ConditionTypeToolConfigChecked     = "ToolConfigSecretChecked"
 	ConditionTypeDerivedObjectsDeleted = "DerivedObjectsDeleted"
+	ConditionTypePreCheckPassed        = "PreCheckPassed"
 
 	// condition reasons
 	ReasonStorageProviderReady      = "StorageProviderReady"
@@ -68,14 +66,15 @@ const (
 	ReasonPrepareCSISecretFailed    = "PrepareCSISecretFailed"
 	ReasonPrepareStorageClassFailed = "PrepareStorageClassFailed"
 	ReasonBadPVCTemplate            = "BadPVCTemplate"
-	ReasonBadToolConfigTemplate     = "BadToolConfigTemplate"
 	ReasonStorageClassCreated       = "StorageClassCreated"
 	ReasonPVCTemplateChecked        = "PVCTemplateChecked"
-	ReasonToolConfigChecked         = "ToolConfigChecked"
 	ReasonHaveAssociatedBackups     = "HaveAssociatedBackups"
 	ReasonHaveResidualPVCs          = "HaveResidualPVCs"
 	ReasonDerivedObjectsDeleted     = "DerivedObjectsDeleted"
+	ReasonPreCheckPassed            = "PreCheckPassed"
+	ReasonPreCheckFailed            = "PreCheckFailed"
 	ReasonUnknownError              = "UnknownError"
+	ReasonSkipped                   = "Skipped"
 )
 
 // constant  for volume populator

--- a/pkg/dataprotection/utils/events.go
+++ b/pkg/dataprotection/utils/events.go
@@ -1,0 +1,37 @@
+/*
+Copyright (C) 2022-2023 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package utils
+
+import (
+	"bytes"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/kubectl/pkg/describe"
+)
+
+func EventsToString(events *corev1.EventList) string {
+	buf := bytes.NewBuffer(nil)
+	pw := describe.NewPrefixWriter(buf)
+	describe.DescribeEvents(events, pw)
+	pw.Flush()
+	// discard the first line
+	_, _ = buf.ReadString('\n')
+	return buf.String()
+}

--- a/pkg/dataprotection/utils/utils.go
+++ b/pkg/dataprotection/utils/utils.go
@@ -80,6 +80,15 @@ func IsJobFinished(job *batchv1.Job) (bool, batchv1.JobConditionType, string) {
 	return false, "", ""
 }
 
+func GetAssociatedPodsOfJob(ctx context.Context, cli client.Client, namespace, jobName string) (*corev1.PodList, error) {
+	podList := &corev1.PodList{}
+	// from https://github.com/kubernetes/kubernetes/issues/24709
+	err := cli.List(ctx, podList, client.InNamespace(namespace), client.MatchingLabels{
+		"job-name": jobName,
+	})
+	return podList, err
+}
+
 func RemoveDataProtectionFinalizer(ctx context.Context, cli client.Client, obj client.Object) error {
 	if !controllerutil.ContainsFinalizer(obj, dptypes.DataProtectionFinalizerName) {
 		return nil


### PR DESCRIPTION
Currently, if the user accidentally fills in a wrong configuration, such as an invalid access key, KubeBlocks can only discover this error when executing a backup task.

This PR adds a pre-check for BackupRepo, which can expose such configuration problems in advance. BackupRepo enters the `PreChecking` state as soon as it is created, and a job is started to try to access the storage corresponding to BackupRepo. If the access is successful, the status of BackupRepo is set to `Ready`; otherwise, the status is set to `Failed`, and the logs and events of the job are collected and saved for debugging.

If the remote storage is accessed based on CSI driver, a configuration error will cause the PVC to fail to provision, resulting in the job being always in a running state. To address this problem, a timeout mechanism is introduced. If the job does not end within 15 minutes, the pre-check is considered to have failed (and the logs and events are also collected at this time).

Here is an example:

```bash
# Create a S3 based BackupRepo with the wrong credential
$ kbcli backuprepo create --provider s3 --region us-west-1 --bucket my-bucket --access-key-id BADDDD --secret-access-key WHATEVERRRRR --access-method Tool


# Monitor the status, it will become 'Failed' after a few minutes
$ kubectl get backuprepo -w
NAME               STATUS        STORAGEPROVIDER   ACCESSMETHOD   DEFAULT   AGE
backuprepo-xhbwr   PreChecking   s3                Tool                    4s
backuprepo-xhbwr   PreChecking   s3                Tool                    3m25s
backuprepo-xhbwr   Failed        s3                Tool                    3m25s


# Check the collected information, then we know it might be a configuration error
$ kubectl get backuprepo backuprepo-xhbwr -o jsonpath='{.status.conditions[?(@.type == "PreCheckPassed")].message}'
Pre-check job failed, information collected for diagnosis.

Job failure message: BackoffLimitExceeded:Job has reached the specified backoff limit

Logs from the pre-check job:
  + export 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/bin/datasafed'
  + echo pre-check
  + datasafed push - /precheck.txt
  2023/11/01 06:09:00 ERROR : precheck.txt: Failed to copy: SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided. Check your key and signing method.
  	status code: 403, request id: G30M0QPAKZY483W3, host id: nL8pYwHck3ab7+53+9OrEIXReHAYTHbKUc1gSb5UZSsF6kU2I2BDO3XGQsasXoV933O64k9/fXA=
  Error: push to "/precheck.txt": SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided. Check your key and signing method.
  	status code: 403, request id: G30M0QPAKZY483W3, host id: nL8pYwHck3ab7+53+9OrEIXReHAYTHbKUc1gSb5UZSsF6kU2I2BDO3XGQsasXoV933O64k9/fXA=

Events from Pod/default/pre-check-23989c99-backuprepo-xhbwr-4c2dd:
  Type	Reason	Age	From	Message
  ----	------	----	----	-------
  Normal	Pulling	29s	kubelet	Pulling image "apecloud/datasafed:latest"
  Normal	Scheduled	29s	default-scheduler	Successfully assigned default/pre-check-23989c99-backuprepo-xhbwr-4c2dd to minikube
  Normal	Pulled	26s	kubelet	Successfully pulled image "apecloud/datasafed:latest" in 2.735136877s (2.735152209s including waiting)
  Normal	Created	26s	kubelet	Created container dp-copy-datasafed
  Normal	Started	26s	kubelet	Started container dp-copy-datasafed
  Normal	Pulling	25s	kubelet	Pulling image "apecloud/kubeblocks-tools:latest"
  Normal	Pulled	23s	kubelet	Successfully pulled image "apecloud/kubeblocks-tools:latest" in 2.263616251s (2.263645084s including waiting)
  Normal	Created	23s	kubelet	Created container pre-check
  Normal	Started	23s	kubelet	Started container pre-check

Events from Job/default/pre-check-23989c99-backuprepo-xhbwr:
  Type	Reason	Age	From	Message
  ----	------	----	----	-------
  Normal	SuccessfulCreate	60s	job-controller	Created pod: pre-check-23989c99-backuprepo-xhbwr-rvvqw
  Normal	SuccessfulCreate	50s	job-controller	Created pod: pre-check-23989c99-backuprepo-xhbwr-jkspj
  Normal	SuccessfulCreate	29s	job-controller	Created pod: pre-check-23989c99-backuprepo-xhbwr-4c2dd
  Warning	BackoffLimitExceeded	0s	job-controller	Job has reached the specified backoff limit

```

Close #5571.