### PR TITLE
feat: integrate with Kopia for database backup

### DIFF
--- a/apis/dataprotection/v1alpha1/backup_types.go
+++ b/apis/dataprotection/v1alpha1/backup_types.go
@@ -118,6 +118,10 @@ type BackupStatus struct {
 	// +optional
 	Path string `json:"path,omitempty"`
 
+	// kopiaRepoPath records the path of the Kopia repository.
+	// +optional
+	KopiaRepoPath string `json:"kopiaRepoPath,omitempty"`
+
 	// persistentVolumeClaimName is the name of the persistent volume claim that
 	// is used to store the backup data.
 	// +optional

--- a/apis/dataprotection/v1alpha1/backuppolicy_types.go
+++ b/apis/dataprotection/v1alpha1/backuppolicy_types.go
@@ -48,6 +48,17 @@ type BackupPolicySpec struct {
 	// backupMethods defines the backup methods.
 	// +kubebuilder:validation:Required
 	BackupMethods []BackupMethod `json:"backupMethods"`
+
+	// useKopia specifies whether backup data should be stored in a Kopia repository.
+	// Data within the Kopia repository is both compressed and encrypted. Furthermore,
+	// data deduplication is implemented across various backups of the same cluster.
+	// This approach significantly reduces the actual storage usage, particularly for
+	// clusters with a low update frequency.
+	// NOTE: This feature should NOT be enabled when using KubeBlocks Community Edition,
+	// otherwise the backup will not be processed.
+	// +optional
+	// +kubebuilder:default=false
+	UseKopia bool `json:"useKopia"`
 }
 
 type BackupTarget struct {

--- a/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -659,6 +659,17 @@ spec:
                       to run the backup workload.
                     type: string
                 type: object
+              useKopia:
+                default: false
+                description: 'useKopia specifies whether backup data should be stored
+                  in a Kopia repository. Data within the Kopia repository is both
+                  compressed and encrypted. Furthermore, data deduplication is implemented
+                  across various backups of the same cluster. This approach significantly
+                  reduces the actual storage usage, particularly for clusters with
+                  a low update frequency. NOTE: This feature should NOT be enabled
+                  when using KubeBlocks Community Edition, otherwise the backup will
+                  not be processed.'
+                type: boolean
             required:
             - backupMethods
             - target

--- a/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
@@ -681,6 +681,9 @@ spec:
                 description: formatVersion is the backup format version, including
                   major, minor and patch version.
                 type: string
+              kopiaRepoPath:
+                description: kopiaRepoPath records the path of the Kopia repository.
+                type: string
               path:
                 description: path is the directory inside the backup repository where
                   the backup data is stored. It is an absolute path in the backup

--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -293,6 +293,14 @@ func (r *BackupReconciler) prepareBackupRequest(
 		request.ActionSet = actionSet
 	}
 
+	if !snapshotVolumes && backupPolicy.Spec.UseKopia {
+		acked := backup.Annotations[dptypes.GeminiAcknowledgedAnnotationKey]
+		if acked != trueVal {
+			return nil, intctrlutil.NewErrorf(dperrors.ErrorTypeWaitForExternalHandler,
+				`wait for external handler to handle this backup because policy.spec.useKopia is true`)
+		}
+	}
+
 	request.BackupPolicy = backupPolicy
 	if !snapshotVolumes {
 		// if use volume snapshot, ignore backup repo
@@ -324,6 +332,9 @@ func (r *BackupReconciler) patchBackupStatus(
 	}
 	if request.BackupRepoPVC != nil {
 		request.Status.PersistentVolumeClaimName = request.BackupRepoPVC.Name
+	}
+	if request.BackupPolicy.Spec.UseKopia {
+		request.Status.KopiaRepoPath = dpbackup.BuildKopiaRepoPath(request.Backup, request.BackupPolicy.Spec.PathPrefix)
 	}
 	// init action status
 	actions, err := request.BuildActions()
@@ -577,7 +588,7 @@ func setConnectionPasswordAnnotation(request *dpbackup.Request) error {
 		return err
 	}
 	if ciphertext != "" {
-		request.Backup.Annotations[dptypes.ConnectionPasswordKey] = ciphertext
+		request.Backup.Annotations[dptypes.ConnectionPasswordAnnotationKey] = ciphertext
 	}
 	return nil
 }

--- a/controllers/dataprotection/backup_controller_test.go
+++ b/controllers/dataprotection/backup_controller_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Backup Controller test", func() {
 					g.Expect(fetched.Status.PersistentVolumeClaimName).Should(Equal(repoPVCName))
 					g.Expect(fetched.Status.Path).Should(Equal(dpbackup.BuildBackupPath(fetched, backupPolicy.Spec.PathPrefix)))
 					g.Expect(fetched.Status.Phase).Should(Equal(dpv1alpha1.BackupPhaseRunning))
-					g.Expect(fetched.Annotations[dptypes.ConnectionPasswordKey]).ShouldNot(BeEmpty())
+					g.Expect(fetched.Annotations[dptypes.ConnectionPasswordAnnotationKey]).ShouldNot(BeEmpty())
 				})).Should(Succeed())
 
 				By("check backup job's nodeName equals pod's nodeName")
