### PR TITLE
improve: provide more annotation control capabilities to control Comp…

### DIFF
--- a/controllers/apps/transformer_component_service.go
+++ b/controllers/apps/transformer_component_service.go
@@ -59,12 +59,16 @@ func (t *componentServiceTransformer) Transform(ctx graph.TransformContext, dag 
 		if t.skipDefaultHeadlessSvc(synthesizeComp, &service) {
 			continue
 		}
-		// component controller does not handle the nodeport service if the feature gate is not enabled.
+		// component controller does not handle the nodeport service if the feature gate is not enabled.the default behavior is 'ignored'.
 		if t.skipNodePortService(cluster, transCtx.CompDef, synthesizeComp, &service) {
 			continue
 		}
-		// component controller does not handle the pod ordinal service if the feature gate is not enabled.
+		// component controller does not handle the pod ordinal service if the feature gate is not enabled.the default behavior is 'ignored'.
 		if t.skipPodOrdinalService(cluster, synthesizeComp, &service) {
+			continue
+		}
+		// component controller does not handle the clusterIp service if the feature gate is not enabled. the default behavior is 'created'.
+		if t.skipClusterIpService(cluster, synthesizeComp, &service) {
 			continue
 		}
 
@@ -124,7 +128,7 @@ func (t *componentServiceTransformer) skipNodePortService(cluster *appsv1alpha1.
 	if cluster == nil || cluster.Annotations == nil {
 		return true
 	}
-	enableNodePortSvcCompList, ok := cluster.Annotations[constant.NodePortSvcAnnotationKey]
+	enableNodePortSvcCompList, ok := cluster.Annotations[constant.EnabledNodePortSvcAnnotationKey]
 	if !ok {
 		return true
 	}
@@ -155,7 +159,7 @@ func (t *componentServiceTransformer) skipPodOrdinalService(cluster *appsv1alpha
 	if cluster == nil || cluster.Annotations == nil {
 		return true
 	}
-	enablePodOrdinalSvcCompList, ok := cluster.Annotations[constant.PodOrdinalSvcAnnotationKey]
+	enablePodOrdinalSvcCompList, ok := cluster.Annotations[constant.EnabledPodOrdinalSvcAnnotationKey]
 	if !ok {
 		return true
 	}
@@ -165,6 +169,31 @@ func (t *componentServiceTransformer) skipPodOrdinalService(cluster *appsv1alpha
 		}
 	}
 	return true
+}
+
+func (t *componentServiceTransformer) skipClusterIpService(cluster *appsv1alpha1.Cluster,
+	synthesizeComp *component.SynthesizedComponent, compService *appsv1alpha1.ComponentService) bool {
+	if compService == nil {
+		return true
+	}
+	// if Service type is not ClusterIp, it should not be skipped.
+	if compService.Spec.Type != corev1.ServiceTypeClusterIP {
+		return false
+	}
+	// if Service type is NodePort, but the feature gate annotation is not enabled, it should be created.
+	if cluster == nil || cluster.Annotations == nil {
+		return false
+	}
+	disabledClusterIpSvcCompList, ok := cluster.Annotations[constant.DisabledClusterIpSvcAnnotationKey]
+	if !ok {
+		return false
+	}
+	for _, compName := range strings.Split(disabledClusterIpSvcCompList, ",") {
+		if compName == synthesizeComp.Name {
+			return true
+		}
+	}
+	return false
 }
 
 func (t *componentServiceTransformer) buildService(comp *appsv1alpha1.Component,

--- a/controllers/apps/transformer_component_service.go
+++ b/controllers/apps/transformer_component_service.go
@@ -180,7 +180,7 @@ func (t *componentServiceTransformer) skipClusterIPService(cluster *appsv1alpha1
 	if compService.Spec.Type != corev1.ServiceTypeClusterIP {
 		return false
 	}
-	// if Service type is NodePort, but the feature gate annotation is not enabled, it should be created.
+	// if Service type is ClusterIp, but the feature gate annotation does not declare which components are disabled, it should be created.
 	if cluster == nil || cluster.Annotations == nil {
 		return false
 	}

--- a/controllers/apps/transformer_component_service.go
+++ b/controllers/apps/transformer_component_service.go
@@ -68,7 +68,7 @@ func (t *componentServiceTransformer) Transform(ctx graph.TransformContext, dag 
 			continue
 		}
 		// component controller does not handle the clusterIp service if the feature gate is not enabled. the default behavior is 'created'.
-		if t.skipClusterIpService(cluster, synthesizeComp, &service) {
+		if t.skipClusterIPService(cluster, synthesizeComp, &service) {
 			continue
 		}
 
@@ -171,7 +171,7 @@ func (t *componentServiceTransformer) skipPodOrdinalService(cluster *appsv1alpha
 	return true
 }
 
-func (t *componentServiceTransformer) skipClusterIpService(cluster *appsv1alpha1.Cluster,
+func (t *componentServiceTransformer) skipClusterIPService(cluster *appsv1alpha1.Cluster,
 	synthesizeComp *component.SynthesizedComponent, compService *appsv1alpha1.ComponentService) bool {
 	if compService == nil {
 		return true
@@ -184,11 +184,11 @@ func (t *componentServiceTransformer) skipClusterIpService(cluster *appsv1alpha1
 	if cluster == nil || cluster.Annotations == nil {
 		return false
 	}
-	disabledClusterIpSvcCompList, ok := cluster.Annotations[constant.DisabledClusterIpSvcAnnotationKey]
+	disabledClusterIPSvcCompList, ok := cluster.Annotations[constant.DisabledClusterIPSvcAnnotationKey]
 	if !ok {
 		return false
 	}
-	for _, compName := range strings.Split(disabledClusterIpSvcCompList, ",") {
+	for _, compName := range strings.Split(disabledClusterIPSvcCompList, ",") {
 		if compName == synthesizeComp.Name {
 			return true
 		}

--- a/pkg/constant/const.go
+++ b/pkg/constant/const.go
@@ -158,15 +158,19 @@ const (
 	HostPortIncludeAnnotationKey                = "network.kubeblocks.io/host-ports-include"
 	HostPortExcludeAnnotationKey                = "network.kubeblocks.io/host-ports-exclude"
 
-	// NodePortSvcAnnotationKey defines the feature gate of NodePort Service defined in ComponentDefinition.Spec.Services.
+	// EnabledNodePortSvcAnnotationKey defines the feature gate of NodePort Service defined in ComponentDefinition.Spec.Services.
 	// Components defined in the annotation value, their all services of type NodePort defined in ComponentDefinition will be created; otherwise, they will be ignored.
 	// Multiple components are separated by ','. for example: "kubeblocks.io/enabled-node-port-svc: comp1,comp2"
-	NodePortSvcAnnotationKey = "kubeblocks.io/enabled-node-port-svc"
-	// PodOrdinalSvcAnnotationKey defines the feature gate of PodOrdinal Service defined in ComponentDefinition.Spec.Services.
+	EnabledNodePortSvcAnnotationKey = "kubeblocks.io/enabled-node-port-svc"
+	// EnabledPodOrdinalSvcAnnotationKey defines the feature gate of PodOrdinal Service defined in ComponentDefinition.Spec.Services.
 	// Components defined in the annotation value, their all Services defined in the ComponentDefinition with the GeneratePodOrdinalService attribute set to true will be created; otherwise, they will be ignored.
 	// This can generate a corresponding Service for each Pod, which can be used in certain specific scenarios: for example, creating a dedicated access service for each read-only Pod.
 	// Multiple components are separated by ','. for example: "kubeblocks.io/enabled-pod-ordinal-svc: comp1,comp2"
-	PodOrdinalSvcAnnotationKey = "kubeblocks.io/enabled-pod-ordinal-svc"
+	EnabledPodOrdinalSvcAnnotationKey = "kubeblocks.io/enabled-pod-ordinal-svc"
+	// DisabledClusterIpSvcAnnotationKey defines whether the feature gate of ClusterIp Service defined in ComponentDefinition.Spec.Services will be effected.
+	// Components defined in the annotation value, their all services of type ClusterIp defined in ComponentDefinition will be ignored; otherwise, they will be created.
+	// Multiple components are separated by ','. for example: "kubeblocks.io/disabled-cluster-ip-svc: comp1,comp2"
+	DisabledClusterIpSvcAnnotationKey = "kubeblocks.io/disabled-cluster-ip-svc"
 	// ShardSvcAnnotationKey defines the feature gate of creating service for each shard.
 	// Sharding name defined in the annotation value, a set of Service defined in Cluster.Spec.Services with the ShardingSelector will be automatically generated for each shard when Cluster.Spec.ShardingSpecs[x].shards is not nil.
 	// Multiple sharding names are separated by ','. for example: "kubeblocks.io/enabled-shard-svc: proxy-shard,db-shard"

--- a/pkg/constant/const.go
+++ b/pkg/constant/const.go
@@ -167,10 +167,10 @@ const (
 	// This can generate a corresponding Service for each Pod, which can be used in certain specific scenarios: for example, creating a dedicated access service for each read-only Pod.
 	// Multiple components are separated by ','. for example: "kubeblocks.io/enabled-pod-ordinal-svc: comp1,comp2"
 	EnabledPodOrdinalSvcAnnotationKey = "kubeblocks.io/enabled-pod-ordinal-svc"
-	// DisabledClusterIpSvcAnnotationKey defines whether the feature gate of ClusterIp Service defined in ComponentDefinition.Spec.Services will be effected.
+	// DisabledClusterIPSvcAnnotationKey defines whether the feature gate of ClusterIp Service defined in ComponentDefinition.Spec.Services will be effected.
 	// Components defined in the annotation value, their all services of type ClusterIp defined in ComponentDefinition will be ignored; otherwise, they will be created.
 	// Multiple components are separated by ','. for example: "kubeblocks.io/disabled-cluster-ip-svc: comp1,comp2"
-	DisabledClusterIpSvcAnnotationKey = "kubeblocks.io/disabled-cluster-ip-svc"
+	DisabledClusterIPSvcAnnotationKey = "kubeblocks.io/disabled-cluster-ip-svc"
 	// ShardSvcAnnotationKey defines the feature gate of creating service for each shard.
 	// Sharding name defined in the annotation value, a set of Service defined in Cluster.Spec.Services with the ShardingSelector will be automatically generated for each shard when Cluster.Spec.ShardingSpecs[x].shards is not nil.
 	// Multiple sharding names are separated by ','. for example: "kubeblocks.io/enabled-shard-svc: proxy-shard,db-shard"


### PR DESCRIPTION
Currently, Component Service can control the corresponding features through:
- 'kubeblocks.io/enabled-node-port-svc'
  control whether create nodeport service
- 'kubeblocks.io/enabled-pod-ordinal-svc'
  control whether create svc per pod 

but the control capability is not enough.
in this pr, an annotation switch is added to control the clusterIp service creation logic.