### PR TITLE
fix: send event retry failed

### DIFF
--- a/lorry/binding/base.go
+++ b/lorry/binding/base.go
@@ -250,7 +250,9 @@ func (ops *BaseOperations) CheckRoleOps(ctx context.Context, req *ProbeRequest, 
 	opsRes["role"] = role
 	if ops.OriRole != role {
 		ops.OriRole = role
-		go SentProbeEvent(ctx, opsRes, resp, ops.Logger)
+		if role != "" {
+			go SentProbeEvent(ctx, opsRes, resp, ops.Logger)
+		}
 	}
 
 	// RoleUnchangedCount is the count of consecutive role unchanged checks.

--- a/lorry/binding/base.go
+++ b/lorry/binding/base.go
@@ -233,7 +233,7 @@ func (ops *BaseOperations) CheckRoleOps(ctx context.Context, req *ProbeRequest, 
 		opsRes["message"] = err.Error()
 		if ops.CheckRoleFailedCount%ops.FailedEventReportFrequency == 0 {
 			ops.Logger.Info("role checks failed continuously", "times", ops.CheckRoleFailedCount)
-			SentProbeEvent(ctx, opsRes, resp, ops.Logger)
+			go SentProbeEvent(ctx, opsRes, resp, ops.Logger)
 		}
 		ops.CheckRoleFailedCount++
 		return opsRes, nil
@@ -250,7 +250,7 @@ func (ops *BaseOperations) CheckRoleOps(ctx context.Context, req *ProbeRequest, 
 	opsRes["role"] = role
 	if ops.OriRole != role {
 		ops.OriRole = role
-		SentProbeEvent(ctx, opsRes, resp, ops.Logger)
+		go SentProbeEvent(ctx, opsRes, resp, ops.Logger)
 	}
 
 	// RoleUnchangedCount is the count of consecutive role unchanged checks.

--- a/lorry/binding/utils.go
+++ b/lorry/binding/utils.go
@@ -223,7 +223,7 @@ func String2RoleType(roleName string) RoleType {
 }
 
 func SentProbeEvent(ctx context.Context, opsResult OpsResult, resp *ProbeResponse, log logr.Logger) {
-	ctx = context.Background()
+	ctx1 := context.Background()
 	log.Info(fmt.Sprintf("send event: %v", opsResult))
 	roleUpdateMechanism := workloads.DirectAPIServerEventUpdate
 	if viper.IsSet(RSMRoleUpdateMechanismVarName) {
@@ -239,7 +239,7 @@ func SentProbeEvent(ctx context.Context, opsResult OpsResult, resp *ProbeRespons
 			return
 		}
 
-		_ = sendEvent(ctx, log, event)
+		_ = sendEvent(ctx1, log, event)
 	default:
 		log.Info(fmt.Sprintf("no event sent, RoleUpdateMechanism: %s", roleUpdateMechanism))
 	}

--- a/lorry/binding/utils.go
+++ b/lorry/binding/utils.go
@@ -223,6 +223,7 @@ func String2RoleType(roleName string) RoleType {
 }
 
 func SentProbeEvent(ctx context.Context, opsResult OpsResult, resp *ProbeResponse, log logr.Logger) {
+	ctx = context.Background()
 	log.Info(fmt.Sprintf("send event: %v", opsResult))
 	roleUpdateMechanism := workloads.DirectAPIServerEventUpdate
 	if viper.IsSet(RSMRoleUpdateMechanismVarName) {

--- a/lorry/dcs/dcs.go
+++ b/lorry/dcs/dcs.go
@@ -61,7 +61,7 @@ var dcs DCS
 
 func init() {
 	viper.SetDefault("KB_TTL", 15)
-	viper.SetDefault("KB_MAX_LAG", 10)
+	viper.SetDefault("KB_MAX_LAG", 100)
 	viper.SetDefault(constant.KubernetesClusterDomainEnv, constant.DefaultDNSDomain)
 }
 

--- a/lorry/highavailability/ha.go
+++ b/lorry/highavailability/ha.go
@@ -274,8 +274,12 @@ func (ha *Ha) Start() {
 	}
 
 	for {
+		startAt := time.Now()
 		ha.RunCycle()
-		time.Sleep(10 * time.Second)
+		duration := time.Since(startAt)
+		if duration < 10*time.Second {
+			time.Sleep(10*time.Second - duration)
+		}
 	}
 }
 


### PR DESCRIPTION
2023-11-30T10:34:30Z    ERROR   Mysql   send event failed       {"error": "client rate limiter Wait returned an error: context canceled"}
github.com/apecloud/kubeblocks/lorry/binding.sendEvent
        /src/lorry/binding/utils.go:325
github.com/apecloud/kubeblocks/lorry/binding.SentProbeEvent
        /src/lorry/binding/utils.go:241
github.com/apecloud/kubeblocks/lorry/binding.(*BaseOperations).CheckRoleOps
        /src/lorry/binding/base.go:253
github.com/apecloud/kubeblocks/lorry/binding/mysql.(*MysqlOperations).Init.(*BaseOperations).RegisterOperationOnDBReady.StartupCheckWraper.func2
        /src/lorry/binding/utils.go:338
github.com/apecloud/kubeblocks/lorry/binding.(*BaseOperations).Invoke
        /src/lorry/binding/base.go:194
github.com/apecloud/kubeblocks/lorry/middleware/probe.route
        /src/lorry/middleware/probe/router.go:170
github.com/apecloud/kubeblocks/lorry/middleware/grpc.NewGRPCServer.GetGrpcRouter.func1
        /src/lorry/middleware/probe/router.go:176
github.com/apecloud/kubeblocks/lorry/middleware/grpc.(*GRPCServer).Check
        /src/lorry/middleware/grpc/gprc_server.go:47
google.golang.org/grpc/health/grpc_health_v1._Health_Check_Handler
        /go/pkg/mod/google.golang.org/grpc@v1.56.3/health/grpc_health_v1/health_grpc.pb.go:170
google.golang.org/grpc.(*Server).processUnaryRPC
        /go/pkg/mod/google.golang.org/grpc@v1.56.3/server.go:1335
google.golang.org/grpc.(*Server).handleStream
        /go/pkg/mod/google.golang.org/grpc@v1.56.3/server.go:1712
google.golang.org/grpc.(*Server).serveStreams.func1.1
        /go/pkg/mod/google.golang.org/grpc@v1.56.3/server.go:947