### PR TITLE
fix: label selector for pod affinity and topology spread constraint

### DIFF
--- a/pkg/controller/component/affinity_utils.go
+++ b/pkg/controller/component/affinity_utils.go
@@ -96,7 +96,7 @@ func BuildPodTopologySpreadConstraints(clusterName, compName string, compAffinit
 			LabelSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					constant.AppInstanceLabelKey:    clusterName,
-					constant.KBAppComponentLabelKey: FullName(clusterName, compName),
+					constant.KBAppComponentLabelKey: compName,
 				},
 			},
 		})
@@ -151,7 +151,7 @@ func buildNewAffinity(clusterName, compName string, compAffinity *appsv1alpha1.A
 			LabelSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					constant.AppInstanceLabelKey:    clusterName,
-					constant.KBAppComponentLabelKey: FullName(clusterName, compName),
+					constant.KBAppComponentLabelKey: compName,
 				},
 			},
 		})


### PR DESCRIPTION
fix #6234 