### PR TITLE
feat: support instanceset scale subresource to fit PDB

### DIFF
--- a/apis/workloads/v1alpha1/instanceset_types.go
+++ b/apis/workloads/v1alpha1/instanceset_types.go
@@ -405,6 +405,7 @@ type InstanceSetStatus struct {
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
 // +kubebuilder:resource:categories={kubeblocks,all},shortName=its
 // +kubebuilder:printcolumn:name="LEADER",type="string",JSONPath=".status.membersStatus[?(@.role.isLeader==true)].podName",description="leader instance name."
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.readyReplicas",description="ready replicas."

--- a/config/crd/bases/workloads.kubeblocks.io_instancesets.yaml
+++ b/config/crd/bases/workloads.kubeblocks.io_instancesets.yaml
@@ -12506,4 +12506,7 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}

--- a/deploy/helm/crds/workloads.kubeblocks.io_instancesets.yaml
+++ b/deploy/helm/crds/workloads.kubeblocks.io_instancesets.yaml
@@ -12506,4 +12506,7 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}


### PR DESCRIPTION
Not all [voluntary disruptions](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#:~:text=call%20other%20cases-,voluntary%20disruptions,-.%20These%20include%20both) are constrained by Pod Disruption Budgets. From my testing, It only works when using `kubectl drain <node-name>` to drain the node that hosts target pods.