### PR TITLE
chore: support empty password when system account refers the custom secret

### DIFF
--- a/controllers/apps/component/transformer_component_account.go
+++ b/controllers/apps/component/transformer_component_account.go
@@ -210,7 +210,7 @@ func (t *componentAccountTransformer) getPasswordFromSecret(ctx graph.TransformC
 	if len(account.SecretRef.Password) > 0 {
 		passwordKey = account.SecretRef.Password
 	}
-	if len(secret.Data) == 0 || len(secret.Data[passwordKey]) == 0 {
+	if _, ok := secret.Data[passwordKey]; !ok {
 		return nil, fmt.Errorf("referenced account secret has no required credential field: %s", passwordKey)
 	}
 	return secret.Data[passwordKey], nil


### PR DESCRIPTION
redis supports empty password