@@ -728,6 +728,101 @@ var _ = Describe("Backup Controller test", func() {
 					g.Expect(backup.Status.Phase).Should(BeEquivalentTo(dpv1alpha1.BackupPhaseFailed))
 					g.Expect(backup.Status.FailureReason).Should(ContainSubstring("no default BackupRepo found"))
 				})).Should(Succeed())
+			})
+		})
+	})
+
+	When("use kopia", func() {
+		var (
+			backupPolicy *dpv1alpha1.BackupPolicy
+			repoPVCName  string
+			cluster      *appsv1alpha1.Cluster
+		)
+
+		BeforeEach(func() {
+			By("creating an actionSet")
+			actionSet := testdp.NewFakeActionSet(&testCtx)
+
+			By("creating storage provider")
+			_ = testdp.NewFakeStorageProvider(&testCtx, nil)
+
+			By("creating backup repo")
+			_, repoPVCName = testdp.NewFakeBackupRepo(&testCtx, nil)
+
+			By("creating a backupPolicy from actionSet: " + actionSet.Name)
+			backupPolicy = testdp.NewFakeBackupPolicy(&testCtx, nil)
+
+			cluster = clusterInfo.Cluster
+		})
+
+		Context("wait for gemini to handle", func() {
+			var (
+				backupKey types.NamespacedName
+				backup    *dpv1alpha1.Backup
+			)
+
+			getJobKey := func() client.ObjectKey {
+				return client.ObjectKey{
+					Name:      dpbackup.GenerateBackupJobName(backup, dpbackup.BackupDataJobNamePrefix),
+					Namespace: backup.Namespace,
+				}
+			}
+
+			BeforeEach(func() {
+				By("making the backupPolicy to use kopia")
+				Eventually(testapps.GetAndChangeObj(&testCtx, client.ObjectKeyFromObject(backupPolicy),
+					func(policy *dpv1alpha1.BackupPolicy) {
+						policy.Spec.UseKopia = true
+					})).Should(Succeed())
+				By("creating a backup from backupPolicy " + testdp.BackupPolicyName)
+				backup = testdp.NewFakeBackup(&testCtx, nil)
+				backupKey = client.ObjectKeyFromObject(backup)
+			})
+
+			It("should continue to process after gemini acknowledged", func() {
+				By("check backup status")
+				Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+					g.Expect(fetched.Status.Phase).Should(BeEmpty())
+				})).Should(Succeed())
+
+				By("simulate gemini processing")
+				Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(backup *dpv1alpha1.Backup) {
+					if backup.Annotations == nil {
+						backup.Annotations = map[string]string{}
+					}
+					backup.Annotations[dptypes.GeminiAcknowledgedAnnotationKey] = trueVal
+				})).Should(Succeed())
+
+				By("check backup status again")
+				Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+					g.Expect(fetched.Status.PersistentVolumeClaimName).Should(Equal(repoPVCName))
+					g.Expect(fetched.Status.Path).Should(Equal(dpbackup.BuildBackupPath(fetched, backupPolicy.Spec.PathPrefix)))
+					g.Expect(fetched.Status.KopiaRepoPath).Should(Equal(dpbackup.BuildKopiaRepoPath(fetched, backupPolicy.Spec.PathPrefix)))
+					g.Expect(fetched.Status.Phase).Should(Equal(dpv1alpha1.BackupPhaseRunning))
+					g.Expect(fetched.Annotations[dptypes.ConnectionPasswordAnnotationKey]).ShouldNot(BeEmpty())
+				})).Should(Succeed())
+
+				testdp.PatchK8sJobStatus(&testCtx, getJobKey(), batchv1.JobComplete)
+
+				By("backup job should have completed")
+				Eventually(testapps.CheckObj(&testCtx, getJobKey(), func(g Gomega, fetched *batchv1.Job) {
+					_, finishedType, _ := dputils.IsJobFinished(fetched)
+					g.Expect(fetched.Labels[constant.AppManagedByLabelKey]).Should(Equal(dptypes.AppName))
+					g.Expect(finishedType).To(Equal(batchv1.JobComplete))
+				})).Should(Succeed())
+
+				By("backup should have completed")
+				Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+					g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseCompleted))
+					g.Expect(fetched.Labels[dptypes.ClusterUIDLabelKey]).Should(Equal(string(cluster.UID)))
+					g.Expect(fetched.Labels[constant.AppInstanceLabelKey]).Should(Equal(testdp.ClusterName))
+					g.Expect(fetched.Labels[constant.KBAppComponentLabelKey]).Should(Equal(testdp.ComponentName))
+					g.Expect(fetched.Labels[constant.AppManagedByLabelKey]).Should(Equal(dptypes.AppName))
+					g.Expect(fetched.Annotations[constant.ClusterSnapshotAnnotationKey]).ShouldNot(BeEmpty())
+				})).Should(Succeed())
+
+				By("backup job should be deleted after backup completed")
+				Eventually(testapps.CheckObjExists(&testCtx, getJobKey(), &batchv1.Job{}, false)).Should(Succeed())
 			})
 		})
 	})

