### PR TITLE
chore: cancel standard pipe for kbagent

### DIFF
--- a/pkg/kbagent/service/command.go
+++ b/pkg/kbagent/service/command.go
@@ -166,12 +166,7 @@ func runCommandX(ctx context.Context, action *proto.ExecAction, parameters map[s
 				execErr = proto.ErrTimedOut
 			}
 		}
-
-		if execErr != nil {
-			errChan <- execErr
-		} else {
-			errChan <- nil
-		}
+		errChan <- execErr
 	}()
 	return errChan, nil
 }

--- a/pkg/kbagent/service/command.go
+++ b/pkg/kbagent/service/command.go
@@ -78,7 +78,7 @@ func runCommandNonBlocking(ctx context.Context, action *proto.ExecAction, parame
 
 	stdoutChan := make(chan []byte, defaultBufferSize)
 	stderrChan := make(chan []byte, defaultBufferSize)
-	errChan := make(chan error)
+	errChan := make(chan error, 1)
 	go func() {
 		defer close(errChan)
 		defer close(stderrChan)


### PR DESCRIPTION
Directly specify the in, out, and err of cmd instead of using pipe and io.Copy. 
Avoiding the resulting occasional output being shut down.