### PR TITLE
chore: update kubeblocks install guide

### DIFF
--- a/docs/user_docs/installation/install-kubeblocks.md
+++ b/docs/user_docs/installation/install-kubeblocks.md
@@ -86,14 +86,14 @@ Follow these steps to install KubeBlocks using Helm.
    kubectl create -f https://github.com/apecloud/kubeblocks/releases/download/v0.9.2/kubeblocks_crds.yaml
    ```
 
-3. Add the KubeBlocks Helm repo.
+3. Add the KubeBlocks Helm repo:
 
    ```bash
    helm repo add kubeblocks https://apecloud.github.io/helm-charts
    helm repo update
    ```
 
-4. Install KubeBlocks.
+4. Install KubeBlocks:
 
    ```bash
    helm install kubeblocks kubeblocks/kubeblocks --namespace kb-system --create-namespace
@@ -107,10 +107,10 @@ Follow these steps to install KubeBlocks using Helm.
        --set-json 'dataPlane.tolerations=[{ "key": "data-plane-taint", "operator": "Equal", "effect": "NoSchedule", "value": "true"    }]'
    ```
 
-   If you want to install KubeBlocks with a specified version, follow the steps below.
+   If you want to install KubeBlocks with a specified version, follow the steps below:
 
    1. View the available versions in the [KubeBlocks Releases](https://github.com/apecloud/kubeblocks/releases/).
-   2. Specify a version with `--version` and run the command below.
+   2. Specify a version with `--version` and run the command below:
 
       ```bash
       helm install kubeblocks kubeblocks/kubeblocks --namespace kb-system --create-namespace --version=<VERSION>
@@ -164,9 +164,9 @@ Like any other resource in Kubernetes, KubeBlocks can be installed through a YAM
    ```
 
    :::note
-4. 
+
    Make sure to use the same version for both CRDs and KubeBlocks installation to avoid compatibility issues.
-5. 
+
    :::
 
 </TabItem>
@@ -181,7 +181,7 @@ kbcli kubeblocks install
 
 If you want to install KubeBlocks with a specified version, follow the steps below.
 
-1. View the available versions.
+1. View the available versions:
 
    ```bash
    kbcli kubeblocks list-versions
@@ -194,7 +194,7 @@ If you want to install KubeBlocks with a specified version, follow the steps bel
    ```
 
    Or you can view all available versions in [KubeBlocks Releases](https://github.com/apecloud/kubeblocks/releases/).
-2. Specify a version with `--version` and run the command below.
+2. Specify a version with `--version` and run the command below:
 
    ```bash
    kbcli kubeblocks install --version=<VERSION>
@@ -204,7 +204,7 @@ If you want to install KubeBlocks with a specified version, follow the steps bel
 
    By default, when installing KubeBlocks, kbcli installs the corresponding version of KubeBlocks. It's important to ensure the major versions of kbcli and KubeBlocks are the same, if you specify a different version explicitly here.
 
-   For example, you can install kbcli v0.8.3 with KubeBlocks v0.8.1, but using mismatched major versions, such as kbcli v0.8.3 with KubeBlocks v0.9.0, may lead to errors.
+   For example, you can install kbcli v0.9.2 with KubeBlocks v0.9.1, but using mismatched major versions, such as kbcli v0.9.2 with KubeBlocks v1.0.0, may lead to errors.
   
   :::
 

--- a/docs/user_docs/installation/install-kubeblocks.md
+++ b/docs/user_docs/installation/install-kubeblocks.md
@@ -163,9 +163,11 @@ Like any other resource in Kubernetes, KubeBlocks can be installed through a YAM
    kubectl create -f https://github.com/apecloud/kubeblocks/releases/download/v0.9.2/kubeblocks.yaml
    ```
 
-:::note
-Make sure to use the same version for both CRDs and KubeBlocks installation to avoid compatibility issues.
-:::
+   :::note
+4. 
+   Make sure to use the same version for both CRDs and KubeBlocks installation to avoid compatibility issues.
+5. 
+   :::
 
 </TabItem>
 

--- a/docs/user_docs/installation/install-kubeblocks.md
+++ b/docs/user_docs/installation/install-kubeblocks.md
@@ -59,30 +59,41 @@ To try out KubeBlocks on your local host, you can use the [Playground](./../try-
 
 <TabItem value="Helm" label="Install with Helm" default>
 
-Use Helm and follow the steps below to install KubeBlocks.
+Follow these steps to install KubeBlocks using Helm.
 
-1. Create dependent CRDs. Specify the version you want to install.
+1. Get the KubeBlocks version:
+
+   * Option A - Get the latest stable version (e.g., v0.9.2):
+   
+      ```bash
+      curl -s "https://api.github.com/repos/apecloud/kubeblocks/releases?per_page=100&page=1" | jq -r '.[] | select(.prerelease == false) | .tag_name' | sort -V -r | head -n 1
+      ```
+        
+   * Option B - View all available versions (including alpha and beta releases):
+      * Visit the [KubeBlocks Releases](https://github.com/apecloud/kubeblocks/releases).
+      * Or use the command:
+        ```bash
+        curl -s "https://api.github.com/repos/apecloud/kubeblocks/releases?per_page=100&page=1" | jq -r '.[].tag_name' | sort -V -r
+        ```
+
+2. Create the required CRDs using your selected version:
 
    ```bash
