### PR TITLE
chore: fix helm invalid null values

### DIFF
--- a/deploy/helm/templates/applications/apecloud-otel-collector-addon.yaml
+++ b/deploy/helm/templates/applications/apecloud-otel-collector-addon.yaml
@@ -25,11 +25,8 @@ spec:
           key: values-kubeblocks-override.yaml
 
     valuesMapping:
-      valueMap:
-
       jsonMap:
         tolerations: tolerations
-
       resources:
         cpu:
           requests: resources.requests.cpu

--- a/deploy/helm/templates/applications/csi-driver-nfs-addon.yaml
+++ b/deploy/helm/templates/applications/csi-driver-nfs-addon.yaml
@@ -19,20 +19,21 @@ spec:
     {{- include "kubeblocks.addonChartsImage" . | indent 4 }}
     {{- include "kubeblocks.addonHelmInstallOptions" (dict "version" "4.5.0" "values" .Values) | indent 4 }}
 
+    {{- $cloudProvider := (include "kubeblocks.cloudProvider" .) }}
+    {{- if eq $cloudProvider "huaweiCloud" }}
     installValues:
-      {{- $cloudProvider := (include "kubeblocks.cloudProvider" .) }}
-      {{- if eq $cloudProvider "huaweiCloud" }}
       setValues:
         - kubeletDir=/mnt/paas/kubernetes/kubelet
-      {{- else if eq $cloudProvider "gcp" }}
+    {{- else if eq $cloudProvider "gcp" }}
       # In GKE, the system-node-critical and system-cluster-critical priority classes
       # can't be used for non-system pods, but csi-driver-nfs uses "system-cluster-critical"
       # by default, so override them here.
+    installValues:
       setValues:
         - controller.priorityClassName=""
         - node.priorityClassName=""
         - externalSnapshotter.priorityClassName=""
-      {{- end }}
+     {{- end }}
 
     valuesMapping:
       valueMap:

--- a/deploy/helm/templates/applications/grafana-addon.yaml
+++ b/deploy/helm/templates/applications/grafana-addon.yaml
@@ -44,7 +44,6 @@ spec:
 
   defaultInstallValues:
     - replicas: 1
-      storageClass:
       resources:
         requests:
           storage: 1Gi

--- a/deploy/helm/templates/applications/loki-addon.yaml
+++ b/deploy/helm/templates/applications/loki-addon.yaml
@@ -38,7 +38,6 @@ spec:
 
   defaultInstallValues:
     - replicas: 1
-      storageClass:
       resources:
         requests:
           storage: 8Gi


### PR DESCRIPTION

* fix https://github.com/apecloud/kubeblocks/issues/8019

Test:

