### PR TITLE
feat(ops): add configurable DeleteRestoreCR option for rebuild

### DIFF
--- a/apis/operations/v1alpha1/opsrequest_types.go
+++ b/apis/operations/v1alpha1/opsrequest_types.go
@@ -283,6 +283,12 @@ type RebuildInstance struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +optional
 	RestoreEnv []corev1.EnvVar `json:"restoreEnv,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+
+	// Specifies whether to delete the Restore CR after the rebuild instance operation is completed.
+	// If not set, the Restore CR will not be deleted by default.
+	//
+	// +optional
+	DeleteRestoreCR *bool `json:"deleteRestoreCR,omitempty"`
 }
 
 type Instance struct {

--- a/pkg/operations/cleanup_restore_test.go
+++ b/pkg/operations/cleanup_restore_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright (C) 2022-2025 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package operations
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	opsv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+)
+
+var _ = Describe("cleanupTmpResources", func() {
+
+	var (
+		cli         client.Client
+		reqCtx      intctrlutil.RequestCtx
+		opsRes      *OpsResource
+		restoreName = "test-restore"
+		podName     = "test-pod"
+	)
+
+	createTestResources := func() {
+		scheme := runtime.NewScheme()
+		Ω(opsv1alpha1.AddToScheme(scheme)).Should(Succeed())
+		Ω(dpv1alpha1.AddToScheme(scheme)).Should(Succeed())
+		Ω(corev1.AddToScheme(scheme)).Should(Succeed())
+
+		opsRequest := &opsv1alpha1.OpsRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-opsrequest",
+				Namespace: "default",
+			},
+		}
+
+		opsRes = &OpsResource{
+			OpsRequest: opsRequest,
+		}
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      podName,
+				Namespace: "default",
+				Labels: map[string]string{
+					constant.OpsRequestNameLabelKey:      opsRequest.Name,
+					constant.OpsRequestNamespaceLabelKey: opsRequest.Namespace,
+				},
+			},
+		}
+
+		restore := &dpv1alpha1.Restore{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      restoreName,
+				Namespace: "default",
+				Labels: map[string]string{
+					constant.OpsRequestNameLabelKey:      opsRequest.Name,
+					constant.OpsRequestNamespaceLabelKey: opsRequest.Namespace,
+				},
+			},
+		}
+
+		objects := []runtime.Object{pod, restore}
+		cli = fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objects...).Build()
+		reqCtx = intctrlutil.RequestCtx{Ctx: context.Background()}
+	}
+
+	Context("when deleteRestoreCR is false", func() {
+		It("should not delete Restore CRs", func() {
+			createTestResources()
+
+			handler := rebuildInstanceOpsHandler{}
+			err := handler.cleanupTmpResources(reqCtx, cli, opsRes, false)
+			Ω(err).ShouldNot(HaveOccurred())
+
+			restoreList := &dpv1alpha1.RestoreList{}
+			Ω(cli.List(reqCtx.Ctx, restoreList, client.MatchingLabels{
+				constant.OpsRequestNameLabelKey:      opsRes.OpsRequest.Name,
+				constant.OpsRequestNamespaceLabelKey: opsRes.OpsRequest.Namespace,
+			})).Should(Succeed())
+			Ω(restoreList.Items).Should(HaveLen(1))
+		})
+	})
+
+	Context("when deleteRestoreCR is true", func() {
+		It("should delete Restore CRs", func() {
+			createTestResources()
+
+			handler := rebuildInstanceOpsHandler{}
+			err := handler.cleanupTmpResources(reqCtx, cli, opsRes, true)
+			Ω(err).ShouldNot(HaveOccurred())
+
+			restoreList := &dpv1alpha1.RestoreList{}
+			Ω(cli.List(reqCtx.Ctx, restoreList, client.MatchingLabels{
+				constant.OpsRequestNameLabelKey:      opsRes.OpsRequest.Name,
+				constant.OpsRequestNamespaceLabelKey: opsRes.OpsRequest.Namespace,
+			})).Should(Succeed())
+			Ω(restoreList.Items).Should(BeEmpty())
+		})
+	})
+})
+
+func TestCleanupTmpResources(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "cleanupTmpResources Test Suite")
+}

--- a/pkg/operations/rebuild_instance.go
+++ b/pkg/operations/rebuild_instance.go
@@ -189,6 +189,7 @@ func (r rebuildInstanceOpsHandler) ReconcileAction(reqCtx intctrlutil.RequestCtx
 		expectCount     int
 		completedCount  int
 		failedCount     int
+		deleteRestoreCR bool
 		err             error
 	)
 	if opsRes.OpsRequest.Status.Components == nil {
@@ -201,12 +202,10 @@ func (r rebuildInstanceOpsHandler) ReconcileAction(reqCtx intctrlutil.RequestCtx
 			subFailedCount    int
 		)
 		if v.InPlace {
-			// rebuild instances in place.
 			if subCompletedCount, subFailedCount, err = r.rebuildInstancesInPlace(reqCtx, cli, opsRes, v, &compStatus); err != nil {
 				return opsRequestPhase, 0, err
 			}
 		} else {
-			// rebuild instances with horizontal scaling
 			if subCompletedCount, subFailedCount, err = r.rebuildInstancesWithHScaling(reqCtx, cli, opsRes, v, &compStatus); err != nil {
 				if intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal) {
 					return opsv1alpha1.OpsFailedPhase, 0, err
@@ -218,6 +217,9 @@ func (r rebuildInstanceOpsHandler) ReconcileAction(reqCtx intctrlutil.RequestCtx
 		completedCount += subCompletedCount
 		failedCount += subFailedCount
 		opsRes.OpsRequest.Status.Components[v.ComponentName] = compStatus
+		if v.DeleteRestoreCR != nil && *v.DeleteRestoreCR {
+			deleteRestoreCR = true
+		}
 	}
 	if !reflect.DeepEqual(oldCluster.Spec, opsRes.Cluster.Spec) {
 		if err = cli.Update(reqCtx.Ctx, opsRes.Cluster); err != nil {
@@ -232,7 +234,7 @@ func (r rebuildInstanceOpsHandler) ReconcileAction(reqCtx intctrlutil.RequestCtx
 		return opsRequestPhase, 0, nil
 	}
 	if failedCount == 0 {
-		return opsv1alpha1.OpsSucceedPhase, 0, r.cleanupTmpResources(reqCtx, cli, opsRes)
+		return opsv1alpha1.OpsSucceedPhase, 0, r.cleanupTmpResources(reqCtx, cli, opsRes, deleteRestoreCR)
 	}
 	return opsv1alpha1.OpsFailedPhase, 0, nil
 }
@@ -622,12 +624,25 @@ func (r rebuildInstanceOpsHandler) prepareInplaceRebuildHelper(reqCtx intctrluti
 // cleanupTmpResources clean up the temporary resources generated during the process of rebuilding the instance.
 func (r rebuildInstanceOpsHandler) cleanupTmpResources(reqCtx intctrlutil.RequestCtx,
 	cli client.Client,
-	opsRes *OpsResource) error {
+	opsRes *OpsResource,
+	deleteRestoreCR bool) error {
 	matchLabels := client.MatchingLabels{
 		constant.OpsRequestNameLabelKey:      opsRes.OpsRequest.Name,
 		constant.OpsRequestNamespaceLabelKey: opsRes.OpsRequest.Namespace,
 	}
-	// TODO: need to delete the restore CR?
-	// Pods are limited in k8s, so we need to release them if they are not needed.
-	return intctrlutil.DeleteOwnedResources(reqCtx.Ctx, cli, opsRes.OpsRequest, matchLabels, generics.PodSignature)
+	if err := intctrlutil.DeleteOwnedResources(reqCtx.Ctx, cli, opsRes.OpsRequest, matchLabels, generics.PodSignature); err != nil {
+		return err
+	}
+	if deleteRestoreCR {
+		restoreList := &dpv1alpha1.RestoreList{}
+		if err := cli.List(reqCtx.Ctx, restoreList, matchLabels); err != nil {
+			return client.IgnoreNotFound(err)
+		}
+		for _, restore := range restoreList.Items {
+			if err := cli.Delete(reqCtx.Ctx, &restore); err != nil {
+				return client.IgnoreNotFound(err)
+			}
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Changes
- Add `DeleteRestoreCR *bool` field to `RebuildInstance` struct
- Giving users control over whether Restore custom resources should be automatically deleted after the rebuild-instance operation completes successfully
- Add unit tests