### PR TITLE
chore: add exit error code prompt information

### DIFF
--- a/pkg/kbagent/service/command.go
+++ b/pkg/kbagent/service/command.go
@@ -56,7 +56,12 @@ func runCommand(ctx context.Context, action *proto.ExecAction, parameters map[st
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
-			err = errors.Wrap(proto.ErrFailed, string(<-stderrChan))
+			stderrMsg := string(<-stderrChan)
+			if len(stderrMsg) > 0 {
+				err = errors.Wrapf(proto.ErrFailed, "exec exit %d and stderr: %s", exitErr.ExitCode(), stderrMsg)
+			} else {
+				err = errors.Wrapf(proto.ErrFailed, "exec exit %d but stderr is blank", exitErr.ExitCode())
+			}
 		}
 		return nil, err
 	}


### PR DESCRIPTION
Fix the situation of ":failed" caused by exitError and empty []byte obtained in stdErrChan.
Add exit error code prompt information for easy debugging.
![image](https://github.com/user-attachments/assets/00ade966-a3cb-4a4f-8e54-74cfa5009de7)
![image](https://github.com/user-attachments/assets/89f9df07-3869-406e-92e1-96f4f7915c45)