```shell
$ helm template kubeblocks ./helm |kubectl apply -f - --server-side=true --dry-run=server
serviceaccount/kubeblocks serverside-applied (server dry run)
serviceaccount/kubeblocks-addon-installer serverside-applied (server dry run)
serviceaccount/kubeblocks-dataprotection-exec-worker serverside-applied (server dry run)
secret/kubeblocks-secret serverside-applied (server dry run)
configmap/alertmanager-webhook-adaptor-chart-kubeblocks-values serverside-applied (server dry run)
configmap/apecloud-otel-collector-chart-kubeblocks-values serverside-applied (server dry run)
configmap/aws-load-balancer-controller-chart-kubeblocks-values serverside-applied (server dry run)
configmap/csi-hostpath-driver-chart-kubeblocks-values serverside-applied (server dry run)
configmap/grafana-chart-kubeblocks-values serverside-applied (server dry run)
configmap/loki-chart-kubeblocks-values serverside-applied (server dry run)
configmap/prometheus-chart-kubeblocks-values serverside-applied (server dry run)
configmap/snapshot-controller-chart-kubeblocks-values serverside-applied (server dry run)
configmap/victoria-metrics-agent-chart-kubeblocks-values serverside-applied (server dry run)
configmap/kubeblocks-manager-config serverside-applied (server dry run)
configmap/kubeblocks-host-ports serverside-applied (server dry run)
configmap/kubeblocks-grafana-datasource serverside-applied (server dry run)
configmap/kb-addon-prometheus-alertmanager-config serverside-applied (server dry run)
configmap/kb-addon-alertmanager-webhook-adaptor-config serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-backuppolicytemplate-editor-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-backuppolicytemplate-viewer-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-cluster-editor-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-cluster-viewer-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-clusterdefinition-editor-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-clusterdefinition-viewer-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-configconstraint-editor-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-configconstraint-viewer-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-metrics-reader serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-proxy-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-cluster-pod-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-lorry-pod-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-patroni-pod-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-backup-pod-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-volume-protection-pod-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-manager-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-dataprotection-worker-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-backup-editor-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-backup-viewer-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-backuppolicy-editor-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-backuppolicy-viewer-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-dataprotection-exec-worker-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-restore-editor-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-restore-viewer-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-nodecountscaler-editor-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-nodecountscaler-viewer-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-editor-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-viewer-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-opsrequest-editor-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-opsrequest-viewer-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-rbac-manager-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-instanceset-editor-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-instanceset-viewer-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-replicatedstatemachine-editor-role serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-replicatedstatemachine-viewer-role serverside-applied (server dry run)
clusterrolebinding.rbac.authorization.k8s.io/kubeblocks-proxy-rolebinding serverside-applied (server dry run)
clusterrolebinding.rbac.authorization.k8s.io/kubeblocks serverside-applied (server dry run)
clusterrolebinding.rbac.authorization.k8s.io/kubeblocks-cluster-admin serverside-applied (server dry run)
clusterrolebinding.rbac.authorization.k8s.io/kubeblocks-dataprotection-exec-worker-rolebinding serverside-applied (server dry run)
role.rbac.authorization.k8s.io/kubeblocks-leader-election-role serverside-applied (server dry run)
rolebinding.rbac.authorization.k8s.io/kubeblocks-leader-election-rolebinding serverside-applied (server dry run)
service/kubeblocks serverside-applied (server dry run)
deployment.apps/kubeblocks-dataprotection serverside-applied (server dry run)
deployment.apps/kubeblocks serverside-applied (server dry run)
addon.extensions.kubeblocks.io/apecloud-mysql serverside-applied (server dry run)
addon.extensions.kubeblocks.io/kafka serverside-applied (server dry run)
addon.extensions.kubeblocks.io/llm serverside-applied (server dry run)
addon.extensions.kubeblocks.io/mongodb serverside-applied (server dry run)
addon.extensions.kubeblocks.io/mysql serverside-applied (server dry run)
addon.extensions.kubeblocks.io/postgresql serverside-applied (server dry run)
addon.extensions.kubeblocks.io/pulsar serverside-applied (server dry run)
addon.extensions.kubeblocks.io/qdrant serverside-applied (server dry run)
addon.extensions.kubeblocks.io/redis serverside-applied (server dry run)
addon.extensions.kubeblocks.io/alertmanager-webhook-adaptor serverside-applied (server dry run)
addon.extensions.kubeblocks.io/apecloud-otel-collector serverside-applied (server dry run)
addon.extensions.kubeblocks.io/aws-load-balancer-controller serverside-applied (server dry run)
addon.extensions.kubeblocks.io/kubeblocks-csi-driver serverside-applied (server dry run)
addon.extensions.kubeblocks.io/csi-driver-nfs serverside-applied (server dry run)
addon.extensions.kubeblocks.io/csi-hostpath-driver serverside-applied (server dry run)
addon.extensions.kubeblocks.io/grafana serverside-applied (server dry run)
addon.extensions.kubeblocks.io/loki serverside-applied (server dry run)
addon.extensions.kubeblocks.io/prometheus serverside-applied (server dry run)
addon.extensions.kubeblocks.io/snapshot-controller serverside-applied (server dry run)
addon.extensions.kubeblocks.io/victoria-metrics-agent serverside-applied (server dry run)
opsdefinition.apps.kubeblocks.io/switchover serverside-applied (server dry run)
storageprovider.dataprotection.kubeblocks.io/cos serverside-applied (server dry run)
storageprovider.dataprotection.kubeblocks.io/ftp serverside-applied (server dry run)
storageprovider.dataprotection.kubeblocks.io/gcs-s3comp serverside-applied (server dry run)
storageprovider.storage.kubeblocks.io/cos serverside-applied (server dry run)
storageprovider.storage.kubeblocks.io/ftp serverside-applied (server dry run)
storageprovider.storage.kubeblocks.io/gcs-s3comp serverside-applied (server dry run)
storageprovider.storage.kubeblocks.io/minio serverside-applied (server dry run)
storageprovider.storage.kubeblocks.io/nfs serverside-applied (server dry run)
storageprovider.storage.kubeblocks.io/obs serverside-applied (server dry run)
storageprovider.storage.kubeblocks.io/oss serverside-applied (server dry run)
storageprovider.storage.kubeblocks.io/pvc serverside-applied (server dry run)
storageprovider.storage.kubeblocks.io/s3 serverside-applied (server dry run)
storageprovider.dataprotection.kubeblocks.io/minio serverside-applied (server dry run)
storageprovider.dataprotection.kubeblocks.io/nfs serverside-applied (server dry run)
storageprovider.dataprotection.kubeblocks.io/obs serverside-applied (server dry run)
storageprovider.dataprotection.kubeblocks.io/oss serverside-applied (server dry run)
storageprovider.dataprotection.kubeblocks.io/pvc serverside-applied (server dry run)
storageprovider.dataprotection.kubeblocks.io/s3 serverside-applied (server dry run)
clusterrole.rbac.authorization.k8s.io/kubeblocks-helmhook-role serverside-applied (server dry run)

```