### PR TITLE
chore: bump datasafed version to 0.2.1

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -393,7 +393,7 @@ dataProtection:
     imagePullSecrets: []
     datasafed:
       repository: apecloud/datasafed
-      tag: "0.2.0"
+      tag: "0.2.1"
   ## @param toleration
   tolerations:
   - key: kb-controller


### PR DESCRIPTION
close #9505.