### PR TITLE
chore: update Go version to 1.24.11

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Build the manager binary
 ARG DIST_IMG=gcr.io/distroless/static:nonroot
 
-ARG GO_VERSION=1.24.9-alpine
+ARG GO_VERSION=1.24.11-alpine
 
 FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} AS builder
 

--- a/docker/Dockerfile-dataprotection
+++ b/docker/Dockerfile-dataprotection
@@ -1,7 +1,7 @@
 # Build the dataprotection binary
 ARG DIST_IMG=gcr.io/distroless/static:nonroot
 
-ARG GO_VERSION=1.24.9-alpine
+ARG GO_VERSION=1.24.11-alpine
 
 FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} AS builder
 

--- a/docker/Dockerfile-redhat
+++ b/docker/Dockerfile-redhat
@@ -1,7 +1,7 @@
 # Build the manager binary
 ARG DIST_IMG=registry.access.redhat.com/ubi9:9.6
 
-ARG GO_VERSION=1.24.9-alpine
+ARG GO_VERSION=1.24.11-alpine
 
 FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} AS builder
 

--- a/docker/Dockerfile-tools
+++ b/docker/Dockerfile-tools
@@ -11,7 +11,7 @@
 #TARGETARCH - Architecture from --platform, e.g. arm64
 #TARGETVARIANT - used to set target ARM variant, e.g. v7
 
-ARG GO_VERSION=1.24.9-alpine
+ARG GO_VERSION=1.24.11-alpine
 
 FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} AS builder
 ARG TARGETOS

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/apecloud/kubeblocks
 
 go 1.24.0
 
+toolchain go1.24.11
+
 require (
 	cuelang.org/go v0.8.0
 	github.com/Masterminds/semver/v3 v3.2.1


### PR DESCRIPTION
- Upgrade Go version from 1.24.9 to 1.24.11 in all Dockerfiles
- Add toolchain specification to go.mod for Go 1.24.11

🤖 Generated with [Claude Code](https://claude.com/claude-code)