### PR TITLE
fix: kb panics when neither clusterServiceSelector nor serviceDescriptor was set in serviceref

### DIFF
--- a/pkg/controller/component/service_reference.go
+++ b/pkg/controller/component/service_reference.go
@@ -74,6 +74,8 @@ func buildServiceReferencesWithoutResolve(ctx context.Context, cli client.Reader
 			sd, err = handleServiceRefFromCluster(ctx, cli, namespace, *serviceRef, serviceRefDecl)
 		case serviceRef.ServiceDescriptor != "":
 			sd, err = handleServiceRefFromServiceDescriptor(ctx, cli, namespace, *serviceRef, serviceRefDecl)
+		default:
+			err = fmt.Errorf("either clusterServiceSelector or serviceDescriptor should be set for service-ref for %s", serviceRefDecl.Name)
 		}
 		if err != nil {
 			return err


### PR DESCRIPTION
fixes https://github.com/apecloud/kubeblocks/issues/9501#issuecomment-3095910339