### PR TITLE
chore: remove monitor from cmpdHash function

### DIFF
--- a/controllers/apps/componentdefinition_controller.go
+++ b/controllers/apps/componentdefinition_controller.go
@@ -435,7 +435,6 @@ func (r *ComponentDefinitionReconciler) cmpdHash(cmpd *appsv1alpha1.ComponentDef
 	// reset all mutable fields
 	objCopy.Spec.Provider = ""
 	objCopy.Spec.Description = ""
-	objCopy.Spec.Monitor = nil
 	objCopy.Spec.Exporter = nil
 	objCopy.Spec.PodManagementPolicy = nil
 


### PR DESCRIPTION
Remove the reference to the monitor field in the cmpdHash function, and also fix the staticcheck failure introduced by the https://github.com/apecloud/kubeblocks/pull/7766.