### PR TITLE
chore: change golang image to 1.21-alpine

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Build the manager binary
 ARG DIST_IMG=gcr.io/distroless/static:nonroot
 
-ARG GO_VERSION=1.21
+ARG GO_VERSION=1.21-alpine
 
 FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} as builder
 

--- a/docker/Dockerfile-dataprotection
+++ b/docker/Dockerfile-dataprotection
@@ -1,7 +1,7 @@
 # Build the dataprotection binary
 ARG DIST_IMG=gcr.io/distroless/static:nonroot
 
-ARG GO_VERSION=1.21
+ARG GO_VERSION=1.21-alpine
 
 FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} as builder
 

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -1,8 +1,8 @@
 # Based on https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/go/.devcontainer/base.Dockerfile
 
 # [Choice] Go version: 1, 1.19, 1.18, etc
-ARG GOVERSION=1.21
-FROM golang:${GOVERSION}-bullseye
+ARG GOVERSION=1.21-alpine
+FROM golang:${GOVERSION}
 
 # Copy library scripts to execute
 COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -1,8 +1,8 @@
 # Based on https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/go/.devcontainer/base.Dockerfile
 
 # [Choice] Go version: 1, 1.19, 1.18, etc
-ARG GOVERSION=1.21-alpine
-FROM golang:${GOVERSION}
+ARG GOVERSION=1.21
+FROM golang:${GOVERSION}-bullseye
 
 # Copy library scripts to execute
 COPY library-scripts/*.sh library-scripts/*.env /tmp/library-scripts/

--- a/docker/Dockerfile-tools
+++ b/docker/Dockerfile-tools
@@ -11,7 +11,7 @@
 #TARGETARCH - Architecture from --platform, e.g. arm64
 #TARGETVARIANT - used to set target ARM variant, e.g. v7
 
-ARG GO_VERSION=1.21
+ARG GO_VERSION=1.21-alpine
 
 FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} as builder
 ARG TARGETOS


### PR DESCRIPTION
1. KubeBlocks install ok
![image](https://github.com/apecloud/kubeblocks/assets/109708205/e4391588-600b-4498-84a9-4e1425b03467)
2. size is the same as base golang:1.21
![img_v3_026g_f1cb6931-f570-4f64-b3be-cfd54e36e76g](https://github.com/apecloud/kubeblocks/assets/109708205/542f79da-926e-4598-8549-66ad0932d85a)
