### PR TITLE
chore: support mark outdated system account secret from backup/support mark outdated system account secret from backup

### DIFF
--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -1016,10 +1016,10 @@ func setEncryptedSystemAccountsAnnotation(request *dpbackup.Request, cluster *ap
 		request.Backup.Annotations[constant.EncryptedSystemAccountsAnnotationKey] = *secretMapString
 	}
 	outdatedSecretMapString, err := getObjectString(outdatedSecretMap)
-	if err!= nil {
+	if err != nil {
 		return err
 	}
-	if outdatedSecretMapString!= nil && *outdatedSecretMapString!= "" {
+	if outdatedSecretMapString != nil && *outdatedSecretMapString != "" {
 		request.Backup.Annotations[constant.OutdatedSystemAccountAnnotationKey] = *outdatedSecretMapString
 	}
 	return nil

--- a/pkg/constant/const.go
+++ b/pkg/constant/const.go
@@ -142,6 +142,9 @@ const (
 	ClusterSnapshotAnnotationKey                = "kubeblocks.io/cluster-snapshot"          // ClusterSnapshotAnnotationKey saves the snapshot of cluster.
 	OpsRequestAnnotationKey                     = "kubeblocks.io/ops-request"               // OpsRequestAnnotationKey OpsRequest annotation key in Cluster
 	EncryptedSystemAccountsAnnotationKey        = "kubeblocks.io/encrypted-system-accounts" // EncryptedSystemAccountsAnnotationKey saves the encrypted system accounts.
+	OutdatedSystemAccountAnnotationKey          = "kubeblocks.io/outdated-system-accounts"  // OutdateSystemAccountAnnotationKey saves the outdate system accounts.
+	SystemAccountOutdatedAnnotationKey          = "kubeblocks.io/secret-outdated"           // if user update the system account by other way, the annotation should be set to true by user yourself.
+	SystemAccountLastUpdateTimeKey              = "kubeblocks.io/secret-last-update-time"   // SystemAccountLastUpdateTimeKey saves the last update time of system account.
 	ReconcileAnnotationKey                      = "kubeblocks.io/reconcile"                 // ReconcileAnnotationKey Notify k8s object to reconcile
 	RestartAnnotationKey                        = "kubeblocks.io/restart"                   // RestartAnnotationKey the annotation which notices the StatefulSet/DeploySet to restart
 	RestoreFromBackupAnnotationKey              = "kubeblocks.io/restore-from-backup"


### PR DESCRIPTION
- If the user modifies the root account password through their own client, they must **manually** add an annotation marking the corresponding secret as outdated. 
- Additionally, the corresponding backup and restore process has been adapted accordingly.