### PR TITLE
chore: cleanup the APIs pkg deps and keep them compact

### DIFF
--- a/apis/extensions/v1alpha1/addon_types_test.go
+++ b/apis/extensions/v1alpha1/addon_types_test.go
@@ -25,8 +25,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-
-	"github.com/apecloud/kubeblocks/pkg/testutil"
 )
 
 func TestSelectorRequirementString(t *testing.T) {
@@ -50,7 +48,7 @@ func TestSelectorRequirementNoOperator(t *testing.T) {
 func TestSelectorRequirementContains(t *testing.T) {
 	g := NewGomegaWithT(t)
 	const distro = "k3s"
-	testutil.SetKubeServerVersionWithDistro("1", "24", "0", distro)
+	SetKubeServerVersionWithDistro("1", "24", "0", distro)
 	r := SelectorRequirement{
 		Key:      KubeGitVersion,
 		Operator: Contains,
@@ -83,7 +81,7 @@ func TestSelectorRequirementContains(t *testing.T) {
 func TestSelectorRequirementNotContains(t *testing.T) {
 	g := NewGomegaWithT(t)
 	const distro = "k3s"
-	testutil.SetKubeServerVersionWithDistro("1", "24", "0", distro)
+	SetKubeServerVersionWithDistro("1", "24", "0", distro)
 	r := SelectorRequirement{
 		Key:      KubeGitVersion,
 		Operator: DoesNotContain,
@@ -115,7 +113,7 @@ func TestSelectorRequirementNotContains(t *testing.T) {
 func TestSelectorRequirementMatchRegex(t *testing.T) {
 	g := NewGomegaWithT(t)
 	const distro = "k3s"
-	testutil.SetKubeServerVersionWithDistro("1", "24", "0", distro)
+	SetKubeServerVersionWithDistro("1", "24", "0", distro)
 	r := SelectorRequirement{
 		Key:      KubeGitVersion,
 		Operator: MatchRegex,
@@ -150,7 +148,7 @@ func TestSelectorRequirementMatchRegex(t *testing.T) {
 		"^v?(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
 	}
 	g.Expect(r.MatchesFromConfig()).Should(BeTrue())
-	testutil.SetKubeServerVersion("1", "24", "0")
+	SetKubeServerVersion("1", "24", "0")
 	g.Expect(r.MatchesFromConfig()).Should(BeTrue())
 
 	// pass KubeVersion
@@ -171,7 +169,7 @@ func TestSelectorRequirementMatchRegex(t *testing.T) {
 func TestSelectorRequirementNotMatchRegex(t *testing.T) {
 	g := NewGomegaWithT(t)
 	const distro = "k3s"
-	testutil.SetKubeServerVersionWithDistro("1", "24", "0", distro)
+	SetKubeServerVersionWithDistro("1", "24", "0", distro)
 	r := SelectorRequirement{
 		Key:      KubeGitVersion,
 		Operator: DoesNotMatchRegex,

--- a/apis/extensions/v1alpha1/type.go
+++ b/apis/extensions/v1alpha1/type.go
@@ -16,6 +16,15 @@ limitations under the License.
 
 package v1alpha1
 
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/version"
+
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
+)
+
 // AddonType defines the addon types.
 // +enum
 // +kubebuilder:validation:Enum={Helm}
@@ -67,3 +76,23 @@ const (
 	ConditionTypeSucceed     = "Succeed"
 	ConditionTypeFailed      = "Failed"
 )
+
+// SetKubeServerVersion provides "_KUBE_SERVER_INFO" viper settings helper function.
+func SetKubeServerVersion(major, minor, patch string) {
+	ver := version.Info{
+		Major:      major,
+		Minor:      minor,
+		GitVersion: fmt.Sprintf("v%s.%s.%s", major, minor, patch),
+	}
+	viper.Set(constant.CfgKeyServerInfo, ver)
+}
+
+// SetKubeServerVersionWithDistro provides "_KUBE_SERVER_INFO" viper settings helper function.
+func SetKubeServerVersionWithDistro(major, minor, patch, distro string) {
+	ver := version.Info{
+		Major:      major,
+		Minor:      minor,
+		GitVersion: fmt.Sprintf("v%s.%s.%s+%s", major, minor, patch, distro),
+	}
+	viper.Set(constant.CfgKeyServerInfo, ver)
+}

--- a/controllers/extensions/addon_controller_test.go
+++ b/controllers/extensions/addon_controller_test.go
@@ -46,7 +46,6 @@ import (
 	extensionsv1alpha1 "github.com/apecloud/kubeblocks/apis/extensions/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/generics"
-	"github.com/apecloud/kubeblocks/pkg/testutil"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
 	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
@@ -104,7 +103,7 @@ var _ = Describe("Addon controller", func() {
 		BeforeEach(func() {
 			cleanEnv()
 			const distro = "kubeblocks"
-			testutil.SetKubeServerVersionWithDistro("1", "24", "0", distro)
+			extensionsv1alpha1.SetKubeServerVersionWithDistro("1", "24", "0", distro)
 			Expect(client.IgnoreAlreadyExists(testCtx.CreateNamespace())).To(Not(HaveOccurred()))
 		})
 

--- a/pkg/testutil/type.go
+++ b/pkg/testutil/type.go
@@ -21,7 +21,6 @@ package testutil
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"time"
 
@@ -30,11 +29,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
-	"github.com/apecloud/kubeblocks/pkg/constant"
 	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
 
@@ -183,24 +180,4 @@ func (testCtx TestContext) UseDefaultNamespace() func(client.Object) {
 	return func(obj client.Object) {
 		obj.SetNamespace(testCtx.DefaultNamespace)
 	}
-}
-
-// SetKubeServerVersionWithDistro provides "_KUBE_SERVER_INFO" viper settings helper function.
-func SetKubeServerVersionWithDistro(major, minor, patch, distro string) {
-	ver := version.Info{
-		Major:      major,
-		Minor:      minor,
-		GitVersion: fmt.Sprintf("v%s.%s.%s+%s", major, minor, patch, distro),
-	}
-	viper.Set(constant.CfgKeyServerInfo, ver)
-}
-
-// SetKubeServerVersion provides "_KUBE_SERVER_INFO" viper settings helper function.
-func SetKubeServerVersion(major, minor, patch string) {
-	ver := version.Info{
-		Major:      major,
-		Minor:      minor,
-		GitVersion: fmt.Sprintf("v%s.%s.%s", major, minor, patch),
-	}
-	viper.Set(constant.CfgKeyServerInfo, ver)
 }


### PR DESCRIPTION
resolve #7551 

The dependent pkgs defined by KB:
- github.com/apecloud/kubeblocks/apis/apps/v1
- github.com/apecloud/kubeblocks/apis/apps/v1alpha1
- github.com/apecloud/kubeblocks/apis/apps/v1beta1
- github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1
- github.com/apecloud/kubeblocks/apis/workloads/v1
- github.com/apecloud/kubeblocks/apis/workloads/v1alpha1
- github.com/apecloud/kubeblocks/pkg/constant
- github.com/apecloud/kubeblocks/pkg/viperx