### PR TITLE
fix: add the description of wal_level in the pg configconstrant file

### DIFF
--- a/deploy/postgresql/config/pg12-config-constraint.cue
+++ b/deploy/postgresql/config/pg12-config-constraint.cue
@@ -1024,6 +1024,9 @@
 	// If set to on (the default), this option causes new WAL files to be filled with zeroes. On some file systems, this ensures that space is allocated before we need to write WAL records. However, Copy-On-Write (COW) file systems may not benefit from this technique, so the option is given to skip the unnecessary work. If set to off, only the final byte is written when the file is created so that it has the expected size.
 	wal_init_zero?: string & "on" | "off"
 
+	// Sets the level of information written to the WAL. replica writes enough data to support WAL archiving and replication, including running read-only queries on a standby server. minimal removes all logging except the information required to recover from a crash or immediate shutdown. Finally, logical adds information necessary to support logical decoding
+  wal_level?: string & "minimal" | "replica" | "logical"
+
 	// (kB) Sets the maximum memory to be used for query workspaces.
 	work_mem?: int & >=64 & <=2147483647 @storeResource(1KB)
 

--- a/deploy/postgresql/config/pg12-config-constraint.cue
+++ b/deploy/postgresql/config/pg12-config-constraint.cue
@@ -1025,7 +1025,7 @@
 	wal_init_zero?: string & "on" | "off"
 
 	// Sets the level of information written to the WAL. replica writes enough data to support WAL archiving and replication, including running read-only queries on a standby server. minimal removes all logging except the information required to recover from a crash or immediate shutdown. Finally, logical adds information necessary to support logical decoding
-  wal_level?: string & "minimal" | "replica" | "logical"
+	wal_level?: string & "minimal" | "replica" | "logical"
 
 	// (kB) Sets the maximum memory to be used for query workspaces.
 	work_mem?: int & >=64 & <=2147483647 @storeResource(1KB)

--- a/deploy/postgresql/config/pg14-config-constraint.cue
+++ b/deploy/postgresql/config/pg14-config-constraint.cue
@@ -1103,7 +1103,7 @@
 	wal_init_zero?: string & "on" | "off"
 
 	// Sets the level of information written to the WAL. replica writes enough data to support WAL archiving and replication, including running read-only queries on a standby server. minimal removes all logging except the information required to recover from a crash or immediate shutdown. Finally, logical adds information necessary to support logical decoding
-  wal_level?: string & "minimal" | "replica" | "logical"
+	wal_level?: string & "minimal" | "replica" | "logical"
 
 	// Sets how binary values are to be encoded in XML.
 	xmlbinary?: string & "base64" | "hex"

--- a/deploy/postgresql/config/pg14-config-constraint.cue
+++ b/deploy/postgresql/config/pg14-config-constraint.cue
@@ -1102,6 +1102,9 @@
 	// If set to on (the default), this option causes new WAL files to be filled with zeroes. On some file systems, this ensures that space is allocated before we need to write WAL records. However, Copy-On-Write (COW) file systems may not benefit from this technique, so the option is given to skip the unnecessary work. If set to off, only the final byte is written when the file is created so that it has the expected size.
 	wal_init_zero?: string & "on" | "off"
 
+	// Sets the level of information written to the WAL. replica writes enough data to support WAL archiving and replication, including running read-only queries on a standby server. minimal removes all logging except the information required to recover from a crash or immediate shutdown. Finally, logical adds information necessary to support logical decoding
+  wal_level?: string & "minimal" | "replica" | "logical"
+
 	// Sets how binary values are to be encoded in XML.
 	xmlbinary?: string & "base64" | "hex"
 


### PR DESCRIPTION
https://github.com/apecloud/kubeblocks/issues/6100

add the 'wal_level' information in PG config-constrant