### PR TITLE
chore: enhance kbcli backuprepo cmds

### DIFF
--- a/controllers/dataprotection/backuprepo_controller.go
+++ b/controllers/dataprotection/backuprepo_controller.go
@@ -848,27 +848,6 @@ func (r *BackupRepoReconciler) collectPreCheckFailureMessage(reconCtx *reconcile
 		return -1
 	})
 
-	prependSpaces := func(content string, spaces int) string {
-		prefix := ""
-		for i := 0; i < spaces; i++ {
-			prefix += " "
-		}
-		r := bytes.NewBufferString(content)
-		w := bytes.NewBuffer(nil)
-		w.Grow(r.Len())
-		for {
-			line, err := r.ReadString('\n')
-			if len(line) > 0 {
-				w.WriteString(prefix)
-				w.WriteString(line)
-			}
-			if err != nil {
-				break
-			}
-		}
-		return w.String()
-	}
-
 	var message string
 
 	// collect failure logs from the pod
@@ -880,7 +859,7 @@ func (r *BackupRepoReconciler) collectPreCheckFailureMessage(reconCtx *reconcile
 	if failureLogs == "" {
 		message += "No logs are available.\n\n"
 	} else {
-		message += fmt.Sprintf("Logs from the pre-check job:\n%s\n", prependSpaces(failureLogs, 2))
+		message += fmt.Sprintf("Logs from the pre-check job:\n%s\n", utils.PrependSpaces(failureLogs, 2))
 	}
 
 	collectEvents := func(object client.Object) error {

--- a/docs/user_docs/cli/cli.md
+++ b/docs/user_docs/cli/cli.md
@@ -32,6 +32,7 @@ BackupRepo command.
 * [kbcli backuprepo create](kbcli_backuprepo_create.md)	 - Create a backup repo
 * [kbcli backuprepo describe](kbcli_backuprepo_describe.md)	 - Describe a backup repository.
 * [kbcli backuprepo list](kbcli_backuprepo_list.md)	 - List Backup Repositories.
+* [kbcli backuprepo update](kbcli_backuprepo_update.md)	 - Update a backup repository.
 
 
 ## [bench](kbcli_bench.md)

--- a/docs/user_docs/cli/kbcli_backuprepo.md
+++ b/docs/user_docs/cli/kbcli_backuprepo.md
@@ -40,6 +40,7 @@ BackupRepo command.
 * [kbcli backuprepo create](kbcli_backuprepo_create.md)	 - Create a backup repo
 * [kbcli backuprepo describe](kbcli_backuprepo_describe.md)	 - Describe a backup repository.
 * [kbcli backuprepo list](kbcli_backuprepo_list.md)	 - List Backup Repositories.
+* [kbcli backuprepo update](kbcli_backuprepo_update.md)	 - Update a backup repository.
 
 #### Go Back to [CLI Overview](cli.md) Homepage.
 

--- a/docs/user_docs/cli/kbcli_backuprepo_update.md
+++ b/docs/user_docs/cli/kbcli_backuprepo_update.md
@@ -1,0 +1,60 @@
+---
+title: kbcli backuprepo update
+---
+
+Update a backup repository.
+
+```
+kbcli backuprepo update BACKUP_REPO_NAME [flags]
+```
+
+### Examples
+
+```
+  # Update the credential of a S3-based backuprepo
+  kbcli backuprepo update my-backuprepo --access-key-id=<NEW ACCESS KEY> --secret-access-key=<NEW SECRET KEY>
+  
+  # Set the backuprepo as default
+  kbcli backuprepo update my-backuprepo --default
+  
+  # Unset the default backuprepo
+  kbcli backuprepo update my-backuprepo --default=false
+```
+
+### Options
+
+```
+      --default   Specify whether to set the created backup repo as default
+  -h, --help      help for update
+```
+
+### Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --disable-compression            If true, opt-out of response compression for all requests to the server
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --match-server-version           Require server version to match client version
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+### SEE ALSO
+
+* [kbcli backuprepo](kbcli_backuprepo.md)	 - BackupRepo command.
+
+#### Go Back to [CLI Overview](cli.md) Homepage.
+

--- a/docs/user_docs/cli/kbcli_cluster_create_xinference.md
+++ b/docs/user_docs/cli/kbcli_cluster_create_xinference.md
@@ -1,0 +1,72 @@
+---
+title: kbcli cluster create xinference
+---
+
+Create a xinference cluster.
+
+```
+kbcli cluster create xinference NAME [flags]
+```
+
+### Examples
+
+```
+  # Create a cluster with the default values
+  kbcli cluster create xinference
+  
+  # Create a cluster with the specified cpu, memory and storage
+  kbcli cluster create xinference --cpu 1 --memory 2 --storage 10
+```
+
+### Options
+
+```
+      --availability-policy string   The availability policy of cluster. Legal values [none, node, zone]. (default "node")
+      --cpu float                    CPU cores. Value range [0.5, 64]. (default 2)
+      --cpu-mode                     Set to true if no GPU is available
+      --gpu float                    GPU cores. Value range [0, 64]. (default 1)
+  -h, --help                         help for xinference
+      --host-network-accessible      Specify whether the cluster can be accessed from within the VPC.
+      --memory float                 Memory, the unit is Gi. Value range [0.5, 1000]. (default 6)
+      --monitoring-interval int      The monitoring interval of cluster, 0 is disabled, the unit is second. Value range [0, 60].
+      --publicly-accessible          Specify whether the cluster can be accessed from the public internet.
+      --rbac-enabled                 Specify whether rbac resources will be created by client, otherwise KubeBlocks server will try to create rbac resources.
+      --replicas int                 The number of replicas, for standalone mode, the replicas is 1, for replication mode, the default replicas is 2. Value range [1, 5]. (default 1)
+      --tenancy string               The tenancy of cluster. Legal values [SharedNode, DedicatedNode]. (default "SharedNode")
+      --termination-policy string    The termination policy of cluster. Legal values [DoNotTerminate, Halt, Delete, WipeOut]. (default "Delete")
+      --version string               Cluster version.
+```
+
+### Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --disable-compression            If true, opt-out of response compression for all requests to the server
+      --dry-run string[="unchanged"]   Must be "client", or "server". If with client strategy, only print the object that would be sent, and no data is actually sent. If with server strategy, submit the server-side request, but no data is persistent. (default "none")
+      --edit                           Edit the API resource before creating
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --match-server-version           Require server version to match client version
+  -n, --namespace string               If present, the namespace scope for this CLI request
+  -o, --output format                  Prints the output in the specified format. Allowed values: JSON and YAML (default yaml)
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+### SEE ALSO
+
+* [kbcli cluster create](kbcli_cluster_create.md)	 - Create a cluster.
+
+#### Go Back to [CLI Overview](cli.md) Homepage.
+

--- a/docs/user_docs/cli/kbcli_login.md
+++ b/docs/user_docs/cli/kbcli_login.md
@@ -1,0 +1,49 @@
+---
+title: kbcli login
+---
+
+Authenticate with the KubeBlocks Cloud
+
+```
+kbcli login [flags]
+```
+
+### Options
+
+```
+  -c, --context string   Context name.
+  -h, --help             help for login
+      --no-browser       Do not open the browser for authentication.
+  -o, --org string       Organization name.
+  -r, --region string    Specify the region [jp] to log in. (default "jp")
+```
+
+### Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --disable-compression            If true, opt-out of response compression for all requests to the server
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --match-server-version           Require server version to match client version
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+### SEE ALSO
+
+
+
+#### Go Back to [CLI Overview](cli.md) Homepage.
+

--- a/docs/user_docs/cli/kbcli_logout.md
+++ b/docs/user_docs/cli/kbcli_logout.md
@@ -1,0 +1,47 @@
+---
+title: kbcli logout
+---
+
+Log out of the KubeBlocks Cloud
+
+```
+kbcli logout [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for logout
+  -r, --region string   Specify the region [jp] to log in. (default "jp")
+```
+
+### Options inherited from parent commands
+
+```
+      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --as-uid string                  UID to impersonate for the operation.
+      --cache-dir string               Default cache directory (default "$HOME/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --disable-compression            If true, opt-out of response compression for all requests to the server
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --match-server-version           Require server version to match client version
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+### SEE ALSO
+
+
+
+#### Go Back to [CLI Overview](cli.md) Homepage.
+

--- a/pkg/cli/cmd/backuprepo/backuprepo.go
+++ b/pkg/cli/cmd/backuprepo/backuprepo.go
@@ -32,9 +32,9 @@ func NewBackupRepoCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *co
 	}
 	cmd.AddCommand(
 		newCreateCommand(nil, f, streams),
-		// newUpdateCommand(f, streams), // TODO:
+		newUpdateCommand(nil, f, streams),
 		newListCommand(f, streams),
-		newDescribeCmd(f, streams), // TODO:
+		newDescribeCommand(f, streams),
 	)
 	return cmd
 }

--- a/pkg/cli/cmd/backuprepo/common.go
+++ b/pkg/cli/cmd/backuprepo/common.go
@@ -1,0 +1,58 @@
+/*
+Copyright (C) 2022-2023 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package backuprepo
+
+import (
+	"encoding/json"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	trueVal = "true"
+
+	associatedBackupRepoKey = "dataprotection.kubeblocks.io/backup-repo-name"
+)
+
+func flagsToValues(fs *pflag.FlagSet, explicit bool) map[string]string {
+	values := make(map[string]string)
+	fs.VisitAll(func(f *pflag.Flag) {
+		if f.Name == "help" || (explicit && !f.Changed) {
+			return
+		}
+		val, _ := fs.GetString(f.Name)
+		values[f.Name] = val
+	})
+	return values
+}
+
+func createPatchData(oldObj, newObj runtime.Object) ([]byte, error) {
+	oldData, err := json.Marshal(oldObj)
+	if err != nil {
+		return nil, err
+	}
+	newData, err := json.Marshal(newObj)
+	if err != nil {
+		return nil, err
+	}
+	return jsonpatch.CreateMergePatch(oldData, newData)
+}

--- a/pkg/cli/cmd/backuprepo/describe.go
+++ b/pkg/cli/cmd/backuprepo/describe.go
@@ -22,6 +22,7 @@ package backuprepo
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
@@ -38,6 +39,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/cli/printer"
 	"github.com/apecloud/kubeblocks/pkg/cli/types"
 	"github.com/apecloud/kubeblocks/pkg/cli/util"
+	"github.com/apecloud/kubeblocks/pkg/dataprotection/utils"
 )
 
 var (
@@ -60,7 +62,7 @@ type describeBackupRepoOptions struct {
 	genericiooptions.IOStreams
 }
 
-func newDescribeCmd(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
+func newDescribeCommand(f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
 	o := &describeBackupRepoOptions{
 		factory:   f,
 		IOStreams: streams,
@@ -149,6 +151,21 @@ func (o *describeBackupRepoOptions) printBackupRepo(backupRepo *dpv1alpha1.Backu
 	printer.PrintPairStringToLine("BackupPVCName", backupRepo.Status.BackupPVCName)
 	printer.PrintPairStringToLine("ObservedGeneration", fmt.Sprintf("%d", backupRepo.Status.ObservedGeneration))
 
+	printer.PrintLine("\n  Conditions:")
+	for _, cond := range backupRepo.Status.Conditions {
+		printer.PrintLine("    " + cond.Type + ":")
+		printer.PrintPairStringToLine("    Status", string(cond.Status))
+		printer.PrintPairStringToLine("    Reason", cond.Reason)
+		if !strings.Contains(cond.Message, "\n") {
+			if cond.Message != "" {
+				printer.PrintPairStringToLine("    Message", cond.Message)
+			}
+		} else {
+			printer.PrintLine("      Message:")
+			printer.PrintLine(utils.PrependSpaces(cond.Message, 8))
+		}
+	}
+
 	return nil
 }
 
@@ -157,7 +174,7 @@ func countBackupNumsAndSize(dynamic dynamic.Interface, backupRepo *dpv1alpha1.Ba
 	count := 0
 
 	backupList, err := dynamic.Resource(types.BackupGVR()).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("dataprotection.kubeblocks.io/backup-repo-name=%s", backupRepo.Name),
+		LabelSelector: fmt.Sprintf("%s=%s", associatedBackupRepoKey, backupRepo.Name),
 	})
 	if err != nil {
 		return count, humanize.Bytes(size), err

--- a/pkg/cli/cmd/backuprepo/describe_test.go
+++ b/pkg/cli/cmd/backuprepo/describe_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright (C) 2022-2023 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package backuprepo
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	clientfake "k8s.io/client-go/rest/fake"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+
+	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/cli/testing"
+)
+
+var _ = Describe("backuprepo describe command", func() {
+	var streams genericiooptions.IOStreams
+	var tf *cmdtesting.TestFactory
+
+	BeforeEach(func() {
+		streams, _, _, _ = genericiooptions.NewTestIOStreams()
+		tf = cmdtesting.NewTestFactory().WithNamespace(testing.Namespace)
+		tf.Client = &clientfake.RESTClient{}
+		repoObj := testing.FakeBackupRepo("test-backuprepo", false)
+		backupObj := testing.FakeBackup("backup1")
+		backupObj.Labels = map[string]string{associatedBackupRepoKey: "test-backuprepo"}
+		backupObj.Status.Phase = dpv1alpha1.BackupPhaseCompleted
+		backupObj.Status.TotalSize = "123456"
+		tf.FakeDynamicClient = testing.FakeDynamicClient(repoObj, backupObj)
+	})
+
+	AfterEach(func() {
+		tf.Cleanup()
+	})
+
+	It("should run", func() {
+		cmd := newDescribeCommand(tf, streams)
+		cmd.SetArgs([]string{"test-backuprepo"})
+		err := cmd.Execute()
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+})

--- a/pkg/cli/cmd/backuprepo/list_test.go
+++ b/pkg/cli/cmd/backuprepo/list_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright (C) 2022-2023 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package backuprepo
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/apecloud/kubeblocks/pkg/cli/testing"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+
+	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+)
+
+var _ = Describe("backuprepo list command", func() {
+	var streams genericiooptions.IOStreams
+	var tf *cmdtesting.TestFactory
+
+	BeforeEach(func() {
+		streams, _, _, _ = genericiooptions.NewTestIOStreams()
+		tf = cmdtesting.NewTestFactory().WithNamespace(testing.Namespace)
+		repoObj1 := testing.FakeBackupRepo("test-backuprepo", false)
+		repoObj2 := testing.FakeBackupRepo("default-backuprepo", true)
+		backupObj := testing.FakeBackup("backup1")
+		backupObj.Labels = map[string]string{associatedBackupRepoKey: "default-backuprepo"}
+		backupObj.Status.Phase = dpv1alpha1.BackupPhaseCompleted
+		backupObj.Status.TotalSize = "123456"
+		tf.FakeDynamicClient = testing.FakeDynamicClient(repoObj1, repoObj2, backupObj)
+	})
+
+	AfterEach(func() {
+		tf.Cleanup()
+	})
+
+	It("should run", func() {
+		cmd := newListCommand(tf, streams)
+		cmd.SetArgs([]string{""})
+		err := cmd.Execute()
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+})

--- a/pkg/cli/cmd/backuprepo/update.go
+++ b/pkg/cli/cmd/backuprepo/update.go
@@ -1,0 +1,369 @@
+/*
+Copyright (C) 2022-2023 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package backuprepo
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/stoewer/go-strcase"
+	"github.com/xeipuuv/gojsonschema"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/kube-openapi/pkg/validation/spec"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/templates"
+
+	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	storagev1alpha1 "github.com/apecloud/kubeblocks/apis/storage/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/cli/printer"
+	"github.com/apecloud/kubeblocks/pkg/cli/types"
+	"github.com/apecloud/kubeblocks/pkg/cli/util"
+	"github.com/apecloud/kubeblocks/pkg/cli/util/flags"
+	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
+)
+
+var (
+	updateExample = templates.Examples(`
+	# Update the credential of a S3-based backuprepo
+	kbcli backuprepo update my-backuprepo --access-key-id=<NEW ACCESS KEY> --secret-access-key=<NEW SECRET KEY>
+
+	# Set the backuprepo as default
+	kbcli backuprepo update my-backuprepo --default
+
+	# Unset the default backuprepo
+	kbcli backuprepo update my-backuprepo --default=false
+	`)
+)
+
+type updateOptions struct {
+	genericiooptions.IOStreams
+	dynamic dynamic.Interface
+	client  kubernetes.Interface
+	factory cmdutil.Factory
+
+	repo            *dpv1alpha1.BackupRepo
+	storageProvider string
+	providerObject  *storagev1alpha1.StorageProvider
+	isDefault       bool
+	hasDefaultFlag  bool
+	repoName        string
+	config          map[string]string
+	credential      map[string]string
+	allValues       map[string]string
+}
+
+func newUpdateCommand(o *updateOptions, f cmdutil.Factory, streams genericiooptions.IOStreams) *cobra.Command {
+	if o == nil {
+		o = &updateOptions{}
+	}
+	o.IOStreams = streams
+
+	cmd := &cobra.Command{
+		Use:               "update BACKUP_REPO_NAME",
+		Short:             "Update a backup repository.",
+		Example:           updateExample,
+		ValidArgsFunction: util.ResourceNameCompletionFunc(f, types.BackupRepoGVR()),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdutil.BehaviorOnFatal(printer.FatalWithRedColor)
+			util.CheckErr(o.init(f))
+			err := o.parseFlags(cmd, args, f)
+			if errors.Is(err, pflag.ErrHelp) {
+				return err
+			} else {
+				util.CheckErr(err)
+			}
+			util.CheckErr(o.complete(cmd))
+			util.CheckErr(o.validate(cmd))
+			util.CheckErr(o.run())
+			return nil
+		},
+		DisableFlagParsing: true,
+	}
+	cmd.Flags().BoolVar(&o.isDefault, "default", false, "Specify whether to set the created backup repo as default")
+
+	return cmd
+}
+
+func (o *updateOptions) init(f cmdutil.Factory) error {
+	var err error
+	if o.dynamic, err = f.DynamicClient(); err != nil {
+		return err
+	}
+	if o.client, err = f.KubernetesClientSet(); err != nil {
+		return err
+	}
+	o.factory = f
+	return nil
+}
+
+func (o *updateOptions) parseFlags(cmd *cobra.Command, args []string, f cmdutil.Factory) error {
+	// Since we disabled the flag parsing of the cmd, we need to parse it from args
+	help := false
+	tmpFlags := pflag.NewFlagSet("tmp", pflag.ContinueOnError)
+	tmpFlags.BoolVarP(&help, "help", "h", false, "") // eat --help and -h
+	tmpFlags.ParseErrorsWhitelist.UnknownFlags = true
+	_ = tmpFlags.Parse(args)
+	tmpArgs := tmpFlags.Args()
+	if len(tmpArgs) == 0 {
+		if help {
+			cmd.Long = templates.LongDesc(`
+                Note: This help information only shows the common flags for updating a
+                backup repository, to show provider-specific flags, please specify
+                the name of the backup repository to update. For example:
+
+                    kbcli backuprepo update my-backuprepo --help
+            `)
+			return pflag.ErrHelp
+		}
+		return fmt.Errorf("please specify the name of the backup repository to update")
+	}
+
+	o.repoName = tmpArgs[0]
+
+	// Get the backup repo from API server
+	obj, err := o.dynamic.Resource(types.BackupRepoGVR()).Get(
+		context.Background(), o.repoName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("backup repository \"%s\" is not found", o.repoName)
+		}
+		return err
+	}
+	repo := &dpv1alpha1.BackupRepo{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, repo)
+	if err != nil {
+		return err
+	}
+	o.repo = repo
+
+	// Get provider info from API server
+	o.storageProvider = repo.Spec.StorageProviderRef
+	obj, err = o.dynamic.Resource(types.StorageProviderGVR()).Get(
+		context.Background(), o.storageProvider, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("storage provider \"%s\" is not found", o.storageProvider)
+		}
+		return err
+	}
+	provider := &storagev1alpha1.StorageProvider{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, provider)
+	if err != nil {
+		return err
+	}
+	o.providerObject = provider
+
+	// Filter out non-credential fields
+	filtered := map[string]apiextensionsv1.JSONSchemaProps{}
+	for _, name := range provider.Spec.ParametersSchema.CredentialFields {
+		if s, ok := provider.Spec.ParametersSchema.OpenAPIV3Schema.Properties[name]; ok {
+			filtered[name] = s
+		}
+	}
+	provider.Spec.ParametersSchema.OpenAPIV3Schema.Properties = filtered
+	provider.Spec.ParametersSchema.OpenAPIV3Schema.Required = nil // all fields are optional when doing update
+
+	// Build flags by schema
+	if provider.Spec.ParametersSchema != nil &&
+		provider.Spec.ParametersSchema.OpenAPIV3Schema != nil {
+		// Convert apiextensionsv1.JSONSchemaProps to spec.Schema
+		schemaData, err := json.Marshal(provider.Spec.ParametersSchema.OpenAPIV3Schema)
+		if err != nil {
+			return err
+		}
+		schema := &spec.Schema{}
+		if err = json.Unmarshal(schemaData, schema); err != nil {
+			return err
+		}
+		if err = flags.BuildFlagsBySchema(cmd, schema); err != nil {
+			return err
+		}
+	}
+
+	// Parse dynamic flags
+	cmd.DisableFlagParsing = false
+	err = cmd.ParseFlags(args)
+	if err != nil {
+		return err
+	}
+	helpFlag := cmd.Flags().Lookup("help")
+	if helpFlag != nil && helpFlag.Value.String() == trueVal {
+		return pflag.ErrHelp
+	}
+	defaultFlag := cmd.Flags().Lookup("default")
+	if defaultFlag != nil && defaultFlag.Changed {
+		o.hasDefaultFlag = true
+	}
+
+	return nil
+}
+
+func (o *updateOptions) complete(cmd *cobra.Command) error {
+	o.config = map[string]string{}
+	o.credential = map[string]string{}
+	o.allValues = map[string]string{}
+	schema := o.providerObject.Spec.ParametersSchema
+	// Construct config and credential map from flags
+	if schema != nil && schema.OpenAPIV3Schema != nil {
+		credMap := map[string]bool{}
+		for _, x := range schema.CredentialFields {
+			credMap[x] = true
+		}
+		// Collect flags explicitly set by user
+		fromFlags := flagsToValues(cmd.LocalNonPersistentFlags(), true)
+		for name := range schema.OpenAPIV3Schema.Properties {
+			flagName := strcase.KebabCase(name)
+			if val, ok := fromFlags[flagName]; ok {
+				o.allValues[name] = val
+				if credMap[name] {
+					o.credential[name] = val
+				} else {
+					o.config[name] = val
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (o *updateOptions) validate(cmd *cobra.Command) error {
+	// Validate values by the json schema
+	schema := o.providerObject.Spec.ParametersSchema
+	if schema != nil && schema.OpenAPIV3Schema != nil {
+		schemaLoader := gojsonschema.NewGoLoader(schema.OpenAPIV3Schema)
+		docLoader := gojsonschema.NewGoLoader(o.allValues)
+		result, err := gojsonschema.Validate(schemaLoader, docLoader)
+		if err != nil {
+			return err
+		}
+		if !result.Valid() {
+			for _, err := range result.Errors() {
+				flagName := strcase.KebabCase(err.Field())
+				cmd.Printf("invalid value \"%v\" for \"--%s\": %s\n",
+					err.Value(), flagName, err.Description())
+			}
+			return fmt.Errorf("invalid flags")
+		}
+	}
+
+	// Check if there are any default backup repo already exists
+	if o.isDefault {
+		list, err := o.dynamic.Resource(types.BackupRepoGVR()).List(
+			context.Background(), metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
+		for _, item := range list.Items {
+			if item.GetName() == o.repoName {
+				continue
+			}
+			if item.GetAnnotations()[dptypes.DefaultBackupRepoAnnotationKey] == trueVal {
+				name := item.GetName()
+				return fmt.Errorf("there is already a default backup repository \"%s\","+
+					" please set \"%s\" as non-default first",
+					name, name)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (o *updateOptions) updateCredentialSecret() error {
+	if len(o.credential) == 0 {
+		// nothing to update
+		return nil
+	}
+	if o.repo.Spec.Credential == nil {
+		return nil
+	}
+	secretObj, err := o.client.CoreV1().Secrets(o.repo.Spec.Credential.Namespace).Get(
+		context.Background(), o.repo.Spec.Credential.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	original := secretObj.DeepCopy()
+	for k, v := range o.credential {
+		secretObj.Data[k] = []byte(v)
+	}
+	if reflect.DeepEqual(original.Data, secretObj.Data) {
+		// nothing to update
+		return nil
+	}
+	patchData, err := createPatchData(original, secretObj)
+	if err != nil {
+		return err
+	}
+	_, err = o.client.CoreV1().Secrets(o.repo.Spec.Credential.Namespace).Patch(
+		context.Background(), o.repo.Spec.Credential.Name, k8stypes.MergePatchType, patchData, metav1.PatchOptions{})
+	return err
+}
+
+func (o *updateOptions) updateDefaultAnnotation() error {
+	if !o.hasDefaultFlag {
+		// nothing to update
+		return nil
+	}
+	original := o.repo.DeepCopy()
+	if o.isDefault {
+		if o.repo.Annotations == nil {
+			o.repo.Annotations = map[string]string{}
+		}
+		o.repo.Annotations[dptypes.DefaultBackupRepoAnnotationKey] = trueVal
+	} else {
+		delete(o.repo.Annotations, dptypes.DefaultBackupRepoAnnotationKey)
+	}
+	if reflect.DeepEqual(original.ObjectMeta, o.repo.ObjectMeta) {
+		// nothing to update
+		return nil
+	}
+	patchData, err := createPatchData(original, o.repo)
+	if err != nil {
+		return err
+	}
+	_, err = o.dynamic.Resource(types.BackupRepoGVR()).Patch(
+		context.Background(), o.repo.Name, k8stypes.MergePatchType, patchData, metav1.PatchOptions{})
+	return err
+}
+
+func (o *updateOptions) run() error {
+	if err := o.updateCredentialSecret(); err != nil {
+		return err
+	}
+
+	if err := o.updateDefaultAnnotation(); err != nil {
+		return err
+	}
+
+	printer.PrintLine(fmt.Sprintf("Updated."))
+	return nil
+}

--- a/pkg/cli/cmd/backuprepo/update.go
+++ b/pkg/cli/cmd/backuprepo/update.go
@@ -364,6 +364,6 @@ func (o *updateOptions) run() error {
 		return err
 	}
 
-	printer.PrintLine(fmt.Sprintf("Updated."))
+	printer.PrintLine("Updated.")
 	return nil
 }

--- a/pkg/cli/cmd/backuprepo/update_test.go
+++ b/pkg/cli/cmd/backuprepo/update_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright (C) 2022-2023 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package backuprepo
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/dynamic/fake"
+	clientfake "k8s.io/client-go/rest/fake"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+
+	"github.com/apecloud/kubeblocks/pkg/cli/scheme"
+	"github.com/apecloud/kubeblocks/pkg/cli/testing"
+)
+
+var _ = Describe("backuprepo update command", func() {
+	var streams genericiooptions.IOStreams
+	var tf *cmdtesting.TestFactory
+	var cmd *cobra.Command
+	var options *updateOptions
+
+	BeforeEach(func() {
+		streams, _, _, _ = genericiooptions.NewTestIOStreams()
+		tf = cmdtesting.NewTestFactory().WithNamespace(testing.Namespace)
+		codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+		httpResp := func(obj runtime.Object) *http.Response {
+			return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, obj)}
+		}
+
+		secretObj := testing.FakeSecret("credential", testing.Namespace)
+
+		tf.UnstructuredClient = &clientfake.RESTClient{
+			NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+			Client: clientfake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+				urlPrefix := "/api/v1/namespaces/" + testing.Namespace
+				if req.URL.Path == urlPrefix+"/secrets" && req.Method == http.MethodPost {
+					dec := json.NewDecoder(req.Body)
+					secret := &corev1.Secret{}
+					_ = dec.Decode(secret)
+					if secret.Name == "" && secret.GenerateName != "" {
+						secret.Name = secret.GenerateName + "123456"
+					}
+					return httpResp(secret), nil
+				}
+				if strings.HasPrefix(req.URL.Path, urlPrefix+"/secrets") && req.Method == http.MethodPatch {
+					return httpResp(&corev1.Secret{}), nil
+				}
+				mapping := map[string]*http.Response{
+					"/api/v1/secrets": httpResp(&corev1.SecretList{}),
+					"/api/v1/namespaces/fake-namespace/secrets/credential": httpResp(secretObj),
+				}
+				return mapping[req.URL.Path], nil
+			}),
+		}
+		tf.Client = tf.UnstructuredClient
+
+		options = &updateOptions{}
+		cmd = newUpdateCommand(options, tf, streams)
+		err := options.init(tf)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		providerObj := testing.FakeStorageProvider("fake-storage-provider", nil)
+		repoObj1 := testing.FakeBackupRepo("backuprepo-non-existent-provider", false)
+		repoObj1.Spec.StorageProviderRef = "non-existent"
+		repoObj2 := testing.FakeBackupRepo("default-backuprepo", true)
+		repoObj3 := testing.FakeBackupRepo("test-backuprepo", false)
+		repoObj3.Spec.Credential = &corev1.SecretReference{
+			Name:      "credential",
+			Namespace: testing.Namespace,
+		}
+		tf.FakeDynamicClient = fake.NewSimpleDynamicClient(
+			scheme.Scheme, providerObj, repoObj1, repoObj2, repoObj3)
+		err = options.init(tf)
+		Expect(err).ShouldNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		tf.Cleanup()
+	})
+
+	Describe("parseFlags", func() {
+		It("should fail if backuprepo name is not specified", func() {
+			err := options.parseFlags(cmd, []string{}, tf)
+			Expect(err).Should(MatchError(ContainSubstring("please specify the name of the backup repository to update")))
+		})
+
+		It("should fail if the backuprepo is not existing", func() {
+			err := options.parseFlags(cmd, []string{"non-existent"}, tf)
+			Expect(err).Should(MatchError(ContainSubstring("backup repository \"non-existent\" is not found")))
+		})
+
+		It("should fail if the referenced storage provider is not existing", func() {
+			err := options.parseFlags(cmd, []string{"backuprepo-non-existent-provider"}, tf)
+			Expect(err).Should(MatchError(ContainSubstring("storage provider \"non-existent\" is not found")))
+		})
+
+		It("should able to parse flags", func() {
+			err := options.parseFlags(cmd, []string{"test-backuprepo"}, tf)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("should fail to parse unknown flags", func() {
+			err := options.parseFlags(cmd, []string{"test-backuprepo", "--foo", "abc"}, tf)
+			Expect(err).Should(MatchError(ContainSubstring("unknown flag: --foo")))
+		})
+
+		It("should only parse flags about credential", func() {
+			err := options.parseFlags(cmd, []string{"test-backuprepo", "--region", "us-west-2"}, tf)
+			Expect(err).Should(MatchError(ContainSubstring("unknown flag: --region")))
+		})
+
+		It("should return ErrHelp if --help is specified", func() {
+			err := options.parseFlags(cmd, []string{"test-backuprepo", "--help"}, tf)
+			Expect(err).Should(MatchError(pflag.ErrHelp))
+		})
+	})
+
+	Describe("complete", func() {
+		It("should set fields in updateOptions", func() {
+			err := options.parseFlags(cmd, []string{
+				"test-backuprepo",
+				"--access-key-id", "",
+				"--secret-access-key", "def",
+			}, tf)
+			Expect(err).ShouldNot(HaveOccurred())
+			err = options.complete(cmd)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(options.repoName).Should(Equal("test-backuprepo"))
+			Expect(options.allValues).Should(Equal(map[string]string{
+				"accessKeyId":     "",
+				"secretAccessKey": "def",
+			}))
+			Expect(options.credential).Should(Equal(map[string]string{
+				"accessKeyId":     "",
+				"secretAccessKey": "def",
+			}))
+		})
+	})
+
+	Describe("validate", func() {
+		BeforeEach(func() {
+			err := options.parseFlags(cmd, []string{
+				"test-backuprepo", "--access-key-id", "abc", "--secret-access-key", "def",
+			}, tf)
+			Expect(err).ShouldNot(HaveOccurred())
+			err = options.complete(cmd)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("should validate if there is a default backup repo", func() {
+			options.isDefault = true
+			options.hasDefaultFlag = true
+			err := options.validate(cmd)
+			Expect(err).Should(MatchError(ContainSubstring("there is already a default backup repo")))
+		})
+	})
+
+	Describe("run", func() {
+		It("should update the credential secret", func() {
+			cmd.SetArgs([]string{"test-backuprepo", "--access-key-id", "foo", "--secret-access-key", "bar"})
+			err := cmd.Execute()
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("should unset the default backuprepo", func() {
+			cmd.SetArgs([]string{"default-backuprepo", "--default=false"})
+			err := cmd.Execute()
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("should set the backuprepo as default", func() {
+			providerObj := testing.FakeStorageProvider("fake-storage-provider", nil)
+			repoObj := testing.FakeBackupRepo("test-backuprepo", false)
+			tf.FakeDynamicClient = fake.NewSimpleDynamicClient(scheme.Scheme, providerObj, repoObj)
+			err := options.init(tf)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			cmd.SetArgs([]string{"test-backuprepo", "--default"})
+			err = cmd.Execute()
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+})

--- a/pkg/dataprotection/utils/utils.go
+++ b/pkg/dataprotection/utils/utils.go
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package utils
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"reflect"
@@ -215,4 +216,26 @@ func GetBackupType(actionSet *dpv1alpha1.ActionSet, useSnapshot *bool) dpv1alpha
 		return dpv1alpha1.BackupTypeFull
 	}
 	return ""
+}
+
+// PrependSpaces prepends spaces to each line of the content.
+func PrependSpaces(content string, spaces int) string {
+	prefix := ""
+	for i := 0; i < spaces; i++ {
+		prefix += " "
+	}
+	r := bytes.NewBufferString(content)
+	w := bytes.NewBuffer(nil)
+	w.Grow(r.Len())
+	for {
+		line, err := r.ReadString('\n')
+		if len(line) > 0 {
+			w.WriteString(prefix)
+			w.WriteString(line)
+		}
+		if err != nil {
+			break
+		}
+	}
+	return w.String()
 }


### PR DESCRIPTION
* Add update subcommand, which can be used to modify the storage authentication credentials, and also to make a backupRepo the global default repo (or vice versa)
* Enhance describe subcommand, to better show the reason for pre-check failure
* Add unit tests, to improve test coverage