### PR TITLE
fix: the format difference between number/boo/float and string for json

### DIFF
--- a/pkg/configuration/config_manager/reload_util.go
+++ b/pkg/configuration/config_manager/reload_util.go
@@ -128,7 +128,7 @@ func constructReloadBuiltinFuncs(ctx context.Context, cc DynamicParamUpdater, fo
 			if err != nil {
 				return err
 			}
-			newConfig, err := core.ApplyConfigPatch(b, core.FromStringPointerMap(updatedParams), formatConfig)
+			newConfig, err := core.ApplyConfigPatch(b, core.FromStringPointerMap(updatedParams), formatConfig, nil)
 			if err != nil {
 				return err
 			}

--- a/pkg/controller/configuration/patch_merger.go
+++ b/pkg/controller/configuration/patch_merger.go
@@ -34,14 +34,16 @@ func DoMerge(baseData map[string]string,
 		updatedParams = make([]core.ParamPairs, 0, len(patch))
 	)
 
+	builder := NewValueManager(paramsDefs, configDescs)
 	for key, params := range patch {
 		if params.Content != nil {
 			updatedFiles[key] = *params.Content
 		}
 		if len(params.Parameters) > 0 {
+			upParams, _ := core.FromStringMap(params.Parameters, builder.buildValueTransformer(key))
 			updatedParams = append(updatedParams, core.ParamPairs{
 				Key:           key,
-				UpdatedParams: core.FromStringMap(params.Parameters),
+				UpdatedParams: upParams,
 			})
 		}
 	}

--- a/pkg/controller/configuration/value_transformer.go
+++ b/pkg/controller/configuration/value_transformer.go
@@ -1,0 +1,93 @@
+/*
+Copyright (C) 2022-2024 ApeCloud Co., Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configuration
+
+import (
+	"strconv"
+
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/configuration/openapi"
+	"github.com/apecloud/kubeblocks/pkg/generics"
+)
+
+type ValueTransformer interface {
+	transformValue(value string, schema string) (any, error)
+}
+
+type defaultValueTransformer struct {
+	flattenedSchema apiextv1.JSONSchemaProps
+}
+
+func (d *defaultValueTransformer) transformValue(value string, key string) (any, error) {
+	schema, ok := FindParameterSchema(d.flattenedSchema.Properties, key)
+	if !ok {
+		return value, nil
+	}
+	switch schema.Type {
+	default:
+		return value, nil
+	case "integer":
+		return strconv.ParseInt(value, 10, 64)
+	case "number":
+		return strconv.ParseFloat(value, 64)
+	case "boolean":
+		return strconv.ParseBool(value)
+	}
+}
+
+type valueManager struct {
+	paramsDefs    []*parametersv1alpha1.ParametersDefinition
+	formatConfigs map[string]parametersv1alpha1.FileFormatConfig
+}
+
+func (v *valueManager) buildValueTransformer(key string) func(value string, schema string) (any, error) {
+	// NODE: The JSON format requires distinguishing value types, and encode/decode will not perform automatic conversion.
+	if format, ok := v.formatConfigs[key]; !ok || format.Format != parametersv1alpha1.JSON {
+		return nil
+	}
+	index := generics.FindFirstFunc(v.paramsDefs, func(paramDef *parametersv1alpha1.ParametersDefinition) bool {
+		return paramDef.Spec.FileName == key
+	})
+	if index < 0 || v.paramsDefs[index].Spec.ParametersSchema == nil {
+		return nil
+	}
+	schema := v.paramsDefs[index].Spec.ParametersSchema.SchemaInJSON
+	if _, ok := schema.Properties[openapi.DefaultSchemaName]; !ok {
+		return nil
+	}
+	transformer := &defaultValueTransformer{
+		flattenedSchema: openapi.FlattenSchema(schema.Properties[openapi.DefaultSchemaName]),
+	}
+	return func(value string, schema string) (any, error) {
+		return transformer.transformValue(value, schema)
+	}
+}
+
+func NewValueManager(paramsDefs []*parametersv1alpha1.ParametersDefinition, configs []parametersv1alpha1.ComponentConfigDescription) *valueManager {
+	manager := &valueManager{
+		paramsDefs:    paramsDefs,
+		formatConfigs: make(map[string]parametersv1alpha1.FileFormatConfig),
+	}
+	for _, config := range configs {
+		if config.FileFormatConfig != nil {
+			manager.formatConfigs[config.Name] = *config.FileFormatConfig
+		}
+	}
+	return manager
+}

--- a/pkg/unstructured/viper_wrap.go
+++ b/pkg/unstructured/viper_wrap.go
@@ -90,7 +90,12 @@ func (v *viperWrap) Marshal() (string, error) {
 	return dumpCfgContent(v.Viper, tmpFile)
 }
 
-func (v viperWrap) Unmarshal(str string) error {
+const emptyJson = "{}"
+
+func (v *viperWrap) Unmarshal(str string) error {
+	if v.format == parametersv1alpha1.JSON && str == "" {
+		str = emptyJson
+	}
 	return v.ReadConfig(bytes.NewReader([]byte(str)))
 }
 


### PR DESCRIPTION
String-type parameters and non-string-type parameters have differences in JSON format.
For example, for an int-type parameter like intparams, the correct format should be `{"intparams": 1000}` instead of `{"intparams": "1000"}`