### PR TITLE
feat: add BuildInstanceName2TemplateMap public api

### DIFF
--- a/pkg/controller/instanceset/instance_template_util.go
+++ b/pkg/controller/instanceset/instance_template_util.go
@@ -43,6 +43,40 @@ type InstanceTemplateExt struct {
 	VolumeClaimTemplates []corev1.PersistentVolumeClaim
 }
 
+// BuildInstanceName2TemplateMap serves as a Public API, through which users can obtain InstanceName2TemplateMap objects
+// processed by the buildInstanceName2TemplateMap function.
+func BuildInstanceName2TemplateMap(itsExt *InstanceSetExt) (map[string]*instanceTemplateExt, error) {
+	instanceTemplateList := buildInstanceTemplateExts(&instanceSetExt{
+		its:               itsExt.Its,
+		instanceTemplates: itsExt.InstanceTemplates,
+	})
+	allNameTemplateMap := make(map[string]*instanceTemplateExt)
+	var instanceNameList []string
+	for _, template := range instanceTemplateList {
+		ordinalList, err := GetOrdinalListByTemplateName(itsExt.Its, template.Name)
+		if err != nil {
+			return nil, err
+		}
+		instanceNames, err := GenerateInstanceNamesFromTemplate(itsExt.Its.Name, template.Name, template.Replicas, itsExt.Its.Spec.OfflineInstances, ordinalList)
+		if err != nil {
+			return nil, err
+		}
+		instanceNameList = append(instanceNameList, instanceNames...)
+		for _, name := range instanceNames {
+			allNameTemplateMap[name] = template
+		}
+	}
+	// validate duplicate pod names
+	getNameFunc := func(n string) string {
+		return n
+	}
+	if err := ValidateDupInstanceNames(instanceNameList, getNameFunc); err != nil {
+		return nil, err
+	}
+
+	return allNameTemplateMap, nil
+}
+
 // BuildInstanceTemplateExts serves as a Public API, through which users can obtain InstanceTemplateExt objects
 // processed by the buildInstanceTemplateExts function.
 // Its main purpose is to acquire the PodTemplate rendered by InstanceTemplate.


### PR DESCRIPTION
merge the capability from https://github.com/apecloud/kubeblocks/pull/8193 into release-0.9.