### PR TITLE
chore: pick update headless svc labels for the prometheus scrape job to release-0.9 (#8088)

### DIFF
--- a/pkg/constant/labels.go
+++ b/pkg/constant/labels.go
@@ -57,6 +57,13 @@ func GetClusterWellKnownLabels(clusterName string) map[string]string {
 	}
 }
 
+// GetKBKnownLabels returns the kb-known labels for the headless svc
+func GetKBKnownLabels() map[string]string {
+	return map[string]string{
+		AppManagedByLabelKey: AppName,
+	}
+}
+
 // GetComponentWellKnownLabels returns the well-known labels for Component API
 func GetComponentWellKnownLabels(clusterName, componentName string) map[string]string {
 	return map[string]string{

--- a/pkg/controller/instanceset/object_builder.go
+++ b/pkg/controller/instanceset/object_builder.go
@@ -54,6 +54,7 @@ func buildHeadlessSvc(its workloads.InstanceSet, labels, selectors map[string]st
 	annotations := ParseAnnotationsOfScope(HeadlessServiceScope, its.Annotations)
 	hdlBuilder := builder.NewHeadlessServiceBuilder(its.Namespace, getHeadlessSvcName(its.Name)).
 		AddLabelsInMap(labels).
+		AddLabelsInMap(constant.GetKBKnownLabels()).
 		AddSelectorsInMap(selectors).
 		AddAnnotationsInMap(annotations).
 		SetPublishNotReadyAddresses(true)


### PR DESCRIPTION
(cherry picked from commit b019f2c8c29b43cbeb601ebe0100ff78e98081a6)