### PR TITLE
feat: support referencing pre-defined secret as encryptionKey

### DIFF
--- a/apis/dataprotection/v1alpha1/types.go
+++ b/apis/dataprotection/v1alpha1/types.go
@@ -238,6 +238,10 @@ const (
 	OneToManyRestorePolicy DataRestorePolicy = "OneToMany"
 )
 
+const (
+	DefaultEncryptionAlgorithm = "AES-256-CFB"
+)
+
 // EncryptionConfig defines the parameters for encrypting backup data.
 type EncryptionConfig struct {
 	// Specifies the encryption algorithm. Currently supported algorithms are:

--- a/controllers/apps/transformer_cluster_backup_policy.go
+++ b/controllers/apps/transformer_cluster_backup_policy.go
@@ -257,14 +257,14 @@ func (r *clusterBackupPolicyTransformer) transformBackupSchedule(
 }
 
 func (r *clusterBackupPolicyTransformer) setDefaultEncryptionConfig(backupPolicy *dpv1alpha1.BackupPolicy) {
-	secretKeyRefJson := viper.GetString(constant.CfgKeyDPBackupEncryptionSecretKeyRef)
-	if secretKeyRefJson == "" {
+	secretKeyRefJSON := viper.GetString(constant.CfgKeyDPBackupEncryptionSecretKeyRef)
+	if secretKeyRefJSON == "" {
 		return
 	}
 	secretKeyRef := &corev1.SecretKeySelector{}
-	err := json.Unmarshal([]byte(secretKeyRefJson), secretKeyRef)
+	err := json.Unmarshal([]byte(secretKeyRefJSON), secretKeyRef)
 	if err != nil {
-		r.Error(err, "failed to unmarshal secretKeyRef", "json", secretKeyRefJson)
+		r.Error(err, "failed to unmarshal secretKeyRef", "json", secretKeyRefJSON)
 		return
 	}
 	if secretKeyRef.Name == "" || secretKeyRef.Key == "" {

--- a/deploy/helm/templates/_dataprotection.tpl
+++ b/deploy/helm/templates/_dataprotection.tpl
@@ -30,3 +30,34 @@ Create the name of the Role for exec worker pods.
 {{- include "kubeblocks.fullname" . }}-dataprotection-exec-worker-role
 {{- end }}
 
+{{/*
+Render the secret key reference of the encryptionKey.
+*/}}
+{{- define "dataprotection.encryptionKeySecretKeyRef" -}}
+  {{- $ref := .Values.dataProtection.encryptionKeySecretKeyRef -}}
+  {{- if or (eq $ref.name "") (eq $ref.key "") -}}
+name: {{ include "kubeblocks.fullname" . }}-secret
+key: dataProtectionEncryptionKey
+  {{- else -}}
+    {{- $secret := lookup "v1" "Secret" .Release.Namespace $ref.name -}}
+    {{- if not $secret -}}
+      {{- fail (printf "Invalid value \".Values.dataProtection.encryptionKeySecretKeyRef\", secret %q is not found from the namespace %q." $ref.name .Release.Namespace) -}}
+    {{- else if not (hasKey $secret.data $ref.key) -}}
+      {{- fail (printf "Invalid value \".Values.dataProtection.encryptionKeySecretKeyRef\", secret %q doesn't have key %q." $ref.name $ref.key) -}}
+    {{- end -}}
+name: {{ $ref.name }}
+key:  {{ $ref.key }}
+  {{- end -}}
+{{- end }}
+
+{{/*
+Render the algorithm for backup encryption, empty if not specified or invalid.
+*/}}
+{{- define "dataprotection.backupEncryptionAlgorithm" -}}
+  {{- $allowed := list "AES-128-CFB" "AES-192-CFB" "AES-256-CFB" -}}
+  {{- if has .Values.dataProtection.backupEncryptionAlgorithm $allowed -}}
+    {{ .Values.dataProtection.backupEncryptionAlgorithm | quote }}
+  {{- else -}}
+    {{ "" | quote }}
+  {{- end -}}
+{{- end }}

--- a/deploy/helm/templates/dataprotection.yaml
+++ b/deploy/helm/templates/dataprotection.yaml
@@ -114,8 +114,7 @@ spec:
             - name: DP_ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "kubeblocks.fullname" . }}-secret
-                  key: dataProtectionEncryptionKey
+                  {{- include "dataprotection.encryptionKeySecretKeyRef" . | nindent 18 }}
             - name: DATASAFED_IMAGE
               value: "{{ .Values.dataProtection.image.registry | default $dataProtectionImageRegistry }}/{{ .Values.dataProtection.image.datasafed.repository }}:{{ .Values.dataProtection.image.datasafed.tag | default "latest" }}"
             - name: GC_FREQUENCY_SECONDS

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -139,8 +139,13 @@ spec:
             - name: DP_ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "kubeblocks.fullname" . }}-secret
