### PR TITLE
feat: manage dedicated ServiceAccount for dataprotection worker pods

### DIFF
--- a/cmd/dataprotection/main.go
+++ b/cmd/dataprotection/main.go
@@ -100,6 +100,9 @@ func init() {
 	viper.SetDefault(constant.CfgKeyCtrlrMgrNS, "default")
 	viper.SetDefault(constant.KubernetesClusterDomainEnv, constant.DefaultDNSDomain)
 	viper.SetDefault(dptypes.CfgKeyGCFrequencySeconds, dptypes.DefaultGCFrequencySeconds)
+	viper.SetDefault(dptypes.CfgKeyWorkerServiceAccountName, "kb-kubeblocks-dataprotection-worker")
+	viper.SetDefault(dptypes.CfgKeyWorkerServiceAccountAnnotations, "{}")
+	viper.SetDefault(dptypes.CfgKeyWorkerClusterRoleName, "kb-kubeblocks-dataprotection-worker-role")
 }
 
 func main() {
@@ -334,6 +337,14 @@ func validateRequiredToParseConfigs() error {
 		return json.Unmarshal([]byte(val), &affinity)
 	}
 
+	validateWorkerServiceAccountAnnotations := func(val string) error {
+		if val == "" {
+			return nil
+		}
+		annotations := map[string]string{}
+		return json.Unmarshal([]byte(val), &annotations)
+	}
+
 	if err := validateTolerations(viper.GetString(constant.CfgKeyCtrlrMgrTolerations)); err != nil {
 		return err
 	}
@@ -345,6 +356,9 @@ func validateRequiredToParseConfigs() error {
 		if err := json.Unmarshal([]byte(cmNodeSelector), &nodeSelector); err != nil {
 			return err
 		}
+	}
+	if err := validateWorkerServiceAccountAnnotations(viper.GetString(dptypes.CfgKeyWorkerServiceAccountAnnotations)); err != nil {
+		return err
 	}
 	return nil
 }

--- a/cmd/dataprotection/main.go
+++ b/cmd/dataprotection/main.go
@@ -101,6 +101,7 @@ func init() {
 	viper.SetDefault(constant.KubernetesClusterDomainEnv, constant.DefaultDNSDomain)
 	viper.SetDefault(dptypes.CfgKeyGCFrequencySeconds, dptypes.DefaultGCFrequencySeconds)
 	viper.SetDefault(dptypes.CfgKeyWorkerServiceAccountName, "kubeblocks-dataprotection-worker")
+	viper.SetDefault(dptypes.CfgKeyExecWorkerServiceAccountName, "kubeblocks-dataprotection-exec-worker")
 	viper.SetDefault(dptypes.CfgKeyWorkerServiceAccountAnnotations, "{}")
 	viper.SetDefault(dptypes.CfgKeyWorkerClusterRoleName, "kubeblocks-dataprotection-worker-role")
 }

--- a/cmd/dataprotection/main.go
+++ b/cmd/dataprotection/main.go
@@ -100,9 +100,9 @@ func init() {
 	viper.SetDefault(constant.CfgKeyCtrlrMgrNS, "default")
 	viper.SetDefault(constant.KubernetesClusterDomainEnv, constant.DefaultDNSDomain)
 	viper.SetDefault(dptypes.CfgKeyGCFrequencySeconds, dptypes.DefaultGCFrequencySeconds)
-	viper.SetDefault(dptypes.CfgKeyWorkerServiceAccountName, "kb-kubeblocks-dataprotection-worker")
+	viper.SetDefault(dptypes.CfgKeyWorkerServiceAccountName, "kubeblocks-dataprotection-worker")
 	viper.SetDefault(dptypes.CfgKeyWorkerServiceAccountAnnotations, "{}")
-	viper.SetDefault(dptypes.CfgKeyWorkerClusterRoleName, "kb-kubeblocks-dataprotection-worker-role")
+	viper.SetDefault(dptypes.CfgKeyWorkerClusterRoleName, "kubeblocks-dataprotection-worker-role")
 }
 
 func main() {

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -574,8 +574,12 @@ rules:
   resources:
   - serviceaccounts
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - ""
@@ -830,8 +834,12 @@ rules:
   resources:
   - rolebindings
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - rbac.authorization.k8s.io

--- a/controllers/apps/transformer_cluster_backup_policy.go
+++ b/controllers/apps/transformer_cluster_backup_policy.go
@@ -408,12 +408,6 @@ func (r *clusterBackupPolicyTransformer) buildBackupTarget(targetTpl appsv1alpha
 	comp *appsv1alpha1.ClusterComponentSpec) *dpv1alpha1.BackupTarget {
 	clusterName := r.OrigCluster.Name
 
-	getSAName := func() string {
-		if comp.ServiceAccountName != "" {
-			return comp.ServiceAccountName
-		}
-		return constant.GenerateDefaultServiceAccountName(r.Cluster.Name)
-	}
 	if targetTpl.Strategy == "" {
 		targetTpl.Strategy = dpv1alpha1.PodSelectionStrategyAny
 	}
@@ -424,7 +418,8 @@ func (r *clusterBackupPolicyTransformer) buildBackupTarget(targetTpl appsv1alpha
 				MatchLabels: r.buildTargetPodLabels(targetTpl, comp),
 			},
 		},
-		ServiceAccountName: getSAName(),
+		// dataprotection will use its dedicated service account if this field is empty.
+		ServiceAccountName: "",
 	}
 
 	// build the target connection credential

--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -327,9 +327,12 @@ func (r *BackupReconciler) prepareBackupRequest(
 	}
 	request.TargetPods = targetPods
 
-	saName, err := EnsureWorkerServiceAccount(reqCtx, r.Client, backup.Namespace)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get worker service account: %w", err)
+	saName := backupPolicy.Spec.Target.ServiceAccountName
+	if saName == "" {
+		saName, err = EnsureWorkerServiceAccount(reqCtx, r.Client, backup.Namespace)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get worker service account: %w", err)
+		}
 	}
 	request.WorkerServiceAccount = saName
 

--- a/controllers/dataprotection/backup_controller_test.go
+++ b/controllers/dataprotection/backup_controller_test.go
@@ -25,11 +25,11 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	vsv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -46,6 +46,7 @@ import (
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
 	testdp "github.com/apecloud/kubeblocks/pkg/testutil/dataprotection"
 	testk8s "github.com/apecloud/kubeblocks/pkg/testutil/k8s"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
 
 var _ = Describe("Backup Controller test", func() {
@@ -154,6 +155,7 @@ var _ = Describe("Backup Controller test", func() {
 					g.Expect(fetched.Spec.Template.Spec.NodeSelector[corev1.LabelHostname]).To(Equal(targetPod.Spec.NodeName))
 					// image should be expanded by env
 					g.Expect(fetched.Spec.Template.Spec.Containers[0].Image).Should(ContainSubstring(testdp.ImageTag))
+					g.Expect(fetched.Spec.Template.Spec.ServiceAccountName).Should(Equal(viper.GetString(dptypes.CfgKeyWorkerServiceAccountName)))
 				})).Should(Succeed())
 
 				testdp.PatchK8sJobStatus(&testCtx, getJobKey(), batchv1.JobComplete)
@@ -368,6 +370,7 @@ var _ = Describe("Backup Controller test", func() {
 							Name:      volumeName,
 							MountPath: dpbackup.RepoVolumeMountPath,
 						}))
+					Expect(job.Spec.Template.Spec.ServiceAccountName).Should(Equal(viper.GetString(dptypes.CfgKeyWorkerServiceAccountName)))
 				})).Should(Succeed())
 
 				By("checking backup object, it should not be deleted")

--- a/controllers/dataprotection/backuprepo_controller.go
+++ b/controllers/dataprotection/backuprepo_controller.go
@@ -631,7 +631,10 @@ func (r *BackupRepoReconciler) preCheckRepo(reconCtx *reconcileContext) (err err
 	}()
 
 	namespace := viper.GetString(constant.CfgKeyCtrlrMgrNS)
-	saName := viper.GetString(dptypes.CfgKeyWorkerServiceAccountName)
+	saName, err := EnsureWorkerServiceAccount(reconCtx.RequestCtx, r.Client, namespace)
+	if err != nil {
+		return err
+	}
 
 	var job *batchv1.Job
 	var pvc *corev1.PersistentVolumeClaim

