### PR TITLE
chore: refine mysql semisync

### DIFF
--- a/pkg/lorry/engines/mysql/get_replica_role.go
+++ b/pkg/lorry/engines/mysql/get_replica_role.go
@@ -35,7 +35,7 @@ func (mgr *Manager) GetReplicaRole(ctx context.Context, cluster *dcs.Cluster) (s
 
 	if !cluster.IsLocked() {
 		mgr.Logger.Info("cluster has no leader lease")
-		return "", errors.New("cluster has no leader lease")
+		return models.SECONDARY, nil
 	}
 
 	if cluster.Leader.Name != mgr.CurrentMemberName {

--- a/pkg/lorry/engines/mysql/get_replica_role_test.go
+++ b/pkg/lorry/engines/mysql/get_replica_role_test.go
@@ -44,8 +44,8 @@ func TestManager_GetRole(t *testing.T) {
 		cluster := &dcs.Cluster{}
 
 		role, err := manager.GetReplicaRole(ctx, cluster)
-		assert.Empty(t, role)
-		assert.NotNil(t, err)
+		assert.Equal(t, role, models.SECONDARY)
+		assert.Nil(t, err)
 	})
 
 	t.Run("get role successfully", func(t *testing.T) {

--- a/pkg/lorry/engines/mysql/manager.go
+++ b/pkg/lorry/engines/mysql/manager.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -308,6 +309,22 @@ func (mgr *Manager) GetDBState(ctx context.Context, cluster *dcs.Cluster) *dcs.D
 	return dbState
 }
 
+func (mgr *Manager) GetSecondsBehindMaster(ctx context.Context) (int, error) {
+	slaveStatus, err := mgr.GetSlaveStatus(ctx, mgr.DB)
+	if err != nil {
+		mgr.Logger.Info("show slave status failed", "error", err)
+		return 0, err
+	}
+	if len(slaveStatus) == 0 {
+		return 0, nil
+	}
+	secondsBehindMaster := slaveStatus.GetString("Seconds_Behind_Master")
+	if secondsBehindMaster == "NULL" {
+		return 0, nil
+	}
+	return strconv.Atoi(secondsBehindMaster)
+}
+
 func (mgr *Manager) WriteCheck(ctx context.Context, db *sql.DB) bool {
 	writeSQL := fmt.Sprintf(`BEGIN;
 CREATE DATABASE IF NOT EXISTS kubeblocks;
@@ -539,11 +556,29 @@ func (mgr *Manager) EnableSemiSyncIfNeed(ctx context.Context) error {
 }
 
 func (mgr *Manager) Promote(ctx context.Context, cluster *dcs.Cluster) error {
+	err := mgr.EnableSemiSyncSource(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = mgr.DisableSemiSyncReplica(ctx)
+	if err != nil {
+		return err
+	}
+
 	if (mgr.globalState["super_read_only"] == "0" && mgr.globalState["read_only"] == "0") &&
 		(len(mgr.slaveStatus) == 0 || (mgr.slaveStatus.GetString("Slave_IO_Running") == "No" &&
 			mgr.slaveStatus.GetString("Slave_SQL_Running") == "No")) {
 		return nil
 	}
+
+	// wait relay log to play
+	secondsBehindMaster, err := mgr.GetSecondsBehindMaster(ctx)
+	for err != nil || secondsBehindMaster != 0 {
+		time.Sleep(time.Second)
+		secondsBehindMaster, err = mgr.GetSecondsBehindMaster(ctx)
+	}
+
 	stopReadOnly := `set global read_only=off;set global super_read_only=off;`
 	stopSlave := `stop slave;`
 	resp, err := mgr.DB.Exec(stopReadOnly + stopSlave)
@@ -583,6 +618,14 @@ func (mgr *Manager) Follow(ctx context.Context, cluster *dcs.Cluster) error {
 	if !mgr.isRecoveryConfOutdated(cluster.Leader.Name) {
 		return nil
 	}
+	err := mgr.EnableSemiSyncReplica(ctx)
+	if err != nil {
+		return err
+	}
+	err = mgr.DisableSemiSyncSource(ctx)
+	if err != nil {
+		return err
+	}
 
 	stopSlave := `stop slave;`
 	// MySQL 5.7 has a limitation where the length of the master_host cannot exceed 60 characters.
@@ -592,9 +635,14 @@ func (mgr *Manager) Follow(ctx context.Context, cluster *dcs.Cluster) error {
 	mgr.Logger.Info("follow new leader", "changemaster", changeMaster)
 	startSlave := `start slave;`
 
-	_, err := mgr.DB.Exec(stopSlave + changeMaster + startSlave)
+	_, err = mgr.DB.Exec(stopSlave + changeMaster + startSlave)
 	if err != nil {
 		mgr.Logger.Info("Follow master failed", "error", err.Error())
+		return err
+	}
+
+	err = mgr.SetSemiSyncSourceTimeout(ctx, cluster, leaderMember)
+	if err != nil {
 		return err
 	}
 

--- a/pkg/lorry/engines/mysql/manager.go
+++ b/pkg/lorry/engines/mysql/manager.go
@@ -422,6 +422,11 @@ func (mgr *Manager) LeaveMemberFromCluster(context.Context, *dcs.Cluster, string
 
 // IsClusterInitialized is a method to check if cluster is initialized or not
 func (mgr *Manager) IsClusterInitialized(ctx context.Context, cluster *dcs.Cluster) (bool, error) {
+	_, err := mgr.GetVersion(ctx)
+	if err != nil {
+		return false, err
+	}
+
 	if cluster != nil {
 		isValid, err := mgr.ValidateAddr(ctx, cluster)
 		if err != nil || !isValid {
@@ -429,10 +434,10 @@ func (mgr *Manager) IsClusterInitialized(ctx context.Context, cluster *dcs.Clust
 		}
 	}
 
-	err := mgr.EnableSemiSyncIfNeed(ctx)
-	if err != nil {
-		return false, err
-	}
+	// err = mgr.EnableSemiSyncIfNeed(ctx)
+	// if err != nil {
+	// 	return false, err
+	// }
 	return mgr.EnsureServerID(ctx)
 }
 
@@ -449,15 +454,11 @@ func (mgr *Manager) GetVersion(ctx context.Context) (string, error) {
 
 func (mgr *Manager) ValidateAddr(ctx context.Context, cluster *dcs.Cluster) (bool, error) {
 	// The maximum length of the server addr is 255 characters. Before MySQL 8.0.17 it was 60 characters.
-	version, err := mgr.GetVersion(ctx)
-	if err != nil {
-		return false, err
-	}
 	currentMemberName := mgr.GetCurrentMemberName()
 	member := cluster.GetMemberWithName(currentMemberName)
 	addr := cluster.GetMemberShortAddr(*member)
 	maxLength := 255
-	if IsBeforeVersion(version, "8.0.17") {
+	if IsBeforeVersion(mgr.version, "8.0.17") {
 		maxLength = 60
 	}
 

--- a/pkg/lorry/engines/mysql/manager_test.go
+++ b/pkg/lorry/engines/mysql/manager_test.go
@@ -555,21 +555,6 @@ func TestManager_IsClusterInitialized(t *testing.T) {
 		assert.Nil(t, err)
 	})
 
-	//t.Run("set semi sync successfully", func(t *testing.T) {
-	//	mock.ExpectQuery("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS " +
-	//		"WHERE PLUGIN_NAME ='rpl_semi_sync_source';").WillReturnRows(sqlmock.NewRows([]string{"PLUGIN_STATUS"}).AddRow("ACTIVE"))
-	//	mock.ExpectExec("SET GLOBAL rpl_semi_sync_source_enabled = 1;" +
-	//		"SET GLOBAL rpl_semi_sync_source_timeout = 100000;").
-	//		WillReturnResult(sqlmock.NewResult(1, 1))
-
-	//	mock.ExpectQuery("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS " +
-	//		"WHERE PLUGIN_NAME ='rpl_semi_sync_replica';").WillReturnRows(sqlmock.NewRows([]string{"PLUGIN_STATUS"}).AddRow("ACTIVE"))
-	//	mock.ExpectExec("SET GLOBAL rpl_semi_sync_replica_enabled = 1;").
-	//		WillReturnResult(sqlmock.NewResult(1, 1))
-	//	err := manager.EnableSemiSyncIfNeed(ctx)
-	//	assert.Nil(t, err)
-	//})
-
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("there were unfulfilled expectations: %v", err)
 	}

--- a/pkg/lorry/engines/mysql/manager_test.go
+++ b/pkg/lorry/engines/mysql/manager_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/go-sql-driver/mysql"
+	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 
@@ -504,11 +505,10 @@ func TestManager_GetMasterStatus(t *testing.T) {
 func TestManager_IsClusterInitialized(t *testing.T) {
 	ctx := context.TODO()
 	manager, mock, _ := mockDatabase(t)
+	manager.version = "5.7.42"
 	manager.serverID = 1
 
 	t.Run("query server id failed", func(t *testing.T) {
-		mock.ExpectQuery("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS " +
-			"WHERE PLUGIN_NAME ='rpl_semi_sync_source';").WillReturnRows(sqlmock.NewRows([]string{"PLUGIN_STATUS"}))
 		mock.ExpectQuery("select @@global.server_id").
 			WillReturnError(fmt.Errorf("some error"))
 
@@ -519,8 +519,6 @@ func TestManager_IsClusterInitialized(t *testing.T) {
 	})
 
 	t.Run("server id equal to manager's server id", func(t *testing.T) {
-		mock.ExpectQuery("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS " +
-			"WHERE PLUGIN_NAME ='rpl_semi_sync_source';").WillReturnRows(sqlmock.NewRows([]string{"PLUGIN_STATUS"}))
 		mock.ExpectQuery("select @@global.server_id").
 			WillReturnRows(sqlmock.NewRows([]string{"@@global.server_id"}).AddRow(1))
 
@@ -530,8 +528,6 @@ func TestManager_IsClusterInitialized(t *testing.T) {
 	})
 
 	t.Run("set server id failed", func(t *testing.T) {
-		mock.ExpectQuery("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS " +
-			"WHERE PLUGIN_NAME ='rpl_semi_sync_source';").WillReturnRows(sqlmock.NewRows([]string{"PLUGIN_STATUS"}))
 		mock.ExpectQuery("select @@global.server_id").
 			WillReturnRows(sqlmock.NewRows([]string{"@@global.server_id"}).AddRow(2))
 		mock.ExpectExec("set global server_id").
@@ -544,8 +540,10 @@ func TestManager_IsClusterInitialized(t *testing.T) {
 	})
 
 	t.Run("set server id successfully", func(t *testing.T) {
-		mock.ExpectQuery("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS " +
-			"WHERE PLUGIN_NAME ='rpl_semi_sync_source';").WillReturnRows(sqlmock.NewRows([]string{"PLUGIN_STATUS"}))
+		manager.version = ""
+		const version = "5.7.42"
+		mock.ExpectQuery("select version()").
+			WillReturnRows(sqlmock.NewRows([]string{"version"}).AddRow(version))
 		mock.ExpectQuery("select @@global.server_id").
 			WillReturnRows(sqlmock.NewRows([]string{"@@global.server_id"}).AddRow(2))
 		mock.ExpectExec("set global server_id").
@@ -553,23 +551,24 @@ func TestManager_IsClusterInitialized(t *testing.T) {
 
 		isInitialized, err := manager.IsClusterInitialized(ctx, nil)
 		assert.True(t, isInitialized)
+		assert.Equal(t, manager.version, version)
 		assert.Nil(t, err)
 	})
 
-	t.Run("set semi sync successfully", func(t *testing.T) {
-		mock.ExpectQuery("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS " +
-			"WHERE PLUGIN_NAME ='rpl_semi_sync_source';").WillReturnRows(sqlmock.NewRows([]string{"PLUGIN_STATUS"}).AddRow("ACTIVE"))
-		mock.ExpectExec("SET GLOBAL rpl_semi_sync_source_enabled = 1;" +
-			"SET GLOBAL rpl_semi_sync_source_timeout = 100000;").
-			WillReturnResult(sqlmock.NewResult(1, 1))
+	//t.Run("set semi sync successfully", func(t *testing.T) {
+	//	mock.ExpectQuery("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS " +
+	//		"WHERE PLUGIN_NAME ='rpl_semi_sync_source';").WillReturnRows(sqlmock.NewRows([]string{"PLUGIN_STATUS"}).AddRow("ACTIVE"))
+	//	mock.ExpectExec("SET GLOBAL rpl_semi_sync_source_enabled = 1;" +
+	//		"SET GLOBAL rpl_semi_sync_source_timeout = 100000;").
+	//		WillReturnResult(sqlmock.NewResult(1, 1))
 
-		mock.ExpectQuery("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS " +
-			"WHERE PLUGIN_NAME ='rpl_semi_sync_replica';").WillReturnRows(sqlmock.NewRows([]string{"PLUGIN_STATUS"}).AddRow("ACTIVE"))
-		mock.ExpectExec("SET GLOBAL rpl_semi_sync_replica_enabled = 1;").
-			WillReturnResult(sqlmock.NewResult(1, 1))
-		err := manager.EnableSemiSyncIfNeed(ctx)
-		assert.Nil(t, err)
-	})
+	//	mock.ExpectQuery("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS " +
+	//		"WHERE PLUGIN_NAME ='rpl_semi_sync_replica';").WillReturnRows(sqlmock.NewRows([]string{"PLUGIN_STATUS"}).AddRow("ACTIVE"))
+	//	mock.ExpectExec("SET GLOBAL rpl_semi_sync_replica_enabled = 1;").
+	//		WillReturnResult(sqlmock.NewResult(1, 1))
+	//	err := manager.EnableSemiSyncIfNeed(ctx)
+	//	assert.Nil(t, err)
+	//})
 
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("there were unfulfilled expectations: %v", err)
@@ -583,8 +582,10 @@ func TestManager_Promote(t *testing.T) {
 	manager.slaveStatus = RowMap{}
 
 	t.Run("execute promote failed", func(t *testing.T) {
-		mock.ExpectExec("set global read_only=off").
-			WillReturnError(fmt.Errorf("some error"))
+		mock.ExpectQuery("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS " +
+			"WHERE PLUGIN_NAME ='rpl_semi_sync_source';").WillReturnError(errors.New("some error"))
+		// mock.ExpectExec("set global read_only=off").
+		// 	WillReturnError(fmt.Errorf("some error"))
 
 		err := manager.Promote(ctx, nil)
 		assert.NotNil(t, err)
@@ -592,6 +593,12 @@ func TestManager_Promote(t *testing.T) {
 	})
 
 	t.Run("execute promote successfully", func(t *testing.T) {
+		mock.ExpectQuery("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS " +
+			"WHERE PLUGIN_NAME ='rpl_semi_sync_source';").WillReturnRows(sqlmock.NewRows([]string{"PLUGIN_STATUS"}).AddRow("ACTIVE"))
+		mock.ExpectQuery("select @@global.rpl_semi_sync_source_enabled").WillReturnRows(sqlmock.NewRows([]string{"STATUS"}).AddRow(1))
+		mock.ExpectQuery("select @@global.rpl_semi_sync_replica_enabled").WillReturnRows(sqlmock.NewRows([]string{"STATUS"}).AddRow(0))
+		mock.ExpectQuery("show slave status").
+			WillReturnRows(sqlmock.NewRows([]string{"Seconds_Behind_Master"}).AddRow(0))
 		mock.ExpectExec("set global read_only=off").
 			WillReturnResult(sqlmock.NewResult(1, 1))
 
@@ -600,6 +607,10 @@ func TestManager_Promote(t *testing.T) {
 	})
 
 	t.Run("current member has been promoted", func(t *testing.T) {
+		mock.ExpectQuery("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS " +
+			"WHERE PLUGIN_NAME ='rpl_semi_sync_source';").WillReturnRows(sqlmock.NewRows([]string{"PLUGIN_STATUS"}).AddRow("ACTIVE"))
+		mock.ExpectQuery("select @@global.rpl_semi_sync_source_enabled").WillReturnRows(sqlmock.NewRows([]string{"STATUS"}).AddRow(1))
+		mock.ExpectQuery("select @@global.rpl_semi_sync_replica_enabled").WillReturnRows(sqlmock.NewRows([]string{"STATUS"}).AddRow(0))
 		manager.globalState["super_read_only"] = "0"
 		manager.globalState["read_only"] = "0"
 
@@ -681,6 +692,10 @@ func TestManager_Follow(t *testing.T) {
 		},
 	}
 	t.Run("execute follow failed", func(t *testing.T) {
+		mock.ExpectQuery("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS " +
+			"WHERE PLUGIN_NAME ='rpl_semi_sync_replica';").WillReturnRows(sqlmock.NewRows([]string{"PLUGIN_STATUS"}).AddRow("ACTIVE"))
+		mock.ExpectQuery("select @@global.rpl_semi_sync_replica_enabled").WillReturnRows(sqlmock.NewRows([]string{"STATUS"}).AddRow(1))
+		mock.ExpectQuery("select @@global.rpl_semi_sync_source_enabled").WillReturnRows(sqlmock.NewRows([]string{"STATUS"}).AddRow(0))
 		mock.ExpectExec("stop slave").
 			WillReturnError(fmt.Errorf("some error"))
 
@@ -690,10 +705,23 @@ func TestManager_Follow(t *testing.T) {
 	})
 
 	t.Run("execute follow successfully", func(t *testing.T) {
+		mock.ExpectQuery("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS " +
+			"WHERE PLUGIN_NAME ='rpl_semi_sync_replica';").WillReturnRows(sqlmock.NewRows([]string{"PLUGIN_STATUS"}).AddRow("ACTIVE"))
+		mock.ExpectQuery("select @@global.rpl_semi_sync_replica_enabled").WillReturnRows(sqlmock.NewRows([]string{"STATUS"}).AddRow(1))
+		mock.ExpectQuery("select @@global.rpl_semi_sync_source_enabled").WillReturnRows(sqlmock.NewRows([]string{"STATUS"}).AddRow(0))
 		mock.ExpectExec("stop slave").
 			WillReturnResult(sqlmock.NewResult(1, 1))
+		mock.ExpectExec("SET GLOBAL rpl_semi_sync_source_timeout = 4294967295").
+			WillReturnResult(sqlmock.NewResult(1, 1))
+		addr := cluster.GetMemberAddrWithPort(*cluster.GetLeaderMember())
+		mysqlConfig, err := mysql.ParseDSN(config.url)
+		assert.Nil(t, err)
+		mysqlConfig.User = config.Username
+		mysqlConfig.Passwd = config.password
+		mysqlConfig.Addr = addr
+		connectionPoolCache[mysqlConfig.FormatDSN()] = manager.DB
 
-		err := manager.Follow(ctx, cluster)
+		err = manager.Follow(ctx, cluster)
 		assert.Nil(t, err)
 	})
 

--- a/pkg/lorry/engines/mysql/semei_sync_test.go
+++ b/pkg/lorry/engines/mysql/semei_sync_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright (C) 2022-2023 ApeCloud Co., Ltd
+
+# This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package mysql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestManager_SemiSync(t *testing.T) {
+	ctx := context.TODO()
+	manager, mock, _ := mockDatabase(t)
+	_, _ = NewConfig(fakeProperties)
+
+	t.Run("semi sync plugin", func(t *testing.T) {
+		t.Run("version before 8.0.26", func(t *testing.T) {
+			manager.version = "5.7.42"
+			semiSyncSourcePlugin := manager.GetSemiSyncSourcePlugin()
+			semiSyncReplicaPlugin := manager.GetSemiSyncReplicaPlugin()
+			assert.Equal(t, semiSyncSourcePlugin, "rpl_semi_sync_master")
+			assert.Equal(t, semiSyncReplicaPlugin, "rpl_semi_sync_slave")
+		})
+
+		t.Run("version after 8.0.26", func(t *testing.T) {
+			manager.version = "8.0.30"
+			semiSyncSourcePlugin := manager.GetSemiSyncSourcePlugin()
+			semiSyncReplicaPlugin := manager.GetSemiSyncReplicaPlugin()
+			assert.Equal(t, semiSyncSourcePlugin, "rpl_semi_sync_source")
+			assert.Equal(t, semiSyncReplicaPlugin, "rpl_semi_sync_replica")
+		})
+	})
+
+	t.Run("enable semi sync source", func(t *testing.T) {
+		t.Run("failed if plugin not load", func(t *testing.T) {
+			mock.ExpectQuery("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS " +
+				"WHERE PLUGIN_NAME ='rpl_semi_sync_source';").WillReturnRows(sqlmock.NewRows([]string{"PLUGIN_STATUS"}))
+			err := manager.EnableSemiSyncSource(ctx)
+			assert.NotNil(t, err)
+			assert.ErrorContains(t, err, "plugin status failed")
+		})
+		t.Run("failed if plugin not active", func(t *testing.T) {
+			mock.ExpectQuery("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS " +
+				"WHERE PLUGIN_NAME ='rpl_semi_sync_source';").WillReturnRows(sqlmock.NewRows([]string{"PLUGIN_STATUS"}).AddRow("NotActive"))
+			err := manager.EnableSemiSyncSource(ctx)
+			assert.NotNil(t, err)
+			assert.ErrorContains(t, err, "is not active")
+		})
+
+		t.Run("already enabled", func(t *testing.T) {
+			mock.ExpectQuery("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS " +
+				"WHERE PLUGIN_NAME ='rpl_semi_sync_source';").WillReturnRows(sqlmock.NewRows([]string{"PLUGIN_STATUS"}).AddRow("ACTIVE"))
+			mock.ExpectQuery("select @@global.rpl_semi_sync_source_enabled").WillReturnRows(sqlmock.NewRows([]string{"STATUS"}).AddRow(1))
+			err := manager.EnableSemiSyncSource(ctx)
+			assert.Nil(t, err)
+		})
+
+		t.Run("enable", func(t *testing.T) {
+			mock.ExpectQuery("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS " +
+				"WHERE PLUGIN_NAME ='rpl_semi_sync_source';").WillReturnRows(sqlmock.NewRows([]string{"PLUGIN_STATUS"}).AddRow("ACTIVE"))
+			mock.ExpectQuery("select @@global.rpl_semi_sync_source_enabled").WillReturnRows(sqlmock.NewRows([]string{"STATUS"}).AddRow(0))
+			mock.ExpectExec("SET GLOBAL rpl_semi_sync_source_enabled = 1;" +
+				"SET GLOBAL rpl_semi_sync_source_timeout = 10000;").
+				WillReturnResult(sqlmock.NewResult(1, 1))
+			err := manager.EnableSemiSyncSource(ctx)
+			assert.Nil(t, err)
+		})
+	})
+
+	t.Run("disable semi sync source", func(t *testing.T) {
+		t.Run("already disabled", func(t *testing.T) {
+			mock.ExpectQuery("select @@global.rpl_semi_sync_source_enabled").WillReturnRows(sqlmock.NewRows([]string{"STATUS"}).AddRow(0))
+			err := manager.DisableSemiSyncSource(ctx)
+			assert.Nil(t, err)
+		})
+
+		t.Run("disable", func(t *testing.T) {
+			mock.ExpectQuery("select @@global.rpl_semi_sync_source_enabled").WillReturnRows(sqlmock.NewRows([]string{"STATUS"}).AddRow(1))
+			mock.ExpectExec("SET GLOBAL rpl_semi_sync_source_enabled = 0;").
+				WillReturnResult(sqlmock.NewResult(1, 1))
+			err := manager.DisableSemiSyncSource(ctx)
+			assert.Nil(t, err)
+		})
+	})
+
+	t.Run("enable semi sync replica", func(t *testing.T) {
+		t.Run("failed if plugin not load", func(t *testing.T) {
+			mock.ExpectQuery("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS " +
+				"WHERE PLUGIN_NAME ='rpl_semi_sync_replica';").WillReturnRows(sqlmock.NewRows([]string{"PLUGIN_STATUS"}))
+			err := manager.EnableSemiSyncReplica(ctx)
+			assert.NotNil(t, err)
+			assert.ErrorContains(t, err, "status failed")
+		})
+		t.Run("failed if plugin not active", func(t *testing.T) {
+			mock.ExpectQuery("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS " +
+				"WHERE PLUGIN_NAME ='rpl_semi_sync_replica';").WillReturnRows(sqlmock.NewRows([]string{"PLUGIN_STATUS"}).AddRow("NotActive"))
+			err := manager.EnableSemiSyncReplica(ctx)
+			assert.NotNil(t, err)
+			assert.ErrorContains(t, err, "is not active")
+		})
+
+		t.Run("already enabled", func(t *testing.T) {
+			mock.ExpectQuery("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS " +
+				"WHERE PLUGIN_NAME ='rpl_semi_sync_replica';").WillReturnRows(sqlmock.NewRows([]string{"PLUGIN_STATUS"}).AddRow("ACTIVE"))
+			mock.ExpectQuery("select @@global.rpl_semi_sync_replica_enabled").WillReturnRows(sqlmock.NewRows([]string{"STATUS"}).AddRow(1))
+			err := manager.EnableSemiSyncReplica(ctx)
+			assert.Nil(t, err)
+		})
+
+		t.Run("enable", func(t *testing.T) {
+			mock.ExpectQuery("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS " +
+				"WHERE PLUGIN_NAME ='rpl_semi_sync_replica';").WillReturnRows(sqlmock.NewRows([]string{"PLUGIN_STATUS"}).AddRow("ACTIVE"))
+			mock.ExpectQuery("select @@global.rpl_semi_sync_replica_enabled").WillReturnRows(sqlmock.NewRows([]string{"STATUS"}).AddRow(0))
+			mock.ExpectExec("SET GLOBAL rpl_semi_sync_replica_enabled = 1;").
+				WillReturnResult(sqlmock.NewResult(1, 1))
+			err := manager.EnableSemiSyncReplica(ctx)
+			assert.Nil(t, err)
+		})
+	})
+
+	t.Run("disable semi sync replica", func(t *testing.T) {
+		t.Run("already disabled", func(t *testing.T) {
+			mock.ExpectQuery("select @@global.rpl_semi_sync_replica_enabled").WillReturnRows(sqlmock.NewRows([]string{"STATUS"}).AddRow(0))
+			err := manager.DisableSemiSyncReplica(ctx)
+			assert.Nil(t, err)
+		})
+
+		t.Run("disable", func(t *testing.T) {
+			mock.ExpectQuery("select @@global.rpl_semi_sync_replica_enabled").WillReturnRows(sqlmock.NewRows([]string{"STATUS"}).AddRow(1))
+			mock.ExpectExec("SET GLOBAL rpl_semi_sync_replica_enabled = 0;").
+				WillReturnResult(sqlmock.NewResult(1, 1))
+			err := manager.DisableSemiSyncReplica(ctx)
+			assert.Nil(t, err)
+		})
+	})
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %v", err)
+	}
+}

--- a/pkg/lorry/engines/mysql/semi_sync.go
+++ b/pkg/lorry/engines/mysql/semi_sync.go
@@ -1,0 +1,108 @@
+/*
+Copyright (C) 2022-2023 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package mysql
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+)
+
+var semiSyncMaxTimeout int = 4294967295
+var semiSyncSourceVersion string = "8.0.26"
+
+func (mgr *Manager) EnableSemiSyncSource(ctx context.Context) error {
+	plugin := "rpl_semi_sync_source"
+	if IsBeforeVersion(mgr.version, semiSyncSourceVersion) {
+		plugin = "rpl_semi_sync_master"
+	}
+	var status string
+	sql := fmt.Sprintf("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME ='%s';", plugin)
+	err := mgr.DB.QueryRowContext(ctx, sql).Scan(&status)
+	if err != nil {
+		errors.Wrapf(err, "Get %s plugin status failed", plugin)
+	}
+
+	// In MySQL 8.0, semi-sync configuration options should not be specified in my.cnf,
+	// as this may cause the database initialization process to fail:
+	//    [Warning] [MY-013501] [Server] Ignoring --plugin-load[_add] list as the server is running with --initialize(-insecure).
+	//    [ERROR] [MY-000067] [Server] unknown variable 'rpl_semi_sync_master_enabled=1'.
+	if status != "ACTIVE" {
+		return errors.Errorf("plugin %s is not active: %s", plugin, status)
+	}
+
+	setSourceEnable := fmt.Sprintf("SET GLOBAL %s_enabled = 1;", plugin)
+	setSourceTimeout := fmt.Sprintf("SET GLOBAL %s_timeout = %d;", plugin, semiSyncMaxTimeout)
+	_, err = mgr.DB.Exec(setSourceEnable + setSourceTimeout)
+	if err != nil {
+		return errors.Wrap(err, setSourceEnable+setSourceTimeout+" execute failed")
+	}
+	return nil
+}
+
+func (mgr *Manager) DisableSemiSyncSource(ctx context.Context) error {
+	plugin := "rpl_semi_sync_source"
+	if IsBeforeVersion(mgr.version, semiSyncSourceVersion) {
+		plugin = "rpl_semi_sync_master"
+	}
+	setSourceDisable := fmt.Sprintf("SET GLOBAL %s_enabled = 0;", plugin)
+	_, err := mgr.DB.Exec(setSourceDisable)
+	if err != nil {
+		return errors.Wrap(err, setSourceDisable+" execute failed")
+	}
+	return nil
+}
+
+func (mgr *Manager) EnableSemiSyncReplica(ctx context.Context) error {
+	plugin := "rpl_semi_sync_replica"
+	if IsBeforeVersion(mgr.version, semiSyncSourceVersion) {
+		plugin = "rpl_semi_sync_slave"
+	}
+	var status string
+	sql := fmt.Sprintf("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME ='%s';", plugin)
+	err := mgr.DB.QueryRowContext(ctx, sql).Scan(&status)
+	if err != nil {
+		return errors.Wrap(err, "get "+plugin+" status failed")
+	}
+
+	if status == "ACTIVE" {
+		return errors.Errorf("plugin %s is not active: %s", plugin, status)
+	}
+	setReplicaEnable := fmt.Sprintf("SET GLOBAL %s_enabled = 1;", plugin)
+	_, err = mgr.DB.Exec(setReplicaEnable)
+	if err != nil {
+		return errors.Wrap(err, setReplicaEnable+" execute failed")
+	}
+	return nil
+}
+
+func (mgr *Manager) DisableSemiSyncReplica(ctx context.Context) error {
+	plugin := "rpl_semi_sync_replica"
+	if IsBeforeVersion(mgr.version, semiSyncSourceVersion) {
+		plugin = "rpl_semi_sync_slave"
+	}
+	setReplicaDisable := fmt.Sprintf("SET GLOBAL %s_enabled = 0;", plugin)
+	_, err := mgr.DB.Exec(setReplicaDisable)
+	if err != nil {
+		return errors.Wrap(err, setReplicaDisable+" execute failed")
+	}
+	return nil
+}

--- a/pkg/lorry/engines/mysql/semi_sync.go
+++ b/pkg/lorry/engines/mysql/semi_sync.go
@@ -143,7 +143,7 @@ func (mgr *Manager) EnableSemiSyncReplica(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "get "+plugin+" status failed")
 	}
-	if status == "ACTIVE" {
+	if status != "ACTIVE" {
 		return errors.Errorf("plugin %s is not active: %s", plugin, status)
 	}
 

--- a/pkg/lorry/engines/mysql/semi_sync.go
+++ b/pkg/lorry/engines/mysql/semi_sync.go
@@ -53,7 +53,7 @@ func (mgr *Manager) EnableSemiSyncSource(ctx context.Context) error {
 	sql := fmt.Sprintf("SELECT PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME ='%s';", plugin)
 	err := mgr.DB.QueryRowContext(ctx, sql).Scan(&status)
 	if err != nil {
-		errors.Wrapf(err, "Get %s plugin status failed", plugin)
+		return errors.Wrapf(err, "Get %s plugin status failed", plugin)
 	}
 
 	// In MySQL 8.0, semi-sync configuration options should not be specified in my.cnf,


### PR DESCRIPTION
- Disable semi-sync at startup
- Enable semi-source and disable semi-replica when promoting to primary
- Disable semi-source and enable semi-replica when following a primary
- Reset primary semi-source timeout to the maximum when secondary successfully follows