### PR TITLE
chore: support to run a opsRequest after the dependent opsRequests are succeed.

### DIFF
--- a/controllers/apps/operations/ops_manager.go
+++ b/controllers/apps/operations/ops_manager.go
@@ -20,14 +20,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package operations
 
 import (
+	"slices"
+	"strings"
 	"sync"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 )
 
@@ -95,6 +99,15 @@ func (opsMgr *OpsManager) Do(reqCtx intctrlutil.RequestCtx, cli client.Client, o
 				// if the opsRequest is in the queue, return
 				return intctrlutil.ResultToP(intctrlutil.Reconciled())
 			}
+		}
+
+		// validate if the dependent ops have been successful
+		if pass, err := opsMgr.validateDependOnSuccessfulOps(reqCtx, cli, opsRes); intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal) {
+			return &ctrl.Result{}, patchValidateErrorCondition(reqCtx.Ctx, cli, opsRes, err.Error())
+		} else if err != nil {
+			return nil, err
+		} else if !pass {
+			return intctrlutil.ResultToP(intctrlutil.Reconciled())
 		}
 		opsDeepCopy := opsRequest.DeepCopy()
 		// save last configuration into status.lastConfiguration
@@ -173,6 +186,49 @@ func (opsMgr *OpsManager) handleOpsCompleted(reqCtx intctrlutil.RequestCtx,
 		return PatchOpsStatus(reqCtx.Ctx, cli, opsRes, appsv1alpha1.OpsCancelledPhase, cancelledCondition)
 	}
 	return PatchOpsStatus(reqCtx.Ctx, cli, opsRes, opsRequestPhase, completedCondition)
+}
+
+// validateDependOnOps validates if the dependent ops have been successful
+func (opsMgr *OpsManager) validateDependOnSuccessfulOps(reqCtx intctrlutil.RequestCtx,
+	cli client.Client,
+	opsRes *OpsResource) (bool, error) {
+	dependentOpsStr := opsRes.OpsRequest.Annotations[constant.OpsDependentOnSuccessfulOpsAnnoKey]
+	if dependentOpsStr == "" {
+		return true, nil
+	}
+	opsNames := strings.Split(dependentOpsStr, ",")
+	for _, opsName := range opsNames {
+		ops := &appsv1alpha1.OpsRequest{}
+		if err := cli.Get(reqCtx.Ctx, client.ObjectKey{Name: opsName, Namespace: opsRes.OpsRequest.Namespace}, ops); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, intctrlutil.NewFatalError(err.Error())
+			}
+			return false, err
+		}
+		var relatedOpsArr []string
+		relatedOpsStr := ops.Annotations[constant.RelatedOpsAnnotationKey]
+		if relatedOpsStr != "" {
+			relatedOpsArr = strings.Split(relatedOpsStr, ",")
+		}
+		if !slices.Contains(relatedOpsArr, opsRes.OpsRequest.Name) {
+			// annotate to the dependent opsRequest
+			relatedOpsArr = append(relatedOpsArr, opsRes.OpsRequest.Name)
+			if ops.Annotations == nil {
+				ops.Annotations = map[string]string{}
+			}
+			ops.Annotations[constant.RelatedOpsAnnotationKey] = strings.Join(relatedOpsArr, ",")
+			if err := cli.Update(reqCtx.Ctx, ops); err != nil {
+				return false, err
+			}
+		}
+		if slices.Contains([]appsv1alpha1.OpsPhase{appsv1alpha1.OpsFailedPhase, appsv1alpha1.OpsCancelledPhase, appsv1alpha1.OpsAbortedPhase}, ops.Status.Phase) {
+			return false, PatchOpsStatus(reqCtx.Ctx, cli, opsRes, appsv1alpha1.OpsCancelledPhase)
+		}
+		if ops.Status.Phase != appsv1alpha1.OpsSucceedPhase {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 func GetOpsManager() *OpsManager {

--- a/controllers/apps/opsrequest_controller.go
+++ b/controllers/apps/opsrequest_controller.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"math"
 	"reflect"
+	"strings"
 	"time"
 
 	"golang.org/x/exp/slices"
@@ -175,10 +176,12 @@ func (r *OpsRequestReconciler) handleOpsRequestByPhase(reqCtx intctrlutil.Reques
 		return r.reconcileStatusDuringRunningOrCanceling(reqCtx, opsRes)
 	case appsv1alpha1.OpsSucceedPhase:
 		return r.handleSucceedOpsRequest(reqCtx, opsRes.OpsRequest)
-	case appsv1alpha1.OpsFailedPhase, appsv1alpha1.OpsCancelledPhase:
+	default:
+		if err := r.annotateRelatedOps(reqCtx, opsRes.OpsRequest); err != nil {
+			return intctrlutil.ResultToP(intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, ""))
+		}
 		return intctrlutil.ResultToP(intctrlutil.Reconciled())
 	}
-	return intctrlutil.ResultToP(intctrlutil.Reconciled())
 }
 
 // handleCancelSignal handles the cancel signal for opsRequest.
