### PR TITLE
feat: support encryption for backup data

### DIFF
--- a/apis/dataprotection/v1alpha1/backup_types.go
+++ b/apis/dataprotection/v1alpha1/backup_types.go
@@ -163,6 +163,11 @@ type BackupStatus struct {
 	// +optional
 	BackupMethod *BackupMethod `json:"backupMethod,omitempty"`
 
+	// Records the encryption config for this backup.
+	//
+	// +optional
+	EncryptionConfig *EncryptionConfig `json:"encryptionConfig,omitempty"`
+
 	// Records the actions status for this backup.
 	//
 	// +optional

--- a/apis/dataprotection/v1alpha1/backuppolicy_types.go
+++ b/apis/dataprotection/v1alpha1/backuppolicy_types.go
@@ -66,6 +66,12 @@ type BackupPolicySpec struct {
 	// +optional
 	// +kubebuilder:default=false
 	UseKopia bool `json:"useKopia"`
+
+	// Specifies the parameters for encrypting backup data.
+	// Encryption will be disabled if the field is not set.
+	//
+	// +optional
+	EncryptionConfig *EncryptionConfig `json:"encryptionConfig,omitempty"`
 }
 
 type BackupTarget struct {

--- a/apis/dataprotection/v1alpha1/types.go
+++ b/apis/dataprotection/v1alpha1/types.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"time"
 	"unicode"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 // Phase defines the BackupPolicy and ActionSet CR .status.phase
@@ -228,3 +230,23 @@ const (
 	VolumeClaimRestorePolicyParallel VolumeClaimRestorePolicy = "Parallel"
 	VolumeClaimRestorePolicySerial   VolumeClaimRestorePolicy = "Serial"
 )
+
+// EncryptionConfig defines the parameters for encrypting backup data.
+type EncryptionConfig struct {
+	// Specifies the encryption algorithm. Currently supported algorithms are:
+	//
+	// - AES-128-CFB
+	// - AES-192-CFB
+	// - AES-256-CFB
+	//
+	// +kubebuilder:validation:Required
+	// +kubebuilder:default=AES-256-CFB
+	// +kubebuilder:validation:Enum={AES-128-CFB,AES-192-CFB,AES-256-CFB}
+	Algorithm string `json:"algorithm"`
+
+	// Selects the key of a secret in the current namespace, the value of the secret
+	// is used as the encryption key.
+	//
+	// +kubebuilder:validation:Required
+	PassPhraseSecretKeyRef *corev1.SecretKeySelector `json:"passPhraseSecretKeyRef"`
+}

--- a/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -483,6 +483,42 @@ spec:
                   repository.
                 pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                 type: string
+              encryptionConfig:
+                description: Specifies the parameters for encrypting backup data.
+                  Encryption will be disabled if the field is not set.
+                properties:
+                  algorithm:
+                    description: "Specifies the encryption algorithm. Currently supported
+                      algorithms are: \n - AES-128-CFB - AES-192-CFB - AES-256-CFB"
+                    enum:
+                    - AES-128-CFB
+                    - AES-192-CFB
+                    - AES-256-CFB
+                    type: string
+                  passPhraseSecretKeyRef:
+                    description: Selects the key of a secret in the current namespace,
+                      the value of the secret is used as the encryption key.
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - algorithm
+                - passPhraseSecretKeyRef
+                type: object
               pathPrefix:
                 description: Specifies the directory inside the backup repository
                   to store the backup. This path is relative to the path of the backup

--- a/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -488,6 +488,7 @@ spec:
                   Encryption will be disabled if the field is not set.
                 properties:
                   algorithm:
+                    default: AES-256-CFB
                     description: "Specifies the encryption algorithm. Currently supported
                       algorithms are: \n - AES-128-CFB - AES-192-CFB - AES-256-CFB"
                     enum:

--- a/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
@@ -662,6 +662,7 @@ spec:
                 description: Records the encryption config for this backup.
                 properties:
                   algorithm:
+                    default: AES-256-CFB
                     description: "Specifies the encryption algorithm. Currently supported
                       algorithms are: \n - AES-128-CFB - AES-192-CFB - AES-256-CFB"
                     enum:

--- a/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
@@ -658,6 +658,41 @@ spec:
                 description: Records the duration of the backup operation. When converted
                   to a string, the format is "1h2m0.5s".
                 type: string
+              encryptionConfig:
+                description: Records the encryption config for this backup.
+                properties:
+                  algorithm:
+                    description: "Specifies the encryption algorithm. Currently supported
+                      algorithms are: \n - AES-128-CFB - AES-192-CFB - AES-256-CFB"
+                    enum:
+                    - AES-128-CFB
+                    - AES-192-CFB
+                    - AES-256-CFB
+                    type: string
+                  passPhraseSecretKeyRef:
+                    description: Selects the key of a secret in the current namespace,
+                      the value of the secret is used as the encryption key.
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - algorithm
+                - passPhraseSecretKeyRef
+                type: object
               expiration:
                 description: Indicates when this backup becomes eligible for garbage
                   collection. A 'null' value implies that the backup will not be cleaned

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -483,6 +483,42 @@ spec:
                   repository.
                 pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                 type: string
+              encryptionConfig:
+                description: Specifies the parameters for encrypting backup data.
+                  Encryption will be disabled if the field is not set.
+                properties:
+                  algorithm:
+                    description: "Specifies the encryption algorithm. Currently supported
+                      algorithms are: \n - AES-128-CFB - AES-192-CFB - AES-256-CFB"
+                    enum:
+                    - AES-128-CFB
+                    - AES-192-CFB
+                    - AES-256-CFB
+                    type: string
+                  passPhraseSecretKeyRef:
+                    description: Selects the key of a secret in the current namespace,
+                      the value of the secret is used as the encryption key.
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - algorithm
+                - passPhraseSecretKeyRef
+                type: object
               pathPrefix:
                 description: Specifies the directory inside the backup repository
                   to store the backup. This path is relative to the path of the backup

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -488,6 +488,7 @@ spec:
                   Encryption will be disabled if the field is not set.
                 properties:
                   algorithm:
+                    default: AES-256-CFB
                     description: "Specifies the encryption algorithm. Currently supported
                       algorithms are: \n - AES-128-CFB - AES-192-CFB - AES-256-CFB"
                     enum:

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
@@ -662,6 +662,7 @@ spec:
                 description: Records the encryption config for this backup.
                 properties:
                   algorithm:
+                    default: AES-256-CFB
                     description: "Specifies the encryption algorithm. Currently supported
                       algorithms are: \n - AES-128-CFB - AES-192-CFB - AES-256-CFB"
                     enum:

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
@@ -658,6 +658,41 @@ spec:
                 description: Records the duration of the backup operation. When converted
                   to a string, the format is "1h2m0.5s".
                 type: string
+              encryptionConfig:
+                description: Records the encryption config for this backup.
+                properties:
+                  algorithm:
+                    description: "Specifies the encryption algorithm. Currently supported
+                      algorithms are: \n - AES-128-CFB - AES-192-CFB - AES-256-CFB"
+                    enum:
+                    - AES-128-CFB
+                    - AES-192-CFB
+                    - AES-256-CFB
+                    type: string
+                  passPhraseSecretKeyRef:
+                    description: Selects the key of a secret in the current namespace,
+                      the value of the secret is used as the encryption key.
+                    properties:
+                      key:
+                        description: The key of the secret to select from.  Must be
+                          a valid secret key.
+                        type: string
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                      optional:
+                        description: Specify whether the Secret or its key must be
+                          defined
+                        type: boolean
+                    required:
+                    - key
+                    type: object
+                    x-kubernetes-map-type: atomic
+                required:
+                - algorithm
+                - passPhraseSecretKeyRef
+                type: object
               expiration:
                 description: Indicates when this backup becomes eligible for garbage
                   collection. A 'null' value implies that the backup will not be cleaned

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -332,7 +332,7 @@ dataProtection:
     imagePullSecrets: []
     datasafed:
       repository: apecloud/datasafed
-      tag: "0.1.0"
+      tag: "0.2.0"
 
 ## BackupRepo settings
 ##

--- a/docs/developer_docs/api-reference/backup.md
+++ b/docs/developer_docs/api-reference/backup.md
@@ -475,6 +475,21 @@ for clusters with a low update frequency.</p>
 <p>NOTE: This feature should NOT be enabled when using KubeBlocks Community Edition, otherwise the backup will not be processed.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>encryptionConfig</code><br/>
+<em>
+<a href="#dataprotection.kubeblocks.io/v1alpha1.EncryptionConfig">
+EncryptionConfig
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Specifies the parameters for encrypting backup data.
+Encryption will be disabled if the field is not set.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -1824,6 +1839,21 @@ for clusters with a low update frequency.</p>
 <p>NOTE: This feature should NOT be enabled when using KubeBlocks Community Edition, otherwise the backup will not be processed.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>encryptionConfig</code><br/>
+<em>
+<a href="#dataprotection.kubeblocks.io/v1alpha1.EncryptionConfig">
+EncryptionConfig
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Specifies the parameters for encrypting backup data.
+Encryption will be disabled if the field is not set.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="dataprotection.kubeblocks.io/v1alpha1.BackupPolicyStatus">BackupPolicyStatus
@@ -2643,6 +2673,20 @@ Refer to BackupMethod for more details.</p>
 </tr>
 <tr>
 <td>
+<code>encryptionConfig</code><br/>
+<em>
+<a href="#dataprotection.kubeblocks.io/v1alpha1.EncryptionConfig">
+EncryptionConfig
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Records the encryption config for this backup.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>actions</code><br/>
 <em>
 <a href="#dataprotection.kubeblocks.io/v1alpha1.ActionStatus">
@@ -2950,6 +2994,54 @@ string
 <td>
 <em>(Optional)</em>
 <p>Specifies the map key of the port in the connection credential secret.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="dataprotection.kubeblocks.io/v1alpha1.EncryptionConfig">EncryptionConfig
+</h3>
+<p>
+(<em>Appears on:</em><a href="#dataprotection.kubeblocks.io/v1alpha1.BackupPolicySpec">BackupPolicySpec</a>, <a href="#dataprotection.kubeblocks.io/v1alpha1.BackupStatus">BackupStatus</a>)
+</p>
+<div>
+<p>EncryptionConfig defines the parameters for encrypting backup data.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>algorithm</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Specifies the encryption algorithm. Currently supported algorithms are:</p>
+<ul>
+<li>AES-128-CFB</li>
+<li>AES-192-CFB</li>
+<li>AES-256-CFB</li>
+</ul>
+</td>
+</tr>
+<tr>
+<td>
+<code>passPhraseSecretKeyRef</code><br/>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#secretkeyselector-v1-core">
+Kubernetes core/v1.SecretKeySelector
+</a>
+</em>
+</td>
+<td>
+<p>Selects the key of a secret in the current namespace, the value of the secret
+is used as the encryption key.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/dataprotection/backup/deleter.go
+++ b/pkg/dataprotection/backup/deleter.go
@@ -257,8 +257,9 @@ func (d *Deleter) createDeleteJob(container corev1.Container,
 		return err
 	}
 	kopiaRepoPath := backup.Status.KopiaRepoPath
+	encryptionConfig := backup.Status.EncryptionConfig
 	if backupRepo != nil {
-		utils.InjectDatasafed(&podSpec, backupRepo, RepoVolumeMountPath, kopiaRepoPath)
+		utils.InjectDatasafed(&podSpec, backupRepo, RepoVolumeMountPath, encryptionConfig, kopiaRepoPath)
 	} else {
 		utils.InjectDatasafedWithPVC(&podSpec, legacyPVCName, RepoVolumeMountPath, kopiaRepoPath)
 	}

--- a/pkg/dataprotection/backup/request.go
+++ b/pkg/dataprotection/backup/request.go
@@ -429,7 +429,8 @@ func (r *Request) BuildJobActionPodSpec(targetPod *corev1.Pod,
 		}
 	}
 
-	utils.InjectDatasafed(podSpec, r.BackupRepo, RepoVolumeMountPath, r.Status.KopiaRepoPath)
+	utils.InjectDatasafed(podSpec, r.BackupRepo, RepoVolumeMountPath,
+		r.Status.EncryptionConfig, r.Status.KopiaRepoPath)
 	return podSpec, nil
 }
 

