### PR TITLE
chore: add exit error code prompt information

### DIFF
--- a/pkg/kbagent/service/command.go
+++ b/pkg/kbagent/service/command.go
@@ -56,7 +56,12 @@ func runCommand(ctx context.Context, action *proto.ExecAction, parameters map[st
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
-			err = errors.Wrap(proto.ErrFailed, string(<-stderrChan))
+			stderrMsg := string(<-stderrChan)
+			if len(stderrMsg) > 0 {
+				err = errors.Wrapf(proto.ErrFailed, "exec exit %d and stderr: %s", exitErr.ExitCode(), stderrMsg)
+			} else {
+				err = errors.Wrapf(proto.ErrFailed, "exec exit %d but stderr is blank", exitErr.ExitCode())
+			}
 		}
 		return nil, err
 	}


### PR DESCRIPTION
- Fix the situation of "**：failed**" caused by exitError and empty []byte obtained in stdErrChan.
- Add exit error code prompt information for easy debugging.

![image](https://github.com/user-attachments/assets/8b1a538f-327b-4eed-8b3d-70abd7b10ef6)
![image](https://github.com/user-attachments/assets/75b9fc20-563e-4fbb-ab7d-e0a3621e7b34)
