### PR TITLE
feat: toggle to disable helm render-time validation of encryptionKeySecretKeyRef

### DIFF
--- a/deploy/helm/templates/_dataprotection.tpl
+++ b/deploy/helm/templates/_dataprotection.tpl
@@ -39,11 +39,13 @@ Render the secret key reference of the encryptionKey.
 name: {{ include "kubeblocks.fullname" . }}-secret
 key: dataProtectionEncryptionKey
   {{- else -}}
-    {{- $secret := lookup "v1" "Secret" .Release.Namespace $ref.name -}}
-    {{- if not $secret -}}
-      {{- fail (printf "Invalid value \".Values.dataProtection.encryptionKeySecretKeyRef\", secret %q is not found from the namespace %q." $ref.name .Release.Namespace) -}}
-    {{- else if not (hasKey $secret.data $ref.key) -}}
-      {{- fail (printf "Invalid value \".Values.dataProtection.encryptionKeySecretKeyRef\", secret %q doesn't have key %q." $ref.name $ref.key) -}}
+    {{- if not .Values.dataProtection.encryptionKeySecretKeyRef.skipValidation -}}
+      {{- $secret := lookup "v1" "Secret" .Release.Namespace $ref.name -}}
+      {{- if not $secret -}}
+        {{- fail (printf "Invalid value \".Values.dataProtection.encryptionKeySecretKeyRef\", secret %q is not found from the namespace %q." $ref.name .Release.Namespace) -}}
+      {{- else if not (hasKey $secret.data $ref.key) -}}
+        {{- fail (printf "Invalid value \".Values.dataProtection.encryptionKeySecretKeyRef\", secret %q doesn't have key %q." $ref.name $ref.key) -}}
+      {{- end -}}
     {{- end -}}
 name: {{ $ref.name }}
 key:  {{ $ref.key }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -342,6 +342,7 @@ dataProtection:
   encryptionKeySecretKeyRef:
     name: ""
     key: ""
+    skipValidation: false
   enableBackupEncryption: false
   backupEncryptionAlgorithm: ""
   gcFrequencySeconds: 3600


### PR DESCRIPTION
As mentioned in #7103, it would be helpful to be able to skip the lookup of an externally-deployed Secret for the dataProtectionEncryptionKey, in order to be able to deploy this helm chart via tools that template it out without access to the cluster (such as argo-cd). 

Defaults to the current behaviour of performing the lookup.