--- a/controllers/dataprotection/backup_controller_test.go
+++ b/controllers/dataprotection/backup_controller_test.go
@@ -763,7 +763,7 @@ var _ = Describe("Backup Controller test", func() {
 
 			getJobKey := func() client.ObjectKey {
 				return client.ObjectKey{
-					Name:      dpbackup.GenerateBackupJobName(backup, dpbackup.BackupDataJobNamePrefix),
+					Name:      dpbackup.GenerateBackupJobName(backup, dpbackup.BackupDataJobNamePrefix+"-0"),
 					Namespace: backup.Namespace,
 				}
 			}

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -659,6 +659,17 @@ spec:
                       to run the backup workload.
                     type: string
                 type: object
+              useKopia:
+                default: false
+                description: 'useKopia specifies whether backup data should be stored
+                  in a Kopia repository. Data within the Kopia repository is both
+                  compressed and encrypted. Furthermore, data deduplication is implemented
+                  across various backups of the same cluster. This approach significantly
+                  reduces the actual storage usage, particularly for clusters with
+                  a low update frequency. NOTE: This feature should NOT be enabled
+                  when using KubeBlocks Community Edition, otherwise the backup will
+                  not be processed.'
+                type: boolean
             required:
             - backupMethods
             - target

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
@@ -681,6 +681,9 @@ spec:
                 description: formatVersion is the backup format version, including
                   major, minor and patch version.
                 type: string
+              kopiaRepoPath:
+                description: kopiaRepoPath records the path of the Kopia repository.
+                type: string
               path:
                 description: path is the directory inside the backup repository where
                   the backup data is stored. It is an absolute path in the backup

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -318,7 +318,7 @@ dataProtection:
     imagePullSecrets: []
     datasafed:
       repository: apecloud/datasafed
-      tag: "0.0.6"
+      tag: "0.1.0"
 
 ## BackupRepo settings
 ##

--- a/pkg/dataprotection/backup/request.go
+++ b/pkg/dataprotection/backup/request.go
@@ -425,8 +425,7 @@ func (r *Request) BuildJobActionPodSpec(targetPod *corev1.Pod,
 		}
 	}
 
-	utils.InjectDatasafed(podSpec, r.BackupRepo, RepoVolumeMountPath,
-		BuildBackupPath(r.Backup, r.BackupPolicy.Spec.PathPrefix))
+	utils.InjectDatasafed(podSpec, r.BackupRepo, RepoVolumeMountPath, r.Status.KopiaRepoPath)
 	return podSpec, nil
 }
 

