### PR TITLE
fix: restart ops is always running for restored cluster when the source backup has been deleted

### DIFF
--- a/pkg/controller/plan/restore.go
+++ b/pkg/controller/plan/restore.go
@@ -115,6 +115,7 @@ func (r *RestoreManager) DoRestore(comp *component.SynthesizedComponent, compObj
 	// mark component restore done
 	if compObj.Annotations != nil {
 		compObj.Annotations[constant.RestoreDoneAnnotationKey] = "true"
+		delete(compObj.Annotations, constant.RestoreFromBackupAnnotationKey)
 	}
 	// do clean up
 	return r.cleanupRestoreAnnotations(comp.Name)


### PR DESCRIPTION
build account from backup but backup has been deleted, so the controller is blocked