### PR TITLE
chore: merge same event for kbagent

### DIFF
--- a/deploy/helm/templates/rbac/cluster_pod_required_role.yaml
+++ b/deploy/helm/templates/rbac/cluster_pod_required_role.yaml
@@ -25,6 +25,10 @@ rules:
   - events
   verbs:
   - create
+  - get
+  - list
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:

--- a/pkg/kbagent/util/event.go
+++ b/pkg/kbagent/util/event.go
@@ -45,15 +45,15 @@ var (
 	clientSet *kubernetes.Clientset
 )
 
-func SendEventWithMessage(logger logr.Logger, reason, message string) {
+func SendEventWithMessage(logger *logr.Logger, reason, message string) {
 	once.Do(func() {
-		if err := initEventRecorder(); err != nil {
+		if err := initEventRecorder(); err != nil && logger != nil {
 			logger.Error(err, "Failed to initialize event recorder")
 		}
 	})
 
 	go func() {
-		if err := sendEvent(reason, message); err != nil {
+		if err := sendEvent(reason, message); err != nil && logger != nil {
 			logger.Error(err, "Failed to send event")
 		}
 	}()


### PR DESCRIPTION
Use the event recorder to automatically merge identical events instead of manually updating and maintaining events.

<img width="476" alt="image" src="https://github.com/user-attachments/assets/5fd7a340-f8a2-4e5d-b905-eb0802fed4a2">
