### PR TITLE
fix: fix incompatible upgrade for qdrant from 0.6 to 0.7

### DIFF
--- a/pkg/cli/util/breakingchange/upgradehandlerto0.7.go
+++ b/pkg/cli/util/breakingchange/upgradehandlerto0.7.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	apitypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/client-go/dynamic"
 
@@ -73,6 +74,21 @@ func (u *upgradeHandlerTo7) snapshot(dynamic dynamic.Interface) (map[string][]un
 	}); err != nil {
 		return nil, err
 	}
+
+	// get cd/cv objs for qdrant
+	if err := fillResourcesMap(dynamic, resourcesMap, types.ClusterDefGVR(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", constant.AppNameLabelKey, "qdrant"),
+	}); err != nil {
+		return nil, err
+
+	}
+
+	if err := fillResourcesMap(dynamic, resourcesMap, types.ClusterVersionGVR(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", constant.AppNameLabelKey, "qdrant"),
+	}); err != nil {
+		return nil, err
+	}
+
 	return resourcesMap, nil
 }
 
@@ -94,6 +110,14 @@ func (u *upgradeHandlerTo7) transform(dynamic dynamic.Interface, resourcesMap ma
 				}
 			case types.KindConfigMap:
 				if err := u.transformConfigMap(dynamic, obj); err != nil {
+					return err
+				}
+			case types.KindClusterDef:
+				if err := u.transformQdrantCd(dynamic, obj); err != nil {
+					return err
+				}
+			case types.KindClusterVersion:
+				if err := u.transformQdrantCv(dynamic, obj); err != nil {
 					return err
 				}
 			}
@@ -505,5 +529,85 @@ func (u *upgradeHandlerTo7) transformConfigMap(dynamic dynamic.Interface, obj un
 	if _, err := dynamic.Resource(types.ConfigmapGVR()).Namespace(obj.GetNamespace()).Patch(context.TODO(), obj.GetName(), apitypes.MergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
 		return fmt.Errorf("update pulsar configmap %s failed: %s", obj.GetName(), err.Error())
 	}
+	return nil
+}
+
+func (u *upgradeHandlerTo7) transformQdrantCd(dynamic dynamic.Interface, obj unstructured.Unstructured) error {
+	if obj.GetName() != "qdrant" {
+		return nil
+	}
+
+	specMap, _, _ := unstructured.NestedMap(obj.Object, "spec")
+	componentDefs, _, _ := unstructured.NestedSlice(specMap, "componentDefs")
+	qdrantComp := componentDefs[0].(map[string]interface{})
+
+	// add web-ui service ports
+	service, _, _ := unstructured.NestedMap(qdrantComp, "service")
+	servicePorts, _, _ := unstructured.NestedSlice(service, "ports")
+	// append the webUiPort into the servicePorts
+	servicePorts = append(servicePorts, corev1.ServicePort{
+		Name:       "web-ui",
+		Port:       3000,
+		Protocol:   corev1.ProtocolTCP,
+		TargetPort: intstr.IntOrString{Type: 1, StrVal: "web-ui"},
+	})
+	service["ports"] = servicePorts
+	qdrantComp["service"] = service
+
+	// add web-ui container to podSpec
+	var runAsUser int64 = 0
+	qdrantPodSpec, _, _ := unstructured.NestedMap(qdrantComp, "podSpec")
+	qdrantContainers, _, _ := unstructured.NestedSlice(qdrantPodSpec, "containers")
+	// append the webUiContainer into the qdrantContainers
+	qdrantContainers = append(qdrantContainers, corev1.Container{
+		Name:            "web-ui",
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser: &runAsUser,
+		},
+		Command: []string{"bash", "-c", " echo VITE_PORT=6333 >> .env; echo VITE_HOSTNAME=http://127.0.0.1 >> .env; npm run build; cd dist/ && serve"},
+		Ports: []corev1.ContainerPort{{
+			Name:          "web-ui",
+			ContainerPort: 3000,
+		}},
+	})
+
+	qdrantPodSpec["containers"] = qdrantContainers
+	qdrantComp["podSpec"] = qdrantPodSpec
+	componentDefs[0] = qdrantComp
+	specMap["componentDefs"] = componentDefs
+
+	patchBytes, _ := json.Marshal(map[string]interface{}{"spec": specMap})
+	if _, err := dynamic.Resource(types.ClusterDefGVR()).Namespace(obj.GetNamespace()).Patch(context.TODO(), obj.GetName(), apitypes.MergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
+		return fmt.Errorf("update pulsar configmap %s failed: %s", obj.GetName(), err.Error())
+	}
+	return nil
+}
+
+func (u *upgradeHandlerTo7) transformQdrantCv(dynamic dynamic.Interface, obj unstructured.Unstructured) error {
+	labels := obj.GetLabels()
+	if labels[constant.AppNameLabelKey] != "qdrant" {
+		return nil
+	}
+
+	specMap, _, _ := unstructured.NestedMap(obj.Object, "spec")
+	componentVersions, _, _ := unstructured.NestedSlice(specMap, "componentVersions")
+
+	// add web-ui container to versionContext
+	versionContext, _, _ := unstructured.NestedMap(componentVersions[0].(map[string]interface{}), "versionsContext")
+	containers, _, _ := unstructured.NestedSlice(versionContext, "containers")
+	containers = append(containers, corev1.Container{
+		Name:  "web-ui",
+		Image: "docker.io/apecloud/qdrant-web-ui:latest",
+	})
+	versionContext["containers"] = containers
+	componentVersions[0].(map[string]interface{})["versionsContext"] = versionContext
+	specMap["componentVersions"] = componentVersions
+
+	patchBytes, _ := json.Marshal(map[string]interface{}{"spec": specMap})
+	if _, err := dynamic.Resource(types.ClusterVersionGVR()).Namespace(obj.GetNamespace()).Patch(context.TODO(), obj.GetName(), apitypes.MergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
+		return fmt.Errorf("update pulsar configmap %s failed: %s", obj.GetName(), err.Error())
+	}
+
 	return nil
 }

--- a/pkg/cli/util/breakingchange/upgradehandlerto0.7.go
+++ b/pkg/cli/util/breakingchange/upgradehandlerto0.7.go
@@ -529,7 +529,7 @@ func (u *upgradeHandlerTo7) transformQdrantCluster(dynamic dynamic.Interface, ob
 	specMap["clusterVersionRef"] = "qdrant-1.5.0"
 	patchBytes, _ := json.Marshal(map[string]interface{}{"spec": specMap})
 	if _, err := dynamic.Resource(types.ClusterGVR()).Namespace(obj.GetNamespace()).Patch(context.TODO(), obj.GetName(), apitypes.MergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
-		return fmt.Errorf("update pulsar configmap %s failed: %s", obj.GetName(), err.Error())
+		return fmt.Errorf("update qdrant cluster %s failed: %s", obj.GetName(), err.Error())
 	}
 
 	return nil


### PR DESCRIPTION
- fix #5705

What i do:
Using `breakingChange` fix the incompatible upgrade.  
- Add the `web-ui` container, `web-ui` service port into the qdrant cluster definition 
- Add the `web-ui` container into the qdrant cluster version. 


![img_v2_5540475f-9da3-41d0-838a-3c29a11c422g](https://github.com/apecloud/kubeblocks/assets/101848970/e866258f-3626-41ba-99b8-451ce9c62901)
