### PR TITLE
chore: bump datasafed version to 0.2.3

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -397,7 +397,7 @@ dataProtection:
     imagePullSecrets: []
     datasafed:
       repository: apecloud/datasafed
-      tag: "0.2.2"
+      tag: "0.2.3"
   ## @param toleration
   tolerations:
   - key: kb-controller


### PR DESCRIPTION
Bump datasafed version to 0.2.3 https://github.com/apecloud/datasafed/releases/tag/v0.2.3 that fix the vulnerabilities.