### PR TITLE
chore: upgrade e2e K8s version to 1.33

### DIFF
--- a/.github/workflows/e2e-kbcli.yml
+++ b/.github/workflows/e2e-kbcli.yml
@@ -12,16 +12,13 @@ on:
         required: false
         default: ''
       TEST_TYPE:
-        description: 'test type (e.g.  apecloud-mysql|postgresql|redis|mongodb|kafka|asmysql|elasticsearch|zookeeper|
-        rabbitmq|mysqlscale|weaviate|qdrant|smartengine|greptimedb|nebula|risingwave|starrocks|etcd|oceanbase|
-        orioledb|vanilla-pg|polardbx|opensearch|tdengine|milvus|clickhouse|mariadb|tidb|influxdb|mogdb|
-        yashandb|redis-cluster|minio|orchestrator)'
+        description: 'test type (e.g.  mysql|postgresql|redis|mongodb)'
         required: false
         default: ''
       CLOUD_PROVIDER:
         description: 'cloud provider'
         required: true
-        default: 'eks'
+        default: 'aks'
         type: choice
         options:
           - eks
@@ -32,9 +29,12 @@ on:
       CLUSTER_VERSION:
         description: 'k8s cluster version'
         required: false
-        default: "1.32"
+        default: "1.33"
         type: choice
         options:
+          - "1.35"
+          - "1.34"
+          - "1.33"
           - "1.32"
           - "1.31"
           - "1.30"


### PR DESCRIPTION
```
╷
│ Error: creating Kubernetes Cluster (Subscription: "***"
│ Resource Group Name: "***"
│ Kubernetes Cluster Name: "***"): performing CreateOrUpdate: unexpected status 400 (400 Bad Request) with response: ***
│   "code": "K8sVersionNotSupported",
│   "details": null,
│   "message": "Managed cluster *** is on version 1.32.11, which is only available for Long-Term Support (LTS). If you intend to onboard to LTS, please ensure the cluster is in Premium tier and LTS support plan (see https://aka.ms/aks/enable-lts). Otherwise, use [az aks get-versions] command to get the supported version list in this region. For more information, please check https://aka.ms/supported-version-list",
│   "subcode": ""
│  ***
│ 
│   with azurerm_kubernetes_cluster.default,
│   on aks.tf line 20, in resource "azurerm_kubernetes_cluster" "default":
│   20: resource "azurerm_kubernetes_cluster" "default" ***
│ 
╵
```