--- a/pkg/dataprotection/backup/utils.go
+++ b/pkg/dataprotection/backup/utils.go
@@ -180,6 +180,15 @@ func BuildBackupPath(backup *dpv1alpha1.Backup, pathPrefix string) string {
 	return fmt.Sprintf("/%s/%s/%s", backup.Namespace, pathPrefix, backup.Name)
 }
 
+// BuildKopiaRepoPath builds the path of kopia repository.
+func BuildKopiaRepoPath(backup *dpv1alpha1.Backup, pathPrefix string) string {
+	pathPrefix = strings.TrimRight(pathPrefix, "/")
+	if strings.TrimSpace(pathPrefix) == "" || strings.HasPrefix(pathPrefix, "/") {
+		return fmt.Sprintf("/%s%s/%s", backup.Namespace, pathPrefix, types.KopiaRepoFolderName)
+	}
+	return fmt.Sprintf("/%s/%s/%s", backup.Namespace, pathPrefix, types.KopiaRepoFolderName)
+}
+
 func GetSchedulePolicyByMethod(backupSchedule *dpv1alpha1.BackupSchedule, method string) *dpv1alpha1.SchedulePolicy {
 	for _, s := range backupSchedule.Spec.Schedules {
 		if s.BackupMethod == method {

--- a/pkg/dataprotection/restore/builder.go
+++ b/pkg/dataprotection/restore/builder.go
@@ -361,13 +361,13 @@ func (r *restoreJobBuilder) build() *batchv1.Job {
 	// 3. inject datasafed if needed
 	if r.buildWithRepo {
 		mountPath := "/backupdata"
-		backupPath := r.backupSet.Backup.Status.Path
+		kopiaRepoPath := r.backupSet.Backup.Status.KopiaRepoPath
 		if r.backupRepo != nil {
-			utils.InjectDatasafed(&job.Spec.Template.Spec, r.backupRepo, mountPath, backupPath)
+			utils.InjectDatasafed(&job.Spec.Template.Spec, r.backupRepo, mountPath, kopiaRepoPath)
 		} else if pvcName := r.backupSet.Backup.Status.PersistentVolumeClaimName; pvcName != "" {
 			// If the backup object was created in an old version that doesn't have the backupRepo field,
 			// use the PVC name field as a fallback.
-			utils.InjectDatasafedWithPVC(&job.Spec.Template.Spec, pvcName, mountPath, backupPath)
+			utils.InjectDatasafedWithPVC(&job.Spec.Template.Spec, pvcName, mountPath, kopiaRepoPath)
 		}
 	}
 	return job

--- a/pkg/dataprotection/restore/utils.go
+++ b/pkg/dataprotection/restore/utils.go
@@ -293,7 +293,7 @@ func GetRestoreFromBackupAnnotation(backup *dpv1alpha1.Backup, compSpecs []appsv
 	if restoreTime != "" {
 		restoreInfoMap[constant.RestoreTimeKeyForRestore] = restoreTime
 	}
-	connectionPassword := backup.Annotations[dptypes.ConnectionPasswordKey]
+	connectionPassword := backup.Annotations[dptypes.ConnectionPasswordAnnotationKey]
 	if connectionPassword != "" {
 		restoreInfoMap[constant.ConnectionPassword] = connectionPassword
 	}

--- a/pkg/dataprotection/types/constant.go
+++ b/pkg/dataprotection/types/constant.go
@@ -48,6 +48,10 @@ const (
 	DefaultBackupRepoAnnotationKey = "dataprotection.kubeblocks.io/is-default-repo"
 	// ReconfigureRefAnnotationKey specifies the reconfigure ref.
 	ReconfigureRefAnnotationKey = "dataprotection.kubeblocks.io/reconfigure-ref"
+	// ConnectionPasswordAnnotationKey specifies the password of the connection credential.
+	ConnectionPasswordAnnotationKey = "dataprotection.kubeblocks.io/connection-password"
+	// GeminiAcknowledgedAnnotationKey indicates whether Gemini has acknowledged the backup.
+	GeminiAcknowledgedAnnotationKey = "dataprotection.kubeblocks.io/gemini-acknowledged"
 )
 
 // label keys
@@ -70,8 +74,6 @@ const (
 	AutoBackupLabelKey = "dataprotection.kubeblocks.io/autobackup"
 	// BackupTargetPodLabelKey specifies the backup target pod label key.
 	BackupTargetPodLabelKey = "dataprotection.kubeblocks.io/target-pod-name"
-	// ConnectionPasswordKey specifies the password of the connection credential.
-	ConnectionPasswordKey = "dataprotection.kubeblocks.io/connection-password"
 )
 
 // env names
@@ -107,9 +109,13 @@ const (
 	// DPDatasafedLocalBackendPath force datasafed to use local backend with the path
 	// NOTE: do not add 'DP_' for this constant, it is the datasafed built-in environment.
 	DPDatasafedLocalBackendPath = "DATASAFED_LOCAL_BACKEND_PATH"
+	// DPDatasafedKopiaRepoRoot specifies the root of the Kopia repository
+	// NOTE: do not add 'DP_' for this constant, it is the datasafed built-in environment.
+	DPDatasafedKopiaRepoRoot = "DATASAFED_KOPIA_REPO_ROOT"
 )
 
 const (
 	RestoreKind            = "Restore"
 	DataprotectionAPIGroup = "dataprotection.kubeblocks.io"
+	KopiaRepoFolderName    = "kopia"
 )


### PR DESCRIPTION
Kopia has many advanced features such as content de-duplication, data compression, and encryption. If the data in the cluster is not frequently updated, using Kopia to back up data can reduce the amount of data that actually needs to be stored.

This PR introduces Kopia as the format for backup storage. Most of the code changes are done in `datasafed`. Users can enable this feature by setting `backupPolicy.spec.useKopia` to true. When this feature is enabled, the BackupController will inject the appropriate environment variables so that `datasafed` stores the data in the `Kopia Repository`.

Different Backups under the same cluster will store data in the same `Kopia Repository`. The actual path of the `Kopia Repository` on the storage backend is `{namespace}/{cluster_name}-{cluster_uid}/{component}/kopia`. When the last Backup in the cluster is deleted, the `Kopia Repository` will also be completely cleared on the storage backend.

We define this feature as an enterprise feature, which needs to be used in conjunction with gemini. Currently, it is confirmed whether gemini has been processed through the `dataprotection.kubeblocks.io/gemini-acknowledged` annotation in the Backup CR, otherwise, the Backup CR will be stuck and do nothing.

Close #6383.