### PR TITLE
feat: supports incremental backup

### DIFF
--- a/apis/dataprotection/v1alpha1/backup_types.go
+++ b/apis/dataprotection/v1alpha1/backup_types.go
@@ -195,11 +195,13 @@ type BackupStatus struct {
 	VolumeSnapshots []VolumeSnapshotStatus `json:"volumeSnapshots,omitempty"`
 
 	// Records the parent backup name for incremental or differential backup.
+	// When the parent backup is deleted, the backup will also be deleted.
 	//
 	// +optional
 	ParentBackupName string `json:"parentBackupName,omitempty"`
 
 	// Records the base full backup name for incremental backup or differential backup.
+	// When the base backup is deleted, the backup will also be deleted.
 	//
 	// +optional
 	BaseBackupName string `json:"baseBackupName,omitempty"`

--- a/apis/dataprotection/v1alpha1/backup_types.go
+++ b/apis/dataprotection/v1alpha1/backup_types.go
@@ -194,6 +194,16 @@ type BackupStatus struct {
 	// +optional
 	VolumeSnapshots []VolumeSnapshotStatus `json:"volumeSnapshots,omitempty"`
 
+	// Records the parent backup name for incremental or differential backup.
+	//
+	// +optional
+	ParentBackupName string `json:"parentBackupName,omitempty"`
+
+	// Records the base full backup name for incremental backup or differential backup.
+	//
+	// +optional
+	BaseBackupName string `json:"baseBackupName,omitempty"`
+
 	// Records any additional information for the backup.
 	//
 	// +optional

--- a/apis/dataprotection/v1alpha1/backuppolicy_types.go
+++ b/apis/dataprotection/v1alpha1/backuppolicy_types.go
@@ -221,6 +221,12 @@ type BackupMethod struct {
 	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
 	Name string `json:"name"`
 
+	// The name of the compatible full backup method, used by incremental backups.
+	//
+	// +optional
+	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
+	CompatibleMethod string `json:"compatibleMethod,omitempty"`
+
 	// Specifies whether to take snapshots of persistent volumes. If true,
 	// the ActionSetName is not required, the controller will use the CSI volume
 	// snapshotter to create the snapshot.

--- a/apis/dataprotection/v1alpha1/backuppolicytemplate_types.go
+++ b/apis/dataprotection/v1alpha1/backuppolicytemplate_types.go
@@ -81,6 +81,12 @@ type BackupMethodTPL struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
 	Name string `json:"name"`
+	
+	// The name of the compatible full backup method, used by incremental backups.
+	//
+	// +optional
+	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
+	CompatibleMethod string `json:"compatibleMethod,omitempty"`
 
 	// Specifies whether to take snapshots of persistent volumes. If true,
 	// the ActionSetName is not required, the controller will use the CSI volume

--- a/apis/dataprotection/v1alpha1/backuppolicytemplate_types.go
+++ b/apis/dataprotection/v1alpha1/backuppolicytemplate_types.go
@@ -81,7 +81,7 @@ type BackupMethodTPL struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
 	Name string `json:"name"`
-	
+
 	// The name of the compatible full backup method, used by incremental backups.
 	//
 	// +optional

--- a/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -73,6 +73,11 @@ spec:
                         For volume snapshot backup, the actionSet is not required, the controller
                         will use the CSI volume snapshotter to create the snapshot.
                       type: string
+                    compatibleMethod:
+                      description: The name of the compatible full backup method,
+                        used by incremental backups.
+                      pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                      type: string
                     env:
                       description: Specifies the environment variables for the backup
                         workload.

--- a/config/crd/bases/dataprotection.kubeblocks.io_backuppolicytemplates.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backuppolicytemplates.yaml
@@ -76,6 +76,11 @@ spec:
                         For volume snapshot backup, the actionSet is not required, the controller
                         will use the CSI volume snapshotter to create the snapshot.
                       type: string
+                    compatibleMethod:
+                      description: The name of the compatible full backup method,
+                        used by incremental backups.
+                      pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                      type: string
                     env:
                       description: Specifies the environment variables for the backup
                         workload.

--- a/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
@@ -298,6 +298,11 @@ spec:
                       For volume snapshot backup, the actionSet is not required, the controller
                       will use the CSI volume snapshotter to create the snapshot.
                     type: string
+                  compatibleMethod:
+                    description: The name of the compatible full backup method, used
+                      by incremental backups.
+                    pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                    type: string
                   env:
                     description: Specifies the environment variables for the backup
                       workload.
@@ -1013,6 +1018,10 @@ spec:
               backupRepoName:
                 description: The name of the backup repository.
                 type: string
+              baseBackupName:
+                description: Records the base full backup name for incremental backup
+                  or differential backup.
+                type: string
               completionTimestamp:
                 description: |-
                   Records the time when the backup operation was completed.
@@ -1091,6 +1100,10 @@ spec:
                 type: string
               kopiaRepoPath:
                 description: Records the path of the Kopia repository.
+                type: string
+              parentBackupName:
+                description: Records the parent backup name for incremental or differential
+                  backup.
                 type: string
               path:
                 description: |-

--- a/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
@@ -1019,8 +1019,9 @@ spec:
                 description: The name of the backup repository.
                 type: string
               baseBackupName:
-                description: Records the base full backup name for incremental backup
-                  or differential backup.
+                description: |-
+                  Records the base full backup name for incremental backup or differential backup.
+                  When the base backup is deleted, the backup will also be deleted.
                 type: string
               completionTimestamp:
                 description: |-
@@ -1102,8 +1103,9 @@ spec:
                 description: Records the path of the Kopia repository.
                 type: string
               parentBackupName:
-                description: Records the parent backup name for incremental or differential
-                  backup.
+                description: |-
+                  Records the parent backup name for incremental or differential backup.
+                  When the parent backup is deleted, the backup will also be deleted.
                 type: string
               path:
                 description: |-

--- a/controllers/apps/transformer_cluster_backup_policy.go
+++ b/controllers/apps/transformer_cluster_backup_policy.go
@@ -415,6 +415,7 @@ func (r *backupPolicyBuilder) syncBackupMethods(backupPolicy *dpv1alpha1.BackupP
 	for _, backupMethodTPL := range r.backupPolicyTPL.Spec.BackupMethods {
 		backupMethod := dpv1alpha1.BackupMethod{
 			Name:            backupMethodTPL.Name,
+			CompatibleMethod: backupMethodTPL.CompatibleMethod,
 			ActionSetName:   backupMethodTPL.ActionSetName,
 			SnapshotVolumes: backupMethodTPL.SnapshotVolumes,
 			TargetVolumes:   backupMethodTPL.TargetVolumes,

--- a/controllers/apps/transformer_cluster_backup_policy.go
+++ b/controllers/apps/transformer_cluster_backup_policy.go
@@ -414,12 +414,12 @@ func (r *backupPolicyBuilder) syncBackupMethods(backupPolicy *dpv1alpha1.BackupP
 	}
 	for _, backupMethodTPL := range r.backupPolicyTPL.Spec.BackupMethods {
 		backupMethod := dpv1alpha1.BackupMethod{
-			Name:            backupMethodTPL.Name,
+			Name:             backupMethodTPL.Name,
 			CompatibleMethod: backupMethodTPL.CompatibleMethod,
-			ActionSetName:   backupMethodTPL.ActionSetName,
-			SnapshotVolumes: backupMethodTPL.SnapshotVolumes,
-			TargetVolumes:   backupMethodTPL.TargetVolumes,
-			RuntimeSettings: backupMethodTPL.RuntimeSettings,
+			ActionSetName:    backupMethodTPL.ActionSetName,
+			SnapshotVolumes:  backupMethodTPL.SnapshotVolumes,
+			TargetVolumes:    backupMethodTPL.TargetVolumes,
+			RuntimeSettings:  backupMethodTPL.RuntimeSettings,
 		}
 		if m, ok := oldBackupMethodMap[backupMethodTPL.Name]; ok {
 			backupMethod = m

--- a/controllers/dataprotection/actionset_controller_test.go
+++ b/controllers/dataprotection/actionset_controller_test.go
@@ -55,14 +55,14 @@ var _ = Describe("ActionSet Controller test", func() {
 
 	Context("create a actionSet", func() {
 		It("should be available", func() {
-			as := testdp.NewFakeActionSet(&testCtx)
+			as := testdp.NewFakeActionSet(&testCtx, nil)
 			Expect(as).ShouldNot(BeNil())
 		})
 	})
 
 	Context("validate a actionSet", func() {
 		It("validate withParameters", func() {
-			as := testdp.NewFakeActionSet(&testCtx)
+			as := testdp.NewFakeActionSet(&testCtx, nil)
 			Expect(as).ShouldNot(BeNil())
 			By("set invalid withParameters and schema")
 			Expect(testapps.ChangeObj(&testCtx, as, func(action *dpv1alpha1.ActionSet) {

--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -456,7 +456,6 @@ func (r *BackupReconciler) prepareBackupRequest(
 		}
 		if parentBackupType == dpv1alpha1.BackupTypeFull {
 			request.BaseBackup = request.ParentBackup
-			request.Status.BaseBackupName = request.ParentBackup.Name
 		} else if parentBackupType == dpv1alpha1.BackupTypeIncremental {
 			baseBackup := &dpv1alpha1.Backup{}
 			baseBackupName := request.ParentBackup.Status.BaseBackupName
@@ -468,10 +467,12 @@ func (r *BackupReconciler) prepareBackupRequest(
 				return nil, fmt.Errorf("failed to get base backup %s/%s: %w", request.ParentBackup.Namespace, baseBackupName, err)
 			}
 			request.BaseBackup = baseBackup
-			request.Status.BaseBackupName = baseBackup.Name
 		} else {
 			return nil, fmt.Errorf("parent backup type is %s, but only full and incremental backup are supported", parentBackupType)
 		}
+		// set status parent backup name and base backup name
+		request.Status.ParentBackupName = request.ParentBackup.Name
+		request.Status.BaseBackupName = request.BaseBackup.Name
 	}
 	return request, nil
 }

--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -786,6 +786,7 @@ func (r *BackupReconciler) deleteExternalResources(
 	return deleteRelatedObjectList(reqCtx, r.Client, &appsv1.StatefulSetList{}, namespaces, labels)
 }
 
+// deleteRelatedBackups deletes the related backups.
 func (r *BackupReconciler) deleteRelatedBackups(
 	reqCtx intctrlutil.RequestCtx,
 	backup *dpv1alpha1.Backup) error {
@@ -799,6 +800,7 @@ func (r *BackupReconciler) deleteRelatedBackups(
 	}
 	for i := range backupList.Items {
 		bp := &backupList.Items[i]
+		// delete backups related to the current backup
 		if bp.Status.ParentBackupName != backup.Name && bp.Status.BaseBackupName != backup.Name {
 			continue
 		}

--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -774,6 +774,7 @@ func (r *BackupReconciler) deleteRelatedBackups(
 	for i := range backupList.Items {
 		bp := &backupList.Items[i]
 		// delete backups related to the current backup
+		// files in the related backup's status.path will be deleted by its own associated deleter
 		if bp.Status.ParentBackupName != backup.Name && bp.Status.BaseBackupName != backup.Name {
 			continue
 		}

--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -454,9 +454,10 @@ func (r *BackupReconciler) prepareBackupRequest(
 		if err != nil {
 			return nil, err
 		}
-		if parentBackupType == dpv1alpha1.BackupTypeFull {
+		switch parentBackupType {
+		case dpv1alpha1.BackupTypeFull:
 			request.BaseBackup = request.ParentBackup
-		} else if parentBackupType == dpv1alpha1.BackupTypeIncremental {
+		case dpv1alpha1.BackupTypeIncremental:
 			baseBackup := &dpv1alpha1.Backup{}
 			baseBackupName := request.ParentBackup.Status.BaseBackupName
 			if len(baseBackupName) == 0 {
@@ -467,7 +468,7 @@ func (r *BackupReconciler) prepareBackupRequest(
 				return nil, fmt.Errorf("failed to get base backup %s/%s: %w", request.ParentBackup.Namespace, baseBackupName, err)
 			}
 			request.BaseBackup = baseBackup
-		} else {
+		default:
 			return nil, fmt.Errorf("parent backup type is %s, but only full and incremental backup are supported", parentBackupType)
 		}
 		// set status parent backup name and base backup name

--- a/controllers/dataprotection/backuppolicy_controller_test.go
+++ b/controllers/dataprotection/backuppolicy_controller_test.go
@@ -75,7 +75,7 @@ var _ = Describe("BackupPolicy Controller test", func() {
 
 		It("backup policy should be available for target", func() {
 			By("creating actionSet used by backup policy")
-			as := testdp.NewFakeActionSet(&testCtx)
+			as := testdp.NewFakeActionSet(&testCtx, nil)
 			Expect(as).ShouldNot(BeNil())
 
 			By("creating backupPolicy and its status should be available")
@@ -85,7 +85,7 @@ var _ = Describe("BackupPolicy Controller test", func() {
 
 		It("test backup policy with targets", func() {
 			By("creating actionSet used by backup policy")
-			as := testdp.NewFakeActionSet(&testCtx)
+			as := testdp.NewFakeActionSet(&testCtx, nil)
 			Expect(as).ShouldNot(BeNil())
 
 			By("creating backupPolicy")

--- a/controllers/dataprotection/backuppolicytemplate_controller_test.go
+++ b/controllers/dataprotection/backuppolicytemplate_controller_test.go
@@ -96,7 +96,7 @@ var _ = Describe("", func() {
 			})).Should(Succeed())
 
 			By("should be available")
-			testdp.NewFakeActionSet(&testCtx)
+			testdp.NewFakeActionSet(&testCtx, nil)
 			Eventually(testapps.CheckObj(&testCtx, key, func(g Gomega, pobj *dpv1alpha1.BackupPolicyTemplate) {
 				g.Expect(pobj.Status.ObservedGeneration).To(Equal(bpt.Generation))
 				g.Expect(pobj.Status.Phase).To(Equal(dpv1alpha1.AvailablePhase))
@@ -109,7 +109,7 @@ var _ = Describe("", func() {
 				scheduleName2 = "test2"
 			)
 			By("set backup parameters and schema in acitionSet")
-			actionSet := testdp.NewFakeActionSet(&testCtx)
+			actionSet := testdp.NewFakeActionSet(&testCtx, nil)
 			testdp.MockActionSetWithSchema(&testCtx, actionSet)
 			bpt := testdp.NewBackupPolicyTemplateFactory(BackupPolicyTemplateName).
 				AddBackupMethod(BackupMethod, false, testdp.ActionSetName).

--- a/controllers/dataprotection/backupschedule_controller_test.go
+++ b/controllers/dataprotection/backupschedule_controller_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Backup Schedule Controller", func() {
 
 		BeforeEach(func() {
 			By("creating an actionSet")
-			actionSet = testdp.NewFakeActionSet(&testCtx)
+			actionSet = testdp.NewFakeActionSet(&testCtx, nil)
 
 			By("creating storage provider")
 			_ = testdp.NewFakeStorageProvider(&testCtx, nil)

--- a/controllers/dataprotection/gc_controller_test.go
+++ b/controllers/dataprotection/gc_controller_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Data Protection Garbage Collection Controller", func() {
 
 		BeforeEach(func() {
 			By("creating an actionSet")
-			actionSet := testdp.NewFakeActionSet(&testCtx)
+			actionSet := testdp.NewFakeActionSet(&testCtx, nil)
 
 			By("creating storage provider")
 			_ = testdp.NewFakeStorageProvider(&testCtx, nil)

--- a/controllers/dataprotection/log_collection_controller_test.go
+++ b/controllers/dataprotection/log_collection_controller_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Log Collection Controller", func() {
 		BeforeEach(func() {
 
 			By("creating an actionSet")
-			actionSet := testdp.NewFakeActionSet(&testCtx)
+			actionSet := testdp.NewFakeActionSet(&testCtx, nil)
 
 			By("creating storage provider")
 			_ = testdp.NewFakeStorageProvider(&testCtx, nil)

--- a/controllers/dataprotection/restore_controller_test.go
+++ b/controllers/dataprotection/restore_controller_test.go
@@ -120,7 +120,7 @@ var _ = Describe("Restore Controller test", func() {
 
 		BeforeEach(func() {
 			By("creating an actionSet")
-			actionSet = testdp.NewFakeActionSet(&testCtx)
+			actionSet = testdp.NewFakeActionSet(&testCtx, nil)
 
 			By("creating storage provider")
 			_ = testdp.NewFakeStorageProvider(&testCtx, nil)

--- a/controllers/dataprotection/restore_controller_test.go
+++ b/controllers/dataprotection/restore_controller_test.go
@@ -23,12 +23,14 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -133,11 +135,15 @@ var _ = Describe("Restore Controller test", func() {
 			mockBackupCompleted,
 			useVolumeSnapshot,
 			isSerialPolicy bool,
+			backupType dpv1alpha1.BackupType,
 			expectRestorePhase dpv1alpha1.RestorePhase,
 			change func(f *testdp.MockRestoreFactory),
-			changeBackupStatus func(b *dpv1alpha1.Backup)) *dpv1alpha1.Restore {
+			changeBackupStatus func(b *dpv1alpha1.Backup),
+			backupNames ...string,
+		) *dpv1alpha1.Restore {
 			By("create a completed backup")
-			backup := mockBackupForRestore(actionSet.Name, repo.Name, repoPVCName, mockBackupCompleted, useVolumeSnapshot)
+			backup := mockBackupForRestore(actionSet.Name, repo.Name, repoPVCName, mockBackupCompleted,
+				useVolumeSnapshot, backupType, backupNames...)
 			if changeBackupStatus != nil {
 				Expect(testapps.ChangeObjStatus(&testCtx, backup, func() {
 					changeBackupStatus(backup)
@@ -218,7 +224,7 @@ var _ = Describe("Restore Controller test", func() {
 		}
 
 		testRestoreWithVolumeClaimsTemplate := func(replicas, startingIndex int) {
-			restore := initResourcesAndWaitRestore(true, false, false, dpv1alpha1.RestorePhaseRunning,
+			restore := initResourcesAndWaitRestore(true, false, false, "", dpv1alpha1.RestorePhaseRunning,
 				func(f *testdp.MockRestoreFactory) {
 					f.SetVolumeClaimsTemplate(testdp.MysqlTemplateName, testdp.DataVolumeName,
 						testdp.DataVolumeMountPath, "", int32(replicas), int32(startingIndex), nil)
@@ -259,7 +265,7 @@ var _ = Describe("Restore Controller test", func() {
 		Context("with restore fails", func() {
 			It("test restore is Failed when backup is not completed", func() {
 				By("expect for restore is Failed ")
-				initResourcesAndWaitRestore(false, false, true, dpv1alpha1.RestorePhaseFailed,
+				initResourcesAndWaitRestore(false, false, true, "", dpv1alpha1.RestorePhaseFailed,
 					func(f *testdp.MockRestoreFactory) {
 						f.SetVolumeClaimsTemplate(testdp.MysqlTemplateName, testdp.DataVolumeName,
 							testdp.DataVolumeMountPath, "", int32(3), int32(0), nil)
@@ -268,7 +274,7 @@ var _ = Describe("Restore Controller test", func() {
 
 			It("test restore is failed when check failed in new action", func() {
 				By("expect for restore is Failed")
-				restore := initResourcesAndWaitRestore(true, false, true, dpv1alpha1.RestorePhaseFailed,
+				restore := initResourcesAndWaitRestore(true, false, true, "", dpv1alpha1.RestorePhaseFailed,
 					func(f *testdp.MockRestoreFactory) {
 						f.Get().Spec.Backup.Name = "wrongBackup"
 					}, nil)
@@ -281,7 +287,7 @@ var _ = Describe("Restore Controller test", func() {
 
 			It("test restore is failed when validate failed in new action", func() {
 				By("expect for restore is Failed")
-				restore := initResourcesAndWaitRestore(false, false, true, dpv1alpha1.RestorePhaseFailed, func(f *testdp.MockRestoreFactory) {
+				restore := initResourcesAndWaitRestore(false, false, true, "", dpv1alpha1.RestorePhaseFailed, func(f *testdp.MockRestoreFactory) {
 					f.SetVolumeClaimsTemplate(testdp.MysqlTemplateName, testdp.DataVolumeName,
 						testdp.DataVolumeMountPath, "", int32(3), int32(0), nil)
 				}, nil)
@@ -294,7 +300,7 @@ var _ = Describe("Restore Controller test", func() {
 
 			It("test restore is Failed when restore job is not Failed", func() {
 				By("expect for restore is Failed ")
-				restore := initResourcesAndWaitRestore(true, false, true, dpv1alpha1.RestorePhaseRunning,
+				restore := initResourcesAndWaitRestore(true, false, true, "", dpv1alpha1.RestorePhaseRunning,
 					func(f *testdp.MockRestoreFactory) {
 						f.SetVolumeClaimsTemplate(testdp.MysqlTemplateName, testdp.DataVolumeName,
 							testdp.DataVolumeMountPath, "", int32(3), int32(0), nil)
@@ -332,7 +338,7 @@ var _ = Describe("Restore Controller test", func() {
 				testdp.MockActionSetWithSchema(&testCtx, actionSet)
 				replicas := 3
 				startingIndex := 0
-				restore := initResourcesAndWaitRestore(true, false, false, dpv1alpha1.RestorePhaseRunning,
+				restore := initResourcesAndWaitRestore(true, false, false, "", dpv1alpha1.RestorePhaseRunning,
 					func(f *testdp.MockRestoreFactory) {
 						f.SetVolumeClaimsTemplate(testdp.MysqlTemplateName, testdp.DataVolumeName,
 							testdp.DataVolumeMountPath, "", int32(replicas), int32(startingIndex), nil)
@@ -349,7 +355,7 @@ var _ = Describe("Restore Controller test", func() {
 			It("test volumeClaimsTemplate when volumeClaimRestorePolicy is Serial", func() {
 				replicas := 2
 				startingIndex := 1
-				restore := initResourcesAndWaitRestore(true, false, true, dpv1alpha1.RestorePhaseRunning,
+				restore := initResourcesAndWaitRestore(true, false, true, "", dpv1alpha1.RestorePhaseRunning,
 					func(f *testdp.MockRestoreFactory) {
 						f.SetVolumeClaimsTemplate(testdp.MysqlTemplateName, testdp.DataVolumeName,
 							testdp.DataVolumeMountPath, "", int32(replicas), int32(startingIndex), nil)
@@ -391,7 +397,7 @@ var _ = Describe("Restore Controller test", func() {
 			})
 
 			It("test dataSourceRef", func() {
-				initResourcesAndWaitRestore(true, true, false, dpv1alpha1.RestorePhaseAsDataSource,
+				initResourcesAndWaitRestore(true, true, false, "", dpv1alpha1.RestorePhaseAsDataSource,
 					func(f *testdp.MockRestoreFactory) {
 						f.SetDataSourceRef(testdp.DataVolumeName, testdp.DataVolumeMountPath)
 					}, nil)
@@ -400,7 +406,7 @@ var _ = Describe("Restore Controller test", func() {
 			It("test when dataRestorePolicy is OneToOne", func() {
 				startingIndex := 0
 				restoredReplicas := 2
-				restore := initResourcesAndWaitRestore(true, false, false, dpv1alpha1.RestorePhaseRunning,
+				restore := initResourcesAndWaitRestore(true, false, false, "", dpv1alpha1.RestorePhaseRunning,
 					func(f *testdp.MockRestoreFactory) {
 						f.SetVolumeClaimsTemplate(testdp.MysqlTemplateName, testdp.DataVolumeName,
 							testdp.DataVolumeMountPath, "", int32(restoredReplicas), int32(startingIndex), nil)
@@ -438,7 +444,7 @@ var _ = Describe("Restore Controller test", func() {
 				startingIndex := 0
 				restoredReplicas := 2
 				sourcePodName := "pod-0"
-				restore := initResourcesAndWaitRestore(true, false, false, dpv1alpha1.RestorePhaseRunning,
+				restore := initResourcesAndWaitRestore(true, false, false, "", dpv1alpha1.RestorePhaseRunning,
 					func(f *testdp.MockRestoreFactory) {
 						f.SetVolumeClaimsTemplate(testdp.MysqlTemplateName, testdp.DataVolumeName,
 							testdp.DataVolumeMountPath, "", int32(restoredReplicas), int32(startingIndex), nil)
@@ -469,6 +475,7 @@ var _ = Describe("Restore Controller test", func() {
 				By("mock jobs are completed and wait for restore is completed")
 				mockAndCheckRestoreCompleted(restore)
 			})
+
 		})
 
 		Context("test postReady stage", func() {
@@ -487,7 +494,7 @@ var _ = Describe("Restore Controller test", func() {
 				matchLabels := map[string]string{
 					constant.AppInstanceLabelKey: testdp.ClusterName,
 				}
-				restore := initResourcesAndWaitRestore(true, false, false, dpv1alpha1.RestorePhaseRunning,
+				restore := initResourcesAndWaitRestore(true, false, false, "", dpv1alpha1.RestorePhaseRunning,
 					func(f *testdp.MockRestoreFactory) {
 						f.SetConnectCredential(testdp.ClusterName).SetJobActionConfig(matchLabels).SetExecActionConfig(matchLabels)
 					}, nil)
@@ -525,7 +532,7 @@ var _ = Describe("Restore Controller test", func() {
 					constant.AppInstanceLabelKey: testdp.ClusterName,
 				}
 
-				restore := initResourcesAndWaitRestore(true, false, false, dpv1alpha1.RestorePhaseRunning,
+				restore := initResourcesAndWaitRestore(true, false, false, "", dpv1alpha1.RestorePhaseRunning,
 					func(f *testdp.MockRestoreFactory) {
 						f.SetJobActionConfig(matchLabels).SetExecActionConfig(matchLabels)
 					}, func(b *dpv1alpha1.Backup) {
@@ -581,7 +588,7 @@ var _ = Describe("Restore Controller test", func() {
 					constant.AppInstanceLabelKey: testdp.ClusterName,
 				}
 
-				restore := initResourcesAndWaitRestore(true, false, false, dpv1alpha1.RestorePhaseRunning,
+				restore := initResourcesAndWaitRestore(true, false, false, "", dpv1alpha1.RestorePhaseRunning,
 					func(f *testdp.MockRestoreFactory) {
 						f.SetJobActionConfig(matchLabels).SetExecActionConfig(matchLabels)
 						f.SetParameters(testdp.TestParameters)
@@ -596,17 +603,102 @@ var _ = Describe("Restore Controller test", func() {
 		Context("test cross namespace", func() {
 			It("should wait for preparation of backup repo", func() {
 				By("creating a restore in a different namespace from backup")
-				initResourcesAndWaitRestore(true, false, true, dpv1alpha1.RestorePhaseRunning,
+				initResourcesAndWaitRestore(true, false, true, "", dpv1alpha1.RestorePhaseRunning,
 					func(f *testdp.MockRestoreFactory) {
 						f.SetNamespace(namespace2)
 					}, nil)
 			})
 		})
+
+		Context("test restore from incremental backup", func() {
+			var (
+				baseBackup       *dpv1alpha1.Backup
+				parentBackupName string
+				ancestorBackups  = []*dpv1alpha1.Backup{}
+				cnt              = 0
+			)
+
+			genIncBackupName := func() string {
+				cnt++
+				return fmt.Sprintf("inc-backup-%d", cnt)
+			}
+
+			BeforeEach(func() {
+				By("mock completed full backup and parent incremental backup")
+				baseBackup = mockBackupForRestore(actionSet.Name, repo.Name, repoPVCName, true, false, dpv1alpha1.BackupTypeFull)
+				actionSet = testdp.NewFakeIncActionSet(&testCtx)
+				parentBackupName = baseBackup.Name
+				for i := 0; i < 3; i++ {
+					backup := mockBackupForRestore(actionSet.Name, repo.Name, repoPVCName, true, false, dpv1alpha1.BackupTypeIncremental,
+						genIncBackupName(), parentBackupName, baseBackup.Name)
+					ancestorBackups = append(ancestorBackups, backup)
+					parentBackupName = backup.Name
+				}
+			})
+
+			AfterEach(func() {
+				ancestorBackups = []*dpv1alpha1.Backup{}
+				cnt = 0
+			})
+
+			It("test restore from incremental backup", func() {
+				replicas, startingIndex := 3, 0
+				restore := initResourcesAndWaitRestore(true, false, false, dpv1alpha1.BackupTypeIncremental, dpv1alpha1.RestorePhaseRunning,
+					func(f *testdp.MockRestoreFactory) {
+						f.SetVolumeClaimsTemplate(testdp.MysqlTemplateName, testdp.DataVolumeName,
+							testdp.DataVolumeMountPath, "", int32(replicas), int32(startingIndex), nil)
+						f.SetPrepareDataRequiredPolicy(dpv1alpha1.OneToOneRestorePolicy, "")
+					}, nil, genIncBackupName(), parentBackupName, baseBackup.Name)
+
+				By("wait for creating jobs and pvcs")
+				checkJobAndPVCSCount(restore, replicas, replicas, 0)
+				By("check job env")
+				ancestorIncrementalBackupNames := []string{}
+				for _, backup := range ancestorBackups {
+					ancestorIncrementalBackupNames = append(ancestorIncrementalBackupNames, backup.Name)
+				}
+				expectedEnv := map[string]string{
+					dptypes.DPAncestorIncrementalBackupNames: strings.Join(ancestorIncrementalBackupNames, ","),
+					dptypes.DPBaseBackupName:                 baseBackup.Name,
+				}
+				jobList := &batchv1.JobList{}
+				Expect(k8sClient.List(ctx, jobList,
+					client.MatchingLabels{dprestore.DataProtectionRestoreLabelKey: restore.Name},
+					client.InNamespace(testCtx.DefaultNamespace))).Should(Succeed())
+				for _, job := range jobList.Items {
+					cnt := 0
+					for _, env := range job.Spec.Template.Spec.Containers[0].Env {
+						if value, ok := expectedEnv[env.Name]; ok {
+							Expect(env.Value).Should(Equal(value))
+							cnt++
+						}
+					}
+					Expect(cnt).To(Equal(len(expectedEnv)))
+				}
+				By("mock jobs are completed and wait for restore is completed")
+				mockAndCheckRestoreCompleted(restore)
+			})
+		})
 	})
 })
 
-func mockBackupForRestore(actionSetName, repoName, backupPVCName string, mockBackupCompleted, useVolumeSnapshotBackup bool) *dpv1alpha1.Backup {
-	backup := testdp.NewFakeBackup(&testCtx, nil)
+func mockBackupForRestore(
+	actionSetName, repoName, backupPVCName string,
+	mockBackupCompleted, useVolumeSnapshotBackup bool,
+	backupType dpv1alpha1.BackupType,
+	backupNames ...string,
+) *dpv1alpha1.Backup {
+	backup := testdp.NewFakeBackup(&testCtx, func(backup *dpv1alpha1.Backup) {
+		if len(backupNames) > 0 {
+			backup.Name = backupNames[0]
+		}
+		if backupType == dpv1alpha1.BackupTypeIncremental {
+			if len(backupNames) > 1 {
+				backup.Spec.ParentBackupName = backupNames[1]
+			}
+			backup.Spec.BackupMethod = testdp.IncBackupMethodName
+		}
+	})
 	// wait for backup is failed by backup controller.
 	// it will be failed if the backupPolicy is not created.
 	Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(backup), func(g Gomega, tmpBackup *dpv1alpha1.Backup) {
@@ -621,7 +713,14 @@ func mockBackupForRestore(actionSetName, repoName, backupPVCName string, mockBac
 				backupMethodName = testdp.VSBackupMethodName
 				testdp.MockBackupVSStatusActions(backup)
 			}
-			backup.Status.Path = "/backup-data"
+			if backupType == dpv1alpha1.BackupTypeIncremental {
+				backupMethodName = testdp.IncBackupMethodName
+				if len(backupNames) > 2 {
+					backup.Status.ParentBackupName = backupNames[1]
+					backup.Status.BaseBackupName = backupNames[2]
+				}
+			}
+			backup.Status.Path = "/backup-data" + "/" + backup.Name
 			backup.Status.Phase = dpv1alpha1.BackupPhaseCompleted
 			backup.Status.BackupRepoName = repoName
 			backup.Status.PersistentVolumeClaimName = backupPVCName
@@ -631,6 +730,14 @@ func mockBackupForRestore(actionSetName, repoName, backupPVCName string, mockBac
 				PortName:      testdp.PortName,
 			}
 			testdp.MockBackupStatusMethod(backup, backupMethodName, testdp.DataVolumeName, actionSetName)
+			backup.Status.TimeRange = &dpv1alpha1.BackupTimeRange{
+				Start: &metav1.Time{},
+				End:   &metav1.Time{},
+			}
+			fakeClock.Step(time.Hour)
+			backup.Status.TimeRange.Start.Time = fakeClock.Now()
+			fakeClock.Step(time.Hour)
+			backup.Status.TimeRange.End.Time = fakeClock.Now()
 		})).Should(Succeed())
 	}
 	return backup

--- a/controllers/dataprotection/utils.go
+++ b/controllers/dataprotection/utils.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 	"sync"
 
@@ -260,6 +261,10 @@ func getObjectString(object any) (*string, error) {
 
 func getClusterLabelKeys() []string {
 	return []string{constant.AppInstanceLabelKey, constant.KBAppComponentLabelKey, constant.KBAppShardingNameLabelKey}
+}
+
+func getComonentLabelKeys() []string {
+	return []string{constant.AppInstanceLabelKey, dptypes.ClusterUIDLabelKey, constant.KBAppComponentLabelKey}
 }
 
 // sendWarningEventForError sends warning event for controller error
@@ -579,6 +584,189 @@ func fromFlattenName(flatten string) (name string, namespace string) {
 		name = flatten
 	}
 	return
+}
+
+func GetParentBackup(ctx context.Context, cli client.Client, backup *dpv1alpha1.Backup,
+	backupPolicy *dpv1alpha1.BackupPolicy) (*dpv1alpha1.Backup, error) {
+	if backup == nil {
+		return nil, nil
+	}
+	var parentBackup *dpv1alpha1.Backup
+	if len(backup.Spec.ParentBackupName) != 0 {
+		if err := cli.Get(ctx, client.ObjectKey{
+			Namespace: backup.Namespace,
+			Name:      backup.Spec.ParentBackupName,
+		}, parentBackup); err != nil {
+			return nil, err
+		}
+		if err := ValidateParentBackup(backup, parentBackup, backupPolicy); err != nil {
+			if intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeNeedWaiting) {
+				return nil, err
+			}
+			return nil, fmt.Errorf("failed to validate specified parent backup %s: %w", backup.Spec.ParentBackupName, err)
+		}
+		return parentBackup, nil
+	}
+	parentBackup, err := FindParentBackup(ctx, cli, backup, backupPolicy)
+	if err != nil {
+		if intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeNeedWaiting) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("failed to find parent backup: %w", err)
+	}
+	if parentBackup == nil {
+		return nil, fmt.Errorf("failed to find an invalid parent backup for backup %s/%s", backup.Namespace, backup.Name)
+	}
+	return parentBackup, nil
+}
+
+func FindParentBackup(ctx context.Context, cli client.Client, backup *dpv1alpha1.Backup,
+	backupPolicy *dpv1alpha1.BackupPolicy) (*dpv1alpha1.Backup, error) {
+	compareWithEndTime := func(backupI *dpv1alpha1.Backup, backupJ *dpv1alpha1.Backup) bool {
+		endTimeI := backupI.GetEndTime()
+		endTimeJ := backupJ.GetEndTime()
+		if endTimeI.Equal(endTimeJ) {
+			return backupI.Name > backupJ.Name
+		}
+		return endTimeJ.Before(endTimeI)
+	}
+	getLatestBackup := func(backupList []*dpv1alpha1.Backup) *dpv1alpha1.Backup {
+		if len(backupList) == 0 {
+			return nil
+		}
+		// sort by stop time in descending order
+		sort.Slice(backupList, func(i, j int) bool {
+			return compareWithEndTime(backupList[i], backupList[j])
+		})
+		return backupList[0]
+	}
+	// build list labels
+	labelMap, err := GetBackupTargetLabels(backup)
+	if err != nil {
+		return nil, err
+	}
+	// with backup policy label
+	labelMap[dptypes.BackupPolicyLabelKey] = backup.Spec.BackupPolicyName
+	getLatestParentBackup := func(labels map[string]string, incremental bool) (*dpv1alpha1.Backup, error) {
+		backupList := &dpv1alpha1.BackupList{}
+		if err := cli.List(ctx, backupList, client.InNamespace(backup.Namespace),
+			client.MatchingLabels(labels)); err != nil && !apierrors.IsNotFound(err) {
+			return nil, err
+		}
+		filteredbackupList, err := FilterParentBackups(backupList, backup, backupPolicy, incremental)
+		if err != nil {
+			return nil, err
+		}
+		return getLatestBackup(filteredbackupList), nil
+	}
+	// add the schedule label if specified schedule
+	if schedule, ok := backup.Labels[dptypes.BackupScheduleLabelKey]; ok && len(schedule) > 0 {
+		labelMap[dptypes.BackupScheduleLabelKey] = schedule
+	}
+	// 1. get the latest incremental backups
+	labelMap[dptypes.BackupTypeLabelKey] = string(dpv1alpha1.BackupTypeIncremental)
+	latestIncrementalBackup, err := getLatestParentBackup(labelMap, true)
+	if err != nil {
+		return nil, err
+	}
+	// 2. get the latest full backups
+	labelMap[dptypes.BackupTypeLabelKey] = string(dpv1alpha1.BackupTypeFull)
+	latestFullBackup, err := getLatestParentBackup(labelMap, false)
+	if err != nil {
+		return nil, err
+	}
+	// prefer the latest backup
+	if latestIncrementalBackup != nil && latestFullBackup != nil {
+		if compareWithEndTime(latestIncrementalBackup, latestFullBackup) {
+			return latestIncrementalBackup, nil
+		}
+		return latestFullBackup, nil
+	}
+	// other cases
+	if latestIncrementalBackup != nil {
+		return latestIncrementalBackup, nil
+	}
+	return latestFullBackup, nil
+}
+
+func FilterParentBackups(backupList *dpv1alpha1.BackupList, targetBackup *dpv1alpha1.Backup,
+	backupPolicy *dpv1alpha1.BackupPolicy, incremental bool) ([]*dpv1alpha1.Backup, error) {
+	var res []*dpv1alpha1.Backup
+	backupMethod := dputils.GetBackupMethodByName(targetBackup.Spec.BackupMethod, backupPolicy)
+	if backupMethod == nil {
+		return nil, fmt.Errorf("backupMethod %s not found", targetBackup.Spec.BackupMethod)
+	}
+	for i, backup := range backupList.Items {
+		if backup.Status.Phase != dpv1alpha1.BackupPhaseCompleted {
+			continue
+		}
+		if backup.Spec.BackupPolicyName != targetBackup.Spec.BackupPolicyName {
+			continue
+		}
+		if incremental && backup.Spec.BackupMethod != targetBackup.Spec.BackupMethod {
+			continue
+		}
+		if !incremental && backupMethod.CompatibleMethod != backup.Spec.BackupMethod {
+			continue
+		}
+		if backup.GetEndTime().IsZero() {
+			continue
+		}
+		res = append(res, &backupList.Items[i])
+	}
+	return res, nil
+}
+
+func ValidateParentBackup(backup *dpv1alpha1.Backup, parentBackup *dpv1alpha1.Backup,
+	backupPolicy *dpv1alpha1.BackupPolicy) error {
+	// validate parent backup is completed
+	if parentBackup.Status.Phase != dpv1alpha1.BackupPhaseCompleted {
+		return fmt.Errorf("parent backup %s/%s is not completed", parentBackup.Namespace, parentBackup.Name)
+	}
+	// validate parent backup labels
+	labelMap, err := GetBackupTargetLabels(backup)
+	if err != nil {
+		return err
+	}
+	for k, v := range labelMap {
+		if value, ok := parentBackup.Labels[k]; !ok || value != v {
+			return fmt.Errorf("parent backup %s/%s label %s is not consistent with the backup",
+				parentBackup.Namespace, parentBackup.Name, k)
+		}
+	}
+	// validate if parent backup policy is consistent with the backup policy
+	if parentBackup.Spec.BackupPolicyName != backup.Spec.BackupPolicyName {
+		return fmt.Errorf("parent backup %s/%s policy %s is not consistent with the backup",
+			parentBackup.Namespace, parentBackup.Name, parentBackup.Spec.BackupPolicyName)
+	}
+	// validate if parent backup method is compatible with the backup method
+	backupMethod := dputils.GetBackupMethodByName(backup.Spec.BackupMethod, backupPolicy)
+	if backupMethod == nil {
+		return fmt.Errorf("backupMethod %s not found", backup.Spec.BackupMethod)
+	}
+	if backup.Spec.BackupMethod != parentBackup.Spec.BackupMethod &&
+		backupMethod.CompatibleMethod != parentBackup.Spec.BackupMethod {
+		return fmt.Errorf("parent backup %s/%s method %s is useless for incremental backup",
+			parentBackup.Namespace, parentBackup.Name, parentBackup.Spec.BackupMethod)
+	}
+	return nil
+}
+
+func GetBackupTargetLabels(backup *dpv1alpha1.Backup) (map[string]string, error) {
+	labelKeys := getComonentLabelKeys()
+	labelMap := map[string]string{}
+	for _, key := range labelKeys {
+		value, ok := backup.Labels[key]
+		if !ok {
+			if backup.Status.Phase == "" || backup.Status.Phase == dpv1alpha1.BackupPhaseNew {
+				// wait for the backup controller to set the labels
+				return nil, intctrlutil.NewErrorf(intctrlutil.ErrorTypeNeedWaiting, "label %s not found", key)
+			}
+			return nil, fmt.Errorf("fails to validate parent backup, label %s not found", key)
+		}
+		labelMap[key] = value
+	}
+	return labelMap, nil
 }
 
 // restore functions

--- a/controllers/dataprotection/utils.go
+++ b/controllers/dataprotection/utils.go
@@ -624,9 +624,7 @@ func GetParentBackup(ctx context.Context, cli client.Client, backup *dpv1alpha1.
 
 // FindParentBackupIfNotSet finds the latest valid parent backup for the incremental backup.
 // a. return the latest full backup when it is newer than the base backup of the latest incremental backup,
-//
-//	or when the base backup of the latest incremental backup is not found.
-//
+//    or when the base backup of the latest incremental backup is not found.
 // b. return the latest incremental backup.
 // c. return the latest full backup if incremental backups are not found.
 // For scheduled backups, find the parent within scheduled backups, which have the schedule label.

--- a/controllers/dataprotection/utils.go
+++ b/controllers/dataprotection/utils.go
@@ -587,7 +587,7 @@ func GetParentBackup(ctx context.Context, cli client.Client, backup *dpv1alpha1.
 	if backup == nil {
 		return nil, nil
 	}
-	var parentBackup *dpv1alpha1.Backup
+	parentBackup := &dpv1alpha1.Backup{}
 	if len(backup.Spec.ParentBackupName) != 0 {
 		if err := cli.Get(ctx, client.ObjectKey{
 			Namespace: backup.Namespace,
@@ -730,8 +730,12 @@ func ValidateParentBackup(backup *dpv1alpha1.Backup, parentBackup *dpv1alpha1.Ba
 	}
 	if backup.Spec.BackupMethod != parentBackup.Spec.BackupMethod &&
 		backupMethod.CompatibleMethod != parentBackup.Spec.BackupMethod {
-		return fmt.Errorf("parent backup %s/%s method %s is useless for incremental backup",
+		return fmt.Errorf("parent backup %s/%s method %s is invalid for incremental backup",
 			parentBackup.Namespace, parentBackup.Name, parentBackup.Spec.BackupMethod)
+	}
+	// valiate parent end time
+	if parentBackup.GetEndTime().IsZero() {
+		return fmt.Errorf("parent backup %s/%s end time is zero", parentBackup.Namespace, parentBackup.Name)
 	}
 	return nil
 }

--- a/controllers/dataprotection/utils.go
+++ b/controllers/dataprotection/utils.go
@@ -695,11 +695,14 @@ func FilterParentBackups(backupList *dpv1alpha1.BackupList, targetBackup *dpv1al
 		if backup.Spec.BackupPolicyName != targetBackup.Spec.BackupPolicyName {
 			continue
 		}
-		if incremental && backup.Spec.BackupMethod != targetBackup.Spec.BackupMethod {
-			continue
-		}
-		if !incremental && backupMethod.CompatibleMethod != backup.Spec.BackupMethod {
-			continue
+		if incremental {
+			if backup.Spec.BackupMethod != targetBackup.Spec.BackupMethod {
+				continue
+			}
+		} else {
+			if backupMethod.CompatibleMethod != backup.Spec.BackupMethod {
+				continue
+			}
 		}
 		if backup.GetEndTime().IsZero() {
 			continue

--- a/controllers/dataprotection/utils.go
+++ b/controllers/dataprotection/utils.go
@@ -627,8 +627,8 @@ func GetParentBackup(ctx context.Context, cli client.Client, backup *dpv1alpha1.
 // or when the base backup of the latest incremental backup is not found.
 // b. return the latest incremental backup.
 // c. return the latest full backup if incremental backups are not found.
-// For scheduled backups, find the parent within scheduled backups, which have the schedule label.
-// If not found, find the full backup as the parent within all backups.
+// For scheduled backups, find the parent within scheduled backups, which have the schedule label,
+// if not found, find the full backup as the parent within all backups.
 // For on-demand backups, find the parent within all backups.
 func FindParentBackupIfNotSet(ctx context.Context, cli client.Client, backup *dpv1alpha1.Backup,
 	backupMethod *dpv1alpha1.BackupMethod, scheduleName string) (*dpv1alpha1.Backup, error) {
@@ -694,7 +694,7 @@ func FindParentBackupIfNotSet(ctx context.Context, cli client.Client, backup *dp
 	if latestFullBackup != nil {
 		return latestFullBackup, nil
 	}
-	// illegal case: no full backup found but incremental backup found,
+	// illegal case: no full backup found but incremental backup found
 	if latestIncrementalBackup != nil {
 		return nil, fmt.Errorf("ilegal incremental backup %s/%s", latestIncrementalBackup.Namespace,
 			latestIncrementalBackup.Name)

--- a/controllers/dataprotection/utils.go
+++ b/controllers/dataprotection/utils.go
@@ -624,7 +624,7 @@ func GetParentBackup(ctx context.Context, cli client.Client, backup *dpv1alpha1.
 
 // FindParentBackupIfNotSet finds the latest valid parent backup for the incremental backup.
 // a. return the latest full backup when it is newer than the base backup of the latest incremental backup,
-//    or when the base backup of the latest incremental backup is not found.
+// or when the base backup of the latest incremental backup is not found.
 // b. return the latest incremental backup.
 // c. return the latest full backup if incremental backups are not found.
 // For scheduled backups, find the parent within scheduled backups, which have the schedule label.

--- a/controllers/dataprotection/utils.go
+++ b/controllers/dataprotection/utils.go
@@ -696,7 +696,7 @@ func FindParentBackupIfNotSet(ctx context.Context, cli client.Client, backup *dp
 	}
 	// illegal case: no full backup found but incremental backup found
 	if latestIncrementalBackup != nil {
-		return nil, fmt.Errorf("ilegal incremental backup %s/%s", latestIncrementalBackup.Namespace,
+		return nil, fmt.Errorf("illegal incremental backup %s/%s", latestIncrementalBackup.Namespace,
 			latestIncrementalBackup.Name)
 	}
 	// 6. no backup found
@@ -714,6 +714,8 @@ func FilterParentBackups(backupList *dpv1alpha1.BackupList, targetBackup *dpv1al
 		if err := ValidateParentBackup(targetBackup, &backup, backupMethod); err != nil {
 			continue
 		}
+		// backups are listed by backup type label, validate if the backup method matches
+		// the backup type specified by label value.
 		if incremental {
 			if backup.Spec.BackupMethod != targetBackup.Spec.BackupMethod {
 				continue

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Volume Populator Controller test", func() {
 			createStorageClass(volumeBinding)
 
 			By("create backup")
-			backup := mockBackupForRestore(actionSet.Name, "", "", mockBackupCompleted, useVolumeSnapshotBackup)
+			backup := mockBackupForRestore(actionSet.Name, "", "", mockBackupCompleted, useVolumeSnapshotBackup, "")
 
 			By("create restore ")
 			restore := testdp.NewRestoreFactory(testCtx.DefaultNamespace, testdp.RestoreName).

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -101,7 +101,7 @@ var _ = Describe("Volume Populator Controller test", func() {
 
 		BeforeEach(func() {
 			By("create actionSet")
-			actionSet = testdp.NewFakeActionSet(&testCtx)
+			actionSet = testdp.NewFakeActionSet(&testCtx, nil)
 		})
 
 		initResources := func(volumeBinding storagev1.VolumeBindingMode, useVolumeSnapshotBackup, mockBackupCompleted bool) *corev1.PersistentVolumeClaim {

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -73,6 +73,11 @@ spec:
                         For volume snapshot backup, the actionSet is not required, the controller
                         will use the CSI volume snapshotter to create the snapshot.
                       type: string
+                    compatibleMethod:
+                      description: The name of the compatible full backup method,
+                        used by incremental backups.
+                      pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                      type: string
                     env:
                       description: Specifies the environment variables for the backup
                         workload.

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicytemplates.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicytemplates.yaml
@@ -76,6 +76,11 @@ spec:
                         For volume snapshot backup, the actionSet is not required, the controller
                         will use the CSI volume snapshotter to create the snapshot.
                       type: string
+                    compatibleMethod:
+                      description: The name of the compatible full backup method,
+                        used by incremental backups.
+                      pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                      type: string
                     env:
                       description: Specifies the environment variables for the backup
                         workload.

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
@@ -298,6 +298,11 @@ spec:
                       For volume snapshot backup, the actionSet is not required, the controller
                       will use the CSI volume snapshotter to create the snapshot.
                     type: string
+                  compatibleMethod:
+                    description: The name of the compatible full backup method, used
+                      by incremental backups.
+                    pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                    type: string
                   env:
                     description: Specifies the environment variables for the backup
                       workload.
@@ -1013,6 +1018,10 @@ spec:
               backupRepoName:
                 description: The name of the backup repository.
                 type: string
+              baseBackupName:
+                description: Records the base full backup name for incremental backup
+                  or differential backup.
+                type: string
               completionTimestamp:
                 description: |-
                   Records the time when the backup operation was completed.
@@ -1091,6 +1100,10 @@ spec:
                 type: string
               kopiaRepoPath:
                 description: Records the path of the Kopia repository.
+                type: string
+              parentBackupName:
+                description: Records the parent backup name for incremental or differential
+                  backup.
                 type: string
               path:
                 description: |-

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
@@ -1019,8 +1019,9 @@ spec:
                 description: The name of the backup repository.
                 type: string
               baseBackupName:
-                description: Records the base full backup name for incremental backup
-                  or differential backup.
+                description: |-
+                  Records the base full backup name for incremental backup or differential backup.
+                  When the base backup is deleted, the backup will also be deleted.
                 type: string
               completionTimestamp:
                 description: |-
@@ -1102,8 +1103,9 @@ spec:
                 description: Records the path of the Kopia repository.
                 type: string
               parentBackupName:
-                description: Records the parent backup name for incremental or differential
-                  backup.
+                description: |-
+                  Records the parent backup name for incremental or differential backup.
+                  When the parent backup is deleted, the backup will also be deleted.
                 type: string
               path:
                 description: |-

--- a/docs/developer_docs/api-reference/backup.md
+++ b/docs/developer_docs/api-reference/backup.md
@@ -2054,6 +2054,18 @@ string
 </tr>
 <tr>
 <td>
+<code>compatibleMethod</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The name of the compatible full backup method, used by incremental backups.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>snapshotVolumes</code><br/>
 <em>
 bool
@@ -3561,7 +3573,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Records the parent backup name for incremental or differential backup.</p>
+<p>Records the parent backup name for incremental or differential backup.
+When the parent backup is deleted, the backup will also be deleted.</p>
 </td>
 </tr>
 <tr>
@@ -3573,7 +3586,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Records the base full backup name for incremental backup or differential backup.</p>
+<p>Records the base full backup name for incremental backup or differential backup.
+When the base backup is deleted, the backup will also be deleted.</p>
 </td>
 </tr>
 <tr>

--- a/docs/developer_docs/api-reference/backup.md
+++ b/docs/developer_docs/api-reference/backup.md
@@ -1915,6 +1915,18 @@ string
 </tr>
 <tr>
 <td>
+<code>compatibleMethod</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The name of the compatible full backup method, used by incremental backups.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>snapshotVolumes</code><br/>
 <em>
 bool
@@ -3538,6 +3550,30 @@ EncryptionConfig
 <td>
 <em>(Optional)</em>
 <p>Records the volume snapshot status for the action.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>parentBackupName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Records the parent backup name for incremental or differential backup.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>baseBackupName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Records the base full backup name for incremental backup or differential backup.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/dataprotection/backup/utils.go
+++ b/pkg/dataprotection/backup/utils.go
@@ -211,6 +211,14 @@ func BuildBaseBackupPath(backup *dpv1alpha1.Backup, repoPathPrefix, pathPrefix s
 	return filepath.Join("/", repoPathPrefix, backup.Namespace, pathPrefix, backup.Name)
 }
 
+// BuildBackupRootPath builds the root path to storage backup data in backup repository.
+func BuildBackupRootPath(backup *dpv1alpha1.Backup, repoPathPrefix, pathPrefix string) string {
+	repoPathPrefix = strings.Trim(repoPathPrefix, "/")
+	pathPrefix = strings.Trim(pathPrefix, "/")
+	// pattern: ${repoPathPrefix}/${namespace}/${pathPrefix}
+	return filepath.Join("/", repoPathPrefix, backup.Namespace, pathPrefix)
+}
+
 // BuildBackupPathByTarget builds the backup by target.name and podSelectionStrategy.
 func BuildBackupPathByTarget(backup *dpv1alpha1.Backup,
 	target *dpv1alpha1.BackupTarget,
@@ -218,13 +226,21 @@ func BuildBackupPathByTarget(backup *dpv1alpha1.Backup,
 	pathPrefix,
 	targetPodName string) string {
 	baseBackupPath := BuildBaseBackupPath(backup, repoPathPrefix, pathPrefix)
+	targetRelativePath := BuildTargetRelativePath(target, targetPodName)
+	return filepath.Join("/", baseBackupPath, targetRelativePath)
+}
+
+// BuildTargetRelativePath builds the relative path by target.name and podSelectionStrategy.
+func BuildTargetRelativePath(target *dpv1alpha1.BackupTarget, targetPodName string) string {
+	path := ""
 	if target.Name != "" {
-		baseBackupPath = filepath.Join("/", baseBackupPath, target.Name)
+		path = filepath.Join("/", path, target.Name)
 	}
 	if target.PodSelector.Strategy == dpv1alpha1.PodSelectionStrategyAll {
-		baseBackupPath = filepath.Join("/", baseBackupPath, targetPodName)
+		path = filepath.Join("/", path, targetPodName)
 	}
-	return baseBackupPath
+	// return /${DP_TARGET_RELATIVE_PATH}
+	return path
 }
 
 // BuildKopiaRepoPath builds the path of kopia repository.

--- a/pkg/dataprotection/backup/utils.go
+++ b/pkg/dataprotection/backup/utils.go
@@ -233,12 +233,12 @@ func BuildBackupPathByTarget(backup *dpv1alpha1.Backup,
 func BuildTargetRelativePath(target *dpv1alpha1.BackupTarget, targetPodName string) string {
 	path := ""
 	if target.Name != "" {
-		path = filepath.Join("/", path, target.Name)
+		path = filepath.Join(path, target.Name)
 	}
 	if target.PodSelector.Strategy == dpv1alpha1.PodSelectionStrategyAll {
-		path = filepath.Join("/", path, targetPodName)
+		path = filepath.Join(path, targetPodName)
 	}
-	// return /${DP_TARGET_RELATIVE_PATH}
+	// return ${DP_TARGET_RELATIVE_PATH}
 	return path
 }
 

--- a/pkg/dataprotection/backup/utils.go
+++ b/pkg/dataprotection/backup/utils.go
@@ -205,10 +205,9 @@ func GenerateLegacyCRNameByBackupSchedule(backupSchedule *dpv1alpha1.BackupSched
 
 // BuildBaseBackupPath builds the path to storage backup data in backup repository.
 func BuildBaseBackupPath(backup *dpv1alpha1.Backup, repoPathPrefix, pathPrefix string) string {
-	repoPathPrefix = strings.Trim(repoPathPrefix, "/")
-	pathPrefix = strings.Trim(pathPrefix, "/")
+	backupRootPath := BuildBackupRootPath(backup, repoPathPrefix, pathPrefix)
 	// pattern: ${repoPathPrefix}/${namespace}/${pathPrefix}/${backupName}
-	return filepath.Join("/", repoPathPrefix, backup.Namespace, pathPrefix, backup.Name)
+	return filepath.Join("/", backupRootPath, backup.Name)
 }
 
 // BuildBackupRootPath builds the root path to storage backup data in backup repository.

--- a/pkg/dataprotection/restore/builder.go
+++ b/pkg/dataprotection/restore/builder.go
@@ -22,7 +22,6 @@ package restore
 import (
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -192,17 +191,8 @@ func (r *restoreJobBuilder) addCommonEnv(sourceTargetPodName string) *restoreJob
 	// add common env
 	filePath := r.backupSet.Backup.Status.Path
 	if filePath != "" {
-		// append targetName in backup path
-		if r.restore.Spec.Backup.SourceTargetName != "" {
-			filePath = filepath.Join("/", filePath, r.restore.Spec.Backup.SourceTargetName)
-		}
-		// append sourceTargetPodName in backup path
-		if sourceTargetPodName != "" {
-			filePath = filepath.Join("/", filePath, sourceTargetPodName)
-		}
-		r.env = append(r.env, corev1.EnvVar{Name: dptypes.DPBackupBasePath, Value: filePath})
+		r.env = append(r.env, BackupFilePathEnv(filePath, r.restore.Spec.Backup.SourceTargetName, sourceTargetPodName)...)
 	}
-	r.env = append(r.env, BackupFilePathEnv(filePath, r.restore.Spec.Backup.SourceTargetName, sourceTargetPodName)...)
 	if r.backupSet.BaseBackup != nil {
 		r.env = append(r.env, corev1.EnvVar{Name: dptypes.DPBaseBackupName, Value: r.backupSet.BaseBackup.Name})
 	}

--- a/pkg/dataprotection/restore/builder.go
+++ b/pkg/dataprotection/restore/builder.go
@@ -202,6 +202,17 @@ func (r *restoreJobBuilder) addCommonEnv(sourceTargetPodName string) *restoreJob
 		}
 		r.env = append(r.env, corev1.EnvVar{Name: dptypes.DPBackupBasePath, Value: filePath})
 	}
+	r.env = append(r.env, BackupFilePathEnv(filePath, r.restore.Spec.Backup.SourceTargetName, sourceTargetPodName)...)
+	if r.backupSet.BaseBackup != nil {
+		r.env = append(r.env, corev1.EnvVar{Name: dptypes.DPBaseBackupName, Value: r.backupSet.BaseBackup.Name})
+	}
+	if len(r.backupSet.AncestorIncrementalBackups) > 0 {
+		ancestorIncrementalBackupNames := []string{}
+		for _, backup := range r.backupSet.AncestorIncrementalBackups {
+			ancestorIncrementalBackupNames = append(ancestorIncrementalBackupNames, backup.Name)
+		}
+		r.env = append(r.env, corev1.EnvVar{Name: dptypes.DPAncestorIncrementalBackupNames, Value: strings.Join(ancestorIncrementalBackupNames, ",")})
+	}
 	// add time env
 	actionSetEnv := r.backupSet.ActionSet.Spec.Env
 	timeFormat := getTimeFormat(actionSetEnv)

--- a/pkg/dataprotection/restore/manager.go
+++ b/pkg/dataprotection/restore/manager.go
@@ -204,7 +204,9 @@ func (r *RestoreManager) getBackupActionSetForContinuous(reqCtx intctrlutil.Requ
 	if err != nil {
 		return nil, err
 	}
-	backupItems := append(fullBackupItems, incrementalBackupItems...)
+	backupItems := []dpv1alpha1.Backup{}
+	backupItems = append(backupItems, fullBackupItems...)
+	backupItems = append(backupItems, incrementalBackupItems...)
 	// sort by completed time in descending order
 	sort.Slice(backupItems, func(i, j int) bool {
 		i, j = j, i

--- a/pkg/dataprotection/restore/utils.go
+++ b/pkg/dataprotection/restore/utils.go
@@ -471,10 +471,10 @@ func ValidateParentBackupSet(parentBackupSet *BackupActionSet, backupSet *Backup
 func GetTargetRelativePath(targetName, targetPodName string) string {
 	targetRelativePath := ""
 	if targetName != "" {
-		targetRelativePath = filepath.Join("/", targetRelativePath, targetName)
+		targetRelativePath = filepath.Join(targetRelativePath, targetName)
 	}
 	if targetPodName != "" {
-		targetRelativePath = filepath.Join("/", targetRelativePath, targetPodName)
+		targetRelativePath = filepath.Join(targetRelativePath, targetPodName)
 	}
 	return targetRelativePath
 }

--- a/pkg/dataprotection/restore/utils.go
+++ b/pkg/dataprotection/restore/utils.go
@@ -476,6 +476,7 @@ func GetTargetRelativePath(targetName, targetPodName string) string {
 	if targetPodName != "" {
 		targetRelativePath = filepath.Join(targetRelativePath, targetPodName)
 	}
+	// ${targetName}/${targetPodName}
 	return targetRelativePath
 }
 
@@ -495,7 +496,7 @@ func BackupFilePathEnv(filePath, targetName, targetPodName string) []corev1.EnvV
 			Name:  dptypes.DPBackupRootPath,
 			Value: filepath.Join("/", filePath, "../"),
 		},
-		// append targetName and sourceTargetPodName in backup path
+		// construct the backup base path with target relative path
 		{
 			Name:  dptypes.DPBackupBasePath,
 			Value: filepath.Join("/", filePath, targetRelativePath),

--- a/pkg/dataprotection/restore/utils.go
+++ b/pkg/dataprotection/restore/utils.go
@@ -433,7 +433,7 @@ func ValidateParentBackupSet(parentBackupSet *BackupActionSet, backupSet *Backup
 		return fmt.Errorf(`parent backup policy: "%s" is defferent with child backup policy: "%s"`,
 			parentBackup.Spec.BackupPolicyName, backup.Spec.BackupPolicyName)
 	}
-	// validate parent backup method
+	// validate parent backup method and base backup name
 	var parentBackupType dpv1alpha1.BackupType
 	if parentBackupSet.ActionSet != nil {
 		parentBackupType = parentBackupSet.ActionSet.Spec.BackupType
@@ -444,10 +444,18 @@ func ValidateParentBackupSet(parentBackupSet *BackupActionSet, backupSet *Backup
 			return fmt.Errorf(`the parent incremental backup method "%s" is not the same with the child backup method "%s"`,
 				parentBackup.Spec.BackupMethod, backup.Spec.BackupMethod)
 		}
+		if parentBackup.Status.BaseBackupName != backup.Status.BaseBackupName {
+			return fmt.Errorf(`the parent incremental backup base backup "%s" is not the same with the child backup base backup "%s"`,
+				parentBackup.Status.BaseBackupName, backup.Status.BaseBackupName)
+		}
 	case dpv1alpha1.BackupTypeFull:
 		if parentBackup.Spec.BackupMethod != backup.Status.BackupMethod.CompatibleMethod {
 			return fmt.Errorf(`the parent full backup method "%s" is not compatible with the child backup method "%s"`,
 				parentBackup.Spec.BackupMethod, backup.Spec.BackupMethod)
+		}
+		if parentBackup.Name != backup.Status.BaseBackupName {
+			return fmt.Errorf(`the parent full backup base backup "%s" is not the same with the child backup base backup "%s"`,
+				parentBackup.Name, backup.Status.BaseBackupName)
 		}
 	default:
 		return fmt.Errorf(`the parent backup "%s" is not incremental or full backup`, parentBackup.Name)

--- a/pkg/dataprotection/restore/utils.go
+++ b/pkg/dataprotection/restore/utils.go
@@ -467,12 +467,8 @@ func ValidateParentBackupSet(parentBackupSet *BackupActionSet, backupSet *Backup
 	return nil
 }
 
-// BackupFilePathEnv returns the envs for backup root path and target relative path.
-func BackupFilePathEnv(filePath, targetName, targetPodName string) []corev1.EnvVar {
-	envs := []corev1.EnvVar{}
-	if len(filePath) == 0 {
-		return envs
-	}
+// GetTargetRelativePath returns the target relative path.
+func GetTargetRelativePath(targetName, targetPodName string) string {
 	targetRelativePath := ""
 	if targetName != "" {
 		targetRelativePath = filepath.Join("/", targetRelativePath, targetName)
@@ -480,6 +476,16 @@ func BackupFilePathEnv(filePath, targetName, targetPodName string) []corev1.EnvV
 	if targetPodName != "" {
 		targetRelativePath = filepath.Join("/", targetRelativePath, targetPodName)
 	}
+	return targetRelativePath
+}
+
+// BackupFilePathEnv returns the envs for backup root path and target relative path.
+func BackupFilePathEnv(filePath, targetName, targetPodName string) []corev1.EnvVar {
+	envs := []corev1.EnvVar{}
+	if len(filePath) == 0 {
+		return envs
+	}
+	targetRelativePath := GetTargetRelativePath(targetName, targetPodName)
 	envs = append(envs, []corev1.EnvVar{
 		{
 			Name:  dptypes.DPTargetRelativePath,
@@ -488,6 +494,11 @@ func BackupFilePathEnv(filePath, targetName, targetPodName string) []corev1.EnvV
 		{
 			Name:  dptypes.DPBackupRootPath,
 			Value: filepath.Join("/", filePath, "../"),
+		},
+		// append targetName and sourceTargetPodName in backup path
+		{
+			Name:  dptypes.DPBackupBasePath,
+			Value: filepath.Join("/", filePath, targetRelativePath),
 		},
 	}...)
 	return envs

--- a/pkg/dataprotection/restore/utils.go
+++ b/pkg/dataprotection/restore/utils.go
@@ -422,35 +422,36 @@ func ValidateParentBackupSet(parentBackupSet *BackupActionSet, backupSet *Backup
 	parentBackup := parentBackupSet.Backup
 	backup := backupSet.Backup
 	if parentBackup == nil || backup == nil {
-		return intctrlutil.NewFatalError("parent backup or child backup is nil")
+		return fmt.Errorf("parent backup or child backup is nil")
+	}
+	if parentBackup.Status.Phase != dpv1alpha1.BackupPhaseCompleted ||
+		backup.Status.Phase != dpv1alpha1.BackupPhaseCompleted {
+		return fmt.Errorf("parent backup or child backup is not completed")
 	}
 	// validate parent backup policy
 	if parentBackup.Spec.BackupPolicyName != backup.Spec.BackupPolicyName {
-		return intctrlutil.NewFatalError(
-			fmt.Sprintf(`parent backup policy: "%s" is defferent with child backup policy: "%s"`,
-				parentBackup.Spec.BackupPolicyName, backup.Spec.BackupPolicyName))
+		return fmt.Errorf(`parent backup policy: "%s" is defferent with child backup policy: "%s"`,
+			parentBackup.Spec.BackupPolicyName, backup.Spec.BackupPolicyName)
 	}
 	// validate parent backup method
 	if parentBackupSet.ActionSet != nil && parentBackupSet.ActionSet.Spec.BackupType == dpv1alpha1.BackupTypeIncremental {
 		if parentBackup.Spec.BackupMethod != backup.Spec.BackupMethod {
-			return intctrlutil.NewFatalError(
-				fmt.Sprintf(`the parent incremental backup method "%s" is not the same with the child backup method "%s"`,
-					parentBackup.Spec.BackupMethod, backup.Spec.BackupMethod))
+			return fmt.Errorf(`the parent incremental backup method "%s" is not the same with the child backup method "%s"`,
+				parentBackup.Spec.BackupMethod, backup.Spec.BackupMethod)
 		}
 	} else if parentBackupSet.ActionSet != nil && parentBackupSet.ActionSet.Spec.BackupType == dpv1alpha1.BackupTypeFull {
 		if parentBackup.Spec.BackupMethod != backup.Status.BackupMethod.CompatibleMethod {
-			return intctrlutil.NewFatalError(
-				fmt.Sprintf(`the parent full backup method "%s" is not compatible with the child backup method "%s"`,
-					parentBackup.Spec.BackupMethod, backup.Spec.BackupMethod))
+			return fmt.Errorf(`the parent full backup method "%s" is not compatible with the child backup method "%s"`,
+				parentBackup.Spec.BackupMethod, backup.Spec.BackupMethod)
 		}
 	} else {
-		return intctrlutil.NewFatalError(fmt.Sprintf(`the parent backup "%s" is not incremental or full backup`,
-			parentBackup.Name))
+		return fmt.Errorf(`the parent backup "%s" is not incremental or full backup`,
+			parentBackup.Name)
 	}
 	// validate parent backup end time
 	if !utils.CompareWithBackupStopTime(*parentBackup, *backup) {
-		return intctrlutil.NewFatalError(fmt.Sprintf(`the parent backup "%s" is not before the child backup "%s"`,
-			parentBackup.Name, backup.Name))
+		return fmt.Errorf(`the parent backup "%s" is not before the child backup "%s"`,
+			parentBackup.Name, backup.Name)
 	}
 	return nil
 }

--- a/pkg/dataprotection/types/constant.go
+++ b/pkg/dataprotection/types/constant.go
@@ -104,6 +104,8 @@ const (
 	DPTargetPodRole = "DP_TARGET_POD_ROLE"
 	// DPBackupBasePath the base path for backup data in the storage
 	DPBackupBasePath = "DP_BACKUP_BASE_PATH"
+	// DPParentBackupBasePath the base path for parent backup data in the storage
+	DPParentBackupBasePath = "DP_PARENT_BACKUP_BASE_PATH"
 	// DPBackupName backup CR name
 	DPBackupName = "DP_BACKUP_NAME"
 	// DPParentBackupName backup CR name

--- a/pkg/dataprotection/types/constant.go
+++ b/pkg/dataprotection/types/constant.go
@@ -103,7 +103,7 @@ const (
 	// DPTargetPodRole the target pod role
 	DPTargetPodRole = "DP_TARGET_POD_ROLE"
 	// DPBackupBasePath the base path for backup data in the storage
-	// For a backup action pod, it equals ${DP_BACKUP_ROOT_PATH}/${DP_BACKUP_NAME}/${DP_TARGET_RELATIVE_PATH}
+	// In a backup action pod, it equals ${DP_BACKUP_ROOT_PATH}/${DP_BACKUP_NAME}/${DP_TARGET_RELATIVE_PATH}
 	DPBackupBasePath = "DP_BACKUP_BASE_PATH"
 	// DPBackupRootPath the root path for backup data
 	DPBackupRootPath = "DP_BACKUP_ROOT_PATH"

--- a/pkg/dataprotection/types/constant.go
+++ b/pkg/dataprotection/types/constant.go
@@ -103,13 +103,22 @@ const (
 	// DPTargetPodRole the target pod role
 	DPTargetPodRole = "DP_TARGET_POD_ROLE"
 	// DPBackupBasePath the base path for backup data in the storage
+	// For a backup action pod, it equals ${DP_BACKUP_ROOT_PATH}/${DP_BACKUP_NAME}/${DP_TARGET_RELATIVE_PATH}
 	DPBackupBasePath = "DP_BACKUP_BASE_PATH"
-	// DPParentBackupBasePath the base path for parent backup data in the storage
-	DPParentBackupBasePath = "DP_PARENT_BACKUP_BASE_PATH"
+	// DPBackupRootPath the root path for backup data
+	DPBackupRootPath = "DP_BACKUP_ROOT_PATH"
+	// DPTargetRelativePath the relative path based on the backup data root path
+	DPTargetRelativePath = "DP_TARGET_RELATIVE_PATH"
 	// DPBackupName backup CR name
 	DPBackupName = "DP_BACKUP_NAME"
 	// DPParentBackupName backup CR name
 	DPParentBackupName = "DP_PARENT_BACKUP_NAME"
+	// DPBaseBackupName backup CR name
+	DPBaseBackupName = "DP_BASE_BACKUP_NAME"
+	// DPAncestorIncrementalBackupNames backup CR names
+	// Used to restore incremental backups, recording the incremental ancestor backup names in order of end time
+	// For example: ${DP_ANCESTOR_INCREMENTAL_BACKUP_NAMES}=incrementalBackupName1,incrementalBackupName2,incrementalBackupName3
+	DPAncestorIncrementalBackupNames = "DP_ANCESTOR_INCREMENTAL_BACKUP_NAMES"
 	// DPTTL backup time to live, reference the backup.spec.retentionPeriod
 	DPTTL = "DP_TTL"
 	// DPCheckInterval check interval for sync backup progress

--- a/pkg/dataprotection/types/constant.go
+++ b/pkg/dataprotection/types/constant.go
@@ -108,7 +108,7 @@ const (
 	// DPBackupRootPath the root path for backup data
 	DPBackupRootPath = "DP_BACKUP_ROOT_PATH"
 	// DPTargetRelativePath the relative path based on the backup data root path
-	// ${DP_TARGET_RELATIVE_PATH}=/${target.name}/${target.selectedTargetPod[*]}
+	// ${DP_TARGET_RELATIVE_PATH}=${target.name}/${target.selectedTargetPod[*]}
 	DPTargetRelativePath = "DP_TARGET_RELATIVE_PATH"
 	// DPBackupName backup CR name
 	DPBackupName = "DP_BACKUP_NAME"

--- a/pkg/dataprotection/types/constant.go
+++ b/pkg/dataprotection/types/constant.go
@@ -108,6 +108,7 @@ const (
 	// DPBackupRootPath the root path for backup data
 	DPBackupRootPath = "DP_BACKUP_ROOT_PATH"
 	// DPTargetRelativePath the relative path based on the backup data root path
+	// ${DP_TARGET_RELATIVE_PATH}=/${target.name}/${target.selectedTargetPod[*]}
 	DPTargetRelativePath = "DP_TARGET_RELATIVE_PATH"
 	// DPBackupName backup CR name
 	DPBackupName = "DP_BACKUP_NAME"

--- a/pkg/dataprotection/utils/utils.go
+++ b/pkg/dataprotection/utils/utils.go
@@ -452,3 +452,18 @@ func ValidateParameters(actionSet *dpv1alpha1.ActionSet, parameters []dpv1alpha1
 	}
 	return nil
 }
+
+func CompareWithBackupStopTime(backupI, backupJ dpv1alpha1.Backup) bool {
+	endTimeI := backupI.GetEndTime()
+	endTimeJ := backupJ.GetEndTime()
+	if endTimeI.IsZero() {
+		return false
+	}
+	if endTimeJ.IsZero() {
+		return true
+	}
+	if endTimeI.Equal(endTimeJ) {
+		return backupI.Name < backupJ.Name
+	}
+	return endTimeI.Before(endTimeJ)
+}

--- a/pkg/dataprotection/utils/utils.go
+++ b/pkg/dataprotection/utils/utils.go
@@ -253,6 +253,19 @@ func GetBackupType(actionSet *dpv1alpha1.ActionSet, useSnapshot *bool) dpv1alpha
 	return ""
 }
 
+func GetBackupTypeByMethodName(reqCtx intctrlutil.RequestCtx, cli client.Client, methodName string,
+	backupPolicy *dpv1alpha1.BackupPolicy) (dpv1alpha1.BackupType, error) {
+	backupMethod := GetBackupMethodByName(methodName, backupPolicy)
+	if backupMethod == nil {
+		return "", nil
+	}
+	actionSet, err := GetActionSetByName(reqCtx, cli, backupMethod.ActionSetName)
+	if err != nil {
+		return "", err
+	}
+	return GetBackupType(actionSet, backupMethod.SnapshotVolumes), nil
+}
+
 // PrependSpaces prepends spaces to each line of the content.
 func PrependSpaces(content string, spaces int) string {
 	prefix := ""

--- a/pkg/testutil/dataprotection/backup_utils.go
+++ b/pkg/testutil/dataprotection/backup_utils.go
@@ -40,9 +40,14 @@ import (
 	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
 
-func NewFakeActionSet(testCtx *testutil.TestContext) *dpv1alpha1.ActionSet {
+func NewFakeActionSet(testCtx *testutil.TestContext, change func(as *dpv1alpha1.ActionSet)) *dpv1alpha1.ActionSet {
 	as := testapps.CreateCustomizedObj(testCtx, "backup/actionset.yaml",
-		&dpv1alpha1.ActionSet{}, testapps.WithName(ActionSetName))
+		&dpv1alpha1.ActionSet{}, func(obj *dpv1alpha1.ActionSet) {
+			obj.Name = ActionSetName
+			if change != nil {
+				change(obj)
+			}
+		})
 	Eventually(testapps.CheckObj(testCtx, client.ObjectKeyFromObject(as),
 		func(g Gomega, as *dpv1alpha1.ActionSet) {
 			g.Expect(as.Status.Phase).Should(BeEquivalentTo(dpv1alpha1.AvailablePhase))
@@ -63,6 +68,10 @@ func NewFakeBackupPolicy(testCtx *testutil.TestContext,
 		AddBackupMethod(BackupMethodName, false, ActionSetName).
 		SetBackupMethodVolumeMounts(DataVolumeName, DataVolumeMountPath,
 			LogVolumeName, LogVolumeMountPath).
+		AddBackupMethod(IncBackupMethodName, false, IncActionSetName).
+		SetBackupMethodVolumeMounts(DataVolumeName, DataVolumeMountPath,
+			LogVolumeName, LogVolumeMountPath).
+		SetBackupMethodCompatibleMethod(BackupMethodName).
 		AddBackupMethod(VSBackupMethodName, true, "").
 		SetBackupMethodVolumes([]string{DataVolumeName}).
 		Apply(change).

--- a/pkg/testutil/dataprotection/backup_utils.go
+++ b/pkg/testutil/dataprotection/backup_utils.go
@@ -284,6 +284,9 @@ func MockBackupStatusMethod(backup *dpv1alpha1.Backup, backupMethodName, targetV
 			},
 		},
 	}
+	if backupMethodName == IncBackupMethodName {
+		backup.Status.BackupMethod.CompatibleMethod = BackupMethodName
+	}
 }
 
 func MockBackupStatusTarget(backup *dpv1alpha1.Backup, podSelectionStrategy dpv1alpha1.PodSelectionStrategy) {

--- a/pkg/testutil/dataprotection/backuppolicy_factory.go
+++ b/pkg/testutil/dataprotection/backuppolicy_factory.go
@@ -68,6 +68,11 @@ func (f *MockBackupPolicyFactory) AddBackupMethod(name string,
 	return f
 }
 
+func (f *MockBackupPolicyFactory) SetBackupMethodCompatibleMethod(name string) *MockBackupPolicyFactory {
+	f.Get().Spec.BackupMethods[len(f.Get().Spec.BackupMethods)-1].CompatibleMethod = name
+	return f
+}
+
 func (f *MockBackupPolicyFactory) SetBackupMethodVolumes(names []string) *MockBackupPolicyFactory {
 	f.Get().Spec.BackupMethods[len(f.Get().Spec.BackupMethods)-1].TargetVolumes.Volumes = names
 	return f

--- a/pkg/testutil/dataprotection/constant.go
+++ b/pkg/testutil/dataprotection/constant.go
@@ -29,13 +29,15 @@ const (
 	ProtocolName  = "TCP"
 	PortNum       = 10000
 
-	BackupName         = "test-backup"
-	BackupRepoName     = "test-repo"
-	BackupPolicyName   = "test-backup-policy"
-	BackupMethodName   = "xtrabackup"
-	VSBackupMethodName = "volume-snapshot"
-	BackupPathPrefix   = "/backup"
-	ActionSetName      = "xtrabackup"
+	BackupName          = "test-backup"
+	BackupRepoName      = "test-repo"
+	BackupPolicyName    = "test-backup-policy"
+	BackupMethodName    = "xtrabackup"
+	IncBackupMethodName = "xtrabackup-inc"
+	VSBackupMethodName  = "volume-snapshot"
+	BackupPathPrefix    = "/backup"
+	ActionSetName       = "xtrabackup"
+	IncActionSetName    = "xtrabackup-inc"
 
 	DataVolumeName      = "data"
 	DataVolumeMountPath = "/data"

--- a/pkg/testutil/dataprotection/utils.go
+++ b/pkg/testutil/dataprotection/utils.go
@@ -180,3 +180,10 @@ func MockActionSetWithSchema(testCtx *testutil.TestContext, actionSet *dpv1alpha
 			g.Expect(as.Status.Message).Should(BeEmpty())
 		})).Should(Succeed())
 }
+
+func NewFakeIncActionSet(testCtx *testutil.TestContext) *dpv1alpha1.ActionSet {
+	return NewFakeActionSet(testCtx, func(as *dpv1alpha1.ActionSet) {
+		as.Name = IncActionSetName
+		as.Spec.BackupType = dpv1alpha1.BackupTypeIncremental
+	})
+}


### PR DESCRIPTION
fix https://github.com/apecloud/kubeblocks/issues/8708
xtrabackup incremental backup for mysql ref https://github.com/apecloud/kubeblocks-addons/pull/1358

# Incremental Backup Support

## Backup
![whiteboard_exported_image (1)](https://github.com/user-attachments/assets/795a1687-c275-4910-855d-b19f140e0768)


### 1. Backup API
Incremental backups depend on existing full or incremental backups, forming a backup chain. 
- We use `status.parentBackupName` to indicate the parent backup of the incremental backup, which may be either an incremental or a full backup.
- When `spec.parentBackupName` is empty, the backup controller selects the most recent incremental or full backup as `status.parentBackupName`, prioritizing scheduled backups if the backup is scheduled.
- `status.BaseBackupName` indicates the full backup that the incremental backup is based on.
```
apiVersion: dataprotection.kubeblocks.io/v1alpha1
kind: Backup
  name: inc-backup-2
  namespace: default
spec:
  backupMethod: xtrabackup-inc
  backupPolicyName: mysql-backup-policy
  deletionPolicy: Delete
  retentionPeriod: 7d
  parentBackupName: inc-backup-1
status:
  parentBackupName: inc-backup-1
  BaseBackupName: full-backup
```
### 2. Backup Method

We introduced `compatibleMethod` to indicate which full backup methods are compatible with the incremental backup methods. For example:

```yaml
backupMethods:
  - name: mysql-inc
    actionSetName: xtrabackup-inc
    snapshotVolumes: false
    compatibleMethod: mysql-full
  - name: mysql-full
    actionSetName: xtrabackup-full
    snapshotVolumes: false
```

### 3. Backup Deletion

When a parent backup or base backup is deleted, all backups related to them will also be deleted.

## Restore

* The restore process for incremental backups is similar to that of full backups. The backup chain must be passed to the restore workload through environment variables.
* For point-in-time recovery, the most recent full or incremental backup closest to the specified time will be selected as the base backup.