--- a/controllers/dataprotection/backuprepo_controller_test.go
+++ b/controllers/dataprotection/backuprepo_controller_test.go
@@ -592,6 +592,14 @@ parameters:
 					&batchv1.Job{}, exists)).WithOffset(1).Should(Succeed())
 				Eventually(testapps.CheckObjExists(&testCtx, types.NamespacedName{Name: pvcName, Namespace: namespace},
 					&corev1.PersistentVolumeClaim{}, exists)).WithOffset(1).Should(Succeed())
+				if exists {
+					// the job has desired status
+					Eventually(testapps.CheckObj(&testCtx, types.NamespacedName{Name: jobName, Namespace: namespace},
+						func(g Gomega, job *batchv1.Job) {
+							g.Expect(job.Spec.Template.Spec.ServiceAccountName).
+								Should(Equal(viper.GetString(dptypes.CfgKeyWorkerServiceAccountName)))
+						})).WithOffset(1).Should(Succeed())
+				}
 			}
 			checkResources(true)
 
@@ -1002,6 +1010,14 @@ new-item=new-value
 						&batchv1.Job{}, exists)).WithOffset(1).Should(Succeed())
 					Eventually(testapps.CheckObjExists(&testCtx, types.NamespacedName{Name: secretName, Namespace: namespace},
 						&corev1.Secret{}, exists)).WithOffset(1).Should(Succeed())
+					if exists {
+						// the job has desired status
+						Eventually(testapps.CheckObj(&testCtx, types.NamespacedName{Name: jobName, Namespace: namespace},
+							func(g Gomega, job *batchv1.Job) {
+								g.Expect(job.Spec.Template.Spec.ServiceAccountName).
+									Should(Equal(viper.GetString(dptypes.CfgKeyWorkerServiceAccountName)))
+							})).WithOffset(1).Should(Succeed())
+					}
 				}
 				checkResources(true)
 

--- a/controllers/dataprotection/backupschedule_controller.go
+++ b/controllers/dataprotection/backupschedule_controller.go
@@ -196,12 +196,17 @@ func (r *BackupScheduleReconciler) handleSchedule(
 	if err = r.patchScheduleMetadata(reqCtx, backupSchedule); err != nil {
 		return err
 	}
+	saName, err := EnsureWorkerServiceAccount(reqCtx, r.Client, backupSchedule.Namespace)
+	if err != nil {
+		return err
+	}
 	scheduler := dpbackup.Scheduler{
-		RequestCtx:     reqCtx,
-		BackupSchedule: backupSchedule,
-		BackupPolicy:   backupPolicy,
-		Client:         r.Client,
-		Scheme:         r.Scheme,
+		RequestCtx:           reqCtx,
+		BackupSchedule:       backupSchedule,
+		BackupPolicy:         backupPolicy,
+		Client:               r.Client,
+		Scheme:               r.Scheme,
+		WorkerServiceAccount: saName,
 	}
 	return scheduler.Schedule()
 }

--- a/controllers/dataprotection/backupschedule_controller.go
+++ b/controllers/dataprotection/backupschedule_controller.go
@@ -196,9 +196,12 @@ func (r *BackupScheduleReconciler) handleSchedule(
 	if err = r.patchScheduleMetadata(reqCtx, backupSchedule); err != nil {
 		return err
 	}
-	saName, err := EnsureWorkerServiceAccount(reqCtx, r.Client, backupSchedule.Namespace)
-	if err != nil {
-		return err
+	saName := backupPolicy.Spec.Target.ServiceAccountName
+	if saName == "" {
+		saName, err = EnsureWorkerServiceAccount(reqCtx, r.Client, backupSchedule.Namespace)
+		if err != nil {
+			return err
+		}
 	}
 	scheduler := dpbackup.Scheduler{
 		RequestCtx:           reqCtx,

--- a/controllers/dataprotection/backupschedule_controller_test.go
+++ b/controllers/dataprotection/backupschedule_controller_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/generics"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
 	testdp "github.com/apecloud/kubeblocks/pkg/testutil/dataprotection"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
 
 var _ = Describe("Backup Schedule Controller", func() {
@@ -150,6 +151,7 @@ var _ = Describe("Backup Schedule Controller", func() {
 					}
 					g.Expect(fetched.Spec.StartingDeadlineSeconds).ShouldNot(BeNil())
 					g.Expect(*fetched.Spec.StartingDeadlineSeconds).To(Equal(getStartingDeadlineSeconds(backupSchedule)))
+					g.Expect(fetched.Spec.JobTemplate.Spec.Template.Spec.ServiceAccountName).To(Equal(viper.GetString(dptypes.CfgKeyWorkerServiceAccountName)))
 				})).Should(Succeed())
 			})
 		})

