### PR TITLE
fix: both replicas in a OceanBase Cluster have the primary role assigned

### DIFF
--- a/pkg/lorry/engines/models/replca_role_types.go
+++ b/pkg/lorry/engines/models/replca_role_types.go
@@ -19,6 +19,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 package models
 
+import (
+	"errors"
+	"fmt"
+)
+
 const (
 	PRIMARY   = "primary"
 	SECONDARY = "secondary"
@@ -29,3 +34,20 @@ const (
 	LEARNER   = "Learner"
 	CANDIDATE = "Candidate"
 )
+
+func IsLeaderOrPrimaryOrMaster(role string) bool {
+	return role == LEADER || role == PRIMARY || role == MASTER
+}
+
+func GetRelatedSecondaryRole(role string) (string, error) {
+	switch role {
+	case PRIMARY:
+		return SECONDARY, nil
+	case LEADER:
+		return FOLLOWER, nil
+	case MASTER:
+		return SLAVE, nil
+	default:
+		return "", errors.New(fmt.Sprintf("unknown role %s", role))
+	}
+}

--- a/pkg/lorry/engines/models/replca_role_types.go
+++ b/pkg/lorry/engines/models/replca_role_types.go
@@ -19,11 +19,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 package models
 
-import (
-	"errors"
-	"fmt"
-)
-
 const (
 	PRIMARY   = "primary"
 	SECONDARY = "secondary"
@@ -34,20 +29,3 @@ const (
 	LEARNER   = "Learner"
 	CANDIDATE = "Candidate"
 )
-
-func IsLeaderOrPrimaryOrMaster(role string) bool {
-	return role == LEADER || role == PRIMARY || role == MASTER
-}
-
-func GetRelatedSecondaryRole(role string) (string, error) {
-	switch role {
-	case PRIMARY:
-		return SECONDARY, nil
-	case LEADER:
-		return FOLLOWER, nil
-	case MASTER:
-		return SLAVE, nil
-	default:
-		return "", errors.New(fmt.Sprintf("unknown role %s", role))
-	}
-}

--- a/pkg/lorry/engines/redis/get_replica_role.go
+++ b/pkg/lorry/engines/redis/get_replica_role.go
@@ -54,7 +54,7 @@ func (mgr *Manager) GetReplicaRole(ctx context.Context, _ *dcs.Cluster) (string,
 				}
 			}
 		}
-		if role == models.PRIMARY {
+		if role == models.MASTER {
 			return models.PRIMARY, nil
 		} else {
 			return models.SECONDARY, nil

--- a/pkg/lorry/engines/redis/get_replica_role.go
+++ b/pkg/lorry/engines/redis/get_replica_role.go
@@ -54,7 +54,7 @@ func (mgr *Manager) GetReplicaRole(ctx context.Context, _ *dcs.Cluster) (string,
 				}
 			}
 		}
