### PR TITLE
fix: add labels to distinguish kb and dataprotection

### DIFF
--- a/deploy/helm/templates/dataprotection.yaml
+++ b/deploy/helm/templates/dataprotection.yaml
@@ -14,6 +14,9 @@ spec:
   selector:
     matchLabels:
       {{- include "kubeblocks.selectorLabels" . | nindent 6 }}
+      {{- with .Values.dataProtection.extraLables }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
   {{- if .Values.updateStrategy }}
   strategy:
     {{ toYaml .Values.updateStrategy | nindent 4 | trim }}
@@ -26,6 +29,9 @@ spec:
       {{- end }}
       labels:
         {{- include "kubeblocks.selectorLabels" . | nindent 8 }}
+        {{- with .Values.dataProtection.extraLables }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       priorityClassName: {{ template "kubeblocks.priorityClassName" . }}
       {{- with .Values.dataProtection.image.imagePullSecrets }}
@@ -179,11 +185,11 @@ spec:
       {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
       {{- end }}
-      {{- with .Values.topologySpreadConstraints }}
+      {{- with .Values.dataProtection.topologySpreadConstraints }}
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.dataProtection.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -191,7 +197,7 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.dataProtection.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -12,6 +12,9 @@ spec:
   selector:
     matchLabels:
       {{- include "kubeblocks.selectorLabels" . | nindent 6 }}
+      {{- with .Values.extraLables }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
   {{- if .Values.updateStrategy }}
   strategy:
     {{ toYaml .Values.updateStrategy | nindent 4 | trim }}
@@ -24,6 +27,9 @@ spec:
       {{- end }}
       labels:
         {{- include "kubeblocks.selectorLabels" . | nindent 8 }}
+        {{- with .Values.extraLables }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       priorityClassName: {{ template "kubeblocks.priorityClassName" . }}
       {{- with .Values.image.imagePullSecrets }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -296,7 +296,6 @@ affinity:
           operator: In
           values:
           - "true"
-
 ## @param data plane settings
 ##
 dataPlane:
@@ -316,6 +315,9 @@ dataPlane:
             operator: In
             values:
             - "true"
+
+# Add extra pod labels to KubeBlocks Deployment
+extraLables: []
 
 ## AdmissionWebhooks settings
 ##
@@ -370,6 +372,29 @@ dataProtection:
     datasafed:
       repository: apecloud/datasafed
       tag: "0.2.0"
+  ## @param toleration
+  tolerations:
+  - key: kb-controller
+    operator: Equal
+    value: "true"
+    effect: NoSchedule
+  ## @param affinity
+  ##
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+          - key: kb-controller
+            operator: In
+            values:
+            - "true"
+  ## @param topologySpreadConstraints
+  topologySpreadConstraints: []
+
+  # Add extra pod labels to KubeBlocks-DataProtection Deployment
+  extraLables: []
 
 ## BackupRepo settings
 ##
@@ -1286,7 +1311,7 @@ prometheus:
               annotations:
                 summary: 'MongoDB is Down'
                 description: 'MongoDB instance is down\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}'
-      
+
             - alert: MongodbRestarted
               expr: 'mongodb_instance_uptime_seconds < 60'
               for: 0m
@@ -1295,7 +1320,7 @@ prometheus:
               annotations:
                 summary: 'Mongodb has just been restarted (< 60s)'
                 description: 'Mongodb has just been restarted {{ $value | printf "%.1f" }} seconds ago\n LABELS = {{ $labels }}'
-      
+
             - alert: MongodbReplicaMemberUnhealthy
               expr: 'max_over_time(mongodb_rs_members_health[1m]) == 0'
               for: 0m
@@ -1304,7 +1329,7 @@ prometheus:
               annotations:
                 summary: 'Mongodb replica member is unhealthy'
                 description: 'MongoDB replica member is not healthy\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}'
-      
+
             - alert: MongodbReplicationLag
               expr: '(mongodb_rs_members_optimeDate{member_state="PRIMARY"} - on (pod) group_right mongodb_rs_members_optimeDate{member_state="SECONDARY"}) / 1000 > 10'
               for: 0m
@@ -1313,7 +1338,7 @@ prometheus:
               annotations:
                 summary: 'MongoDB replication lag (> 10s)'
                 description: 'Mongodb replication lag is more than 10s\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}'
-      
+
             - alert: MongodbReplicationHeadroom
               expr: 'sum(avg(mongodb_mongod_replset_oplog_head_timestamp - mongodb_mongod_replset_oplog_tail_timestamp)) - sum(avg(mongodb_rs_members_optimeDate{member_state="PRIMARY"} - on (pod) group_right mongodb_rs_members_optimeDate{member_state="SECONDARY"})) <= 0'
               for: 0m
@@ -1322,7 +1347,7 @@ prometheus:
               annotations:
                 summary: 'MongoDB replication headroom (< 0)'
                 description: 'MongoDB replication headroom is <= 0\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}'
-      
+
             - alert: MongodbNumberCursorsOpen
               expr: 'mongodb_ss_metrics_cursor_open{csr_type="total"} > 10 * 1000'
               for: 2m
@@ -1331,16 +1356,16 @@ prometheus:
               annotations:
                 summary: 'MongoDB opened cursors num (> 10k)'
                 description: 'Too many cursors opened by MongoDB for clients (> 10k)\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}'
-      
+
             - alert: MongodbCursorsTimeouts
               expr: 'increase(mongodb_ss_metrics_cursor_timedOut[1m]) > 100'
               for: 2m
               labels:
                 severity: warning
               annotations:
-                summary: 'MongoDB cursors timeouts (>100/minute)' 
+                summary: 'MongoDB cursors timeouts (>100/minute)'
                 description: 'Too many cursors are timing out (> 100/minute)\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}'
-      
+
             - alert: MongodbTooManyConnections
               expr: 'avg by(pod) (rate(mongodb_ss_connections{conn_type="current"}[1m])) / avg by(pod) (sum (mongodb_ss_connections) by(pod)) * 100 > 80'
               for: 2m
@@ -1349,7 +1374,7 @@ prometheus:
               annotations:
                 summary: 'MongoDB too many connections (> 80%)'
                 description: 'Too many connections (> 80%)\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}'
-      
+
             - alert: MongodbVirtualMemoryUsage
               expr: '(sum(mongodb_ss_mem_virtual) BY (pod) / sum(mongodb_ss_mem_resident) BY (pod)) > 100'
               for: 2m


### PR DESCRIPTION
- fix #7353 

and here is an example of values to deploy KB with 3 replicas, and specify extraLables, affinity and antiaffinity for KB and DP respectively.

```bash
helm -n kb-system upgrade -i kubeblocks  ./deploy/helm -f values.yaml --create-namespace
```
and the `values.yaml` file contains following values:
```yaml
replicaCount: 3
image:
  tag: 0.8.3-beta.19
extraLables:
  app.kubernetes.io/component: "kubeblocks"
tolerations:
- key: kb-controller
  operator: Equal
  value: "true"
  effect: NoSchedule
affinity:
  nodeAffinity:
    preferredDuringSchedulingIgnoredDuringExecution:
    - weight: 100
      preference:
        matchExpressions:
        - key: kb-controller
          operator: In
          values:
          - "true"
  podAntiAffinity:
    requiredDuringSchedulingIgnoredDuringExecution:
    - labelSelector:
        matchLabels:
          app.kubernetes.io/instance: kubeblocks
          app.kubernetes.io/component: "kubeblocks"
      topologyKey: kubernetes.io/hostname
dataProtection:
  image:
    tag: 0.8.3-beta.19
  affinity:
    nodeAffinity:
      preferredDuringSchedulingIgnoredDuringExecution:
      - weight: 100
        preference:
          matchExpressions:
          - key: kb-controller
            operator: In
            values:
            - "true"
    podAntiAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
      - labelSelector:
          matchLabels:
            app.kubernetes.io/instance: kubeblocks
            app.kubernetes.io/component: "dataprotection"
        topologyKey: kubernetes.io/hostname
  extraLables:
    app.kubernetes.io/component: "dataprotection"
```