### PR TITLE
chore: fix unstable UT in storageprovider_controller_test.go

### DIFF
--- a/controllers/dataprotection/storageprovider_controller_test.go
+++ b/controllers/dataprotection/storageprovider_controller_test.go
@@ -132,9 +132,9 @@ var _ = Describe("StorageProvider controller", func() {
 			g.ExpectWithOffset(1, val).Should(BeTrue())
 		}
 
-		reconcileNoError := func() {
+		reconcileNoError := func(g Gomega) {
 			_, err := reconclier.Reconcile(testCtx.Ctx, reconcile.Request{NamespacedName: key})
-			Expect(err).ToNot(HaveOccurred())
+			g.ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		}
 
 		It("should reconcile a StorageProvider to Ready status if it doesn't specify csiDriverName", func() {
@@ -143,7 +143,7 @@ var _ = Describe("StorageProvider controller", func() {
 
 			By("checking status.phase and status.conditions")
 			Eventually(func(g Gomega) {
-				reconcileNoError()
+				reconcileNoError(g)
 				shouldReady(g, getProvider(g))
 			}).Should(Succeed())
 		})
@@ -155,7 +155,7 @@ var _ = Describe("StorageProvider controller", func() {
 
 			By("checking status.phase and status.conditions")
 			Eventually(func(g Gomega) {
-				reconcileNoError()
+				reconcileNoError(g)
 				provider := getProvider(g)
 				g.Expect(provider.Status.Phase).Should(BeEquivalentTo(dpv1alpha1.StorageProviderReady))
 
@@ -170,7 +170,7 @@ var _ = Describe("StorageProvider controller", func() {
 			createStorageProviderSpec("csi2")
 			By("checking status.phase, it should be NotReady because CSI driver is not installed yet")
 			Eventually(func(g Gomega) {
-				reconcileNoError()
+				reconcileNoError(g)
 				shouldNotReady(g, getProvider(g))
 			}).Should(Succeed())
 
@@ -178,7 +178,7 @@ var _ = Describe("StorageProvider controller", func() {
 			createCSIDriverObjectSpec("csi2")
 			By("checking status.phase, it should become Ready")
 			Eventually(func(g Gomega) {
-				reconcileNoError()
+				reconcileNoError(g)
 				shouldReady(g, getProvider(g))
 			}).Should(Succeed())
 
@@ -186,7 +186,7 @@ var _ = Describe("StorageProvider controller", func() {
 			deleteCSIDriverObject("csi2")
 			By("checking status.phase, it should become NotReady")
 			Eventually(func(g Gomega) {
-				reconcileNoError()
+				reconcileNoError(g)
 				shouldNotReady(g, getProvider(g))
 			}).Should(Succeed())
 		})
@@ -197,13 +197,13 @@ var _ = Describe("StorageProvider controller", func() {
 
 			By("checking StorageProvider object")
 			Eventually(testapps.CheckObj(&testCtx, key, func(g Gomega, provider *dpv1alpha1.StorageProvider) {
-				reconcileNoError()
+				reconcileNoError(g)
 				g.Expect(provider.GetFinalizers()).To(ContainElement(dptypes.DataProtectionFinalizerName))
 			})).Should(Succeed())
 
 			By("deleting StorageProvider object")
 			Eventually(func(g Gomega) {
-				reconcileNoError()
+				reconcileNoError(g)
 				provider := &dpv1alpha1.StorageProvider{}
 				err := testCtx.Cli.Get(ctx, key, provider)
 				if apierrors.IsNotFound(err) {

--- a/pkg/testutil/apps/common_util.go
+++ b/pkg/testutil/apps/common_util.go
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package apps
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -333,7 +334,8 @@ func ClearResourcesWithRemoveFinalizerOption[T intctrlutil.Object, PT intctrluti
 		for _, obj := range items {
 			pobj := PT(&obj)
 			if pobj.GetDeletionTimestamp().IsZero() {
-				panic("expected DeletionTimestamp is not nil")
+				d, _ := json.Marshal(pobj)
+				panic("expected DeletionTimestamp is not nil, obj: " + string(d))
 			}
 			finalizers := pobj.GetFinalizers()
 			if len(finalizers) > 0 {


### PR DESCRIPTION
https://github.com/apecloud/kubeblocks/actions/runs/11622958513/job/32369246442

```
[FAILED] Unexpected error:
      <*errors.StatusError | 0xc0029db0e0>: 
      Operation cannot be fulfilled on storageproviders.dataprotection.kubeblocks.io "storageprovider-6jdjq": the object has been modified; please apply your changes to the latest version and try again
      {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "Operation cannot be fulfilled on storageproviders.dataprotection.kubeblocks.io \"storageprovider-6jdjq\": the object has been modified; please apply your changes to the latest version and try again",
              Reason: "Conflict",
              Details: {
                  Name: "storageprovider-6jdjq",
                  Group: "dataprotection.kubeblocks.io",
                  Kind: "storageproviders",
                  UID: "",
                  Causes: nil,
                  RetryAfterSeconds: 0,
              },
              Code: 409,
          },
      }
  occurred
  In [It] at: /home/runner/work/kubeblocks/kubeblocks/controllers/dataprotection/storageprovider_controller_test.go:137 @ 11/01/24 02:10:35.318
------------------------------
••••••••••••••W1101 02:10:46.013852   31[417](https://github.com/apecloud/kubeblocks/actions/runs/11622958513/job/32369246442#step:6:418) reflector.go:462] pkg/mod/k8s.io/client-go@v0.29.2/tools/cache/reflector.go:229: watch of *v1.CSIDriver ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding
W1101 02:10:46.013937   31417 reflector.go:462] pkg/mod/k8s.io/client-go@v0.29.2/tools/cache/reflector.go:229: watch of *v1alpha1.Restore ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding
W1101 02:10:46.013997   31417 reflector.go:462] pkg/mod/k8s.io/client-go@v0.29.2/tools/cache/reflector.go:229: watch of *v1alpha1.BackupPolicy ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding
W1101 02:10:46.014056   31417 reflector.go:462] pkg/mod/k8s.io/client-go@v0.29.2/tools/cache/reflector.go:229: watch of *v1alpha1.BackupPolicyTemplate ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding
W1101 02:10:46.014112   31417 reflector.go:462] pkg/mod/k8s.io/client-go@v0.29.2/tools/cache/reflector.go:229: watch of *v1alpha1.BackupSchedule ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding
W1101 02:10:46.014681   31417 reflector.go:462] pkg/mod/k8s.io/client-go@v0.29.2/tools/cache/reflector.go:229: watch of *v1alpha1.ActionSet ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding
W1101 02:10:46.014761   31417 reflector.go:462] pkg/mod/k8s.io/client-go@v0.29.2/tools/cache/reflector.go:229: watch of *v1.ComponentDefinition ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding
W1101 02:10:46.014818   31417 reflector.go:462] pkg/mod/k8s.io/client-go@v0.29.2/tools/cache/reflector.go:229: watch of *v1.VolumeSnapshot ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding
W1101 02:10:46.014871   31417 reflector.go:462] pkg/mod/k8s.io/client-go@v0.29.2/tools/cache/reflector.go:229: watch of *v1alpha1.Backup ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding
W1101 02:10:46.014922   31417 reflector.go:462] pkg/mod/k8s.io/client-go@v0.29.2/tools/cache/reflector.go:229: watch of *v1.StorageClass ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding
W1101 02:10:46.014977   31417 reflector.go:462] pkg/mod/k8s.io/client-go@v0.29.2/tools/cache/reflector.go:229: watch of *v1.PersistentVolumeClaim ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding
W1101 02:10:46.015032   31417 reflector.go:462] pkg/mod/k8s.io/client-go@v0.29.2/tools/cache/reflector.go:229: watch of *v1alpha1.StorageProvider ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding
W1101 02:10:46.015097   31417 reflector.go:462] pkg/mod/k8s.io/client-go@v0.29.2/tools/cache/reflector.go:229: watch of *v1alpha1.BackupRepo ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding
W1101 02:10:46.015151   31417 reflector.go:462] pkg/mod/k8s.io/client-go@v0.29.2/tools/cache/reflector.go:229: watch of *v1.Secret ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding
W1101 02:10:46.015207   31417 reflector.go:462] pkg/mod/k8s.io/client-go@v0.29.2/tools/cache/reflector.go:229: watch of *v1.CronJob ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding
W1101 02:10:46.015372   31417 reflector.go:462] pkg/mod/k8s.io/client-go@v0.29.2/tools/cache/reflector.go:229: watch of *v1.StatefulSet ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding
W1101 02:10:46.015[450](https://github.com/apecloud/kubeblocks/actions/runs/11622958513/job/32369246442#step:6:451)   31417 reflector.go:462] pkg/mod/k8s.io/client-go@v0.29.2/tools/cache/reflector.go:229: watch of *v1.Pod ended with: an error on the server ("unable to decode an event from the watch stream: context canceled") has prevented the request from succeeding


Summarizing 1 Failure:
  [FAIL] StorageProvider controller StorageProvider controller test [It] should reconcile a StorageProvider base on the status of the CSI driver object
  /home/runner/work/kubeblocks/kubeblocks/controllers/dataprotection/storageprovider_controller_test.go:137

Ran 100 of 100 Specs in 79.165 seconds
FAIL! -- 99 Passed | 1 Failed | 0 Pending | 0 Skipped
```