### PR TITLE
feat: make StorageClass reclaimPolicy configurable via values.yaml

### DIFF
--- a/deploy/helm/templates/storageclass.yaml
+++ b/deploy/helm/templates/storageclass.yaml
@@ -14,7 +14,7 @@ parameters:
   type: {{ .Values.storageClass.provider.aws.volumeType }} # io2, io1, gp3, gp2 are all SSD variant
   "csi.storage.k8s.io/fstype": {{ .Values.storageClass.provider.aws.fsType | default "xfs" }}
 provisioner: ebs.csi.aws.com
-reclaimPolicy: Delete
+reclaimPolicy: {{ .Values.storageClass.reclaimPolicy | default "Delete" }}
 volumeBindingMode: WaitForFirstConsumer
 ---
 {{- else if eq $cloudProvider "gcp" }}
@@ -30,7 +30,7 @@ parameters:
   type: {{ .Values.storageClass.provider.gcp.volumeType }}
   csi.storage.k8s.io/fstype: {{ .Values.storageClass.provider.gcp.fsType | default "xfs" }}
 provisioner: pd.csi.storage.gke.io
-reclaimPolicy: Delete
+reclaimPolicy: {{ .Values.storageClass.reclaimPolicy | default "Delete" }}
 volumeBindingMode: WaitForFirstConsumer
 ---
 {{- else if eq $cloudProvider "aliyun" }}
@@ -46,7 +46,7 @@ parameters:
   fstype: {{ .Values.storageClass.provider.aliyun.fsType | default "xfs" }}
   type: {{ .Values.storageClass.provider.aliyun.volumeType }}
 provisioner: diskplugin.csi.alibabacloud.com
-reclaimPolicy: Delete
+reclaimPolicy: {{ .Values.storageClass.reclaimPolicy | default "Delete" }}
 volumeBindingMode: WaitForFirstConsumer
 ---
 {{- else if eq $cloudProvider "tencentCloud" }}
@@ -59,7 +59,7 @@ metadata:
 parameters:
   ## parameters references: https://cloud.tencent.com/document/product/457/44239, the fsType is not supported by tke.
   type: {{ .Values.storageClass.provider.tencentCloud.volumeType }}
-reclaimPolicy: Delete
+reclaimPolicy: {{ .Values.storageClass.reclaimPolicy | default "Delete" }}
 provisioner: com.tencent.cloud.csi.cbs
 volumeBindingMode: WaitForFirstConsumer
 ---
@@ -78,7 +78,7 @@ parameters:
   kind: {{ .Values.storageClass.provider.azure.volumeType }}
   skuName: Standard_LRS
 provisioner: kubernetes.io/azure-disk
-reclaimPolicy: Delete
+reclaimPolicy: {{ .Values.storageClass.reclaimPolicy | default "Delete" }}
 volumeBindingMode: WaitForFirstConsumer
 ---
 {{- else if eq $cloudProvider "huaweiCloud" }} # huawei cloud
@@ -95,7 +95,7 @@ parameters:
   everest.io/disk-volume-type: {{ .Values.storageClass.provider.huaweiCloud.volumeType }}
   everest.io/passthrough: "true"
 provisioner: everest-csi-provisioner
-reclaimPolicy: Delete
+reclaimPolicy: {{ .Values.storageClass.reclaimPolicy | default "Delete" }}
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 ---

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -511,6 +511,13 @@ storageClass:
   ## specified or generated, this value will be ignored.
   ##
   create: true
+  ## @param storageClass.reclaimPolicy -- Specifies the reclaim policy for the storage class.
+  ## Valid options: Retain, Delete. Default is Delete to preserve existing behaviour.
+  ## Set to Retain for production datastore workloads to protect PVCs from deletion.
+  ## Note: reclaimPolicy is inherited by PVs at creation time only — existing PVs must
+  ## be patched individually if this value is changed after provisioning.
+  ##
+  reclaimPolicy: Delete
   mountOptions:
   - noatime
   - nobarrier


### PR DESCRIPTION
## Problem                                                                                                                                                                   
                                                                                                                                                                               
  `reclaimPolicy: Delete` is hardcoded as a literal in `deploy/helm/templates/storageclass.yaml` for all six cloud providers (AWS, GCP, Alibaba, Tencent, Azure, Huawei). Other
   fields in the same template — `volumeType`, `fsType` — are already templated through `values.yaml`, but `reclaimPolicy` is not.                                             
                                                                                                                                                                               
  This means there is no way to set `reclaimPolicy: Retain` on the KubeBlocks-provisioned StorageClass without either skipping StorageClass creation entirely or patching every
   PV individually after provisioning. For datastore workloads (MongoDB, PostgreSQL, MySQL, Redis), this removes the standard Kubernetes safety net against accidental PVC     
  deletion — particularly dangerous when combined with `terminationPolicy: Delete`, which explicitly deletes PVCs during cluster teardown.                                     
                                                                                                                                                                               
  ## Changes                                                                                                                                                                   
                                                                                                                                                                               
  - `deploy/helm/templates/storageclass.yaml` — replaced hardcoded `reclaimPolicy: Delete` in all six provider blocks with `{{ .Values.storageClass.reclaimPolicy | default    
  "Delete" }}`                                                                                                                                                                 
  - `deploy/helm/values.yaml` — added `storageClass.reclaimPolicy` with default `Delete`                                                                                       
                                                                                                                                                                               
  ## Behaviour                                                                                                                                                                 
                                                                                                                                                                               
  - **Default is `Delete`** — zero change for any existing install unless the value is explicitly set                                                                          
  - To opt in: `helm upgrade kubeblocks kubeblocks/kubeblocks --set storageClass.reclaimPolicy=Retain`                                                                         
                                                                                                                                                                               
  ## Migration note for existing clusters                                                                                                                                      
                                                                                                                                                                               
  `reclaimPolicy` is inherited by each PV at creation time only. Changing the StorageClass does **not** retroactively update already-provisioned PVs. Existing PVs must be     
  patched individually:                                                                                                                                                        
                                                                                                                                                                               
  ```bash                                                                                                                                                                      
  kubectl patch pv <pv-name> -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'                                                                                          
                                                                                                                                                                               
  References                                                                                                                                                                   
                                                                                                                                                                               
  - Kubernetes docs on reclaim policy: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#reclaiming                                                              
  - Related: terminationPolicy gap for datastore workloads (Halt removal in v1.0)                                                                                              
                                                                                                                                                                               
  ---