### PR TITLE
chore: restore action phase is incorrect when the job is failed

### DIFF
--- a/controllers/dataprotection/log_collection_controller.go
+++ b/controllers/dataprotection/log_collection_controller.go
@@ -181,9 +181,8 @@ func (r *LogCollectionReconciler) patchBackupStatus(reqCtx intctrlutil.RequestCt
 	if errorLogs == "" {
 		return nil
 	}
-	patch := client.MergeFrom(backup.DeepCopy())
 	backup.Status.FailureReason = errorLogs
-	return r.Client.Status().Patch(reqCtx.Ctx, backup, patch)
+	return r.Client.Status().Update(reqCtx.Ctx, backup)
 }
 
 func (r *LogCollectionReconciler) patchRestoreStatus(reqCtx intctrlutil.RequestCtx, job *batchv1.Job, restoreName string) error {
@@ -197,7 +196,6 @@ func (r *LogCollectionReconciler) patchRestoreStatus(reqCtx intctrlutil.RequestC
 		return nil
 	}
 
-	patch := client.MergeFrom(restore.DeepCopy())
 	objectKey := dprestore.BuildJobKeyForActionStatus(job.Name)
 	logPrefix := "Collection logs"
 	var hasPatchedLogs bool
@@ -231,7 +229,7 @@ func (r *LogCollectionReconciler) patchRestoreStatus(reqCtx intctrlutil.RequestC
 	if hasPatchedLogs {
 		return nil
 	}
-	return r.Client.Status().Patch(reqCtx.Ctx, restore, patch)
+	return r.Client.Status().Update(reqCtx.Ctx, restore)
 }
 
 type failedJobUpdatePredicate struct {


### PR DESCRIPTION
log collection controller will collect logs and patch the status when the job failed,  this operation may overwrite the later modified status.  