### PR TITLE
Revert "fix: exclude data-protection pods from kb service (#7239)"

### DIFF
--- a/deploy/helm/templates/dataprotection.yaml
+++ b/deploy/helm/templates/dataprotection.yaml
@@ -14,7 +14,6 @@ spec:
   selector:
     matchLabels:
       {{- include "kubeblocks.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: "dataprotection"
   {{- if .Values.updateStrategy }}
   strategy:
     {{ toYaml .Values.updateStrategy | nindent 4 | trim }}
@@ -27,7 +26,6 @@ spec:
       {{- end }}
       labels:
         {{- include "kubeblocks.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: "dataprotection"
     spec:
       priorityClassName: {{ template "kubeblocks.priorityClassName" . }}
       {{- with .Values.dataProtection.image.imagePullSecrets }}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -12,7 +12,6 @@ spec:
   selector:
     matchLabels:
       {{- include "kubeblocks.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: "apps"
   {{- if .Values.updateStrategy }}
   strategy:
     {{ toYaml .Values.updateStrategy | nindent 4 | trim }}
@@ -25,7 +24,6 @@ spec:
       {{- end }}
       labels:
         {{- include "kubeblocks.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: "apps"
     spec:
       priorityClassName: {{ template "kubeblocks.priorityClassName" . }}
       {{- with .Values.image.imagePullSecrets }}

--- a/deploy/helm/templates/service.yaml
+++ b/deploy/helm/templates/service.yaml
@@ -26,4 +26,3 @@ spec:
     {{- end }}
   selector:
     {{- include "kubeblocks.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/component: "apps"


### PR DESCRIPTION
This reverts commit 37a288d6762d2280208fee8106c3e72a73ea4a1f.

fix https://github.com/apecloud/kubeblocks/issues/7250