-   kubectl create -f https://github.com/apecloud/kubeblocks/releases/download/vx.y.z/kubeblocks_crds.yaml
+   # Replace <VERSION> with your selected version
+   kubectl create -f https://github.com/apecloud/kubeblocks/releases/download/<VERSION>/kubeblocks_crds.yaml
+   
+   # Example: If the version is v0.9.2
+   kubectl create -f https://github.com/apecloud/kubeblocks/releases/download/v0.9.2/kubeblocks_crds.yaml
    ```
 
-   You can view all versions of kubeblocks, including alpha and beta releases, on the [kubeblocks releases list](https://github.com/apecloud/kubeblocks/releases).
-
-   To get stable releases, use this command:
-
-   ```bash
-   curl -s "https://api.github.com/repos/apecloud/kubeblocks/releases?per_page=100&page=1" | jq -r '.[] | select(.prerelease == false) | .tag_name' | sort -V -r
-   ```
-
-2. Add the KubeBlocks Helm repo.
+3. Add the KubeBlocks Helm repo.
 
    ```bash
    helm repo add kubeblocks https://apecloud.github.io/helm-charts
    helm repo update
    ```
 
-3. Install KubeBlocks.
+4. Install KubeBlocks.
 
    ```bash
    helm install kubeblocks kubeblocks/kubeblocks --namespace kb-system --create-namespace
@@ -98,11 +109,11 @@ Use Helm and follow the steps below to install KubeBlocks.
 
    If you want to install KubeBlocks with a specified version, follow the steps below.
 
