### PR TITLE
fix: preserve rbac assistant objects before workload build

### DIFF
--- a/controllers/apps/component/transformer_component_rbac.go
+++ b/controllers/apps/component/transformer_component_rbac.go
@@ -173,7 +173,7 @@ func (t *componentRBACTransformer) Transform(ctx graph.TransformContext, dag *gr
 		}
 	}
 
-	t.rbacInstanceAssistantObjects(graphCli, dag, objs)
+	t.rbacInstanceAssistantObjects(synthesizedComp, objs)
 
 	return nil
 }
@@ -211,7 +211,8 @@ func (t *componentRBACTransformer) handleRBACNewRule(transCtx *componentTransfor
 		}
 	}
 
-	t.rbacInstanceAssistantObjects(graphCli, dag, objs)
+	t.rbacInstanceAssistantObjects(synthesizedComp, objs)
+
 	return nil
 }
 
@@ -265,11 +266,9 @@ func createOrUpdateRoleBindingNew(transCtx *componentTransformContext,
 	return res, nil
 }
 
-func (t *componentRBACTransformer) rbacInstanceAssistantObjects(graphCli model.GraphClient, dag *graph.DAG, objs []client.Object) {
-	itsList := graphCli.FindAll(dag, &workloads.InstanceSet{})
-	for _, itsObj := range itsList {
-		its := itsObj.(*workloads.InstanceSet)
-		component.AddInstanceAssistantObjectsToITS(its, objs...)
+func (t *componentRBACTransformer) rbacInstanceAssistantObjects(synthesizedComp *component.SynthesizedComponent, objs []client.Object) {
+	for _, obj := range objs {
+		component.AddInstanceAssistantObject(synthesizedComp, obj)
 	}
 }
 

--- a/controllers/apps/component/transformer_component_rbac_test.go
+++ b/controllers/apps/component/transformer_component_rbac_test.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
@@ -129,6 +130,39 @@ var _ = Describe("object rbac transformer test.", func() {
 	}
 
 	Context("transformer rbac manager", func() {
+		It("adds RBAC assistant objects to synthesized component before workload exists", func() {
+			init(true, true)
+			dag = graph.NewDAG()
+			graphCli.Root(dag, compObj, compObj, model.ActionStatusPtr())
+			synthesizedComp.EnableInstanceAPI = ptr.To(true)
+			if synthesizedComp.Annotations == nil {
+				synthesizedComp.Annotations = map[string]string{}
+			}
+			synthesizedComp.Annotations[constant.KBAppMultiClusterPlacementKey] = "test-context"
+
+			Expect(transformer.Transform(transCtx, dag)).Should(BeNil())
+
+			actual := synthesizedComp.InstanceAssistantObjects
+			Expect(actual).To(HaveLen(3))
+			Expect(actual).To(ContainElements(
+				corev1.ObjectReference{
+					Kind:      "RoleBinding",
+					Namespace: testCtx.DefaultNamespace,
+					Name:      serviceAccountName,
+				},
+				corev1.ObjectReference{
+					Kind:      "RoleBinding",
+					Namespace: testCtx.DefaultNamespace,
+					Name:      fmt.Sprintf("%v-pod", serviceAccountName),
+				},
+				corev1.ObjectReference{
+					Kind:      "ServiceAccount",
+					Namespace: testCtx.DefaultNamespace,
+					Name:      serviceAccountName,
+				},
+			))
+		})
+
 		It("tests labelAndAnnotationEqual", func() {
 			// nil and not nil
 			Expect(labelAndAnnotationEqual(

--- a/pkg/controller/component/utils.go
+++ b/pkg/controller/component/utils.go
@@ -199,12 +199,6 @@ func AddInstanceAssistantObject(synthesizedComp *SynthesizedComponent, object cl
 	}
 }
 
-func AddInstanceAssistantObjectsToITS(its *workloads.InstanceSet, objs ...client.Object) {
-	if instanceAPINAssistantObjectsEnabled(its) {
-		its.Spec.InstanceAssistantObjects = addInstanceAssistantObjects(its.Spec.InstanceAssistantObjects, objs...)
-	}
-}
-
 func instanceAPINAssistantObjectsEnabled(its *workloads.InstanceSet) bool {
 	if !ptr.Deref(its.Spec.EnableInstanceAPI, false) {
 		return false


### PR DESCRIPTION
close https://github.com/apecloud/kubeblocks/issues/10139