### PR TITLE
fix: pg cluster connect fail

### DIFF
--- a/pkg/lorry/engines/foxlake/commands.go
+++ b/pkg/lorry/engines/foxlake/commands.go
@@ -63,7 +63,7 @@ func (r *Commands) ConnectCommand(connectInfo *engines.AuthInfo) []string {
 		userPass = connectInfo.UserPasswd
 	}
 
-	foxlakeCmd := []string{fmt.Sprintf("%s mysql://%s:%s@:${serverPort}", r.info.Client, userName, userPass)}
+	foxlakeCmd := []string{fmt.Sprintf("%s %s", r.info.Client, engines.AddSingleQuote(fmt.Sprintf("mysql://%s:%s@:${serverPort}", userName, userPass)))}
 
 	return []string{"sh", "-c", strings.Join(foxlakeCmd, " ")}
 }

--- a/pkg/lorry/engines/mongodb/commands.go
+++ b/pkg/lorry/engines/mongodb/commands.go
@@ -64,7 +64,7 @@ func (r Commands) ConnectCommand(connectInfo *engines.AuthInfo) []string {
 		userPass = connectInfo.UserPasswd
 	}
 
-	mongodbCmd := []string{fmt.Sprintf("export CLIENT=`which mongosh>/dev/null&&echo %s||echo mongo`; $CLIENT mongodb://%s:%s@$KB_POD_FQDN:27017/admin?replicaSet=$KB_CLUSTER_COMP_NAME", r.info.Client, userName, userPass)}
+	mongodbCmd := []string{fmt.Sprintf("export CLIENT=`which mongosh>/dev/null&&echo %s||echo mongo`; $CLIENT %s", r.info.Client, engines.AddSingleQuote(fmt.Sprintf("mongodb://%s:%s@$KB_POD_FQDN:27017/admin?replicaSet=$KB_CLUSTER_COMP_NAME", userName, userPass)))}
 
 	return []string{"sh", "-c", strings.Join(mongodbCmd, " ")}
 }

--- a/pkg/lorry/engines/mysql/commands.go
+++ b/pkg/lorry/engines/mysql/commands.go
@@ -268,7 +268,7 @@ func (m *Commands) ConnectCommand(connectInfo *engines.AuthInfo) []string {
 	// MYSQL_PWD is deprecated as of MySQL 8.0; expect it to be removed in a future version of MySQL.
 	// ref to mysql manual for more details.
 	// https://dev.mysql.com/doc/refman/8.0/en/environment-variables.html
-	mysqlCmd := []string{fmt.Sprintf("%s -u%s -p%s", m.info.Client, userName, userPass)}
+	mysqlCmd := []string{fmt.Sprintf("%s -u%s -p%s", m.info.Client, engines.AddSingleQuote(userName), engines.AddSingleQuote(userPass))}
 
 	return []string{"sh", "-c", strings.Join(mysqlCmd, " ")}
 }

--- a/pkg/lorry/engines/nebula/commands.go
+++ b/pkg/lorry/engines/nebula/commands.go
@@ -61,7 +61,7 @@ func (r *Commands) ConnectCommand(connectInfo *engines.AuthInfo) []string {
 		userPass = connectInfo.UserPasswd
 	}
 
-	nebulaCmd := []string{fmt.Sprintf("%s --addr $GRAPHD_SVC_NAME --port $GRAPHD_SVC_PORT --user %s --password %s", r.info.Client, userName, userPass)}
+	nebulaCmd := []string{fmt.Sprintf("%s --addr $GRAPHD_SVC_NAME --port $GRAPHD_SVC_PORT --user %s --password %s", r.info.Client, userName, engines.AddSingleQuote(userPass))}
 
 	return []string{"sh", "-c", strings.Join(nebulaCmd, " ")}
 }

