### PR TITLE
fix: mysql replication initialization and  failover

### DIFF
--- a/controllers/apps/transformer_component_workload.go
+++ b/controllers/apps/transformer_component_workload.go
@@ -310,7 +310,7 @@ func copyAndMergeRSM(oldRsm, newRsm *workloads.ReplicatedStateMachine, synthesiz
 	// keep the original template annotations.
 	// if annotations exist and are replaced, the rsm will be updated.
 	mergeMetadataMap(rsmObjCopy.Spec.Template.Annotations, &rsmProto.Spec.Template.Annotations)
-	rsmObjCopy.Spec.Template = rsmProto.Spec.Template
+	rsmObjCopy.Spec.Template = *rsmProto.Spec.Template.DeepCopy()
 	rsmObjCopy.Spec.Replicas = rsmProto.Spec.Replicas
 	rsmObjCopy.Spec.Service = updateService(rsmObjCopy, rsmProto)
 	rsmObjCopy.Spec.AlternativeServices = rsmProto.Spec.AlternativeServices

--- a/pkg/lorry/dcs/types.go
+++ b/pkg/lorry/dcs/types.go
@@ -99,7 +99,7 @@ func (c *Cluster) GetMemberAddr(member Member) string {
 }
 
 func (c *Cluster) GetMemberShortAddr(member Member) string {
-	return fmt.Sprintf("%s.%s-headless.%s.svc", member.Name, c.ClusterCompName, c.Namespace)
+	return fmt.Sprintf("%s.%s-headless", member.Name, c.ClusterCompName)
 }
 
 func (c *Cluster) GetMemberAddrs() []string {

--- a/pkg/lorry/engines/mysql/get_replica_role.go
+++ b/pkg/lorry/engines/mysql/get_replica_role.go
@@ -35,7 +35,7 @@ func (mgr *Manager) GetReplicaRole(ctx context.Context, cluster *dcs.Cluster) (s
 
 	if !cluster.IsLocked() {
 		mgr.Logger.Info("cluster has no leader lease")
-		return mgr.getReplicaRoleFromDB(ctx)
+		return "", errors.New("cluster has no leader lease")
 	}
 
 	if cluster.Leader.Name != mgr.CurrentMemberName {
@@ -45,7 +45,7 @@ func (mgr *Manager) GetReplicaRole(ctx context.Context, cluster *dcs.Cluster) (s
 	return models.PRIMARY, nil
 }
 
-func (mgr *Manager) getReplicaRoleFromDB(ctx context.Context) (string, error) {
+func (mgr *Manager) GetReplicaRoleFromDB(ctx context.Context) (string, error) {
 	slaveRunning, err := mgr.isSlaveRunning(ctx)
 	if err != nil {
 		return "", err

--- a/pkg/lorry/engines/mysql/manager.go
+++ b/pkg/lorry/engines/mysql/manager.go
@@ -423,6 +423,7 @@ func (mgr *Manager) LeaveMemberFromCluster(context.Context, *dcs.Cluster, string
 // IsClusterInitialized is a method to check if cluster is initialized or not
 func (mgr *Manager) IsClusterInitialized(ctx context.Context, cluster *dcs.Cluster) (bool, error) {
 	if cluster != nil {
+		// The maximum length of the server addr is 255 characters. Before MySQL 8.0.17 it was 60 characters.
 		var version string
 		err := mgr.DB.QueryRowContext(ctx, "select version()").Scan(&version)
 		if err != nil {

--- a/pkg/lorry/engines/mysql/manager.go
+++ b/pkg/lorry/engines/mysql/manager.go
@@ -130,7 +130,7 @@ func (mgr *Manager) IsDBStartupReady() bool {
 func (mgr *Manager) IsReadonly(ctx context.Context, cluster *dcs.Cluster, member *dcs.Member) (bool, error) {
 	db, err := mgr.GetMemberConnection(cluster, member)
 	if err != nil {
-		mgr.Logger.Error(err, "Get Member conn failed")
+		mgr.Logger.Info("Get Member conn failed", "error", err.Error())
 		return false, err
 	}
 
@@ -140,7 +140,7 @@ func (mgr *Manager) IsReadonly(ctx context.Context, cluster *dcs.Cluster, member
 		Scan(&mgr.hostname, &mgr.version, &readonly, &mgr.binlogFormat,
 			&mgr.logbinEnabled, &mgr.logReplicationUpdatesEnabled)
 	if err != nil {
-		mgr.Logger.Error(err, "Get global readonly failed")
+		mgr.Logger.Info("Get global readonly failed", "error", err.Error())
 		return false, err
 	}
 	return readonly, nil
@@ -206,14 +206,14 @@ func (mgr *Manager) IsMemberLagging(ctx context.Context, cluster *dcs.Cluster, m
 	var leaderDBState *dcs.DBState
 	if cluster.Leader == nil || cluster.Leader.DBState == nil {
 		mgr.Logger.Info("No leader DBState info")
-		return false, 0
+		return true, 0
 	}
 	leaderDBState = cluster.Leader.DBState
 
 	db, err := mgr.GetMemberConnection(cluster, member)
 	if err != nil {
 		mgr.Logger.Info("Get Member conn failed", "error", err)
-		return false, 0
+		return true, 0
 	}
 
 	opTimestamp, err := mgr.GetOpTimestamp(ctx, db)

--- a/pkg/lorry/engines/mysql/manager.go
+++ b/pkg/lorry/engines/mysql/manager.go
@@ -219,14 +219,14 @@ func (mgr *Manager) IsMemberLagging(ctx context.Context, cluster *dcs.Cluster, m
 	opTimestamp, err := mgr.GetOpTimestamp(ctx, db)
 	if err != nil {
 		mgr.Logger.Info("get op timestamp failed", "error", err)
-		return false, 0
+		return true, 0
 	}
-
-	if leaderDBState.OpTimestamp-opTimestamp <= cluster.HaConfig.GetMaxLagOnSwitchover() {
-		return false, 0
+	lag := leaderDBState.OpTimestamp - opTimestamp
+	if lag <= cluster.HaConfig.GetMaxLagOnSwitchover() {
+		return false, lag
 	}
-	mgr.Logger.Info(fmt.Sprintf("The member %s has lag: %d", member.Name, leaderDBState.OpTimestamp-opTimestamp))
-	return true, leaderDBState.OpTimestamp - opTimestamp
+	mgr.Logger.Info(fmt.Sprintf("The member %s has lag: %d", member.Name, lag))
+	return true, lag
 }
 
 func (mgr *Manager) IsMemberHealthy(ctx context.Context, cluster *dcs.Cluster, member *dcs.Member) bool {

--- a/pkg/lorry/engines/mysql/manager.go
+++ b/pkg/lorry/engines/mysql/manager.go
@@ -488,7 +488,7 @@ func (mgr *Manager) EnableSemiSyncIfNeed(ctx context.Context) error {
 	//    [ERROR] [MY-000067] [Server] unknown variable 'rpl_semi_sync_master_enabled=1'.
 	if status == "ACTIVE" {
 		setSourceEnable := "SET GLOBAL rpl_semi_sync_source_enabled = 1;" +
-			"SET GLOBAL rpl_semi_sync_source_timeout = 1000;"
+			"SET GLOBAL rpl_semi_sync_source_timeout = 100000;"
 		_, err = mgr.DB.Exec(setSourceEnable)
 		if err != nil {
 			mgr.Logger.Error(err, setSourceEnable+" execute failed")

--- a/pkg/lorry/engines/mysql/manager_test.go
+++ b/pkg/lorry/engines/mysql/manager_test.go
@@ -264,7 +264,7 @@ func TestManager_IsMemberLagging(t *testing.T) {
 
 	t.Run("No leader DBState info", func(t *testing.T) {
 		isMemberLagging, lags := manager.IsMemberLagging(ctx, cluster, nil)
-		assert.False(t, isMemberLagging)
+		assert.True(t, isMemberLagging)
 		assert.Zero(t, lags)
 	})
 
@@ -273,7 +273,7 @@ func TestManager_IsMemberLagging(t *testing.T) {
 		_, _ = NewConfig(fakePropertiesWithWrongURL)
 
 		isMemberLagging, lags := manager.IsMemberLagging(ctx, cluster, &dcs.Member{})
-		assert.False(t, isMemberLagging)
+		assert.True(t, isMemberLagging)
 		assert.Zero(t, lags)
 	})
 
@@ -283,7 +283,7 @@ func TestManager_IsMemberLagging(t *testing.T) {
 			WillReturnError(fmt.Errorf("some error"))
 
 		isMemberLagging, lags := manager.IsMemberLagging(ctx, cluster, &dcs.Member{Name: fakePodName})
-		assert.False(t, isMemberLagging)
+		assert.True(t, isMemberLagging)
 		assert.Zero(t, lags)
 	})
 
@@ -560,7 +560,7 @@ func TestManager_IsClusterInitialized(t *testing.T) {
 		mock.ExpectQuery("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS " +
 			"WHERE PLUGIN_NAME ='rpl_semi_sync_source';").WillReturnRows(sqlmock.NewRows([]string{"PLUGIN_STATUS"}).AddRow("ACTIVE"))
 		mock.ExpectExec("SET GLOBAL rpl_semi_sync_source_enabled = 1;" +
-			"SET GLOBAL rpl_semi_sync_source_timeout = 1000;").
+			"SET GLOBAL rpl_semi_sync_source_timeout = 100000;").
 			WillReturnResult(sqlmock.NewResult(1, 1))
 
 		mock.ExpectQuery("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS " +

--- a/pkg/lorry/engines/mysql/util.go
+++ b/pkg/lorry/engines/mysql/util.go
@@ -23,6 +23,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -227,4 +228,28 @@ func QueryRowsMap(db *sql.DB, query string, onRow func(RowMap) error, args ...in
 	}
 	err = ScanRowsToMaps(rows, onRow)
 	return
+}
+
+func VersionParts(version string) []string {
+	return strings.Split(version, ".")
+}
+
+func IsSmallerVersion(version string, otherVersion string) bool {
+	thisVersions := VersionParts(version)
+	otherVersions := VersionParts(otherVersion)
+	if len(thisVersions) < len(otherVersions) {
+		return false
+	}
+
+	for i := 0; i < len(thisVersions); i++ {
+		thisToken, _ := strconv.Atoi(thisVersions[i])
+		otherToken, _ := strconv.Atoi(otherVersions[i])
+		if thisToken < otherToken {
+			return true
+		}
+		if thisToken > otherToken {
+			return false
+		}
+	}
+	return false
 }

--- a/pkg/lorry/engines/postgres/officalpostgres/manager.go
+++ b/pkg/lorry/engines/postgres/officalpostgres/manager.go
@@ -279,7 +279,7 @@ func (mgr *Manager) IsMemberLagging(ctx context.Context, cluster *dcs.Cluster, m
 		return true, maxLag + 1
 	}
 
-	return cluster.Leader.DBState.OpTimestamp-walPosition > cluster.HaConfig.GetMaxLagOnSwitchover(), cluster.Leader.DBState.OpTimestamp - walPosition
+	return cluster.Leader.DBState.OpTimestamp-walPosition > maxLag, cluster.Leader.DBState.OpTimestamp - walPosition
 }
 
 // Typically, the synchronous_commit parameter remains consistent between the primary and standby

--- a/pkg/lorry/highavailability/ha.go
+++ b/pkg/lorry/highavailability/ha.go
@@ -328,7 +328,8 @@ func (ha *Ha) IsHealthiestMember(ctx context.Context, cluster *dcs3.Cluster) boo
 
 		if candidate == currentMemberName {
 			ha.logger.Info("manual switchover to current member", "member", candidate)
-			return true
+			isCurrentLagging, _ := ha.dbManager.IsMemberLagging(ctx, cluster, currentMember)
+			return !isCurrentLagging
 		}
 
 		if candidate != "" {
@@ -452,15 +453,15 @@ func (ha *Ha) IsPodReady() (bool, error) {
 
 func (ha *Ha) isMinimumLag(ctx context.Context, cluster *dcs3.Cluster, member *dcs3.Member) bool {
 	isCurrentLagging, currentLag := ha.dbManager.IsMemberLagging(ctx, cluster, member)
-	if !isCurrentLagging {
-		return true
+	if isCurrentLagging {
+		return false
 	}
 
 	for _, m := range cluster.Members {
 		if m.Name != member.Name {
 			isLagging, lag := ha.dbManager.IsMemberLagging(ctx, cluster, &m)
 			// There are other members with smaller lag
-			if !isLagging || lag < currentLag {
+			if !isLagging && lag < currentLag {
 				return false
 			}
 		}

--- a/pkg/lorry/highavailability/ha.go
+++ b/pkg/lorry/highavailability/ha.go
@@ -243,6 +243,8 @@ func (ha *Ha) Start() {
 			if err != nil {
 				ha.logger.Error(err, "Cluster initialize failed")
 			}
+		} else if err != nil {
+			ha.logger.Info("Initialize the database cluster Failed.", "error", err.Error())
 		}
 		time.Sleep(5 * time.Second)
 		isInitialized, err = ha.dbManager.IsClusterInitialized(context.TODO(), cluster)

--- a/pkg/lorry/httpserver/server.go
+++ b/pkg/lorry/httpserver/server.go
@@ -114,10 +114,16 @@ func (s *server) apiLogger(next fasthttp.RequestHandler) fasthttp.RequestHandler
 			reqLogger = logger.WithValues("useragent", userAgent)
 		}
 		start := time.Now()
-		reqLogger.Info("HTTP API Called", "method", string(ctx.Method()), "path", string(ctx.Path()))
-		next(ctx)
+		path := string(ctx.Path())
+		if path == "/v1.0/checkrole" {
+			// do not log for checkrole
+			next(ctx)
+			return
+		}
+
+		reqLogger.Info("HTTP API Called", "method", string(ctx.Method()), "path", path)
 		elapsed := float64(time.Since(start) / time.Millisecond)
-		reqLogger.Info("HTTP API Response", "status code", ctx.Response.StatusCode(), "cost", elapsed)
+		reqLogger.Info("HTTP API Called", "status code", ctx.Response.StatusCode(), "cost", elapsed)
 	}
 }
 

--- a/pkg/lorry/httpserver/server.go
+++ b/pkg/lorry/httpserver/server.go
@@ -122,6 +122,7 @@ func (s *server) apiLogger(next fasthttp.RequestHandler) fasthttp.RequestHandler
 		}
 
 		reqLogger.Info("HTTP API Called", "method", string(ctx.Method()), "path", path)
+		next(ctx)
 		elapsed := float64(time.Since(start) / time.Millisecond)
 		reqLogger.Info("HTTP API Called", "status code", ctx.Response.StatusCode(), "cost", elapsed)
 	}

--- a/pkg/lorry/operations/replica/checkrole.go
+++ b/pkg/lorry/operations/replica/checkrole.go
@@ -120,7 +120,7 @@ func (s *CheckRole) Do(ctx context.Context, req *operations.OpsRequest) (*operat
 	defer cancel()
 	role, err := manager.GetReplicaRole(ctx1, cluster)
 	if err != nil {
-		s.logger.Info("executing checkRole error", "error", err)
+		s.logger.Info("executing checkRole error", "error", err.Error())
 		// do not return err, as it will cause readinessprobe to fail
 		err = nil
 		if s.CheckRoleFailedCount%s.FailedEventReportFrequency == 0 {

--- a/pkg/lorry/operations/volume/protect.go
+++ b/pkg/lorry/operations/volume/protect.go
@@ -150,6 +150,10 @@ func (p *Protection) Do(ctx context.Context, req *operations.OpsRequest) (*opera
 func (p *Protection) initVolumes() error {
 	spec := &appsv1alpha1.VolumeProtectionSpec{}
 	raw := viper.GetString(constant.KBEnvVolumeProtectionSpec)
+	if raw == "" {
+		return nil
+	}
+
 	if err := json.Unmarshal([]byte(raw), spec); err != nil {
 		p.Logger.Error(err, "unmarshal volume protection spec error", "raw spec", raw)
 		return err

--- a/pkg/lorry/operations/volume/protect_test.go
+++ b/pkg/lorry/operations/volume/protect_test.go
@@ -134,12 +134,12 @@ var _ = Describe("Volume Protection Operation", func() {
 			Expect(len(protection.Volumes)).Should(Equal(len(volumeProtectionSpec.Volumes)))
 		})
 
-		It("init - invalid volume protection spec env", func() {
+		It("init - empty volume protection spec env", func() {
 			viper.SetDefault(constant.KBEnvVolumeProtectionSpec, "")
 			protection := &Protection{
 				Requester: &mockVolumeStatsRequester{},
 			}
-			Expect(protection.initVolumes()).Should(HaveOccurred())
+			Expect(protection.initVolumes()).Should(BeNil())
 		})
 
 		It("init - init requester error", func() {


### PR DESCRIPTION
1. Use a shorter addr, limit the length of addr, for versions below 8.0.17 the limit is 60, new versions limit it to 255. If the length exceeds the limit, the cluster will not be initialized.
2. During failover, if the delay is greater than 10s, the switch will not be executed, it will wait for the primary to recover by itself.