### PR TITLE
chore: support to get ca-key file when enabling tls

### DIFF
--- a/apis/apps/v1/componentdefinition_types.go
+++ b/apis/apps/v1/componentdefinition_types.go
@@ -1275,6 +1275,13 @@ type TLS struct {
 	// +optional
 	CAFile *string `json:"caFile,omitempty"`
 
+	// The CA key file of the TLS.
+	//
+	// This field is immutable once set.
+	//
+	// +optional
+	CAKeyFile *string `json:"caKeyFile,omitempty"`
+
 	// The certificate file of the TLS.
 	//
 	// This field is immutable once set.

--- a/apis/apps/v1/zz_generated.deepcopy.go
+++ b/apis/apps/v1/zz_generated.deepcopy.go
@@ -3311,6 +3311,11 @@ func (in *TLS) DeepCopyInto(out *TLS) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.CAKeyFile != nil {
+		in, out := &in.CAKeyFile, &out.CAKeyFile
+		*out = new(string)
+		**out = **in
+	}
 	if in.CertFile != nil {
 		in, out := &in.CertFile, &out.CertFile
 		*out = new(string)

--- a/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
@@ -16782,6 +16782,13 @@ spec:
 
                       This field is immutable once set.
                     type: string
+                  caKeyFile:
+                    description: |-
+                      The CA key file of the TLS.
+
+
+                      This field is immutable once set.
+                    type: string
                   certFile:
                     description: |-
                       The certificate file of the TLS.

--- a/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
@@ -16782,6 +16782,13 @@ spec:
 
                       This field is immutable once set.
                     type: string
+                  caKeyFile:
+                    description: |-
+                      The CA key file of the TLS.
+
+
+                      This field is immutable once set.
+                    type: string
                   certFile:
                     description: |-
                       The certificate file of the TLS.

--- a/docs/developer_docs/api-reference/cluster.md
+++ b/docs/developer_docs/api-reference/cluster.md
@@ -11385,6 +11385,19 @@ string
 </tr>
 <tr>
 <td>
+<code>caKeyFile</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The CA key file of the TLS.</p>
+<p>This field is immutable once set.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>certFile</code><br/>
 <em>
 string

--- a/pkg/controller/plan/tls.go
+++ b/pkg/controller/plan/tls.go
@@ -78,27 +78,32 @@ func ComposeTLSSecret(compDef *appsv1.ComponentDefinition, synthesizedComp compo
 	{{- $cert := genSignedCert "%s peer" (list "127.0.0.1" "::1") (list "localhost" "*.%s-%s-headless.%s.svc.cluster.local") 36500 $ca -}}
 	{{- $ca.Cert -}}
 	{{- print "%s" -}}
+    {{- $ca.Key -}}
+	{{- print "%s" -}}
 	{{- $cert.Cert -}}
 	{{- print "%s" -}}
 	{{- $cert.Key -}}
-`, compName, clusterName, compName, namespace, spliter, spliter)
+`, compName, clusterName, compName, namespace, spliter, spliter, spliter)
 	out, err := buildFromTemplate(SignedCertTpl, nil)
 	if err != nil {
 		return nil, err
 	}
 	parts := strings.Split(out, spliter)
-	if len(parts) != 3 {
+	if len(parts) != 4 {
 		return nil, errors.Errorf("generate TLS certificates failed with cluster name %s, component name %s in namespace %s",
 			clusterName, compName, namespace)
 	}
 	if compDef.Spec.TLS.CAFile != nil {
 		secret.StringData[*compDef.Spec.TLS.CAFile] = parts[0]
 	}
+	if compDef.Spec.TLS.CAKeyFile != nil {
+		secret.StringData[*compDef.Spec.TLS.CAKeyFile] = parts[1]
+	}
 	if compDef.Spec.TLS.CertFile != nil {
-		secret.StringData[*compDef.Spec.TLS.CertFile] = parts[1]
+		secret.StringData[*compDef.Spec.TLS.CertFile] = parts[2]
 	}
 	if compDef.Spec.TLS.KeyFile != nil {
-		secret.StringData[*compDef.Spec.TLS.KeyFile] = parts[2]
+		secret.StringData[*compDef.Spec.TLS.KeyFile] = parts[3]
 	}
 	return secret, nil
 }

--- a/pkg/controller/plan/tls_test.go
+++ b/pkg/controller/plan/tls_test.go
@@ -46,9 +46,10 @@ var _ = Describe("TLSUtilsTest", func() {
 			compDef := &appsv1.ComponentDefinition{
 				Spec: appsv1.ComponentDefinitionSpec{
 					TLS: &appsv1.TLS{
-						CAFile:   ptr.To("ca.pem"),
-						CertFile: ptr.To("cert.pem"),
-						KeyFile:  ptr.To("key.pem"),
+						CAFile:    ptr.To("ca.pem"),
+						CAKeyFile: ptr.To("ca-key.pem"),
+						CertFile:  ptr.To("cert.pem"),
+						KeyFile:   ptr.To("key.pem"),
 					},
 				},
 			}
@@ -67,6 +68,7 @@ var _ = Describe("TLSUtilsTest", func() {
 			Expect(secret.Labels[constant.KBAppComponentLabelKey]).Should(Equal(synthesizedComp.Name))
 			Expect(secret.StringData).ShouldNot(BeNil())
 			Expect(secret.StringData[*compDef.Spec.TLS.CAFile]).ShouldNot(BeZero())
+			Expect(secret.StringData[*compDef.Spec.TLS.CAKeyFile]).ShouldNot(BeZero())
 			Expect(secret.StringData[*compDef.Spec.TLS.CertFile]).ShouldNot(BeZero())
 			Expect(secret.StringData[*compDef.Spec.TLS.KeyFile]).ShouldNot(BeZero())
 		})


### PR DESCRIPTION
Some databases require mutual authentication, which means both the client and server must verify each other’s identity. In such cases, you need a CA (Certificate Authority) key file and a CA certificate to issue client certificates