--- a/pkg/lorry/engines/oceanbase/commands.go
+++ b/pkg/lorry/engines/oceanbase/commands.go
@@ -64,7 +64,7 @@ func (r *Commands) ConnectCommand(connectInfo *engines.AuthInfo) []string {
 	var obCmd []string
 
 	if userPass != "" {
-		obCmd = []string{fmt.Sprintf("%s -h127.0.0.1 -P2881 -u%s -A -p%s", r.info.Client, userName, userPass)}
+		obCmd = []string{fmt.Sprintf("%s -h127.0.0.1 -P2881 -u%s -A -p%s", r.info.Client, userName, engines.AddSingleQuote(userPass))}
 	} else {
 		obCmd = []string{fmt.Sprintf("%s -h127.0.0.1 -P2881 -u%s -A", r.info.Client, userName)}
 	}

--- a/pkg/lorry/engines/postgres/commands.go
+++ b/pkg/lorry/engines/postgres/commands.go
@@ -248,7 +248,7 @@ func (m *Commands) ConnectCommand(connectInfo *engines.AuthInfo) []string {
 
 	// please refer to PostgreSQL documentation for more details
 	// https://www.postgresql.org/docs/current/libpq-envars.html
-	cmd := []string{fmt.Sprintf("PGUSER=%s PGPASSWORD=%s PGDATABASE=%s %s", userName, userPass, m.info.Database, m.info.Client)}
+	cmd := []string{fmt.Sprintf("PGUSER=\"%s\" PGPASSWORD=\"%s\" PGDATABASE=%s %s", userName, userPass, m.info.Database, m.info.Client)}
 	return []string{"sh", "-c", strings.Join(cmd, " ")}
 }
 

--- a/pkg/lorry/engines/postgres/commands.go
+++ b/pkg/lorry/engines/postgres/commands.go
@@ -248,7 +248,7 @@ func (m *Commands) ConnectCommand(connectInfo *engines.AuthInfo) []string {
 
 	// please refer to PostgreSQL documentation for more details
 	// https://www.postgresql.org/docs/current/libpq-envars.html
-	cmd := []string{fmt.Sprintf("PGUSER=\"%s\" PGPASSWORD=\"%s\" PGDATABASE=%s %s", userName, userPass, m.info.Database, m.info.Client)}
+	cmd := []string{fmt.Sprintf("PGUSER=%s PGPASSWORD=%s PGDATABASE=%s %s", engines.AddSingleQuote(userName), engines.AddSingleQuote(userPass), m.info.Database, m.info.Client)}
 	return []string{"sh", "-c", strings.Join(cmd, " ")}
 }
 

--- a/pkg/lorry/engines/redis/commands.go
+++ b/pkg/lorry/engines/redis/commands.go
@@ -58,8 +58,8 @@ func (r Commands) ConnectCommand(connectInfo *engines.AuthInfo) []string {
 	}
 
 	if connectInfo != nil {
-		redisCmd = append(redisCmd, "--user", connectInfo.UserName)
-		redisCmd = append(redisCmd, "--pass", connectInfo.UserPasswd)
+		redisCmd = append(redisCmd, "--user", engines.AddSingleQuote(connectInfo.UserName))
+		redisCmd = append(redisCmd, "--pass", engines.AddSingleQuote(connectInfo.UserPasswd))
 	}
 	return []string{"sh", "-c", strings.Join(redisCmd, " ")}
 }

--- a/pkg/lorry/engines/util.go
+++ b/pkg/lorry/engines/util.go
@@ -47,4 +47,8 @@ func GetIndex(memberName string) (int, error) {
 	return strconv.Atoi(memberName[i+1:])
 }
 
+func AddSingleQuote(str string) string {
+	return "'" + str + "'"
+}
+
 type Properties map[string]string


### PR DESCRIPTION
- fix #5855

![e1a698e2-5613-49d9-a801-c671a6c0d758](https://github.com/apecloud/kubeblocks/assets/101848970/aae96781-d488-4e82-92e2-cf3cc1b29cd3)
![d280865c-f5ef-4925-86b4-5a470fc55223](https://github.com/apecloud/kubeblocks/assets/101848970/04e75939-6614-4ba6-923e-0f62a5c154f4)
The password needs to be enclosed in quotation marks because it may contain special characters such as '&'.

Test:
- [x] mysql
![image](https://github.com/apecloud/kubeblocks/assets/101848970/7113e02a-36ca-4945-b6bc-37d5b4fc32e2)
![image](https://github.com/apecloud/kubeblocks/assets/101848970/738d1335-012b-4129-b34c-58c00902e106)
- [x] postgres
![image](https://github.com/apecloud/kubeblocks/assets/101848970/acabb71f-d7e2-4889-9598-7b86f7ead926)
- [x] redis
![image](https://github.com/apecloud/kubeblocks/assets/101848970/738d1335-012b-4129-b34c-58c00902e106)
- [ ] mongodb : mongodb cluster create failed: https://github.com/apecloud/kubeblocks/issues/5863
- [ ] foxlake : foxlake connect will fix in the other PR due to https://github.com/apecloud/kubeblocks/issues/5864
- [x] nebula : no need change due to the password is always 'nebula'
- [ ] oceanbase
- [x] pulsar : no need change