### PR TITLE
fix: overwrite nodeselectorterm when merging

### DIFF
--- a/apis/apps/v1/types.go
+++ b/apis/apps/v1/types.go
@@ -639,6 +639,9 @@ type SchedulingPolicy struct {
 
 	// Specifies a group of affinity scheduling rules of the Cluster, including NodeAffinity, PodAffinity, and PodAntiAffinity.
 	//
+	// When merging, NodeAffinity's nodeSelectorTerms are overwritten by the destination's nodeSelectorTerms (if destination is not nil).
+	// Other lists are appended with duplicated items removed.
+	//
 	// +optional
 	Affinity *corev1.Affinity `json:"affinity,omitempty"`
 

--- a/config/crd/bases/apps.kubeblocks.io_clusters.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusters.yaml
@@ -1027,9 +1027,12 @@ spec:
                             description: Specifies the scheduling policy for the Component.
                             properties:
                               affinity:
-                                description: Specifies a group of affinity scheduling
-                                  rules of the Cluster, including NodeAffinity, PodAffinity,
-                                  and PodAntiAffinity.
+                                description: |-
+                                  Specifies a group of affinity scheduling rules of the Cluster, including NodeAffinity, PodAffinity, and PodAntiAffinity.
+
+
+                                  When merging, NodeAffinity's nodeSelectorTerms are overwritten by the destination's nodeSelectorTerms (if destination is not nil).
+                                  Other lists are appended with duplicated items removed.
                                 properties:
                                   nodeAffinity:
                                     description: Describes node affinity scheduling
@@ -2415,9 +2418,12 @@ spec:
                       description: Specifies the scheduling policy for the Component.
                       properties:
                         affinity:
-                          description: Specifies a group of affinity scheduling rules
-                            of the Cluster, including NodeAffinity, PodAffinity, and
-                            PodAntiAffinity.
+                          description: |-
+                            Specifies a group of affinity scheduling rules of the Cluster, including NodeAffinity, PodAffinity, and PodAntiAffinity.
+
+
+                            When merging, NodeAffinity's nodeSelectorTerms are overwritten by the destination's nodeSelectorTerms (if destination is not nil).
+                            Other lists are appended with duplicated items removed.
                           properties:
                             nodeAffinity:
                               description: Describes node affinity scheduling rules
@@ -5745,8 +5751,12 @@ spec:
                 description: Specifies the scheduling policy for the Cluster.
                 properties:
                   affinity:
-                    description: Specifies a group of affinity scheduling rules of
-                      the Cluster, including NodeAffinity, PodAffinity, and PodAntiAffinity.
+                    description: |-
+                      Specifies a group of affinity scheduling rules of the Cluster, including NodeAffinity, PodAffinity, and PodAntiAffinity.
+
+
+                      When merging, NodeAffinity's nodeSelectorTerms are overwritten by the destination's nodeSelectorTerms (if destination is not nil).
+                      Other lists are appended with duplicated items removed.
                     properties:
                       nodeAffinity:
                         description: Describes node affinity scheduling rules for
@@ -8240,9 +8250,12 @@ spec:
                                   Component.
                                 properties:
                                   affinity:
-                                    description: Specifies a group of affinity scheduling
-                                      rules of the Cluster, including NodeAffinity,
-                                      PodAffinity, and PodAntiAffinity.
+                                    description: |-
+                                      Specifies a group of affinity scheduling rules of the Cluster, including NodeAffinity, PodAffinity, and PodAntiAffinity.
+
+
+                                      When merging, NodeAffinity's nodeSelectorTerms are overwritten by the destination's nodeSelectorTerms (if destination is not nil).
+                                      Other lists are appended with duplicated items removed.
                                     properties:
                                       nodeAffinity:
                                         description: Describes node affinity scheduling
@@ -9646,9 +9659,12 @@ spec:
                           description: Specifies the scheduling policy for the Component.
                           properties:
                             affinity:
-                              description: Specifies a group of affinity scheduling
-                                rules of the Cluster, including NodeAffinity, PodAffinity,
-                                and PodAntiAffinity.
+                              description: |-
+                                Specifies a group of affinity scheduling rules of the Cluster, including NodeAffinity, PodAffinity, and PodAntiAffinity.
+
+
+                                When merging, NodeAffinity's nodeSelectorTerms are overwritten by the destination's nodeSelectorTerms (if destination is not nil).
+                                Other lists are appended with duplicated items removed.
                               properties:
                                 nodeAffinity:
                                   description: Describes node affinity scheduling

--- a/config/crd/bases/apps.kubeblocks.io_components.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_components.yaml
@@ -892,9 +892,12 @@ spec:
                       description: Specifies the scheduling policy for the Component.
                       properties:
                         affinity:
-                          description: Specifies a group of affinity scheduling rules
-                            of the Cluster, including NodeAffinity, PodAffinity, and
-                            PodAntiAffinity.
+                          description: |-
+                            Specifies a group of affinity scheduling rules of the Cluster, including NodeAffinity, PodAffinity, and PodAntiAffinity.
+
+
+                            When merging, NodeAffinity's nodeSelectorTerms are overwritten by the destination's nodeSelectorTerms (if destination is not nil).
+                            Other lists are appended with duplicated items removed.
                           properties:
                             nodeAffinity:
                               description: Describes node affinity scheduling rules
@@ -2198,8 +2201,12 @@ spec:
                 description: Specifies the scheduling policy for the Component.
                 properties:
                   affinity:
-                    description: Specifies a group of affinity scheduling rules of
-                      the Cluster, including NodeAffinity, PodAffinity, and PodAntiAffinity.
+                    description: |-
+                      Specifies a group of affinity scheduling rules of the Cluster, including NodeAffinity, PodAffinity, and PodAntiAffinity.
+
+
+                      When merging, NodeAffinity's nodeSelectorTerms are overwritten by the destination's nodeSelectorTerms (if destination is not nil).
+                      Other lists are appended with duplicated items removed.
                     properties:
                       nodeAffinity:
                         description: Describes node affinity scheduling rules for

--- a/config/crd/bases/operations.kubeblocks.io_opsrequests.yaml
+++ b/config/crd/bases/operations.kubeblocks.io_opsrequests.yaml
@@ -898,9 +898,12 @@ spec:
                                   Component.
                                 properties:
                                   affinity:
-                                    description: Specifies a group of affinity scheduling
-                                      rules of the Cluster, including NodeAffinity,
-                                      PodAffinity, and PodAntiAffinity.
+                                    description: |-
+                                      Specifies a group of affinity scheduling rules of the Cluster, including NodeAffinity, PodAffinity, and PodAntiAffinity.
+
+
+                                      When merging, NodeAffinity's nodeSelectorTerms are overwritten by the destination's nodeSelectorTerms (if destination is not nil).
+                                      Other lists are appended with duplicated items removed.
                                     properties:
                                       nodeAffinity:
                                         description: Describes node affinity scheduling
@@ -3473,9 +3476,12 @@ spec:
                                   Component.
                                 properties:
                                   affinity:
-                                    description: Specifies a group of affinity scheduling
-                                      rules of the Cluster, including NodeAffinity,
-                                      PodAffinity, and PodAntiAffinity.
+                                    description: |-
+                                      Specifies a group of affinity scheduling rules of the Cluster, including NodeAffinity, PodAffinity, and PodAntiAffinity.
+
+
+                                      When merging, NodeAffinity's nodeSelectorTerms are overwritten by the destination's nodeSelectorTerms (if destination is not nil).
+                                      Other lists are appended with duplicated items removed.
                                     properties:
                                       nodeAffinity:
                                         description: Describes node affinity scheduling

--- a/config/crd/bases/workloads.kubeblocks.io_instancesets.yaml
+++ b/config/crd/bases/workloads.kubeblocks.io_instancesets.yaml
@@ -705,9 +705,12 @@ spec:
                       description: Specifies the scheduling policy for the Component.
                       properties:
                         affinity:
-                          description: Specifies a group of affinity scheduling rules
-                            of the Cluster, including NodeAffinity, PodAffinity, and
-                            PodAntiAffinity.
+                          description: |-
+                            Specifies a group of affinity scheduling rules of the Cluster, including NodeAffinity, PodAffinity, and PodAntiAffinity.
+
+
+                            When merging, NodeAffinity's nodeSelectorTerms are overwritten by the destination's nodeSelectorTerms (if destination is not nil).
+                            Other lists are appended with duplicated items removed.
                           properties:
                             nodeAffinity:
                               description: Describes node affinity scheduling rules

--- a/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
@@ -1027,9 +1027,12 @@ spec:
                             description: Specifies the scheduling policy for the Component.
                             properties:
                               affinity:
-                                description: Specifies a group of affinity scheduling
-                                  rules of the Cluster, including NodeAffinity, PodAffinity,
-                                  and PodAntiAffinity.
+                                description: |-
+                                  Specifies a group of affinity scheduling rules of the Cluster, including NodeAffinity, PodAffinity, and PodAntiAffinity.
+
+
+                                  When merging, NodeAffinity's nodeSelectorTerms are overwritten by the destination's nodeSelectorTerms (if destination is not nil).
+                                  Other lists are appended with duplicated items removed.
                                 properties:
                                   nodeAffinity:
                                     description: Describes node affinity scheduling
@@ -2415,9 +2418,12 @@ spec:
                       description: Specifies the scheduling policy for the Component.
                       properties:
                         affinity:
-                          description: Specifies a group of affinity scheduling rules
-                            of the Cluster, including NodeAffinity, PodAffinity, and
-                            PodAntiAffinity.
+                          description: |-
+                            Specifies a group of affinity scheduling rules of the Cluster, including NodeAffinity, PodAffinity, and PodAntiAffinity.
+
+
+                            When merging, NodeAffinity's nodeSelectorTerms are overwritten by the destination's nodeSelectorTerms (if destination is not nil).
+                            Other lists are appended with duplicated items removed.
                           properties:
                             nodeAffinity:
                               description: Describes node affinity scheduling rules
@@ -5745,8 +5751,12 @@ spec:
                 description: Specifies the scheduling policy for the Cluster.
                 properties:
                   affinity:
-                    description: Specifies a group of affinity scheduling rules of
-                      the Cluster, including NodeAffinity, PodAffinity, and PodAntiAffinity.
+                    description: |-
+                      Specifies a group of affinity scheduling rules of the Cluster, including NodeAffinity, PodAffinity, and PodAntiAffinity.
+
+
+                      When merging, NodeAffinity's nodeSelectorTerms are overwritten by the destination's nodeSelectorTerms (if destination is not nil).
+                      Other lists are appended with duplicated items removed.
                     properties:
                       nodeAffinity:
                         description: Describes node affinity scheduling rules for
@@ -8240,9 +8250,12 @@ spec:
                                   Component.
                                 properties:
                                   affinity:
-                                    description: Specifies a group of affinity scheduling
-                                      rules of the Cluster, including NodeAffinity,
-                                      PodAffinity, and PodAntiAffinity.
+                                    description: |-
+                                      Specifies a group of affinity scheduling rules of the Cluster, including NodeAffinity, PodAffinity, and PodAntiAffinity.
+
+
+                                      When merging, NodeAffinity's nodeSelectorTerms are overwritten by the destination's nodeSelectorTerms (if destination is not nil).
+                                      Other lists are appended with duplicated items removed.
                                     properties:
                                       nodeAffinity:
                                         description: Describes node affinity scheduling
@@ -9646,9 +9659,12 @@ spec:
                           description: Specifies the scheduling policy for the Component.
                           properties:
                             affinity:
-                              description: Specifies a group of affinity scheduling
-                                rules of the Cluster, including NodeAffinity, PodAffinity,
-                                and PodAntiAffinity.
+                              description: |-
+                                Specifies a group of affinity scheduling rules of the Cluster, including NodeAffinity, PodAffinity, and PodAntiAffinity.
+
+
+                                When merging, NodeAffinity's nodeSelectorTerms are overwritten by the destination's nodeSelectorTerms (if destination is not nil).
+                                Other lists are appended with duplicated items removed.
                               properties:
                                 nodeAffinity:
                                   description: Describes node affinity scheduling

--- a/deploy/helm/crds/apps.kubeblocks.io_components.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_components.yaml
@@ -892,9 +892,12 @@ spec:
                       description: Specifies the scheduling policy for the Component.
                       properties:
                         affinity:
-                          description: Specifies a group of affinity scheduling rules
-                            of the Cluster, including NodeAffinity, PodAffinity, and
-                            PodAntiAffinity.
+                          description: |-
+                            Specifies a group of affinity scheduling rules of the Cluster, including NodeAffinity, PodAffinity, and PodAntiAffinity.
+
+
+                            When merging, NodeAffinity's nodeSelectorTerms are overwritten by the destination's nodeSelectorTerms (if destination is not nil).
+                            Other lists are appended with duplicated items removed.
                           properties:
                             nodeAffinity:
                               description: Describes node affinity scheduling rules
@@ -2198,8 +2201,12 @@ spec:
                 description: Specifies the scheduling policy for the Component.
                 properties:
                   affinity:
-                    description: Specifies a group of affinity scheduling rules of
-                      the Cluster, including NodeAffinity, PodAffinity, and PodAntiAffinity.
+                    description: |-
+                      Specifies a group of affinity scheduling rules of the Cluster, including NodeAffinity, PodAffinity, and PodAntiAffinity.
+
+
+                      When merging, NodeAffinity's nodeSelectorTerms are overwritten by the destination's nodeSelectorTerms (if destination is not nil).
+                      Other lists are appended with duplicated items removed.
                     properties:
                       nodeAffinity:
                         description: Describes node affinity scheduling rules for

--- a/deploy/helm/crds/operations.kubeblocks.io_opsrequests.yaml
+++ b/deploy/helm/crds/operations.kubeblocks.io_opsrequests.yaml
@@ -898,9 +898,12 @@ spec:
                                   Component.
                                 properties:
                                   affinity:
-                                    description: Specifies a group of affinity scheduling
-                                      rules of the Cluster, including NodeAffinity,
-                                      PodAffinity, and PodAntiAffinity.
+                                    description: |-
+                                      Specifies a group of affinity scheduling rules of the Cluster, including NodeAffinity, PodAffinity, and PodAntiAffinity.
+
+
+                                      When merging, NodeAffinity's nodeSelectorTerms are overwritten by the destination's nodeSelectorTerms (if destination is not nil).
+                                      Other lists are appended with duplicated items removed.
                                     properties:
                                       nodeAffinity:
                                         description: Describes node affinity scheduling
@@ -3473,9 +3476,12 @@ spec:
                                   Component.
                                 properties:
                                   affinity:
-                                    description: Specifies a group of affinity scheduling
-                                      rules of the Cluster, including NodeAffinity,
-                                      PodAffinity, and PodAntiAffinity.
+                                    description: |-
+                                      Specifies a group of affinity scheduling rules of the Cluster, including NodeAffinity, PodAffinity, and PodAntiAffinity.
+
+
+                                      When merging, NodeAffinity's nodeSelectorTerms are overwritten by the destination's nodeSelectorTerms (if destination is not nil).
+                                      Other lists are appended with duplicated items removed.
                                     properties:
                                       nodeAffinity:
                                         description: Describes node affinity scheduling

--- a/deploy/helm/crds/workloads.kubeblocks.io_instancesets.yaml
+++ b/deploy/helm/crds/workloads.kubeblocks.io_instancesets.yaml
@@ -705,9 +705,12 @@ spec:
                       description: Specifies the scheduling policy for the Component.
                       properties:
                         affinity:
-                          description: Specifies a group of affinity scheduling rules
-                            of the Cluster, including NodeAffinity, PodAffinity, and
-                            PodAntiAffinity.
+                          description: |-
+                            Specifies a group of affinity scheduling rules of the Cluster, including NodeAffinity, PodAffinity, and PodAntiAffinity.
+
+
+                            When merging, NodeAffinity's nodeSelectorTerms are overwritten by the destination's nodeSelectorTerms (if destination is not nil).
+                            Other lists are appended with duplicated items removed.
                           properties:
                             nodeAffinity:
                               description: Describes node affinity scheduling rules

--- a/docs/developer_docs/api-reference/cluster.md
+++ b/docs/developer_docs/api-reference/cluster.md
@@ -9281,6 +9281,8 @@ Kubernetes core/v1.Affinity
 <td>
 <em>(Optional)</em>
 <p>Specifies a group of affinity scheduling rules of the Cluster, including NodeAffinity, PodAffinity, and PodAntiAffinity.</p>
+<p>When merging, NodeAffinity&rsquo;s nodeSelectorTerms are overwritten by the destination&rsquo;s nodeSelectorTerms (if destination is not nil).
+Other lists are appended with duplicated items removed.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/controller/scheduling/scheduling_utils.go
+++ b/pkg/controller/scheduling/scheduling_utils.go
@@ -139,10 +139,7 @@ func MergeAffinity(src, dst *corev1.Affinity) *corev1.Affinity {
 			rtn.NodeAffinity = &corev1.NodeAffinity{}
 		}
 		if src.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
-			if rtn.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
-				rtn.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &corev1.NodeSelector{}
-			}
-			intctrlutil.MergeList(&src.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms, &rtn.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms, makeCmp[corev1.NodeSelectorTerm]())
+			rtn.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = src.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.DeepCopy()
 		}
 		intctrlutil.MergeList(&src.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution, &rtn.NodeAffinity.PreferredDuringSchedulingIgnoredDuringExecution, makeCmp[corev1.PreferredSchedulingTerm]())
 	}

