### PR TITLE
chore: skip check zh-cn dir

### DIFF
--- a/.github/workflows/cicd-push.yml
+++ b/.github/workflows/cicd-push.yml
@@ -72,7 +72,7 @@ jobs:
           echo "FILE_PATH: $FILE_PATH"
           for filePath in $(echo "$FILE_PATH"); do
               filePath="${filePath%/*}"
-              if [[ -d $filePath ]]; then
+              if [[ -d $filePath && "$filePath" != *"i18n/zh-cn"* ]]; then
                   echo $(pcregrep -r -n -I '[^\x00-\x7f]' $filePath >> pcregrep.out)
               fi
           done


### PR DESCRIPTION
fix https://github.com/apecloud/kubeblocks/actions/runs/7582113857/job/20651040139