-   1. View the available versions in the [KubeBlocks Release](https://github.com/apecloud/kubeblocks/releases/).
+   1. View the available versions in the [KubeBlocks Releases](https://github.com/apecloud/kubeblocks/releases/).
    2. Specify a version with `--version` and run the command below.
 
       ```bash
-      helm install kubeblocks kubeblocks/kubeblocks --namespace kb-system --create-namespace --version="x.y.z"
+      helm install kubeblocks kubeblocks/kubeblocks --namespace kb-system --create-namespace --version=<VERSION>
       ```
 
      :::note
@@ -117,26 +128,44 @@ Use Helm and follow the steps below to install KubeBlocks.
 
 Like any other resource in Kubernetes, KubeBlocks can be installed through a YAML manifest applied via `kubectl`.
 
-1. Create dependent CRDs. Specify the version you want to install.
+1. Get the KubeBlocks version:
+
+   * Option A - Get the latest stable version (e.g., v0.9.2):
+
+      ```bash
+      curl -s "https://api.github.com/repos/apecloud/kubeblocks/releases?per_page=100&page=1" | jq -r '.[] | select(.prerelease == false) | .tag_name' | sort -V -r | head -n 1
+      ```
+
+   * Option B - View all available versions (including alpha and beta releases):
+      * Visit the [KubeBlocks Releases](https://github.com/apecloud/kubeblocks/releases).
+      * Or use the command:
+        ```bash
+        curl -s "https://api.github.com/repos/apecloud/kubeblocks/releases?per_page=100&page=1" | jq -r '.[].tag_name' | sort -V -r
+        ```
+
+2. Create the required CRDs using your selected version:
 
    ```bash
-   kubectl create -f https://github.com/apecloud/kubeblocks/releases/download/vx.y.z/kubeblocks_crds.yaml
+   # Replace <VERSION> with your selected version
+   kubectl create -f https://github.com/apecloud/kubeblocks/releases/download/<VERSION>/kubeblocks_crds.yaml
+   
+   # Example: If the version is v0.9.2
+   kubectl create -f https://github.com/apecloud/kubeblocks/releases/download/v0.9.2/kubeblocks_crds.yaml
    ```
 
-   You can view all versions of kubeblocks, including alpha and beta releases, on the [kubeblocks releases list](https://github.com/apecloud/kubeblocks/releases).
-
-   To get stable releases, use this command:
+3. Install KubeBlocks:
 
    ```bash
-   curl -s "https://api.github.com/repos/apecloud/kubeblocks/releases?per_page=100&page=1" | jq -r '.[] | select(.prerelease == false) | .tag_name' | sort -V -r
+   # Replace <VERSION> with the same version used in step 2
+   kubectl create -f https://github.com/apecloud/kubeblocks/releases/download/<VERSION>/kubeblocks.yaml
+
+   # Example: If the version is v0.9.2
+   kubectl create -f https://github.com/apecloud/kubeblocks/releases/download/v0.9.2/kubeblocks.yaml
    ```
 
-2. Copy the URL of the `kubeblocks.yaml` file for the version you need from the Assets on the [KubeBlocks Release page](https://github.com/apecloud/kubeblocks/releases).
-3. Replace the YAML file URL in the command below and run this command to install KubeBlocks.
-
-     ```bash
-     kubectl create -f https://github.com/apecloud/kubeblocks/releases/download/vx.y.x/kubeblocks.yaml
-     ```
+:::note
+Make sure to use the same version for both CRDs and KubeBlocks installation to avoid compatibility issues.
+:::
 
 </TabItem>
 
@@ -162,11 +191,11 @@ If you want to install KubeBlocks with a specified version, follow the steps bel
    kbcli kb list-versions --devel --limit=100
    ```
 
-   Or you can view all available versions in [KubeBlocks Release](https://github.com/apecloud/kubeblocks/releases/).
+   Or you can view all available versions in [KubeBlocks Releases](https://github.com/apecloud/kubeblocks/releases/).
 2. Specify a version with `--version` and run the command below.
 
    ```bash
-   kbcli kubeblocks install --version=x.y.z
+   kbcli kubeblocks install --version=<VERSION>
    ```
 
   :::note
@@ -224,7 +253,7 @@ kbcli kubeblocks status
 If the KubeBlocks Workloads are all ready, KubeBlocks has been installed successfully.
 
 ```bash
-KubeBlocks is deployed in namespace: kb-system,version: x.y.z
+KubeBlocks is deployed in namespace: kb-system, version: <VERSION>
 >
 KubeBlocks Workloads:
 NAMESPACE   KIND         NAME                           READY PODS   CPU(CORES)   MEMORY(BYTES)   CREATED-AT

--- a/i18n/zh-cn/user-docs/installation/install-kubeblocks.md
+++ b/i18n/zh-cn/user-docs/installation/install-kubeblocks.md
@@ -61,7 +61,7 @@ KubeBlocks 是 Kubernetes 原生 operator，可通过 Helm、 kubectl 应用 YAM
 
 <TabItem value="Helm" label="Helm" default>
 
-按照以下步骤使用 Helm 安装 KubeBlocks。
+按照以下步骤使用 Helm 安装 KubeBlocks：
 
 1. 获取 KubeBlocks 版本:
 
@@ -71,7 +71,7 @@ KubeBlocks 是 Kubernetes 原生 operator，可通过 Helm、 kubectl 应用 YAM
    ```
 
    * 选项 B - 查看所有可用版本(包括 alpha 和 beta 版本):
-     * 访问 [KubeBlocks 发布列表](https://github.com/apecloud/kubeblocks/releases)
+     * 访问 [KubeBlocks 发布列表](https://github.com/apecloud/kubeblocks/releases)。
      * 或使用命令:
      ```bash
      curl -s "https://api.github.com/repos/apecloud/kubeblocks/releases?per_page=100&page=1" | jq -r '.[].tag_name' | sort -V -r
@@ -86,14 +86,14 @@ KubeBlocks 是 Kubernetes 原生 operator，可通过 Helm、 kubectl 应用 YAM
    kubectl create -f https://github.com/apecloud/kubeblocks/releases/download/v0.9.2/kubeblocks_crds.yaml
    ```
 
-3. 添加 KubeBlocks 的 Helm 仓库。
+3. 添加 KubeBlocks 的 Helm 仓库：
 
    ```bash
    helm repo add kubeblocks https://apecloud.github.io/helm-charts
    helm repo update
    ```
 
-4. 安装 KubeBlocks。
+4. 安装 KubeBlocks：
 
    ```bash
    helm install kubeblocks kubeblocks/kubeblocks --namespace kb-system --create-namespace
@@ -110,7 +110,7 @@ KubeBlocks 是 Kubernetes 原生 operator，可通过 Helm、 kubectl 应用 YAM
    如果您想要安装指定版本的 KubeBlocks，可执行如下步骤：
 
    1. 在 [KubeBlocks 发布列表](https://github.com/apecloud/kubeblocks/releases/) 中查看可用版本。
-   2. 使用 `--version` 指定版本，并执行以下命令。
+   2. 使用 `--version` 指定版本，并执行以下命令：
 
       ```bash
       helm install kubeblocks kubeblocks/kubeblocks --namespace kb-system --create-namespace --version=<VERSION>
@@ -136,7 +136,7 @@ KubeBlocks 是 Kubernetes 原生 operator，可通过 Helm、 kubectl 应用 YAM
    ```
 
    * 选项 B - 查看所有可用版本(包括 alpha 和 beta 版本):
-      * 访问 [KubeBlocks 发布列表](https://github.com/apecloud/kubeblocks/releases)
+      * 访问 [KubeBlocks 发布列表](https://github.com/apecloud/kubeblocks/releases)。
       * 或使用命令:
      ```bash
      curl -s "https://api.github.com/repos/apecloud/kubeblocks/releases?per_page=100&page=1" | jq -r '.[].tag_name' | sort -V -r
@@ -179,13 +179,13 @@ kbcli kubeblocks install
 
 如果想安装 KubeBlocks 的指定版本，请按照以下步骤操作：
 
-1. 查看可用的版本。
+1. 查看可用的版本：
 
     ```bash
     kbcli kubeblocks list-versions
     ```
 
-    如需查看包含 alpha 和 beta 在内的版本，可执行以下命令。
+    如需查看包含 alpha 和 beta 在内的版本，可执行以下命令：
 
     ```bash
     kbcli kb list-versions --devel --limit=100
@@ -193,7 +193,7 @@ kbcli kubeblocks install
 
     或者，你可以在 [KubeBlocks 发布列表](https://github.com/apecloud/kubeblocks/releases/)中查看可用的版本。
 
-2. 使用 `--version` 指定版本。
+2. 使用 `--version` 指定版本：
 
     ```bash
     kbcli kubeblocks install --version=<VERSION>
@@ -203,7 +203,7 @@ kbcli kubeblocks install
 
     kbcli 默认安装最新版本。如果您的环境中已有正在运行的 KubeBlocks 实例，则需要安装与之匹配的 kbcli 版本。
 
-    例如，如果您当前使用的 KubeBlocks 版本是 v0.8.3，kbcli 应安装对应的 v0.8.3，而不是更高版本（如 v0.9.0），否则系统将因版本不匹配产生报错。
+    例如，如果您当前使用的 KubeBlocks 版本是 v0.9.2，kbcli 应安装对应的 v0.9.2，而不是更高版本（如 v1.0.0），否则系统将因版本不匹配产生报错。
 
     :::
 
@@ -213,7 +213,7 @@ kbcli kubeblocks install
 
 ## 验证 KubeBlocks 安装
 
-执行以下命令，检查 KubeBlocks 是否已成功安装。
+执行以下命令，检查 KubeBlocks 是否已成功安装：
 
 <Tabs>
 

--- a/i18n/zh-cn/user-docs/installation/install-kubeblocks.md
+++ b/i18n/zh-cn/user-docs/installation/install-kubeblocks.md
@@ -160,10 +160,12 @@ KubeBlocks 是 Kubernetes 原生 operator，可通过 Helm、 kubectl 应用 YAM
    # 示例:如果版本是 v0.9.2
    kubectl create -f https://github.com/apecloud/kubeblocks/releases/download/v0.9.2/kubeblocks.yaml
    ```
-
-:::note
-请确保创建 CRDs 和安装 KubeBlocks 时使用相同版本以避免兼容性问题。
-:::
+   
+   :::note
+   
+   请确保创建 CRDs 和安装 KubeBlocks 时使用相同版本以避免兼容性问题。
+   
+   :::
 
 </TabItem>
 

--- a/i18n/zh-cn/user-docs/installation/install-kubeblocks.md
+++ b/i18n/zh-cn/user-docs/installation/install-kubeblocks.md
@@ -63,28 +63,37 @@ KubeBlocks 是 Kubernetes 原生 operator，可通过 Helm、 kubectl 应用 YAM
 
 按照以下步骤使用 Helm 安装 KubeBlocks。
 
-1. 创建安装所依赖的 CRDs，并指定您想要安装的版本。
+1. 获取 KubeBlocks 版本:
 
+   * 选项 A - 获取最新稳定版本(例如 v0.9.2):
    ```bash
-   kubectl create -f https://github.com/apecloud/kubeblocks/releases/download/vx.y.z/kubeblocks_crds.yaml
+   curl -s "https://api.github.com/repos/apecloud/kubeblocks/releases?per_page=100&page=1" | jq -r '.[] | select(.prerelease == false) | .tag_name' | sort -V -r | head -n 1
    ```
 
-   您可以通过 [KubeBlocks 发布列表](https://github.com/apecloud/kubeblocks/releases) 查看 KubeBlocks 的所有版本，包括 alpha 及 beta 版本。
+   * 选项 B - 查看所有可用版本(包括 alpha 和 beta 版本):
+     * 访问 [KubeBlocks 发布列表](https://github.com/apecloud/kubeblocks/releases)
+     * 或使用命令:
+     ```bash
+     curl -s "https://api.github.com/repos/apecloud/kubeblocks/releases?per_page=100&page=1" | jq -r '.[].tag_name' | sort -V -r
+     ```
 
-   也可通过执行以下命令，获取稳定版本：
-
+2. 使用选择的版本创建所需的 CRDs:
    ```bash
-   curl -s "https://api.github.com/repos/apecloud/kubeblocks/releases?per_page=100&page=1" | jq -r '.[] | select(.prerelease == false) | .tag_name' | sort -V -r
+   # 将 <VERSION> 替换为您选择的版本
+   kubectl create -f https://github.com/apecloud/kubeblocks/releases/download/<VERSION>/kubeblocks_crds.yaml
+   
+   # 示例:如果版本是 v0.9.2
+   kubectl create -f https://github.com/apecloud/kubeblocks/releases/download/v0.9.2/kubeblocks_crds.yaml
    ```
 
-2. 添加 KubeBlocks 的 Helm 仓库。
+3. 添加 KubeBlocks 的 Helm 仓库。
 
    ```bash
    helm repo add kubeblocks https://apecloud.github.io/helm-charts
    helm repo update
    ```
 
-3. 安装 KubeBlocks。
+4. 安装 KubeBlocks。
 
    ```bash
    helm install kubeblocks kubeblocks/kubeblocks --namespace kb-system --create-namespace
@@ -104,7 +113,7 @@ KubeBlocks 是 Kubernetes 原生 operator，可通过 Helm、 kubectl 应用 YAM
    2. 使用 `--version` 指定版本，并执行以下命令。
 
       ```bash
-      helm install kubeblocks kubeblocks/kubeblocks --namespace kb-system --create-namespace --version="x.y.z"
+      helm install kubeblocks kubeblocks/kubeblocks --namespace kb-system --create-namespace --version=<VERSION>
       ```
 
      :::note
@@ -119,27 +128,42 @@ KubeBlocks 是 Kubernetes 原生 operator，可通过 Helm、 kubectl 应用 YAM
 
 与 Kubernetes 中的其他资源相同，KubeBlocks 也可以通过 YAML 文件和 kubectl 命令进行安装。
 
-1. 创建安装所依赖的 CRDs，并指定您想要安装的版本。
+1. 获取 KubeBlocks 版本:
 
+   * 选项 A - 获取最新稳定版本(例如 v0.9.2):
    ```bash
-   kubectl create -f https://github.com/apecloud/kubeblocks/releases/download/vx.y.z/kubeblocks_crds.yaml
+   curl -s "https://api.github.com/repos/apecloud/kubeblocks/releases?per_page=100&page=1" | jq -r '.[] | select(.prerelease == false) | .tag_name' | sort -V -r | head -n 1
    ```
 
-   您可以通过 [KubeBlocks 发布列表](https://github.com/apecloud/kubeblocks/releases) 查看 KubeBlocks 的所有版本，包括 alpha 及 beta 版本。
-
-   也可通过执行以下命令，获取稳定版本：
-
-   ```bash
-   curl -s "https://api.github.com/repos/apecloud/kubeblocks/releases?per_page=100&page=1" | jq -r '.[] | select(.prerelease == false) | .tag_name' | sort -V -r
-   ```
-
-2. 从对应版本的 [KubeBlocks 发布列表](https://github.com/apecloud/kubeblocks/releases) 中的资产部分获取 `kubeblocks.yaml` 文件地址。
-
-3. 替换 YAML 文件地址，执行以下命令，安装 KubeBlocks。
-
+   * 选项 B - 查看所有可用版本(包括 alpha 和 beta 版本):
+      * 访问 [KubeBlocks 发布列表](https://github.com/apecloud/kubeblocks/releases)
+      * 或使用命令:
      ```bash
-     kubectl create -f https://github.com/apecloud/kubeblocks/releases/download/vx.y.x/kubeblocks.yaml
+     curl -s "https://api.github.com/repos/apecloud/kubeblocks/releases?per_page=100&page=1" | jq -r '.[].tag_name' | sort -V -r
      ```
+
+2. 使用选择的版本创建所需的 CRDs:
+   ```bash
+   # 将 <VERSION> 替换为您选择的版本
+   kubectl create -f https://github.com/apecloud/kubeblocks/releases/download/<VERSION>/kubeblocks_crds.yaml
+   
+   # 示例:如果版本是 v0.9.2
+   kubectl create -f https://github.com/apecloud/kubeblocks/releases/download/v0.9.2/kubeblocks_crds.yaml
+   ```
+
+3. 安装 KubeBlocks:
+
+   ```bash
+   # 将 <VERSION> 替换为在步骤 2 中使用的相同版本
+   kubectl create -f https://github.com/apecloud/kubeblocks/releases/download/<VERSION>/kubeblocks.yaml
+
+   # 示例:如果版本是 v0.9.2
+   kubectl create -f https://github.com/apecloud/kubeblocks/releases/download/v0.9.2/kubeblocks.yaml
+   ```
+
+:::note
+请确保创建 CRDs 和安装 KubeBlocks 时使用相同版本以避免兼容性问题。
+:::
 
 </TabItem>
 
@@ -165,12 +189,12 @@ kbcli kubeblocks install
     kbcli kb list-versions --devel --limit=100
     ```
 
-    或者，你可以在 [KubeBlocks Release 页面](https://github.com/apecloud/kubeblocks/releases/)中查看可用的版本。
+    或者，你可以在 [KubeBlocks 发布列表](https://github.com/apecloud/kubeblocks/releases/)中查看可用的版本。
 
 2. 使用 `--version` 指定版本。
 
     ```bash
-    kbcli kubeblocks install --version=x.x.x
+    kbcli kubeblocks install --version=<VERSION>
     ```
 
     :::note
@@ -228,7 +252,7 @@ kbcli kubeblocks status
 如果工作负载都显示已准备就绪，则表明已成功安装 KubeBlocks。
 
 ```bash
-KubeBlocks is deployed in namespace: kb-system,version: x.x.x
+KubeBlocks is deployed in namespace: kb-system, version: <VERSION>
 >
 KubeBlocks Workloads:
 NAMESPACE   KIND         NAME                           READY PODS   CPU(CORES)   MEMORY(BYTES)   CREATED-AT


### PR DESCRIPTION
# Backgroud:
When I was reading the documentation, I was confused about the content related to version acquisition and installation of crds.
The **"vx.y.z"** used here is easily ignored, resulting in instruction execution errors.
![image](https://github.com/user-attachments/assets/2ef5209b-6591-4c87-8195-1b0115ffe92d)


# What's changed:
This PR updates the KB installation documentation to provide clearer guidance on version selection and installation steps. Main changes include:

- Add explicit version selection options:
  - Option A: Get latest stable version with curl command
  - Option B: View all versions (including alpha/beta) via GitHub releases or curl
- Provide concrete examples using v0.9.2 to demonstrate proper version usage

These changes aim to:
- Make the installation process more intuitive for new users
- Reduce potential version mismatch issues
- Maintain consistency between English and Chinese documentation