### PR TITLE
fix: when ParallelPodManagementConcurrency is nil, scaling down to 0 fails

### DIFF
--- a/pkg/controller/instanceset/utils.go
+++ b/pkg/controller/instanceset/utils.go
@@ -260,7 +260,7 @@ func GetPodNameSetFromInstanceSetCondition(its *workloads.InstanceSet, condition
 // if concurrency is nil, concurrency will be treated as 100%.
 func CalculateConcurrencyReplicas(concurrency *intstr.IntOrString, replicas int) (int, error) {
 	if concurrency == nil {
-		return replicas, nil
+		return integer.IntMax(replicas, 1), nil
 	}
 
 	// 'roundUp=true' will ensure at least 1 pod is reserved if concurrency > "0%" and replicas > 0.

--- a/pkg/controller/instanceset/utils_test.go
+++ b/pkg/controller/instanceset/utils_test.go
@@ -335,6 +335,20 @@ var _ = Describe("utils test", func() {
 			concurrencyReplicas, err = CalculateConcurrencyReplicas(concurrent, replicas)
 			Expect(err).Should(BeNil())
 			Expect(concurrencyReplicas).Should(Equal(10))
+
+			By("concurrent is nil, replicas = 10")
+			replicas = 10
+			concurrent = nil
+			concurrencyReplicas, err = CalculateConcurrencyReplicas(concurrent, replicas)
+			Expect(err).Should(BeNil())
+			Expect(concurrencyReplicas).Should(Equal(10))
+
+			By("concurrent is nil, replicas = 0")
+			replicas = 0
+			concurrent = nil
+			concurrencyReplicas, err = CalculateConcurrencyReplicas(concurrent, replicas)
+			Expect(err).Should(BeNil())
+			Expect(concurrencyReplicas).Should(Equal(1))
 		})
 	})
 })


### PR DESCRIPTION
resolve #7947 