### PR TITLE
chore: set resource for kb init container and addon job

### DIFF
--- a/deploy/helm/templates/dataprotection.yaml
+++ b/deploy/helm/templates/dataprotection.yaml
@@ -38,6 +38,8 @@ spec:
         - name: tools
           image: "{{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.tools.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
           command:
             - /bin/true
       containers:

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -37,11 +37,15 @@ spec:
         - name: tools
           image: "{{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.tools.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
           command:
             - /bin/true
         - name: datascript
           image: "{{ .Values.image.registry | default "docker.io" }}/{{ .Values.image.datascript.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
           command:
             - /bin/true
       containers:


### PR DESCRIPTION
* Add resource for init container of KB and DataProtection deployment
* Add resource for addon job, include initContainer and container

When install KubeBlocks, please set its resource to avoid set a zero resources.

```
helm template kb ./deploy/helm --output-dir temp --set resources.requests.cpu=100m,resources.requests.memory=128Mi,resources.limits.cpu=200m,resources.limits.memory=256Mi
```

```
## Resource settings
##
## @param resources.limits
## @param resources.requests
resources: {}
  # We usually recommend not to specify default resources and to leave this as a conscious
  # choice for the user. This also increases chances charts run on environments with little
  # resources, such as Minikube. If you do want to specify resources, uncomment the following
  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
  # TODO(user): Configure the resources accordingly based on the project requirements.
  # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
  # limits:
  #   cpu: 500m
  #   memory: 128Mi
  # requests:
  #   cpu: 10m
#   memory: 64Mi
```