--- a/pkg/dataprotection/restore/builder.go
+++ b/pkg/dataprotection/restore/builder.go
@@ -378,8 +378,10 @@ func (r *restoreJobBuilder) build() *batchv1.Job {
 	if r.buildWithRepo {
 		mountPath := "/backupdata"
 		kopiaRepoPath := r.backupSet.Backup.Status.KopiaRepoPath
+		encryptionConfig := r.backupSet.Backup.Status.EncryptionConfig
 		if r.backupRepo != nil {
-			utils.InjectDatasafed(&job.Spec.Template.Spec, r.backupRepo, mountPath, kopiaRepoPath)
+			utils.InjectDatasafed(&job.Spec.Template.Spec, r.backupRepo, mountPath,
+				encryptionConfig, kopiaRepoPath)
 		} else if pvcName := r.backupSet.Backup.Status.PersistentVolumeClaimName; pvcName != "" {
 			// If the backup object was created in an old version that doesn't have the backupRepo field,
 			// use the PVC name field as a fallback.

--- a/pkg/dataprotection/types/constant.go
+++ b/pkg/dataprotection/types/constant.go
@@ -118,12 +118,17 @@ const (
 	DPBackupStopTime = "DP_BACKUP_STOP_TIME" // backup stop time
 	// DPDatasafedBinPath the path containing the datasafed binary
 	DPDatasafedBinPath = "DP_DATASAFED_BIN_PATH"
+
+	// NOTE: do not add 'DP_' prefix to the value of the following constants, they are the datasafed built-in environment.
+
 	// DPDatasafedLocalBackendPath force datasafed to use local backend with the path
-	// NOTE: do not add 'DP_' for this constant, it is the datasafed built-in environment.
 	DPDatasafedLocalBackendPath = "DATASAFED_LOCAL_BACKEND_PATH"
 	// DPDatasafedKopiaRepoRoot specifies the root of the Kopia repository
-	// NOTE: do not add 'DP_' for this constant, it is the datasafed built-in environment.
 	DPDatasafedKopiaRepoRoot = "DATASAFED_KOPIA_REPO_ROOT"
+	// DPDatasafedEncryptionAlgorithm specifies the encryption algorithm for backup data
+	DPDatasafedEncryptionAlgorithm = "DATASAFED_ENCRYPTION_ALGORITHM"
+	// DPDatasafedEncryptionPassPhrase specifies the encryption key
+	DPDatasafedEncryptionPassPhrase = "DATASAFED_ENCRYPTION_PASS_PHRASE"
 )
 
 const (


### PR DESCRIPTION
This PR integrates data encryption functionality from datasafed. Backup data is encrypted before being written to storage. Currently, the supported encryption algorithms are `AES-128-CFB`, `AES-192-CFB`, and `AES-256-CFB`. In the future, additional algorithms can be supported based on requirements.

Usage instructions:

1. Create a Secret to store the encryption key:
    ```bash
    kubectl create secret generic backup-encryption \
      --from-literal=secretKey='your secret key'
    ```

2. Patch the backupPolicy to enable encryption. Reference the previously created key here:
    ```bash
    kubectl --type merge patch backuppolicy mysqlcluster-mysql-backup-policy \
      -p '{"spec":{"encryptionConfig":{"algorithm":"AES-256-CFB","passPhraseSecretKeyRef":{"name":"backup-encryption","key":"secretKey"}}}}'
    ```

3. Configuration is complete. Perform backups and restores as usual.

Note: The content of the Secret created in step one should not be modified or deleted; otherwise, decryption of backups will fail in the future.

Subsequent simplification of these operations can be achieved through kbcli.

Close #6722.