### PR TITLE
chore: remove x-kubernetes-validations from CRD for being compatible with kubernetes 1.22

### DIFF
--- a/apis/apps/v1alpha1/backuppolicytemplate_types.go
+++ b/apis/apps/v1alpha1/backuppolicytemplate_types.go
@@ -29,7 +29,7 @@ type BackupPolicyTemplateSpec struct {
 	// And this field is deprecated since v0.9, consider using the ComponentDef instead.
 	//
 	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="clusterDefinitionRef is immutable"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="clusterDefinitionRef is immutable"
 	// +kubebuilder:deprecatedversion:warning="This field has been deprecated since 0.9.0, consider using the ComponentDef instead"
 	ClusterDefRef string `json:"clusterDefinitionRef,omitempty"`
 

--- a/apis/apps/v1alpha1/cluster_types.go
+++ b/apis/apps/v1alpha1/cluster_types.go
@@ -53,7 +53,7 @@ type ClusterSpec struct {
 	//
 	// +kubebuilder:validation:MaxLength=63
 	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="clusterDefinitionRef is immutable"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="clusterDefinitionRef is immutable"
 	// +optional
 	ClusterDefRef string `json:"clusterDefinitionRef,omitempty"`
 
@@ -130,8 +130,8 @@ type ClusterSpec struct {
 	//
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=128
-	// +kubebuilder:validation:XValidation:rule="self.all(x, size(self.filter(c, c.name == x.name)) == 1)",message="duplicated component"
-	// +kubebuilder:validation:XValidation:rule="self.all(x, size(self.filter(c, has(c.componentDef))) == 0) || self.all(x, size(self.filter(c, has(c.componentDef))) == size(self))",message="two kinds of definition API can not be used simultaneously"
+	// TODO +kubebuilder:validation:XValidation:rule="self.all(x, size(self.filter(c, c.name == x.name)) == 1)",message="duplicated component"
+	// TODO +kubebuilder:validation:XValidation:rule="self.all(x, size(self.filter(c, has(c.componentDef))) == 0) || self.all(x, size(self.filter(c, has(c.componentDef))) == size(self))",message="two kinds of definition API can not be used simultaneously"
 	// +optional
 	ComponentSpecs []ClusterComponentSpec `json:"componentSpecs,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"name"`
 
@@ -524,7 +524,7 @@ type ShardingSpec struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MaxLength=15
 	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="name is immutable"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="name is immutable"
 	Name string `json:"name"`
 
 	// The template for generating Components for shards, where each shard consists of one Component.

--- a/apis/apps/v1alpha1/clusterdefinition_types.go
+++ b/apis/apps/v1alpha1/clusterdefinition_types.go
@@ -524,7 +524,7 @@ type MonitorConfig struct {
 //
 // Deprecated: Use ComponentDefinition instead. This type is deprecated as of version 0.8.
 //
-// +kubebuilder:validation:XValidation:rule="has(self.workloadType) && self.workloadType == 'Consensus' ? (has(self.consensusSpec) || has(self.rsmSpec)) : !has(self.consensusSpec)",message="componentDefs.consensusSpec(deprecated) or componentDefs.rsmSpec(recommended) is required when componentDefs.workloadType is Consensus, and forbidden otherwise"
+// TODO +kubebuilder:validation:XValidation:rule="has(self.workloadType) && self.workloadType == 'Consensus' ? (has(self.consensusSpec) || has(self.rsmSpec)) : !has(self.consensusSpec)",message="componentDefs.consensusSpec(deprecated) or componentDefs.rsmSpec(recommended) is required when componentDefs.workloadType is Consensus, and forbidden otherwise"
 type ClusterComponentDefinition struct {
 	// This name could be used as default name of `cluster.spec.componentSpecs.name`, and needs to conform with same
 	// validation rules as `cluster.spec.componentSpecs.name`, currently complying with IANA Service Naming rule.

--- a/apis/apps/v1alpha1/componentdefinition_types.go
+++ b/apis/apps/v1alpha1/componentdefinition_types.go
@@ -560,8 +560,8 @@ type ComponentVolume struct {
 
 // ReplicasLimit defines the valid range of number of replicas supported.
 //
-// +kubebuilder:validation:XValidation:rule="self.minReplicas >= 0 && self.maxReplicas <= 128",message="the minimum and maximum limit of replicas should be in the range of [0, 128]"
-// +kubebuilder:validation:XValidation:rule="self.minReplicas <= self.maxReplicas",message="the minimum replicas limit should be no greater than the maximum"
+// TODO +kubebuilder:validation:XValidation:rule="self.minReplicas >= 0 && self.maxReplicas <= 128",message="the minimum and maximum limit of replicas should be in the range of [0, 128]"
+// TODO +kubebuilder:validation:XValidation:rule="self.minReplicas <= self.maxReplicas",message="the minimum replicas limit should be no greater than the maximum"
 type ReplicasLimit struct {
 	// The minimum limit of replicas.
 	//

--- a/apis/apps/v1alpha1/componentversion_types.go
+++ b/apis/apps/v1alpha1/componentversion_types.go
@@ -89,8 +89,8 @@ type ComponentVersionRelease struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinProperties=1
 	// +kubebuilder:validation:MaxProperties=128
-	// +kubebuilder:validation:XValidation:rule="self.all(key, size(key) <= 32)",message="Container name may not exceed maximum length of 32 characters"
-	// +kubebuilder:validation:XValidation:rule="self.all(key, size(self[key]) <= 256)",message="Image name may not exceed maximum length of 256 characters"
+	// TODO +kubebuilder:validation:XValidation:rule="self.all(key, size(key) <= 32)",message="Container name may not exceed maximum length of 32 characters"
+	// TODO +kubebuilder:validation:XValidation:rule="self.all(key, size(self[key]) <= 256)",message="Image name may not exceed maximum length of 256 characters"
 	Images map[string]string `json:"images"`
 }
 

--- a/apis/apps/v1alpha1/configuration_types.go
+++ b/apis/apps/v1alpha1/configuration_types.go
@@ -90,13 +90,13 @@ type ConfigurationSpec struct {
 	// Specifies the name of the Cluster that this configuration is associated with.
 	//
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.clusterRef"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.clusterRef"
 	ClusterRef string `json:"clusterRef"`
 
 	// Represents the name of the Component that this configuration pertains to.
 	//
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.clusterRef"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.clusterRef"
 	ComponentName string `json:"componentName"`
 
 	// ConfigItemDetails is an array of ConfigurationItemDetail objects.

--- a/apis/apps/v1alpha1/opsdefinition_types.go
+++ b/apis/apps/v1alpha1/opsdefinition_types.go
@@ -160,7 +160,7 @@ type OpsEnvVar struct {
 	ValueFrom *OpsVarSource `json:"valueFrom"`
 }
 
-// +kubebuilder:validation:XValidation:rule="has(self.envRef) || has(self.fieldPath)", message="either fieldPath and envRef."
+// TODO +kubebuilder:validation:XValidation:rule="has(self.envRef) || has(self.fieldPath)", message="either fieldPath and envRef."
 
 type OpsVarSource struct {
 	// Specifies a reference to a specific environment variable within a container.
@@ -252,7 +252,7 @@ type ParametersSchema struct {
 //     suitable for immediate, short-lived operations.
 //   - resourceModifier: Modifies a K8s object using JSON patches, useful for updating the spec of some resource.
 //
-// +kubebuilder:validation:XValidation:rule="has(self.workload) || has(self.exec) || has(self.resourceModifier)", message="at least one action exists for workload, exec and resourceModifier."
+// TODO +kubebuilder:validation:XValidation:rule="has(self.workload) || has(self.exec) || has(self.resourceModifier)", message="at least one action exists for workload, exec and resourceModifier."
 type OpsAction struct {
 	// Specifies the name of the OpsAction.
 	// +kubebuilder:validation:MaxLength=20

--- a/apis/apps/v1alpha1/opsrequest_types.go
+++ b/apis/apps/v1alpha1/opsrequest_types.go
@@ -27,17 +27,17 @@ import (
 
 // OpsRequestSpec defines the desired state of OpsRequest
 //
-// +kubebuilder:validation:XValidation:rule="has(self.cancel) && self.cancel ? (self.type in ['VerticalScaling', 'HorizontalScaling']) : true",message="forbidden to cancel the opsRequest which type not in ['VerticalScaling','HorizontalScaling']"
+// TODO +kubebuilder:validation:XValidation:rule="has(self.cancel) && self.cancel ? (self.type in ['VerticalScaling', 'HorizontalScaling']) : true",message="forbidden to cancel the opsRequest which type not in ['VerticalScaling','HorizontalScaling']"
 type OpsRequestSpec struct {
 	// Specifies the name of the Cluster resource that this operation is targeting.
 	//
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.clusterName"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.clusterName"
 	ClusterName string `json:"clusterName,omitempty"`
 
 	// Deprecated: since v0.9, use clusterName instead.
 	// Specifies the name of the Cluster resource that this operation is targeting.
 	// +kubebuilder:deprecatedversion:warning="This field has been deprecated since 0.9.0"
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.clusterRef"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.clusterRef"
 	ClusterRef string `json:"clusterRef,omitempty"`
 
 	// Indicates whether the current operation should be canceled and terminated gracefully if it's in the
@@ -60,7 +60,7 @@ type OpsRequestSpec struct {
 	//
 	// Note: Once set, the `force` field is immutable and cannot be updated.
 	//
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.force"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.force"
 	// +optional
 	Force bool `json:"force,omitempty"`
 
@@ -71,7 +71,7 @@ type OpsRequestSpec struct {
 	// Note: This field is immutable once set.
 	//
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.type"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.type"
 	Type OpsType `json:"type"`
 
 	// Specifies the duration in seconds that an OpsRequest will remain in the system after successfully completing
@@ -90,7 +90,7 @@ type SpecificOpsRequest struct {
 	// Note: This field is immutable once set.
 	//
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.upgrade"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.upgrade"
 	Upgrade *Upgrade `json:"upgrade,omitempty"`
 
 	// Lists HorizontalScaling objects, each specifying scaling requirements for a Component,
@@ -102,7 +102,7 @@ type SpecificOpsRequest struct {
 	// +patchStrategy=merge,retainKeys
 	// +listType=map
 	// +listMapKey=componentName
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.horizontalScaling"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.horizontalScaling"
 	HorizontalScalingList []HorizontalScaling `json:"horizontalScaling,omitempty"  patchStrategy:"merge,retainKeys" patchMergeKey:"componentName"`
 
 	// Lists VolumeExpansion objects, each specifying a component and its corresponding volumeClaimTemplates
@@ -118,7 +118,7 @@ type SpecificOpsRequest struct {
 	// Lists Components to be restarted.
 	//
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.restart"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.restart"
 	// +kubebuilder:validation:MaxItems=1024
 	// +patchMergeKey=componentName
 	// +patchStrategy=merge,retainKeys
@@ -133,7 +133,7 @@ type SpecificOpsRequest struct {
 	// +patchStrategy=merge,retainKeys
 	// +listType=map
 	// +listMapKey=componentName
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.switchover"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.switchover"
 	SwitchoverList []Switchover `json:"switchover,omitempty"  patchStrategy:"merge,retainKeys" patchMergeKey:"componentName"`
 
 	// Lists VerticalScaling objects, each specifying a component and its desired compute resources for vertical scaling.
@@ -155,7 +155,7 @@ type SpecificOpsRequest struct {
 
 	// Lists Reconfigure objects, each specifying a Component and its configuration updates.
 	//
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.reconfigure"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.reconfigure"
 	// +optional
 	// +patchMergeKey=componentName
 	// +patchStrategy=merge,retainKeys
@@ -219,7 +219,7 @@ type SpecificOpsRequest struct {
 	// +patchStrategy=merge,retainKeys
 	// +listType=map
 	// +listMapKey=componentName
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.rebuildFrom"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.rebuildFrom"
 	RebuildFrom []RebuildInstance `json:"rebuildFrom,omitempty"  patchStrategy:"merge,retainKeys" patchMergeKey:"componentName"`
 
 	// Specifies a custom operation defined by OpsDefinition.
@@ -328,7 +328,7 @@ type Upgrade struct {
 	Components []UpgradeComponent `json:"components,omitempty" patchStrategy:"merge,retainKeys" patchMergeKey:"componentName"`
 }
 
-// +kubebuilder:validation:XValidation:rule="has(self.componentDefinitionName) || has(self.serviceVersion)",message="at least one componentDefinitionName or serviceVersion"
+// TODO +kubebuilder:validation:XValidation:rule="has(self.componentDefinitionName) || has(self.serviceVersion)",message="at least one componentDefinitionName or serviceVersion"
 
 type UpgradeComponent struct {
 	// Specifies the name of the Component.
@@ -872,7 +872,7 @@ type ScriptSpec struct {
 	// Note: this field cannot be modified once set.
 	//
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.scriptSpec.script"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.scriptSpec.script"
 	Script []string `json:"script,omitempty"`
 
 	// Specifies the sources of the scripts to be executed.
@@ -889,7 +889,7 @@ type ScriptSpec struct {
 	// Note: this field cannot be modified once set.
 	//
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.scriptSpec.scriptFrom"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.scriptSpec.scriptFrom"
 	ScriptFrom *ScriptFrom `json:"scriptFrom,omitempty"`
 
 	// Specifies the labels used to select the Pods on which the script should be executed.
@@ -903,7 +903,7 @@ type ScriptSpec struct {
 	// Note: this field cannot be modified once set.
 	//
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.scriptSpec.script.selector"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.scriptSpec.script.selector"
 	Selector *metav1.LabelSelector `json:"selector,omitempty"`
 }
 
@@ -1021,7 +1021,7 @@ type ScriptFrom struct {
 	// Note: This field cannot be modified once set.
 	//
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.scriptSpec.scriptFrom.configMapRef"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.scriptSpec.scriptFrom.configMapRef"
 	ConfigMapRef []corev1.ConfigMapKeySelector `json:"configMapRef,omitempty"`
 
 	// A list of SecretKeySelector objects, each specifies a Secret and a key containing the script.
@@ -1029,7 +1029,7 @@ type ScriptFrom struct {
 	// Note: This field cannot be modified once set.
 	//
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.scriptSpec.scriptFrom.secretRef"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.scriptSpec.scriptFrom.secretRef"
 	SecretRef []corev1.SecretKeySelector `json:"secretRef,omitempty"`
 }
 
@@ -1092,7 +1092,7 @@ type OpsRequestStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// +kubebuilder:validation:XValidation:rule="has(self.objectKey) || has(self.actionName)", message="at least one objectKey or actionName."
+// TODO +kubebuilder:validation:XValidation:rule="has(self.objectKey) || has(self.actionName)", message="at least one objectKey or actionName."
 
 type ProgressStatusDetail struct {
 	// Specifies the group to which the current object belongs to.

--- a/apis/dataprotection/v1alpha1/backup_types.go
+++ b/apis/dataprotection/v1alpha1/backup_types.go
@@ -27,13 +27,13 @@ type BackupSpec struct {
 	//
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.backupPolicyName"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.backupPolicyName"
 	BackupPolicyName string `json:"backupPolicyName"`
 
 	// Specifies the backup method name that is defined in the backup policy.
 	//
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.backupMethod"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.backupMethod"
 	BackupMethod string `json:"backupMethod"`
 
 	// Determines whether the backup contents stored in the backup repository
@@ -72,7 +72,7 @@ type BackupSpec struct {
 	// Determines the parent backup name for incremental or differential backup.
 	//
 	// +optional
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.parentBackupName"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.parentBackupName"
 	ParentBackupName string `json:"parentBackupName,omitempty"`
 }
 

--- a/apis/dataprotection/v1alpha1/backuppolicy_types.go
+++ b/apis/dataprotection/v1alpha1/backuppolicy_types.go
@@ -22,7 +22,7 @@ import (
 )
 
 // BackupPolicySpec defines the desired state of BackupPolicy
-// +kubebuilder:validation:XValidation:rule="(has(self.target) && !has(self.targets)) || (has(self.targets) && !has(self.target))",message="either spec.target or spec.targets"
+// TODO +kubebuilder:validation:XValidation:rule="(has(self.target) && !has(self.targets)) || (has(self.targets) && !has(self.target))",message="either spec.target or spec.targets"
 type BackupPolicySpec struct {
 	// Specifies the name of BackupRepo where the backup data will be stored.
 	// If not set, data will be stored in the default backup repository.

--- a/apis/dataprotection/v1alpha1/backuprepo_types.go
+++ b/apis/dataprotection/v1alpha1/backuprepo_types.go
@@ -39,7 +39,7 @@ const (
 type BackupRepoSpec struct {
 	// Specifies the name of the `StorageProvider` used by this backup repository.
 	//
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="StorageProviderRef is immutable"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="StorageProviderRef is immutable"
 	// +kubebuilder:validation:Required
 	StorageProviderRef string `json:"storageProviderRef"`
 

--- a/apis/dataprotection/v1alpha1/restore_types.go
+++ b/apis/dataprotection/v1alpha1/restore_types.go
@@ -31,19 +31,19 @@ type RestoreSpec struct {
 	// 4. Continuous: will find the most recent full backup at this time point and the continuous backups after it to restore.
 	//
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.backupName"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.backupName"
 	Backup BackupRef `json:"backup"`
 
 	// Specifies the point in time for restoring.
 	//
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.restoreTime"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.restoreTime"
 	// +optional
 	// +kubebuilder:validation:Pattern=`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`
 	RestoreTime string `json:"restoreTime,omitempty"`
 
 	// Restores the specified resources of Kubernetes.
 	//
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.resources"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.resources"
 	// +optional
 	Resources *RestoreKubeResources `json:"resources,omitempty"`
 
@@ -60,7 +60,7 @@ type RestoreSpec struct {
 
 	// Configuration for the action of "postReady" phase.
 	//
-	// +kubebuilder:validation:XValidation:rule="has(self.jobAction) || has(self.execAction)", message="at least one exists for jobAction and execAction."
+	// TODO +kubebuilder:validation:XValidation:rule="has(self.jobAction) || has(self.execAction)", message="at least one exists for jobAction and execAction."
 	// +optional
 	ReadyConfig *ReadyConfig `json:"readyConfig,omitempty"`
 
@@ -131,15 +131,15 @@ type PrepareDataConfig struct {
 	// Specifies the configuration when using `persistentVolumeClaim.spec.dataSourceRef` method for restoring.
 	// Describes the source volume of the backup targetVolumes and the mount path in the restoring container.
 	//
-	// +kubebuilder:validation:XValidation:rule="self.volumeSource != '' || self.mountPath !=''",message="at least one exists for volumeSource and mountPath."
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.prepareDataConfig.dataSourceRef"
+	// TODO +kubebuilder:validation:XValidation:rule="self.volumeSource != '' || self.mountPath !=''",message="at least one exists for volumeSource and mountPath."
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.prepareDataConfig.dataSourceRef"
 	// +optional
 	DataSourceRef *VolumeConfig `json:"dataSourceRef,omitempty"`
 
 	// Defines the persistent Volume claims that need to be restored and mounted together into the restore job.
 	// These persistent Volume claims will be created if they do not exist.
 	//
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.prepareDataConfig.volumeClaims"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.prepareDataConfig.volumeClaims"
 	// +patchMergeKey=name
 	// +patchStrategy=merge,retainKeys
 	// +optional
@@ -148,7 +148,7 @@ type PrepareDataConfig struct {
 	// Defines a template to build persistent Volume claims that need to be restored.
 	// These claims will be created in an orderly manner based on the number of replicas or reused if they already exist.
 	//
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.prepareDataConfig.volumeClaimsTemplate"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.prepareDataConfig.volumeClaimsTemplate"
 	// +patchMergeKey=name
 	// +patchStrategy=merge,retainKeys
 	// +optional
@@ -166,7 +166,7 @@ type PrepareDataConfig struct {
 
 	// Specifies the scheduling spec for the restoring pod.
 	//
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.prepareDataConfig.schedulingSpec"
+	// TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden to update spec.prepareDataConfig.schedulingSpec"
 	// +optional
 	SchedulingSpec SchedulingSpec `json:"schedulingSpec,omitempty"`
 }
@@ -286,7 +286,7 @@ type RestoreVolumeClaim struct {
 	// Describes the source volume of the backup target volumes and the mount path in the restoring container.
 	// At least one must exist for volumeSource and mountPath.
 	//
-	// +kubebuilder:validation:XValidation:rule="self.volumeSource != '' || self.mountPath !=''",message="at least one exists for volumeSource and mountPath."
+	// TODO +kubebuilder:validation:XValidation:rule="self.volumeSource != '' || self.mountPath !=''",message="at least one exists for volumeSource and mountPath."
 	VolumeConfig `json:",inline"`
 }
 

--- a/apis/extensions/v1alpha1/addon_types.go
+++ b/apis/extensions/v1alpha1/addon_types.go
@@ -30,7 +30,7 @@ import (
 )
 
 // AddonSpec defines the desired state of an add-on.
-// +kubebuilder:validation:XValidation:rule="has(self.type) && self.type == 'Helm' ?  has(self.helm) : !has(self.helm)",message="spec.helm is required when spec.type is Helm, and forbidden otherwise"
+// TODO +kubebuilder:validation:XValidation:rule="has(self.type) && self.type == 'Helm' ?  has(self.helm) : !has(self.helm)",message="spec.helm is required when spec.type is Helm, and forbidden otherwise"
 type AddonSpec struct {
 	// Specifies the description of the add-on.
 	//
@@ -145,7 +145,7 @@ type SelectorRequirement struct {
 }
 
 // HelmTypeInstallSpec defines the Helm installation spec.
-// +kubebuilder:validation:XValidation:rule="self.chartLocationURL.startsWith('file://') ? has(self.chartsImage) : true",message="chartsImage is required when chartLocationURL starts with 'file://'"
+// TODO +kubebuilder:validation:XValidation:rule="self.chartLocationURL.startsWith('file://') ? has(self.chartsImage) : true",message="chartsImage is required when chartLocationURL starts with 'file://'"
 type HelmTypeInstallSpec struct {
 	// Specifies the URL location of the Helm Chart.
 	//

--- a/config/crd/bases/apps.kubeblocks.io_backuppolicytemplates.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_backuppolicytemplates.yaml
@@ -971,15 +971,13 @@ spec:
                 minItems: 1
                 type: array
               clusterDefinitionRef:
-                description: Specifies the name of a ClusterDefinition. This is an
+                description: "Specifies the name of a ClusterDefinition. This is an
                   immutable attribute that cannot be changed after creation. And this
                   field is deprecated since v0.9, consider using the ComponentDef
-                  instead.
+                  instead. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"clusterDefinitionRef is immutable\""
                 pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                 type: string
-                x-kubernetes-validations:
-                - message: clusterDefinitionRef is immutable
-                  rule: self == oldSelf
               identifier:
                 description: "Specifies a unique identifier for the BackupPolicyTemplate.
                   \n This identifier will be used as the suffix of the name of automatically

--- a/config/crd/bases/apps.kubeblocks.io_clusterdefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusterdefinitions.yaml
@@ -75,7 +75,11 @@ spec:
                   description: "ClusterComponentDefinition defines a Component within
                     a ClusterDefinition but is deprecated and has been replaced by
                     ComponentDefinition. \n Deprecated: Use ComponentDefinition instead.
-                    This type is deprecated as of version 0.8."
+                    This type is deprecated as of version 0.8. \n TODO +kubebuilder:validation:XValidation:rule=\"has(self.workloadType)
+                    && self.workloadType == 'Consensus' ? (has(self.consensusSpec)
+                    || has(self.rsmSpec)) : !has(self.consensusSpec)\",message=\"componentDefs.consensusSpec(deprecated)
+                    or componentDefs.rsmSpec(recommended) is required when componentDefs.workloadType
+                    is Consensus, and forbidden otherwise\""
                   properties:
                     characterType:
                       description: Defines well-known database component name, such
@@ -10115,12 +10119,6 @@ spec:
                   - name
                   - workloadType
                   type: object
-                  x-kubernetes-validations:
-                  - message: componentDefs.consensusSpec(deprecated) or componentDefs.rsmSpec(recommended)
-                      is required when componentDefs.workloadType is Consensus, and
-                      forbidden otherwise
-                    rule: 'has(self.workloadType) && self.workloadType == ''Consensus''
-                      ? (has(self.consensusSpec) || has(self.rsmSpec)) : !has(self.consensusSpec)'
                 type: array
                 x-kubernetes-list-map-keys:
                 - name

--- a/config/crd/bases/apps.kubeblocks.io_clusters.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusters.yaml
@@ -227,13 +227,11 @@ spec:
                   specific ComponentDefinitions for each component within `componentSpecs[*].componentDef`.
                   \n If this field is not provided, each component must be explicitly
                   defined in `componentSpecs[*].componentDef`. \n Note: Once set,
-                  this field cannot be modified; it is immutable."
+                  this field cannot be modified; it is immutable. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"clusterDefinitionRef is immutable\""
                 maxLength: 63
                 pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                 type: string
-                x-kubernetes-validations:
-                - message: clusterDefinitionRef is immutable
-                  rule: self == oldSelf
               clusterVersionRef:
                 description: "Refers to the ClusterVersion name. \n Deprecated since
                   v0.9, use ComponentVersion instead. This field is maintained for
@@ -248,7 +246,13 @@ spec:
                   to define the individual Components that make up a Cluster. This
                   field allows for detailed configuration of each Component within
                   the Cluster. \n Note: `shardingSpecs` and `componentSpecs` cannot
-                  both be empty; at least one must be defined to configure a Cluster."
+                  both be empty; at least one must be defined to configure a Cluster.
+                  \n TODO +kubebuilder:validation:XValidation:rule=\"self.all(x, size(self.filter(c,
+                  c.name == x.name)) == 1)\",message=\"duplicated component\" TODO
+                  +kubebuilder:validation:XValidation:rule=\"self.all(x, size(self.filter(c,
+                  has(c.componentDef))) == 0) || self.all(x, size(self.filter(c, has(c.componentDef)))
+                  == size(self))\",message=\"two kinds of definition API can not be
+                  used simultaneously\""
                 items:
                   description: ClusterComponentSpec defines the specification of a
                     Component within a Cluster. TODO +kubebuilder:validation:XValidation:rule="!has(oldSelf.componentDefRef)
@@ -6044,12 +6048,6 @@ spec:
                 maxItems: 128
                 minItems: 1
                 type: array
-                x-kubernetes-validations:
-                - message: duplicated component
-                  rule: self.all(x, size(self.filter(c, c.name == x.name)) == 1)
-                - message: two kinds of definition API can not be used simultaneously
-                  rule: self.all(x, size(self.filter(c, has(c.componentDef))) == 0)
-                    || self.all(x, size(self.filter(c, has(c.componentDef))) == size(self))
               network:
                 description: "The configuration of network. \n Deprecated since v0.9.
                   This field is maintained for backward compatibility and its use
@@ -7679,13 +7677,12 @@ spec:
                         Component name would be \"my-shard-abc\". \n Note that the
                         name defined in Component template(`shardingSpec.template.name`)
                         will be disregarded when generating the Component names of
-                        the shards. The `shardingSpec.name` field takes precedence."
+                        the shards. The `shardingSpec.name` field takes precedence.
+                        \n TODO +kubebuilder:validation:XValidation:rule=\"self ==
+                        oldSelf\",message=\"name is immutable\""
                       maxLength: 15
                       pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                       type: string
-                      x-kubernetes-validations:
-                      - message: name is immutable
-                        rule: self == oldSelf
                     shards:
                       description: "Specifies the desired number of shards. Users
                         can declare the desired number of shards through this field.

--- a/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
@@ -5294,13 +5294,6 @@ spec:
                 - maxReplicas
                 - minReplicas
                 type: object
-                x-kubernetes-validations:
-                - message: the minimum and maximum limit of replicas should be in
-                    the range of [0, 128]
-                  rule: self.minReplicas >= 0 && self.maxReplicas <= 128
-                - message: the minimum replicas limit should be no greater than the
-                    maximum
-                  rule: self.minReplicas <= self.maxReplicas
               roles:
                 description: "Enumerate all possible roles assigned to each replica
                   of the Component, influencing its behavior. \n A replica can have

--- a/config/crd/bases/apps.kubeblocks.io_componentversions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_componentversions.yaml
@@ -98,17 +98,15 @@ spec:
                     images:
                       additionalProperties:
                         type: string
-                      description: Images define the new images for different containers
-                        within the release.
+                      description: "Images define the new images for different containers
+                        within the release. \n TODO +kubebuilder:validation:XValidation:rule=\"self.all(key,
+                        size(key) <= 32)\",message=\"Container name may not exceed
+                        maximum length of 32 characters\" TODO +kubebuilder:validation:XValidation:rule=\"self.all(key,
+                        size(self[key]) <= 256)\",message=\"Image name may not exceed
+                        maximum length of 256 characters\""
                       maxProperties: 128
                       minProperties: 1
                       type: object
-                      x-kubernetes-validations:
-                      - message: Container name may not exceed maximum length of 32
-                          characters
-                        rule: self.all(key, size(key) <= 32)
-                      - message: Image name may not exceed maximum length of 256 characters
-                        rule: self.all(key, size(self[key]) <= 256)
                     name:
                       description: Name is a unique identifier for this release. Cannot
                         be updated.

--- a/config/crd/bases/apps.kubeblocks.io_configurations.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_configurations.yaml
@@ -40,19 +40,15 @@ spec:
               resource.
             properties:
               clusterRef:
-                description: Specifies the name of the Cluster that this configuration
-                  is associated with.
+                description: "Specifies the name of the Cluster that this configuration
+                  is associated with. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.clusterRef\""
                 type: string
-                x-kubernetes-validations:
-                - message: forbidden to update spec.clusterRef
-                  rule: self == oldSelf
               componentName:
-                description: Represents the name of the Component that this configuration
-                  pertains to.
+                description: "Represents the name of the Component that this configuration
+                  pertains to. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.clusterRef\""
                 type: string
-                x-kubernetes-validations:
-                - message: forbidden to update spec.clusterRef
-                  rule: self == oldSelf
               configItemDetails:
                 description: "ConfigItemDetails is an array of ConfigurationItemDetail
                   objects. \n Each ConfigurationItemDetail corresponds to a configuration

--- a/config/crd/bases/apps.kubeblocks.io_opsdefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_opsdefinitions.yaml
@@ -59,7 +59,9 @@ spec:
                     commands directly within an existing container using the kubectl
                     exec interface, suitable for immediate, short-lived operations.
                     - resourceModifier: Modifies a K8s object using JSON patches,
-                    useful for updating the spec of some resource."
+                    useful for updating the spec of some resource. \n TODO +kubebuilder:validation:XValidation:rule=\"has(self.workload)
+                    || has(self.exec) || has(self.resourceModifier)\", message=\"at
+                    least one action exists for workload, exec and resourceModifier.\""
                   properties:
                     exec:
                       description: Specifies the configuration for a 'exec' action.
@@ -8378,9 +8380,6 @@ spec:
                   required:
                   - name
                   type: object
-                  x-kubernetes-validations:
-                  - message: at least one action exists for workload, exec and resourceModifier.
-                    rule: has(self.workload) || has(self.exec) || has(self.resourceModifier)
                 minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
@@ -8491,9 +8490,6 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                             type: object
-                            x-kubernetes-validations:
-                            - message: either fieldPath and envRef.
-                              rule: has(self.envRef) || has(self.fieldPath)
                         required:
                         - name
                         - valueFrom

--- a/config/crd/bases/apps.kubeblocks.io_opsrequests.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_opsrequests.yaml
@@ -58,7 +58,11 @@ spec:
           metadata:
             type: object
           spec:
-            description: OpsRequestSpec defines the desired state of OpsRequest
+            description: "OpsRequestSpec defines the desired state of OpsRequest \n
+              TODO +kubebuilder:validation:XValidation:rule=\"has(self.cancel) &&
+              self.cancel ? (self.type in ['VerticalScaling', 'HorizontalScaling'])
+              : true\",message=\"forbidden to cancel the opsRequest which type not
+              in ['VerticalScaling','HorizontalScaling']\""
             properties:
               backup:
                 description: Specifies the parameters to backup a Cluster.
@@ -160,19 +164,16 @@ spec:
                   ineffective."
                 type: boolean
               clusterName:
-                description: Specifies the name of the Cluster resource that this
-                  operation is targeting.
+                description: "Specifies the name of the Cluster resource that this
+                  operation is targeting. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.clusterName\""
                 type: string
-                x-kubernetes-validations:
-                - message: forbidden to update spec.clusterName
-                  rule: self == oldSelf
               clusterRef:
                 description: 'Deprecated: since v0.9, use clusterName instead. Specifies
-                  the name of the Cluster resource that this operation is targeting.'
+                  the name of the Cluster resource that this operation is targeting.
+                  TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden
+                  to update spec.clusterRef"'
                 type: string
-                x-kubernetes-validations:
-                - message: forbidden to update spec.clusterRef
-                  rule: self == oldSelf
               custom:
                 description: Specifies a custom operation defined by OpsDefinition.
                 properties:
@@ -465,16 +466,15 @@ spec:
                   'HorizontalScaling' opsRequests. By setting `force` to true, you
                   can bypass the default checks and demand these opsRequests to run
                   simultaneously. \n Note: Once set, the `force` field is immutable
-                  and cannot be updated."
+                  and cannot be updated. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.force\""
                 type: boolean
-                x-kubernetes-validations:
-                - message: forbidden to update spec.force
-                  rule: self == oldSelf
               horizontalScaling:
-                description: Lists HorizontalScaling objects, each specifying scaling
+                description: "Lists HorizontalScaling objects, each specifying scaling
                   requirements for a Component, including desired replica changes,
                   configurations for new instances, modifications for existing instances,
-                  and take offline/online the specified instances.
+                  and take offline/online the specified instances. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.horizontalScaling\""
                 items:
                   description: HorizontalScaling defines the parameters of a horizontal
                     scaling operation.
@@ -4330,9 +4330,6 @@ spec:
                 x-kubernetes-list-map-keys:
                 - componentName
                 x-kubernetes-list-type: map
-                x-kubernetes-validations:
-                - message: forbidden to update spec.horizontalScaling
-                  rule: self == oldSelf
               preConditionDeadlineSeconds:
                 default: 0
                 description: Specifies the maximum time in seconds that the OpsRequest
@@ -4342,11 +4339,12 @@ spec:
                 format: int32
                 type: integer
               rebuildFrom:
-                description: Specifies the parameters to rebuild some instances. Rebuilding
-                  an instance involves restoring its data from a backup or another
-                  database replica. The instances being rebuilt usually serve as standby
-                  in the cluster. Hence rebuilding instances is often also referred
-                  to as "standby reconstruction".
+                description: "Specifies the parameters to rebuild some instances.
+                  Rebuilding an instance involves restoring its data from a backup
+                  or another database replica. The instances being rebuilt usually
+                  serve as standby in the cluster. Hence rebuilding instances is often
+                  also referred to as \"standby reconstruction\". \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.rebuildFrom\""
                 items:
                   properties:
                     backupName:
@@ -4514,9 +4512,6 @@ spec:
                 x-kubernetes-list-map-keys:
                 - componentName
                 x-kubernetes-list-type: map
-                x-kubernetes-validations:
-                - message: forbidden to update spec.rebuildFrom
-                  rule: self == oldSelf
               reconfigure:
                 description: "Specifies a component and its configuration updates.
                   \n This field is deprecated and replaced by `reconfigures`."
@@ -4609,8 +4604,9 @@ spec:
                 - configurations
                 type: object
               reconfigures:
-                description: Lists Reconfigure objects, each specifying a Component
-                  and its configuration updates.
+                description: "Lists Reconfigure objects, each specifying a Component
+                  and its configuration updates. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.reconfigure\""
                 items:
                   description: Reconfigure defines the parameters for updating a Component's
                     configuration.
@@ -4706,11 +4702,9 @@ spec:
                 x-kubernetes-list-map-keys:
                 - componentName
                 x-kubernetes-list-type: map
-                x-kubernetes-validations:
-                - message: forbidden to update spec.reconfigure
-                  rule: self == oldSelf
               restart:
-                description: Lists Components to be restarted.
+                description: "Lists Components to be restarted. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.restart\""
                 items:
                   description: ComponentOps specifies the Component to be operated
                     on.
@@ -4726,9 +4720,6 @@ spec:
                 x-kubernetes-list-map-keys:
                 - componentName
                 x-kubernetes-list-type: map
-                x-kubernetes-validations:
-                - message: forbidden to update spec.restart
-                  rule: self == oldSelf
               restore:
                 description: Specifies the parameters to restore a Cluster. Note that
                   this restore operation will roll back cluster services.
@@ -4820,13 +4811,11 @@ spec:
                     description: "Defines the content of scripts to be executed. \n
                       All scripts specified in this field will be executed in the
                       order they are provided. \n Note: this field cannot be modified
-                      once set."
+                      once set. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                      == oldSelf\",message=\"forbidden to update spec.scriptSpec.script\""
                     items:
                       type: string
                     type: array
-                    x-kubernetes-validations:
-                    - message: forbidden to update spec.scriptSpec.script
-                      rule: self == oldSelf
                   scriptFrom:
                     description: "Specifies the sources of the scripts to be executed.
                       Each script can be imported either from a ConfigMap or a Secret.
@@ -4836,12 +4825,14 @@ spec:
                       field, in the order of the scripts listed. 2. Scripts imported
                       from ConfigMaps, in the order of the sources listed. 3. Scripts
                       imported from Secrets, in the order of the sources listed. \n
-                      Note: this field cannot be modified once set."
+                      Note: this field cannot be modified once set. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                      == oldSelf\",message=\"forbidden to update spec.scriptSpec.scriptFrom\""
                     properties:
                       configMapRef:
                         description: "A list of ConfigMapKeySelector objects, each
                           specifies a ConfigMap and a key containing the script. \n
-                          Note: This field cannot be modified once set."
+                          Note: This field cannot be modified once set. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                          == oldSelf\",message=\"forbidden to update spec.scriptSpec.scriptFrom.configMapRef\""
                         items:
                           description: Selects a key from a ConfigMap.
                           properties:
@@ -4861,13 +4852,11 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         type: array
-                        x-kubernetes-validations:
-                        - message: forbidden to update spec.scriptSpec.scriptFrom.configMapRef
-                          rule: self == oldSelf
                       secretRef:
                         description: "A list of SecretKeySelector objects, each specifies
                           a Secret and a key containing the script. \n Note: This
-                          field cannot be modified once set."
+                          field cannot be modified once set. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                          == oldSelf\",message=\"forbidden to update spec.scriptSpec.scriptFrom.secretRef\""
                         items:
                           description: SecretKeySelector selects a key of a Secret.
                           properties:
@@ -4888,13 +4877,7 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         type: array
-                        x-kubernetes-validations:
-                        - message: forbidden to update spec.scriptSpec.scriptFrom.secretRef
-                          rule: self == oldSelf
                     type: object
-                    x-kubernetes-validations:
-                    - message: forbidden to update spec.scriptSpec.scriptFrom
-                      rule: self == oldSelf
                   secret:
                     description: Defines the secret to be used to execute the script.
                       If not specified, the default cluster root credential secret
@@ -4924,7 +4907,9 @@ spec:
                       \n However, some Components, such as Redis, do not synchronize
                       account information between primary and secondary Pods. In these
                       cases, the script must be executed on all replica Pods matching
-                      the selector. \n Note: this field cannot be modified once set."
+                      the selector. \n Note: this field cannot be modified once set.
+                      \n TODO +kubebuilder:validation:XValidation:rule=\"self == oldSelf\",message=\"forbidden
+                      to update spec.scriptSpec.script.selector\""
                     properties:
                       matchExpressions:
                         description: matchExpressions is a list of label selector
@@ -4968,15 +4953,13 @@ spec:
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
-                    x-kubernetes-validations:
-                    - message: forbidden to update spec.scriptSpec.script.selector
-                      rule: self == oldSelf
                 required:
                 - componentName
                 type: object
               switchover:
-                description: Lists Switchover objects, each specifying a Component
-                  to perform the switchover operation.
+                description: "Lists Switchover objects, each specifying a Component
+                  to perform the switchover operation. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.switchover\""
                 items:
                   properties:
                     componentName:
@@ -5005,9 +4988,6 @@ spec:
                 x-kubernetes-list-map-keys:
                 - componentName
                 x-kubernetes-list-type: map
-                x-kubernetes-validations:
-                - message: forbidden to update spec.switchover
-                  rule: self == oldSelf
               ttlSecondsAfterSucceed:
                 description: Specifies the duration in seconds that an OpsRequest
                   will remain in the system after successfully completing (when `opsRequest.status.phase`
@@ -5019,7 +4999,8 @@ spec:
                   include \"Start\", \"Stop\", \"Restart\", \"Switchover\", \"VerticalScaling\",
                   \"HorizontalScaling\", \"VolumeExpansion\", \"Reconfiguring\", \"Upgrade\",
                   \"Backup\", \"Restore\", \"Expose\", \"DataScript\", \"RebuildInstance\",
-                  \"Custom\". \n Note: This field is immutable once set."
+                  \"Custom\". \n Note: This field is immutable once set. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.type\""
                 enum:
                 - Upgrade
                 - VerticalScaling
@@ -5037,12 +5018,10 @@ spec:
                 - RebuildInstance
                 - Custom
                 type: string
-                x-kubernetes-validations:
-                - message: forbidden to update spec.type
-                  rule: self == oldSelf
               upgrade:
                 description: "Specifies the desired new version of the Cluster. \n
-                  Note: This field is immutable once set."
+                  Note: This field is immutable once set. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.upgrade\""
                 properties:
                   clusterVersionRef:
                     description: 'Deprecated: since v0.9 because ClusterVersion is
@@ -5084,18 +5063,12 @@ spec:
                       required:
                       - componentName
                       type: object
-                      x-kubernetes-validations:
-                      - message: at least one componentDefinitionName or serviceVersion
-                        rule: has(self.componentDefinitionName) || has(self.serviceVersion)
                     maxItems: 1024
                     type: array
                     x-kubernetes-list-map-keys:
                     - componentName
                     x-kubernetes-list-type: map
                 type: object
-                x-kubernetes-validations:
-                - message: forbidden to update spec.upgrade
-                  rule: self == oldSelf
               verticalScaling:
                 description: Lists VerticalScaling objects, each specifying a component
                   and its desired compute resources for vertical scaling.
@@ -5316,10 +5289,6 @@ spec:
             required:
             - type
             type: object
-            x-kubernetes-validations:
-            - message: forbidden to cancel the opsRequest which type not in ['VerticalScaling','HorizontalScaling']
-              rule: 'has(self.cancel) && self.cancel ? (self.type in [''VerticalScaling'',
-                ''HorizontalScaling'']) : true'
           status:
             description: OpsRequestStatus represents the observed state of an OpsRequest.
             properties:
@@ -5458,9 +5427,6 @@ spec:
                         required:
                         - status
                         type: object
-                        x-kubernetes-validations:
-                        - message: at least one objectKey or actionName.
-                          rule: has(self.objectKey) || has(self.actionName)
                       type: array
                     reason:
                       description: Provides an explanation for the Component being

--- a/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -48,6 +48,9 @@ spec:
             type: object
           spec:
             description: BackupPolicySpec defines the desired state of BackupPolicy
+              TODO +kubebuilder:validation:XValidation:rule="(has(self.target) &&
+              !has(self.targets)) || (has(self.targets) && !has(self.target))",message="either
+              spec.target or spec.targets"
             properties:
               backoffLimit:
                 default: 2
@@ -1075,10 +1078,6 @@ spec:
             required:
             - backupMethods
             type: object
-            x-kubernetes-validations:
-            - message: either spec.target or spec.targets
-              rule: (has(self.target) && !has(self.targets)) || (has(self.targets)
-                && !has(self.target))
           status:
             description: BackupPolicyStatus defines the observed state of BackupPolicy
             properties:

--- a/config/crd/bases/dataprotection.kubeblocks.io_backuprepos.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backuprepos.yaml
@@ -92,12 +92,10 @@ spec:
                 - Retain
                 type: string
               storageProviderRef:
-                description: Specifies the name of the `StorageProvider` used by this
-                  backup repository.
+                description: "Specifies the name of the `StorageProvider` used by
+                  this backup repository. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"StorageProviderRef is immutable\""
                 type: string
-                x-kubernetes-validations:
-                - message: StorageProviderRef is immutable
-                  rule: self == oldSelf
               volumeCapacity:
                 anyOf:
                 - type: integer

--- a/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
@@ -66,19 +66,16 @@ spec:
             description: BackupSpec defines the desired state of Backup.
             properties:
               backupMethod:
-                description: Specifies the backup method name that is defined in the
-                  backup policy.
+                description: "Specifies the backup method name that is defined in
+                  the backup policy. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.backupMethod\""
                 type: string
-                x-kubernetes-validations:
-                - message: forbidden to update spec.backupMethod
-                  rule: self == oldSelf
               backupPolicyName:
-                description: Specifies the backup policy to be applied for this backup.
+                description: "Specifies the backup policy to be applied for this backup.
+                  \n TODO +kubebuilder:validation:XValidation:rule=\"self == oldSelf\",message=\"forbidden
+                  to update spec.backupPolicyName\""
                 pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                 type: string
-                x-kubernetes-validations:
-                - message: forbidden to update spec.backupPolicyName
-                  rule: self == oldSelf
               deletionPolicy:
                 allOf:
                 - enum:
@@ -100,12 +97,10 @@ spec:
                   of backup data."
                 type: string
               parentBackupName:
-                description: Determines the parent backup name for incremental or
-                  differential backup.
+                description: "Determines the parent backup name for incremental or
+                  differential backup. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.parentBackupName\""
                 type: string
-                x-kubernetes-validations:
-                - message: forbidden to update spec.parentBackupName
-                  rule: self == oldSelf
               retentionPeriod:
                 description: "Determines a duration up to which the backup should
                   be kept. Controller will remove all backups that are older than

--- a/config/crd/bases/dataprotection.kubeblocks.io_restores.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_restores.yaml
@@ -73,7 +73,9 @@ spec:
                   the most recent full backup of this incremental backup. 3. Differential:
                   will be restored sequentially from the parent backup of the differential
                   backup. 4. Continuous: will find the most recent full backup at
-                  this time point and the continuous backups after it to restore."
+                  this time point and the continuous backups after it to restore.
+                  \n TODO +kubebuilder:validation:XValidation:rule=\"self == oldSelf\",message=\"forbidden
+                  to update spec.backupName\""
                 properties:
                   name:
                     description: Specifies the backup name.
@@ -89,9 +91,6 @@ spec:
                 - name
                 - namespace
                 type: object
-                x-kubernetes-validations:
-                - message: forbidden to update spec.backupName
-                  rule: self == oldSelf
               containerResources:
                 description: Specifies the required resources of restore job's container.
                 properties:
@@ -259,9 +258,13 @@ spec:
                   and scheduling strategy of temporary recovery pod.
                 properties:
                   dataSourceRef:
-                    description: Specifies the configuration when using `persistentVolumeClaim.spec.dataSourceRef`
+                    description: "Specifies the configuration when using `persistentVolumeClaim.spec.dataSourceRef`
                       method for restoring. Describes the source volume of the backup
                       targetVolumes and the mount path in the restoring container.
+                      \n TODO +kubebuilder:validation:XValidation:rule=\"self.volumeSource
+                      != '' || self.mountPath !=''\",message=\"at least one exists
+                      for volumeSource and mountPath.\" TODO +kubebuilder:validation:XValidation:rule=\"self
+                      == oldSelf\",message=\"forbidden to update spec.prepareDataConfig.dataSourceRef\""
                     properties:
                       mountPath:
                         description: Specifies the path within the restoring container
@@ -273,11 +276,6 @@ spec:
                           required if the backup uses a volume snapshot.
                         type: string
                     type: object
-                    x-kubernetes-validations:
-                    - message: at least one exists for volumeSource and mountPath.
-                      rule: self.volumeSource != '' || self.mountPath !=''
-                    - message: forbidden to update spec.prepareDataConfig.dataSourceRef
-                      rule: self == oldSelf
                   requiredPolicyForAllPodSelection:
                     description: Specifies the restore policy, which is required when
                       the pod selection strategy for the source target is 'All'. This
@@ -309,7 +307,9 @@ spec:
                     - dataRestorePolicy
                     type: object
                   schedulingSpec:
-                    description: Specifies the scheduling spec for the restoring pod.
+                    description: "Specifies the scheduling spec for the restoring
+                      pod. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                      == oldSelf\",message=\"forbidden to update spec.prepareDataConfig.schedulingSpec\""
                     properties:
                       affinity:
                         description: Contains a group of affinity scheduling rules.
@@ -1466,9 +1466,6 @@ spec:
                           type: object
                         type: array
                     type: object
-                    x-kubernetes-validations:
-                    - message: forbidden to update spec.prepareDataConfig.schedulingSpec
-                      rule: self == oldSelf
                   volumeClaimRestorePolicy:
                     default: Parallel
                     description: "Defines restore policy for persistent volume claim.
@@ -1481,9 +1478,11 @@ spec:
                     - Serial
                     type: string
                   volumeClaims:
-                    description: Defines the persistent Volume claims that need to
+                    description: "Defines the persistent Volume claims that need to
                       be restored and mounted together into the restore job. These
                       persistent Volume claims will be created if they do not exist.
+                      \n TODO +kubebuilder:validation:XValidation:rule=\"self == oldSelf\",message=\"forbidden
+                      to update spec.prepareDataConfig.volumeClaims\""
                     items:
                       properties:
                         metadata:
@@ -1740,18 +1739,13 @@ spec:
                       - metadata
                       - volumeClaimSpec
                       type: object
-                      x-kubernetes-validations:
-                      - message: at least one exists for volumeSource and mountPath.
-                        rule: self.volumeSource != '' || self.mountPath !=''
                     type: array
-                    x-kubernetes-validations:
-                    - message: forbidden to update spec.prepareDataConfig.volumeClaims
-                      rule: self == oldSelf
                   volumeClaimsTemplate:
-                    description: Defines a template to build persistent Volume claims
+                    description: "Defines a template to build persistent Volume claims
                       that need to be restored. These claims will be created in an
                       orderly manner based on the number of replicas or reused if
-                      they already exist.
+                      they already exist. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                      == oldSelf\",message=\"forbidden to update spec.prepareDataConfig.volumeClaimsTemplate\""
                     properties:
                       replicas:
                         description: Specifies the replicas of persistent volume claim
@@ -2038,22 +2032,19 @@ spec:
                           - metadata
                           - volumeClaimSpec
                           type: object
-                          x-kubernetes-validations:
-                          - message: at least one exists for volumeSource and mountPath.
-                            rule: self.volumeSource != '' || self.mountPath !=''
                         type: array
                     required:
                     - replicas
                     - templates
                     type: object
-                    x-kubernetes-validations:
-                    - message: forbidden to update spec.prepareDataConfig.volumeClaimsTemplate
-                      rule: self == oldSelf
                 required:
                 - volumeClaimRestorePolicy
                 type: object
               readyConfig:
-                description: Configuration for the action of "postReady" phase.
+                description: "Configuration for the action of \"postReady\" phase.
+                  \n TODO +kubebuilder:validation:XValidation:rule=\"has(self.jobAction)
+                  || has(self.execAction)\", message=\"at least one exists for jobAction
+                  and execAction.\""
                 properties:
                   connectionCredential:
                     description: Defines the credential template used to create a
@@ -2341,11 +2332,10 @@ spec:
                     - exec
                     type: object
                 type: object
-                x-kubernetes-validations:
-                - message: at least one exists for jobAction and execAction.
-                  rule: has(self.jobAction) || has(self.execAction)
               resources:
-                description: Restores the specified resources of Kubernetes.
+                description: "Restores the specified resources of Kubernetes. \n TODO
+                  +kubebuilder:validation:XValidation:rule=\"self == oldSelf\",message=\"forbidden
+                  to update spec.resources\""
                 properties:
                   included:
                     description: Restores the specified resources.
@@ -2405,16 +2395,11 @@ spec:
                       type: object
                     type: array
                 type: object
-                x-kubernetes-validations:
-                - message: forbidden to update spec.resources
-                  rule: self == oldSelf
               restoreTime:
-                description: Specifies the point in time for restoring.
+                description: "Specifies the point in time for restoring. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.restoreTime\""
                 pattern: ^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$
                 type: string
-                x-kubernetes-validations:
-                - message: forbidden to update spec.restoreTime
-                  rule: self == oldSelf
               serviceAccountName:
                 description: Specifies the service account name needed for recovery
                   pod.

--- a/config/crd/bases/extensions.kubeblocks.io_addons.yaml
+++ b/config/crd/bases/extensions.kubeblocks.io_addons.yaml
@@ -55,7 +55,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: AddonSpec defines the desired state of an add-on.
+            description: 'AddonSpec defines the desired state of an add-on. TODO +kubebuilder:validation:XValidation:rule="has(self.type)
+              && self.type == ''Helm'' ?  has(self.helm) : !has(self.helm)",message="spec.helm
+              is required when spec.type is Helm, and forbidden otherwise"'
             properties:
               cliPlugins:
                 description: Specifies the CLI plugin installation specifications.
@@ -462,11 +464,6 @@ spec:
                 required:
                 - chartLocationURL
                 type: object
-                x-kubernetes-validations:
-                - message: chartsImage is required when chartLocationURL starts with
-                    'file://'
-                  rule: 'self.chartLocationURL.startsWith(''file://'') ? has(self.chartsImage)
-                    : true'
               install:
                 description: Defines the installation parameters.
                 properties:
@@ -644,10 +641,6 @@ spec:
             - defaultInstallValues
             - type
             type: object
-            x-kubernetes-validations:
-            - message: spec.helm is required when spec.type is Helm, and forbidden
-                otherwise
-              rule: 'has(self.type) && self.type == ''Helm'' ?  has(self.helm) : !has(self.helm)'
           status:
             description: AddonStatus defines the observed state of an add-on.
             properties:

--- a/deploy/helm/crds/apps.kubeblocks.io_backuppolicytemplates.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_backuppolicytemplates.yaml
@@ -971,15 +971,13 @@ spec:
                 minItems: 1
                 type: array
               clusterDefinitionRef:
-                description: Specifies the name of a ClusterDefinition. This is an
+                description: "Specifies the name of a ClusterDefinition. This is an
                   immutable attribute that cannot be changed after creation. And this
                   field is deprecated since v0.9, consider using the ComponentDef
-                  instead.
+                  instead. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"clusterDefinitionRef is immutable\""
                 pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                 type: string
-                x-kubernetes-validations:
-                - message: clusterDefinitionRef is immutable
-                  rule: self == oldSelf
               identifier:
                 description: "Specifies a unique identifier for the BackupPolicyTemplate.
                   \n This identifier will be used as the suffix of the name of automatically

--- a/deploy/helm/crds/apps.kubeblocks.io_clusterdefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusterdefinitions.yaml
@@ -75,7 +75,11 @@ spec:
                   description: "ClusterComponentDefinition defines a Component within
                     a ClusterDefinition but is deprecated and has been replaced by
                     ComponentDefinition. \n Deprecated: Use ComponentDefinition instead.
-                    This type is deprecated as of version 0.8."
+                    This type is deprecated as of version 0.8. \n TODO +kubebuilder:validation:XValidation:rule=\"has(self.workloadType)
+                    && self.workloadType == 'Consensus' ? (has(self.consensusSpec)
+                    || has(self.rsmSpec)) : !has(self.consensusSpec)\",message=\"componentDefs.consensusSpec(deprecated)
+                    or componentDefs.rsmSpec(recommended) is required when componentDefs.workloadType
+                    is Consensus, and forbidden otherwise\""
                   properties:
                     characterType:
                       description: Defines well-known database component name, such
@@ -10115,12 +10119,6 @@ spec:
                   - name
                   - workloadType
                   type: object
-                  x-kubernetes-validations:
-                  - message: componentDefs.consensusSpec(deprecated) or componentDefs.rsmSpec(recommended)
-                      is required when componentDefs.workloadType is Consensus, and
-                      forbidden otherwise
-                    rule: 'has(self.workloadType) && self.workloadType == ''Consensus''
-                      ? (has(self.consensusSpec) || has(self.rsmSpec)) : !has(self.consensusSpec)'
                 type: array
                 x-kubernetes-list-map-keys:
                 - name

--- a/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
@@ -227,13 +227,11 @@ spec:
                   specific ComponentDefinitions for each component within `componentSpecs[*].componentDef`.
                   \n If this field is not provided, each component must be explicitly
                   defined in `componentSpecs[*].componentDef`. \n Note: Once set,
-                  this field cannot be modified; it is immutable."
+                  this field cannot be modified; it is immutable. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"clusterDefinitionRef is immutable\""
                 maxLength: 63
                 pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                 type: string
-                x-kubernetes-validations:
-                - message: clusterDefinitionRef is immutable
-                  rule: self == oldSelf
               clusterVersionRef:
                 description: "Refers to the ClusterVersion name. \n Deprecated since
                   v0.9, use ComponentVersion instead. This field is maintained for
@@ -248,7 +246,13 @@ spec:
                   to define the individual Components that make up a Cluster. This
                   field allows for detailed configuration of each Component within
                   the Cluster. \n Note: `shardingSpecs` and `componentSpecs` cannot
-                  both be empty; at least one must be defined to configure a Cluster."
+                  both be empty; at least one must be defined to configure a Cluster.
+                  \n TODO +kubebuilder:validation:XValidation:rule=\"self.all(x, size(self.filter(c,
+                  c.name == x.name)) == 1)\",message=\"duplicated component\" TODO
+                  +kubebuilder:validation:XValidation:rule=\"self.all(x, size(self.filter(c,
+                  has(c.componentDef))) == 0) || self.all(x, size(self.filter(c, has(c.componentDef)))
+                  == size(self))\",message=\"two kinds of definition API can not be
+                  used simultaneously\""
                 items:
                   description: ClusterComponentSpec defines the specification of a
                     Component within a Cluster. TODO +kubebuilder:validation:XValidation:rule="!has(oldSelf.componentDefRef)
@@ -6044,12 +6048,6 @@ spec:
                 maxItems: 128
                 minItems: 1
                 type: array
-                x-kubernetes-validations:
-                - message: duplicated component
-                  rule: self.all(x, size(self.filter(c, c.name == x.name)) == 1)
-                - message: two kinds of definition API can not be used simultaneously
-                  rule: self.all(x, size(self.filter(c, has(c.componentDef))) == 0)
-                    || self.all(x, size(self.filter(c, has(c.componentDef))) == size(self))
               network:
                 description: "The configuration of network. \n Deprecated since v0.9.
                   This field is maintained for backward compatibility and its use
@@ -7679,13 +7677,12 @@ spec:
                         Component name would be \"my-shard-abc\". \n Note that the
                         name defined in Component template(`shardingSpec.template.name`)
                         will be disregarded when generating the Component names of
-                        the shards. The `shardingSpec.name` field takes precedence."
+                        the shards. The `shardingSpec.name` field takes precedence.
+                        \n TODO +kubebuilder:validation:XValidation:rule=\"self ==
+                        oldSelf\",message=\"name is immutable\""
                       maxLength: 15
                       pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                       type: string
-                      x-kubernetes-validations:
-                      - message: name is immutable
-                        rule: self == oldSelf
                     shards:
                       description: "Specifies the desired number of shards. Users
                         can declare the desired number of shards through this field.

--- a/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
@@ -5294,13 +5294,6 @@ spec:
                 - maxReplicas
                 - minReplicas
                 type: object
-                x-kubernetes-validations:
-                - message: the minimum and maximum limit of replicas should be in
-                    the range of [0, 128]
-                  rule: self.minReplicas >= 0 && self.maxReplicas <= 128
-                - message: the minimum replicas limit should be no greater than the
-                    maximum
-                  rule: self.minReplicas <= self.maxReplicas
               roles:
                 description: "Enumerate all possible roles assigned to each replica
                   of the Component, influencing its behavior. \n A replica can have

--- a/deploy/helm/crds/apps.kubeblocks.io_componentversions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_componentversions.yaml
@@ -98,17 +98,15 @@ spec:
                     images:
                       additionalProperties:
                         type: string
-                      description: Images define the new images for different containers
-                        within the release.
+                      description: "Images define the new images for different containers
+                        within the release. \n TODO +kubebuilder:validation:XValidation:rule=\"self.all(key,
+                        size(key) <= 32)\",message=\"Container name may not exceed
+                        maximum length of 32 characters\" TODO +kubebuilder:validation:XValidation:rule=\"self.all(key,
+                        size(self[key]) <= 256)\",message=\"Image name may not exceed
+                        maximum length of 256 characters\""
                       maxProperties: 128
                       minProperties: 1
                       type: object
-                      x-kubernetes-validations:
-                      - message: Container name may not exceed maximum length of 32
-                          characters
-                        rule: self.all(key, size(key) <= 32)
-                      - message: Image name may not exceed maximum length of 256 characters
-                        rule: self.all(key, size(self[key]) <= 256)
                     name:
                       description: Name is a unique identifier for this release. Cannot
                         be updated.

--- a/deploy/helm/crds/apps.kubeblocks.io_configurations.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_configurations.yaml
@@ -40,19 +40,15 @@ spec:
               resource.
             properties:
               clusterRef:
-                description: Specifies the name of the Cluster that this configuration
-                  is associated with.
+                description: "Specifies the name of the Cluster that this configuration
+                  is associated with. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.clusterRef\""
                 type: string
-                x-kubernetes-validations:
-                - message: forbidden to update spec.clusterRef
-                  rule: self == oldSelf
               componentName:
-                description: Represents the name of the Component that this configuration
-                  pertains to.
+                description: "Represents the name of the Component that this configuration
+                  pertains to. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.clusterRef\""
                 type: string
-                x-kubernetes-validations:
-                - message: forbidden to update spec.clusterRef
-                  rule: self == oldSelf
               configItemDetails:
                 description: "ConfigItemDetails is an array of ConfigurationItemDetail
                   objects. \n Each ConfigurationItemDetail corresponds to a configuration

--- a/deploy/helm/crds/apps.kubeblocks.io_opsdefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_opsdefinitions.yaml
@@ -59,7 +59,9 @@ spec:
                     commands directly within an existing container using the kubectl
                     exec interface, suitable for immediate, short-lived operations.
                     - resourceModifier: Modifies a K8s object using JSON patches,
-                    useful for updating the spec of some resource."
+                    useful for updating the spec of some resource. \n TODO +kubebuilder:validation:XValidation:rule=\"has(self.workload)
+                    || has(self.exec) || has(self.resourceModifier)\", message=\"at
+                    least one action exists for workload, exec and resourceModifier.\""
                   properties:
                     exec:
                       description: Specifies the configuration for a 'exec' action.
@@ -8378,9 +8380,6 @@ spec:
                   required:
                   - name
                   type: object
-                  x-kubernetes-validations:
-                  - message: at least one action exists for workload, exec and resourceModifier.
-                    rule: has(self.workload) || has(self.exec) || has(self.resourceModifier)
                 minItems: 1
                 type: array
                 x-kubernetes-list-map-keys:
@@ -8491,9 +8490,6 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                             type: object
-                            x-kubernetes-validations:
-                            - message: either fieldPath and envRef.
-                              rule: has(self.envRef) || has(self.fieldPath)
                         required:
                         - name
                         - valueFrom

--- a/deploy/helm/crds/apps.kubeblocks.io_opsrequests.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_opsrequests.yaml
@@ -58,7 +58,11 @@ spec:
           metadata:
             type: object
           spec:
-            description: OpsRequestSpec defines the desired state of OpsRequest
+            description: "OpsRequestSpec defines the desired state of OpsRequest \n
+              TODO +kubebuilder:validation:XValidation:rule=\"has(self.cancel) &&
+              self.cancel ? (self.type in ['VerticalScaling', 'HorizontalScaling'])
+              : true\",message=\"forbidden to cancel the opsRequest which type not
+              in ['VerticalScaling','HorizontalScaling']\""
             properties:
               backup:
                 description: Specifies the parameters to backup a Cluster.
@@ -160,19 +164,16 @@ spec:
                   ineffective."
                 type: boolean
               clusterName:
-                description: Specifies the name of the Cluster resource that this
-                  operation is targeting.
+                description: "Specifies the name of the Cluster resource that this
+                  operation is targeting. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.clusterName\""
                 type: string
-                x-kubernetes-validations:
-                - message: forbidden to update spec.clusterName
-                  rule: self == oldSelf
               clusterRef:
                 description: 'Deprecated: since v0.9, use clusterName instead. Specifies
-                  the name of the Cluster resource that this operation is targeting.'
+                  the name of the Cluster resource that this operation is targeting.
+                  TODO +kubebuilder:validation:XValidation:rule="self == oldSelf",message="forbidden
+                  to update spec.clusterRef"'
                 type: string
-                x-kubernetes-validations:
-                - message: forbidden to update spec.clusterRef
-                  rule: self == oldSelf
               custom:
                 description: Specifies a custom operation defined by OpsDefinition.
                 properties:
@@ -465,16 +466,15 @@ spec:
                   'HorizontalScaling' opsRequests. By setting `force` to true, you
                   can bypass the default checks and demand these opsRequests to run
                   simultaneously. \n Note: Once set, the `force` field is immutable
-                  and cannot be updated."
+                  and cannot be updated. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.force\""
                 type: boolean
-                x-kubernetes-validations:
-                - message: forbidden to update spec.force
-                  rule: self == oldSelf
               horizontalScaling:
-                description: Lists HorizontalScaling objects, each specifying scaling
+                description: "Lists HorizontalScaling objects, each specifying scaling
                   requirements for a Component, including desired replica changes,
                   configurations for new instances, modifications for existing instances,
-                  and take offline/online the specified instances.
+                  and take offline/online the specified instances. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.horizontalScaling\""
                 items:
                   description: HorizontalScaling defines the parameters of a horizontal
                     scaling operation.
@@ -4330,9 +4330,6 @@ spec:
                 x-kubernetes-list-map-keys:
                 - componentName
                 x-kubernetes-list-type: map
-                x-kubernetes-validations:
-                - message: forbidden to update spec.horizontalScaling
-                  rule: self == oldSelf
               preConditionDeadlineSeconds:
                 default: 0
                 description: Specifies the maximum time in seconds that the OpsRequest
@@ -4342,11 +4339,12 @@ spec:
                 format: int32
                 type: integer
               rebuildFrom:
-                description: Specifies the parameters to rebuild some instances. Rebuilding
-                  an instance involves restoring its data from a backup or another
-                  database replica. The instances being rebuilt usually serve as standby
-                  in the cluster. Hence rebuilding instances is often also referred
-                  to as "standby reconstruction".
+                description: "Specifies the parameters to rebuild some instances.
+                  Rebuilding an instance involves restoring its data from a backup
+                  or another database replica. The instances being rebuilt usually
+                  serve as standby in the cluster. Hence rebuilding instances is often
+                  also referred to as \"standby reconstruction\". \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.rebuildFrom\""
                 items:
                   properties:
                     backupName:
@@ -4514,9 +4512,6 @@ spec:
                 x-kubernetes-list-map-keys:
                 - componentName
                 x-kubernetes-list-type: map
-                x-kubernetes-validations:
-                - message: forbidden to update spec.rebuildFrom
-                  rule: self == oldSelf
               reconfigure:
                 description: "Specifies a component and its configuration updates.
                   \n This field is deprecated and replaced by `reconfigures`."
@@ -4609,8 +4604,9 @@ spec:
                 - configurations
                 type: object
               reconfigures:
-                description: Lists Reconfigure objects, each specifying a Component
-                  and its configuration updates.
+                description: "Lists Reconfigure objects, each specifying a Component
+                  and its configuration updates. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.reconfigure\""
                 items:
                   description: Reconfigure defines the parameters for updating a Component's
                     configuration.
@@ -4706,11 +4702,9 @@ spec:
                 x-kubernetes-list-map-keys:
                 - componentName
                 x-kubernetes-list-type: map
-                x-kubernetes-validations:
-                - message: forbidden to update spec.reconfigure
-                  rule: self == oldSelf
               restart:
-                description: Lists Components to be restarted.
+                description: "Lists Components to be restarted. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.restart\""
                 items:
                   description: ComponentOps specifies the Component to be operated
                     on.
@@ -4726,9 +4720,6 @@ spec:
                 x-kubernetes-list-map-keys:
                 - componentName
                 x-kubernetes-list-type: map
-                x-kubernetes-validations:
-                - message: forbidden to update spec.restart
-                  rule: self == oldSelf
               restore:
                 description: Specifies the parameters to restore a Cluster. Note that
                   this restore operation will roll back cluster services.
@@ -4820,13 +4811,11 @@ spec:
                     description: "Defines the content of scripts to be executed. \n
                       All scripts specified in this field will be executed in the
                       order they are provided. \n Note: this field cannot be modified
-                      once set."
+                      once set. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                      == oldSelf\",message=\"forbidden to update spec.scriptSpec.script\""
                     items:
                       type: string
                     type: array
-                    x-kubernetes-validations:
-                    - message: forbidden to update spec.scriptSpec.script
-                      rule: self == oldSelf
                   scriptFrom:
                     description: "Specifies the sources of the scripts to be executed.
                       Each script can be imported either from a ConfigMap or a Secret.
@@ -4836,12 +4825,14 @@ spec:
                       field, in the order of the scripts listed. 2. Scripts imported
                       from ConfigMaps, in the order of the sources listed. 3. Scripts
                       imported from Secrets, in the order of the sources listed. \n
-                      Note: this field cannot be modified once set."
+                      Note: this field cannot be modified once set. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                      == oldSelf\",message=\"forbidden to update spec.scriptSpec.scriptFrom\""
                     properties:
                       configMapRef:
                         description: "A list of ConfigMapKeySelector objects, each
                           specifies a ConfigMap and a key containing the script. \n
-                          Note: This field cannot be modified once set."
+                          Note: This field cannot be modified once set. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                          == oldSelf\",message=\"forbidden to update spec.scriptSpec.scriptFrom.configMapRef\""
                         items:
                           description: Selects a key from a ConfigMap.
                           properties:
@@ -4861,13 +4852,11 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         type: array
-                        x-kubernetes-validations:
-                        - message: forbidden to update spec.scriptSpec.scriptFrom.configMapRef
-                          rule: self == oldSelf
                       secretRef:
                         description: "A list of SecretKeySelector objects, each specifies
                           a Secret and a key containing the script. \n Note: This
-                          field cannot be modified once set."
+                          field cannot be modified once set. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                          == oldSelf\",message=\"forbidden to update spec.scriptSpec.scriptFrom.secretRef\""
                         items:
                           description: SecretKeySelector selects a key of a Secret.
                           properties:
@@ -4888,13 +4877,7 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         type: array
-                        x-kubernetes-validations:
-                        - message: forbidden to update spec.scriptSpec.scriptFrom.secretRef
-                          rule: self == oldSelf
                     type: object
-                    x-kubernetes-validations:
-                    - message: forbidden to update spec.scriptSpec.scriptFrom
-                      rule: self == oldSelf
                   secret:
                     description: Defines the secret to be used to execute the script.
                       If not specified, the default cluster root credential secret
@@ -4924,7 +4907,9 @@ spec:
                       \n However, some Components, such as Redis, do not synchronize
                       account information between primary and secondary Pods. In these
                       cases, the script must be executed on all replica Pods matching
-                      the selector. \n Note: this field cannot be modified once set."
+                      the selector. \n Note: this field cannot be modified once set.
+                      \n TODO +kubebuilder:validation:XValidation:rule=\"self == oldSelf\",message=\"forbidden
+                      to update spec.scriptSpec.script.selector\""
                     properties:
                       matchExpressions:
                         description: matchExpressions is a list of label selector
@@ -4968,15 +4953,13 @@ spec:
                         type: object
                     type: object
                     x-kubernetes-map-type: atomic
-                    x-kubernetes-validations:
-                    - message: forbidden to update spec.scriptSpec.script.selector
-                      rule: self == oldSelf
                 required:
                 - componentName
                 type: object
               switchover:
-                description: Lists Switchover objects, each specifying a Component
-                  to perform the switchover operation.
+                description: "Lists Switchover objects, each specifying a Component
+                  to perform the switchover operation. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.switchover\""
                 items:
                   properties:
                     componentName:
@@ -5005,9 +4988,6 @@ spec:
                 x-kubernetes-list-map-keys:
                 - componentName
                 x-kubernetes-list-type: map
-                x-kubernetes-validations:
-                - message: forbidden to update spec.switchover
-                  rule: self == oldSelf
               ttlSecondsAfterSucceed:
                 description: Specifies the duration in seconds that an OpsRequest
                   will remain in the system after successfully completing (when `opsRequest.status.phase`
@@ -5019,7 +4999,8 @@ spec:
                   include \"Start\", \"Stop\", \"Restart\", \"Switchover\", \"VerticalScaling\",
                   \"HorizontalScaling\", \"VolumeExpansion\", \"Reconfiguring\", \"Upgrade\",
                   \"Backup\", \"Restore\", \"Expose\", \"DataScript\", \"RebuildInstance\",
-                  \"Custom\". \n Note: This field is immutable once set."
+                  \"Custom\". \n Note: This field is immutable once set. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.type\""
                 enum:
                 - Upgrade
                 - VerticalScaling
@@ -5037,12 +5018,10 @@ spec:
                 - RebuildInstance
                 - Custom
                 type: string
-                x-kubernetes-validations:
-                - message: forbidden to update spec.type
-                  rule: self == oldSelf
               upgrade:
                 description: "Specifies the desired new version of the Cluster. \n
-                  Note: This field is immutable once set."
+                  Note: This field is immutable once set. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.upgrade\""
                 properties:
                   clusterVersionRef:
                     description: 'Deprecated: since v0.9 because ClusterVersion is
@@ -5084,18 +5063,12 @@ spec:
                       required:
                       - componentName
                       type: object
-                      x-kubernetes-validations:
-                      - message: at least one componentDefinitionName or serviceVersion
-                        rule: has(self.componentDefinitionName) || has(self.serviceVersion)
                     maxItems: 1024
                     type: array
                     x-kubernetes-list-map-keys:
                     - componentName
                     x-kubernetes-list-type: map
                 type: object
-                x-kubernetes-validations:
-                - message: forbidden to update spec.upgrade
-                  rule: self == oldSelf
               verticalScaling:
                 description: Lists VerticalScaling objects, each specifying a component
                   and its desired compute resources for vertical scaling.
@@ -5316,10 +5289,6 @@ spec:
             required:
             - type
             type: object
-            x-kubernetes-validations:
-            - message: forbidden to cancel the opsRequest which type not in ['VerticalScaling','HorizontalScaling']
-              rule: 'has(self.cancel) && self.cancel ? (self.type in [''VerticalScaling'',
-                ''HorizontalScaling'']) : true'
           status:
             description: OpsRequestStatus represents the observed state of an OpsRequest.
             properties:
@@ -5458,9 +5427,6 @@ spec:
                         required:
                         - status
                         type: object
-                        x-kubernetes-validations:
-                        - message: at least one objectKey or actionName.
-                          rule: has(self.objectKey) || has(self.actionName)
                       type: array
                     reason:
                       description: Provides an explanation for the Component being

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -48,6 +48,9 @@ spec:
             type: object
           spec:
             description: BackupPolicySpec defines the desired state of BackupPolicy
+              TODO +kubebuilder:validation:XValidation:rule="(has(self.target) &&
+              !has(self.targets)) || (has(self.targets) && !has(self.target))",message="either
+              spec.target or spec.targets"
             properties:
               backoffLimit:
                 default: 2
@@ -1075,10 +1078,6 @@ spec:
             required:
             - backupMethods
             type: object
-            x-kubernetes-validations:
-            - message: either spec.target or spec.targets
-              rule: (has(self.target) && !has(self.targets)) || (has(self.targets)
-                && !has(self.target))
           status:
             description: BackupPolicyStatus defines the observed state of BackupPolicy
             properties:

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backuprepos.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backuprepos.yaml
@@ -92,12 +92,10 @@ spec:
                 - Retain
                 type: string
               storageProviderRef:
-                description: Specifies the name of the `StorageProvider` used by this
-                  backup repository.
+                description: "Specifies the name of the `StorageProvider` used by
+                  this backup repository. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"StorageProviderRef is immutable\""
                 type: string
-                x-kubernetes-validations:
-                - message: StorageProviderRef is immutable
-                  rule: self == oldSelf
               volumeCapacity:
                 anyOf:
                 - type: integer

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
@@ -66,19 +66,16 @@ spec:
             description: BackupSpec defines the desired state of Backup.
             properties:
               backupMethod:
-                description: Specifies the backup method name that is defined in the
-                  backup policy.
+                description: "Specifies the backup method name that is defined in
+                  the backup policy. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.backupMethod\""
                 type: string
-                x-kubernetes-validations:
-                - message: forbidden to update spec.backupMethod
-                  rule: self == oldSelf
               backupPolicyName:
-                description: Specifies the backup policy to be applied for this backup.
+                description: "Specifies the backup policy to be applied for this backup.
+                  \n TODO +kubebuilder:validation:XValidation:rule=\"self == oldSelf\",message=\"forbidden
+                  to update spec.backupPolicyName\""
                 pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                 type: string
-                x-kubernetes-validations:
-                - message: forbidden to update spec.backupPolicyName
-                  rule: self == oldSelf
               deletionPolicy:
                 allOf:
                 - enum:
@@ -100,12 +97,10 @@ spec:
                   of backup data."
                 type: string
               parentBackupName:
-                description: Determines the parent backup name for incremental or
-                  differential backup.
+                description: "Determines the parent backup name for incremental or
+                  differential backup. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.parentBackupName\""
                 type: string
-                x-kubernetes-validations:
-                - message: forbidden to update spec.parentBackupName
-                  rule: self == oldSelf
               retentionPeriod:
                 description: "Determines a duration up to which the backup should
                   be kept. Controller will remove all backups that are older than

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_restores.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_restores.yaml
@@ -73,7 +73,9 @@ spec:
                   the most recent full backup of this incremental backup. 3. Differential:
                   will be restored sequentially from the parent backup of the differential
                   backup. 4. Continuous: will find the most recent full backup at
-                  this time point and the continuous backups after it to restore."
+                  this time point and the continuous backups after it to restore.
+                  \n TODO +kubebuilder:validation:XValidation:rule=\"self == oldSelf\",message=\"forbidden
+                  to update spec.backupName\""
                 properties:
                   name:
                     description: Specifies the backup name.
@@ -89,9 +91,6 @@ spec:
                 - name
                 - namespace
                 type: object
-                x-kubernetes-validations:
-                - message: forbidden to update spec.backupName
-                  rule: self == oldSelf
               containerResources:
                 description: Specifies the required resources of restore job's container.
                 properties:
@@ -259,9 +258,13 @@ spec:
                   and scheduling strategy of temporary recovery pod.
                 properties:
                   dataSourceRef:
-                    description: Specifies the configuration when using `persistentVolumeClaim.spec.dataSourceRef`
+                    description: "Specifies the configuration when using `persistentVolumeClaim.spec.dataSourceRef`
                       method for restoring. Describes the source volume of the backup
                       targetVolumes and the mount path in the restoring container.
+                      \n TODO +kubebuilder:validation:XValidation:rule=\"self.volumeSource
+                      != '' || self.mountPath !=''\",message=\"at least one exists
+                      for volumeSource and mountPath.\" TODO +kubebuilder:validation:XValidation:rule=\"self
+                      == oldSelf\",message=\"forbidden to update spec.prepareDataConfig.dataSourceRef\""
                     properties:
                       mountPath:
                         description: Specifies the path within the restoring container
@@ -273,11 +276,6 @@ spec:
                           required if the backup uses a volume snapshot.
                         type: string
                     type: object
-                    x-kubernetes-validations:
-                    - message: at least one exists for volumeSource and mountPath.
-                      rule: self.volumeSource != '' || self.mountPath !=''
-                    - message: forbidden to update spec.prepareDataConfig.dataSourceRef
-                      rule: self == oldSelf
                   requiredPolicyForAllPodSelection:
                     description: Specifies the restore policy, which is required when
                       the pod selection strategy for the source target is 'All'. This
@@ -309,7 +307,9 @@ spec:
                     - dataRestorePolicy
                     type: object
                   schedulingSpec:
-                    description: Specifies the scheduling spec for the restoring pod.
+                    description: "Specifies the scheduling spec for the restoring
+                      pod. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                      == oldSelf\",message=\"forbidden to update spec.prepareDataConfig.schedulingSpec\""
                     properties:
                       affinity:
                         description: Contains a group of affinity scheduling rules.
@@ -1466,9 +1466,6 @@ spec:
                           type: object
                         type: array
                     type: object
-                    x-kubernetes-validations:
-                    - message: forbidden to update spec.prepareDataConfig.schedulingSpec
-                      rule: self == oldSelf
                   volumeClaimRestorePolicy:
                     default: Parallel
                     description: "Defines restore policy for persistent volume claim.
@@ -1481,9 +1478,11 @@ spec:
                     - Serial
                     type: string
                   volumeClaims:
-                    description: Defines the persistent Volume claims that need to
+                    description: "Defines the persistent Volume claims that need to
                       be restored and mounted together into the restore job. These
                       persistent Volume claims will be created if they do not exist.
+                      \n TODO +kubebuilder:validation:XValidation:rule=\"self == oldSelf\",message=\"forbidden
+                      to update spec.prepareDataConfig.volumeClaims\""
                     items:
                       properties:
                         metadata:
@@ -1740,18 +1739,13 @@ spec:
                       - metadata
                       - volumeClaimSpec
                       type: object
-                      x-kubernetes-validations:
-                      - message: at least one exists for volumeSource and mountPath.
-                        rule: self.volumeSource != '' || self.mountPath !=''
                     type: array
-                    x-kubernetes-validations:
-                    - message: forbidden to update spec.prepareDataConfig.volumeClaims
-                      rule: self == oldSelf
                   volumeClaimsTemplate:
-                    description: Defines a template to build persistent Volume claims
+                    description: "Defines a template to build persistent Volume claims
                       that need to be restored. These claims will be created in an
                       orderly manner based on the number of replicas or reused if
-                      they already exist.
+                      they already exist. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                      == oldSelf\",message=\"forbidden to update spec.prepareDataConfig.volumeClaimsTemplate\""
                     properties:
                       replicas:
                         description: Specifies the replicas of persistent volume claim
@@ -2038,22 +2032,19 @@ spec:
                           - metadata
                           - volumeClaimSpec
                           type: object
-                          x-kubernetes-validations:
-                          - message: at least one exists for volumeSource and mountPath.
-                            rule: self.volumeSource != '' || self.mountPath !=''
                         type: array
                     required:
                     - replicas
                     - templates
                     type: object
-                    x-kubernetes-validations:
-                    - message: forbidden to update spec.prepareDataConfig.volumeClaimsTemplate
-                      rule: self == oldSelf
                 required:
                 - volumeClaimRestorePolicy
                 type: object
               readyConfig:
-                description: Configuration for the action of "postReady" phase.
+                description: "Configuration for the action of \"postReady\" phase.
+                  \n TODO +kubebuilder:validation:XValidation:rule=\"has(self.jobAction)
+                  || has(self.execAction)\", message=\"at least one exists for jobAction
+                  and execAction.\""
                 properties:
                   connectionCredential:
                     description: Defines the credential template used to create a
@@ -2341,11 +2332,10 @@ spec:
                     - exec
                     type: object
                 type: object
-                x-kubernetes-validations:
-                - message: at least one exists for jobAction and execAction.
-                  rule: has(self.jobAction) || has(self.execAction)
               resources:
-                description: Restores the specified resources of Kubernetes.
+                description: "Restores the specified resources of Kubernetes. \n TODO
+                  +kubebuilder:validation:XValidation:rule=\"self == oldSelf\",message=\"forbidden
+                  to update spec.resources\""
                 properties:
                   included:
                     description: Restores the specified resources.
@@ -2405,16 +2395,11 @@ spec:
                       type: object
                     type: array
                 type: object
-                x-kubernetes-validations:
-                - message: forbidden to update spec.resources
-                  rule: self == oldSelf
               restoreTime:
-                description: Specifies the point in time for restoring.
+                description: "Specifies the point in time for restoring. \n TODO +kubebuilder:validation:XValidation:rule=\"self
+                  == oldSelf\",message=\"forbidden to update spec.restoreTime\""
                 pattern: ^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$
                 type: string
-                x-kubernetes-validations:
-                - message: forbidden to update spec.restoreTime
-                  rule: self == oldSelf
               serviceAccountName:
                 description: Specifies the service account name needed for recovery
                   pod.

--- a/deploy/helm/crds/extensions.kubeblocks.io_addons.yaml
+++ b/deploy/helm/crds/extensions.kubeblocks.io_addons.yaml
@@ -55,7 +55,9 @@ spec:
           metadata:
             type: object
           spec:
-            description: AddonSpec defines the desired state of an add-on.
+            description: 'AddonSpec defines the desired state of an add-on. TODO +kubebuilder:validation:XValidation:rule="has(self.type)
+              && self.type == ''Helm'' ?  has(self.helm) : !has(self.helm)",message="spec.helm
+              is required when spec.type is Helm, and forbidden otherwise"'
             properties:
               cliPlugins:
                 description: Specifies the CLI plugin installation specifications.
@@ -462,11 +464,6 @@ spec:
                 required:
                 - chartLocationURL
                 type: object
-                x-kubernetes-validations:
-                - message: chartsImage is required when chartLocationURL starts with
-                    'file://'
-                  rule: 'self.chartLocationURL.startsWith(''file://'') ? has(self.chartsImage)
-                    : true'
               install:
                 description: Defines the installation parameters.
                 properties:
@@ -644,10 +641,6 @@ spec:
             - defaultInstallValues
             - type
             type: object
-            x-kubernetes-validations:
-            - message: spec.helm is required when spec.type is Helm, and forbidden
-                otherwise
-              rule: 'has(self.type) && self.type == ''Helm'' ?  has(self.helm) : !has(self.helm)'
           status:
             description: AddonStatus defines the observed state of an add-on.
             properties:


### PR DESCRIPTION
[CRD Validation Rules](https://github.com/kubernetes/enhancements/issues/2876) was introduced in Kubernetes 1.23, then beta in 1.25, then stable in 1.29.
KubeBlocks claims to support Kubernetes 1.22 and above, so either the validation rules should be removed, or bumping up the supported Kubernetes version to 1.23 and above(with `CustomResourceValidationExpressions` feature gate enabled in 1.23 and 1.34).

This PR choses the former option: remove validation rules.