### PR TITLE
chore: release the connection to kbagent after calling the action

### DIFF
--- a/cmd/kbagent/main.go
+++ b/cmd/kbagent/main.go
@@ -41,7 +41,7 @@ import (
 )
 
 const (
-	defaultMaxConcurrency = 8
+	defaultMaxConcurrency = 32
 )
 
 var serverConfig server.Config

--- a/pkg/controller/lifecycle/kbagent.go
+++ b/pkg/controller/lifecycle/kbagent.go
@@ -305,7 +305,10 @@ func (a *kbagent) callActionWithSelector(ctx context.Context, spec *appsv1.Actio
 		if cli == nil {
 			continue // not kb-agent container and port defined, for test only
 		}
+
 		rsp, err := cli.Action(ctx, *req)
+		_ = cli.Close()
+
 		if err != nil {
 			return nil, errors.Wrapf(err, "http error occurred when executing action %s at pod %s", lfa.name(), pod.Name)
 		}

--- a/pkg/kbagent/client/client.go
+++ b/pkg/kbagent/client/client.go
@@ -21,6 +21,7 @@ package client
 
 import (
 	"context"
+	"io"
 	"net"
 	"net/http"
 	"time"
@@ -33,6 +34,7 @@ const (
 )
 
 type Client interface {
+	io.Closer
 	Action(ctx context.Context, req proto.ActionRequest) (proto.ActionResponse, error)
 }
 

--- a/pkg/kbagent/client/client_mock.go
+++ b/pkg/kbagent/client/client_mock.go
@@ -56,6 +56,10 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
+func (m *MockClient) Close() error {
+	return nil
+}
+
 // Action mocks base method.
 func (m *MockClient) Action(arg0 context.Context, arg1 proto.ActionRequest) (proto.ActionResponse, error) {
 	m.ctrl.T.Helper()

--- a/pkg/kbagent/client/http_client.go
+++ b/pkg/kbagent/client/http_client.go
@@ -43,6 +43,11 @@ type httpClient struct {
 
 var _ Client = &httpClient{}
 
+func (c *httpClient) Close() error {
+	c.client.CloseIdleConnections()
+	return nil
+}
+
 func (c *httpClient) Action(ctx context.Context, req proto.ActionRequest) (proto.ActionResponse, error) {
 	rsp := proto.ActionResponse{}
 


### PR DESCRIPTION
cherry picked from commit 5753c230cc4a57c869d959a333de4524fa87897e