### PR TITLE
fix: prohibit stop when post-provision is not completed

### DIFF
--- a/controllers/apps/component/transformer_component_status.go
+++ b/controllers/apps/component/transformer_component_status.go
@@ -119,7 +119,6 @@ func (t *componentStatusTransformer) reconcileStatus(transCtx *componentTransfor
 	}()
 
 	stopped := isCompStopped(t.synthesizeComp)
-	postProvisionDone := checkPostProvisionDone(transCtx)
 
 	hasRunningPods := func() bool {
 		return t.runningITS.Status.Replicas > 0
@@ -167,7 +166,7 @@ func (t *componentStatusTransformer) reconcileStatus(transCtx *componentTransfor
 	switch {
 	case isDeleting:
 		t.setComponentStatusPhase(transCtx, appsv1.DeletingComponentPhase, nil, "component is Deleting")
-	case stopped && (hasRunningPods || !postProvisionDone):
+	case stopped && (hasRunningPods || !checkPostProvisionDone(transCtx)):
 		t.setComponentStatusPhase(transCtx, appsv1.StoppingComponentPhase, nil, "component is Stopping")
 	case stopped:
 		t.setComponentStatusPhase(transCtx, appsv1.StoppedComponentPhase, nil, "component is Stopped")

--- a/controllers/apps/component/transformer_component_workload.go
+++ b/controllers/apps/component/transformer_component_workload.go
@@ -203,14 +203,13 @@ func (t *componentWorkloadTransformer) handleUpdate(transCtx *componentTransform
 func (t *componentWorkloadTransformer) handleWorkloadStartNStop(transCtx *componentTransformContext, synthesizedComp *component.SynthesizedComponent,
 	runningITS *workloads.InstanceSet, protoITS **workloads.InstanceSet) (bool, bool, error) {
 	var (
-		stop              = isCompStopped(synthesizedComp)
-		start             = !stop && isWorkloadStopped(runningITS)
-		postProvisionDone = checkPostProvisionDone(transCtx)
+		stop  = isCompStopped(synthesizedComp)
+		start = !stop && isWorkloadStopped(runningITS)
 	)
 	if start || stop {
 		*protoITS = runningITS.DeepCopy() // don't modify the runningITS except for the replicas
 	}
-	if stop && postProvisionDone {
+	if stop && checkPostProvisionDone(transCtx) {
 		return start, stop, t.stopWorkload(synthesizedComp, runningITS, *protoITS)
 	}
 	if start {


### PR DESCRIPTION
When post-provision is not completed but the stop field of the component is set to true, ITS will set the replica to 0. At this point, post-provision will continuously fail due to the lack of available pods for execution, preventing the component from ever transitioning to the stopped state. The result is that there are no pods under the component, but the component still shows as running, and the cluster also displays as running.