-		if role == models.MASTER {
+		if role == models.PRIMARY {
 			return models.PRIMARY, nil
 		} else {
 			return models.SECONDARY, nil
@@ -82,7 +82,7 @@ func (mgr *Manager) SubscribeRoleChange(ctx context.Context) {
 		masterName := strings.Split(masterAddr[3], ".")[0]
 
 		if masterName == mgr.CurrentMemberName {
-			mgr.role = models.MASTER
+			mgr.role = models.PRIMARY
 		} else {
 			mgr.role = models.SECONDARY
 		}

--- a/pkg/lorry/engines/redis/get_replica_role.go
+++ b/pkg/lorry/engines/redis/get_replica_role.go
@@ -21,11 +21,9 @@ package redis
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 	"time"
 
-	"github.com/apecloud/kubeblocks/pkg/common"
 	"github.com/apecloud/kubeblocks/pkg/lorry/dcs"
 	"github.com/apecloud/kubeblocks/pkg/lorry/engines/models"
 )
@@ -83,27 +81,8 @@ func (mgr *Manager) SubscribeRoleChange(ctx context.Context) {
 		masterAddr := strings.Split(msg.Payload, " ")
 		masterName := strings.Split(masterAddr[3], ".")[0]
 
-		// When network partition occurs, the new primary needs to send global role change information to the controller.
 		if masterName == mgr.CurrentMemberName {
-			cluster := dcs.GetStore().GetClusterFromCache()
-			roleSnapshot := &common.GlobalRoleSnapshot{}
-			oldMasterName := strings.Split(masterAddr[1], ".")[0]
-			roleSnapshot.PodRoleNamePairs = []common.PodRoleNamePair{
-				{
-					PodName:  oldMasterName,
-					RoleName: models.SECONDARY,
-					PodUID:   cluster.GetMemberWithName(oldMasterName).UID,
-				},
-				{
-					PodName:  masterName,
-					RoleName: models.PRIMARY,
-					PodUID:   cluster.GetMemberWithName(masterName).UID,
-				},
-			}
-			roleSnapshot.Version = time.Now().Format(time.RFC3339Nano)
-
-			b, _ := json.Marshal(roleSnapshot)
-			mgr.role = string(b)
+			mgr.role = models.MASTER
 		} else {
 			mgr.role = models.SECONDARY
 		}

--- a/pkg/lorry/engines/redis/get_replica_role.go
+++ b/pkg/lorry/engines/redis/get_replica_role.go
@@ -71,7 +71,7 @@ func (mgr *Manager) GetReplicaRole(ctx context.Context, _ *dcs.Cluster) (string,
 	return models.PRIMARY, nil
 }
 
-func (mgr *Manager) SubscribeRoleChange(ctx context.Context, cluster *dcs.Cluster) {
+func (mgr *Manager) SubscribeRoleChange(ctx context.Context) {
 	pubSub := mgr.sentinelClient.Subscribe(ctx, "+switch-master")
 
 	// go-redis periodically sends ping messages to test connection health
@@ -85,6 +85,7 @@ func (mgr *Manager) SubscribeRoleChange(ctx context.Context, cluster *dcs.Cluste
 
 		// When network partition occurs, the new primary needs to send global role change information to the controller.
 		if masterName == mgr.CurrentMemberName {
+			cluster := dcs.GetStore().GetClusterFromCache()
 			roleSnapshot := &common.GlobalRoleSnapshot{}
 			oldMasterName := strings.Split(masterAddr[1], ".")[0]
 			roleSnapshot.PodRoleNamePairs = []common.PodRoleNamePair{

--- a/pkg/lorry/engines/redis/manager.go
+++ b/pkg/lorry/engines/redis/manager.go
@@ -28,7 +28,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/apecloud/kubeblocks/pkg/constant"
-	"github.com/apecloud/kubeblocks/pkg/lorry/dcs"
 	"github.com/apecloud/kubeblocks/pkg/lorry/engines"
 	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
@@ -89,7 +88,7 @@ func NewManager(properties engines.Properties) (engines.DBManager, error) {
 
 	mgr.ctx, mgr.cancel = context.WithCancel(context.Background())
 
-	go mgr.SubscribeRoleChange(mgr.ctx, dcs.GetStore().GetClusterFromCache())
+	go mgr.SubscribeRoleChange(mgr.ctx)
 	return mgr, nil
 }
 

--- a/pkg/lorry/operations/replica/checkrole.go
+++ b/pkg/lorry/operations/replica/checkrole.go
@@ -231,6 +231,7 @@ func (s *CheckRole) buildGlobalRoleSnapshot(cluster *dcs.Cluster, mgr engines.DB
 			if member.Role == role {
 				_, err := mgr.IsLeaderMember(context.Background(), cluster, &member)
 				if err == nil {
+					// old leader member is still healthy, just ignore it, and let it's lorry to handle the role change
 					continue
 				}
 				s.logger.Info("old leader member access failed and reset it's role", "member", member.Name, "error", err.Error())


### PR DESCRIPTION
Fix cloud issue 3797.

When the primary oceanbase replica's node is down,  the status of Pod becoms "Terminating".

```
root@yjtest-1:/data/kubeblocks# k get pod | grep maize59
399fa706-maize59-ob-bundle-0-b-archive-log-0                      2/2     Running       0          41m
maize59-ob-bundle-0-0                                             4/4     Running       0          108m
maize59-ob-bundle-1-0                                             4/4     Terminating   0          108m
```

After a while, the new primary is elected, however both Pods're labelled with primary role.

<img width="581" alt="image" src="https://github.com/apecloud/kubeblocks/assets/1135270/dd4096ee-47b8-4054-b4cd-058539d471e2">

This will affect the rebuilding of the secondary database because currently, the target componentName for rebuilding the secondary database needs to be a non-primary role.
