### PR TITLE
fix: dynamic parameters and static parameters are modified together for partoni postgresql, and the dynamic parameters do not take effect (#5450)

### DIFF
--- a/apis/apps/v1alpha1/configconstraint_types.go
+++ b/apis/apps/v1alpha1/configconstraint_types.go
@@ -32,6 +32,11 @@ type ConfigConstraintSpec struct {
 	// +optional
 	ReloadOptions *ReloadOptions `json:"reloadOptions,omitempty"`
 
+	// forceHotUpdate indicates whether to execute hot update parameters when the pod needs to be restarted.
+	// if set true, the controller does the hot update and then restarts the pod.
+	// +optional
+	ForceHotUpdate *bool `json:"forceHotUpdate,omitempty"`
+
 	// toolConfig used to config init container.
 	// +optional
 	ToolsImageSpec *ToolsImageSpec `json:"toolsImageSpec,omitempty"`
@@ -313,4 +318,11 @@ type ConfigConstraintList struct {
 
 func init() {
 	SchemeBuilder.Register(&ConfigConstraint{}, &ConfigConstraintList{})
+}
+
+func (in *ConfigConstraintSpec) NeedForceUpdateHot() bool {
+	if in.ForceHotUpdate != nil {
+		return *in.ForceHotUpdate
+	}
+	return false
 }

--- a/apis/apps/v1alpha1/type.go
+++ b/apis/apps/v1alpha1/type.go
@@ -486,12 +486,13 @@ const (
 type UpgradePolicy string
 
 const (
-	NonePolicy         UpgradePolicy = "none"
-	NormalPolicy       UpgradePolicy = "simple"
-	RestartPolicy      UpgradePolicy = "parallel"
-	RollingPolicy      UpgradePolicy = "rolling"
-	AutoReload         UpgradePolicy = "autoReload"
-	OperatorSyncUpdate UpgradePolicy = "operatorSyncUpdate"
+	NonePolicy                UpgradePolicy = "none"
+	NormalPolicy              UpgradePolicy = "simple"
+	RestartPolicy             UpgradePolicy = "parallel"
+	RollingPolicy             UpgradePolicy = "rolling"
+	AutoReload                UpgradePolicy = "autoReload"
+	HotUpdateAndRestartPolicy UpgradePolicy = "reloadAndRestart"
+	OperatorSyncUpdate        UpgradePolicy = "operatorSyncUpdate"
 )
 
 // CfgReloadType defines reload method.

--- a/apis/apps/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/apps/v1alpha1/zz_generated.deepcopy.go
@@ -2376,6 +2376,11 @@ func (in *ConfigConstraintSpec) DeepCopyInto(out *ConfigConstraintSpec) {
 		*out = new(ReloadOptions)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ForceHotUpdate != nil {
+		in, out := &in.ForceHotUpdate, &out.ForceHotUpdate
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ToolsImageSpec != nil {
 		in, out := &in.ToolsImageSpec, &out.ToolsImageSpec
 		*out = new(ToolsImageSpec)

--- a/config/crd/bases/apps.kubeblocks.io_configconstraints.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_configconstraints.yaml
@@ -162,6 +162,11 @@ spec:
                   type: string
                 type: array
                 x-kubernetes-list-type: set
+              forceHotUpdate:
+                description: forceHotUpdate indicates whether to execute hot update
+                  parameters when the pod needs to be restarted. if set true, the
+                  controller does the hot update and then restarts the pod.
+                type: boolean
               formatterConfig:
                 description: "formatterConfig describes the format of the configuration
                   file, the controller will: \n 1. parses configuration file 2. analyzes

--- a/controllers/apps/configuration/combine_upgrade_policy.go
+++ b/controllers/apps/configuration/combine_upgrade_policy.go
@@ -1,0 +1,48 @@
+/*
+Copyright (C) 2022-2023 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package configuration
+
+import appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
+
+type combineUpgradePolicy struct {
+	policyExecutors []reconfigurePolicy
+}
+
+func init() {
+	RegisterPolicy(appsv1alpha1.HotUpdateAndRestartPolicy, &combineUpgradePolicy{
+		policyExecutors: []reconfigurePolicy{&syncPolicy{}, &simplePolicy{}},
+	})
+}
+
+func (h *combineUpgradePolicy) GetPolicyName() string {
+	return string(appsv1alpha1.HotUpdateAndRestartPolicy)
+}
+
+func (h *combineUpgradePolicy) Upgrade(params reconfigureParams) (ReturnedStatus, error) {
+	var ret ReturnedStatus
+	for _, executor := range h.policyExecutors {
+		retStatus, err := executor.Upgrade(params)
+		if err != nil {
+			return retStatus, err
+		}
+		ret = retStatus
+	}
+	return ret, nil
+}

--- a/controllers/apps/configuration/combine_upgrade_policy_test.go
+++ b/controllers/apps/configuration/combine_upgrade_policy_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright (C) 2022-2023 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package configuration
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
+	testutil "github.com/apecloud/kubeblocks/pkg/testutil/k8s"
+)
+
+var _ = Describe("Reconfigure CombineSyncPolicy", func() {
+
+	var (
+		k8sMockClient *testutil.K8sClientMockHelper
+	)
+
+	BeforeEach(func() {
+		k8sMockClient = testutil.NewK8sMockClient()
+	})
+
+	AfterEach(func() {
+		k8sMockClient.Finish()
+	})
+
+	Context("combine reconfigure policy test", func() {
+		It("Should success without error", func() {
+			By("check normal policy name")
+			testPolicyExecs := &combineUpgradePolicy{
+				policyExecutors: []reconfigurePolicy{&testPolicy{}},
+			}
+
+			Expect(upgradePolicyMap[appsv1alpha1.HotUpdateAndRestartPolicy]).ShouldNot(BeNil())
+
+			mockParam := newMockReconfigureParams("simplePolicy", k8sMockClient.Client(),
+				withMockStatefulSet(2, nil),
+				withConfigSpec("for_test", map[string]string{
+					"key": "value",
+				}),
+				withClusterComponent(2),
+				withCDComponent(appsv1alpha1.Consensus, []appsv1alpha1.ComponentConfigSpec{{
+					ComponentTemplateSpec: appsv1alpha1.ComponentTemplateSpec{
+						Name:       "for_test",
+						VolumeName: "test_volume",
+					}}}))
+
+			Expect(testPolicyExecs.GetPolicyName()).Should(BeEquivalentTo("reloadAndRestart"))
+			status, err := testPolicyExecs.Upgrade(mockParam)
+			Expect(err).Should(Succeed())
+			Expect(status.Status).Should(BeEquivalentTo(ESNone))
+		})
+
+		It("Should success without error", func() {
+			By("check failed policy name")
+			testPolicyExecs := &combineUpgradePolicy{
+				policyExecutors: []reconfigurePolicy{&testErrorPolicy{}},
+			}
+
+			mockParam := newMockReconfigureParams("simplePolicy", k8sMockClient.Client(),
+				withMockStatefulSet(2, nil),
+				withConfigSpec("for_test", map[string]string{
+					"key": "value",
+				}),
+				withClusterComponent(2),
+				withCDComponent(appsv1alpha1.Consensus, []appsv1alpha1.ComponentConfigSpec{{
+					ComponentTemplateSpec: appsv1alpha1.ComponentTemplateSpec{
+						Name:       "for_test",
+						VolumeName: "test_volume",
+					}}}))
+
+			Expect(testPolicyExecs.GetPolicyName()).Should(BeEquivalentTo("reloadAndRestart"))
+			status, err := testPolicyExecs.Upgrade(mockParam)
+			Expect(err).ShouldNot(Succeed())
+			Expect(status.Status).Should(BeEquivalentTo(ESFailedAndRetry))
+		})
+	})
+})
+
+type testPolicy struct {
+}
+
+type testErrorPolicy struct {
+}
+
+func (t testErrorPolicy) Upgrade(params reconfigureParams) (ReturnedStatus, error) {
+	return makeReturnedStatus(ESFailedAndRetry), fmt.Errorf("testErrorPolicy failed")
+}
+
+func (t testErrorPolicy) GetPolicyName() string {
+	return "testErrorPolicy"
+}
+
+func (t testPolicy) Upgrade(params reconfigureParams) (ReturnedStatus, error) {
+	return makeReturnedStatus(ESNone), nil
+}
+
+func (t testPolicy) GetPolicyName() string {
+	return "testPolicy"
+}

--- a/controllers/apps/configuration/reconfigure_policy.go
+++ b/controllers/apps/configuration/reconfigure_policy.go
@@ -231,6 +231,9 @@ func NewReconfigurePolicy(cc *appsv1alpha1.ConfigConstraintSpec, cfgPatch *core.
 	// if not specify policy, or cannot decision policy, use default policy.
 	if policy == appsv1alpha1.NonePolicy {
 		policy = appsv1alpha1.NormalPolicy
+		if cc.NeedForceUpdateHot() && enableSyncTrigger(cc.ReloadOptions) {
+			policy = appsv1alpha1.HotUpdateAndRestartPolicy
+		}
 	}
 
 	if action, ok := upgradePolicyMap[policy]; ok {

--- a/deploy/helm/crds/apps.kubeblocks.io_configconstraints.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_configconstraints.yaml
@@ -162,6 +162,11 @@ spec:
                   type: string
                 type: array
                 x-kubernetes-list-type: set
+              forceHotUpdate:
+                description: forceHotUpdate indicates whether to execute hot update
+                  parameters when the pod needs to be restarted. if set true, the
+                  controller does the hot update and then restarts the pod.
+                type: boolean
               formatterConfig:
                 description: "formatterConfig describes the format of the configuration
                   file, the controller will: \n 1. parses configuration file 2. analyzes

--- a/docs/developer_docs/api-reference/cluster.md
+++ b/docs/developer_docs/api-reference/cluster.md
@@ -1651,6 +1651,19 @@ restart or reload depending on whether any parameters in the StaticParameters ha
 </tr>
 <tr>
 <td>
+<code>forceHotUpdate</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>forceHotUpdate indicates whether to execute hot update parameters when the pod needs to be restarted.
+if set true, the controller does the hot update and then restarts the pod.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>toolsImageSpec</code><br/>
 <em>
 <a href="#apps.kubeblocks.io/v1alpha1.ToolsImageSpec">
@@ -8074,6 +8087,19 @@ ReloadOptions
 <p>reloadOptions indicates whether the process supports reload.</p>
 <p>if set, the controller will determine the behavior of the engine instance based on the configuration templates,
 restart or reload depending on whether any parameters in the StaticParameters have been modified.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>forceHotUpdate</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>forceHotUpdate indicates whether to execute hot update parameters when the pod needs to be restarted.
+if set true, the controller does the hot update and then restarts the pod.</p>
 </td>
 </tr>
 <tr>
@@ -16784,6 +16810,8 @@ string
 </tr>
 </thead>
 <tbody><tr><td><p>&#34;autoReload&#34;</p></td>
+<td></td>
+</tr><tr><td><p>&#34;reloadAndRestart&#34;</p></td>
 <td></td>
 </tr><tr><td><p>&#34;none&#34;</p></td>
 <td></td>

--- a/pkg/configuration/core/reconfigure_util.go
+++ b/pkg/configuration/core/reconfigure_util.go
@@ -22,6 +22,7 @@ package core
 import (
 	"encoding/json"
 	"reflect"
+	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -131,6 +132,17 @@ func IsUpdateDynamicParameters(cc *appsv1alpha1.ConfigConstraintSpec, cfg *Confi
 	// if the updated parameter is not in list of DynamicParameter,
 	// it is StaticParameter by default, and restart is the default behavior.
 	return false, nil
+}
+
+// IsDynamicParameter checks if the parameter supports hot update
+func IsDynamicParameter(paramName string, cc *appsv1alpha1.ConfigConstraintSpec) bool {
+	if len(cc.DynamicParameters) != 0 {
+		return slices.Contains(cc.DynamicParameters, paramName)
+	}
+	if len(cc.StaticParameters) != 0 {
+		return !slices.Contains(cc.StaticParameters, paramName)
+	}
+	return false
 }
 
 // IsParametersUpdateFromManager checks if the parameters are updated from manager

--- a/pkg/configuration/core/reconfigure_util_test.go
+++ b/pkg/configuration/core/reconfigure_util_test.go
@@ -334,3 +334,71 @@ func TestValidateConfigPatch(t *testing.T) {
 		})
 	}
 }
+
+func TestIsDynamicParameter(t *testing.T) {
+	type args struct {
+		paramName string
+		ccSpec    *appsv1alpha1.ConfigConstraintSpec
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{{
+		name: "test",
+		// null
+		args: args{
+			paramName: "test",
+			ccSpec:    &appsv1alpha1.ConfigConstraintSpec{},
+		},
+		want: false,
+	}, {
+		name: "test",
+		// static parameters contains
+		args: args{
+			ccSpec: &appsv1alpha1.ConfigConstraintSpec{
+				StaticParameters: []string{"param1", "param2", "param3"},
+			},
+			paramName: "param3",
+		},
+		want: false,
+	}, {
+		name: "test",
+		// static parameters not contains
+		args: args{
+			paramName: "param4",
+			ccSpec: &appsv1alpha1.ConfigConstraintSpec{
+				StaticParameters: []string{"param1", "param2", "param3"},
+			},
+		},
+		want: true,
+	}, {
+		name: "test",
+		// dynamic parameters contains
+		args: args{
+			paramName: "param1",
+			ccSpec: &appsv1alpha1.ConfigConstraintSpec{
+				DynamicParameters: []string{"param1", "param2", "param3"},
+			},
+		},
+		want: true,
+	}, {
+		name: "test",
+		// dynamic/static parameters not contains
+		args: args{
+			paramName: "test",
+			ccSpec: &appsv1alpha1.ConfigConstraintSpec{
+				DynamicParameters: []string{"dparam1", "dparam2", "dparam3"},
+				StaticParameters:  []string{"sparam1", "sparam2", "sparam3"},
+			},
+		},
+		want: false,
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsDynamicParameter(tt.args.paramName, tt.args.ccSpec); got != tt.want {
+				t.Errorf("IsDynamicParameter() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Bug: [[BUG] support dynamic and static parameters updates for partoni in one reconfiguring](https://github.com/apecloud/kubeblocks/issues/5450)