### PR TITLE
chore: kbagent log stdout on error

### DIFF
--- a/pkg/kbagent/service/command.go
+++ b/pkg/kbagent/service/command.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/apecloud/kubeblocks/pkg/kbagent/proto"
@@ -144,6 +145,11 @@ func runCommandX(ctx context.Context, action *proto.ExecAction, parameters map[s
 	cmd.Stdin = stdinReader
 	cmd.Stdout = stdoutWriter
 	cmd.Stderr = stderrWriter
+	cmd.WaitDelay = time.Second * 1
+	// gracefully terminate, go will kill it after waitDelay
+	cmd.Cancel = func() error {
+		return cmd.Process.Signal(syscall.SIGTERM)
+	}
 
 	errChan := make(chan error, 1)
 	go func() {

--- a/pkg/kbagent/service/command_test.go
+++ b/pkg/kbagent/service/command_test.go
@@ -271,11 +271,10 @@ var _ = Describe("command", func() {
 			action := &proto.ExecAction{
 				Commands: []string{"/bin/bash", "-c", "command-not-found"},
 			}
-			output, err := runCommand(ctx, action, nil, nil)
+			_, err := runCommand(ctx, action, nil, nil)
 			Expect(err).ShouldNot(BeNil())
 			Expect(errors.Is(err, proto.ErrFailed)).Should(BeTrue())
 			Expect(err.Error()).Should(ContainSubstring("command not found"))
-			Expect(output).Should(BeNil())
 		})
 
 		It("timeout", func() {
@@ -283,10 +282,9 @@ var _ = Describe("command", func() {
 				Commands: []string{"/bin/bash", "-c", "sleep 60"},
 			}
 			timeout := int32(1)
-			output, err := runCommand(ctx, action, nil, &timeout)
+			_, err := runCommand(ctx, action, nil, &timeout)
 			Expect(err).ShouldNot(BeNil())
 			Expect(errors.Is(err, proto.ErrTimedOut)).Should(BeTrue())
-			Expect(output).Should(BeNil())
 		})
 	})
 })


### PR DESCRIPTION
Log kbagent command's stdout on error so that users would have more context to debug.

One more thing. Action command is executed by os/exec. If the command A has created a subprocess B, and A exits before B exits, the command's timeout, which is included in the context, is not respected. (the exact same problem described in https://github.com/golang/go/issues/23019) That is because B shares stdout/stderr fd with A, and go will wait for the fd to close before `cmd.Wait()` returns. This PR adds `cmd.WaitDelay` to handle this.

The timeout parameter seems like not used currently, but it makes the test slow.