### PR TITLE
fix: minReadySeconds not respected during pod update

### DIFF
--- a/pkg/controller/instanceset/reconciler_update.go
+++ b/pkg/controller/instanceset/reconciler_update.go
@@ -143,7 +143,7 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 		}
 		if isPodPending(pod) && updatePolicy != NoOpsPolicy {
 			err = tree.Delete(pod)
-			// wait another reconcilation, so that the following update process won't be confused
+			// wait another reconciliation, so that the following update process won't be confused
 			return kubebuilderx.Continue, err
 		}
 	}

--- a/pkg/controller/instanceset/reconciler_update.go
+++ b/pkg/controller/instanceset/reconciler_update.go
@@ -110,7 +110,7 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 	}
 	currentUnavailable := 0
 	for _, pod := range oldPodList {
-		if !intctrlutil.IsPodAvailable(pod, its.Spec.MinReadySeconds) && !isPodPending(pod) {
+		if !intctrlutil.IsPodAvailable(pod, its.Spec.MinReadySeconds) {
 			currentUnavailable++
 		}
 	}
@@ -134,11 +134,21 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 	needRetry := false
 	sortObjects(oldPodList, priorities, false)
 
-	canBeUpdated := func(pod *corev1.Pod) bool {
-		// pending pod can be updated because there's no consequence of deleting it
-		if isPodPending(pod) {
-			return true
+	// treat old and Pending pod as a special case, as they can be updated without a consequence
+	// PodUpdatePolicy is ignored here since in-place update for a pending pod doesn't make much sense.
+	for _, pod := range oldPodList {
+		updatePolicy, err := getPodUpdatePolicy(its, pod)
+		if err != nil {
+			return kubebuilderx.Continue, err
 		}
+		if isPodPending(pod) && updatePolicy != NoOpsPolicy {
+			err = tree.Delete(pod)
+			// wait another reconcilation, so that the following update process won't be confused
+			return kubebuilderx.Continue, err
+		}
+	}
+
+	canBeUpdated := func(pod *corev1.Pod) bool {
 		if !isImageMatched(pod) {
 			tree.Logger.Info(fmt.Sprintf("InstanceSet %s/%s blocks on update as the pod %s does not have the same image(s) in the status and in the spec", its.Namespace, its.Name, pod.Name))
 			return false


### PR DESCRIPTION
In https://github.com/apecloud/kubeblocks/pull/9208, pending pod was not counted as unavailable. 

Suppose maxUnavailable=1, pod=3, and current pod status is pod-0 (new, pending), pod-1 (old, running), pod-2 (old, running). Instanceset controller will delete pod-1 since it considers pod-0 as available.