### PR TITLE
docs: Align case for Maintenance label

### DIFF
--- a/docs/user_docs/maintenance/_category_.yaml
+++ b/docs/user_docs/maintenance/_category_.yaml
@@ -1,4 +1,4 @@
 position: 5
-label: maintenance
+label: Maintenance
 collapsible: true 
 collapsed: true


### PR DESCRIPTION
All other labels are in "Title case".