### PR TITLE
chore: fix addon list output display

### DIFF
--- a/pkg/cli/cmd/addon/addon.go
+++ b/pkg/cli/cmd/addon/addon.go
@@ -816,11 +816,8 @@ func addonListRun(o *list.ListOptions) error {
 			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, addon); err != nil {
 				return err
 			}
-			extraNames := addon.GetExtraNames()
-			var selectors []string
 			var autoInstall bool
 			if addon.Spec.Installable != nil {
-				selectors = addon.Spec.Installable.GetSelectorsStrings()
 				autoInstall = addon.Spec.Installable.AutoInstall
 			}
 			label := obj.GetLabels()
@@ -830,15 +827,13 @@ func addonListRun(o *list.ListOptions) error {
 				provider,
 				addon.Status.Phase,
 				autoInstall,
-				strings.Join(selectors, ";"),
-				strings.Join(extraNames, ","),
 			)
 		}
 		return nil
 	}
 
 	if err = printer.PrintTable(o.Out, nil, printRows,
-		"NAME", "TYPE", "PROVIDER", "STATUS", "AUTO-INSTALL", "AUTO-INSTALLABLE-SELECTOR", "EXTRAS"); err != nil {
+		"NAME", "TYPE", "PROVIDER", "STATUS", "AUTO-INSTALL"); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
Now `kbcli addon list` outputs so many additional information including the **AUTO-INSTALLABLE-SELECTOR** and **EXTRAS** . Most addons do not have these properties, so I have moved them to `--output wide` to ensure that the `kbcli addon list` command remains concise.
![image](https://github.com/apecloud/kubeblocks/assets/101848970/7680699d-92d5-4d49-b299-28a6cbcb3ea5)

**Notes**:
Furthermore, in the upcoming 0.8 release, there will be a **refactoring** based on the new definition of `addons`, keeping only the ones related to `cd/cv.` The work on kbcli will also align with these changes.