### PR TITLE
fix: do not set runAsNonRoot to the init container of datasafed

### DIFF
--- a/controllers/dataprotection/backuprepo_controller.go
+++ b/controllers/dataprotection/backuprepo_controller.go
@@ -776,7 +776,6 @@ func (r *BackupRepoReconciler) runPreCheckJobForMounting(reconCtx *reconcileCont
 						}},
 						SecurityContext: &corev1.SecurityContext{
 							AllowPrivilegeEscalation: boolptr.False(),
-							RunAsNonRoot:             boolptr.True(),
 						},
 					}},
 					Volumes: []corev1.Volume{{
@@ -788,6 +787,9 @@ func (r *BackupRepoReconciler) runPreCheckJobForMounting(reconCtx *reconcileCont
 						},
 					}},
 					ServiceAccountName: saName,
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: boolptr.True(),
+					},
 				},
 			},
 			BackoffLimit: pointer.Int32(2),
@@ -856,10 +858,12 @@ datasafed rm %s`, precheckFilePath, precheckFilePath, precheckFilePath),
 						},
 						SecurityContext: &corev1.SecurityContext{
 							AllowPrivilegeEscalation: boolptr.False(),
-							RunAsNonRoot:             boolptr.True(),
 						},
 					}},
 					ServiceAccountName: saName,
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: boolptr.True(),
+					},
 				},
 			},
 			BackoffLimit: pointer.Int32(2),

--- a/pkg/dataprotection/utils/backuprepo.go
+++ b/pkg/dataprotection/utils/backuprepo.go
@@ -155,7 +155,6 @@ func injectDatasafedInstaller(podSpec *corev1.PodSpec) {
 		VolumeMounts:    []corev1.VolumeMount{sharedVolumeMount},
 		SecurityContext: &corev1.SecurityContext{
 			AllowPrivilegeEscalation: boolptr.False(),
-			RunAsNonRoot:             boolptr.True(),
 		},
 	}
 	intctrlutil.InjectZeroResourcesLimitsIfEmpty(&initContainer)


### PR DESCRIPTION
fix #9725.