### PR TITLE
chore: adjust environment variable append order to ensure env in acti…

### DIFF
--- a/pkg/kbagent/service/command.go
+++ b/pkg/kbagent/service/command.go
@@ -119,10 +119,10 @@ func runCommandX(ctx context.Context, action *proto.ExecAction, parameters map[s
 	}()
 
 	mergedEnv := func() []string {
-		// order: parameters (action specific variables) | os env
+		// order: os env | parameters (action specific variables)
 		env := util.EnvM2L(parameters)
 		if len(env) > 0 {
-			env = append(env, os.Environ()...)
+			env = append(os.Environ(), env...)
 		}
 		return env
 	}()


### PR DESCRIPTION
The following images show the order of `action.parameters` and `os.env` in cmd.env, which may cause the env in the action to be overwritten by environment variables with the same name.

<img width="440" alt="image" src="https://github.com/user-attachments/assets/b9563bb2-d981-49c5-988e-519ec92e7f20">
<img width="368" alt="image" src="https://github.com/user-attachments/assets/abd31a1f-2879-459a-8c09-9f8915810e14">
