### PR TITLE
fix: exclude data-protection pods from kb service

### DIFF
--- a/deploy/helm/templates/dataprotection.yaml
+++ b/deploy/helm/templates/dataprotection.yaml
@@ -14,6 +14,7 @@ spec:
   selector:
     matchLabels:
       {{- include "kubeblocks.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "dataprotection"
   {{- if .Values.updateStrategy }}
   strategy:
     {{ toYaml .Values.updateStrategy | nindent 4 | trim }}
@@ -26,6 +27,7 @@ spec:
       {{- end }}
       labels:
         {{- include "kubeblocks.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "dataprotection"
     spec:
       priorityClassName: {{ template "kubeblocks.priorityClassName" . }}
       {{- with .Values.dataProtection.image.imagePullSecrets }}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -12,6 +12,7 @@ spec:
   selector:
     matchLabels:
       {{- include "kubeblocks.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: "apps"
   {{- if .Values.updateStrategy }}
   strategy:
     {{ toYaml .Values.updateStrategy | nindent 4 | trim }}
@@ -24,6 +25,7 @@ spec:
       {{- end }}
       labels:
         {{- include "kubeblocks.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: "apps"
     spec:
       priorityClassName: {{ template "kubeblocks.priorityClassName" . }}
       {{- with .Values.image.imagePullSecrets }}

--- a/deploy/helm/templates/service.yaml
+++ b/deploy/helm/templates/service.yaml
@@ -26,3 +26,4 @@ spec:
     {{- end }}
   selector:
     {{- include "kubeblocks.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: "apps"


### PR DESCRIPTION
fix #7234 