### PR TITLE
feat: support installing releases of dependencies when enabling an addon (#5780)

### DIFF
--- a/apis/extensions/v1alpha1/addon_types.go
+++ b/apis/extensions/v1alpha1/addon_types.go
@@ -80,6 +80,10 @@ type AddonSpec struct {
 	//
 	// +optional
 	CliPlugins []CliPlugin `json:"cliPlugins,omitempty"`
+
+	// Specifies the dependencies of this addon
+	// +optional
+	Dependencies []DependencySpec `json:"dependencies,omitempty"`
 }
 
 // AddonStatus defines the observed state of an add-on.
@@ -470,6 +474,11 @@ type ResourceRequirements struct {
 	//
 	// +optional
 	Requests corev1.ResourceList `json:"requests,omitempty"`
+}
+
+type DependencySpec struct {
+	Name    string `json:"name"`
+	Version string `json:"version,omitempty"`
 }
 
 // +genclient

--- a/apis/extensions/v1alpha1/addon_types.go
+++ b/apis/extensions/v1alpha1/addon_types.go
@@ -82,6 +82,7 @@ type AddonSpec struct {
 	CliPlugins []CliPlugin `json:"cliPlugins,omitempty"`
 
 	// Specifies the dependencies of this addon
+	//
 	// +optional
 	Dependencies []DependencySpec `json:"dependencies,omitempty"`
 }

--- a/apis/extensions/v1alpha1/addon_types.go
+++ b/apis/extensions/v1alpha1/addon_types.go
@@ -478,7 +478,14 @@ type ResourceRequirements struct {
 }
 
 type DependencySpec struct {
-	Name    string `json:"name"`
+	// Specifies the name of the dependency.
+	//
+	// +kubebuilder:validation:Required
+	Name string `json:"name"`
+
+	// Specifies the version of the dependency.
+	//
+	// +kubebuilder:validation:Required
 	Version string `json:"version,omitempty"`
 }
 

--- a/controllers/extensions/addon_controller_test.go
+++ b/controllers/extensions/addon_controller_test.go
@@ -431,7 +431,9 @@ var _ = Describe("Addon controller", func() {
 			for i := range names {
 				createAddonSpecWithRequiredAttributes(func(newOjb *extensionsv1alpha1.Addon) {
 					newOjb.Name = names[i]
-					newOjb.Spec.Installable.AutoInstall = true
+					if i == 0 {
+						newOjb.Spec.Installable.AutoInstall = true
+					}
 					newOjb.Spec.Version = "1.0.0"
 					if i < len(dependencies) {
 						newOjb.Spec.Dependencies = dependencies[i]

--- a/controllers/extensions/addon_controller_test.go
+++ b/controllers/extensions/addon_controller_test.go
@@ -437,7 +437,6 @@ var _ = Describe("Addon controller", func() {
 						newOjb.Spec.Dependencies = dependencies[i]
 					}
 				})
-				Expect(key.Name).Should(BeEquivalentTo(names[i]))
 			}
 			key.Name = "a"
 			Eventually(func(g Gomega) {

--- a/controllers/extensions/addon_controller_test.go
+++ b/controllers/extensions/addon_controller_test.go
@@ -118,17 +118,6 @@ var _ = Describe("Addon controller", func() {
 			return addonReconciler.Reconcile(ctx, req)
 		}
 
-		//doReconcileWithKey := func(specifiedKey types.NamespacedName) (ctrl.Result, error) {
-		//	addonReconciler := &AddonReconciler{
-		//		Client: testCtx.Cli,
-		//		Scheme: testCtx.Cli.Scheme(),
-		//	}
-		//	req := reconcile.Request{
-		//		NamespacedName: specifiedKey,
-		//	}
-		//	return addonReconciler.Reconcile(ctx, req)
-		//}
-
 		doReconcileOnce := func(g Gomega) {
 			By("Reconciling once")
 			result, err := doReconcile()
@@ -451,7 +440,6 @@ var _ = Describe("Addon controller", func() {
 				Expect(key.Name).Should(BeEquivalentTo(names[i]))
 			}
 			key.Name = "a"
-			//enablingPhaseCheck(2)
 			Eventually(func(g Gomega) {
 				_, err := doReconcile()
 				g.Expect(err).To(Not(HaveOccurred()))
@@ -556,7 +544,8 @@ var _ = Describe("Addon controller", func() {
 			}
 			key.Name = "a"
 			Eventually(func(g Gomega) {
-				doReconcile()
+				_, err := doReconcile()
+				g.Expect(err).To(Not(HaveOccurred()))
 				addon := &extensionsv1alpha1.Addon{}
 				g.Expect(testCtx.Cli.Get(ctx, key, addon)).To(Not(HaveOccurred()))
 				g.Expect(addon.Status.Phase).Should(Equal(extensionsv1alpha1.AddonFailed))


### PR DESCRIPTION
When installing an addon, automatically enabling the dependencies. And stop the process if there is a circular dependency or the version of the dependency is not matched.
