### PR TITLE
fix: endless affinity list when there's a DataPlaneAffinity

### DIFF
--- a/pkg/controller/scheduling/scheduling_utils.go
+++ b/pkg/controller/scheduling/scheduling_utils.go
@@ -46,9 +46,10 @@ func BuildSchedulingPolicy4Component(clusterName, compName string, affinity *app
 }
 
 func buildSchedulingPolicy(cluster *appsv1alpha1.Cluster, compSpec *appsv1alpha1.ClusterComponentSpec) (*appsv1alpha1.SchedulingPolicy, error) {
-	schedulingPolicy := cluster.Spec.SchedulingPolicy
+	// make a copy, or it will affect cluster's spec
+	schedulingPolicy := cluster.Spec.SchedulingPolicy.DeepCopy()
 	if compSpec != nil && compSpec.SchedulingPolicy != nil {
-		schedulingPolicy = compSpec.SchedulingPolicy
+		schedulingPolicy = compSpec.SchedulingPolicy.DeepCopy()
 	}
 
 	mergeGlobalAffinity := func() error {

--- a/pkg/controller/scheduling/scheduling_utils_test.go
+++ b/pkg/controller/scheduling/scheduling_utils_test.go
@@ -70,7 +70,60 @@ var _ = Describe("affinity utils", func() {
 			compSpec = &clusterObj.Spec.ComponentSpecs[0]
 
 		}
+
+		buildObjsNewAPI = func() {
+			affinity := &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{
+										Key:      labelKey,
+										Operator: corev1.NodeSelectorOpIn,
+										Values:   []string{labelValue},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			schedulingPolocy := appsv1alpha1.SchedulingPolicy{
+				Affinity: affinity,
+			}
+
+			clusterObj = testapps.NewClusterFactory("default", clusterName, "", "").
+				AddComponent(compName, "").
+				SetSchedulingPolicy(schedulingPolocy).
+				GetObject()
+			compSpec = &clusterObj.Spec.ComponentSpecs[0]
+		}
 	)
+
+	Context("with new scheduling policy API", func() {
+		BeforeEach(func() {
+			buildObjsNewAPI()
+		})
+
+		It("should have correct Affinity when data plane affinity is set", func() {
+			viper.Set(constant.CfgKeyDataPlaneAffinity,
+				fmt.Sprintf("{\"nodeAffinity\":{\"preferredDuringSchedulingIgnoredDuringExecution\":[{\"preference\":{\"matchExpressions\":[{\"key\":\"%s\",\"operator\":\"In\",\"values\":[\"true\"]}]},\"weight\":100}]}}", nodeKey))
+			defer viper.Set(constant.CfgKeyDataPlaneAffinity, "")
+
+			originClusteSchedulingPolicy := clusterObj.Spec.SchedulingPolicy.DeepCopy()
+			schedulingPolicy, err := BuildSchedulingPolicy(clusterObj, compSpec)
+			Expect(err).Should(Succeed())
+			Expect(schedulingPolicy).ShouldNot(BeNil())
+			// cluster's scheduling policy should be unchanged
+			Expect(clusterObj.Spec.SchedulingPolicy).Should(Equal(originClusteSchedulingPolicy))
+
+			nodeAffinity := schedulingPolicy.Affinity.NodeAffinity
+			Expect(nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0].Key).Should(Equal(labelKey))
+			Expect(nodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0].Preference.MatchExpressions[0].Key).Should(Equal(nodeKey))
+		})
+	})
 
 	Context("with PodAntiAffinity set to Required", func() {
 		BeforeEach(func() {

--- a/pkg/testutil/apps/cluster_factory.go
+++ b/pkg/testutil/apps/cluster_factory.go
@@ -58,6 +58,11 @@ func (factory *MockClusterFactory) SetClusterAffinity(affinity *appsv1alpha1.Aff
 	return factory
 }
 
+func (factory *MockClusterFactory) SetSchedulingPolicy(schedulingPolicy appsv1alpha1.SchedulingPolicy) *MockClusterFactory {
+	factory.Get().Spec.SchedulingPolicy = &schedulingPolicy
+	return factory
+}
+
 func (factory *MockClusterFactory) AddClusterToleration(toleration corev1.Toleration) *MockClusterFactory {
 	tolerations := factory.Get().Spec.Tolerations
 	if len(tolerations) == 0 {


### PR DESCRIPTION
cherry-pick f8cc2d1444790a70558f3fdeb6b049badcceaa1e to 0.9