### PR TITLE
fix: mongo dump backup failed with incorrect version

### DIFF
--- a/apis/apps/v1alpha1/backuppolicytemplate_types.go
+++ b/apis/apps/v1alpha1/backuppolicytemplate_types.go
@@ -146,6 +146,11 @@ type ValueFrom struct {
 	//
 	// +optional
 	ComponentDef []ValueMapping `json:"componentDef,omitempty"`
+
+	// Determine the appropriate version of the backup tool image from ServiceVersion.
+	//
+	// +optional
+	ServiceVersion []ValueMapping `json:"serviceVersion,omitempty"`
 }
 
 type ValueMapping struct {

--- a/config/crd/bases/apps.kubeblocks.io_backuppolicytemplates.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_backuppolicytemplates.yaml
@@ -268,6 +268,30 @@ spec:
                                         - names
                                         type: object
                                       type: array
+                                    serviceVersion:
+                                      description: Determine the appropriate version
+                                        of the backup tool image from ServiceVersion.
+                                      items:
+                                        properties:
+                                          mappingValue:
+                                            description: Specifies the appropriate
+                                              version of the backup tool image.
+                                            type: string
+                                          names:
+                                            description: |-
+                                              Represents an array of names of ClusterVersion or ComponentDefinition that can be mapped to
+                                              the appropriate version of the backup tool image.
+
+
+                                              This mapping allows different versions of component images to correspond to specific versions of backup tool images.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - mappingValue
+                                        - names
+                                        type: object
+                                      type: array
                                   type: object
                               required:
                               - key

--- a/controllers/apps/transformer_cluster_backup_policy.go
+++ b/controllers/apps/transformer_cluster_backup_policy.go
@@ -468,6 +468,15 @@ func (r *clusterBackupPolicyTransformer) doEnvMapping(comp *appsv1alpha1.Cluster
 				Value: cm.MappingValue,
 			})
 		}
+		for _, sv := range v.ValueFrom.ServiceVersion {
+			if !slices.Contains(sv.Names, comp.ServiceVersion) {
+				continue
+			}
+			env = append(env, corev1.EnvVar{
+				Name:  v.Key,
+				Value: sv.MappingValue,
+			})
+		}
 	}
 	return env
 }

--- a/deploy/helm/crds/apps.kubeblocks.io_backuppolicytemplates.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_backuppolicytemplates.yaml
@@ -268,6 +268,30 @@ spec:
                                         - names
                                         type: object
                                       type: array
+                                    serviceVersion:
+                                      description: Determine the appropriate version
+                                        of the backup tool image from ServiceVersion.
+                                      items:
+                                        properties:
+                                          mappingValue:
+                                            description: Specifies the appropriate
+                                              version of the backup tool image.
+                                            type: string
+                                          names:
+                                            description: |-
+                                              Represents an array of names of ClusterVersion or ComponentDefinition that can be mapped to
+                                              the appropriate version of the backup tool image.
+
+
+                                              This mapping allows different versions of component images to correspond to specific versions of backup tool images.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - mappingValue
+                                        - names
+                                        type: object
+                                      type: array
                                   type: object
                               required:
                               - key

--- a/docs/developer_docs/api-reference/cluster.md
+++ b/docs/developer_docs/api-reference/cluster.md
@@ -22074,6 +22074,20 @@ use the latest available version in ComponentVersion.</p>
 <p>Determine the appropriate version of the backup tool image from ComponentDefinition.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>serviceVersion</code><br/>
+<em>
+<a href="#apps.kubeblocks.io/v1alpha1.ValueMapping">
+[]ValueMapping
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Determine the appropriate version of the backup tool image from ServiceVersion.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="apps.kubeblocks.io/v1alpha1.ValueMapping">ValueMapping


### PR DESCRIPTION
mongodb addon uses a common componentDefinition with different service version, and bpt not supports to mapping the env value to replace image tag with service version. 