### PR TITLE
chore: force delete target pod during rebuilding instance when spec.force is true

### DIFF
--- a/controllers/apps/operations/rebuild_instance.go
+++ b/controllers/apps/operations/rebuild_instance.go
@@ -658,7 +658,11 @@ func (r rebuildInstanceOpsHandler) rebuildSourcePVCsAndRecreateInstance(reqCtx i
 	}
 	// update progress message and recreate the target instance by deleting it.
 	progressDetail.Message = waitingForInstanceReadyMessage
-	return intctrlutil.BackgroundDeleteObject(cli, reqCtx.Ctx, insHelper.targetPod)
+	var options []client.DeleteOption
+	if opsRequest.Spec.Force {
+		options = append(options, client.GracePeriodSeconds(0))
+	}
+	return intctrlutil.BackgroundDeleteObject(cli, reqCtx.Ctx, insHelper.targetPod, options...)
 }
 
 func (r rebuildInstanceOpsHandler) getRestoredPV(reqCtx intctrlutil.RequestCtx,


### PR DESCRIPTION
when node is down, pod will always deleting due to the kubelet is down. in this case,  users can delete node or force delete pod