### PR TITLE
fix: minReadySeconds not respected during pod update

### DIFF
--- a/pkg/controller/instanceset/reconciler_update.go
+++ b/pkg/controller/instanceset/reconciler_update.go
@@ -99,7 +99,7 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 	}
 	currentUnavailable := 0
 	for _, pod := range oldPodList {
-		if !isHealthy(pod) && !isPodPending(pod) {
+		if !isHealthy(pod) {
 			currentUnavailable++
 		}
 	}
@@ -124,11 +124,21 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 	needRetry := false
 	sortObjects(oldPodList, priorities, false)
 
-	canBeUpdated := func(pod *corev1.Pod) bool {
-		// pending pod can be updated because there's no consequence of deleting it
-		if isPodPending(pod) {
-			return true
+	// treat old and Pending pod as a special case, as they can be updated without a consequence
+	// PodUpdatePolicy is ignored here since in-place update for a pending pod doesn't make much sense.
+	for _, pod := range oldPodList {
+		updatePolicy, err := getPodUpdatePolicy(its, pod)
+		if err != nil {
+			return kubebuilderx.Continue, err
 		}
+		if isPodPending(pod) && updatePolicy != NoOpsPolicy {
+			err = tree.Delete(pod)
+			// wait another reconciliation, so that the following update process won't be confused
+			return kubebuilderx.Continue, err
+		}
+	}
+
+	canBeUpdated := func(pod *corev1.Pod) bool {
 		// when PodUpdatePolicy is Recreate, no need to check whether containers are ready.
 		if its.Spec.PodUpdatePolicy != workloads.RecreatePodUpdatePolicyType && !isContainersReady(pod) {
 			tree.Logger.Info(fmt.Sprintf("InstanceSet %s/%s blocks on update as some the container(s) of pod %s are not ready", its.Namespace, its.Name, pod.Name))


### PR DESCRIPTION
manually pick https://github.com/apecloud/kubeblocks/pull/9312