### PR TITLE
chore: remove cancel validation for ops

### DIFF
--- a/apis/operations/v1alpha1/opsrequest_types.go
+++ b/apis/operations/v1alpha1/opsrequest_types.go
@@ -27,8 +27,6 @@ import (
 )
 
 // OpsRequestSpec defines the desired state of OpsRequest
-//
-// +kubebuilder:validation:XValidation:rule="has(self.cancel) && self.cancel ? (self.type in ['VerticalScaling', 'HorizontalScaling']) : true",message="forbidden to cancel the opsRequest which type not in ['VerticalScaling','HorizontalScaling']"
 type OpsRequestSpec struct {
 	// Specifies the name of the Cluster resource that this operation is targeting.
 	//

--- a/config/crd/bases/operations.kubeblocks.io_opsrequests.yaml
+++ b/config/crd/bases/operations.kubeblocks.io_opsrequests.yaml
@@ -3354,10 +3354,6 @@ spec:
             required:
             - type
             type: object
-            x-kubernetes-validations:
-            - message: forbidden to cancel the opsRequest which type not in ['VerticalScaling','HorizontalScaling']
-              rule: 'has(self.cancel) && self.cancel ? (self.type in [''VerticalScaling'',
-                ''HorizontalScaling'']) : true'
           status:
             description: OpsRequestStatus represents the observed state of an OpsRequest.
             properties:

--- a/deploy/helm/crds/operations.kubeblocks.io_opsrequests.yaml
+++ b/deploy/helm/crds/operations.kubeblocks.io_opsrequests.yaml
@@ -3354,10 +3354,6 @@ spec:
             required:
             - type
             type: object
-            x-kubernetes-validations:
-            - message: forbidden to cancel the opsRequest which type not in ['VerticalScaling','HorizontalScaling']
-              rule: 'has(self.cancel) && self.cancel ? (self.type in [''VerticalScaling'',
-                ''HorizontalScaling'']) : true'
           status:
             description: OpsRequestStatus represents the observed state of an OpsRequest.
             properties:


### PR DESCRIPTION
supports all pending ops for all opsrequest types