### PR TITLE
fix: skip config-manager image rollback (#10034)

### DIFF
--- a/controllers/apps/component/transformer_component_reload_sidecar.go
+++ b/controllers/apps/component/transformer_component_reload_sidecar.go
@@ -77,5 +77,5 @@ func (t *componentReloadSidecarTransformer) Transform(ctx graph.TransformContext
 		ClusterName:   builtinComp.ClusterName,
 		ComponentName: builtinComp.Name,
 	}
-	return configctrl.BuildReloadActionContainer(reconcileCtx, cluster, builtinComp, transCtx.CompDef)
+	return configctrl.BuildReloadActionContainer(reconcileCtx, cluster, builtinComp, transCtx.CompDef, transCtx.RunningWorkload)
 }

--- a/pkg/controller/configuration/config_utils.go
+++ b/pkg/controller/configuration/config_utils.go
@@ -33,6 +33,7 @@ import (
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
+	workloadsv1 "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	cfgcm "github.com/apecloud/kubeblocks/pkg/configuration/config_manager"
 	"github.com/apecloud/kubeblocks/pkg/configuration/core"
 	cfgutil "github.com/apecloud/kubeblocks/pkg/configuration/util"
@@ -46,7 +47,8 @@ import (
 
 // BuildReloadActionContainer build the configmgr sidecar container and update it
 // into PodSpec if configuration reload option is on
-func BuildReloadActionContainer(resourceCtx *render.ResourceCtx, cluster *appsv1.Cluster, synthesizedComp *component.SynthesizedComponent, cmpd *appsv1.ComponentDefinition) error {
+func BuildReloadActionContainer(resourceCtx *render.ResourceCtx, cluster *appsv1.Cluster,
+	synthesizedComp *component.SynthesizedComponent, cmpd *appsv1.ComponentDefinition, itsObj client.Object) error {
 	var (
 		err         error
 		buildParams *cfgcm.CfgManagerBuildParams
@@ -99,6 +101,32 @@ func BuildReloadActionContainer(resourceCtx *render.ResourceCtx, cluster *appsv1
 	if len(buildParams.ToolsContainers) > 0 {
 		podSpec.InitContainers = append(podSpec.InitContainers, buildParams.ToolsContainers...)
 	}
+
+	getRunningIts := func() *workloadsv1.InstanceSet {
+		if itsObj == nil {
+			return nil
+		}
+		return itsObj.(*workloadsv1.InstanceSet)
+	}
+
+	// Update the runningITS container in advance to prevent it from being rollback.
+	if runningITS := getRunningIts(); runningITS != nil {
+		for i, c := range runningITS.Spec.Template.Spec.Containers {
+			if c.Name == container.Name {
+				runningITS.Spec.Template.Spec.Containers[i].Image = container.Image
+				break
+			}
+		}
+		for _, tc := range buildParams.ToolsContainers {
+			for j, ic := range runningITS.Spec.Template.Spec.InitContainers {
+				if ic.Name == tc.Name {
+					runningITS.Spec.Template.Spec.InitContainers[j].Image = tc.Image
+					break
+				}
+			}
+		}
+	}
+
 	filter := func(c *corev1.Container) bool {
 		names := []string{container.Name}
 		for _, cc := range buildParams.ToolsContainers {


### PR DESCRIPTION
(cherry picked from commit a54d6f65d109ab6d90c5298048a5ea956de4a057)