### PR TITLE
chore: fix BackupRepo precheck job permission denied error by setting FSGroup

### DIFF
--- a/controllers/dataprotection/backuprepo_controller.go
+++ b/controllers/dataprotection/backuprepo_controller.go
@@ -788,7 +788,9 @@ func (r *BackupRepoReconciler) runPreCheckJobForMounting(reconCtx *reconcileCont
 					}},
 					ServiceAccountName: saName,
 					SecurityContext: &corev1.PodSecurityContext{
-						RunAsNonRoot: boolptr.True(),
+						// Set FSGroup to 65532 to ensure the mounted PVC has correct group ownership
+						// for the container user (65532:65532 defined in Dockerfile) to write files
+						FSGroup: pointer.Int64(65532),
 					},
 				},
 			},
@@ -862,7 +864,9 @@ datasafed rm %s`, precheckFilePath, precheckFilePath, precheckFilePath),
 					}},
 					ServiceAccountName: saName,
 					SecurityContext: &corev1.PodSecurityContext{
-						RunAsNonRoot: boolptr.True(),
+						// Set FSGroup to 65532 to ensure the mounted volumes have correct group ownership
+						// for the container user (65532:65532 defined in Dockerfile) to access files
+						FSGroup: pointer.Int64(65532),
 					},
 				},
 			},


### PR DESCRIPTION
## Problem Description

BackupRepo precheck jobs encounter permission denied errors when attempting to write files to mounted PVCs:
```
sh: can't create /backup/precheck.txt: Permission denied
```

## Root Cause

Although the container image has `USER 65532:65532` set, the mounted PVC may not have the correct group permissions, preventing the container user from writing files.

## Solution

By setting `FSGroup: 65532` in the Pod's SecurityContext, we ensure:
1. The mounted PVC has the correct group ownership (GID 65532)
2. The container user (65532:65532) can read and write to the mounted volumes

## Changes Made

- Removed unnecessary `RunAsNonRoot: true` setting (container image already uses non-root user)
- Added `FSGroup: 65532` to ensure correct volume permissions
- Applied this fix to both types of precheck jobs:
  - Mount-based precheck jobs (for PVC access)
  - Tool-based precheck jobs (for datasafed configuration)
- Added detailed comments explaining the rationale

## Testing

This fix resolves the permission issues during BackupRepo precheck phase, ensuring precheck jobs can successfully create, write, and delete test files.

Fixes #9799