### PR TITLE
Chore: support leave member by using any pods

### DIFF
--- a/apis/apps/v1alpha1/componentdefinition_types.go
+++ b/apis/apps/v1alpha1/componentdefinition_types.go
@@ -758,6 +758,21 @@ type ExecAction struct {
 	// +optional
 	MatchingKey string `json:"matchingKey,omitempty"`
 
+	// Defines whether to retry the action call on another pod when an error occurs during the action call on the pods selected by the targetPodSelector.
+	// If error occurs during the retry, it won't retry recursively.
+	// This field is invalid when the pod selector is set to "All" or "Role."
+	// The specific pod chosen for retry depends on the actions:
+	//
+	// - With the "member leave" action, the selected pod will remain the same as long as the cluster remains unchanged,
+	//   ensuring that the action is not executed simultaneously by multiple different pods.
+	//
+	// This field cannot be updated.
+	//
+	// Note: This field is reserved for future use and is not currently active.
+	//
+	// +optional
+	RetryByAnotherPod bool `json:"RetryByAnotherPod,omitempty"`
+
 	// Defines the name of the container within the target Pod where the action will be executed.
 	//
 	// This name must correspond to one of the containers defined in `componentDefinition.spec.runtime`.

--- a/controllers/apps/component_controller.go
+++ b/controllers/apps/component_controller.go
@@ -21,6 +21,7 @@ package apps
 
 import (
 	"context"
+	"github.com/apecloud/kubeblocks/pkg/controller/component/lifecycle"
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -204,6 +205,12 @@ func (r *ComponentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ComponentReconciler) SetupWithManager(mgr ctrl.Manager, multiClusterMgr multicluster.Manager) error {
+	// todo should this code move to other places?
+	err := lifecycle.InitConfigMapForMemberLeave(context.Background(), r.Client)
+	if err != nil {
+		return err
+	}
+
 	retryDurationMS := viper.GetInt(constant.CfgKeyCtrlrReconcileRetryDurationMS)
 	if retryDurationMS != 0 {
 		requeueDuration = time.Millisecond * time.Duration(retryDurationMS)

--- a/pkg/controller/component/lifecycle/lfa_account.go
+++ b/pkg/controller/component/lifecycle/lfa_account.go
@@ -31,8 +31,10 @@ type accountProvision struct {
 
 var _ lifecycleAction = &accountProvision{}
 
+const AccountProvisionName = "accountProvision"
+
 func (a *accountProvision) name() string {
-	return "accountProvision"
+	return AccountProvisionName
 }
 
 func (a *accountProvision) parameters(ctx context.Context, cli client.Reader) (map[string]string, error) {

--- a/pkg/controller/component/lifecycle/lfa_component.go
+++ b/pkg/controller/component/lifecycle/lfa_component.go
@@ -33,8 +33,10 @@ type postProvision struct {
 
 var _ lifecycleAction = &postProvision{}
 
+const PostProvisionName = "postProvision"
+
 func (a *postProvision) name() string {
-	return "postProvision"
+	return PostProvisionName
 }
 
 func (a *postProvision) parameters(ctx context.Context, cli client.Reader) (map[string]string, error) {
@@ -49,8 +51,10 @@ type preTerminate struct {
 
 var _ lifecycleAction = &preTerminate{}
 
+const PreTerminate = "preTerminate"
+
 func (a *preTerminate) name() string {
-	return "preTerminate"
+	return PreTerminate
 }
 
 func (a *preTerminate) parameters(ctx context.Context, cli client.Reader) (map[string]string, error) {

--- a/pkg/controller/component/lifecycle/lfa_data.go
+++ b/pkg/controller/component/lifecycle/lfa_data.go
@@ -29,8 +29,10 @@ type dataDump struct{}
 
 var _ lifecycleAction = &dataDump{}
 
+const DataDumpName = "dataDump"
+
 func (a *dataDump) name() string {
-	return "dataDump"
+	return DataDumpName
 }
 
 func (a *dataDump) parameters(ctx context.Context, cli client.Reader) (map[string]string, error) {
@@ -41,8 +43,10 @@ type dataLoad struct{}
 
 var _ lifecycleAction = &dataLoad{}
 
+const DataLoadName = "dataLoad"
+
 func (a *dataLoad) name() string {
-	return "dataLoad"
+	return DataLoadName
 }
 
 func (a *dataLoad) parameters(ctx context.Context, cli client.Reader) (map[string]string, error) {

--- a/pkg/controller/component/lifecycle/lfa_member.go
+++ b/pkg/controller/component/lifecycle/lfa_member.go
@@ -21,9 +21,19 @@ package lifecycle
 
 import (
 	"context"
-
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	kbacli "github.com/apecloud/kubeblocks/pkg/kbagent/client"
+	"github.com/apecloud/kubeblocks/pkg/kbagent/proto"
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+	"sync"
 
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 )
@@ -42,8 +52,10 @@ type memberJoin struct {
 
 var _ lifecycleAction = &memberJoin{}
 
+const MemberJoinName = "memberJoin"
+
 func (a *memberJoin) name() string {
-	return "memberJoin"
+	return MemberJoinName
 }
 
 func (a *memberJoin) parameters(ctx context.Context, cli client.Reader) (map[string]string, error) {
@@ -64,8 +76,10 @@ type memberLeave struct {
 
 var _ lifecycleAction = &memberLeave{}
 
+const MemberLeaveName = "memberLeave"
+
 func (a *memberLeave) name() string {
-	return "memberLeave"
+	return MemberLeaveName
 }
 
 func (a *memberLeave) parameters(ctx context.Context, cli client.Reader) (map[string]string, error) {
@@ -77,4 +91,141 @@ func (a *memberLeave) parameters(ctx context.Context, cli client.Reader) (map[st
 		leaveMemberPodFQDNVar: component.PodFQDN(a.synthesizedComp.Namespace, a.synthesizedComp.FullCompName, a.pod.Name),
 		leaveMemberPodNameVar: a.pod.Name,
 	}, nil
+}
+
+// todo should modify request?
+const RetryMemberLeaveByAnotherPodParamCli = "retryMemberLeaveByAnotherPodParamCli"
+
+func retryMemberLeaveByAnotherPod(ctx context.Context, allPods []*corev1.Pod, podToLeave *corev1.Pod, req *proto.ActionRequest, cli *client.Client) error {
+	podToRetry, err := getPodToRetryForMemberLeave(allPods, podToLeave, cli)
+	if err != nil {
+		return err
+	}
+
+	podCli, cliErr := kbacli.NewClient(*podToRetry)
+	if cliErr != nil {
+		return cliErr
+	}
+
+	if podCli == nil {
+		return fmt.Errorf("podToRetry %s cli is err", podToRetry.Name)
+	}
+
+	_, actionErr := podCli.CallAction(ctx, *req)
+
+	return actionErr
+}
+
+// todo is hardcode ok for namespace?
+const MemberLeaveCMNamespace = "kb-system"
+const MemberLeaveCMName = "kb-component-member-leave"
+
+func getPodToRetryForMemberLeave(allPods []*corev1.Pod, podToLeave *corev1.Pod, cli *client.Client) (*corev1.Pod, error) {
+	retryPodName := ""
+
+	cmData, err := GetConfigMapData(*cli, MemberLeaveCMNamespace, MemberLeaveCMName)
+	if err != nil {
+		return nil, err
+	}
+
+	retryPodName, exists := cmData[podToLeave.Name]
+
+	if !exists {
+		idx := HashAndModSHA256(podToLeave.Name, len(allPods))
+		cmData[podToLeave.Name] = allPods[idx].Name
+		retryPodName = allPods[idx].Name
+		err2 := SetConfigMapData(*cli, MemberLeaveCMNamespace, MemberLeaveCMName, cmData)
+		if err2 != nil {
+			return nil, err2
+		}
+	}
+
+	for _, pod := range allPods {
+		if pod.Name == retryPodName {
+			return pod, nil
+		}
+	}
+
+	return nil, errors.New("can't get pod to retry for member leave")
+}
+
+var leaveMemberCMMutex = &sync.Mutex{}
+
+// todo move this code to other place
+// todo should we use a global mutex?
+func CreateConfigMap(ctx context.Context, cli client.Client, namespace string, name string, data map[string]string) error {
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: data,
+	}
+
+	err := cli.Create(ctx, configMap)
+	if err != nil {
+		return fmt.Errorf("failed to create configmap %s/%s: %v", namespace, name, err)
+	}
+
+	fmt.Printf("ConfigMap %s/%s created successfully.\n", namespace, name)
+	return nil
+}
+
+// todo move this code to other place
+// todo should we use a global mutex?
+func GetConfigMapData(cli client.Client, namespace, name string) (map[string]string, error) {
+	leaveMemberCMMutex.Lock()
+	defer leaveMemberCMMutex.Unlock()
+	ctx := context.Background()
+	configMap := &corev1.ConfigMap{}
+	err := cli.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, configMap)
+	if err != nil {
+		return nil, err
+	}
+	return configMap.Data, nil
+}
+
+// todo move this code to other place
+// todo should we use a global mutex?
+func SetConfigMapData(cli client.Client, namespace, name string, data map[string]string) error {
+	leaveMemberCMMutex.Lock()
+	defer leaveMemberCMMutex.Unlock()
+	ctx := context.Background()
+	configMap := &corev1.ConfigMap{}
+	err := cli.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, configMap)
+	if err != nil {
+		return err
+	}
+
+	configMap.Data = data
+	return cli.Update(ctx, configMap)
+}
+
+func InitConfigMapForMemberLeave(ctx context.Context, cli client.Client) error {
+	err := CreateConfigMap(ctx, cli, MemberLeaveCMNamespace, MemberLeaveCMName, map[string]string{})
+	if err != nil {
+		if strings.Contains(err.Error(), "already exists") {
+			return nil
+		}
+		return fmt.Errorf("failed to create configmap %s/%s: %v", MemberLeaveCMNamespace, MemberLeaveCMName, err)
+	}
+	return nil
+}
+
+// todo move this code to other place
+func HashAndModSHA256(a string, b int) int {
+	hash := sha256.Sum256([]byte(a))
+	hashValue := binary.BigEndian.Uint64(hash[:8])
+	return int(hashValue % uint64(b))
+}
+
+// todo move this code to other place
+func HashAnyToString(input any) (string, error) {
+	jsonData, err := json.Marshal(input)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal input to JSON: %w", err)
+	}
+	hash := sha256.Sum256(jsonData)
+
+	return hex.EncodeToString(hash[:]), nil
 }

--- a/pkg/controller/component/lifecycle/lfa_role.go
+++ b/pkg/controller/component/lifecycle/lfa_role.go
@@ -32,8 +32,10 @@ type switchover struct {
 
 var _ lifecycleAction = &switchover{}
 
+const SwitchoverName = "switchover"
+
 func (a *switchover) name() string {
-	return "switchover"
+	return SwitchoverName
 }
 
 func (a *switchover) parameters(ctx context.Context, cli client.Reader) (map[string]string, error) {


### PR DESCRIPTION
## Background
The background is described in issue: #7753 

## My proposal
The steps to connect to lorry and execute the leave member action are:
1. Obtain the lorry client for the pod.
2. Send the leave member action using this client.

If an error occurs at any step, invoke the leaveMemberByOtherPods process for the pod to leave. This process iterates through all pods intended to be retained during the scale-down process, attempting to use them to evict the problematic pod until successful.

the key point in this solution is to **evict one pod from cluster by any other pod**,  which is almost done in the original KB code of leave action by every database engine, except for ploar db, which is fixed in this PR.
