### PR TITLE
chore: fix specify all resource image registry

### DIFF
--- a/deploy/helm/templates/_addon.tpl
+++ b/deploy/helm/templates/_addon.tpl
@@ -1,9 +1,8 @@
-{{- $addonImageRegistry := include "kubeblocks.imageRegistry" . }}
 {{/*
 Define addon Helm charts image information.
 */}}
 {{- define "kubeblocks.addonChartsImage" }}
-{{- $addonImageRegistry := index . "addonImageRegistry" }}
+{{- $addonImageRegistry := include "kubeblocks.imageRegistry" . }}
 chartsImage: {{ .Values.addonChartsImage.registry | default $addonImageRegistry }}/{{ .Values.addonChartsImage.repository }}:{{ .Values.addonChartsImage.tag | default .Chart.AppVersion }}
 chartsPathInImage: {{ .Values.addonChartsImage.chartsPath }}
 {{- end }}
@@ -42,7 +41,7 @@ Parameters:
 - kbVersion: KubeBlocks version that this addon is compatible with
 */}}
 {{- define "kubeblocks.buildAddonCR" }}
-{{- $addonImageRegistry := index . "addonImageRegistry" }}
+{{- $addonImageRegistry := include "kubeblocks.imageRegistry" . }}
 {{- $upgrade:= or .Release.IsInstall (and .Release.IsUpgrade .Values.upgradeAddons) }}
 {{- $existingAddon := lookup "extensions.kubeblocks.io/v1alpha1" "Addon" "" .name -}}
 {{- if and (not $upgrade) $existingAddon -}}

--- a/deploy/helm/templates/_addon.tpl
+++ b/deploy/helm/templates/_addon.tpl
@@ -1,8 +1,10 @@
+{{- $addonImageRegistry := include "kubeblocks.imageRegistry" . }}
 {{/*
 Define addon Helm charts image information.
 */}}
 {{- define "kubeblocks.addonChartsImage" }}
-chartsImage: {{ .Values.addonChartsImage.registry | default "docker.io" }}/{{ .Values.addonChartsImage.repository }}:{{ .Values.addonChartsImage.tag | default .Chart.AppVersion }}
+{{- $addonImageRegistry := index . "addonImageRegistry" }}
+chartsImage: {{ .Values.addonChartsImage.registry | default $addonImageRegistry }}/{{ .Values.addonChartsImage.repository }}:{{ .Values.addonChartsImage.tag | default .Chart.AppVersion }}
 chartsPathInImage: {{ .Values.addonChartsImage.chartsPath }}
 {{- end }}
 
@@ -40,6 +42,7 @@ Parameters:
 - kbVersion: KubeBlocks version that this addon is compatible with
 */}}
 {{- define "kubeblocks.buildAddonCR" }}
+{{- $addonImageRegistry := index . "addonImageRegistry" }}
 {{- $upgrade:= or .Release.IsInstall (and .Release.IsUpgrade .Values.upgradeAddons) }}
 {{- $existingAddon := lookup "extensions.kubeblocks.io/v1alpha1" "Addon" "" .name -}}
 {{- if and (not $upgrade) $existingAddon -}}
@@ -69,7 +72,7 @@ spec:
   type: Helm
   helm:
     {{- include "kubeblocks.addonChartLocationURL" ( dict "name" .name "version" .version "values" .Values) | indent 4 }}
-    chartsImage: {{ .Values.addonChartsImage.registry | default "docker.io" }}/{{ .Values.addonChartsImage.repository }}:{{ .Values.addonChartsImage.tag | default .Chart.AppVersion }}
+    chartsImage: {{ .Values.addonChartsImage.registry | default $addonImageRegistry }}/{{ .Values.addonChartsImage.repository }}:{{ .Values.addonChartsImage.tag | default .Chart.AppVersion }}
     chartsPathInImage: {{ .Values.addonChartsImage.chartsPath }}
     installOptions:
       {{- if hasPrefix "oci://" .Values.addonChartLocationBase }}

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -327,9 +327,9 @@ Define default storage class name, if cloud provider is known, specify a default
 
 
 {{- define "kubeblocks.imageRegistry" }}
-{{- if .Values.image.registry }}
-{{- .Values.image.registry }}
-{{- else }}
+{{- if not .Values.image.registry }}
 {{- "infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com" }}
