### PR TITLE
feat: export user-defined environment variables to lifecycle actions

### DIFF
--- a/pkg/controller/component/synthesize_component.go
+++ b/pkg/controller/component/synthesize_component.go
@@ -121,10 +121,6 @@ func BuildSynthesizedComponent(ctx context.Context, cli client.Reader,
 		InstanceUpdateStrategy:           comp.Spec.InstanceUpdateStrategy,
 	}
 
-	if err = mergeUserDefinedEnv(synthesizeComp, comp); err != nil {
-		return nil, err
-	}
-
 	// build scheduling policy for workload
 	scheduling.ApplySchedulingPolicyToPodSpec(synthesizeComp.PodSpec, comp.Spec.SchedulingPolicy)
 
@@ -165,6 +161,10 @@ func BuildSynthesizedComponent(ctx context.Context, cli client.Reader,
 
 	// build volume mounts after kb-agent containers
 	buildVolumeMounts(synthesizeComp)
+
+	if err = mergeUserDefinedEnv(synthesizeComp, comp); err != nil {
+		return nil, err
+	}
 
 	if err = buildServiceReferences(ctx, cli, synthesizeComp, compDef, comp); err != nil {
 		return nil, errors.Wrap(err, "build service references failed")


### PR DESCRIPTION
After adding environment variables (env) to the componentSpecs in the cluster, I noticed that the kbagent container in the pod did not contain the env variables I defined. Upon reviewing the source code, I found that the kbagent container is created after the environment variables are merged, and therefore does not utilize the env variables I specified.