### PR TITLE
fix(dataprotection): shorten restore-derived restore names

### DIFF
--- a/pkg/dataprotection/restore/builder.go
+++ b/pkg/dataprotection/restore/builder.go
@@ -81,12 +81,13 @@ func (r *restoreJobBuilder) buildPVCVolumeAndMount(
 	claim dpv1alpha1.VolumeConfig,
 	claimName,
 	identifier string) (*corev1.Volume, *corev1.VolumeMount, error) {
-	volumeName := fmt.Sprintf("%s-%s", identifier, claimName)
+	rawVolumeName := fmt.Sprintf("%s-%s", identifier, claimName)
+	safeVolumeName := shortenRestoreDerivedName(rawVolumeName, 63)
 	volume := &corev1.Volume{
-		Name:         volumeName,
+		Name:         safeVolumeName,
 		VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: claimName}},
 	}
-	volumeMount := &corev1.VolumeMount{Name: volumeName}
+	volumeMount := &corev1.VolumeMount{Name: safeVolumeName}
 	if claim.MountPath != "" {
 		volumeMount.MountPath = claim.MountPath
 		return volume, volumeMount, nil

--- a/pkg/dataprotection/restore/utils.go
+++ b/pkg/dataprotection/restore/utils.go
@@ -22,6 +22,7 @@ package restore
 import (
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -138,8 +139,30 @@ func GetRestoreActionsCountForPrepareData(config *dpv1alpha1.PrepareDataConfig) 
 func BuildRestoreLabels(restoreName string) map[string]string {
 	return map[string]string{
 		constant.AppManagedByLabelKey: dptypes.AppName,
-		DataProtectionRestoreLabelKey: restoreName,
+		DataProtectionRestoreLabelKey: shortenRestoreDerivedName(restoreName, 63),
 	}
+}
+
+func shortenRestoreDerivedName(raw string, maxLen int) string {
+	if maxLen <= 0 || len(raw) <= maxLen {
+		return raw
+	}
+	suffix := shortHash(raw)
+	if maxLen <= len(suffix)+1 {
+		return suffix[:maxLen]
+	}
+	prefixLen := maxLen - len(suffix) - 1
+	prefix := strings.TrimSuffix(raw[:prefixLen], "-")
+	if prefix == "" {
+		return suffix[:maxLen]
+	}
+	return fmt.Sprintf("%s-%s", prefix, suffix)
+}
+
+func shortHash(raw string) string {
+	hasher := fnv.New32a()
+	_, _ = hasher.Write([]byte(raw))
+	return fmt.Sprintf("%08x", hasher.Sum32())
 }
 
 func GetRestoreDuration(status dpv1alpha1.RestoreStatus) *metav1.Duration {


### PR DESCRIPTION
## Summary
- shorten restore-derived label values to avoid Kubernetes 63-char failures
- shorten and share restore-derived volume names between Volume and VolumeMount
- keep the validated core restore naming fix isolated to dataprotection/restore

## Validation
- targeted restore validation no longer reproduced restore label > 63 failures
- targeted restore validation no longer reproduced `Volume.Name / VolumeMount.Name` `too long + Not found`
- `prepareData` jobs were created and completed successfully

## Boundary
This PR only covers the core restore naming-length failures in `kubeblocks`.
The later Valkey addon `post-ready / Sentinel registration` stop point is tracked separately in `kubeblocks-addons`.
