### PR TITLE
fix: ensure GeneratePassword returns password with mixed cases in release-0.9

### DIFF
--- a/controllers/apps/transformer_cluster_shared_account.go
+++ b/controllers/apps/transformer_cluster_shared_account.go
@@ -151,12 +151,14 @@ func (t *clusterSharedAccountTransformer) buildAccountSecret(cluster *appsv1alph
 
 func (t *clusterSharedAccountTransformer) generatePassword(account appsv1alpha1.ComponentSystemAccount) []byte {
 	config := account.PasswordConfig
-	passwd, _ := common.GeneratePassword((int)(config.Length), (int)(config.NumDigits), (int)(config.NumSymbols), false, "")
+	passwd, _ := common.GeneratePassword((int)(config.Length), (int)(config.NumDigits), (int)(config.NumSymbols), config.Seed)
 	switch config.LetterCase {
 	case appsv1alpha1.UpperCases:
 		passwd = strings.ToUpper(passwd)
 	case appsv1alpha1.LowerCases:
 		passwd = strings.ToLower(passwd)
+	case appsv1alpha1.MixedCases:
+		passwd, _ = common.EnsureMixedCase(passwd, config.Seed)
 	}
 	return []byte(passwd)
 }

--- a/controllers/apps/transformer_component_account.go
+++ b/controllers/apps/transformer_component_account.go
@@ -148,12 +148,14 @@ func (t *componentAccountTransformer) buildPassword(ctx *componentTransformConte
 
 func (t *componentAccountTransformer) generatePassword(account appsv1alpha1.SystemAccount) []byte {
 	config := account.PasswordGenerationPolicy
-	passwd, _ := common.GeneratePassword((int)(config.Length), (int)(config.NumDigits), (int)(config.NumSymbols), false, config.Seed)
+	passwd, _ := common.GeneratePassword((int)(config.Length), (int)(config.NumDigits), (int)(config.NumSymbols), config.Seed)
 	switch config.LetterCase {
 	case appsv1alpha1.UpperCases:
 		passwd = strings.ToUpper(passwd)
 	case appsv1alpha1.LowerCases:
 		passwd = strings.ToLower(passwd)
+	case appsv1alpha1.MixedCases:
+		passwd, _ = common.EnsureMixedCase(passwd, config.Seed)
 	}
 	return []byte(passwd)
 }

--- a/pkg/common/password_test.go
+++ b/pkg/common/password_test.go
@@ -34,7 +34,7 @@ func testGeneratorGeneratePasswordWithSeed(t *testing.T) {
 	resultSeedFirstTime := ""
 	resultSeedEachTime := ""
 	for i := 0; i < N; i++ {
-		res, err := GeneratePassword(10, 5, 0, false, seed)
+		res, err := GeneratePassword(10, 5, 0, seed)
 		if err != nil {
 			t.Error(err)
 		}
@@ -52,11 +52,11 @@ func testGeneratorGeneratePassword(t *testing.T) {
 	t.Run("exceeds_length", func(t *testing.T) {
 		t.Parallel()
 
-		if _, err := GeneratePassword(0, 1, 0, false, ""); err != password.ErrExceedsTotalLength {
+		if _, err := GeneratePassword(0, 1, 0, ""); err != password.ErrExceedsTotalLength {
 			t.Errorf("expected %q to be %q", err, password.ErrExceedsTotalLength)
 		}
 
-		if _, err := GeneratePassword(0, 0, 1, false, ""); err != password.ErrExceedsTotalLength {
+		if _, err := GeneratePassword(0, 0, 1, ""); err != password.ErrExceedsTotalLength {
 			t.Errorf("expected %q to be %q", err, password.ErrExceedsTotalLength)
 		}
 	})
@@ -67,7 +67,7 @@ func testGeneratorGeneratePassword(t *testing.T) {
 		resultSeedEachTime := ""
 		hasDiffPassword := false
 		for i := 0; i < N; i++ {
-			res, err := GeneratePassword(i%len(password.LowerLetters), 0, 0, true, "")
+			res, err := GeneratePassword(i%(len(password.LowerLetters)+len(password.UpperLetters)), 0, 0, "")
 			if err != nil {
 				t.Error(err)
 			}
@@ -92,4 +92,75 @@ func TestGeneratorGeneratePassword(t *testing.T) {
 
 func TestGeneratorGeneratePasswordWithSeed(t *testing.T) {
 	testGeneratorGeneratePasswordWithSeed(t)
+}
+
+// containsUppercase checks if s has at least one uppercase letter (A-Z).
+func containsUppercase(s string) bool {
+	for _, r := range s {
+		if r >= 'A' && r <= 'Z' {
+			return true
+		}
+	}
+	return false
+}
+
+// containsLowercase checks if s has at least one lowercase letter (a-z).
+func containsLowercase(s string) bool {
+	for _, r := range s {
+		if r >= 'a' && r <= 'z' {
+			return true
+		}
+	}
+	return false
+}
+
+// TestGeneratorEnsureMixedCase verifies two requirements:
+// 1) When noUpper = false, the generated password contains uppercase and lowercase letters.
+// 2) Passwords generated with the same seed are identical.
+func TestGeneratorEnsureMixedCase(t *testing.T) {
+	t.Run("should_contain_mixed_case_when_noUpper_false", func(t *testing.T) {
+		length := 12
+		numDigits := 3
+		numSymbols := 2
+		seed := ""
+
+		// Generate multiple passwords and check they have both upper and lower letters.
+		for i := 0; i < 100; i++ {
+			pwd, err := GeneratePassword(length, numDigits, numSymbols, seed)
+			if err != nil {
+				t.Fatalf("unexpected error generating password: %v", err)
+			}
+			pwd, err = EnsureMixedCase(pwd, seed)
+			if err != nil {
+				t.Fatalf("unexpected error Ensuring mixed-case password: %v", err)
+			}
+			if !containsUppercase(pwd) || !containsLowercase(pwd) {
+				t.Errorf("password %q does not contain both uppercase and lowercase letters", pwd)
+			}
+		}
+	})
+
+	t.Run("should_produce_same_result_with_same_seed", func(t *testing.T) {
+		length := 10
+		numDigits := 2
+		numSymbols := 1
+		seed := "fixed-seed-123"
+
+		var firstPwd string
+		for i := 0; i < 50; i++ {
+			pwd, err := GeneratePassword(length, numDigits, numSymbols, seed)
+			if err != nil {
+				t.Fatalf("unexpected error generating password with seed: %v", err)
+			}
+			pwd, err = EnsureMixedCase(pwd, seed)
+			if err != nil {
+				t.Fatalf("unexpected error Ensuring mixed-case password: %v", err)
+			}
+			if i == 0 {
+				firstPwd = pwd
+			} else if pwd != firstPwd {
+				t.Errorf("expected the same password for the same seed, but got %q vs %q", firstPwd, pwd)
+			}
+		}
+	})
 }

--- a/pkg/controller/factory/builder.go
+++ b/pkg/controller/factory/builder.go
@@ -215,7 +215,7 @@ func randomString(length int) string {
 }
 
 func strongRandomString(length int) string {
-	str, _ := common.GeneratePassword(length, 3, 3, false, "")
+	str, _ := common.GeneratePassword(length, 3, 3, "")
 	return str
 }
 

--- a/pkg/testutil/apps/cluster_util.go
+++ b/pkg/testutil/apps/cluster_util.go
@@ -20,8 +20,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package apps
 
 import (
-	"context"
-
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -82,8 +80,7 @@ func CheckedCreateK8sResource(testCtx *testutil.TestContext, obj client.Object) 
 func GetClusterComponentPhase(testCtx *testutil.TestContext, clusterKey types.NamespacedName, componentName string) func(g gomega.Gomega) appsv1alpha1.ClusterComponentPhase {
 	return func(g gomega.Gomega) appsv1alpha1.ClusterComponentPhase {
 		tmpCluster := &appsv1alpha1.Cluster{}
-		g.Expect(testCtx.Cli.Get(context.Background(), client.ObjectKey{Name: clusterKey.Name,
-			Namespace: clusterKey.Namespace}, tmpCluster)).Should(gomega.Succeed())
+		g.Expect(testCtx.Cli.Get(testCtx.Ctx, clusterKey, tmpCluster)).Should(gomega.Succeed())
 		return tmpCluster.Status.Components[componentName].Phase
 	}
 }


### PR DESCRIPTION
fix #8837
cherry-pick [commit](https://github.com/apecloud/kubeblocks/commit/972c0d837e5c3280e45c5f46eae2f43bfb850b8c) to release-0.9 