### PR TITLE
fix: use restore.Spec.ServiceAccountName if not empty

### DIFF
--- a/controllers/dataprotection/restore_controller.go
+++ b/controllers/dataprotection/restore_controller.go
@@ -182,10 +182,8 @@ func (r *RestoreReconciler) inProgressAction(reqCtx intctrlutil.RequestCtx, rest
 		saName := restore.Spec.ServiceAccountName
 		if saName == "" {
 			saName, err = EnsureWorkerServiceAccount(reqCtx, r.Client, restore.Namespace)
-			if err == nil {
-				restoreMgr.WorkerServiceAccount = saName
-			}
 		}
+		restoreMgr.WorkerServiceAccount = saName
 	}
 	if err == nil {
 		// handle restore actions


### PR DESCRIPTION
fix #6606.