-                  key: dataProtectionEncryptionKey
+                  {{- include "dataprotection.encryptionKeySecretKeyRef" . | nindent 18 }}
+            {{- if .Values.dataProtection.enableBackupEncryption }}
+            - name: DP_BACKUP_ENCRYPTION_SECRET_KEY_REF
+              value: {{ include "dataprotection.encryptionKeySecretKeyRef" . | fromYaml | toJson | quote }}
+            - name: DP_BACKUP_ENCRYPTION_ALGORITHM
+              value: {{ include "dataprotection.backupEncryptionAlgorithm" . }}
+            {{- end }}
             - name: KUBE_PROVIDER
               value: {{ .Values.provider | quote }}
             - name: HOST_PORT_INCLUDE_RANGES

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -337,6 +337,11 @@ dataProtection:
   # using the default key can potentially lead to the exposure of database passwords
   # if 'get/list' role of the backup CR are compromised.
   encryptionKey: ""
+  encryptionKeySecretKeyRef:
+    name: ""
+    key: ""
+  enableBackupEncryption: false
+  backupEncryptionAlgorithm: ""
   gcFrequencySeconds: 3600
   ## MaxConcurrentReconciles for backup controller.
   reconcileWorkers: ""

--- a/pkg/constant/const.go
+++ b/pkg/constant/const.go
@@ -45,7 +45,9 @@ const (
 	CfgKeyDefaultStorageClass = "DEFAULT_STORAGE_CLASS"
 
 	// customized encryption key for encrypting the password of connection credential.
-	CfgKeyDPEncryptionKey = "DP_ENCRYPTION_KEY"
+	CfgKeyDPEncryptionKey                = "DP_ENCRYPTION_KEY"
+	CfgKeyDPBackupEncryptionSecretKeyRef = "DP_BACKUP_ENCRYPTION_SECRET_KEY_REF"
+	CfgKeyDPBackupEncryptionAlgorithm    = "DP_BACKUP_ENCRYPTION_ALGORITHM"
 
 	CfgKBReconcileWorkers = "KUBEBLOCKS_RECONCILE_WORKERS"
 	CfgClientQPS          = "CLIENT_QPS"


### PR DESCRIPTION
### Background
As described in #7103, sometimes we would like to reference a pre-defined secret instead of setting `dataProtection.encryptionKey`. This PR allows users to do so.

### Usage
Assuming there is a pre-defined secret named `dp-encryption-key` and a key `encryptionKey` inside it. For example, a secret created by this command:

```bash
kubectl create secret generic dp-encryption-key \
    --from-literal=encryptionKey='S!B\*d$zDsb='
```

And then reference it when installing or upgrading KubeBlocks:

```bash
kbcli kubeblocks install \
    --set dataProtection.encryptionKeySecretKeyRef.name="dp-encryption-key" \
    --set dataProtection.encryptionKeySecretKeyRef.key="encryptionKey"

# The above command is equivalent to:
#   kbcli kubeblocks install --set dataProtection.encryptionKey='S!B\*d$zDsb='
```

By default, the `encrytpionKey` is only used for encrypting the connection password, if you want to use it to encrypt backup data as well, add `--set dataProtection.enableBackupEncryption=true` to the above command.

Close #7103.
