### PR TITLE
feat: support queue for opsRequest which cannot run concurrently.

### DIFF
--- a/apis/apps/v1alpha1/opsrequest_conditions.go
+++ b/apis/apps/v1alpha1/opsrequest_conditions.go
@@ -25,23 +25,23 @@ import (
 
 const (
 	// condition types
-	ConditionTypeCancelled         = "Cancelled"
-	ConditionTypeProgressing       = "Progressing"
-	ConditionTypeValidated         = "Validated"
-	ConditionTypeSucceed           = "Succeed"
-	ConditionTypeFailed            = "Failed"
-	ConditionTypeRestarting        = "Restarting"
-	ConditionTypeVerticalScaling   = "VerticalScaling"
-	ConditionTypeHorizontalScaling = "HorizontalScaling"
-	ConditionTypeVolumeExpanding   = "VolumeExpanding"
-	ConditionTypeReconfigure       = "Reconfigure"
-	ConditionTypeSwitchover        = "Switchover"
-	ConditionTypeStop              = "Stopping"
-	ConditionTypeStart             = "Starting"
-	ConditionTypeVersionUpgrading  = "VersionUpgrading"
-	ConditionTypeExpose            = "Exposing"
-	ConditionTypeDataScript        = "ExecuteDataScript"
-	ConditionTypeBackup            = "Backup"
+	ConditionTypeCancelled          = "Cancelled"
+	ConditionTypeWaitForProgressing = "WaitForProgressing"
+	ConditionTypeValidated          = "Validated"
+	ConditionTypeSucceed            = "Succeed"
+	ConditionTypeFailed             = "Failed"
+	ConditionTypeRestarting         = "Restarting"
+	ConditionTypeVerticalScaling    = "VerticalScaling"
+	ConditionTypeHorizontalScaling  = "HorizontalScaling"
+	ConditionTypeVolumeExpanding    = "VolumeExpanding"
+	ConditionTypeReconfigure        = "Reconfigure"
+	ConditionTypeSwitchover         = "Switchover"
+	ConditionTypeStop               = "Stopping"
+	ConditionTypeStart              = "Starting"
+	ConditionTypeVersionUpgrading   = "VersionUpgrading"
+	ConditionTypeExpose             = "Exposing"
+	ConditionTypeDataScript         = "ExecuteDataScript"
+	ConditionTypeBackup             = "Backup"
 
 	// condition and event reasons
 
@@ -61,20 +61,21 @@ const (
 	ReasonOpsCanceling             = "Canceling"
 	ReasonOpsCancelFailed          = "CancelFailed"
 	ReasonOpsCancelSucceed         = "CancelSucceed"
+	ReasonOpsCancelByController    = "CancelByController"
 )
 
 func (r *OpsRequest) SetStatusCondition(condition metav1.Condition) {
 	meta.SetStatusCondition(&r.Status.Conditions, condition)
 }
 
-// NewProgressingCondition the controller is progressing the OpsRequest
-func NewProgressingCondition(ops *OpsRequest) *metav1.Condition {
+// NewWaitForProcessingCondition waits the controller to process the opsRequest.
+func NewWaitForProcessingCondition(ops *OpsRequest) *metav1.Condition {
 	return &metav1.Condition{
-		Type:               ConditionTypeProgressing,
+		Type:               ConditionTypeWaitForProgressing,
 		Status:             metav1.ConditionTrue,
-		Reason:             "OpsRequestProgressingStarted",
+		Reason:             ConditionTypeWaitForProgressing,
 		LastTransitionTime: metav1.Now(),
-		Message: fmt.Sprintf("Start to process the OpsRequest: %s in Cluster: %s",
+		Message: fmt.Sprintf("wait for the controller to process the OpsRequest: %s in Cluster: %s",
 			ops.Name, ops.Spec.ClusterRef),
 	}
 }

--- a/apis/apps/v1alpha1/opsrequest_conditions_test.go
+++ b/apis/apps/v1alpha1/opsrequest_conditions_test.go
@@ -25,7 +25,6 @@ import (
 
 func TestNewAllCondition(t *testing.T) {
 	opsRequest := createTestOpsRequest("mysql-test", "mysql-restart", RestartType)
-	NewProgressingCondition(opsRequest)
 	NewVolumeExpandingCondition(opsRequest)
 	NewRestartingCondition(opsRequest)
 	NewHorizontalScalingCondition(opsRequest)
@@ -58,7 +57,7 @@ func TestNewAllCondition(t *testing.T) {
 
 func TestSetStatusCondition(t *testing.T) {
 	opsRequest := createTestOpsRequest("mysql-test", "mysql-restart", RestartType)
-	progressingCondition := NewProgressingCondition(opsRequest)
+	progressingCondition := NewVerticalScalingCondition(opsRequest)
 	opsRequest.SetStatusCondition(*progressingCondition)
 	checkCondition := meta.FindStatusCondition(opsRequest.Status.Conditions, progressingCondition.Type)
 	if checkCondition == nil {

--- a/apis/apps/v1alpha1/opsrequest_webhook_test.go
+++ b/apis/apps/v1alpha1/opsrequest_webhook_test.go
@@ -76,14 +76,6 @@ var _ = Describe("OpsRequest webhook", func() {
 		cleanupObjects()
 	})
 
-	/*	addClusterRequestAnnotation := func(cluster *Cluster, opsName string, toClusterPhase ClusterPhase) {
-		clusterPatch := client.MergeFrom(cluster.DeepCopy())
-		cluster.Annotations = map[string]string{
-			opsRequestAnnotationKey: fmt.Sprintf(`[{"name":"%s","clusterPhase":"%s"}]`, opsName, toClusterPhase),
-		}
-		Expect(k8sClient.Patch(ctx, cluster, clusterPatch)).Should(Succeed())
-	}*/
-
 	createStorageClass := func(ctx context.Context, storageClassName string, isDefault string, allowVolumeExpansion bool) *storagev1.StorageClass {
 		storageClass := &storagev1.StorageClass{
 			ObjectMeta: metav1.ObjectMeta{
@@ -165,13 +157,6 @@ var _ = Describe("OpsRequest webhook", func() {
 		clusterPatch := client.MergeFrom(cluster.DeepCopy())
 		cluster.Status.Phase = RunningClusterPhase
 		Expect(k8sClient.Status().Patch(ctx, cluster, clusterPatch)).Should(Succeed())
-
-		/*By("Test existing other operations in cluster")
-		// update cluster existing operations
-		addClusterRequestAnnotation(cluster, "testOpsName", UpdatingClusterPhase)
-		Expect(testCtx.CreateObj(ctx, opsRequest).Error()).Should(ContainSubstring("existing OpsRequest: testOpsName"))
-		// test opsRequest reentry
-		addClusterRequestAnnotation(cluster, opsRequest.Name, UpdatingClusterPhase)*/
 
 		By("By creating a upgrade opsRequest, it should be succeed")
 		opsRequest.Spec.Upgrade.ClusterVersionRef = newClusterVersion.Name

--- a/apis/apps/v1alpha1/opsrequest_webhook_test.go
+++ b/apis/apps/v1alpha1/opsrequest_webhook_test.go
@@ -76,13 +76,13 @@ var _ = Describe("OpsRequest webhook", func() {
 		cleanupObjects()
 	})
 
-	addClusterRequestAnnotation := func(cluster *Cluster, opsName string, toClusterPhase ClusterPhase) {
+	/*	addClusterRequestAnnotation := func(cluster *Cluster, opsName string, toClusterPhase ClusterPhase) {
 		clusterPatch := client.MergeFrom(cluster.DeepCopy())
 		cluster.Annotations = map[string]string{
 			opsRequestAnnotationKey: fmt.Sprintf(`[{"name":"%s","clusterPhase":"%s"}]`, opsName, toClusterPhase),
 		}
 		Expect(k8sClient.Patch(ctx, cluster, clusterPatch)).Should(Succeed())
-	}
+	}*/
 
 	createStorageClass := func(ctx context.Context, storageClassName string, isDefault string, allowVolumeExpansion bool) *storagev1.StorageClass {
 		storageClass := &storagev1.StorageClass{
@@ -166,12 +166,12 @@ var _ = Describe("OpsRequest webhook", func() {
 		cluster.Status.Phase = RunningClusterPhase
 		Expect(k8sClient.Status().Patch(ctx, cluster, clusterPatch)).Should(Succeed())
 
-		By("Test existing other operations in cluster")
+		/*By("Test existing other operations in cluster")
 		// update cluster existing operations
 		addClusterRequestAnnotation(cluster, "testOpsName", UpdatingClusterPhase)
 		Expect(testCtx.CreateObj(ctx, opsRequest).Error()).Should(ContainSubstring("existing OpsRequest: testOpsName"))
 		// test opsRequest reentry
-		addClusterRequestAnnotation(cluster, opsRequest.Name, UpdatingClusterPhase)
+		addClusterRequestAnnotation(cluster, opsRequest.Name, UpdatingClusterPhase)*/
 
 		By("By creating a upgrade opsRequest, it should be succeed")
 		opsRequest.Spec.Upgrade.ClusterVersionRef = newClusterVersion.Name

--- a/apis/apps/v1alpha1/type.go
+++ b/apis/apps/v1alpha1/type.go
@@ -351,16 +351,17 @@ const (
 )
 
 type OpsRequestBehaviour struct {
-	FromClusterPhases                  []ClusterPhase
-	ToClusterPhase                     ClusterPhase
-	ProcessingReasonInClusterCondition string
+	FromClusterPhases []ClusterPhase
+	ToClusterPhase    ClusterPhase
 }
 
 type OpsRecorder struct {
 	// name OpsRequest name
 	Name string `json:"name"`
-	// clusterPhase the cluster phase when the OpsRequest is running
+	// opsRequest type
 	Type OpsType `json:"type"`
+	// indicates whether the current opsRequest is in the queue
+	InQueue bool `json:"inQueue,omitempty"`
 }
 
 // ProvisionPolicyType defines the policy for creating accounts.

--- a/apis/apps/v1alpha1/webhook_suite_test.go
+++ b/apis/apps/v1alpha1/webhook_suite_test.go
@@ -159,8 +159,6 @@ var _ = BeforeSuite(func() {
 
 	RegisterWebhookManager(mgr)
 
-	testCtx = testutil.NewDefaultTestContext(ctx, k8sClient, testEnv)
-
 	err = (&ComponentDefinition{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/controllers/apps/component_controller.go
+++ b/controllers/apps/component_controller.go
@@ -213,11 +213,12 @@ func (r *ComponentReconciler) filterComponentResources(ctx context.Context, obj 
 	if _, ok := labels[constant.KBAppComponentLabelKey]; !ok {
 		return []reconcile.Request{}
 	}
+	fullCompName := constant.GenerateClusterComponentName(labels[constant.AppInstanceLabelKey], labels[constant.KBAppComponentLabelKey])
 	return []reconcile.Request{
 		{
 			NamespacedName: types.NamespacedName{
 				Namespace: obj.GetNamespace(),
-				Name:      obj.GetName(),
+				Name:      fullCompName,
 			},
 		},
 	}

--- a/controllers/apps/operations/backup.go
+++ b/controllers/apps/operations/backup.go
@@ -44,9 +44,8 @@ var _ OpsHandler = BackupOpsHandler{}
 func init() {
 	// ToClusterPhase is not defined, because 'backup' does not affect the cluster phase.
 	backupBehaviour := OpsBehaviour{
-		FromClusterPhases:                  appsv1alpha1.GetClusterUpRunningPhases(),
-		OpsHandler:                         BackupOpsHandler{},
-		ProcessingReasonInClusterCondition: ProcessingReasonBackup,
+		FromClusterPhases: appsv1alpha1.GetClusterUpRunningPhases(),
+		OpsHandler:        BackupOpsHandler{},
 	}
 
 	opsMgr := GetOpsManager()

--- a/controllers/apps/operations/backup_test.go
+++ b/controllers/apps/operations/backup_test.go
@@ -75,6 +75,8 @@ var _ = Describe("Backup OpsRequest", func() {
 		It("should create a backup resource for cluster", func() {
 			By("create Backup OpsRequest")
 			opsRes.OpsRequest = createBackupOpsObj(clusterName, "backup-ops-"+randomStr)
+			// set ops phase to Pending
+			opsRes.OpsRequest.Status.Phase = appsv1alpha1.OpsPendingPhase
 
 			By("mock backup OpsRequest is Running")
 			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)

--- a/controllers/apps/operations/datascript_test.go
+++ b/controllers/apps/operations/datascript_test.go
@@ -89,6 +89,7 @@ var _ = Describe("DataScriptOps", func() {
 		}
 		ops.Spec.TTLSecondsBeforeAbort = int32Ptr(ttlBeforeAbort)
 		Expect(testCtx.CreateObj(testCtx.Ctx, ops)).Should(Succeed())
+		ops.Status.Phase = appsv1alpha1.OpsPendingPhase
 		return ops
 	}
 
@@ -178,7 +179,7 @@ var _ = Describe("DataScriptOps", func() {
 			reqCtx.Req = reconcile.Request{NamespacedName: opsKey}
 			By("check the opsRequest phase, should fail")
 			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsResource)
-			Expect(err).Should(HaveOccurred())
+			Expect(err).ShouldNot(HaveOccurred())
 			Expect(ops.Status.Phase).Should(Equal(appsv1alpha1.OpsFailedPhase))
 		})
 
@@ -217,7 +218,7 @@ var _ = Describe("DataScriptOps", func() {
 			reqCtx.Req = reconcile.Request{NamespacedName: opsKey}
 			By("check the opsRequest phase, should fail, cause pod is missing")
 			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsResource)
-			Expect(err).Should(HaveOccurred())
+			Expect(err).ShouldNot(HaveOccurred())
 			Expect(ops.Status.Phase).Should(Equal(appsv1alpha1.OpsFailedPhase))
 		})
 

--- a/controllers/apps/operations/expose_test.go
+++ b/controllers/apps/operations/expose_test.go
@@ -85,6 +85,8 @@ var _ = Describe("", func() {
 				},
 			}
 			opsRes.OpsRequest = testapps.CreateOpsRequest(ctx, testCtx, ops)
+			// set ops phase to Pending
+			opsRes.OpsRequest.Status.Phase = appsv1alpha1.OpsPendingPhase
 
 			By("mock expose OpsRequest phase is Creating")
 			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)

--- a/controllers/apps/operations/horizontal_scaling.go
+++ b/controllers/apps/operations/horizontal_scaling.go
@@ -39,11 +39,10 @@ func init() {
 	horizontalScalingBehaviour := OpsBehaviour{
 		// if cluster is Abnormal or Failed, new opsRequest may repair it.
 		// TODO: we should add "force" flag for these opsRequest.
-		FromClusterPhases:                  appsv1alpha1.GetClusterUpRunningPhases(),
-		ToClusterPhase:                     appsv1alpha1.UpdatingClusterPhase,
-		OpsHandler:                         hsHandler,
-		CancelFunc:                         hsHandler.Cancel,
-		ProcessingReasonInClusterCondition: ProcessingReasonHorizontalScaling,
+		FromClusterPhases: appsv1alpha1.GetClusterUpRunningPhases(),
+		ToClusterPhase:    appsv1alpha1.UpdatingClusterPhase,
+		OpsHandler:        hsHandler,
+		CancelFunc:        hsHandler.Cancel,
 	}
 	opsMgr := GetOpsManager()
 	opsMgr.RegisterOps(appsv1alpha1.HorizontalScalingType, horizontalScalingBehaviour)

--- a/controllers/apps/operations/ops_progress_util_test.go
+++ b/controllers/apps/operations/ops_progress_util_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Ops ProgressDetails", func() {
 	AfterEach(cleanEnv)
 
 	initClusterForOps := func(opsRes *OpsResource) {
-		Expect(opsutil.PatchClusterOpsAnnotations(ctx, k8sClient, opsRes.Cluster, nil)).Should(Succeed())
+		Expect(opsutil.UpdateClusterOpsAnnotations(ctx, k8sClient, opsRes.Cluster, nil)).Should(Succeed())
 		opsRes.Cluster.Status.Phase = appsv1alpha1.RunningClusterPhase
 	}
 

--- a/controllers/apps/operations/ops_util.go
+++ b/controllers/apps/operations/ops_util.go
@@ -28,6 +28,7 @@ import (
 
 	"golang.org/x/exp/slices"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -40,8 +41,12 @@ import (
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 )
 
-// componentFailedTimeout when the duration of component failure exceeds this threshold, it is determined that opsRequest has failed
-const componentFailedTimeout = 30 * time.Second
+const (
+	// componentFailedTimeout when the duration of component failure exceeds this threshold, it is determined that opsRequest has failed
+	componentFailedTimeout = 30 * time.Second
+
+	opsRequestQueueLimitSize = 10
+)
 
 var _ error = &WaitForClusterPhaseErr{}
 
@@ -227,17 +232,17 @@ func PatchOpsStatusWithOpsDeepCopy(ctx context.Context,
 		}
 		opsRes.Recorder.Event(opsRequest, eventType, v.Reason, v.Message)
 	}
+	opsRequest.Status.Phase = phase
 	if opsRequest.IsComplete(phase) {
 		opsRequest.Status.CompletionTimestamp = metav1.Time{Time: time.Now()}
 		// when OpsRequest is completed, remove it from annotation
-		if err := DeleteOpsRequestAnnotationInCluster(ctx, cli, opsRes); err != nil {
+		if err := DequeueOpsRequestInClusterAnnotation(ctx, cli, opsRes); err != nil {
 			return err
 		}
 	}
-	if phase == appsv1alpha1.OpsCreatingPhase && opsRequest.Status.Phase != phase {
+	if phase == appsv1alpha1.OpsCreatingPhase && opsRequest.Status.StartTimestamp.IsZero() {
 		opsRequest.Status.StartTimestamp = metav1.Time{Time: time.Now()}
 	}
-	opsRequest.Status.Phase = phase
 	return cli.Status().Patch(ctx, opsRequest, patch)
 }
 
@@ -303,9 +308,9 @@ func patchOpsRequestToCreating(reqCtx intctrlutil.RequestCtx,
 	return PatchOpsStatusWithOpsDeepCopy(reqCtx.Ctx, cli, opsRes, opsDeepCoy, appsv1alpha1.OpsCreatingPhase, validatePassCondition, condition)
 }
 
-// DeleteOpsRequestAnnotationInCluster when OpsRequest.status.phase is Succeeded or Failed
+// DequeueOpsRequestInClusterAnnotation when OpsRequest.status.phase is Succeeded or Failed
 // we should remove the OpsRequest Annotation of cluster, then unlock cluster
-func DeleteOpsRequestAnnotationInCluster(ctx context.Context, cli client.Client, opsRes *OpsResource) error {
+func DequeueOpsRequestInClusterAnnotation(ctx context.Context, cli client.Client, opsRes *OpsResource) error {
 	var (
 		opsRequestSlice []appsv1alpha1.OpsRecorder
 		err             error
@@ -313,43 +318,87 @@ func DeleteOpsRequestAnnotationInCluster(ctx context.Context, cli client.Client,
 	if opsRequestSlice, err = opsutil.GetOpsRequestSliceFromCluster(opsRes.Cluster); err != nil {
 		return err
 	}
-	index, opsRecord := GetOpsRecorderFromSlice(opsRequestSlice, opsRes.OpsRequest.Name)
-	if opsRecord.Name == "" {
+	index, _ := GetOpsRecorderFromSlice(opsRequestSlice, opsRes.OpsRequest.Name)
+	if index == -1 {
 		return nil
 	}
-	// delete the opsRequest information in Cluster.annotations
-	opsRequestSlice = slices.Delete(opsRequestSlice, index, index+1)
-	return opsutil.PatchClusterOpsAnnotations(ctx, cli, opsRes.Cluster, opsRequestSlice)
+	if opsRes.OpsRequest.Status.Phase == appsv1alpha1.OpsFailedPhase && index == 0 {
+		// 1. update all pending opsRequest phase to Cancelled if the head opsRequest is Failed.
+		for i := 1; i < len(opsRequestSlice); i++ {
+			ops := &appsv1alpha1.OpsRequest{}
+			if err = cli.Get(ctx, client.ObjectKey{Name: opsRequestSlice[i].Name, Namespace: opsRes.OpsRequest.Namespace}, ops); err != nil {
+				if apierrors.IsNotFound(err) {
+					continue
+				}
+				return err
+			}
+			patch := client.MergeFrom(ops.DeepCopy())
+			ops.Status.Phase = appsv1alpha1.OpsCancelledPhase
+			ops.Status.CompletionTimestamp = metav1.Time{Time: time.Now()}
+			ops.SetStatusCondition(metav1.Condition{
+				Type:    appsv1alpha1.ConditionTypeCancelled,
+				Reason:  appsv1alpha1.ReasonOpsCancelByController,
+				Status:  metav1.ConditionTrue,
+				Message: fmt.Sprintf(`Cancelled by controller due to the failure of previous OpsRequest "%s"`, opsRes.OpsRequest.Name),
+			})
+			if err = cli.Status().Patch(ctx, ops, patch); err != nil && apierrors.IsNotFound(err) {
+				return err
+			}
+		}
+		// 2. cleanup opsRequest queue
+		opsRequestSlice = nil
+	} else {
+		// delete the opsRequest in Cluster.annotations
+		opsRequestSlice = slices.Delete(opsRequestSlice, index, index+1)
+	}
+	return opsutil.UpdateClusterOpsAnnotations(ctx, cli, opsRes.Cluster, opsRequestSlice)
 }
 
-// addOpsRequestAnnotationToCluster adds the OpsRequest Annotation to Cluster.metadata.Annotations to acquire the lock.
-func addOpsRequestAnnotationToCluster(ctx context.Context, cli client.Client, opsRes *OpsResource, opsBehaviour OpsBehaviour) error {
+// enqueueOpsRequestToClusterAnnotation adds the OpsRequest Annotation to Cluster.metadata.Annotations to acquire the lock.
+func enqueueOpsRequestToClusterAnnotation(ctx context.Context, cli client.Client, opsRes *OpsResource, opsBehaviour OpsBehaviour) ([]appsv1alpha1.OpsRecorder, error) {
 	var (
 		opsRequestSlice []appsv1alpha1.OpsRecorder
 		err             error
 	)
 	if opsBehaviour.ToClusterPhase == "" {
-		return nil
+		return nil, nil
 	}
-	// if the running opsRequest is deleted, do not patch the opsRequest annotation on cluster.
+	// if the running opsRequest is deleted, do not enqueue the opsRequest to cluster annotation.
 	if !opsRes.OpsRequest.DeletionTimestamp.IsZero() {
-		return nil
+		return nil, nil
 	}
 	if opsRequestSlice, err = opsutil.GetOpsRequestSliceFromCluster(opsRes.Cluster); err != nil {
-		return err
+		return nil, err
 	}
-	// check the OpsRequest is existed
-	if _, opsRecorder := GetOpsRecorderFromSlice(opsRequestSlice, opsRes.OpsRequest.Name); opsRecorder.Name != "" {
-		return nil
+
+	index, opsRecorder := GetOpsRecorderFromSlice(opsRequestSlice, opsRes.OpsRequest.Name)
+	switch index {
+	case -1:
+		// if not exists but reach the queue limit size, throw an error
+		if len(opsRequestSlice) >= opsRequestQueueLimitSize {
+			return nil, intctrlutil.NewFatalError("The opsRequest queue is limited to a size of 8")
+		}
+		// if not exists, enqueue
+		if opsRequestSlice == nil {
+			opsRequestSlice = make([]appsv1alpha1.OpsRecorder, 0)
+		}
+		opsRequestSlice = append(opsRequestSlice, appsv1alpha1.OpsRecorder{
+			Name:    opsRes.OpsRequest.Name,
+			Type:    opsRes.OpsRequest.Spec.Type,
+			InQueue: len(opsRequestSlice) != 0,
+		})
+	case 0:
+		// head opsRequest
+		if !opsRecorder.InQueue {
+			return opsRequestSlice, nil
+		}
+		// mark the head opsRequest is running
+		opsRequestSlice[0].InQueue = false
+	default:
+		// if exists and is not the head opsRequest, return
+		return opsRequestSlice, nil
 	}
-	if opsRequestSlice == nil {
-		opsRequestSlice = make([]appsv1alpha1.OpsRecorder, 0)
-	}
-	opsRequestSlice = append(opsRequestSlice, appsv1alpha1.OpsRecorder{
-		Name: opsRes.OpsRequest.Name,
-		Type: opsRes.OpsRequest.Spec.Type,
-	})
-	return opsutil.UpdateClusterOpsAnnotations(ctx, cli, opsRes.Cluster, opsRequestSlice)
+	return opsRequestSlice, opsutil.UpdateClusterOpsAnnotations(ctx, cli, opsRes.Cluster, opsRequestSlice)
 }
 
 // isOpsRequestFailedPhase checks the OpsRequest phase is Failed
@@ -449,24 +498,21 @@ func validateOpsWaitingPhase(cluster *appsv1alpha1.Cluster, ops *appsv1alpha1.Op
 	// or opsRequest status.phase is not Pending,
 	// or opsRequest will create cluster,
 	// we don't validate the cluster phase.
-	if len(opsBehaviour.FromClusterPhases) == 0 || ops.Status.Phase != appsv1alpha1.OpsPendingPhase {
+	if len(opsBehaviour.FromClusterPhases) == 0 || ops.Status.Phase != appsv1alpha1.OpsPendingPhase || opsBehaviour.IsClusterCreation {
 		return nil
 	}
-	// check if the opsRequest can be executed in the current cluster phase unless this opsRequest is reentrant.
-	if !slices.Contains(opsBehaviour.FromClusterPhases, cluster.Status.Phase) {
-		// check if entry-condition is met
-		// if the cluster is not in the expected phase, we should wait for it for up to TTLSecondsBeforeAbort seconds.
-		// if len(opsRecorder) == 0 && !slices.Contains(opsBehaviour.FromClusterPhases, cluster.Status.Phase) {
-		// TTLSecondsBeforeAbort is 0 means that the we do not need to wait for the cluster to reach the expected phase.
-		if ops.Spec.TTLSecondsBeforeAbort == nil || (time.Now().After(ops.GetCreationTimestamp().Add(time.Duration(*ops.Spec.TTLSecondsBeforeAbort) * time.Second))) {
-			return fmt.Errorf("OpsRequest.spec.type=%s is forbidden when Cluster.status.phase=%s", ops.Spec.Type, cluster.Status.Phase)
-		}
-
-		return &WaitForClusterPhaseErr{
-			clusterName:   cluster.Name,
-			currentPhase:  cluster.Status.Phase,
-			expectedPhase: opsBehaviour.FromClusterPhases,
-		}
+	if slices.Contains(opsBehaviour.FromClusterPhases, cluster.Status.Phase) {
+		return nil
 	}
-	return nil
+	// check if entry-condition is met
+	// if the cluster is not in the expected phase, we should wait for it for up to TTLSecondsBeforeAbort seconds.
+	if ops.Spec.TTLSecondsBeforeAbort == nil || (time.Now().After(ops.GetCreationTimestamp().Add(time.Duration(*ops.Spec.TTLSecondsBeforeAbort) * time.Second))) {
+		return nil
+	}
+
+	return &WaitForClusterPhaseErr{
+		clusterName:   cluster.Name,
+		currentPhase:  cluster.Status.Phase,
+		expectedPhase: opsBehaviour.FromClusterPhases,
+	}
 }

--- a/controllers/apps/operations/ops_util_test.go
+++ b/controllers/apps/operations/ops_util_test.go
@@ -136,7 +136,7 @@ var _ = Describe("OpsUtil functions", func() {
 			Expect(opsSlice[1].InQueue).Should(BeTrue())
 
 			By("test enqueueOpsRequestToClusterAnnotation function with Reentry")
-			opsBehaviour, _ := opsManager.OpsMap[ops2.Spec.Type]
+			opsBehaviour := opsManager.OpsMap[ops2.Spec.Type]
 			opsSlice, _ = enqueueOpsRequestToClusterAnnotation(ctx, k8sClient, opsRes, opsBehaviour)
 			Expect(len(opsSlice)).Should(Equal(2))
 

--- a/controllers/apps/operations/ops_util_test.go
+++ b/controllers/apps/operations/ops_util_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
+	opsutil "github.com/apecloud/kubeblocks/controllers/apps/operations/util"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	"github.com/apecloud/kubeblocks/pkg/generics"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
@@ -106,5 +107,54 @@ var _ = Describe("OpsUtil functions", func() {
 
 		})
 
+		It("Test opsRequest Queue functions", func() {
+			By("init operations resources ")
+			reqCtx := intctrlutil.RequestCtx{Ctx: testCtx.Ctx}
+			opsRes, _, _ := initOperationsResources(clusterDefinitionName, clusterVersionName, clusterName)
+
+			runHscaleOps := func(expectPhase appsv1alpha1.OpsPhase) *appsv1alpha1.OpsRequest {
+				ops := createHorizontalScaling(clusterName, 1)
+				opsRes.OpsRequest = ops
+				_, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(opsRes.OpsRequest.Status.Phase).Should(Equal(expectPhase))
+				return ops
+			}
+
+			By("run first h-scale ops, expect phase to Creating")
+			ops1 := runHscaleOps(appsv1alpha1.OpsCreatingPhase)
+
+			By("run next h-scale ops, expect phase to Pending")
+			ops2 := runHscaleOps(appsv1alpha1.OpsPendingPhase)
+
+			By("check opsRequest annotation in cluster")
+			cluster := &appsv1alpha1.Cluster{}
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(opsRes.Cluster), cluster)).Should(Succeed())
+			opsSlice, _ := opsutil.GetOpsRequestSliceFromCluster(cluster)
+			Expect(len(opsSlice)).Should(Equal(2))
+			Expect(opsSlice[0].InQueue).Should(BeFalse())
+			Expect(opsSlice[1].InQueue).Should(BeTrue())
+
+			By("test enqueueOpsRequestToClusterAnnotation function with Reentry")
+			opsBehaviour, _ := opsManager.OpsMap[ops2.Spec.Type]
+			opsSlice, _ = enqueueOpsRequestToClusterAnnotation(ctx, k8sClient, opsRes, opsBehaviour)
+			Expect(len(opsSlice)).Should(Equal(2))
+
+			By("test DequeueOpsRequestInClusterAnnotation function when first opsRequest is Failed")
+			// mock ops1 is Failed
+			ops1.Status.Phase = appsv1alpha1.OpsFailedPhase
+			opsRes.OpsRequest = ops1
+			Expect(DequeueOpsRequestInClusterAnnotation(ctx, k8sClient, opsRes)).Should(Succeed())
+			testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(ops2), func(g Gomega, ops *appsv1alpha1.OpsRequest) {
+				// expect ops2 is Cancelled
+				g.Expect(ops.Status.Phase).Should(Equal(appsv1alpha1.OpsCancelledPhase))
+			})
+
+			testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(cluster), func(g Gomega, cluster *appsv1alpha1.Cluster) {
+				opsSlice, _ = opsutil.GetOpsRequestSliceFromCluster(cluster)
+				// expect cluster's opsRequest queue is empty
+				g.Expect(opsSlice).Should(BeEmpty())
+			})
+		})
 	})
 })

--- a/controllers/apps/operations/reconfigure.go
+++ b/controllers/apps/operations/reconfigure.go
@@ -41,9 +41,8 @@ func init() {
 		// REVIEW: can do opsrequest if not running?
 		FromClusterPhases: appsv1alpha1.GetReconfiguringRunningPhases(),
 		// TODO: add cluster reconcile Reconfiguring phase.
-		ToClusterPhase:                     appsv1alpha1.UpdatingClusterPhase,
-		OpsHandler:                         &reAction,
-		ProcessingReasonInClusterCondition: ProcessingReasonReconfiguring,
+		ToClusterPhase: appsv1alpha1.UpdatingClusterPhase,
+		OpsHandler:     &reAction,
 	}
 	opsManager.RegisterOps(appsv1alpha1.ReconfiguringType, reconfigureBehaviour)
 }

--- a/controllers/apps/operations/reconfigure_test.go
+++ b/controllers/apps/operations/reconfigure_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Reconfigure OpsRequest", func() {
 	AfterEach(cleanEnv)
 
 	initClusterForOps := func(opsRes *OpsResource) {
-		Expect(opsutil.PatchClusterOpsAnnotations(ctx, k8sClient, opsRes.Cluster, nil)).Should(Succeed())
+		Expect(opsutil.UpdateClusterOpsAnnotations(ctx, k8sClient, opsRes.Cluster, nil)).Should(Succeed())
 		opsRes.Cluster.Status.Phase = appsv1alpha1.RunningClusterPhase
 	}
 
@@ -228,6 +228,7 @@ var _ = Describe("Reconfigure OpsRequest", func() {
 
 			opsManager := GetOpsManager()
 			By("init ops phase")
+			opsRes.OpsRequest.Status.Phase = appsv1alpha1.OpsPendingPhase
 			_, err := opsManager.Do(reqCtx, k8sClient, opsRes)
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -319,6 +320,7 @@ var _ = Describe("Reconfigure OpsRequest", func() {
 			opsManager := GetOpsManager()
 			// reAction := reconfigureAction{}
 			By("Reconfigure configure")
+			opsRes.OpsRequest.Status.Phase = appsv1alpha1.OpsPendingPhase
 			_, err := opsManager.Do(reqCtx, k8sClient, opsRes)
 			Expect(err).ShouldNot(HaveOccurred())
 			Eventually(testapps.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(appsv1alpha1.OpsCreatingPhase))

--- a/controllers/apps/operations/restart.go
+++ b/controllers/apps/operations/restart.go
@@ -43,10 +43,9 @@ func init() {
 	restartBehaviour := OpsBehaviour{
 		// if cluster is Abnormal or Failed, new opsRequest may repair it.
 		// TODO: we should add "force" flag for these opsRequest.
-		FromClusterPhases:                  appsv1alpha1.GetClusterUpRunningPhases(),
-		ToClusterPhase:                     appsv1alpha1.UpdatingClusterPhase,
-		OpsHandler:                         restartOpsHandler{},
-		ProcessingReasonInClusterCondition: ProcessingReasonRestarting,
+		FromClusterPhases: appsv1alpha1.GetClusterUpRunningPhases(),
+		ToClusterPhase:    appsv1alpha1.UpdatingClusterPhase,
+		OpsHandler:        restartOpsHandler{},
 	}
 
 	opsMgr := GetOpsManager()

--- a/controllers/apps/operations/restore.go
+++ b/controllers/apps/operations/restore.go
@@ -45,10 +45,9 @@ func init() {
 	// register restore operation, it will create a new cluster
 	// so set IsClusterCreationEnabled to true
 	restoreBehaviour := OpsBehaviour{
-		FromClusterPhases:                  appsv1alpha1.GetClusterUpRunningPhases(),
-		OpsHandler:                         RestoreOpsHandler{},
-		ProcessingReasonInClusterCondition: ProcessingReasonRestore,
-		IsClusterCreationEnabled:           true,
+		FromClusterPhases: appsv1alpha1.GetClusterUpRunningPhases(),
+		OpsHandler:        RestoreOpsHandler{},
+		IsClusterCreation: true,
 	}
 
 	opsMgr := GetOpsManager()

--- a/controllers/apps/operations/restore_test.go
+++ b/controllers/apps/operations/restore_test.go
@@ -77,6 +77,8 @@ var _ = Describe("Restore OpsRequest", func() {
 		It("", func() {
 			By("create Restore OpsRequest")
 			opsRes.OpsRequest = createRestoreOpsObj(clusterName, "restore-ops-"+randomStr, backupName)
+			// set ops phase to Pending
+			opsRes.OpsRequest.Status.Phase = appsv1alpha1.OpsPendingPhase
 
 			By("mock restore OpsRequest is Running")
 			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)

--- a/controllers/apps/operations/start.go
+++ b/controllers/apps/operations/start.go
@@ -37,10 +37,9 @@ var _ OpsHandler = StartOpsHandler{}
 
 func init() {
 	stopBehaviour := OpsBehaviour{
-		FromClusterPhases:                  []appsv1alpha1.ClusterPhase{appsv1alpha1.StoppedClusterPhase},
-		ToClusterPhase:                     appsv1alpha1.UpdatingClusterPhase, // appsv1alpha1.StartingPhase,
-		OpsHandler:                         StartOpsHandler{},
-		ProcessingReasonInClusterCondition: ProcessingReasonStarting,
+		FromClusterPhases: []appsv1alpha1.ClusterPhase{appsv1alpha1.StoppedClusterPhase},
+		ToClusterPhase:    appsv1alpha1.UpdatingClusterPhase,
+		OpsHandler:        StartOpsHandler{},
 	}
 
 	opsMgr := GetOpsManager()

--- a/controllers/apps/operations/start_test.go
+++ b/controllers/apps/operations/start_test.go
@@ -89,12 +89,14 @@ var _ = Describe("Start OpsRequest", func() {
 			By("test start action and reconcile function")
 			startHandler := StartOpsHandler{}
 			oldComponentReplicasMap, _ := startHandler.getComponentReplicasSnapshot(opsRes.Cluster.Annotations)
-			Expect(opsutil.PatchClusterOpsAnnotations(ctx, k8sClient, opsRes.Cluster, nil)).Should(Succeed())
+			Expect(opsutil.UpdateClusterOpsAnnotations(ctx, k8sClient, opsRes.Cluster, nil)).Should(Succeed())
 			// mock cluster phase to stopped
 			Expect(testapps.ChangeObjStatus(&testCtx, opsRes.Cluster, func() {
 				opsRes.Cluster.Status.Phase = appsv1alpha1.StoppedClusterPhase
 			})).ShouldNot(HaveOccurred())
 
+			// set ops phase to Pending
+			opsRes.OpsRequest.Status.Phase = appsv1alpha1.OpsPendingPhase
 			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)
 			Expect(err).ShouldNot(HaveOccurred())
 			Eventually(testapps.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(appsv1alpha1.OpsCreatingPhase))

--- a/controllers/apps/operations/stop.go
+++ b/controllers/apps/operations/stop.go
@@ -37,10 +37,9 @@ var _ OpsHandler = StopOpsHandler{}
 
 func init() {
 	stopBehaviour := OpsBehaviour{
-		FromClusterPhases:                  appsv1alpha1.GetClusterUpRunningPhases(),
-		ToClusterPhase:                     appsv1alpha1.StoppingClusterPhase,
-		OpsHandler:                         StopOpsHandler{},
-		ProcessingReasonInClusterCondition: ProcessingReasonStopping,
+		FromClusterPhases: append(appsv1alpha1.GetClusterUpRunningPhases(), appsv1alpha1.UpdatingClusterPhase),
+		ToClusterPhase:    appsv1alpha1.StoppingClusterPhase,
+		OpsHandler:        StopOpsHandler{},
 	}
 
 	opsMgr := GetOpsManager()

--- a/controllers/apps/operations/stop_test.go
+++ b/controllers/apps/operations/stop_test.go
@@ -70,6 +70,8 @@ var _ = Describe("Stop OpsRequest", func() {
 			ops := testapps.NewOpsRequestObj("stop-ops-"+randomStr, testCtx.DefaultNamespace,
 				clusterName, appsv1alpha1.StopType)
 			opsRes.OpsRequest = testapps.CreateOpsRequest(ctx, testCtx, ops)
+			// set ops phase to Pending
+			opsRes.OpsRequest.Status.Phase = appsv1alpha1.OpsPendingPhase
 
 			By("test stop action and reconcile function")
 			// update ops phase to running first

--- a/controllers/apps/operations/switchover.go
+++ b/controllers/apps/operations/switchover.go
@@ -48,10 +48,9 @@ type SwitchoverMessage struct {
 
 func init() {
 	switchoverBehaviour := OpsBehaviour{
-		FromClusterPhases:                  appsv1alpha1.GetClusterUpRunningPhases(),
-		ToClusterPhase:                     appsv1alpha1.UpdatingClusterPhase,
-		OpsHandler:                         switchoverOpsHandler{},
-		ProcessingReasonInClusterCondition: ProcessingReasonSwitchovering,
+		FromClusterPhases: appsv1alpha1.GetClusterUpRunningPhases(),
+		ToClusterPhase:    appsv1alpha1.UpdatingClusterPhase,
+		OpsHandler:        switchoverOpsHandler{},
 	}
 
 	opsMgr := GetOpsManager()

--- a/controllers/apps/operations/switchover_test.go
+++ b/controllers/apps/operations/switchover_test.go
@@ -200,6 +200,8 @@ var _ = Describe("", func() {
 				},
 			}
 			opsRes.OpsRequest = testapps.CreateOpsRequest(ctx, testCtx, ops)
+			// set ops phase to Pending
+			opsRes.OpsRequest.Status.Phase = appsv1alpha1.OpsPendingPhase
 
 			By("mock switchover OpsRequest phase is Creating")
 			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)

--- a/controllers/apps/operations/type.go
+++ b/controllers/apps/operations/type.go
@@ -52,19 +52,15 @@ type OpsBehaviour struct {
 	FromClusterPhases []appsv1alpha1.ClusterPhase
 
 	// ToClusterPhase indicates that the cluster will enter this phase during the operation.
+	// All opsRequest with ToClusterPhase are mutually exclusive.
 	ToClusterPhase appsv1alpha1.ClusterPhase
-
-	// ProcessingReasonInClusterCondition indicates the reason of the condition that type is "OpsRequestProcessed" in Cluster.Status.Conditions and
-	// is only valid when ToClusterPhase is not empty. it will indicate what operation the cluster is doing and
-	// will be displayed of "kbcli cluster list".
-	ProcessingReasonInClusterCondition string
 
 	// CancelFunc this function defines the cancel action and does not patch/update the opsRequest by client-go in here.
 	// only update the opsRequest object, then opsRequest controller will update uniformly.
 	CancelFunc func(reqCtx intctrlutil.RequestCtx, cli client.Client, opsResource *OpsResource) error
 
-	// IsClusterCreationEnabled indicates whether the opsRequest will create a new cluster.
-	IsClusterCreationEnabled bool
+	// IsClusterCreation indicates whether the opsRequest will create a new cluster.
+	IsClusterCreation bool
 
 	OpsHandler OpsHandler
 }
@@ -88,25 +84,3 @@ type progressResource struct {
 	clusterComponentDef *appsv1alpha1.ClusterComponentDefinition
 	opsIsCompleted      bool
 }
-
-const (
-	// ProcessingReasonHorizontalScaling is the reason of the "OpsRequestProcessed" condition for the horizontal scaling opsRequest processing in cluster.
-	ProcessingReasonHorizontalScaling = "HorizontalScaling"
-	// ProcessingReasonVerticalScaling is the reason of the "OpsRequestProcessed" condition for the vertical scaling opsRequest processing in cluster.
-	ProcessingReasonVerticalScaling = "VerticalScaling"
-	// ProcessingReasonStarting is the reason of the "OpsRequestProcessed" condition for the start opsRequest processing in cluster.
-	ProcessingReasonStarting = "Starting"
-	// ProcessingReasonStopping is the reason of the "OpsRequestProcessed" condition for the stop opsRequest processing in cluster.
-	ProcessingReasonStopping = "Stopping"
-	// ProcessingReasonRestarting is the reason of the "OpsRequestProcessed" condition for the restart opsRequest processing in cluster.
-	ProcessingReasonRestarting = "Restarting"
-	// ProcessingReasonReconfiguring is the reason of the "OpsRequestProcessed" condition for the reconfiguration opsRequest processing in cluster.
-	ProcessingReasonReconfiguring = "Reconfiguring"
-	// ProcessingReasonVersionUpgrading is the reason of the "OpsRequestProcessed" condition for the version upgrade opsRequest processing in cluster.
-	ProcessingReasonVersionUpgrading = "VersionUpgrading"
-	// ProcessingReasonSwitchovering is the reason of the "OpsRequestProcessed" condition for the switchover opsRequest processing in cluster.
-	ProcessingReasonSwitchovering = "Switchovering"
-	// ProcessingReasonBackup is the reason of the "OpsRequestProcessed" condition for the backup opsRequest processing in cluster.
-	ProcessingReasonBackup  = "Backup"
-	ProcessingReasonRestore = "Restore"
-)

--- a/controllers/apps/operations/upgrade.go
+++ b/controllers/apps/operations/upgrade.go
@@ -39,10 +39,9 @@ func init() {
 	upgradeBehaviour := OpsBehaviour{
 		// if cluster is Abnormal or Failed, new opsRequest may can repair it.
 		// TODO: we should add "force" flag for these opsRequest.
-		FromClusterPhases:                  appsv1alpha1.GetClusterUpRunningPhases(),
-		ToClusterPhase:                     appsv1alpha1.UpdatingClusterPhase,
-		OpsHandler:                         upgradeOpsHandler{},
-		ProcessingReasonInClusterCondition: ProcessingReasonVersionUpgrading,
+		FromClusterPhases: appsv1alpha1.GetClusterUpRunningPhases(),
+		ToClusterPhase:    appsv1alpha1.UpdatingClusterPhase,
+		OpsHandler:        upgradeOpsHandler{},
 	}
 
 	opsMgr := GetOpsManager()

--- a/controllers/apps/operations/upgrade_test.go
+++ b/controllers/apps/operations/upgrade_test.go
@@ -78,6 +78,8 @@ var _ = Describe("Upgrade OpsRequest", func() {
 				clusterObject.Name, appsv1alpha1.UpgradeType)
 			ops.Spec.Upgrade = &appsv1alpha1.Upgrade{ClusterVersionRef: newClusterVersionName}
 			opsRes.OpsRequest = testapps.CreateOpsRequest(ctx, testCtx, ops)
+			// set ops phase to Pending
+			opsRes.OpsRequest.Status.Phase = appsv1alpha1.OpsPendingPhase
 			mockComponentIsOperating(opsRes.Cluster, appsv1alpha1.UpdatingClusterCompPhase,
 				consensusComp, statelessComp, statefulComp) // appsv1alpha1.VerticalScalingPhase
 			// TODO: add status condition for VerticalScalingPhase

--- a/controllers/apps/operations/util/common_util.go
+++ b/controllers/apps/operations/util/common_util.go
@@ -43,16 +43,6 @@ func SetOpsRequestToCluster(cluster *appsv1alpha1.Cluster, opsRequestSlice []app
 	}
 }
 
-// PatchClusterOpsAnnotations patches OpsRequest annotation in Cluster.annotations
-func PatchClusterOpsAnnotations(ctx context.Context,
-	cli client.Client,
-	cluster *appsv1alpha1.Cluster,
-	opsRequestSlice []appsv1alpha1.OpsRecorder) error {
-	patch := client.MergeFrom(cluster.DeepCopy())
-	SetOpsRequestToCluster(cluster, opsRequestSlice)
-	return cli.Patch(ctx, cluster, patch)
-}
-
 // UpdateClusterOpsAnnotations updates OpsRequest annotation in Cluster.annotations
 func UpdateClusterOpsAnnotations(ctx context.Context,
 	cli client.Client,

--- a/controllers/apps/operations/util/common_util_test.go
+++ b/controllers/apps/operations/util/common_util_test.go
@@ -83,14 +83,14 @@ var _ = Describe("OpsRequest Controller", func() {
 					Type: appsv1alpha1.RestartType,
 				},
 			}
-			Expect(PatchClusterOpsAnnotations(ctx, k8sClient, cluster, opsRecordSlice)).Should(Succeed())
+			Expect(UpdateClusterOpsAnnotations(ctx, k8sClient, cluster, opsRecordSlice)).Should(Succeed())
 
 			By("test GetOpsRequestSliceFromCluster function")
 			opsRecordSlice, _ = GetOpsRequestSliceFromCluster(cluster)
 			Expect(len(opsRecordSlice) == 2 && opsRecordSlice[0].Name == testOpsName).Should(BeTrue())
 
 			By("test no OpsRequest annotation in cluster")
-			Expect(PatchClusterOpsAnnotations(ctx, k8sClient, cluster, nil)).Should(Succeed())
+			Expect(UpdateClusterOpsAnnotations(ctx, k8sClient, cluster, nil)).Should(Succeed())
 			opsRecordSlice, _ = GetOpsRequestSliceFromCluster(cluster)
 			Expect(len(opsRecordSlice) == 0).Should(BeTrue())
 		})

--- a/controllers/apps/operations/vertical_scaling.go
+++ b/controllers/apps/operations/vertical_scaling.go
@@ -38,11 +38,10 @@ func init() {
 	verticalScalingBehaviour := OpsBehaviour{
 		// if cluster is Abnormal or Failed, new opsRequest may can repair it.
 		// TODO: we should add "force" flag for these opsRequest.
-		FromClusterPhases:                  appsv1alpha1.GetClusterUpRunningPhases(),
-		ToClusterPhase:                     appsv1alpha1.UpdatingClusterPhase,
-		OpsHandler:                         vsHandler,
-		ProcessingReasonInClusterCondition: ProcessingReasonVerticalScaling,
-		CancelFunc:                         vsHandler.Cancel,
+		FromClusterPhases: appsv1alpha1.GetClusterUpRunningPhases(),
+		ToClusterPhase:    appsv1alpha1.UpdatingClusterPhase,
+		OpsHandler:        vsHandler,
+		CancelFunc:        vsHandler.Cancel,
 	}
 
 	opsMgr := GetOpsManager()

--- a/controllers/apps/operations/vertical_scaling_test.go
+++ b/controllers/apps/operations/vertical_scaling_test.go
@@ -80,6 +80,9 @@ var _ = Describe("VerticalScaling OpsRequest", func() {
 
 			ops.Spec.VerticalScalingList = verticalScaling
 			opsRes.OpsRequest = testapps.CreateOpsRequest(ctx, testCtx, ops)
+			// set ops phase to Pending
+			opsRes.OpsRequest.Status.Phase = appsv1alpha1.OpsPendingPhase
+
 			By("test save last configuration and OpsRequest phase is Running")
 			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)
 			Expect(err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
function list:
1. opsRequests that cannot run concurrently can be dispatched all at once and queued for execution.
2. if the head opsRequest fails, all subsequent queued opsRequests will fail.