### PR TITLE
fix: ensure GeneratePassword returns password with mixed cases

### DIFF
--- a/controllers/apps/cluster/transformer_cluster_sharding_account.go
+++ b/controllers/apps/cluster/transformer_cluster_sharding_account.go
@@ -164,12 +164,14 @@ func (t *clusterShardingAccountTransformer) buildPassword(transCtx *clusterTrans
 
 func (t *clusterShardingAccountTransformer) generatePassword(account appsv1.SystemAccount) []byte {
 	config := account.PasswordGenerationPolicy
-	passwd, _ := common.GenerateMixedCasePassword((int)(config.Length), (int)(config.NumDigits), (int)(config.NumSymbols), config.Seed)
+	passwd, _ := common.GeneratePassword((int)(config.Length), (int)(config.NumDigits), (int)(config.NumSymbols), config.Seed)
 	switch config.LetterCase {
 	case appsv1.UpperCases:
 		passwd = strings.ToUpper(passwd)
 	case appsv1.LowerCases:
 		passwd = strings.ToLower(passwd)
+	case appsv1.MixedCases:
+		passwd, _ = common.EnsureMixedCase(passwd, config.Seed)
 	}
 	return []byte(passwd)
 }

--- a/controllers/apps/cluster/transformer_cluster_sharding_account.go
+++ b/controllers/apps/cluster/transformer_cluster_sharding_account.go
@@ -164,7 +164,7 @@ func (t *clusterShardingAccountTransformer) buildPassword(transCtx *clusterTrans
 
 func (t *clusterShardingAccountTransformer) generatePassword(account appsv1.SystemAccount) []byte {
 	config := account.PasswordGenerationPolicy
-	passwd, _ := common.GeneratePassword((int)(config.Length), (int)(config.NumDigits), (int)(config.NumSymbols), false, config.Seed)
+	passwd, _ := common.GenerateMixedCasePassword((int)(config.Length), (int)(config.NumDigits), (int)(config.NumSymbols), config.Seed)
 	switch config.LetterCase {
 	case appsv1.UpperCases:
 		passwd = strings.ToUpper(passwd)

--- a/controllers/apps/component/transformer_component_account.go
+++ b/controllers/apps/component/transformer_component_account.go
@@ -219,12 +219,14 @@ func (t *componentAccountTransformer) buildPassword(ctx *componentTransformConte
 
 func (t *componentAccountTransformer) generatePassword(account synthesizedSystemAccount) []byte {
 	config := account.PasswordGenerationPolicy
-	passwd, _ := common.GeneratePassword((int)(config.Length), (int)(config.NumDigits), (int)(config.NumSymbols), false, config.Seed)
+	passwd, _ := common.GeneratePassword((int)(config.Length), (int)(config.NumDigits), (int)(config.NumSymbols), config.Seed)
 	switch config.LetterCase {
 	case appsv1.UpperCases:
 		passwd = strings.ToUpper(passwd)
 	case appsv1.LowerCases:
 		passwd = strings.ToLower(passwd)
+	case appsv1.MixedCases:
+		passwd, _ = common.EnsureMixedCase(passwd, config.Seed)
 	}
 	return []byte(passwd)
 }

--- a/pkg/common/password.go
+++ b/pkg/common/password.go
@@ -46,8 +46,8 @@ func (r *PasswordReader) Seed(seed int64) {
 	r.rand.Seed(seed)
 }
 
-// GenerateMixedCasePassword generates a password with the given requirements and seed with mixed cases.
-func GenerateMixedCasePassword(length, numDigits, numSymbols int, seed string) (string, error) {
+// GeneratePassword generates a password with the given requirements and seed in lowercase.
+func GeneratePassword(length, numDigits, numSymbols int, seed string) (string, error) {
 	rand, err := newRngFromSeed(seed)
 	if err != nil {
 		return "", err
@@ -63,11 +63,7 @@ func GenerateMixedCasePassword(length, numDigits, numSymbols int, seed string) (
 	if err != nil {
 		return "", err
 	}
-	pwd, err := gen.Generate(length, numDigits, numSymbols, true, true)
-	if err != nil {
-		return "", err
-	}
-	return EnsureMixedCase(pwd, seed)
+	return gen.Generate(length, numDigits, numSymbols, true, true)
 }
 
 // EnsureMixedCase randomizes the letter casing in the given string, ensuring

--- a/pkg/common/password.go
+++ b/pkg/common/password.go
@@ -46,8 +46,8 @@ func (r *PasswordReader) Seed(seed int64) {
 	r.rand.Seed(seed)
 }
 
-// GeneratePassword generates a password with the given requirements and seed.
-func GeneratePassword(length, numDigits, numSymbols int, noUpper bool, seed string) (string, error) {
+// GenerateMixedCasePassword generates a password with the given requirements and seed with mixed cases.
+func GenerateMixedCasePassword(length, numDigits, numSymbols int, seed string) (string, error) {
 	rand, err := newRngFromSeed(seed)
 	if err != nil {
 		return "", err
@@ -63,15 +63,11 @@ func GeneratePassword(length, numDigits, numSymbols int, noUpper bool, seed stri
 	if err != nil {
 		return "", err
 	}
-	pwd, err := gen.Generate(length, numDigits, numSymbols, noUpper, true)
+	pwd, err := gen.Generate(length, numDigits, numSymbols, true, true)
 	if err != nil {
 		return "", err
 	}
-	if noUpper {
-		return pwd, nil
-	} else {
-		return EnsureMixedCase(pwd, seed)
-	}
+	return EnsureMixedCase(pwd, seed)
 }
 
 // EnsureMixedCase randomizes the letter casing in the given string, ensuring

--- a/pkg/common/password.go
+++ b/pkg/common/password.go
@@ -22,7 +22,7 @@ package common
 import (
 	"crypto/sha256"
 	"encoding/binary"
-	"fmt"
+	"errors"
 	mathrand "math/rand"
 	"time"
 	"unicode"
@@ -93,19 +93,12 @@ func EnsureMixedCase(in, seed string) (string, error) {
 	}
 	L := len(letterIndices)
 
-	// If fewer than two letters, we cannot guarantee both uppercase and lowercase.
+	// If fewer than two letters,cannot generate both uppercase and lowercase.
 	if L < 2 {
-		return in, nil
-	}
-
-	// To avoid overflow with 1<<L operations, limit L to 62 bits for safe int64 usage.
-	// 2^63 cannot fit in an int64.
-	if L > 62 {
-		return in, fmt.Errorf("too many letters: potential overflow in bit patterns")
+		return in, errors.New("not enough letters in the password to generate mixed cases")
 	}
 
 	// We want an integer in [1, 2^L - 2], effectively discarding the all-0 and all-1 patterns.
-	// => 2^L - 2 is safe because we checked L <= 62 above.
 	rng, err := newRngFromSeed(seed)
 	if err != nil {
 		return in, err

--- a/pkg/common/password_test.go
+++ b/pkg/common/password_test.go
@@ -93,3 +93,68 @@ func TestGeneratorGeneratePassword(t *testing.T) {
 func TestGeneratorGeneratePasswordWithSeed(t *testing.T) {
 	testGeneratorGeneratePasswordWithSeed(t)
 }
+
+// containsUppercase checks if s has at least one uppercase letter (A-Z).
+func containsUppercase(s string) bool {
+	for _, r := range s {
+		if r >= 'A' && r <= 'Z' {
+			return true
+		}
+	}
+	return false
+}
+
+// containsLowercase checks if s has at least one lowercase letter (a-z).
+func containsLowercase(s string) bool {
+	for _, r := range s {
+		if r >= 'a' && r <= 'z' {
+			return true
+		}
+	}
+	return false
+}
+
+// TestGeneratorEnsureMixedCase verifies two requirements:
+// 1) When noUpper = false, the generated password contains uppercase and lowercase letters.
+// 2) Passwords generated with the same seed are identical.
+func TestGeneratorEnsureMixedCase(t *testing.T) {
+	t.Run("should_contain_mixed_case_when_noUpper_false", func(t *testing.T) {
+		length := 12
+		numDigits := 3
+		numSymbols := 2
+		seed := ""
+
+		// Generate multiple passwords and check they have both upper and lower letters.
+		for i := 0; i < 100; i++ {
+			pwd, err := GeneratePassword(length, numDigits, numSymbols, false, seed)
+			if err != nil {
+				t.Fatalf("unexpected error generating password: %v", err)
+			}
+			if !containsUppercase(pwd) || !containsLowercase(pwd) {
+				t.Errorf("password %q does not contain both uppercase and lowercase letters", pwd)
+			}
+		}
+	})
+
+	t.Run("should_produce_same_result_with_same_seed", func(t *testing.T) {
+		length := 10
+		numDigits := 2
+		numSymbols := 1
+		seed := "fixed-seed-123"
+
+		var firstPwd string
+		for i := 0; i < 50; i++ {
+			pwd, err := GeneratePassword(length, numDigits, numSymbols, false, seed)
+			if err != nil {
+				t.Fatalf("unexpected error generating password with seed: %v", err)
+			}
+			if i == 0 {
+				firstPwd = pwd
+			} else {
+				if pwd != firstPwd {
+					t.Errorf("expected the same password for the same seed, but got %q vs %q", firstPwd, pwd)
+				}
+			}
+		}
+	})
+}

--- a/pkg/common/password_test.go
+++ b/pkg/common/password_test.go
@@ -34,7 +34,7 @@ func testGeneratorGeneratePasswordWithSeed(t *testing.T) {
 	resultSeedFirstTime := ""
 	resultSeedEachTime := ""
 	for i := 0; i < N; i++ {
-		res, err := GenerateMixedCasePassword(10, 5, 0, seed)
+		res, err := GeneratePassword(10, 5, 0, seed)
 		if err != nil {
 			t.Error(err)
 		}
@@ -52,11 +52,11 @@ func testGeneratorGeneratePassword(t *testing.T) {
 	t.Run("exceeds_length", func(t *testing.T) {
 		t.Parallel()
 
-		if _, err := GenerateMixedCasePassword(0, 1, 0, ""); err != password.ErrExceedsTotalLength {
+		if _, err := GeneratePassword(0, 1, 0, ""); err != password.ErrExceedsTotalLength {
 			t.Errorf("expected %q to be %q", err, password.ErrExceedsTotalLength)
 		}
 
-		if _, err := GenerateMixedCasePassword(0, 0, 1, ""); err != password.ErrExceedsTotalLength {
+		if _, err := GeneratePassword(0, 0, 1, ""); err != password.ErrExceedsTotalLength {
 			t.Errorf("expected %q to be %q", err, password.ErrExceedsTotalLength)
 		}
 	})
@@ -67,7 +67,7 @@ func testGeneratorGeneratePassword(t *testing.T) {
 		resultSeedEachTime := ""
 		hasDiffPassword := false
 		for i := 0; i < N; i++ {
-			res, err := GenerateMixedCasePassword(i%(len(password.LowerLetters)+len(password.UpperLetters)), 0, 0, "")
+			res, err := GeneratePassword(i%(len(password.LowerLetters)+len(password.UpperLetters)), 0, 0, "")
 			if err != nil {
 				t.Error(err)
 			}
@@ -126,9 +126,13 @@ func TestGeneratorEnsureMixedCase(t *testing.T) {
 
 		// Generate multiple passwords and check they have both upper and lower letters.
 		for i := 0; i < 100; i++ {
-			pwd, err := GenerateMixedCasePassword(length, numDigits, numSymbols, seed)
+			pwd, err := GeneratePassword(length, numDigits, numSymbols, seed)
 			if err != nil {
 				t.Fatalf("unexpected error generating password: %v", err)
+			}
+			pwd, err = EnsureMixedCase(pwd, seed)
+			if err != nil {
+				t.Fatalf("unexpected error Ensuring mixed-case password: %v", err)
 			}
 			if !containsUppercase(pwd) || !containsLowercase(pwd) {
 				t.Errorf("password %q does not contain both uppercase and lowercase letters", pwd)
@@ -144,9 +148,13 @@ func TestGeneratorEnsureMixedCase(t *testing.T) {
 
 		var firstPwd string
 		for i := 0; i < 50; i++ {
-			pwd, err := GenerateMixedCasePassword(length, numDigits, numSymbols, seed)
+			pwd, err := GeneratePassword(length, numDigits, numSymbols, seed)
 			if err != nil {
 				t.Fatalf("unexpected error generating password with seed: %v", err)
+			}
+			pwd, err = EnsureMixedCase(pwd, seed)
+			if err != nil {
+				t.Fatalf("unexpected error Ensuring mixed-case password: %v", err)
 			}
 			if i == 0 {
 				firstPwd = pwd

--- a/pkg/common/password_test.go
+++ b/pkg/common/password_test.go
@@ -34,7 +34,7 @@ func testGeneratorGeneratePasswordWithSeed(t *testing.T) {
 	resultSeedFirstTime := ""
 	resultSeedEachTime := ""
 	for i := 0; i < N; i++ {
-		res, err := GeneratePassword(10, 5, 0, false, seed)
+		res, err := GenerateMixedCasePassword(10, 5, 0, seed)
 		if err != nil {
 			t.Error(err)
 		}
@@ -52,11 +52,11 @@ func testGeneratorGeneratePassword(t *testing.T) {
 	t.Run("exceeds_length", func(t *testing.T) {
 		t.Parallel()
 
-		if _, err := GeneratePassword(0, 1, 0, false, ""); err != password.ErrExceedsTotalLength {
+		if _, err := GenerateMixedCasePassword(0, 1, 0, ""); err != password.ErrExceedsTotalLength {
 			t.Errorf("expected %q to be %q", err, password.ErrExceedsTotalLength)
 		}
 
-		if _, err := GeneratePassword(0, 0, 1, false, ""); err != password.ErrExceedsTotalLength {
+		if _, err := GenerateMixedCasePassword(0, 0, 1, ""); err != password.ErrExceedsTotalLength {
 			t.Errorf("expected %q to be %q", err, password.ErrExceedsTotalLength)
 		}
 	})
@@ -67,7 +67,7 @@ func testGeneratorGeneratePassword(t *testing.T) {
 		resultSeedEachTime := ""
 		hasDiffPassword := false
 		for i := 0; i < N; i++ {
-			res, err := GeneratePassword(i%len(password.LowerLetters), 0, 0, true, "")
+			res, err := GenerateMixedCasePassword(i%(len(password.LowerLetters)+len(password.UpperLetters)), 0, 0, "")
 			if err != nil {
 				t.Error(err)
 			}
@@ -126,7 +126,7 @@ func TestGeneratorEnsureMixedCase(t *testing.T) {
 
 		// Generate multiple passwords and check they have both upper and lower letters.
 		for i := 0; i < 100; i++ {
-			pwd, err := GeneratePassword(length, numDigits, numSymbols, false, seed)
+			pwd, err := GenerateMixedCasePassword(length, numDigits, numSymbols, seed)
 			if err != nil {
 				t.Fatalf("unexpected error generating password: %v", err)
 			}
@@ -144,7 +144,7 @@ func TestGeneratorEnsureMixedCase(t *testing.T) {
 
 		var firstPwd string
 		for i := 0; i < 50; i++ {
-			pwd, err := GeneratePassword(length, numDigits, numSymbols, false, seed)
+			pwd, err := GenerateMixedCasePassword(length, numDigits, numSymbols, seed)
 			if err != nil {
 				t.Fatalf("unexpected error generating password with seed: %v", err)
 			}

--- a/pkg/common/password_test.go
+++ b/pkg/common/password_test.go
@@ -150,10 +150,8 @@ func TestGeneratorEnsureMixedCase(t *testing.T) {
 			}
 			if i == 0 {
 				firstPwd = pwd
-			} else {
-				if pwd != firstPwd {
-					t.Errorf("expected the same password for the same seed, but got %q vs %q", firstPwd, pwd)
-				}
+			} else if pwd != firstPwd {
+				t.Errorf("expected the same password for the same seed, but got %q vs %q", firstPwd, pwd)
 			}
 		}
 	})


### PR DESCRIPTION
fix #8837 

Problem: Mixed-case password doesn't guarantee having both uppercase and lowercase.
Fix: Introduce EnsureMixedCase() post-processor to guarantee at least one uppercase and one lowercase.
Testing: Verified consistent generation with same seed, plus enforced mixed-case distribution.
