### PR TITLE
chore: release ent addons chart

### DIFF
--- a/.github/workflows/cicd-push.yml
+++ b/.github/workflows/cicd-push.yml
@@ -256,21 +256,11 @@ jobs:
           go-version: "${{ env.GO_VERSION }}"
 
       - name: Check apis doc
-        id: check-apis-doc
         run: |
           make doc
           FILE_CHANGES=`git diff --name-only ${{ github.sha }}`
           if [[ ! -z "$FILE_CHANGES" ]]; then
             echo $FILE_CHANGES
-            git config --local user.name "$GITHUB_ACTOR"
-            git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-            git commit -a -m "chore: auto update apis doc changes"
+            echo "make doc causes apis doc changes"
+            exit 1
           fi
-          echo file_changes=$FILE_CHANGES >> $GITHUB_OUTPUT
-
-      - name: Push apis doc changes
-        uses: ad-m/github-push-action@master
-        if: ${{ steps.check-apis-doc.outputs.file_changes }}
-        with:
-          github_token: ${{ env.GITHUB_TOKEN }}
-          branch: ${{ github.ref }}

--- a/.github/workflows/release-helm-chart.yml
+++ b/.github/workflows/release-helm-chart.yml
@@ -14,6 +14,7 @@ on:
 env:
   GH_TOKEN: ${{ github.token }}
   RELEASE_VERSION: ${{ github.ref_name }}
+  GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
 jobs:
   release-version:
@@ -158,5 +159,55 @@ jobs:
       APECD_REF: "v0.1.52"
     secrets: inherit
 
+  release-addons-chart-ent:
+    needs: [ release-addons-chart ]
+    uses: apecloud/apecloud-cd/.github/workflows/release-charts-enterprise.yml@v0.1.53
+    with:
+      GITHUB_REPO: "apecloud/apecloud-addons"
+      GITHUB_REF: ${{ github.ref }}
+      CHART_DIR: "addons"
+      APECD_REF: "v0.1.53"
+      ENABLE_JIHU: false
+    secrets: inherit
 
+  get-addons-chart-dir-ent:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.get_addons_chart_dir.outputs.matrix }}
+    steps:
+      - name: Checkout apecloud-addons Code
+        uses: actions/checkout@v4
+        with:
+          repository: apecloud/apecloud-addons
+          path: apecloud-addons
+          ref: ${{ github.ref }}
+          token: ${{ env.GITHUB_TOKEN }}
 
+      - name: get addons chart dir
+        id: get_addons_chart_dir
+        run: |
+          addons_list=$(ls apecloud-addons/addons)
+          ADDONS_DIR=""
+          for addons_name in $( echo "$addons_list" ); do
+              if [[ -z "$ADDONS_DIR" ]]; then
+                  ADDONS_DIR="{\"addon-name\":\"$addons_name\"}"
+              else
+                  ADDONS_DIR="$ADDONS_DIR,{\"addon-name\":\"$addons_name\"}"
+              fi
+          done
+          echo "$ADDONS_DIR"
+          echo "matrix={\"include\":[$ADDONS_DIR]}" >> $GITHUB_OUTPUT
+
+  release-addons-chart-jihu-ent:
+    needs: [ get-addons-chart-dir-ent ]
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.get-addons-chart-dir-ent.outputs.matrix) }}
+    uses: apecloud/apecloud-cd/.github/workflows/release-charts-jihu-enterprise.yml@v0.1.53
+    with:
+      GITHUB_REPO: "apecloud/apecloud-addons"
+      GITHUB_REF: ${{ github.ref }}
+      CHART_DIR: "addons"
+      SPECIFY_CHART: "${{ matrix.addon-name }}"
+      APECD_REF: "v0.1.53"
+    secrets: inherit

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -104,6 +104,34 @@ jobs:
       - name: checkout branch ${{ github.ref_name }}
         uses: actions/checkout@v4
 
