### PR TITLE
fix: backup always fails during the cluster creation phase

### DIFF
--- a/pkg/dataprotection/backup/utils.go
+++ b/pkg/dataprotection/backup/utils.go
@@ -335,8 +335,10 @@ func StopStatefulSetsWhenFailed(ctx context.Context, cli client.Client, backup *
 	}
 	sts := &appsv1.StatefulSet{}
 	stsName := GenerateBackupStatefulSetName(backup, targetName, BackupDataJobNamePrefix)
-	if err := cli.Get(ctx, client.ObjectKey{Name: stsName, Namespace: backup.Namespace}, sts); client.IgnoreNotFound(err) != nil {
+	if err := cli.Get(ctx, client.ObjectKey{Name: stsName, Namespace: backup.Namespace}, sts); client.IgnoreNotFound(err) == nil {
 		return nil
+	} else if err != nil {
+		return err
 	}
 	sts.Spec.Replicas = pointer.Int32(0)
 	return cli.Update(ctx, sts)


### PR DESCRIPTION
- The backup always fails during the cluster creation phase. Add cluster phase check for `handleNewPhase`
![img_v3_02pp_4b141d40-db13-4860-9b7e-ee94506a659g](https://github.com/user-attachments/assets/e254465f-e0c3-4173-a034-81f3897e45ef)
