### PR TITLE
fix: avoid concurrency is 0

### DIFF
--- a/pkg/controller/instanceset/utils.go
+++ b/pkg/controller/instanceset/utils.go
@@ -274,6 +274,7 @@ func CalculateConcurrencyReplicas(concurrency *intstr.IntOrString, replicas int)
 		pValue = replicas - 1
 	}
 
-	pValue = integer.IntMax(integer.IntMin(pValue, replicas), 0)
+	// if the calculated concurrency is 0, it will ensure the concurrency at least 1.
+	pValue = integer.IntMax(integer.IntMin(pValue, replicas), 1)
 	return pValue, nil
 }

--- a/pkg/controller/instanceset/utils_test.go
+++ b/pkg/controller/instanceset/utils_test.go
@@ -248,14 +248,14 @@ var _ = Describe("utils test", func() {
 			replicas = 0
 			concurrencyReplicas, err = CalculateConcurrencyReplicas(concurrent, replicas)
 			Expect(err).Should(BeNil())
-			Expect(concurrencyReplicas).Should(Equal(0))
+			Expect(concurrencyReplicas).Should(Equal(1))
 
 			By("concurrency = 0%, replicas = 10")
 			concurrent = &intstr.IntOrString{Type: intstr.String, StrVal: "0%"}
 			replicas = 10
 			concurrencyReplicas, err = CalculateConcurrencyReplicas(concurrent, replicas)
 			Expect(err).Should(BeNil())
-			Expect(concurrencyReplicas).Should(Equal(0))
+			Expect(concurrencyReplicas).Should(Equal(1))
 
 			By("concurrency = 5, replicas = 10")
 			concurrent = &intstr.IntOrString{Type: intstr.Int, IntVal: 5}
@@ -269,14 +269,14 @@ var _ = Describe("utils test", func() {
 			replicas = 0
 			concurrencyReplicas, err = CalculateConcurrencyReplicas(concurrent, replicas)
 			Expect(err).Should(BeNil())
-			Expect(concurrencyReplicas).Should(Equal(0))
+			Expect(concurrencyReplicas).Should(Equal(1))
 
 			By("concurrency = 0, replicas = 10")
 			concurrent = &intstr.IntOrString{Type: intstr.Int, IntVal: 0}
 			replicas = 10
 			concurrencyReplicas, err = CalculateConcurrencyReplicas(concurrent, replicas)
 			Expect(err).Should(BeNil())
-			Expect(concurrencyReplicas).Should(Equal(0))
+			Expect(concurrencyReplicas).Should(Equal(1))
 
 			By("concurrency = 10%, replicas = 1")
 			concurrent = &intstr.IntOrString{Type: intstr.String, StrVal: "10%"}
@@ -311,7 +311,7 @@ var _ = Describe("utils test", func() {
 			concurrent = &intstr.IntOrString{Type: intstr.String, StrVal: "-50%"}
 			concurrencyReplicas, err = CalculateConcurrencyReplicas(concurrent, replicas)
 			Expect(err).Should(BeNil())
-			Expect(concurrencyReplicas).Should(Equal(0))
+			Expect(concurrencyReplicas).Should(Equal(1))
 
 			By("concurrency percentage > 100%")
 			replicas = 10


### PR DESCRIPTION
resolve https://github.com/apecloud/kubeblocks/issues/7893