### PR TITLE
fix: support restore manager sidecar

### DIFF
--- a/controllers/dataprotection/restore_controller.go
+++ b/controllers/dataprotection/restore_controller.go
@@ -250,7 +250,7 @@ func (r *RestoreReconciler) newAction(reqCtx intctrlutil.RequestCtx, restore *dp
 		restore.Status.Phase = dpv1alpha1.RestorePhaseAsDataSource
 	} else {
 		// check if restore CR is legal
-		err := r.validateAndBuildMGR(reqCtx, dprestore.NewRestoreManager(restore, r.Recorder, r.Scheme))
+		err := r.validateAndBuildMGR(reqCtx, dprestore.NewRestoreManager(restore, r.Recorder, r.Scheme, r.Client))
 		switch {
 		case intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal):
 			restore.Status.Phase = dpv1alpha1.RestorePhaseFailed
@@ -271,7 +271,7 @@ func (r *RestoreReconciler) newAction(reqCtx intctrlutil.RequestCtx, restore *dp
 }
 
 func (r *RestoreReconciler) handleRunningPhase(reqCtx intctrlutil.RequestCtx, restore *dpv1alpha1.Restore) (ctrl.Result, error) {
-	restoreMgr := dprestore.NewRestoreManager(restore, r.Recorder, r.Scheme)
+	restoreMgr := dprestore.NewRestoreManager(restore, r.Recorder, r.Scheme, r.Client)
 	// validate if the restore.spec is valid and build restore manager.
 	err := r.validateAndBuildMGR(reqCtx, restoreMgr)
 	if err == nil {

--- a/controllers/dataprotection/restore_controller.go
+++ b/controllers/dataprotection/restore_controller.go
@@ -477,7 +477,10 @@ func (r *RestoreReconciler) handleBackupActionSet(reqCtx intctrlutil.RequestCtx,
 	}
 
 	// 4. check if jobs are finished.
-	allActionsFinished, existFailedAction = restoreMgr.CheckJobsDone(stage, actionName, backupSet, jobs)
+	allActionsFinished, existFailedAction, err = restoreMgr.CheckJobsDone(stage, actionName, backupSet, jobs)
+	if err != nil {
+		return false, err
+	}
 	if stage == dpv1alpha1.PrepareData {
 		// recalculation whether all actions have been completed.
 		restoreMgr.Recalculation(backupSet.Backup.Name, actionName, &allActionsFinished, &existFailedAction)

--- a/controllers/dataprotection/restore_controller_test.go
+++ b/controllers/dataprotection/restore_controller_test.go
@@ -251,6 +251,9 @@ var _ = Describe("Restore Controller test", func() {
 			for _, job := range jobList.Items {
 				Expect(len(job.Spec.Template.Spec.Containers)).ShouldNot(BeZero())
 				for _, c := range job.Spec.Template.Spec.Containers {
+					if c.Name != dprestore.Restore {
+						continue
+					}
 					count := 0
 					for _, env := range c.Env {
 						for _, param := range testdp.TestParameters {

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -154,7 +154,7 @@ func (r *VolumePopulatorReconciler) validateRestoreAndBuildMGR(reqCtx intctrluti
 	if restore.Spec.PrepareDataConfig == nil || restore.Spec.PrepareDataConfig.DataSourceRef == nil {
 		return nil, intctrlutil.NewFatalError(fmt.Sprintf(`spec.prepareDataConfig.datasourceRef of restore "%s" can not be empty`, restore.Name))
 	}
-	restoreMgr := dprestore.NewRestoreManager(restore, r.Recorder, r.Scheme)
+	restoreMgr := dprestore.NewRestoreManager(restore, r.Recorder, r.Scheme, r.Client)
 	if err := dprestore.ValidateAndInitRestoreMGR(reqCtx, r.Client, restoreMgr); err != nil {
 		return nil, err
 	}

--- a/pkg/dataprotection/restore/builder.go
+++ b/pkg/dataprotection/restore/builder.go
@@ -411,8 +411,8 @@ func (r *restoreJobBuilder) build() *batchv1.Job {
 	controllerutil.AddFinalizer(job, dptypes.DataProtectionFinalizerName)
 
 	// 3. inject restore manager
-	if r.stage == dpv1alpha1.PrepareData {
-		r.InjectRestoreManagerContainer(&job.Spec.Template.Spec)
+	if r.stage == dpv1alpha1.PrepareData && !r.restore.Spec.PrepareDataConfig.IsSerialPolicy() {
+		r.InjectManagerContainer(&job.Spec.Template.Spec)
 	}
 
 	// 4. inject datasafed if needed
@@ -432,7 +432,7 @@ func (r *restoreJobBuilder) build() *batchv1.Job {
 	return job
 }
 
-func (r *restoreJobBuilder) InjectRestoreManagerContainer(podSpec *corev1.PodSpec) {
+func (r *restoreJobBuilder) InjectManagerContainer(podSpec *corev1.PodSpec) {
 	container := corev1.Container{
 		Name:            restoreManagerContainerName,
 		Image:           viper.GetString(constant.KBToolsImage),

--- a/pkg/dataprotection/restore/builder.go
+++ b/pkg/dataprotection/restore/builder.go
@@ -411,9 +411,7 @@ func (r *restoreJobBuilder) build() *batchv1.Job {
 	controllerutil.AddFinalizer(job, dptypes.DataProtectionFinalizerName)
 
 	// 3. inject restore manager
-	if r.stage == dpv1alpha1.PrepareData && !r.restore.Spec.PrepareDataConfig.IsSerialPolicy() {
-		r.InjectManagerContainer(&job.Spec.Template.Spec)
-	}
+	r.InjectManagerContainer(&job.Spec.Template.Spec)
 
 	// 4. inject datasafed if needed
 	if r.buildWithRepo {
@@ -473,21 +471,21 @@ set -o errexit
 set -o nounset
 
 sleep_seconds="%d"
-signal_file="${%s}"
+signal_file="%s"
 
 if [ "$sleep_seconds" -le 0 ]; then
   sleep_seconds=2
 fi
 
 while true; do
-  if [ -f "$signal_file" && $(cat "$signal_file") == "true" ]; then
+  if [ -f "$signal_file" ] && [ "$(cat "$signal_file")" = "true" ]; then
     break
   fi
   echo "waiting for other restore workloads, sleep ${sleep_seconds}s"
   sleep "$sleep_seconds"
 done
 
-echo "restore done"
+echo "restore manager stopped"
 `, checkIntervalSeconds, filepath.Join(mountPath, fileName))
 	}
 	container.Args = []string{buildSyncProgressCommand()}

--- a/pkg/dataprotection/restore/manager.go
+++ b/pkg/dataprotection/restore/manager.go
@@ -817,7 +817,7 @@ func (r *RestoreManager) CheckJobsDone(
 			}
 		}
 	}
-	// wait until all `restore` containers are terminated normally
+	// wait until all `restore` containers are terminated normally or jobs are completed or failed
 	if finishedCount == len(fetchedJobs) {
 		for i := range fetchedJobs {
 			err := r.StopManagerContainerByJob(fetchedJobs[i])
@@ -884,9 +884,10 @@ func (r *RestoreManager) StopManagerContainer(pod *corev1.Pod) error {
 	if val, ok := modified.Annotations[DataProtectionStopRestoreManagerAnnotationKey]; ok && val == "true" {
 		return nil
 	}
+	// `restore manager` container will read this annotation to stop
 	modified.Annotations[DataProtectionStopRestoreManagerAnnotationKey] = "true"
 	if err := r.Client.Patch(context.Background(), modified, client.MergeFrom(pod)); err != nil {
-		return client.IgnoreAlreadyExists(err)
+		return client.IgnoreNotFound(err)
 	}
 	return nil
 }

--- a/pkg/dataprotection/restore/manager_test.go
+++ b/pkg/dataprotection/restore/manager_test.go
@@ -241,6 +241,7 @@ var _ = Describe("RestoreManager Test", func() {
 			actionSetName := "preparedata-0"
 			testSerialCreateJob := func(expectRestoreFinished bool) {
 				By("test BuildPrepareDataJobs function, expect for 1 job")
+				viper.Set(constant.KBToolsImage, "kubeblocks-tools")
 				target := utils.GetBackupStatusTarget(backupSet.Backup, restoreMGR.Restore.Spec.Backup.SourceTargetName)
 				jobs, err := restoreMGR.BuildPrepareDataJobs(reqCtx, k8sClient, *backupSet, target, actionSetName)
 				Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/dataprotection/restore/manager_test.go
+++ b/pkg/dataprotection/restore/manager_test.go
@@ -141,7 +141,7 @@ var _ = Describe("RestoreManager Test", func() {
 			restore := restoreFactory.Create(&testCtx).Get()
 
 			By("create restore manager")
-			restoreMGR := NewRestoreManager(restore, recorder, k8sClient.Scheme())
+			restoreMGR := NewRestoreManager(restore, recorder, k8sClient.Scheme(), k8sClient)
 			backupSet, err := restoreMGR.GetBackupActionSetByNamespaced(reqCtx, k8sClient, backup.Name, testCtx.DefaultNamespace)
 			Expect(err).ShouldNot(HaveOccurred())
 			return restoreMGR, backupSet

--- a/pkg/dataprotection/restore/manager_test.go
+++ b/pkg/dataprotection/restore/manager_test.go
@@ -251,7 +251,8 @@ var _ = Describe("RestoreManager Test", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 
 				By("test CheckJobsDone function and jobs is running")
-				allJobsFinished, existFailedJob := restoreMGR.CheckJobsDone(dpv1alpha1.PrepareData, actionSetName, *backupSet, jobs)
+				allJobsFinished, existFailedJob, err := restoreMGR.CheckJobsDone(dpv1alpha1.PrepareData, actionSetName, *backupSet, jobs)
+				Expect(err).ShouldNot(HaveOccurred())
 				Expect(allJobsFinished).Should(BeFalse())
 
 				By("mock jobs are completed")
@@ -261,7 +262,8 @@ var _ = Describe("RestoreManager Test", func() {
 				}
 
 				By("test CheckJobsDone function and jobs are finished")
-				allJobsFinished, existFailedJob = restoreMGR.CheckJobsDone(dpv1alpha1.PrepareData, actionSetName, *backupSet, jobs)
+				allJobsFinished, existFailedJob, err = restoreMGR.CheckJobsDone(dpv1alpha1.PrepareData, actionSetName, *backupSet, jobs)
+				Expect(err).ShouldNot(HaveOccurred())
 				Expect(allJobsFinished).Should(BeTrue())
 
 				By("test Recalculation function, allJobFinished should be false because it only restored one pvc.")

--- a/pkg/dataprotection/restore/types.go
+++ b/pkg/dataprotection/restore/types.go
@@ -54,7 +54,8 @@ const (
 
 // Annotations key
 const (
-	DataProtectionBackupExtrasLabelKey = "dataprotection.kubeblocks.io/backup-extras"
+	DataProtectionBackupExtrasLabelKey            = "dataprotection.kubeblocks.io/backup-extras"
+	DataProtectionStopRestoreManagerAnnotationKey = "dataprotection.kubeblocks.io/stop-restore-manager"
 )
 
 // env name for restore


### PR DESCRIPTION
fix https://github.com/apecloud/kubeblocks/issues/9231

we inject `restore manager` container into restore job pod, the container waits until all restore containers from every restore job have finished by monitoring an annotation signal added by the restore controller after all restore containers finish.

To guarantee that the recovered PVCs/PVs and pods are scheduled correctly, we specify the same scheduling policy for job pods. However, the scheduler might not consider the restore job pod when scheduling other pods if it is completed too quickly, which may lead to incorrect scheduling. This container ensures that all job pods are considered by the scheduler.