### PR TITLE
chore: remove scheduling judgments when determining whether pod is Failed

### DIFF
--- a/controllers/apps/component_controller_test.go
+++ b/controllers/apps/component_controller_test.go
@@ -857,12 +857,13 @@ var _ = Describe("Component Controller", func() {
 					Spec: pvcSpec.ToV1PersistentVolumeClaimSpec(),
 				}
 				Expect(testCtx.CreateObj(testCtx.Ctx, pvc)).Should(Succeed())
+				patch := client.MergeFrom(pvc.DeepCopy())
 				pvc.Status.Phase = corev1.ClaimBound // only bound pvc allows resize
 				if pvc.Status.Capacity == nil {
 					pvc.Status.Capacity = corev1.ResourceList{}
 				}
 				pvc.Status.Capacity[corev1.ResourceStorage] = volumeQuantity
-				Expect(k8sClient.Status().Update(testCtx.Ctx, pvc)).Should(Succeed())
+				Expect(k8sClient.Status().Patch(testCtx.Ctx, pvc, patch)).Should(Succeed())
 			}
 		}
 

--- a/controllers/apps/operations/rebuild_instance.go
+++ b/controllers/apps/operations/rebuild_instance.go
@@ -774,7 +774,7 @@ func (r rebuildInstanceOpsHandler) instanceIsAvailable(
 	if !targetPod.DeletionTimestamp.IsZero() {
 		return false, nil
 	}
-	isFailed, isTimeout, _ := intctrlutil.IsPodFailedAndTimedOut(targetPod, true)
+	isFailed, isTimeout, _ := intctrlutil.IsPodFailedAndTimedOut(targetPod)
 	if isFailed && isTimeout {
 		return false, intctrlutil.NewFatalError(fmt.Sprintf(`the new instance "%s" is failed, please check it`, targetPod.Name))
 	}

--- a/pkg/controller/instanceset/reconciler_status.go
+++ b/pkg/controller/instanceset/reconciler_status.go
@@ -170,7 +170,7 @@ func buildFailureCondition(its *workloads.InstanceSet, pods []*corev1.Pod) (*met
 			continue
 		}
 		// KubeBlocks says the Pod is 'Failed'
-		isFailed, isTimedOut, _ := intctrlutil.IsPodFailedAndTimedOut(pod, false)
+		isFailed, isTimedOut, _ := intctrlutil.IsPodFailedAndTimedOut(pod)
 		if isFailed && isTimedOut {
 			failureNames = append(failureNames, pod.Name)
 		}

--- a/pkg/dataprotection/action/action_stateful.go
+++ b/pkg/dataprotection/action/action_stateful.go
@@ -211,6 +211,6 @@ func (s *StatefulSetAction) stsIsFailed(ctx ActionContext) bool {
 		Namespace: s.ObjectMeta.Namespace}, pod); err != nil {
 		return false
 	}
-	isFailed, isTimeout, _ := intctrlutil.IsPodFailedAndTimedOut(pod, false)
+	isFailed, isTimeout, _ := intctrlutil.IsPodFailedAndTimedOut(pod)
 	return isFailed && isTimeout
 }


### PR DESCRIPTION
When the pod scheduling fails, due to the self-healing property of k8s, it can be automatically repaired without manual intervention, and showing `pending` status is also reasonable for instance.