### PR TITLE
fix: failed to reconrigure operation (#674)

### DIFF
--- a/pkg/configuration/core/config_util.go
+++ b/pkg/configuration/core/config_util.go
@@ -38,15 +38,22 @@ type ParamPairs struct {
 }
 
 const pattern = `^[a-z0-9A-Z]([a-zA-Z0-9\.\-\_]*[a-zA-Z0-9])?$`
+const validLabelLength = 63
 
 var regxPattern = regexp.MustCompile(pattern)
 
 func FromValueToString(val interface{}) string {
 	str := strings.Trim(cast.ToString(val), ` '"`)
-	if regxPattern.MatchString(str) {
+	if IsValidLabelKeyOrValue(str) {
 		return str
 	}
 	return ""
+}
+
+// IsValidLabelKeyOrValue checks if the input string is a valid label key or value
+// https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+func IsValidLabelKeyOrValue(label string) bool {
+	return len(label) <= validLabelLength && regxPattern.MatchString(label)
 }
 
 // MergeUpdatedConfig replaces the file content of the changed key.


### PR DESCRIPTION
1.  [[BUG] camellia cluster config error metadata.labels Invalid value must be no more than 63 characters #6746](https://github.com/apecloud/kubeblocks/issues/6746)
2. [[BUG] ob reconfigure invalid error: metadata.labels: Invalid value: "__easy_memory_reserved_percentage" #6765](https://github.com/apecloud/kubeblocks/issues/6765)