### PR TITLE
chore: adjust port name to number port (#7804)

### DIFF
--- a/pkg/common/monitor.go
+++ b/pkg/common/monitor.go
@@ -60,7 +60,7 @@ func getPortNumberFromContainer(portName string, container *corev1.Container) st
 func FromContainerPort(exporter Exporter, container *corev1.Container) string {
 	convertPort := func(port intstr.IntOrString) string {
 		switch {
-		case port.StrVal == "":
+		case port.StrVal != "":
 			return getPortNumberFromContainer(exporter.TargetPort.StrVal, container)
 		case port.IntVal != 0:
 			return strconv.Itoa(int(exporter.TargetPort.IntVal))
@@ -72,6 +72,7 @@ func FromContainerPort(exporter Exporter, container *corev1.Container) string {
 	if exporter.ScrapePort != "" {
 		return getPortNumberFromContainer(exporter.ScrapePort, container)
 	}
+	// handle monitor.exporter in ComponentDefinition for compatibility with previous versions.
 	if exporter.TargetPort != nil {
 		return convertPort(*exporter.TargetPort)
 	}

--- a/pkg/common/monitor.go
+++ b/pkg/common/monitor.go
@@ -17,7 +17,10 @@ limitations under the License.
 package common
 
 import (
+	"strconv"
+
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
 )
@@ -41,15 +44,39 @@ func FromScrapePath(exporter appsv1alpha1.Exporter) string {
 	return defaultScrapePath
 }
 
-func FromContainerPort(exporter Exporter, container *corev1.Container) string {
-	if exporter.ScrapePort != "" {
-		return exporter.ScrapePort
+func getPortNumberFromContainer(portName string, container *corev1.Container) string {
+	if container == nil || portName == "" {
+		return portName
 	}
-	if container != nil && len(container.Ports) > 0 {
-		return container.Ports[0].Name
+	for _, port := range container.Ports {
+		if port.Name == portName {
+			return strconv.Itoa(int(port.ContainerPort))
+		}
+	}
+	// Compatible with number ports.
+	return portName
+}
+
+func FromContainerPort(exporter Exporter, container *corev1.Container) string {
+	convertPort := func(port intstr.IntOrString) string {
+		switch {
+		case port.StrVal == "":
+			return getPortNumberFromContainer(exporter.TargetPort.StrVal, container)
+		case port.IntVal != 0:
+			return strconv.Itoa(int(exporter.TargetPort.IntVal))
+		default:
+			return ""
+		}
+	}
+
+	if exporter.ScrapePort != "" {
+		return getPortNumberFromContainer(exporter.ScrapePort, container)
 	}
 	if exporter.TargetPort != nil {
-		return exporter.TargetPort.String()
+		return convertPort(*exporter.TargetPort)
+	}
+	if container != nil && len(container.Ports) > 0 {
+		return strconv.Itoa(int(container.Ports[0].ContainerPort))
 	}
 	return ""
 }

--- a/pkg/common/monitor_test.go
+++ b/pkg/common/monitor_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright (C) 2022-2024 ApeCloud Co., Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
+)
+
+func TestFromContainerPort(t *testing.T) {
+	container := &corev1.Container{
+		Name: "metrics",
+		Ports: []corev1.ContainerPort{
+			{
+				Name:          "http",
+				ContainerPort: 8080,
+			},
+		},
+	}
+
+	type args struct {
+		exporter  Exporter
+		container *corev1.Container
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{{
+		name: "port name",
+		args: args{
+			exporter: Exporter{
+				Exporter: appsv1alpha1.Exporter{
+					ContainerName: "metrics",
+					ScrapePath:    "/metrics",
+					ScrapePort:    "http",
+				},
+			},
+			container: container,
+		},
+		want: "8080",
+	}, {
+		name: "port number",
+		args: args{
+			exporter: Exporter{
+				Exporter: appsv1alpha1.Exporter{
+					ContainerName: "metrics",
+					ScrapePath:    "/metrics",
+					ScrapePort:    "8080",
+				},
+			},
+			container: container,
+		},
+		want: "8080",
+	}, {
+		name: "empty port test",
+		args: args{
+			exporter: Exporter{
+				Exporter: appsv1alpha1.Exporter{
+					ContainerName: "metrics",
+					ScrapePath:    "/metrics",
+				},
+			},
+			container: container,
+		},
+		want: "8080",
+	}, {
+		name: "compatible with port name",
+		args: args{
+			exporter: Exporter{
+				TargetPort: func() *intstr.IntOrString {
+					r := intstr.FromString("http")
+					return &r
+				}(),
+			},
+			container: container,
+		},
+		want: "8080",
+	}, {
+		name: "compatible with port number",
+		args: args{
+			exporter: Exporter{
+				TargetPort: func() *intstr.IntOrString {
+					r := intstr.FromInt32(8080)
+					return &r
+				}(),
+			},
+			container: container,
+		},
+		want: "8080",
+	}, {
+		name: "invalid port",
+		args: args{exporter: Exporter{}},
+		want: "",
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FromContainerPort(tt.args.exporter, tt.args.container); got != tt.want {
+				t.Errorf("FromContainerPort() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The capture execution process of prometheus is as follows: 
1. Obtain Endpoints and Generate Service List:
```
  for ip in addresses
    for port in ports; 
      services = append(services, ip:port)
```
2. Address Conversion Based on Relabeling Strategy:
```
 - source_labels: [__address__, __meta_kubernetes_service_annotation_monitor_kubeblocks_io_port] 
   action: replace target_label: __address__ 
   regex: (.+?)(?::\d+)?;(\d+) 
   replacement: $1:$2 
```
3. Deduplicate Services After Transformation

If the relabeling step fails, it will be bypassed, causing the deduplication logic to be invalid, and as a result, all ports will be scraped.