### PR TITLE
chore: fix cluster connect Database Env

### DIFF
--- a/pkg/lorry/engines/opengauss/commands.go
+++ b/pkg/lorry/engines/opengauss/commands.go
@@ -41,7 +41,7 @@ func NewCommands() engines.ClusterCommands {
 			Client:      "gsql",
 			PasswordEnv: "$GS_PASSWORD",
 			UserEnv:     "$GS_USERNAME",
-			Database:    "$GS_DATABASE",
+			Database:    "$GS_DB",
 		},
 		examples: map[models.ClientType]engines.BuildConnectExample{
 			models.CLI: func(info *engines.ConnectionInfo) string {


### PR DESCRIPTION
- fix the connect cmd mistake
![img_v3_0263_d6309d3d-e078-481b-9394-1d6a3c30cb2g](https://github.com/apecloud/kubeblocks/assets/101848970/954ad268-3a1d-46b9-858c-e23878ed655c)
