### PR TITLE
chore: release kubeblocks-tools image not use cache

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -82,7 +82,7 @@ jobs:
   release-tools-image:
     if: ${{ inputs.dockerfile == '' || inputs.dockerfile == 'Dockerfile-tools' }}
     needs: release-version
-    uses: apecloud/apecloud-cd/.github/workflows/release-image-cache.yml@v0.1.24
+    uses: apecloud/apecloud-cd/.github/workflows/release-image-no-cache.yml@v0.1.91
     with:
       MAKE_OPS_PRE: "module generate test-go-generate"
       IMG: "apecloud/kubeblocks-tools"


### PR DESCRIPTION
fix https://github.com/apecloud/kubeblocks/issues/9256