### PR TITLE
chore: cluster reconciliation premature stop

### DIFF
--- a/controllers/apps/transformer_cluster_component.go
+++ b/controllers/apps/transformer_cluster_component.go
@@ -37,6 +37,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
+	"github.com/apecloud/kubeblocks/pkg/controllerutil"
 	ictrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 )
 
@@ -142,7 +143,7 @@ func (t *clusterComponentTransformer) handleComps(transCtx *clusterTransformCont
 		}
 	}
 	if len(unmatched) > 0 {
-		return fmt.Errorf("retry later: %s are not ready", strings.Join(unmatched, ","))
+		return controllerutil.NewDelayedRequeueError(0, fmt.Sprintf("retry later: %s are not ready", strings.Join(unmatched, ",")))
 	}
 	return nil
 }


### PR DESCRIPTION
When using new API's topology order, cluster reconciliation transformer will be prematurely stopped due to the error produced in clusterComponentTransformer. Thus causing problems like cluster status' `observedGeneration` not updated.

So I think delaying this error will be appropriate.