### PR TITLE
fix: zap flags not be added

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -237,9 +237,9 @@ func main() {
 		err                    error
 	)
 
-	setupFlags()
-
 	setupLogger()
+
+	setupFlags()
 
 	// Find and read the config file
 	if err := viper.ReadInConfig(); err != nil { // Handle errors reading the config file


### PR DESCRIPTION
fix https://github.com/apecloud/kubeblocks/issues/6449

```
	opts := zap.Options{
		Development: false,
	}
	opts.BindFlags(flag.CommandLine)
```
should be executed before
```
pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
```
Otherwise, we will lost zap related flags.

<img width="1325" alt="截屏2024-01-13 21 32 34" src="https://github.com/apecloud/kubeblocks/assets/32033618/7a4879ee-87a7-48a4-b537-f4bbd98a164e">

