### PR TITLE
fix/KB_CLUSTER_UID env error

### DIFF
--- a/pkg/controller/rsm/transformer_object_generation.go
+++ b/pkg/controller/rsm/transformer_object_generation.go
@@ -781,7 +781,6 @@ func buildEnvConfigData(set workloads.ReplicatedStateMachine) map[string]string 
 	envData[prefix+"REPLICA_COUNT"] = strReplicas
 	generateReplicaEnv(prefix)
 	generateMemberEnv(prefix)
-	envData[prefix+"CLUSTER_UID"] = uid
 
 	// have backward compatible handling for CM key with 'compDefName' being part of the key name, prior 0.5.0
 	// and introduce env/cm key naming reference complexity

--- a/pkg/controller/rsm/transformer_objection_generation_test.go
+++ b/pkg/controller/rsm/transformer_objection_generation_test.go
@@ -207,7 +207,6 @@ var _ = Describe("object generation transformer test.", func() {
 			requiredKeys := []string{
 				"KB_REPLICA_COUNT",
 				"KB_0_HOSTNAME",
-				constant.KBEnvClusterUID,
 			}
 			cfg := buildEnvConfigData(*rsm)
 
@@ -217,9 +216,6 @@ var _ = Describe("object generation transformer test.", func() {
 				_, ok := cfg[k]
 				Expect(ok).Should(BeTrue())
 			}
-
-			By("builds env config with resources recreate")
-			Expect(cfg[constant.KBEnvClusterUID]).Should(BeEquivalentTo(uid))
 
 			By("builds Env Config with ConsensusSet status correctly")
 			toCheckKeys := append(requiredKeys, []string{


### PR DESCRIPTION
When creating a Cluster using the ComponentDefinition Api, the KB_CLUSTER_UID environment variable will be set to RSM UID by the RSM Controller.

Remove this logic in the RSM Controller so that the KB_CLUSTER_UID logic will be executed correctly by the ComponentController.