### PR TITLE
fix: exclude dataprotection pods from kb service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,6 +276,10 @@ dataprotection: generate test-go-generate build-checks ## Build dataprotection b
 kbagent: generate test-go-generate build-checks
 	$(GO) build -ldflags=${LD_FLAGS} -o bin/kbagent ./cmd/kbagent/main.go
 
+.PHONY: helmhook
+helmhook:
+	$(GO) build -o bin/helmhook ./cmd/helmhook/main.go
+
 CERT_ROOT_CA ?= $(WEBHOOK_CERT_DIR)/rootCA.key
 .PHONY: webhook-cert
 webhook-cert: $(CERT_ROOT_CA) ## Create root CA certificates for admission webhooks testing.

--- a/cmd/helmhook/hook/prepare.go
+++ b/cmd/helmhook/hook/prepare.go
@@ -28,7 +28,7 @@ const kubeblocksVersionLabelName = "app.kubernetes.io/version"
 func PrepareFor(ctx *UpgradeContext) (err error) {
 	ctx.From, err = getVersionInfo(ctx, ctx.K8sClient, ctx.Namespace)
 
-	Log("kubeblock upgrade: [from: %v --> to: %v]", ctx.From, ctx.To)
+	Log("kubeblocks upgrade: [from: %v --> to: %v]", ctx.From, ctx.To)
 	return
 }
 

--- a/cmd/helmhook/hook/stop.go
+++ b/cmd/helmhook/hook/stop.go
@@ -33,9 +33,9 @@ type StopOperator struct {
 
 func (p *StopOperator) Handle(ctx *UpgradeContext) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if err := stopKubeBlocksDeploy(ctx, ctx.K8sClient, ctx.Namespace, kubeblocksAppComponent, GetKubeBlocksDeploy); err != nil {
+		if err := deleteDeployment(ctx, ctx.K8sClient, ctx.Namespace, kubeblocksAppComponent, GetKubeBlocksDeploy); err != nil {
 			return err
 		}
-		return stopKubeBlocksDeploy(ctx, ctx.K8sClient, ctx.Namespace, dataprotectionAppComponent, GetKubeBlocksDeploy)
+		return deleteDeployment(ctx, ctx.K8sClient, ctx.Namespace, dataprotectionAppComponent, GetKubeBlocksDeploy)
 	})
 }

--- a/cmd/helmhook/hook/utils.go
+++ b/cmd/helmhook/hook/utils.go
@@ -67,7 +67,7 @@ func deleteDeployment(ctx context.Context, client *kubernetes.Clientset, ns, com
 		return err
 	}
 
-	// before delete deployment, out the deployment yaml, if deployment was deleted
+	// before delete deployment, output the deployment yaml, if deployment was deleted
 	// by mistake, we can recover it by apply the yaml.
 	tempDeploy := deploy.DeepCopy()
 	tempDeploy.ManagedFields = nil

--- a/deploy/helm/templates/dataprotection.yaml
+++ b/deploy/helm/templates/dataprotection.yaml
@@ -13,6 +13,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
+      app.kubernetes.io/component: "dataprotection"
       {{- include "kubeblocks.selectorLabels" . | nindent 6 }}
       {{- with .Values.dataProtection.extraLabels }}
         {{- toYaml . | nindent 6 }}
@@ -28,6 +29,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
+        app.kubernetes.io/component: "dataprotection"
         {{- include "kubeblocks.selectorLabels" . | nindent 8 }}
         {{- with .Values.dataProtection.extraLabels }}
           {{- toYaml . | nindent 8 }}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -11,6 +11,7 @@ spec:
   {{- end }}
   selector:
     matchLabels:
+      app.kubernetes.io/component: "apps"
       {{- include "kubeblocks.selectorLabels" . | nindent 6 }}
       {{- with .Values.extraLabels }}
         {{- toYaml . | nindent 6 }}
@@ -26,6 +27,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
+        app.kubernetes.io/component: "apps"
         {{- include "kubeblocks.selectorLabels" . | nindent 8 }}
         {{- with .Values.extraLabels }}
           {{- toYaml . | nindent 8 }}

--- a/deploy/helm/templates/service.yaml
+++ b/deploy/helm/templates/service.yaml
@@ -25,4 +25,5 @@ spec:
       {{- end }}
     {{- end }}
   selector:
+    app.kubernetes.io/component: "apps"
     {{- include "kubeblocks.selectorLabels" . | nindent 4 }}


### PR DESCRIPTION
* fix https://github.com/apecloud/kubeblocks/issues/8091

As follow:
* KubeBlocks and DataProtection deployment use different pod labels
* The KubeBlocks Service only select the KubeBlocks pods
* Delete the deployment when upgrade to avoid the error like https://github.com/apecloud/kubeblocks/issues/7250