--- a/pkg/controller/scheduling/scheduling_utils_test.go
+++ b/pkg/controller/scheduling/scheduling_utils_test.go
@@ -196,29 +196,6 @@ var _ = Describe("Scheduling util test", func() {
 							{
 								MatchExpressions: []corev1.NodeSelectorRequirement{
 									{
-										Key:      "disktype",
-										Operator: corev1.NodeSelectorOpIn,
-										Values: []string{
-											"hdd",
-										},
-									},
-								},
-								MatchFields: nil,
-							},
-							{
-								MatchExpressions: []corev1.NodeSelectorRequirement{
-									{
-										Key:      "topology.kubernetes.io/zone",
-										Operator: corev1.NodeSelectorOpIn,
-										Values: []string{
-											"west1",
-										},
-									},
-								},
-							},
-							{
-								MatchExpressions: []corev1.NodeSelectorRequirement{
-									{
 										Key:      "node-role.kubernetes.io/worker",
 										Operator: corev1.NodeSelectorOpExists,
 									},
@@ -568,6 +545,31 @@ var _ = Describe("Scheduling util test", func() {
 				},
 			}
 			Expect(rtn).Should(Equal(expectMergedAffinity))
+		})
+		It("don't overwrite when src's nodeaffinity is empty", func() {
+			src := &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{},
+			}
+
+			dst := &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{
+										Key:      "another",
+										Operator: corev1.NodeSelectorOpExists,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			rtn := MergeAffinity(src, dst)
+			Expect(rtn).Should(Equal(dst))
 		})
 	})
 })


### PR DESCRIPTION
fixes https://github.com/apecloud/kubeblocks/issues/9147