### PR TITLE
chore: adjust environment variable append order 

### DIFF
--- a/pkg/kbagent/service/command.go
+++ b/pkg/kbagent/service/command.go
@@ -119,10 +119,10 @@ func runCommandX(ctx context.Context, action *proto.ExecAction, parameters map[s
 	}()
 
 	mergedEnv := func() []string {
-		// order: parameters (action specific variables) | os env
+		// order: os env | parameters (action specific variables)
 		env := util.EnvM2L(parameters)
 		if len(env) > 0 {
-			env = append(env, os.Environ()...)
+			env = append(os.Environ(), env...)
 		}
 		return env
 	}()

--- a/pkg/kbagent/service/command.go
+++ b/pkg/kbagent/service/command.go
@@ -121,17 +121,16 @@ func runCommandX(ctx context.Context, action *proto.ExecAction, parameters map[s
 
 	mergedEnv := func() []string {
 		// order: parameters (action specific variables) | var | action env
-		env := util.EnvM2L(parameters)
-		filterDuplicates := func(env []string, filter func(string) bool) []string {
-			newEnv := make([]string, 0, len(env))
-			for _, e := range env {
+		filterDuplicates := func(osEnv []string, filter func(string) bool) []string {
+			unionEnv := make([]string, 0, len(osEnv))
+			for _, e := range osEnv {
 				if filter(e) {
-					newEnv = append(newEnv, e)
+					unionEnv = append(unionEnv, e)
 				}
 			}
-			return newEnv
+			return unionEnv
 		}
-		env = append(env, filterDuplicates(os.Environ(), func(env string) bool {
+		env := append(util.EnvM2L(parameters), filterDuplicates(os.Environ(), func(env string) bool {
 			kv := strings.Split(env, "=")
 			_, ok := parameters[kv[0]]
 			return !ok


### PR DESCRIPTION

The following images show the order of `req.Parameters` and `os.Environ` in `cmd.Env`, which may cause the env in the action to be overwritten by environment variables with the same name.

<img width="440" alt="image" src="https://github.com/user-attachments/assets/2cd0b086-5242-4301-b319-be2202b4b922">

<img width="368" alt="image" src="https://github.com/user-attachments/assets/8af852f6-6310-4b5b-968d-ba6db5c0e227">
