### PR TITLE
fix: remove the pattern validation for ResourceMeta.MountPoint

### DIFF
--- a/apis/apps/v1alpha1/cluster_types.go
+++ b/apis/apps/v1alpha1/cluster_types.go
@@ -350,7 +350,6 @@ type ResourceMeta struct {
 	//
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MaxLength=256
-	// +kubebuilder:validation:Pattern:=`^/[a-z]([a-z0-9\-]*[a-z0-9])?$`
 	MountPoint string `json:"mountPoint"`
 
 	// SubPath specifies a path within the volume from which to mount.

--- a/config/crd/bases/apps.kubeblocks.io_clusters.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusters.yaml
@@ -22042,7 +22042,6 @@ spec:
                                 description: MountPoint is the filesystem path where
                                   the volume will be mounted.
                                 maxLength: 256
-                                pattern: ^/[a-z]([a-z0-9\-]*[a-z0-9])?$
                                 type: string
                               name:
                                 description: Name is the name of the referenced ConfigMap
@@ -22079,7 +22078,6 @@ spec:
                                 description: MountPoint is the filesystem path where
                                   the volume will be mounted.
                                 maxLength: 256
-                                pattern: ^/[a-z]([a-z0-9\-]*[a-z0-9])?$
                                 type: string
                               name:
                                 description: Name is the name of the referenced ConfigMap
@@ -31278,7 +31276,6 @@ spec:
                                     description: MountPoint is the filesystem path
                                       where the volume will be mounted.
                                     maxLength: 256
-                                    pattern: ^/[a-z]([a-z0-9\-]*[a-z0-9])?$
                                     type: string
                                   name:
                                     description: Name is the name of the referenced
@@ -31316,7 +31313,6 @@ spec:
                                     description: MountPoint is the filesystem path
                                       where the volume will be mounted.
                                     maxLength: 256
-                                    pattern: ^/[a-z]([a-z0-9\-]*[a-z0-9])?$
                                     type: string
                                   name:
                                     description: Name is the name of the referenced

--- a/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
@@ -22042,7 +22042,6 @@ spec:
                                 description: MountPoint is the filesystem path where
                                   the volume will be mounted.
                                 maxLength: 256
-                                pattern: ^/[a-z]([a-z0-9\-]*[a-z0-9])?$
                                 type: string
                               name:
                                 description: Name is the name of the referenced ConfigMap
@@ -22079,7 +22078,6 @@ spec:
                                 description: MountPoint is the filesystem path where
                                   the volume will be mounted.
                                 maxLength: 256
-                                pattern: ^/[a-z]([a-z0-9\-]*[a-z0-9])?$
                                 type: string
                               name:
                                 description: Name is the name of the referenced ConfigMap
@@ -31278,7 +31276,6 @@ spec:
                                     description: MountPoint is the filesystem path
                                       where the volume will be mounted.
                                     maxLength: 256
-                                    pattern: ^/[a-z]([a-z0-9\-]*[a-z0-9])?$
                                     type: string
                                   name:
                                     description: Name is the name of the referenced
@@ -31316,7 +31313,6 @@ spec:
                                     description: MountPoint is the filesystem path
                                       where the volume will be mounted.
                                     maxLength: 256
-                                    pattern: ^/[a-z]([a-z0-9\-]*[a-z0-9])?$
                                     type: string
                                   name:
                                     description: Name is the name of the referenced


### PR DESCRIPTION
Hello, 

When playing with Kubeblock, I wanted to add a custom configMap to my Cluster using `userResourceRefs` it fails when I try to use a mountPoint with 2 directories. 

Right now, the mountPoint option do not allow having a full path in the field with this error

```
spec.componentSpecs[0].userResourceRefs.configMapRefs[0].mountPoint in body should match '^/[a-z]([a-z0-9\-]*[a-z0-9])?$'
```

I'm not sure why it seemed to work [when implementing the feature](https://github.com/apecloud/kubeblocks/pull/5442). 

On my end using a configuration like that it exits with the previous error. 

```
  componentSpecs:
  - componentDefRef: mysql
    ....
   userResourceRefs:
       secretRefs:
           name: my-secret-volume
           mountPoint: /ops/config
           ### asVolumeFrom defines the list of containers will be injected into volumeMounts.
           asVolumeFrom: 
              - mysql
           secret:
                SecretName:  my-secret
       configMapRefs:
           name: my-config-volume
           mountPoint: /ops/scripts
           ### asVolumeFrom defines the list of containers will be injected into volumeMounts.
           asVolumeFrom: 
              - mysql
           configMap:
                name:  my-config  
```