+      - name: install lib
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libbtrfs-dev \
+            libdevmapper-dev
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "${{ env.GO_VERSION }}"
+
+      - name: Update apis doc
+        id: update_apis_doc
+        run: |
+          make doc
+          FILE_CHANGES=`git diff --name-only ${{ github.sha }}`
+          if [[ ! -z "$FILE_CHANGES" ]]; then
+            echo $FILE_CHANGES
+            git config --local user.name "$GITHUB_ACTOR"
+            git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+            git commit -a -m "chore: auto update apis doc changes"
+          fi
+          echo file_changes=$FILE_CHANGES >> $GITHUB_OUTPUT
+          
+          RELEASE_COMMIT="$(git rev-parse HEAD)"
+          echo 'RELEASE_COMMIT='${RELEASE_COMMIT} >> $GITHUB_ENV
+
       - name: Checkout kubeblocks-addons ${{ github.ref_name }}
         uses: actions/checkout@v4
         with:
@@ -127,7 +155,7 @@ jobs:
                   fi
               fi
           done
-          FILE_CHANGES=`git diff --name-only ${{ github.sha }}`
+          FILE_CHANGES=`git diff --name-only ${{ env.RELEASE_COMMIT }}`
           if [[ ! -z "$FILE_CHANGES" ]]; then
               echo $FILE_CHANGES
               git config --local user.name "$GITHUB_ACTOR"
@@ -140,20 +168,20 @@ jobs:
           echo 'RELEASE_COMMIT='${RELEASE_COMMIT} >> $GITHUB_ENV
 
       - name: push addons version changes to new branch
-        if: ${{ steps.upgrade_addon_version.outputs.file_changes && github.ref_name == 'main' }}
+        if: ${{ (steps.update_apis_doc.outputs.file_changes || steps.upgrade_addon_version.outputs.file_changes) && github.ref_name == 'main' }}
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ env.GITHUB_TOKEN }}
           branch: support/auto-upgrade-addons-${{ env.RELEASE_COMMIT }}
 
       - name: auto create pr head new branch
-        if: ${{ steps.upgrade_addon_version.outputs.file_changes && github.ref_name == 'main' }}
+        if: ${{ (steps.update_apis_doc.outputs.file_changes || steps.upgrade_addon_version.outputs.file_changes) && github.ref_name == 'main' }}
         run: |
           gh pr create --head "support/auto-upgrade-addons-${{ env.RELEASE_COMMIT }}" --title "chore: auto upgrade kubeblocks addons version" --body ""
 
       - name: push addons version changes
         uses: ad-m/github-push-action@master
-        if: ${{ steps.upgrade_addon_version.outputs.file_changes && github.ref_name != 'main' }}
+        if: ${{ (steps.update_apis_doc.outputs.file_changes || steps.upgrade_addon_version.outputs.file_changes) && github.ref_name != 'main' }}
         with:
           github_token: ${{ env.GITHUB_TOKEN }}
           branch: ${{ github.ref }}

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -172,12 +172,12 @@ jobs:
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ env.GITHUB_TOKEN }}
-          branch: support/auto-upgrade-addons-${{ env.RELEASE_COMMIT }}
+          branch: support/auto-update-${{ env.RELEASE_COMMIT }}
 
       - name: auto create pr head new branch
         if: ${{ (steps.update_apis_doc.outputs.file_changes || steps.upgrade_addon_version.outputs.file_changes) && github.ref_name == 'main' }}
         run: |
-          gh pr create --head "support/auto-upgrade-addons-${{ env.RELEASE_COMMIT }}" --title "chore: auto upgrade kubeblocks addons version" --body ""
+          gh pr create --head "support/auto-update-${{ env.RELEASE_COMMIT }}" --title "chore: auto upgrade addons version or update apis doc" --body ""
 
       - name: push addons version changes
         uses: ad-m/github-push-action@master


### PR DESCRIPTION
1. release ent addons chart when release kubeblocks
2. only check apis doc change when push
3. auto update apis doc changes when release