### PR TITLE
fix: mysql/wesql has no slow log (#7823)

### DIFF
--- a/pkg/controller/component/synthesize_component.go
+++ b/pkg/controller/component/synthesize_component.go
@@ -181,6 +181,7 @@ func buildSynthesizedComponent(reqCtx intctrlutil.RequestCtx,
 		Stop:                   comp.Spec.Stop,
 		PodManagementPolicy:    compDef.Spec.PodManagementPolicy,
 		PodUpdatePolicy:        comp.Spec.PodUpdatePolicy,
+		EnabledLogs:            comp.Spec.EnabledLogs,
 	}
 
 	// build backward compatible fields, including workload, services, componentRefEnvs, clusterDefName, clusterCompDefName, and clusterCompVer, etc.

--- a/pkg/controller/component/type.go
+++ b/pkg/controller/component/type.go
@@ -80,4 +80,5 @@ type SynthesizedComponent struct {
 	CharacterType         string                          `json:"characterType,omitempty"`
 	HorizontalScalePolicy *v1alpha1.HorizontalScalePolicy `json:"horizontalScalePolicy,omitempty"`
 	VolumeTypes           []v1alpha1.VolumeTypeSpec       `json:"volumeTypes,omitempty"` // The VolumeTypes will be replaced with Volumes in the future.
+	EnabledLogs           []string                        `json:"enabledLogs,omitempty"`
 }


### PR DESCRIPTION
fix enterprise repo bug: 5124 and 5288
Log-related configuration rendering depends on this field enabledLogs.