@@ -218,6 +221,9 @@ func (r *OpsRequestReconciler) handleCancelSignal(reqCtx intctrlutil.RequestCtx,
 
 // handleSucceedOpsRequest the opsRequest will be deleted after one hour when status.phase is Succeed
 func (r *OpsRequestReconciler) handleSucceedOpsRequest(reqCtx intctrlutil.RequestCtx, opsRequest *appsv1alpha1.OpsRequest) (*ctrl.Result, error) {
+	if err := r.annotateRelatedOps(reqCtx, opsRequest); err != nil {
+		return intctrlutil.ResultToP(intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, ""))
+	}
 	if err := r.deleteExternalJobs(reqCtx.Ctx, opsRequest); err != nil {
 		return intctrlutil.ResultToP(intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, ""))
 	}
@@ -485,6 +491,35 @@ func (r *OpsRequestReconciler) deleteCreatedPodsInKBNamespace(reqCtx intctrlutil
 	}
 	for i := range podList.Items {
 		if err := intctrlutil.BackgroundDeleteObject(r.Client, reqCtx.Ctx, &podList.Items[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// annotateRelatedOps annotates the related opsRequests to reconcile.
+func (r *OpsRequestReconciler) annotateRelatedOps(reqCtx intctrlutil.RequestCtx, opsRequest *appsv1alpha1.OpsRequest) error {
+	relatedOpsStr := opsRequest.Annotations[constant.RelatedOpsAnnotationKey]
+	if relatedOpsStr == "" {
+		return nil
+	}
+	relatedOpsNames := strings.Split(relatedOpsStr, ",")
+	for _, opsName := range relatedOpsNames {
+		relatedOps := &appsv1alpha1.OpsRequest{}
+		if err := r.Client.Get(reqCtx.Ctx, client.ObjectKey{Name: opsName, Namespace: opsRequest.Namespace}, relatedOps); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return err
+		}
+		if relatedOps.Annotations[constant.ReconcileAnnotationKey] == opsRequest.ResourceVersion {
+			continue
+		}
+		if relatedOps.Annotations == nil {
+			relatedOps.Annotations = map[string]string{}
+		}
+		relatedOps.Annotations[constant.ReconcileAnnotationKey] = opsRequest.ResourceVersion
+		if err := r.Client.Update(reqCtx.Ctx, relatedOps); err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	}

--- a/pkg/constant/annotations.go
+++ b/pkg/constant/annotations.go
@@ -44,6 +44,8 @@ const (
 	LastRoleSnapshotVersionAnnotationKey     = "apps.kubeblocks.io/last-role-snapshot-version"
 	ComponentScaleInAnnotationKey            = "apps.kubeblocks.io/component-scale-in" // ComponentScaleInAnnotationKey specifies whether the component is scaled in
 	DisableHAAnnotationKey                   = "kubeblocks.io/disable-ha"
+	OpsDependentOnSuccessfulOpsAnnoKey       = "ops.kubeblocks.io/dependent-on-successful-ops" // OpsDependentOnSuccessfulOpsAnnoKey wait for the dependent ops to succeed before executing the current ops. If it fails, this ops will also fail.
+	RelatedOpsAnnotationKey                  = "ops.kubeblocks.io/related-ops"
 )
 
 // annotations for multi-cluster


### PR DESCRIPTION
Sometimes, due to the asynchronous nature of coordination, even if multiple opsRequests are created in sequence, the final execution order may still be inconsistent. To ensure order, add  annotation  `ops.kubeblocks.io/dependent-on-successful-ops ` to solve this problem.