### PR TITLE
chore: remove the table of contents in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,6 @@
 
 ![image](./docs/img/banner-readme.png)
 
-- [KubeBlocks](#kubeblocks)
-  - [What is KubeBlocks](#what-is-kubeblocks)
-    - [Why you need KubeBlocks](#why-you-need-kubeblocks)
-    - [Goals](#goals)
-    - [Key features](#key-features)
-  - [Get started with KubeBlocks](#get-started-with-kubeblocks)
-  - [Community](#community)
-  - [Contributing to KubeBlocks](#contributing-to-kubeblocks)
-  - [Report Vulnerability](#report-vulnerability)
-  - [License](#license)
-
 ## What is KubeBlocks
 
 KubeBlocks is an open source system software that runs and manages data infrastructure on Kubernetes. The name KubeBlocks is inspired by Kubernetes and LEGO blocks, signifying that running and managing data infrastructure on K8s can be standard and productive, like playing with LEGO blocks. 


### PR DESCRIPTION
Our readme file is not lengthy in itself. Additionally, there is a table of contents for the readme available by clicking on the top left corner in GitHub. Therefore, it isn't necessary to add a table of contents within the body of the readme.