### PR TITLE
fix: zero PodUpdatePolicy and PodUpgradePolicy in cmpdHash to prevent immutable-hash mismatch

### DIFF
--- a/controllers/apps/componentdefinition_controller.go
+++ b/controllers/apps/componentdefinition_controller.go
@@ -557,6 +557,8 @@ func (r *ComponentDefinitionReconciler) cmpdHash(cmpd *appsv1.ComponentDefinitio
 	objCopy.Spec.Description = ""
 	objCopy.Spec.Exporter = nil
 	objCopy.Spec.PodManagementPolicy = nil
+	objCopy.Spec.PodUpdatePolicy = nil
+	objCopy.Spec.PodUpgradePolicy = nil
 	objCopy.Spec.MinReadySeconds = 0
 
 	// TODO: bpt


### PR DESCRIPTION
## Summary

When addon charts don't explicitly set `podUpdatePolicy` in their ComponentDefinition templates, the operator defaults it to `PreferInPlace` after creation. This changes the `apps.kubeblocks.io/immutable-hash` annotation, causing reconciliation to fail with `"immutable fields can't be updated"`.

`PodManagementPolicy` is already treated as mutable (zeroed before hashing in `cmpdHash()`). This PR applies the same treatment to `PodUpdatePolicy` and `PodUpgradePolicy`.

## Root Cause

The `podUpdatePolicy` field was added to `ComponentDefinitionSpec` with default `PreferInPlace`, but `cmpdHash()` was not updated to exclude it from the immutable hash. Any ComponentDefinition created before the field existed (or by an addon chart that doesn't set it) gets a different hash after the operator defaults the field — triggering immutability violations.

## Changes

- `controllers/apps/componentdefinition_controller.go`: zero `PodUpdatePolicy` and `PodUpgradePolicy` in `cmpdHash()` alongside `PodManagementPolicy`

## Companion PR

- apecloud/kubeblocks-addons: adds `podUpdatePolicy: PreferInPlace` to all 122 cmpd templates (prevents the defaulting from happening)