### PR TITLE
chore: fix a test case in log_collection_controller_test.go

### DIFF
--- a/controllers/dataprotection/log_collection_controller_test.go
+++ b/controllers/dataprotection/log_collection_controller_test.go
@@ -122,8 +122,7 @@ var _ = Describe("Log Collection Controller", func() {
 				testdp.PatchK8sJobStatus(&testCtx, jobKey, batchv1.JobFailed)
 
 				Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(backup), func(g Gomega, fetched *dpv1alpha1.Backup) {
-					// NOTE: env test can not create a real pod, so FailureReason will always empty
-					g.Expect(fetched.Status.FailureReason).Should(BeEmpty())
+					g.Expect(fetched.Status.FailureReason).Should(ContainSubstring("there are failed actions"))
 				})).Should(Succeed())
 			})
 		})


### PR DESCRIPTION
https://github.com/apecloud/kubeblocks/actions/runs/11267044653/job/31335064912?pr=8251

```
[FAILED] Timed out after 10.001s.
  The function passed to Eventually failed at /home/runner/work/kubeblocks/kubeblocks/controllers/dataprotection/log_collection_controller_test.go:126 with:
  Expected
      <string>: there are failed actions, you can obtain the more informations in the status.actions
  to be empty
  In [It] at: /home/runner/work/kubeblocks/kubeblocks/controllers/dataprotection/log_collection_controller_test.go:127 @ 10/10/24 06:13:46.238

```