--- a/controllers/dataprotection/restore_controller.go
+++ b/controllers/dataprotection/restore_controller.go
@@ -179,10 +179,12 @@ func (r *RestoreReconciler) inProgressAction(reqCtx intctrlutil.RequestCtx, rest
 		return intctrlutil.Reconciled()
 	}
 	if err == nil {
-		var saName string
-		saName, err = EnsureWorkerServiceAccount(reqCtx, r.Client, restore.Namespace)
-		if err == nil {
-			restoreMgr.WorkerServiceAccount = saName
+		saName := restore.Spec.ServiceAccountName
+		if saName == "" {
+			saName, err = EnsureWorkerServiceAccount(reqCtx, r.Client, restore.Namespace)
+			if err == nil {
+				restoreMgr.WorkerServiceAccount = saName
+			}
 		}
 	}
 	if err == nil {

--- a/controllers/dataprotection/restore_controller_test.go
+++ b/controllers/dataprotection/restore_controller_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/generics"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
 	testdp "github.com/apecloud/kubeblocks/pkg/testutil/dataprotection"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
 
 var _ = Describe("Restore Controller test", func() {
@@ -161,6 +162,8 @@ var _ = Describe("Restore Controller test", func() {
 				client.MatchingLabels{dprestore.DataProtectionRestoreLabelKey: restore.Name},
 				client.InNamespace(testCtx.DefaultNamespace))).Should(Succeed())
 			for _, v := range jobList.Items {
+				Expect(v.Spec.Template.Spec.ServiceAccountName).WithOffset(1).
+					Should(Equal(viper.GetString(dptypes.CfgKeyWorkerServiceAccountName)))
 				testdp.PatchK8sJobStatus(&testCtx, client.ObjectKeyFromObject(&v), batchv1.JobComplete)
 			}
 		}

--- a/controllers/dataprotection/suite_test.go
+++ b/controllers/dataprotection/suite_test.go
@@ -85,9 +85,9 @@ var _ = BeforeSuite(func() {
 
 	viper.SetDefault(constant.CfgKeyCtrlrMgrNS, "default")
 	viper.SetDefault(constant.KBToolsImage, "apecloud/kubeblocks:latest")
-	viper.SetDefault(dptypes.CfgKeyWorkerServiceAccountName, "kb-kubeblocks-dataprotection-worker")
+	viper.SetDefault(dptypes.CfgKeyWorkerServiceAccountName, "kubeblocks-dataprotection-worker")
 	viper.SetDefault(dptypes.CfgKeyWorkerServiceAccountAnnotations, `{"role-arn":"arn:xxx:xxx"}`)
-	viper.SetDefault(dptypes.CfgKeyWorkerClusterRoleName, "kb-kubeblocks-dataprotection-worker-role")
+	viper.SetDefault(dptypes.CfgKeyWorkerClusterRoleName, "kubeblocks-dataprotection-worker-role")
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{

--- a/controllers/dataprotection/suite_test.go
+++ b/controllers/dataprotection/suite_test.go
@@ -47,6 +47,7 @@ import (
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
 	storagev1alpha1 "github.com/apecloud/kubeblocks/apis/storage/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
+	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 	"github.com/apecloud/kubeblocks/pkg/testutil"
 	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
@@ -84,6 +85,9 @@ var _ = BeforeSuite(func() {
 
 	viper.SetDefault(constant.CfgKeyCtrlrMgrNS, "default")
 	viper.SetDefault(constant.KBToolsImage, "apecloud/kubeblocks:latest")
+	viper.SetDefault(dptypes.CfgKeyWorkerServiceAccountName, "kb-kubeblocks-dataprotection-worker")
+	viper.SetDefault(dptypes.CfgKeyWorkerServiceAccountAnnotations, `{"role-arn":"arn:xxx:xxx"}`)
+	viper.SetDefault(dptypes.CfgKeyWorkerClusterRoleName, "kb-kubeblocks-dataprotection-worker-role")
 
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{

--- a/controllers/dataprotection/suite_test.go
+++ b/controllers/dataprotection/suite_test.go
@@ -86,6 +86,7 @@ var _ = BeforeSuite(func() {
 	viper.SetDefault(constant.CfgKeyCtrlrMgrNS, "default")
 	viper.SetDefault(constant.KBToolsImage, "apecloud/kubeblocks:latest")
 	viper.SetDefault(dptypes.CfgKeyWorkerServiceAccountName, "kubeblocks-dataprotection-worker")
+	viper.SetDefault(dptypes.CfgKeyExecWorkerServiceAccountName, "kubeblocks-dataprotection-exec-worker")
 	viper.SetDefault(dptypes.CfgKeyWorkerServiceAccountAnnotations, `{"role-arn":"arn:xxx:xxx"}`)
 	viper.SetDefault(dptypes.CfgKeyWorkerClusterRoleName, "kubeblocks-dataprotection-worker-role")
 

--- a/controllers/dataprotection/utils.go
+++ b/controllers/dataprotection/utils.go
@@ -292,8 +292,9 @@ func EnsureWorkerServiceAccount(reqCtx intctrlutil.RequestCtx, cli client.Client
 		return "", fmt.Errorf("worker service account name is empty")
 	}
 	sa := &corev1.ServiceAccount{}
-	err := cli.Get(reqCtx.Ctx, client.ObjectKey{Namespace: namespace, Name: saName}, sa)
-	if client.IgnoreNotFound(err) != nil {
+	saKey := client.ObjectKey{Namespace: namespace, Name: saName}
+	exists, err := intctrlutil.CheckResourceExists(reqCtx.Ctx, cli, saKey, sa)
+	if err != nil {
 		return "", err
 	}
 
@@ -313,7 +314,7 @@ func EnsureWorkerServiceAccount(reqCtx intctrlutil.RequestCtx, cli client.Client
 		}
 	}
 
-	if err == nil {
+	if exists {
 		// SA exists, check if annotations are consistent
 		saCopy := sa.DeepCopy()
 		if len(extraAnnotations) > 0 && sa.Annotations == nil {

--- a/controllers/dataprotection/utils.go
+++ b/controllers/dataprotection/utils.go
@@ -21,13 +21,16 @@ package dataprotection
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -44,6 +47,7 @@ import (
 	dperrors "github.com/apecloud/kubeblocks/pkg/dataprotection/errors"
 	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 	dputils "github.com/apecloud/kubeblocks/pkg/dataprotection/utils"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
 
 var (
@@ -277,6 +281,98 @@ func RecorderEventAndRequeue(reqCtx intctrlutil.RequestCtx, recorder record.Even
 	obj client.Object, err error) (reconcile.Result, error) {
 	sendWarningEventForError(recorder, obj, err)
 	return intctrlutil.RequeueWithError(err, reqCtx.Log, "")
+}
+
+func EnsureWorkerServiceAccount(reqCtx intctrlutil.RequestCtx, cli client.Client, namespace string) (string, error) {
+	if namespace == "" {
+		return "", fmt.Errorf("namespace is empty")
+	}
+	saName := viper.GetString(dptypes.CfgKeyWorkerServiceAccountName)
+	if saName == "" {
+		return "", fmt.Errorf("worker service account name is empty")
+	}
+	sa := &corev1.ServiceAccount{}
+	err := cli.Get(reqCtx.Ctx, client.ObjectKey{Namespace: namespace, Name: saName}, sa)
+	if client.IgnoreNotFound(err) != nil {
+		return "", err
+	}
+
+	clusterRoleName := viper.GetString(dptypes.CfgKeyWorkerClusterRoleName)
+	if clusterRoleName == "" {
+		return "", fmt.Errorf("worker cluster role name is empty")
+	}
+
+	var extraAnnotations map[string]string
+	annotationsJson := viper.GetString(dptypes.CfgKeyWorkerServiceAccountAnnotations)
+	if annotationsJson != "" {
+		extraAnnotations = make(map[string]string)
+		err := json.Unmarshal([]byte(annotationsJson), &extraAnnotations)
+		if err != nil {
+			return "", fmt.Errorf("failed to unmarshal worker service account annotations: %s, json: %q",
+				err.Error(), annotationsJson)
+		}
+	}
+
+	if err == nil {
+		// SA exists, check if annotations are consistent
+		saCopy := sa.DeepCopy()
+		if len(extraAnnotations) > 0 && sa.Annotations == nil {
+			sa.Annotations = extraAnnotations
+		} else {
+			for k, v := range extraAnnotations {
+				sa.Annotations[k] = v
+			}
+		}
+		if !reflect.DeepEqual(sa, saCopy) {
+			err := cli.Patch(reqCtx.Ctx, sa, client.MergeFrom(saCopy))
+			if err != nil {
+				return "", fmt.Errorf("failed to patch worker service account: %w", err)
+			}
+		}
+		// fast path
+		return saName, nil
+	}
+
+	createRoleBinding := func() error {
+		rb := &rbacv1.RoleBinding{}
+		rb.Name = fmt.Sprintf("%s-rolebinding", saName)
+		rb.Namespace = namespace
+		rb.Subjects = []rbacv1.Subject{{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      saName,
+			Namespace: namespace,
+		}}
+		rb.RoleRef = rbacv1.RoleRef{
+			Kind:     "ClusterRole",
+			Name:     clusterRoleName,
+			APIGroup: "rbac.authorization.k8s.io",
+		}
+		if err := cli.Create(reqCtx.Ctx, rb); err != nil {
+			return client.IgnoreAlreadyExists(err)
+		}
+		return nil
+	}
+
+	createServiceAccount := func() error {
+		sa := &corev1.ServiceAccount{}
+		sa.Name = saName
+		sa.Namespace = namespace
+		sa.Annotations = extraAnnotations
+		if err := cli.Create(reqCtx.Ctx, sa); err != nil {
+			return client.IgnoreAlreadyExists(err)
+		}
+		return nil
+	}
+
+	// this function returns earlier if the service account already exists,
+	// so we create the role binding first for idempotent.
+	if err := createRoleBinding(); err != nil {
+		return "", fmt.Errorf("failed to create rolebinding: %w", err)
+	}
+	if err := createServiceAccount(); err != nil {
+		return "", fmt.Errorf("failed to create service account: %w", err)
+	}
+	return saName, nil
 }
 
 // ============================================================================

--- a/controllers/dataprotection/utils.go
+++ b/controllers/dataprotection/utils.go
@@ -303,13 +303,13 @@ func EnsureWorkerServiceAccount(reqCtx intctrlutil.RequestCtx, cli client.Client
 	}
 
 	var extraAnnotations map[string]string
-	annotationsJson := viper.GetString(dptypes.CfgKeyWorkerServiceAccountAnnotations)
-	if annotationsJson != "" {
+	annotationsJSON := viper.GetString(dptypes.CfgKeyWorkerServiceAccountAnnotations)
+	if annotationsJSON != "" {
 		extraAnnotations = make(map[string]string)
-		err := json.Unmarshal([]byte(annotationsJson), &extraAnnotations)
+		err := json.Unmarshal([]byte(annotationsJSON), &extraAnnotations)
 		if err != nil {
 			return "", fmt.Errorf("failed to unmarshal worker service account annotations: %s, json: %q",
-				err.Error(), annotationsJson)
+				err.Error(), annotationsJSON)
 		}
 	}
 

--- a/controllers/dataprotection/utils_test.go
+++ b/controllers/dataprotection/utils_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright (C) 2022-2024 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package dataprotection
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
+	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
+)
+
+var _ = Describe("test EnsureWorkerServiceAccount", func() {
+	cleanEnv := func() {
+		By("clean resources")
+
+		// delete rest mocked objects
+		inNS := client.InNamespace(testCtx.DefaultNamespace)
+		ml := client.HasLabels{testCtx.TestObjLabelKey}
+
+		serviceAccountSignature := func(_ corev1.ServiceAccount, _ *corev1.ServiceAccount, _ corev1.ServiceAccountList, _ *corev1.ServiceAccountList) {
+		}
+		roleBindingSignature := func(_ rbacv1.RoleBinding, _ *rbacv1.RoleBinding, _ rbacv1.RoleBindingList, _ *rbacv1.RoleBindingList) {
+		}
+
+		// namespaced
+		testapps.ClearResources(&testCtx, serviceAccountSignature, inNS, ml)
+		testapps.ClearResources(&testCtx, roleBindingSignature, inNS, ml)
+	}
+
+	const (
+		defaultWorkerServiceAccountName        = "kubeblocks-dataprotection-worker"
+		defaultWorkerServiceAccountAnnotations = `{"role-arn": "arn:xxx:xxx"}`
+		defaultWorkerClusterRoleName           = "kubeblocks-dataprotection-worker-role"
+	)
+
+	var (
+		saKey types.NamespacedName
+		rbKey types.NamespacedName
+	)
+
+	BeforeEach(func() {
+		cleanEnv()
+		viper.SetDefault(dptypes.CfgKeyWorkerServiceAccountName, defaultWorkerServiceAccountName)
+		viper.SetDefault(dptypes.CfgKeyWorkerServiceAccountAnnotations, defaultWorkerServiceAccountAnnotations)
+		viper.SetDefault(dptypes.CfgKeyWorkerClusterRoleName, defaultWorkerClusterRoleName)
+
+		saKey = types.NamespacedName{
+			Name:      defaultWorkerServiceAccountName,
+			Namespace: testCtx.DefaultNamespace,
+		}
+		rbKey = types.NamespacedName{
+			Name:      defaultWorkerServiceAccountName + "-rolebinding",
+			Namespace: testCtx.DefaultNamespace,
+		}
+	})
+
+	AfterEach(func() {
+		cleanEnv()
+	})
+
+	It("should create a service account if not exists", func() {
+		Eventually(testapps.CheckObjExists(&testCtx, saKey, &corev1.ServiceAccount{}, false)).Should(Succeed())
+		Eventually(testapps.CheckObjExists(&testCtx, rbKey, &rbacv1.RoleBinding{}, false)).Should(Succeed())
+
+		reqCtx := intctrlutil.RequestCtx{Ctx: testCtx.Ctx}
+		saName, err := EnsureWorkerServiceAccount(reqCtx, testCtx.Cli, testCtx.DefaultNamespace)
+		Expect(err).To(BeNil())
+		Expect(saName).To(Equal(defaultWorkerServiceAccountName))
+
+		// become available
+		Eventually(testapps.CheckObjExists(&testCtx, saKey, &corev1.ServiceAccount{}, true)).Should(Succeed())
+		Eventually(testapps.CheckObjExists(&testCtx, rbKey, &rbacv1.RoleBinding{}, true)).Should(Succeed())
+
+		Eventually(testapps.CheckObj(&testCtx, saKey, func(g Gomega, sa *corev1.ServiceAccount) {
+			g.Expect(sa.Annotations).To(Equal(map[string]string{
+				"role-arn": "arn:xxx:xxx",
+			}))
+		})).Should(Succeed())
+
+		Eventually(testapps.CheckObj(&testCtx, rbKey, func(g Gomega, rb *rbacv1.RoleBinding) {
+			g.Expect(rb.Subjects).To(HaveLen(1))
+			g.Expect(rb.Subjects[0]).To(Equal(rbacv1.Subject{
+				Kind:      "ServiceAccount",
+				APIGroup:  "",
+				Name:      defaultWorkerServiceAccountName,
+				Namespace: testCtx.DefaultNamespace,
+			}))
+			g.Expect(rb.RoleRef).To(Equal(rbacv1.RoleRef{
+				Kind:     "ClusterRole",
+				APIGroup: "rbac.authorization.k8s.io",
+				Name:     defaultWorkerClusterRoleName,
+			}))
+		})).Should(Succeed())
+	})
+
+	It("should update ServiceAccount's annotation if it's changed", func() {
+		reqCtx := intctrlutil.RequestCtx{Ctx: testCtx.Ctx}
+		saName, err := EnsureWorkerServiceAccount(reqCtx, testCtx.Cli, testCtx.DefaultNamespace)
+		Expect(err).To(BeNil())
+		Expect(saName).To(Equal(defaultWorkerServiceAccountName))
+
+		By("updating annotation env")
+		viper.SetDefault(dptypes.CfgKeyWorkerServiceAccountAnnotations, `{"role-arn":"arn:changed","newfield":"newvalue"}`)
+		By("calling EnsureWorkerServiceAccount() again")
+		saName, err = EnsureWorkerServiceAccount(reqCtx, testCtx.Cli, testCtx.DefaultNamespace)
+		Expect(err).To(BeNil())
+		Expect(saName).To(Equal(defaultWorkerServiceAccountName))
+
+		Eventually(testapps.CheckObj(&testCtx, saKey, func(g Gomega, sa *corev1.ServiceAccount) {
+			g.Expect(sa.Annotations).To(Equal(map[string]string{
+				"role-arn": "arn:changed",
+				"newfield": "newvalue",
+			}))
+		})).Should(Succeed())
+	})
+
+	Context("testing invalid argument", func() {
+		It("should return error if namespace is empty", func() {
+			reqCtx := intctrlutil.RequestCtx{Ctx: testCtx.Ctx}
+			_, err := EnsureWorkerServiceAccount(reqCtx, testCtx.Cli, "")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("namespace is empty"))
+		})
+
+		It("should return error if CfgKeyWorkerServiceAccountName is empty", func() {
+			viper.SetDefault(dptypes.CfgKeyWorkerServiceAccountName, "")
+			reqCtx := intctrlutil.RequestCtx{Ctx: testCtx.Ctx}
+			_, err := EnsureWorkerServiceAccount(reqCtx, testCtx.Cli, testCtx.DefaultNamespace)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("worker service account name is empty"))
+		})
+
+		It("should return error if CfgKeyWorkerServiceAccountAnnotations is invalid json", func() {
+			viper.SetDefault(dptypes.CfgKeyWorkerServiceAccountAnnotations, `{"bad": "json`)
+			reqCtx := intctrlutil.RequestCtx{Ctx: testCtx.Ctx}
+			_, err := EnsureWorkerServiceAccount(reqCtx, testCtx.Cli, testCtx.DefaultNamespace)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to unmarshal worker service account annotations"))
+		})
+
+		It("should return error if CfgKeyWorkerClusterRoleName is empty", func() {
+			viper.SetDefault(dptypes.CfgKeyWorkerClusterRoleName, "")
+			reqCtx := intctrlutil.RequestCtx{Ctx: testCtx.Ctx}
+			_, err := EnsureWorkerServiceAccount(reqCtx, testCtx.Cli, testCtx.DefaultNamespace)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("worker cluster role name is empty"))
+		})
+	})
+})

--- a/controllers/dataprotection/utils_test.go
+++ b/controllers/dataprotection/utils_test.go
@@ -53,9 +53,9 @@ var _ = Describe("test EnsureWorkerServiceAccount", func() {
 	}
 
 	const (
-		defaultWorkerServiceAccountName        = "kubeblocks-dataprotection-worker"
+		defaultWorkerServiceAccountName        = "sa-name"
 		defaultWorkerServiceAccountAnnotations = `{"role-arn": "arn:xxx:xxx"}`
-		defaultWorkerClusterRoleName           = "kubeblocks-dataprotection-worker-role"
+		defaultWorkerClusterRoleName           = "worker-role"
 	)
 
 	var (
@@ -140,6 +140,14 @@ var _ = Describe("test EnsureWorkerServiceAccount", func() {
 	})
 
 	Context("testing invalid argument", func() {
+		updateDefaultEnv := func(key string, value string) func() {
+			old := viper.GetString(key)
+			viper.SetDefault(key, value)
+			return func() {
+				viper.SetDefault(key, old)
+			}
+		}
+
 		It("should return error if namespace is empty", func() {
 			reqCtx := intctrlutil.RequestCtx{Ctx: testCtx.Ctx}
 			_, err := EnsureWorkerServiceAccount(reqCtx, testCtx.Cli, "")
@@ -148,7 +156,7 @@ var _ = Describe("test EnsureWorkerServiceAccount", func() {
 		})
 
 		It("should return error if CfgKeyWorkerServiceAccountName is empty", func() {
-			viper.SetDefault(dptypes.CfgKeyWorkerServiceAccountName, "")
+			defer updateDefaultEnv(dptypes.CfgKeyWorkerServiceAccountName, "")()
 			reqCtx := intctrlutil.RequestCtx{Ctx: testCtx.Ctx}
 			_, err := EnsureWorkerServiceAccount(reqCtx, testCtx.Cli, testCtx.DefaultNamespace)
 			Expect(err).To(HaveOccurred())
@@ -156,7 +164,7 @@ var _ = Describe("test EnsureWorkerServiceAccount", func() {
 		})
 
 		It("should return error if CfgKeyWorkerServiceAccountAnnotations is invalid json", func() {
-			viper.SetDefault(dptypes.CfgKeyWorkerServiceAccountAnnotations, `{"bad": "json`)
+			defer updateDefaultEnv(dptypes.CfgKeyWorkerServiceAccountAnnotations, `{"bad": "json`)()
 			reqCtx := intctrlutil.RequestCtx{Ctx: testCtx.Ctx}
 			_, err := EnsureWorkerServiceAccount(reqCtx, testCtx.Cli, testCtx.DefaultNamespace)
 			Expect(err).To(HaveOccurred())
@@ -164,7 +172,7 @@ var _ = Describe("test EnsureWorkerServiceAccount", func() {
 		})
 
 		It("should return error if CfgKeyWorkerClusterRoleName is empty", func() {
-			viper.SetDefault(dptypes.CfgKeyWorkerClusterRoleName, "")
+			defer updateDefaultEnv(dptypes.CfgKeyWorkerClusterRoleName, "")()
 			reqCtx := intctrlutil.RequestCtx{Ctx: testCtx.Ctx}
 			_, err := EnsureWorkerServiceAccount(reqCtx, testCtx.Cli, testCtx.DefaultNamespace)
 			Expect(err).To(HaveOccurred())

--- a/controllers/dataprotection/utils_test.go
+++ b/controllers/dataprotection/utils_test.go
@@ -54,6 +54,7 @@ var _ = Describe("test EnsureWorkerServiceAccount", func() {
 
 	const (
 		defaultWorkerServiceAccountName        = "sa-name"
+		defaultExecWorkerServiceAccountName    = "exec-sa-name"
 		defaultWorkerServiceAccountAnnotations = `{"role-arn": "arn:xxx:xxx"}`
 		defaultWorkerClusterRoleName           = "worker-role"
 	)
@@ -66,6 +67,7 @@ var _ = Describe("test EnsureWorkerServiceAccount", func() {
 	BeforeEach(func() {
 		cleanEnv()
 		viper.SetDefault(dptypes.CfgKeyWorkerServiceAccountName, defaultWorkerServiceAccountName)
+		viper.SetDefault(dptypes.CfgKeyExecWorkerServiceAccountName, defaultExecWorkerServiceAccountName)
 		viper.SetDefault(dptypes.CfgKeyWorkerServiceAccountAnnotations, defaultWorkerServiceAccountAnnotations)
 		viper.SetDefault(dptypes.CfgKeyWorkerClusterRoleName, defaultWorkerClusterRoleName)
 

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -158,11 +158,14 @@ func (r *VolumePopulatorReconciler) validateRestoreAndBuildMGR(reqCtx intctrluti
 	if err := dprestore.ValidateAndInitRestoreMGR(reqCtx, r.Client, restoreMgr); err != nil {
 		return nil, err
 	}
-	if saName, err := EnsureWorkerServiceAccount(reqCtx, r.Client, restore.Namespace); err != nil {
-		return nil, err
-	} else {
-		restoreMgr.WorkerServiceAccount = saName
+	saName := restore.Spec.ServiceAccountName
+	if saName == "" {
+		var err error
+		if saName, err = EnsureWorkerServiceAccount(reqCtx, r.Client, restore.Namespace); err != nil {
+			return nil, err
+		}
 	}
+	restoreMgr.WorkerServiceAccount = saName
 	return restoreMgr, nil
 }
 

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/generics"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
 	testdp "github.com/apecloud/kubeblocks/pkg/testutil/dataprotection"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
 
 var _ = Describe("Volume Populator Controller test", func() {
@@ -159,6 +160,12 @@ var _ = Describe("Volume Populator Controller test", func() {
 			return pv
 		}
 
+		checkJobsSA := func(jobList *batchv1.JobList) {
+			for _, job := range jobList.Items {
+				Expect(job.Spec.Template.Spec.ServiceAccountName).Should(Equal(viper.GetString(dptypes.CfgKeyWorkerServiceAccountName)))
+			}
+		}
+
 		testVolumePopulate := func(volumeBinding storagev1.VolumeBindingMode, useVolumeSnapshotBackup bool) {
 			pvc := initResources(volumeBinding, useVolumeSnapshotBackup, true)
 
@@ -201,6 +208,7 @@ var _ = Describe("Volume Populator Controller test", func() {
 			Expect(k8sClient.List(ctx, jobList,
 				client.MatchingLabels{dprestore.DataProtectionPopulatePVCLabelKey: getPopulatePVCName(pvc.UID)},
 				client.InNamespace(testCtx.DefaultNamespace))).Should(Succeed())
+			checkJobsSA(jobList)
 			testdp.ReplaceK8sJobStatus(&testCtx, client.ObjectKeyFromObject(&jobList.Items[0]), batchv1.JobComplete)
 
 			By("expect for pvc has been populated")

--- a/deploy/helm/config/rbac/role.yaml
+++ b/deploy/helm/config/rbac/role.yaml
@@ -574,8 +574,12 @@ rules:
   resources:
   - serviceaccounts
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - ""
@@ -830,8 +834,12 @@ rules:
   resources:
   - rolebindings
   verbs:
+  - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - rbac.authorization.k8s.io

--- a/deploy/helm/templates/_dataprotection.tpl
+++ b/deploy/helm/templates/_dataprotection.tpl
@@ -10,9 +10,23 @@ Create the name of the ServiceAccount for worker pods.
 {{- end }}
 
 {{/*
+Create the name of the ServiceAccount for worker pods that runs "kubectl exec".
+*/}}
+{{- define "dataprotection.execWorkerSAName" -}}
+{{- include "kubeblocks.fullname" . }}-dataprotection-exec-worker
+{{- end }}
+
+{{/*
 Create the name of the ClusterRole for worker pods.
 */}}
 {{- define "dataprotection.workerClusterRoleName" -}}
 {{- include "kubeblocks.fullname" . }}-dataprotection-worker-role
+{{- end }}
+
+{{/*
+Create the name of the Role for exec worker pods.
+*/}}
+{{- define "dataprotection.execWorkerRoleName" -}}
+{{- include "kubeblocks.fullname" . }}-dataprotection-exec-worker-role
 {{- end }}
 

--- a/deploy/helm/templates/_dataprotection.tpl
+++ b/deploy/helm/templates/_dataprotection.tpl
@@ -1,0 +1,18 @@
+{{/*
+Create the name of the ServiceAccount for worker pods.
+*/}}
+{{- define "dataprotection.workerSAName" -}}
+{{- if .Values.dataProtection.worker.serviceAccount.name }}
+{{- .Values.dataProtection.worker.serviceAccount.name }}
+{{- else }}
+{{- include "kubeblocks.fullname" . }}-dataprotection-worker
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the ClusterRole for worker pods.
+*/}}
+{{- define "dataprotection.workerClusterRoleName" -}}
+{{- include "kubeblocks.fullname" . }}-dataprotection-worker-role
+{{- end }}
+

--- a/deploy/helm/templates/dataprotection.yaml
+++ b/deploy/helm/templates/dataprotection.yaml
@@ -99,6 +99,12 @@ spec:
               value: "{{ .Values.dataProtection.image.registry | default $dataProtectionImageRegistry }}/{{ .Values.dataProtection.image.datasafed.repository }}:{{ .Values.dataProtection.image.datasafed.tag | default "latest" }}"
             - name: GC_FREQUENCY_SECONDS
               value: "{{ .Values.dataProtection.gcFrequencySeconds }}"
+            - name: WORKER_SERVICE_ACCOUNT_NAME
+              value: {{ include "dataprotection.workerSAName" . }}
+            - name: WORKER_SERVICE_ACCOUNT_ANNOTATIONS
+              value: {{ .Values.dataProtection.worker.serviceAccount.annotations | toJson | quote }}
+            - name: WORKER_CLUSTER_ROLE_NAME
+              value: {{ include "dataprotection.workerClusterRoleName" . }}
           {{- with .Values.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
@@ -166,8 +172,8 @@ spec:
             name: {{ include "kubeblocks.fullname" . }}-manager-config
         {{- if .Values.admissionWebhooks.enabled }}
         - name: cert
-        secret:
-          defaultMode: 420
-          secretName: {{ include "kubeblocks.fullname" . }}.{{ .Release.Namespace }}.svc.tls-pair
+          secret:
+            defaultMode: 420
+            secretName: {{ include "kubeblocks.fullname" . }}.{{ .Release.Namespace }}.svc.tls-pair
         {{- end }}
 {{- end }}

--- a/deploy/helm/templates/dataprotection.yaml
+++ b/deploy/helm/templates/dataprotection.yaml
@@ -101,6 +101,8 @@ spec:
               value: "{{ .Values.dataProtection.gcFrequencySeconds }}"
             - name: WORKER_SERVICE_ACCOUNT_NAME
               value: {{ include "dataprotection.workerSAName" . }}
+            - name: EXEC_WORKER_SERVICE_ACCOUNT_NAME
+              value: {{ include "dataprotection.execWorkerSAName" . }}
             - name: WORKER_SERVICE_ACCOUNT_ANNOTATIONS
               value: {{ .Values.dataProtection.worker.serviceAccount.annotations | toJson | quote }}
             - name: WORKER_CLUSTER_ROLE_NAME

--- a/deploy/helm/templates/rbac/clusterrole.yaml
+++ b/deploy/helm/templates/rbac/clusterrole.yaml
@@ -32,13 +32,6 @@ metadata:
   labels:
     {{- include "kubeblocks.labels" . | nindent 4 }}
 rules:
-# need to run "kubectl exec" inside a worker pod
-- apiGroups:
-  - ""
-  resources:
-  - pods/exec
-  verbs:
-  - create
 # need to run "kubectl patch backup" inside a worker pod to update the status
 - apiGroups:
   - dataprotection.kubeblocks.io

--- a/deploy/helm/templates/rbac/clusterrole.yaml
+++ b/deploy/helm/templates/rbac/clusterrole.yaml
@@ -23,3 +23,29 @@ rules:
   {{- end }}
   {{- if eq $line "rules:" }}{{- $doInclude = true }}{{- end }}
 {{- end }}
+{{- if .Values.dataProtection.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "dataprotection.workerClusterRoleName" . }}
+  labels:
+    {{- include "kubeblocks.labels" . | nindent 4 }}
+rules:
+# need to run "kubectl exec" inside a worker pod
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+# need to run "kubectl patch backup" inside a worker pod to update the status
+- apiGroups:
+  - dataprotection.kubeblocks.io
+  resources:
+  - backups
+  verbs:
+  - get
+  - patch
+  - update
+{{- end }}

--- a/deploy/helm/templates/rbac/clusterrole.yaml
+++ b/deploy/helm/templates/rbac/clusterrole.yaml
@@ -48,4 +48,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - dataprotection.kubeblocks.io
+  resources:
+  - backups/status
+  verbs:
+  - get
+  - patch
+  - update
 {{- end }}

--- a/deploy/helm/templates/rbac/clusterrole_binding.yaml
+++ b/deploy/helm/templates/rbac/clusterrole_binding.yaml
@@ -29,21 +29,3 @@ subjects:
     name: {{ include "kubeblocks.addonSAName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
-{{- if .Values.dataProtection.enabled }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: {{ include "dataprotection.workerSAName" . }}-default-rolebinding
-  labels:
-    {{- include "kubeblocks.labels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ include "dataprotection.workerClusterRoleName" . }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ include "dataprotection.workerSAName" . }}
-    namespace: {{ .Release.Namespace }}
-{{- end }}
-

--- a/deploy/helm/templates/rbac/clusterrole_binding.yaml
+++ b/deploy/helm/templates/rbac/clusterrole_binding.yaml
@@ -29,4 +29,21 @@ subjects:
     name: {{ include "kubeblocks.addonSAName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
+{{- if .Values.dataProtection.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "dataprotection.workerSAName" . }}-default-rolebinding
+  labels:
+    {{- include "kubeblocks.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "dataprotection.workerClusterRoleName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "dataprotection.workerSAName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
 

--- a/deploy/helm/templates/rbac/dataprotection_exec_worker_clusterrole.yaml
+++ b/deploy/helm/templates/rbac/dataprotection_exec_worker_clusterrole.yaml
@@ -1,11 +1,17 @@
 # permissions for dataprotection workers to run "kubectl exec".
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: {{ include "dataprotection.execWorkerRoleName" . }}
   labels:
     {{- include "kubeblocks.labels" . | nindent 4 }}
 rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
 - apiGroups:
   - ""
   resources:

--- a/deploy/helm/templates/rbac/dataprotection_exec_worker_clusterrolebinding.yaml
+++ b/deploy/helm/templates/rbac/dataprotection_exec_worker_clusterrolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: {{ include "kubeblocks.fullname" . }}-dataprotection-exec-worker-rolebinding
   labels:
     {{- include "kubeblocks.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: {{ include "dataprotection.execWorkerRoleName" . }}
 subjects:
 - kind: ServiceAccount

--- a/deploy/helm/templates/rbac/dataprotection_exec_worker_role.yaml
+++ b/deploy/helm/templates/rbac/dataprotection_exec_worker_role.yaml
@@ -1,0 +1,14 @@
+# permissions for dataprotection workers to run "kubectl exec".
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "dataprotection.execWorkerRoleName" . }}
+  labels:
+    {{- include "kubeblocks.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create

--- a/deploy/helm/templates/rbac/dataprotection_exec_worker_role_binding.yaml
+++ b/deploy/helm/templates/rbac/dataprotection_exec_worker_role_binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "kubeblocks.fullname" . }}-dataprotection-exec-worker-rolebinding
+  labels:
+    {{- include "kubeblocks.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "dataprotection.execWorkerRoleName" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "dataprotection.execWorkerSAName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/deploy/helm/templates/serviceaccount.yaml
+++ b/deploy/helm/templates/serviceaccount.yaml
@@ -23,3 +23,17 @@ metadata:
     {{- end }}
   {{- end }}
 {{- end }}
+
+{{- if and .Values.dataProtection.enabled -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "dataprotection.workerSAName" . }}
+  labels:
+    {{- include "kubeblocks.labels" . | nindent 4 }}
+    {{- with .Values.dataProtection.worker.serviceAccount.annotations }}
+  annotations:
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/templates/serviceaccount.yaml
+++ b/deploy/helm/templates/serviceaccount.yaml
@@ -24,7 +24,7 @@ metadata:
   {{- end }}
 {{- end }}
 
-{{- if and .Values.dataProtection.enabled -}}
+{{- if and .Values.dataProtection.enabled }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/deploy/helm/templates/serviceaccount.yaml
+++ b/deploy/helm/templates/serviceaccount.yaml
@@ -29,11 +29,7 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "dataprotection.workerSAName" . }}
+  name: {{ include "dataprotection.execWorkerSAName" . }}
   labels:
     {{- include "kubeblocks.labels" . | nindent 4 }}
-    {{- with .Values.dataProtection.worker.serviceAccount.annotations }}
-  annotations:
-      {{- toYaml . | nindent 4 }}
-    {{- end }}
 {{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -308,6 +308,18 @@ dataProtection:
   encryptionKey: ""
   gcFrequencySeconds: 3600
 
+  worker:
+    serviceAccount:
+      # The name of the service account for worker pods.
+      # ServiceAccount resources will be created in every namespace where a worker pod needs to run.
+      # If not set, a name is generated using the fullname template.
+      name: ""
+
+      # Extra annotations when creating service accounts.
+      # This field is primarily for associating IAM roles in cloud environments.
+      # e.g. EKS associates IAM roles by adding the "eks.amazonaws.com/role-arn" annotation.
+      annotations: {}
+
   image:
     # if the value of dataProtection.image.registry is not specified using `--set`, it will be set to the value of 'image.registry' by default
     registry: ""

--- a/pkg/dataprotection/backup/deleter.go
+++ b/pkg/dataprotection/backup/deleter.go
@@ -58,8 +58,10 @@ const (
 
 type Deleter struct {
 	ctrlutil.RequestCtx
-	Client    client.Client
-	Scheme    *runtime.Scheme
+	Client               client.Client
+	Scheme               *runtime.Scheme
+	WorkerServiceAccount string
+
 	actionSet *dpv1alpha1.ActionSet
 }
 
@@ -247,8 +249,9 @@ func (d *Deleter) createDeleteJob(container corev1.Container,
 
 	// build pod
 	podSpec := corev1.PodSpec{
-		Containers:    []corev1.Container{container},
-		RestartPolicy: corev1.RestartPolicyNever,
+		Containers:         []corev1.Container{container},
+		RestartPolicy:      corev1.RestartPolicyNever,
+		ServiceAccountName: d.WorkerServiceAccount,
 	}
 	if err := utils.AddTolerations(&podSpec); err != nil {
 		return err

--- a/pkg/dataprotection/backup/request.go
+++ b/pkg/dataprotection/backup/request.go
@@ -277,7 +277,7 @@ func (r *Request) buildExecAction(targetPod *corev1.Pod,
 		Namespace:          targetPod.Namespace,
 		PodName:            targetPod.Name,
 		Timeout:            exec.Timeout,
-		ServiceAccountName: r.WorkerServiceAccount,
+		ServiceAccountName: viper.GetString(dptypes.CfgKeyExecWorkerServiceAccountName),
 	}
 }
 

--- a/pkg/dataprotection/backup/request.go
+++ b/pkg/dataprotection/backup/request.go
@@ -502,14 +502,3 @@ func (r *Request) InjectSyncProgressContainer(podSpec *corev1.PodSpec,
 func (r *Request) backupActionSetExists() bool {
 	return r.ActionSet != nil && r.ActionSet.Spec.Backup != nil
 }
-
-// TODO(x.zhou): remove this function
-func (r *Request) targetServiceAccountName() string {
-	saName := r.BackupPolicy.Spec.Target.ServiceAccountName
-	if len(saName) > 0 {
-		return saName
-	}
-	// service account name is not specified, use the target pod service account
-	targetPod := r.TargetPods[0]
-	return targetPod.Spec.ServiceAccountName
-}

--- a/pkg/dataprotection/backup/request.go
+++ b/pkg/dataprotection/backup/request.go
@@ -53,14 +53,15 @@ type Request struct {
 	*dpv1alpha1.Backup
 	intctrlutil.RequestCtx
 
-	Client           client.Client
-	BackupPolicy     *dpv1alpha1.BackupPolicy
-	BackupMethod     *dpv1alpha1.BackupMethod
-	ActionSet        *dpv1alpha1.ActionSet
-	TargetPods       []*corev1.Pod
-	BackupRepoPVC    *corev1.PersistentVolumeClaim
-	BackupRepo       *dpv1alpha1.BackupRepo
-	ToolConfigSecret *corev1.Secret
+	Client               client.Client
+	BackupPolicy         *dpv1alpha1.BackupPolicy
+	BackupMethod         *dpv1alpha1.BackupMethod
+	ActionSet            *dpv1alpha1.ActionSet
+	TargetPods           []*corev1.Pod
+	BackupRepoPVC        *corev1.PersistentVolumeClaim
+	BackupRepo           *dpv1alpha1.BackupRepo
+	ToolConfigSecret     *corev1.Secret
+	WorkerServiceAccount string
 }
 
 func (r *Request) GetBackupType() string {
@@ -271,13 +272,12 @@ func (r *Request) buildExecAction(targetPod *corev1.Pod,
 			ObjectMeta: objectMeta,
 			Owner:      r.Backup,
 		},
-		Command:   exec.Command,
-		Container: containerName,
-		Namespace: targetPod.Namespace,
-		PodName:   targetPod.Name,
-		Timeout:   exec.Timeout,
-		// use the kubeblocks's serviceAccount
-		ServiceAccountName: viper.GetString(constant.KBServiceAccountName),
+		Command:            exec.Command,
+		Container:          containerName,
+		Namespace:          targetPod.Namespace,
+		PodName:            targetPod.Name,
+		Timeout:            exec.Timeout,
+		ServiceAccountName: r.WorkerServiceAccount,
 	}
 }
 
@@ -411,7 +411,7 @@ func (r *Request) BuildJobActionPodSpec(targetPod *corev1.Pod,
 	podSpec := &corev1.PodSpec{
 		Containers:         []corev1.Container{container},
 		Volumes:            buildVolumes(),
-		ServiceAccountName: r.targetServiceAccountName(),
+		ServiceAccountName: r.WorkerServiceAccount,
 		RestartPolicy:      corev1.RestartPolicyNever,
 	}
 
@@ -503,6 +503,7 @@ func (r *Request) backupActionSetExists() bool {
 	return r.ActionSet != nil && r.ActionSet.Spec.Backup != nil
 }
 
+// TODO(x.zhou): remove this function
 func (r *Request) targetServiceAccountName() string {
 	saName := r.BackupPolicy.Spec.Target.ServiceAccountName
 	if len(saName) > 0 {

--- a/pkg/dataprotection/backup/scheduler.go
+++ b/pkg/dataprotection/backup/scheduler.go
@@ -40,10 +40,11 @@ import (
 
 type Scheduler struct {
 	intctrlutil.RequestCtx
-	Client         client.Client
-	Scheme         *k8sruntime.Scheme
-	BackupSchedule *dpv1alpha1.BackupSchedule
-	BackupPolicy   *dpv1alpha1.BackupPolicy
+	Client               client.Client
+	Scheme               *k8sruntime.Scheme
+	BackupSchedule       *dpv1alpha1.BackupSchedule
+	BackupPolicy         *dpv1alpha1.BackupPolicy
+	WorkerServiceAccount string
 }
 
 func (s *Scheduler) Schedule() error {
@@ -190,7 +191,7 @@ EOF
 	intctrlutil.InjectZeroResourcesLimitsIfEmpty(&container)
 
 	podSpec := &corev1.PodSpec{
-		ServiceAccountName: s.BackupPolicy.Spec.Target.ServiceAccountName,
+		ServiceAccountName: s.WorkerServiceAccount,
 		RestartPolicy:      corev1.RestartPolicyNever,
 		Containers:         []corev1.Container{container},
 	}

--- a/pkg/dataprotection/restore/builder.go
+++ b/pkg/dataprotection/restore/builder.go
@@ -59,6 +59,7 @@ type restoreJobBuilder struct {
 	nodeSelector         map[string]string
 	jobName              string
 	labels               map[string]string
+	serviceAccount       string
 }
 
 func newRestoreJobBuilder(restore *dpv1alpha1.Restore, backupSet BackupActionSet, backupRepo *dpv1alpha1.BackupRepo, stage dpv1alpha1.RestoreStage) *restoreJobBuilder {
@@ -168,6 +169,11 @@ func (r *restoreJobBuilder) addLabel(key, value string) *restoreJobBuilder {
 		return r
 	}
 	r.labels[key] = value
+	return r
+}
+
+func (r *restoreJobBuilder) setServiceAccount(serviceAccount string) *restoreJobBuilder {
+	r.serviceAccount = serviceAccount
 	return r
 }
 
@@ -300,6 +306,8 @@ func (r *restoreJobBuilder) build() *batchv1.Job {
 	}
 	r.specificVolumes = append(r.specificVolumes, r.commonVolumes...)
 	podSpec.Volumes = r.specificVolumes
+	podSpec.ServiceAccountName = r.serviceAccount
+
 	job.Spec.Template.Spec = podSpec
 	job.Spec.Template.ObjectMeta = metav1.ObjectMeta{
 		Labels: r.labels,

--- a/pkg/dataprotection/restore/manager.go
+++ b/pkg/dataprotection/restore/manager.go
@@ -480,8 +480,8 @@ func (r *RestoreManager) BuildPostReadyActionJobs(reqCtx intctrlutil.RequestCtx,
 			kbInstalledNamespace := viper.GetString(constant.CfgKeyCtrlrMgrNS)
 			if kbInstalledNamespace != "" {
 				job.Namespace = kbInstalledNamespace
-				// the ServiceAccount has been created by helm in the kubeblocks namespace
-				job.Spec.Template.Spec.ServiceAccountName = viper.GetString(dptypes.CfgKeyWorkerServiceAccountName)
+				// use the dedicated ServiceAccount for executing "kubectl exec"
+				job.Spec.Template.Spec.ServiceAccountName = viper.GetString(dptypes.CfgKeyExecWorkerServiceAccountName)
 			}
 			job.Labels[DataProtectionRestoreNamespaceLabelKey] = r.Restore.Namespace
 			restoreJobs = append(restoreJobs, job)

--- a/pkg/dataprotection/restore/manager.go
+++ b/pkg/dataprotection/restore/manager.go
@@ -37,6 +37,7 @@ import (
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 	"github.com/apecloud/kubeblocks/pkg/dataprotection/utils"
 	"github.com/apecloud/kubeblocks/pkg/dataprotection/utils/boolptr"
 	viper "github.com/apecloud/kubeblocks/pkg/viperx"
@@ -57,6 +58,7 @@ type RestoreManager struct {
 	PostReadyBackupSets   []BackupActionSet
 	Schema                *runtime.Scheme
 	Recorder              record.EventRecorder
+	WorkerServiceAccount  string
 }
 
 func NewRestoreManager(restore *dpv1alpha1.Restore, recorder record.EventRecorder, schema *runtime.Scheme) *RestoreManager {
@@ -277,6 +279,7 @@ func (r *RestoreManager) BuildPrepareDataJobs(reqCtx intctrlutil.RequestCtx, cli
 		setImage(backupSet.ActionSet.Spec.Restore.PrepareData.Image).
 		setCommand(backupSet.ActionSet.Spec.Restore.PrepareData.Command).
 		addCommonEnv().
+		setServiceAccount(r.WorkerServiceAccount).
 		attachBackupRepo()
 
 	createPVCIfNotExistsAndBuildVolume := func(claim dpv1alpha1.RestoreVolumeClaim, identifier string) (*corev1.Volume, *corev1.VolumeMount, error) {
@@ -374,6 +377,7 @@ func (r *RestoreManager) BuildVolumePopulateJob(
 		addLabel(DataProtectionPopulatePVCLabelKey, populatePVC.Name).
 		setImage(backupSet.ActionSet.Spec.Restore.PrepareData.Image).
 		setCommand(backupSet.ActionSet.Spec.Restore.PrepareData.Command).
+		setServiceAccount(r.WorkerServiceAccount).
 		attachBackupRepo().
 		addCommonEnv()
 	volume, volumeMount, err := jobBuilder.buildPVCVolumeAndMount(*prepareDataConfig.DataSourceRef, populatePVC.Name, "dp-claim")
@@ -447,6 +451,7 @@ func (r *RestoreManager) BuildPostReadyActionJobs(reqCtx intctrlutil.RequestCtx,
 			setCommand(actionSpec.Job.Command).
 			setToleration(targetPod.Spec.Tolerations).
 			addTargetPodAndCredentialEnv(targetPod, r.Restore.Spec.ReadyConfig.ConnectionCredential).
+			setServiceAccount(r.WorkerServiceAccount).
 			build()
 		return []*batchv1.Job{job}, nil
 	}
@@ -475,8 +480,8 @@ func (r *RestoreManager) BuildPostReadyActionJobs(reqCtx intctrlutil.RequestCtx,
 			kbInstalledNamespace := viper.GetString(constant.CfgKeyCtrlrMgrNS)
 			if kbInstalledNamespace != "" {
 				job.Namespace = kbInstalledNamespace
-				// use the KubeBlocks' serviceAccount
-				job.Spec.Template.Spec.ServiceAccountName = viper.GetString(constant.KBServiceAccountName)
+				// the ServiceAccount has been created by helm in the kubeblocks namespace
+				job.Spec.Template.Spec.ServiceAccountName = viper.GetString(dptypes.CfgKeyWorkerServiceAccountName)
 			}
 			job.Labels[DataProtectionRestoreNamespaceLabelKey] = r.Restore.Namespace
 			restoreJobs = append(restoreJobs, job)

--- a/pkg/dataprotection/restore/manager_test.go
+++ b/pkg/dataprotection/restore/manager_test.go
@@ -296,9 +296,9 @@ var _ = Describe("Backup Deleter Test", func() {
 
 		testPostReady := func(existVolume bool) {
 			kbNamespace := "kb-system"
-			kbServiceAccountName := "kubeblocks"
+			workerServiceAccountName := "dp-worker"
 			viper.Set(constant.CfgKeyCtrlrMgrNS, kbNamespace)
-			viper.Set(constant.KBServiceAccountName, kbServiceAccountName)
+			viper.Set(dptypes.CfgKeyWorkerServiceAccountName, workerServiceAccountName)
 			reqCtx := getReqCtx()
 			matchLabels := map[string]string{
 				constant.AppInstanceLabelKey: testdp.ClusterName,
@@ -317,7 +317,7 @@ var _ = Describe("Backup Deleter Test", func() {
 			// the count of exec jobs should equal to the pods count of cluster
 			Expect(len(jobs)).Should(Equal(2))
 			Expect(jobs[0].Namespace).Should(Equal(kbNamespace))
-			Expect(jobs[0].Spec.Template.Spec.ServiceAccountName).Should(Equal(kbServiceAccountName))
+			Expect(jobs[0].Spec.Template.Spec.ServiceAccountName).Should(Equal(workerServiceAccountName))
 
 			By("test with jobAction and expect for creating 1 job")
 			// step 0 is the execAction in actionSet

--- a/pkg/dataprotection/restore/manager_test.go
+++ b/pkg/dataprotection/restore/manager_test.go
@@ -296,9 +296,9 @@ var _ = Describe("Backup Deleter Test", func() {
 
 		testPostReady := func(existVolume bool) {
 			kbNamespace := "kb-system"
-			workerServiceAccountName := "dp-worker"
+			execWorkerServiceAccountName := "dp-exec-worker"
 			viper.Set(constant.CfgKeyCtrlrMgrNS, kbNamespace)
-			viper.Set(dptypes.CfgKeyWorkerServiceAccountName, workerServiceAccountName)
+			viper.Set(dptypes.CfgKeyExecWorkerServiceAccountName, execWorkerServiceAccountName)
 			reqCtx := getReqCtx()
 			matchLabels := map[string]string{
 				constant.AppInstanceLabelKey: testdp.ClusterName,
@@ -317,7 +317,7 @@ var _ = Describe("Backup Deleter Test", func() {
 			// the count of exec jobs should equal to the pods count of cluster
 			Expect(len(jobs)).Should(Equal(2))
 			Expect(jobs[0].Namespace).Should(Equal(kbNamespace))
-			Expect(jobs[0].Spec.Template.Spec.ServiceAccountName).Should(Equal(workerServiceAccountName))
+			Expect(jobs[0].Spec.Template.Spec.ServiceAccountName).Should(Equal(execWorkerServiceAccountName))
 
 			By("test with jobAction and expect for creating 1 job")
 			// step 0 is the execAction in actionSet

--- a/pkg/dataprotection/types/constant.go
+++ b/pkg/dataprotection/types/constant.go
@@ -25,6 +25,12 @@ const AppName = "kubeblocks-dataprotection"
 const (
 	// CfgKeyGCFrequencySeconds is the key of gc frequency, its unit is second
 	CfgKeyGCFrequencySeconds = "GC_FREQUENCY_SECONDS"
+	// CfgKeyWorkerServiceAccountName is the key of service account name for worker
+	CfgKeyWorkerServiceAccountName = "WORKER_SERVICE_ACCOUNT_NAME"
+	// CfgKeyWorkerServiceAccountAnnotations is the key of annotations for the service account of the worker
+	CfgKeyWorkerServiceAccountAnnotations = "WORKER_SERVICE_ACCOUNT_ANNOTATIONS"
+	// CfgKeyWorkerClusterRoleName is the key of cluster role name for binding the service account of the worker
+	CfgKeyWorkerClusterRoleName = "WORKER_CLUSTER_ROLE_NAME"
 )
 
 // config default values

--- a/pkg/dataprotection/types/constant.go
+++ b/pkg/dataprotection/types/constant.go
@@ -27,6 +27,8 @@ const (
 	CfgKeyGCFrequencySeconds = "GC_FREQUENCY_SECONDS"
 	// CfgKeyWorkerServiceAccountName is the key of service account name for worker
 	CfgKeyWorkerServiceAccountName = "WORKER_SERVICE_ACCOUNT_NAME"
+	// CfgKeyExecWorkerServiceAccountName is the key of service account name for worker that runs "kubectl exec"
+	CfgKeyExecWorkerServiceAccountName = "EXEC_WORKER_SERVICE_ACCOUNT_NAME"
 	// CfgKeyWorkerServiceAccountAnnotations is the key of annotations for the service account of the worker
 	CfgKeyWorkerServiceAccountAnnotations = "WORKER_SERVICE_ACCOUNT_ANNOTATIONS"
 	// CfgKeyWorkerClusterRoleName is the key of cluster role name for binding the service account of the worker


### PR DESCRIPTION
There will be two dedicated ServiceAccounts for dataprotection, named `kubeblocks-dataprotection-worker` and `kubeblocks-dataprotection-exec-worker` by default.

* `kubeblocks-dataprotection-worker` is intended for worker pods that need to access backup data and has permission to patch backup status. It is dynamically created by the controller in each namespace.
* `kubeblocks-dataprotection-exec-worker` is intended for pods that need to execute kubectl exec and only exists in the kubeblocks release namespace.

Close #6493.