### PR TITLE
fix: allow the comp name in the cluster spec to be empty

### DIFF
--- a/apis/apps/v1/cluster_types.go
+++ b/apis/apps/v1/cluster_types.go
@@ -264,7 +264,7 @@ type ClusterComponentSpec struct {
 	// but required otherwise.
 	//
 	// +kubebuilder:validation:MaxLength=22
-	// +kubebuilder:validation:Pattern:=`^[a-z]([a-z0-9\-]*[a-z0-9])?$`
+	// +kubebuilder:validation:Pattern:=`^$|^[a-z]([a-z0-9-]*[a-z0-9])?$`
 	// +optional
 	Name string `json:"name,omitempty"`
 

--- a/config/crd/bases/apps.kubeblocks.io_clusters.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusters.yaml
@@ -2703,7 +2703,7 @@ spec:
                         The name is optional when ClusterComponentSpec is used as a template (e.g., in `clusterSharding`),
                         but required otherwise.
                       maxLength: 22
-                      pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
+                      pattern: ^$|^[a-z]([a-z0-9-]*[a-z0-9])?$
                       type: string
                     network:
                       description: Defines the network configuration for the Component.
@@ -13953,7 +13953,7 @@ spec:
                             The name is optional when ClusterComponentSpec is used as a template (e.g., in `clusterSharding`),
                             but required otherwise.
                           maxLength: 22
-                          pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
+                          pattern: ^$|^[a-z]([a-z0-9-]*[a-z0-9])?$
                           type: string
                         network:
                           description: Defines the network configuration for the Component.

--- a/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
@@ -2703,7 +2703,7 @@ spec:
                         The name is optional when ClusterComponentSpec is used as a template (e.g., in `clusterSharding`),
                         but required otherwise.
                       maxLength: 22
-                      pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
+                      pattern: ^$|^[a-z]([a-z0-9-]*[a-z0-9])?$
                       type: string
                     network:
                       description: Defines the network configuration for the Component.
@@ -13953,7 +13953,7 @@ spec:
                             The name is optional when ClusterComponentSpec is used as a template (e.g., in `clusterSharding`),
                             but required otherwise.
                           maxLength: 22
-                          pattern: ^[a-z]([a-z0-9\-]*[a-z0-9])?$
+                          pattern: ^$|^[a-z]([a-z0-9-]*[a-z0-9])?$
                           type: string
                         network:
                           description: Defines the network configuration for the Component.


### PR DESCRIPTION
close #9848 