### PR TITLE
fix: cluster can't be deleted after KB upgraded from 0.6 to 0.7

### DIFF
--- a/controllers/apps/transformer_cluster_deletion.go
+++ b/controllers/apps/transformer_cluster_deletion.go
@@ -21,10 +21,10 @@ package apps
 
 import (
 	"encoding/json"
-	appsv1 "k8s.io/api/apps/v1"
 	"strings"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"

--- a/controllers/apps/transformer_cluster_deletion.go
+++ b/controllers/apps/transformer_cluster_deletion.go
@@ -21,6 +21,7 @@ package apps
 
 import (
 	"encoding/json"
+	appsv1 "k8s.io/api/apps/v1"
 	"strings"
 	"time"
 
@@ -195,7 +196,7 @@ func kindsForHalt() ([]client.ObjectList, []client.ObjectList) {
 	nonNamespacedKindsPlus := []client.ObjectList{
 		&rbacv1.ClusterRoleBindingList{},
 	}
-	namespacedKindsPlus = append(namespacedKindsPlus, &workloads.ReplicatedStateMachineList{})
+	namespacedKindsPlus = append(namespacedKindsPlus, &workloads.ReplicatedStateMachineList{}, &appsv1.StatefulSetList{})
 
 	return append(namespacedKinds, namespacedKindsPlus...), append(nonNamespacedKinds, nonNamespacedKindsPlus...)
 }


### PR DESCRIPTION
fix #6165 