### PR TITLE
fix: vscale ops is always running when need to rerender configuration

### DIFF
--- a/controllers/apps/transformer_component_workload.go
+++ b/controllers/apps/transformer_component_workload.go
@@ -442,7 +442,12 @@ func copyAndMergeITS(oldITS, newITS *workloads.InstanceSet) *workloads.InstanceS
 	}
 	intctrlutil.MergeMetadataMapInplace(itsProto.Annotations, &itsObjCopy.Annotations)
 	intctrlutil.MergeMetadataMapInplace(itsProto.Labels, &itsObjCopy.Labels)
-	itsObjCopy.Spec.Template = *itsProto.Spec.Template.DeepCopy()
+	// merge pod spec template annotations
+	intctrlutil.MergeMetadataMapInplace(itsProto.Spec.Template.Annotations, &itsObjCopy.Spec.Template.Annotations)
+	podTemplateCopy := *itsProto.Spec.Template.DeepCopy()
+	podTemplateCopy.Annotations = itsObjCopy.Spec.Template.Annotations
+
+	itsObjCopy.Spec.Template = podTemplateCopy
 	itsObjCopy.Spec.Replicas = itsProto.Spec.Replicas
 	itsObjCopy.Spec.Roles = itsProto.Spec.Roles
 	itsObjCopy.Spec.MembershipReconfiguration = itsProto.Spec.MembershipReconfiguration


### PR DESCRIPTION
configuration controller will annotate the instanceSet.spec.template