+{{- else }}
+{{- .Values.image.registry }}
 {{- end}}
 {{- end}}

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -324,3 +324,12 @@ Define default storage class name, if cloud provider is known, specify a default
 {{- "" }}
 {{- end }}
 {{- end }}
+
+
+{{- define "kubeblocks.imageRegistry" }}
+{{- if .Values.image.registry }}
+{{- .Values.image.registry }}
+{{- else }}
+{{- "infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com" }}
+{{- end}}
+{{- end}}

--- a/deploy/helm/templates/applications/alertmanager-webhook-adaptor-values.yaml
+++ b/deploy/helm/templates/applications/alertmanager-webhook-adaptor-values.yaml
@@ -1,3 +1,4 @@
+{{- $imageRegistry := include "kubeblocks.imageRegistry" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,4 +11,10 @@ metadata:
   {{- end }}
 data:
   values-kubeblocks-override.yaml: |-
-     {{- get ( .Values | toYaml | fromYaml ) "alertmanager-webhook-adaptor" | toYaml | nindent 4 }}
+     {{- $alertmanagerWebhookAdaptor := get .Values "alertmanager-webhook-adaptor" }}
+     {{- $image := get $alertmanagerWebhookAdaptor "image" }}
+     {{- if not $image.registry }}
+       {{- $image = set $image  "registry" $imageRegistry }}
+     {{- end }}
+     {{- $alertmanagerWebhookAdaptor = set $alertmanagerWebhookAdaptor "image" $image }}
+     {{- toYaml $alertmanagerWebhookAdaptor | nindent 4 }}

--- a/deploy/helm/templates/applications/apecloud-otel-collector-values.yaml
+++ b/deploy/helm/templates/applications/apecloud-otel-collector-values.yaml
@@ -1,3 +1,4 @@
+{{- $imageRegistry := include "kubeblocks.imageRegistry" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,4 +11,10 @@ metadata:
   {{- end }}
 data:
   values-kubeblocks-override.yaml: |-
-    {{- get ( .Values | toYaml | fromYaml ) "agamotto" | toYaml | nindent 4 }}
+    {{- $agamotto := get .Values "agamotto" }}
+    {{- $image := get $agamotto "image" }}
+    {{- if not $image.registry }}
+      {{- $image = set $image  "registry" $imageRegistry }}
+    {{- end }}
+    {{- $agamotto = set $agamotto "image" $image }}
+    {{- toYaml $agamotto | nindent 4 }}

--- a/deploy/helm/templates/applications/grafana-values.yaml
+++ b/deploy/helm/templates/applications/grafana-values.yaml
@@ -1,3 +1,4 @@
+{{- $imageRegistry := include "kubeblocks.imageRegistry" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,4 +11,26 @@ metadata:
   {{- end }}
 data:
   values-kubeblocks-override.yaml: |-
-    {{- .Values.grafana | toYaml | nindent 4 }}
+    {{- $grafana := get .Values "grafana" }}
+    {{- $image := get $grafana "image" }}
+    {{- if not $image.repository }}
+       {{- $image = set $image  "repository" (printf "%s/apecloud/grafana" $imageRegistry) }}
+    {{- end }}
+    {{- $grafana = set $grafana "image" $image }}
+    {{- $sidecar := get $grafana "sidecar" }}
+    {{- $sidecarImage := get $sidecar "image" }}
+    {{- if not $sidecarImage.repository }}
+       {{- $sidecarImage = set $sidecarImage  "repository"  (printf "%s/apecloud/k8s-sidecar" $imageRegistry) }}
+    {{- end }}
+    {{- $sidecar = set $sidecar "image" $sidecarImage }}
+    {{- $grafana = set $grafana "sidecar" $sidecar }}
+    {{- toYaml $grafana | nindent 4 }}
+{{/*    image:*/}}
+{{/*    repository: {{ .Values.image.registry | default $grafanaImageRegistry }}/apecloud/grafana*/}}
+{{/*    # Overrides the Grafana image tag whose default is the chart appVersion*/}}
+{{/*    tag: 9.2.4*/}}
+{{/*    image:*/}}
+{{/*      registry: {{}}*/}}
+{{/*      repository: apecloud/grafana*/}}
+{{/*      # Overrides the Grafana image tag whose default is the chart appVersion*/}}
+{{/*      tag: 9.2.4*/}}

--- a/deploy/helm/templates/applications/grafana-values.yaml
+++ b/deploy/helm/templates/applications/grafana-values.yaml
@@ -25,12 +25,3 @@ data:
     {{- $sidecar = set $sidecar "image" $sidecarImage }}
     {{- $grafana = set $grafana "sidecar" $sidecar }}
     {{- toYaml $grafana | nindent 4 }}
-{{/*    image:*/}}
-{{/*    repository: {{ .Values.image.registry | default $grafanaImageRegistry }}/apecloud/grafana*/}}
-{{/*    # Overrides the Grafana image tag whose default is the chart appVersion*/}}
-{{/*    tag: 9.2.4*/}}
-{{/*    image:*/}}
-{{/*      registry: {{}}*/}}
-{{/*      repository: apecloud/grafana*/}}
-{{/*      # Overrides the Grafana image tag whose default is the chart appVersion*/}}
-{{/*      tag: 9.2.4*/}}

--- a/deploy/helm/templates/applications/prometheus-values.yaml
+++ b/deploy/helm/templates/applications/prometheus-values.yaml
@@ -1,3 +1,4 @@
+{{- $imageRegistry := include "kubeblocks.imageRegistry" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,4 +11,46 @@ metadata:
   {{- end }}
 data:
   values-kubeblocks-override.yaml: |-
-     {{- .Values.prometheus | toYaml | nindent 4 }}
+    {{- $prometheus := get .Values "prometheus" }}
+    # set prometheus.alertmanager.image.repository
+    {{- $alertmanager := get $prometheus "alertmanager" }}
+    {{- $alertmanagerImage := get $alertmanager "image" }}
+    {{- if not $alertmanagerImage.repository }}
+       {{- $alertmanagerImage = set $alertmanagerImage  "repository" (printf "%s/apecloud/alertmanager" $imageRegistry) }}
+    {{- end }}
+    {{- $alertmanager = set $alertmanager "image" $alertmanagerImage }}
+    {{- $prometheus = set $prometheus "alertmanager" $alertmanager }}
+    # set prometheus.nodeExporter.image.repository
+    {{- $nodeExporter := get $prometheus "nodeExporter" }}
+    {{- $nodeExporterImage := get $nodeExporter "image" }}
+    {{- if not $nodeExporterImage.repository }}
+       {{- $nodeExporterImage = set $nodeExporterImage  "repository" (printf "%s/apecloud/node-exporter" $imageRegistry) }}
+    {{- end }}
+    {{- $nodeExporter = set $nodeExporter "image" $nodeExporterImage }}
+    {{- $prometheus = set $prometheus "nodeExporter" $nodeExporter }}
+    # set prometheus configmapReload prometheus and alertmanager image.repository
+    {{- $configmapReload := get $prometheus "configmapReload" }}
+    {{- $cmReloadPrometheus := get $configmapReload "prometheus" }}
+    {{- $cmPrometheusImage := get $cmReloadPrometheus "image" }}
+    {{- if not $cmPrometheusImage.repository }}
+       {{- $cmPrometheusImage = set $cmPrometheusImage  "repository" (printf "%s/apecloud/configmap-reload" $imageRegistry) }}
+    {{- end }}
+    {{- $cmReloadPrometheus = set $cmReloadPrometheus "image" $cmPrometheusImage }}
+    {{- $configmapReload = set $configmapReload "prometheus" $cmReloadPrometheus }}
+    {{- $cmReloadalertmanager := get $configmapReload "alertmanager" }}
+    {{- $cmAlertmanagerImage := get $cmReloadalertmanager "image" }}
+    {{- if not $cmAlertmanagerImage.repository }}
+       {{- $cmAlertmanagerImage = set $cmAlertmanagerImage  "repository" (printf "%s/apecloud/configmap-reload" $imageRegistry) }}
+    {{- end }}
+    {{- $cmReloadalertmanager = set $cmReloadalertmanager "image" $cmAlertmanagerImage }}
+    {{- $configmapReload = set $configmapReload "prometheus" $cmReloadalertmanager }}
+    {{- $prometheus = set $prometheus "configmapReload" $configmapReload }}
+    # set prometheus.server.image.repository
+    {{- $server := get $prometheus "server" }}
+    {{- $serverImage := get $server "image" }}
+    {{- if not $serverImage.repository }}
+       {{- $serverImage = set $serverImage  "repository" (printf "%s/apecloud/prometheus" $imageRegistry) }}
+    {{- end }}
+    {{- $server = set $server "image" $serverImage }}
+    {{- $prometheus = set $prometheus "server" $server }}
+    {{- toYaml $prometheus | nindent 4 }}

--- a/deploy/helm/templates/applications/snapshot-controller-values.yaml
+++ b/deploy/helm/templates/applications/snapshot-controller-values.yaml
@@ -1,3 +1,4 @@
+{{- $imageRegistry := include "kubeblocks.imageRegistry" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,4 +11,10 @@ metadata:
   {{- end }}
 data:
   values-kubeblocks-override.yaml: |-
-    {{- get ( .Values | toYaml | fromYaml ) "snapshot-controller" | toYaml | nindent 4 }}
+    {{- $snapshotController := get .Values "snapshot-controller" }}
+    {{- $image := get $snapshotController "image" }}
+    {{- if not $image.repository }}
+       {{- $image = set $image  "repository" (printf "%s/apecloud/snapshot-controller" $imageRegistry) }}
+    {{- end }}
+    {{- $snapshotController = set $snapshotController "image" $image }}
+    {{- toYaml $snapshotController | nindent 4 }}

--- a/deploy/helm/templates/dataprotection.yaml
+++ b/deploy/helm/templates/dataprotection.yaml
@@ -1,3 +1,4 @@
+{{- $dataProtectionImageRegistry := include "kubeblocks.imageRegistry" . }}
 {{- if .Values.dataProtection.enabled }}
 apiVersion: apps/v1
 kind: Deployment
@@ -95,14 +96,14 @@ spec:
                   name: {{ include "kubeblocks.fullname" . }}-secret
                   key: dataProtectionEncryptionKey
             - name: DATASAFED_IMAGE
-              value: "{{ .Values.dataProtection.image.registry | default "docker.io" }}/{{ .Values.dataProtection.image.datasafed.repository }}:{{ .Values.dataProtection.image.datasafed.tag | default "latest" }}"
+              value: "{{ .Values.dataProtection.image.registry | default $dataProtectionImageRegistry }}/{{ .Values.dataProtection.image.datasafed.repository }}:{{ .Values.dataProtection.image.datasafed.tag | default "latest" }}"
             - name: GC_FREQUENCY_SECONDS
               value: "{{ .Values.dataProtection.gcFrequencySeconds }}"
           {{- with .Values.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.dataProtection.image.registry | default "docker.io" }}/{{ .Values.dataProtection.image.repository }}:{{ .Values.dataProtection.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.dataProtection.image.registry | default $dataProtectionImageRegistry }}/{{ .Values.dataProtection.image.repository }}:{{ .Values.dataProtection.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.dataProtection.image.pullPolicy }}
           ports:
             - name: webhook-server

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -309,7 +309,8 @@ dataProtection:
   gcFrequencySeconds: 3600
 
   image:
-    registry:
+    # if the value of dataProtection.image.registry is not specified using `--set`, it will be set to the value of 'image.registry' by default
+    registry: ""
     repository: apecloud/kubeblocks-dataprotection
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
@@ -367,7 +368,8 @@ addonChartLocationBase: file://
 ## @param addonChartsImage - addon charts image, used to copy Helm charts to the addon job container.
 ## @param addonChartsImage.chartsPath - the helm charts path in the addon charts image.
 addonChartsImage:
-  registry:
+  # if the value of addonChartsImage.registry is not specified using `--set`, it will be set to the value of 'image.registry' by default
+  registry: ""
   repository: apecloud/kubeblocks-charts
   pullPolicy: IfNotPresent
   tag: ""
@@ -399,7 +401,8 @@ prometheus:
     ## alertmanager container image
     ##
     image:
-      repository:
+      # If the value of prometheus.alertmanager.image.repository is not specified using --set, it will be set to the value of '${image.registry}/apecloud/alertmanager'.
+      repository: ""
       tag: v0.24.0
 
     ## ConfigMap override where fullname is {{.Release.Name}}-{{.Values.alertmanager.configMapOverrideName}}
@@ -567,7 +570,8 @@ prometheus:
     ## node-exporter container image
     ##
     image:
-      repository:
+      # If the value of prometheus.nodeExporter.image.repository is not specified using --set, it will be set to the value of '${image.registry}/apecloud/node-exporter'.
+      repository: ""
       tag: v1.3.1
 
   configmapReload:
@@ -575,13 +579,17 @@ prometheus:
       ## configmap-reload container image
       ##
       image:
-        repository:
+        # If the value of prometheus.configmapReload.prometheus.image.repository is not specified using --set,
+        # it will be set to the value of '${image.registry}/apecloud/configmap-reload'.
+        repository: ""
         tag: v0.5.0
     alertmanager:
       ## configmap-reload container image
       ##
       image:
-        repository:
+        # If the value of prometheus.configmapReload.alertmanager.image.repository is not specified using --set,
+        # it will be set to the value of '${image.registry}/apecloud/configmap-reload'.
+        repository: ""
         tag: v0.5.0
 
   server:
@@ -592,7 +600,9 @@ prometheus:
     ## Prometheus server container image
     ##
     image:
-      repository:
+      # If the value of prometheus.server.image.repository is not specified using --set,
+      # it will be set to the value of '${image.registry}/apecloud/prometheus'.
+      repository: ""
       tag: v2.44.0
 
     global:
@@ -1475,7 +1485,9 @@ grafana:
   replicas: 1
 
   image:
-    repository:
+    # If the value of grafana.image.repository is not specified using --set,
+    # it will be set to the value of '${image.registry}/apecloud/grafana'.
+    repository: ""
     # Overrides the Grafana image tag whose default is the chart appVersion
     tag: 9.2.4
 
@@ -1520,7 +1532,9 @@ grafana:
 
   sidecar:
     image:
-      repository:
+      # If the value of grafana.sidecar.image.repository is not specified using --set,
+      # it will be set to the value of '${image.registry}/apecloud/k8s-sidecar'.
+      repository: ""
       tag: 1.19.2
 
     dashboards:
@@ -1626,7 +1640,9 @@ snapshot-controller:
   ## @param snapshot-controller.image.repository -- Repository to pull the image from.
   ##
   image:
-    repository:
+    # If the value of snapshot-controller.image.repository is not specified using --set,
+    # it will be set to the value of '${image.registry}/apecloud/snapshot-controller'.
+    repository: ""
     tag: v6.2.1
 
   tolerations:
@@ -1683,7 +1699,8 @@ alertmanager-webhook-adaptor:
   ## Webhook-Adaptor container image
   ##
   image:
-    registry:
+    # if the value of alertmanager-webhook-adaptor.image.registry is not specified using `--set`, it will be set to the value of 'image.registry' by default
+    registry: ""
 
   affinity:
     nodeAffinity:
@@ -1749,7 +1766,8 @@ enabledAlphaFeatureGates:
 agamotto:
   enabled: false
   image:
-    registry:
+    # if the value of agamotto.image.registry is not specified using `--set`, it will be set to the value of 'image.registry' by default
+    registry: ""
 
 
 provider: "" # cloud be "aws","gcp","aliyun","tencentCloud", "huaweiCloud", "azure"

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -309,7 +309,7 @@ dataProtection:
   gcFrequencySeconds: 3600
 
   image:
-    registry: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com
+    registry:
     repository: apecloud/kubeblocks-dataprotection
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
@@ -367,7 +367,7 @@ addonChartLocationBase: file://
 ## @param addonChartsImage - addon charts image, used to copy Helm charts to the addon job container.
 ## @param addonChartsImage.chartsPath - the helm charts path in the addon charts image.
 addonChartsImage:
-  registry: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com
+  registry:
   repository: apecloud/kubeblocks-charts
   pullPolicy: IfNotPresent
   tag: ""
@@ -399,7 +399,7 @@ prometheus:
     ## alertmanager container image
     ##
     image:
-      repository: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/alertmanager
+      repository:
       tag: v0.24.0
 
     ## ConfigMap override where fullname is {{.Release.Name}}-{{.Values.alertmanager.configMapOverrideName}}
@@ -567,7 +567,7 @@ prometheus:
     ## node-exporter container image
     ##
     image:
-      repository: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/node-exporter
+      repository:
       tag: v1.3.1
 
   configmapReload:
@@ -575,13 +575,13 @@ prometheus:
       ## configmap-reload container image
       ##
       image:
-        repository: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/configmap-reload
+        repository:
         tag: v0.5.0
     alertmanager:
       ## configmap-reload container image
       ##
       image:
-        repository: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/configmap-reload
+        repository:
         tag: v0.5.0
 
   server:
@@ -592,7 +592,7 @@ prometheus:
     ## Prometheus server container image
     ##
     image:
-      repository: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/prometheus
+      repository:
       tag: v2.44.0
 
     global:
@@ -782,9 +782,6 @@ prometheus:
       #   - secretName: prometheus-server-tls
       #     hosts:
       #       - prometheus.domain.com
-
-
-
 
   ## AlertManager ConfigMap Entries
   ## NOTE: Please review these carefully as thresholds and behavior may not meet
@@ -1478,7 +1475,7 @@ grafana:
   replicas: 1
 
   image:
-    repository: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/grafana
+    repository:
     # Overrides the Grafana image tag whose default is the chart appVersion
     tag: 9.2.4
 
@@ -1523,7 +1520,7 @@ grafana:
 
   sidecar:
     image:
-      repository: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/k8s-sidecar
+      repository:
       tag: 1.19.2
 
     dashboards:
@@ -1629,7 +1626,7 @@ snapshot-controller:
   ## @param snapshot-controller.image.repository -- Repository to pull the image from.
   ##
   image:
-    repository: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/snapshot-controller
+    repository:
     tag: v6.2.1
 
   tolerations:
@@ -1683,11 +1680,10 @@ alertmanager-webhook-adaptor:
   ## Linkage with prometheus.enabled
   ##
   # enabled: false
-
   ## Webhook-Adaptor container image
   ##
   image:
-    registry: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com
+    registry:
 
   affinity:
     nodeAffinity:
@@ -1753,7 +1749,7 @@ enabledAlphaFeatureGates:
 agamotto:
   enabled: false
   image:
-    registry: infracreate-registry.cn-zhangjiakou.cr.aliyuncs.com
+    registry:
 
 
 provider: "" # cloud be "aws","gcp","aliyun","tencentCloud", "huaweiCloud", "azure"


### PR DESCRIPTION
- We provide a quick way to specify the image registry for **all resources** in the KubeBlocks Helm chart. 
Now, when installing KubeBlocks with `helm install kubeblocks`, you can quickly change the image registry for all resources by using `--set image.registry` like`--set image.registry=docker.io`
![f9f3749b-cca9-4a86-a0d4-974d7a3a8394](https://github.com/apecloud/kubeblocks/assets/101848970/c8a4228d-490e-465c-9d1c-801d090ee3e6)
![img_v3_025t_b51b6250-85ec-4041-b048-4b744f4abb2g](https://github.com/apecloud/kubeblocks/assets/101848970/42b1f0ec-fa2d-43c4-96b3-a8305354a4b4)
![64a4b132-bcd9-461a-a46a-7571b97a38ea](https://github.com/apecloud/kubeblocks/assets/101848970/b65569f7-f57b-4d18-9280-5756a6f2ae3f)

- here is the `helm template test deploy/helm  --set image.registry=docker.io > manifest.txt ` result
[manifest.txt](https://github.com/apecloud/kubeblocks/files/13612960/manifest.txt)


But there is an issue here: the addon files hardcode version information, making the installation of addons less flexible.
![img_v3_025t_88aa0d80-505d-4935-9f35-87649ab2a32g](https://github.com/apecloud/kubeblocks/assets/101848970/454b720d-45a3-44a1-bb32-06e74cc8b66d)
![img_v3_025t_b51b6250-85ec-4041-b048-4b744f4abb2g](https://github.com/apecloud/kubeblocks/assets/101848970/0494e606-dd0f-4221-82fa-2410eace4843)
![ed7ff594-e2e2-4bb6-9b53-0cfb7c1c15d4](https://github.com/apecloud/kubeblocks/assets/101848970/e9a30111-6931-483b-82d0-426d2cefad82)
