### PR TITLE
fix: use the cluster namespace if the secret-ref namespace of the TLS issuer is not set

### DIFF
--- a/controllers/apps/component/transformer_component_tls.go
+++ b/controllers/apps/component/transformer_component_tls.go
@@ -292,6 +292,9 @@ func (i *tlsIssuerUserProvided) referenced(ctx context.Context, cli client.Reade
 		Namespace: secretRef.Namespace,
 		Name:      secretRef.Name,
 	}
+	if len(secretKey.Namespace) == 0 {
+		secretKey.Namespace = i.synthesizedComp.Namespace
+	}
 	secret := &corev1.Secret{}
 	if err := cli.Get(ctx, secretKey, secret); err != nil {
 		return nil, err

--- a/controllers/apps/component/transformer_component_tls_test.go
+++ b/controllers/apps/component/transformer_component_tls_test.go
@@ -68,7 +68,7 @@ var _ = Describe("TLS transformer test", func() {
 
 		tlsSecret4User = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: testCtx.DefaultNamespace,
+				Namespace: "default", // testCtx hasn't been initialized yet
 				Name:      "tls-secret-4-user",
 			},
 			Data: map[string][]byte{


### PR DESCRIPTION
close #9784 