### PR TITLE
fix: restore by ops crash when tls is enable

### DIFF
--- a/pkg/operations/restore.go
+++ b/pkg/operations/restore.go
@@ -230,6 +230,8 @@ func (r RestoreOpsHandler) getClusterObjFromBackup(backup *dpv1alpha1.Backup, op
 	cluster.Spec.Services = services
 	for i := range cluster.Spec.ComponentSpecs {
 		cluster.Spec.ComponentSpecs[i].OfflineInstances = nil
+		cluster.Spec.ComponentSpecs[i].TLS = false
+		cluster.Spec.ComponentSpecs[i].Issuer = nil
 	}
 	r.rebuildShardAccountSecrets(cluster)
 	r.normalizeSchedulePolicy(cluster, cluster.Spec.SchedulingPolicy)


### PR DESCRIPTION
- fix: https://github.com/apecloud/kubeblocks/issues/10092