### PR TITLE
chore: remove dependency on github.com/containers/common

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/bhmj/jsonslice v1.1.2
 	github.com/charmbracelet/keygen v0.5.1
 	github.com/clbanning/mxj/v2 v2.5.7
-	github.com/containers/common v0.55.4
 	github.com/docker/docker v25.0.6+incompatible
 	github.com/evanphx/json-patch v5.6.0+incompatible
 	github.com/fasthttp/router v1.4.20

--- a/go.sum
+++ b/go.sum
@@ -164,8 +164,6 @@ github.com/containerd/continuity v0.4.2 h1:v3y/4Yz5jwnvqPKJJ+7Wf93fyWoCB3F5EclWG
 github.com/containerd/continuity v0.4.2/go.mod h1:F6PTNCKepoxEaXLQp3wDAjygEnImnZ/7o4JzpodfroQ=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
-github.com/containers/common v0.55.4 h1:7IxB/G5qtDU+rp1YiVWkDpd+ZC4ZlCQ7k2jZJYkB/R8=
-github.com/containers/common v0.55.4/go.mod h1:5mVCpfMBWyO+zaD7Fw+DBHFa42YFKROwle1qpEKcX3U=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=

--- a/test/testutils/utils.go
+++ b/test/testutils/utils.go
@@ -169,10 +169,10 @@ func retry(ctx context.Context, operation func() error, maxRetry int) error {
 		delay := time.Duration(int(math.Pow(2, float64(attempt)))) * time.Second
 		klog.V(1).Infof("Failed, retrying in %s ... (%d/%d). Error: %v", delay, attempt+1, maxRetry, err)
 		select {
-		case <-time.After(delay):
-			break
 		case <-ctx.Done():
 			return err
+		case <-time.After(delay):
+			// try again
 		}
 		err = operation()
 	}

--- a/test/testutils/utils.go
+++ b/test/testutils/utils.go
@@ -21,7 +21,9 @@ package testutils
 
 import (
 	"context"
+	"errors"
 	"io"
+	"math"
 	"net/http"
 	"sync"
 	"time"
@@ -159,4 +161,34 @@ func GetIPLocation() (string, error) {
 
 	// remove last "\n"
 	return string(location[:len(location)-1]), nil
+}
+
+func retry(ctx context.Context, operation func() error, maxRetry int) error {
+	err := operation()
+	for attempt := 0; err != nil && isErrorRetryable(err) && attempt < maxRetry; attempt++ {
+		delay := time.Duration(int(math.Pow(2, float64(attempt)))) * time.Second
+		klog.V(1).Infof("Failed, retrying in %s ... (%d/%d). Error: %v", delay, attempt+1, maxRetry, err)
+		select {
+		case <-time.After(delay):
+			break
+		case <-ctx.Done():
+			return err
+		}
+		err = operation()
+	}
+	return err
+}
+
+func isErrorRetryable(err error) bool {
+	switch err {
+	case nil:
+		return false
+	case context.Canceled, context.DeadlineExceeded:
+		return false
+	default: // continue
+	}
+	if e := errors.Unwrap(err); e != nil {
+		return isErrorRetryable(e)
+	}
+	return true
 }


### PR DESCRIPTION
PR #8236 aimed to upgrade github.com/containers/common, but due to a significant version gap, it couldn't be merged directly. This PR removes the dependency on this package.

Closes #8236.