### PR TITLE
fix: redis config get string with quote

### DIFF
--- a/pkg/unstructured/redis_config.go
+++ b/pkg/unstructured/redis_config.go
@@ -124,7 +124,7 @@ func (r *redisConfig) GetString(key string) (string, error) {
 	res := make([]string, 0)
 	for i := len(keys); i < len(item.Values); i++ {
 		v := item.Values[i]
-		if ContainerEscapeString(v) {
+		if v == "" || ContainerEscapeString(v) {
 			res = append(res, strconv.Quote(v))
 		} else {
 			res = append(res, v)


### PR DESCRIPTION
* fix: #10031 

GetAllParameters adds quotes when handling empty strings
```
func encodeStringValue(param Item, index int) string {
	buffer := &bytes.Buffer{}
	for i := index; i < len(param.Values); i++ {
		v := param.Values[i]
		if i > index {
			buffer.WriteByte(' ')
		}
		if v == "" || ContainerEscapeString(v) {
			v = strconv.Quote(v)
		}
		buffer.WriteString(v)
	}
	return buffer.String()
}
```