### PR TITLE
fix: unused import

### DIFF
--- a/pkg/controller/instanceset/object_builder.go
+++ b/pkg/controller/instanceset/object_builder.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"


### PR DESCRIPTION
After #8378 and #8400 merged concurrently, there has been an unused import that breaks the build.