### PR TITLE
chore: allow to define action image in cmpd

### DIFF
--- a/pkg/controller/component/component_version.go
+++ b/pkg/controller/component/component_version.go
@@ -298,11 +298,15 @@ func checkNMergeImages(serviceVersion string, appsInDef, appsInVer map[string]ap
 	apps := make(map[string]appNameVersionImage)
 	merge := func(name string, def, ver appNameVersionImage) appNameVersionImage {
 		if len(ver.name) == 0 {
+			// if not required, fallback to image in cmpd directly
+			if !def.required {
+				return def
+			}
 			match, err := CompareServiceVersion(serviceVersion, def.version)
 			if err != nil {
 				def.err = fmt.Errorf("failed to compare service version (service version: %s, def version: %s): %w", serviceVersion, def.version, err)
 			}
-			if !match && def.required {
+			if !match {
 				def.err = fmt.Errorf("no matched image found for container %s with required version %s", name, serviceVersion)
 			}
 			return def

--- a/pkg/controller/component/component_version_test.go
+++ b/pkg/controller/component/component_version_test.go
@@ -55,6 +55,24 @@ var _ = Describe("Component Version", func() {
 			cleanEnv()
 		})
 
+		It("checkNMergeImages", func() {
+			appsInDef := map[string]appNameVersionImage{
+				"action1": {name: "action1", required: false},
+				"image1":  {name: "image1", version: "1.0.0", image: "wrong", required: true},
+				"image2":  {name: "image2", version: "1.0.1", required: true}, // this image has different serviceVersion
+			}
+			appsInVer := map[string]appNameVersionImage{
+				"image1": {name: "image1", version: "1.0.0", image: "right", required: true}, // this image overrides the one in appsInDef
+			}
+			apps := checkNMergeImages("1.0.0", appsInDef, appsInVer)
+			Expect(apps["image1"].err).NotTo(HaveOccurred())
+			Expect(apps["image1"].image).To(Equal("right"))
+
+			Expect(apps["image2"].err).To(HaveOccurred())
+
+			Expect(apps["action1"].err).NotTo(HaveOccurred())
+		})
+
 		It("resolve images before and after new release", func() {
 			By("create new definition v4.0 with service version v4")
 			compDefObj := testapps.NewComponentDefinitionFactory(testapps.CompDefName("v1")).


### PR DESCRIPTION
So that if one action image is used among all versions, we don't need to repeat it in componentVersion.