### PR TITLE
chore: add reconcile workers for cluster and component controller.

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -24,6 +24,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -34,7 +35,7 @@ import (
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	discoverycli "k8s.io/client-go/discovery"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -83,7 +84,7 @@ const (
 )
 
 var (
-	scheme   = runtime.NewScheme()
+	scheme   = k8sruntime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
 )
 
@@ -127,6 +128,7 @@ func init() {
 	viper.SetDefault(rsm.FeatureGateRSMCompatibilityMode, true)
 	viper.SetDefault(rsm.FeatureGateRSMToPod, true)
 	viper.SetDefault(constant.FeatureGateEnableRuntimeMetrics, false)
+	viper.SetDefault(constant.CfgKBReconcileWorkers, runtime.NumCPU())
 }
 
 type flagName string

--- a/controllers/apps/cluster_controller.go
+++ b/controllers/apps/cluster_controller.go
@@ -28,11 +28,14 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
 
 // +kubebuilder:rbac:groups=apps.kubeblocks.io,resources=clusters,verbs=get;list;watch;create;update;patch;delete
@@ -167,6 +170,9 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return intctrlutil.NewNamespacedControllerManagedBy(mgr).
 		For(&appsv1alpha1.Cluster{}).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: viper.GetInt(constant.CfgKBReconcileWorkers),
+		}).
 		Owns(&appsv1alpha1.Component{}).
 		Owns(&corev1.Service{}). // cluster services
 		Owns(&corev1.Secret{}).  // cluster conn-credential secret

--- a/controllers/apps/component_controller.go
+++ b/controllers/apps/component_controller.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -183,6 +184,9 @@ func (r *ComponentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 	b := intctrlutil.NewNamespacedControllerManagedBy(mgr).
 		For(&appsv1alpha1.Component{}).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: viper.GetInt(constant.CfgKBReconcileWorkers),
+		}).
 		Watches(&workloads.ReplicatedStateMachine{}, handler.EnqueueRequestsFromMapFunc(r.filterComponentResources)).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.Secret{}).

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -75,6 +75,10 @@ spec:
             - name: CM_AFFINITY
               value: {{ toJson . | quote }}
             {{- end }}
+            {{- if .Values.reconcileWorkers }}
+            - name: KUBEBLOCKS_RECONCILE_WORKERS
+              values: {{ .Values.reconcileWorkers }}
+            {{- end }}
             {{- with .Values.nodeSelector }}
             - name: CM_NODE_SELECTOR
               value: {{ toJson . | quote }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -27,6 +27,10 @@ image:
 ##
 replicaCount: 1
 
+## MaxConcurrentReconciles for cluster and component controllers.
+##
+reconcileWorkers: ""
+
 ## @param nameOverride
 ##
 nameOverride: ""

--- a/pkg/constant/const.go
+++ b/pkg/constant/const.go
@@ -46,6 +46,8 @@ const (
 
 	// customized encryption key for encrypting the password of connection credential.
 	CfgKeyDPEncryptionKey = "DP_ENCRYPTION_KEY"
+
+	CfgKBReconcileWorkers = "KB_RECONCILE_WORKERS"
 )
 
 const (

--- a/pkg/constant/const.go
+++ b/pkg/constant/const.go
@@ -47,7 +47,7 @@ const (
 	// customized encryption key for encrypting the password of connection credential.
 	CfgKeyDPEncryptionKey = "DP_ENCRYPTION_KEY"
 
-	CfgKBReconcileWorkers = "KB_RECONCILE_WORKERS"
+	CfgKBReconcileWorkers = "KUBEBLOCKS_RECONCILE_WORKERS"
 )
 
 const (


### PR DESCRIPTION
if the clusters number over than 1000,  RT response is slow. 
for example, it takes 2 minutes or more minutes to start creating pods when creating a cluster.