### PR TITLE
fix: cluster always is deleting

### DIFF
--- a/controllers/apps/transformer_cluster_deletion.go
+++ b/controllers/apps/transformer_cluster_deletion.go
@@ -154,6 +154,7 @@ func kindsForHalt() ([]client.ObjectList, []client.ObjectList) {
 	namespacedKinds, nonNamespacedKinds := kindsForDoNotTerminate()
 	namespacedKindsPlus := []client.ObjectList{
 		&appsv1alpha1.ComponentList{},
+		&appsv1alpha1.OpsRequestList{},
 		&appsv1.StatefulSetList{},           // be compatible with 0.6 workloads.
 		&policyv1.PodDisruptionBudgetList{}, // be compatible with 0.6 workloads.
 		&corev1.ServiceList{},


### PR DESCRIPTION
cluster always is deleting when existing a opsRequest which mounts the pvc of instance