### PR TITLE
fix(dataprotection): shorten restore-derived restore names

### DIFF
--- a/pkg/constant/pattern.go
+++ b/pkg/constant/pattern.go
@@ -41,17 +41,17 @@ func GenerateAccountSecretName(clusterName, compName, name string) string {
 // GenerateClusterServiceName generates the service name for cluster.
 func GenerateClusterServiceName(clusterName, svcName string) string {
 	if len(svcName) > 0 {
-		return ShortenKubeName(fmt.Sprintf("%s-%s", clusterName, svcName), KubeNameMaxLength)
+		return fmt.Sprintf("%s-%s", clusterName, svcName)
 	}
-	return ShortenKubeName(clusterName, KubeNameMaxLength)
+	return clusterName
 }
 
 // GenerateComponentServiceName generates the service name for component.
 func GenerateComponentServiceName(clusterName, compName, svcName string) string {
 	if len(svcName) > 0 {
-		return ShortenKubeName(fmt.Sprintf("%s-%s-%s", clusterName, compName, svcName), KubeNameMaxLength)
+		return fmt.Sprintf("%s-%s-%s", clusterName, compName, svcName)
 	}
-	return ShortenKubeName(fmt.Sprintf("%s-%s", clusterName, compName), KubeNameMaxLength)
+	return fmt.Sprintf("%s-%s", clusterName, compName)
 }
 
 // GenerateDefaultComponentServiceName generates the default service name for component.
@@ -62,9 +62,9 @@ func GenerateDefaultComponentServiceName(clusterName, compName string) string {
 // GenerateComponentHeadlessServiceName generates the headless service name for component.
 func GenerateComponentHeadlessServiceName(clusterName, compName, svcName string) string {
 	if len(svcName) > 0 {
-		return ShortenKubeNameWithSuffix(fmt.Sprintf("%s-%s-%s", clusterName, compName, svcName), "headless", KubeNameMaxLength)
+		return fmt.Sprintf("%s-%s-%s-headless", clusterName, compName, svcName)
 	}
-	return ShortenKubeNameWithSuffix(fmt.Sprintf("%s-%s", clusterName, compName), "headless", KubeNameMaxLength)
+	return fmt.Sprintf("%s-%s-headless", clusterName, compName)
 }
 
 // GenerateDefaultComponentHeadlessServiceName generates the default headless service name for component.

--- a/pkg/constant/pattern.go
+++ b/pkg/constant/pattern.go
@@ -21,8 +21,11 @@ package constant
 
 import (
 	"fmt"
+	"hash/fnv"
 	"strings"
 )
+
+const kubeNameMaxLength = 63
 
 // GenerateClusterComponentName generates the cluster component name.
 func GenerateClusterComponentName(clusterName, compName string) string {
@@ -38,17 +41,17 @@ func GenerateAccountSecretName(clusterName, compName, name string) string {
 // GenerateClusterServiceName generates the service name for cluster.
 func GenerateClusterServiceName(clusterName, svcName string) string {
 	if len(svcName) > 0 {
-		return fmt.Sprintf("%s-%s", clusterName, svcName)
+		return shortenKubeName(fmt.Sprintf("%s-%s", clusterName, svcName), kubeNameMaxLength)
 	}
-	return clusterName
+	return shortenKubeName(clusterName, kubeNameMaxLength)
 }
 
 // GenerateComponentServiceName generates the service name for component.
 func GenerateComponentServiceName(clusterName, compName, svcName string) string {
 	if len(svcName) > 0 {
-		return fmt.Sprintf("%s-%s-%s", clusterName, compName, svcName)
+		return shortenKubeName(fmt.Sprintf("%s-%s-%s", clusterName, compName, svcName), kubeNameMaxLength)
 	}
-	return fmt.Sprintf("%s-%s", clusterName, compName)
+	return shortenKubeName(fmt.Sprintf("%s-%s", clusterName, compName), kubeNameMaxLength)
 }
 
 // GenerateDefaultComponentServiceName generates the default service name for component.
@@ -59,9 +62,9 @@ func GenerateDefaultComponentServiceName(clusterName, compName string) string {
 // GenerateComponentHeadlessServiceName generates the headless service name for component.
 func GenerateComponentHeadlessServiceName(clusterName, compName, svcName string) string {
 	if len(svcName) > 0 {
-		return fmt.Sprintf("%s-%s-%s-headless", clusterName, compName, svcName)
+		return shortenKubeNameWithSuffix(fmt.Sprintf("%s-%s-%s", clusterName, compName, svcName), "headless", kubeNameMaxLength)
 	}
-	return fmt.Sprintf("%s-%s-headless", clusterName, compName)
+	return shortenKubeNameWithSuffix(fmt.Sprintf("%s-%s", clusterName, compName), "headless", kubeNameMaxLength)
 }
 
 // GenerateDefaultComponentHeadlessServiceName generates the default headless service name for component.
@@ -95,4 +98,41 @@ func GenerateDefaultRoleName(cmpdName string) string {
 // GenerateWorkloadNamePattern generates the workload name pattern
 func GenerateWorkloadNamePattern(clusterName, compName string) string {
 	return fmt.Sprintf("%s-%s", clusterName, compName)
+}
+
+func shortenKubeName(raw string, maxLen int) string {
+	if maxLen <= 0 || len(raw) <= maxLen {
+		return raw
+	}
+	suffix := shortHash(raw)
+	if maxLen <= len(suffix)+1 {
+		return suffix[:maxLen]
+	}
+	prefixLen := maxLen - len(suffix) - 1
+	prefix := strings.TrimSuffix(raw[:prefixLen], "-")
+	if prefix == "" {
+		return suffix[:maxLen]
+	}
+	return fmt.Sprintf("%s-%s", prefix, suffix)
+}
+
+func shortenKubeNameWithSuffix(raw, fixedSuffix string, maxLen int) string {
+	if fixedSuffix == "" {
+		return shortenKubeName(raw, maxLen)
+	}
+	fullName := fmt.Sprintf("%s-%s", raw, fixedSuffix)
+	if maxLen <= 0 || len(fullName) <= maxLen {
+		return fullName
+	}
+	reserved := len(fixedSuffix) + 1
+	if maxLen <= reserved {
+		return fullName[:maxLen]
+	}
+	return fmt.Sprintf("%s-%s", shortenKubeName(raw, maxLen-reserved), fixedSuffix)
+}
+
+func shortHash(raw string) string {
+	hasher := fnv.New32a()
+	_, _ = hasher.Write([]byte(raw))
+	return fmt.Sprintf("%08x", hasher.Sum32())
 }

--- a/pkg/constant/pattern.go
+++ b/pkg/constant/pattern.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 )
 
-const kubeNameMaxLength = 63
+const KubeNameMaxLength = 63
 
 // GenerateClusterComponentName generates the cluster component name.
 func GenerateClusterComponentName(clusterName, compName string) string {
@@ -41,17 +41,17 @@ func GenerateAccountSecretName(clusterName, compName, name string) string {
 // GenerateClusterServiceName generates the service name for cluster.
 func GenerateClusterServiceName(clusterName, svcName string) string {
 	if len(svcName) > 0 {
-		return shortenKubeName(fmt.Sprintf("%s-%s", clusterName, svcName), kubeNameMaxLength)
+		return ShortenKubeName(fmt.Sprintf("%s-%s", clusterName, svcName), KubeNameMaxLength)
 	}
-	return shortenKubeName(clusterName, kubeNameMaxLength)
+	return ShortenKubeName(clusterName, KubeNameMaxLength)
 }
 
 // GenerateComponentServiceName generates the service name for component.
 func GenerateComponentServiceName(clusterName, compName, svcName string) string {
 	if len(svcName) > 0 {
-		return shortenKubeName(fmt.Sprintf("%s-%s-%s", clusterName, compName, svcName), kubeNameMaxLength)
+		return ShortenKubeName(fmt.Sprintf("%s-%s-%s", clusterName, compName, svcName), KubeNameMaxLength)
 	}
-	return shortenKubeName(fmt.Sprintf("%s-%s", clusterName, compName), kubeNameMaxLength)
+	return ShortenKubeName(fmt.Sprintf("%s-%s", clusterName, compName), KubeNameMaxLength)
 }
 
 // GenerateDefaultComponentServiceName generates the default service name for component.
@@ -62,9 +62,9 @@ func GenerateDefaultComponentServiceName(clusterName, compName string) string {
 // GenerateComponentHeadlessServiceName generates the headless service name for component.
 func GenerateComponentHeadlessServiceName(clusterName, compName, svcName string) string {
 	if len(svcName) > 0 {
-		return shortenKubeNameWithSuffix(fmt.Sprintf("%s-%s-%s", clusterName, compName, svcName), "headless", kubeNameMaxLength)
+		return ShortenKubeNameWithSuffix(fmt.Sprintf("%s-%s-%s", clusterName, compName, svcName), "headless", KubeNameMaxLength)
 	}
-	return shortenKubeNameWithSuffix(fmt.Sprintf("%s-%s", clusterName, compName), "headless", kubeNameMaxLength)
+	return ShortenKubeNameWithSuffix(fmt.Sprintf("%s-%s", clusterName, compName), "headless", KubeNameMaxLength)
 }
 
 // GenerateDefaultComponentHeadlessServiceName generates the default headless service name for component.
@@ -100,7 +100,7 @@ func GenerateWorkloadNamePattern(clusterName, compName string) string {
 	return fmt.Sprintf("%s-%s", clusterName, compName)
 }
 
-func shortenKubeName(raw string, maxLen int) string {
+func ShortenKubeName(raw string, maxLen int) string {
 	if maxLen <= 0 || len(raw) <= maxLen {
 		return raw
 	}
@@ -116,9 +116,9 @@ func shortenKubeName(raw string, maxLen int) string {
 	return fmt.Sprintf("%s-%s", prefix, suffix)
 }
 
-func shortenKubeNameWithSuffix(raw, fixedSuffix string, maxLen int) string {
+func ShortenKubeNameWithSuffix(raw, fixedSuffix string, maxLen int) string {
 	if fixedSuffix == "" {
-		return shortenKubeName(raw, maxLen)
+		return ShortenKubeName(raw, maxLen)
 	}
 	fullName := fmt.Sprintf("%s-%s", raw, fixedSuffix)
 	if maxLen <= 0 || len(fullName) <= maxLen {
@@ -128,7 +128,7 @@ func shortenKubeNameWithSuffix(raw, fixedSuffix string, maxLen int) string {
 	if maxLen <= reserved {
 		return fullName[:maxLen]
 	}
-	return fmt.Sprintf("%s-%s", shortenKubeName(raw, maxLen-reserved), fixedSuffix)
+	return fmt.Sprintf("%s-%s", ShortenKubeName(raw, maxLen-reserved), fixedSuffix)
 }
 
 func shortHash(raw string) string {

--- a/pkg/constant/pattern_test.go
+++ b/pkg/constant/pattern_test.go
@@ -5,72 +5,57 @@ import (
 	"testing"
 )
 
-func TestGenerateComponentServiceNameShortensLongNames(t *testing.T) {
-	clusterName := "vlk-smoke-rerun-202206-restore-202950"
-	compName := "valkey-sentinel"
-	svcName := "valkey-sentinel"
+func TestShortenKubeNameKeepsShortNames(t *testing.T) {
+	got := ShortenKubeName("demo-valkey-sentinel", KubeNameMaxLength)
+	if got != "demo-valkey-sentinel" {
+		t.Fatalf("shortened name = %s, want unchanged short name", got)
+	}
+}
 
-	got := GenerateComponentServiceName(clusterName, compName, svcName)
-	if len(got) > 63 {
-		t.Fatalf("service name length = %d, want <= 63: %s", len(got), got)
+func TestShortenKubeNameShortensLongNames(t *testing.T) {
+	raw := "vlk-smoke-rerun-202206-restore-202950-valkey-sentinel-valkey-sentinel"
+
+	got := ShortenKubeName(raw, KubeNameMaxLength)
+	if len(got) > KubeNameMaxLength {
+		t.Fatalf("shortened name length = %d, want <= %d: %s", len(got), KubeNameMaxLength, got)
 	}
 	if !strings.HasPrefix(got, "vlk-smoke-rerun-202206-restore-202950-valkey") {
-		t.Fatalf("service name prefix = %s, want stable readable prefix", got)
+		t.Fatalf("shortened name prefix = %s, want stable readable prefix", got)
 	}
-	if got == clusterName+"-"+compName+"-"+svcName {
-		t.Fatalf("service name was not shortened: %s", got)
-	}
-}
-
-func TestGenerateComponentHeadlessServiceNameShortensLongNames(t *testing.T) {
-	clusterName := "vlk-smoke-rerun-202206-restore-202950"
-	compName := "valkey-sentinel"
-	svcName := "valkey-sentinel"
-
-	got := GenerateComponentHeadlessServiceName(clusterName, compName, svcName)
-	if len(got) > 63 {
-		t.Fatalf("headless service name length = %d, want <= 63: %s", len(got), got)
-	}
-	if !strings.HasSuffix(got, "headless") {
-		t.Fatalf("headless service name = %s, want suffix headless", got)
-	}
-	if len(got) > 63 {
-		t.Fatalf("headless service name length = %d, want <= 63: %s", len(got), got)
+	if got == raw {
+		t.Fatalf("name was not shortened: %s", got)
 	}
 }
 
-func TestGenerateComponentServiceNameKeepsShortNames(t *testing.T) {
-	got := GenerateComponentServiceName("demo", "valkey", "sentinel")
-	want := "demo-valkey-sentinel"
-	if got != want {
-		t.Fatalf("service name = %s, want %s", got, want)
-	}
-}
+func TestShortenKubeNameAvoidsCollisionsForSamePrefix(t *testing.T) {
+	rawA := "vlk-smoke-rerun-202206-restore-202950-valkey-sentinel-alpha"
+	rawB := "vlk-smoke-rerun-202206-restore-202950-valkey-sentinel-bravo"
 
-func TestGenerateComponentServiceNameAvoidsCollisionsForSamePrefix(t *testing.T) {
-	clusterName := "vlk-smoke-rerun-202206-restore-202950"
-	compNameA := "valkey-sentinel-alpha"
-	compNameB := "valkey-sentinel-bravo"
-	svcName := "valkey-sentinel"
-
-	nameA := GenerateComponentServiceName(clusterName, compNameA, svcName)
-	nameB := GenerateComponentServiceName(clusterName, compNameB, svcName)
+	nameA := ShortenKubeName(rawA, 40)
+	nameB := ShortenKubeName(rawB, 40)
 	if nameA == nameB {
 		t.Fatalf("different long inputs collided: %s", nameA)
 	}
-	if len(nameA) > 63 || len(nameB) > 63 {
-		t.Fatalf("service names must be <= 63: %s (%d), %s (%d)", nameA, len(nameA), nameB, len(nameB))
+}
+
+func TestShortenKubeNameIsDeterministic(t *testing.T) {
+	raw := "vlk-smoke-rerun-202206-restore-202950-valkey-sentinel-valkey-sentinel"
+
+	name1 := ShortenKubeName(raw, KubeNameMaxLength)
+	name2 := ShortenKubeName(raw, KubeNameMaxLength)
+	if name1 != name2 {
+		t.Fatalf("shortened name generation is not deterministic: %s != %s", name1, name2)
 	}
 }
 
-func TestGenerateComponentServiceNameIsDeterministic(t *testing.T) {
-	clusterName := "vlk-smoke-rerun-202206-restore-202950"
-	compName := "valkey-sentinel"
-	svcName := "valkey-sentinel"
+func TestShortenKubeNameWithSuffixPreservesSuffix(t *testing.T) {
+	raw := "vlk-smoke-rerun-202206-restore-202950-valkey-sentinel-valkey-sentinel"
 
-	name1 := GenerateComponentServiceName(clusterName, compName, svcName)
-	name2 := GenerateComponentServiceName(clusterName, compName, svcName)
-	if name1 != name2 {
-		t.Fatalf("service name generation is not deterministic: %s != %s", name1, name2)
+	got := ShortenKubeNameWithSuffix(raw, "headless", KubeNameMaxLength)
+	if len(got) > KubeNameMaxLength {
+		t.Fatalf("shortened name length = %d, want <= %d: %s", len(got), KubeNameMaxLength, got)
+	}
+	if !strings.HasSuffix(got, "headless") {
+		t.Fatalf("shortened name = %s, want suffix headless", got)
 	}
 }

--- a/pkg/constant/pattern_test.go
+++ b/pkg/constant/pattern_test.go
@@ -1,0 +1,45 @@
+package constant
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateComponentServiceNameShortensLongNames(t *testing.T) {
+	clusterName := "vlk-smoke-rerun-202206-restore-202950"
+	compName := "valkey-sentinel"
+	svcName := "valkey-sentinel"
+
+	got := GenerateComponentServiceName(clusterName, compName, svcName)
+	if len(got) > 63 {
+		t.Fatalf("service name length = %d, want <= 63: %s", len(got), got)
+	}
+	if !strings.HasPrefix(got, "vlk-smoke-rerun-202206-restore-202950-valkey") {
+		t.Fatalf("service name prefix = %s, want stable readable prefix", got)
+	}
+	if got == clusterName+"-"+compName+"-"+svcName {
+		t.Fatalf("service name was not shortened: %s", got)
+	}
+}
+
+func TestGenerateComponentHeadlessServiceNameShortensLongNames(t *testing.T) {
+	clusterName := "vlk-smoke-rerun-202206-restore-202950"
+	compName := "valkey-sentinel"
+	svcName := "valkey-sentinel"
+
+	got := GenerateComponentHeadlessServiceName(clusterName, compName, svcName)
+	if len(got) > 63 {
+		t.Fatalf("headless service name length = %d, want <= 63: %s", len(got), got)
+	}
+	if !strings.HasSuffix(got, "headless") {
+		t.Fatalf("headless service name = %s, want suffix headless", got)
+	}
+}
+
+func TestGenerateComponentServiceNameKeepsShortNames(t *testing.T) {
+	got := GenerateComponentServiceName("demo", "valkey", "sentinel")
+	want := "demo-valkey-sentinel"
+	if got != want {
+		t.Fatalf("service name = %s, want %s", got, want)
+	}
+}

--- a/pkg/constant/pattern_test.go
+++ b/pkg/constant/pattern_test.go
@@ -1,3 +1,22 @@
+/*
+Copyright (C) 2022-2025 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 package constant
 
 import (

--- a/pkg/constant/pattern_test.go
+++ b/pkg/constant/pattern_test.go
@@ -34,6 +34,9 @@ func TestGenerateComponentHeadlessServiceNameShortensLongNames(t *testing.T) {
 	if !strings.HasSuffix(got, "headless") {
 		t.Fatalf("headless service name = %s, want suffix headless", got)
 	}
+	if len(got) > 63 {
+		t.Fatalf("headless service name length = %d, want <= 63: %s", len(got), got)
+	}
 }
 
 func TestGenerateComponentServiceNameKeepsShortNames(t *testing.T) {
@@ -41,5 +44,33 @@ func TestGenerateComponentServiceNameKeepsShortNames(t *testing.T) {
 	want := "demo-valkey-sentinel"
 	if got != want {
 		t.Fatalf("service name = %s, want %s", got, want)
+	}
+}
+
+func TestGenerateComponentServiceNameAvoidsCollisionsForSamePrefix(t *testing.T) {
+	clusterName := "vlk-smoke-rerun-202206-restore-202950"
+	compNameA := "valkey-sentinel-alpha"
+	compNameB := "valkey-sentinel-bravo"
+	svcName := "valkey-sentinel"
+
+	nameA := GenerateComponentServiceName(clusterName, compNameA, svcName)
+	nameB := GenerateComponentServiceName(clusterName, compNameB, svcName)
+	if nameA == nameB {
+		t.Fatalf("different long inputs collided: %s", nameA)
+	}
+	if len(nameA) > 63 || len(nameB) > 63 {
+		t.Fatalf("service names must be <= 63: %s (%d), %s (%d)", nameA, len(nameA), nameB, len(nameB))
+	}
+}
+
+func TestGenerateComponentServiceNameIsDeterministic(t *testing.T) {
+	clusterName := "vlk-smoke-rerun-202206-restore-202950"
+	compName := "valkey-sentinel"
+	svcName := "valkey-sentinel"
+
+	name1 := GenerateComponentServiceName(clusterName, compName, svcName)
+	name2 := GenerateComponentServiceName(clusterName, compName, svcName)
+	if name1 != name2 {
+		t.Fatalf("service name generation is not deterministic: %s != %s", name1, name2)
 	}
 }

--- a/pkg/controller/plan/restore.go
+++ b/pkg/controller/plan/restore.go
@@ -376,7 +376,7 @@ func (r *RestoreManager) GetRestoreObjectMeta(comp *component.SynthesizedCompone
 		r.restoreLabels = constant.GetCompLabels(r.Cluster.Name, comp.Name)
 	}
 	return metav1.ObjectMeta{
-		Name:      name,
+		Name:      constant.ShortenKubeName(name, constant.KubeNameMaxLength),
 		Namespace: r.Cluster.Namespace,
 		Labels:    r.restoreLabels,
 	}

--- a/pkg/controller/plan/restore_name_test.go
+++ b/pkg/controller/plan/restore_name_test.go
@@ -1,3 +1,22 @@
+/*
+Copyright (C) 2022-2025 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 package plan
 
 import (

--- a/pkg/controller/plan/restore_name_test.go
+++ b/pkg/controller/plan/restore_name_test.go
@@ -1,0 +1,34 @@
+package plan
+
+import (
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/component"
+)
+
+func TestGetRestoreObjectMetaShortensName(t *testing.T) {
+	manager := &RestoreManager{
+		Cluster: &appsv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      strings.Repeat("restore-cluster-", 4),
+				Namespace: "default",
+				UID:       types.UID("12345678-1234-1234-1234-1234567890ab"),
+			},
+		},
+	}
+	synthesized := &component.SynthesizedComponent{
+		Name: strings.Repeat("component-", 4),
+	}
+
+	meta := manager.GetRestoreObjectMeta(synthesized, dpv1alpha1.PrepareData, "template")
+	if len(meta.Name) > constant.KubeNameMaxLength {
+		t.Fatalf("restore name length = %d, want <= %d: %s", len(meta.Name), constant.KubeNameMaxLength, meta.Name)
+	}
+}

--- a/pkg/dataprotection/restore/builder.go
+++ b/pkg/dataprotection/restore/builder.go
@@ -81,12 +81,13 @@ func (r *restoreJobBuilder) buildPVCVolumeAndMount(
 	claim dpv1alpha1.VolumeConfig,
 	claimName,
 	identifier string) (*corev1.Volume, *corev1.VolumeMount, error) {
-	volumeName := fmt.Sprintf("%s-%s", identifier, claimName)
+	rawVolumeName := fmt.Sprintf("%s-%s", identifier, claimName)
+	safeVolumeName := shortenRestoreDerivedName(rawVolumeName, 63)
 	volume := &corev1.Volume{
-		Name:         volumeName,
+		Name:         safeVolumeName,
 		VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: claimName}},
 	}
-	volumeMount := &corev1.VolumeMount{Name: volumeName}
+	volumeMount := &corev1.VolumeMount{Name: safeVolumeName}
 	if claim.MountPath != "" {
 		volumeMount.MountPath = claim.MountPath
 		return volume, volumeMount, nil

--- a/pkg/dataprotection/restore/builder.go
+++ b/pkg/dataprotection/restore/builder.go
@@ -82,7 +82,7 @@ func (r *restoreJobBuilder) buildPVCVolumeAndMount(
 	claimName,
 	identifier string) (*corev1.Volume, *corev1.VolumeMount, error) {
 	rawVolumeName := fmt.Sprintf("%s-%s", identifier, claimName)
-	safeVolumeName := shortenRestoreDerivedName(rawVolumeName, 63)
+	safeVolumeName := constant.ShortenKubeName(rawVolumeName, constant.KubeNameMaxLength)
 	volume := &corev1.Volume{
 		Name:         safeVolumeName,
 		VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: claimName}},

--- a/pkg/dataprotection/restore/utils.go
+++ b/pkg/dataprotection/restore/utils.go
@@ -22,6 +22,7 @@ package restore
 import (
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -138,8 +139,30 @@ func GetRestoreActionsCountForPrepareData(config *dpv1alpha1.PrepareDataConfig) 
 func BuildRestoreLabels(restoreName string) map[string]string {
 	return map[string]string{
 		constant.AppManagedByLabelKey: dptypes.AppName,
-		DataProtectionRestoreLabelKey: restoreName,
+		DataProtectionRestoreLabelKey: shortenRestoreDerivedName(restoreName, 63),
 	}
+}
+
+func shortenRestoreDerivedName(raw string, maxLen int) string {
+	if maxLen <= 0 || len(raw) <= maxLen {
+		return raw
+	}
+	suffix := shortHash(raw)
+	if maxLen <= len(suffix)+1 {
+		return suffix[:maxLen]
+	}
+	prefixLen := maxLen - len(suffix) - 1
+	prefix := strings.TrimSuffix(raw[:prefixLen], "-")
+	if prefix == "" {
+		return suffix[:maxLen]
+	}
+	return fmt.Sprintf("%s-%s", prefix, suffix)
+}
+
+func shortHash(raw string) string {
+	hasher := fnv.New32a()
+	_, _ = hasher.Write([]byte(raw))
+	return fmt.Sprintf("%08x", hasher.Sum32())
 }
 
 func GetRestoreDuration(status dpv1alpha1.RestoreStatus) *metav1.Duration {

--- a/pkg/dataprotection/restore/utils.go
+++ b/pkg/dataprotection/restore/utils.go
@@ -22,7 +22,6 @@ package restore
 import (
 	"encoding/json"
 	"fmt"
-	"hash/fnv"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -139,30 +138,8 @@ func GetRestoreActionsCountForPrepareData(config *dpv1alpha1.PrepareDataConfig) 
 func BuildRestoreLabels(restoreName string) map[string]string {
 	return map[string]string{
 		constant.AppManagedByLabelKey: dptypes.AppName,
-		DataProtectionRestoreLabelKey: shortenRestoreDerivedName(restoreName, 63),
+		DataProtectionRestoreLabelKey: restoreName,
 	}
-}
-
-func shortenRestoreDerivedName(raw string, maxLen int) string {
-	if maxLen <= 0 || len(raw) <= maxLen {
-		return raw
-	}
-	suffix := shortHash(raw)
-	if maxLen <= len(suffix)+1 {
-		return suffix[:maxLen]
-	}
-	prefixLen := maxLen - len(suffix) - 1
-	prefix := strings.TrimSuffix(raw[:prefixLen], "-")
-	if prefix == "" {
-		return suffix[:maxLen]
-	}
-	return fmt.Sprintf("%s-%s", prefix, suffix)
-}
-
-func shortHash(raw string) string {
-	hasher := fnv.New32a()
-	_, _ = hasher.Write([]byte(raw))
-	return fmt.Sprintf("%08x", hasher.Sum32())
 }
 
 func GetRestoreDuration(status dpv1alpha1.RestoreStatus) *metav1.Duration {

--- a/pkg/dataprotection/restore/utils_test.go
+++ b/pkg/dataprotection/restore/utils_test.go
@@ -1,3 +1,22 @@
+/*
+Copyright (C) 2022-2025 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 package restore
 
 import (

--- a/pkg/dataprotection/restore/utils_test.go
+++ b/pkg/dataprotection/restore/utils_test.go
@@ -1,0 +1,59 @@
+package restore
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
+)
+
+func TestBuildRestoreLabelsKeepsRestoreNameForControllerLookup(t *testing.T) {
+	restoreName := "restore-name-that-controller-uses-for-label-filtering"
+
+	labels := BuildRestoreLabels(restoreName)
+	if labels[DataProtectionRestoreLabelKey] != restoreName {
+		t.Fatalf("restore label = %q, want %q", labels[DataProtectionRestoreLabelKey], restoreName)
+	}
+	if labels[constant.AppManagedByLabelKey] != dptypes.AppName {
+		t.Fatalf("managed-by label = %q, want %q", labels[constant.AppManagedByLabelKey], dptypes.AppName)
+	}
+}
+
+func TestBuildPVCVolumeAndMountShortensDerivedVolumeName(t *testing.T) {
+	builder := &restoreJobBuilder{
+		restore: &dpv1alpha1.Restore{ObjectMeta: metav1.ObjectMeta{Name: "restore"}},
+		backupSet: BackupActionSet{
+			Backup: &dpv1alpha1.Backup{ObjectMeta: metav1.ObjectMeta{Name: "backup"}},
+		},
+	}
+	claim := dpv1alpha1.VolumeConfig{
+		MountPath: "/data",
+	}
+	claimName := "very-long-claim-name-with-extra-suffix-for-restore-prepare-data"
+	identifier := "restore-prepare-data-job-with-an-overlength-derived-volume-identifier"
+
+	volume, volumeMount, err := builder.buildPVCVolumeAndMount(claim, claimName, identifier)
+	if err != nil {
+		t.Fatalf("buildPVCVolumeAndMount returned error: %v", err)
+	}
+	if volume == nil || volumeMount == nil {
+		t.Fatalf("expected volume and volumeMount to be created")
+	}
+	if len(volume.Name) > constant.KubeNameMaxLength {
+		t.Fatalf("volume name length = %d, want <= %d", len(volume.Name), constant.KubeNameMaxLength)
+	}
+	if volume.Name != volumeMount.Name {
+		t.Fatalf("volume name %q and volumeMount name %q should match", volume.Name, volumeMount.Name)
+	}
+	if volumeMount.MountPath != claim.MountPath {
+		t.Fatalf("volumeMount path = %q, want %q", volumeMount.MountPath, claim.MountPath)
+	}
+	wantSource := corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: claimName}}
+	if volume.VolumeSource.PersistentVolumeClaim == nil || volume.VolumeSource.PersistentVolumeClaim.ClaimName != wantSource.PersistentVolumeClaim.ClaimName {
+		t.Fatalf("volume claim name = %q, want %q", volume.VolumeSource.PersistentVolumeClaim.ClaimName, claimName)
+	}
+}

--- a/pkg/operations/rebuild_instance_inplace.go
+++ b/pkg/operations/rebuild_instance_inplace.go
@@ -100,6 +100,7 @@ func (inPlaceHelper *inplaceRebuildHelper) rebuildInstanceWithBackup(reqCtx intc
 	getRestore := func(stage dpv1alpha1.RestoreStage) (*dpv1alpha1.Restore, string, error) {
 		restoreName := fmt.Sprintf("%s-%s-%s-%s-%d", inPlaceHelper.rebuildPrefix, strings.ToLower(string(stage)),
 			common.CutString(opsRes.OpsRequest.Name, 10), inPlaceHelper.synthesizedComp.Name, inPlaceHelper.index)
+		restoreName = constant.ShortenKubeName(restoreName, constant.KubeNameMaxLength)
 		restore := &dpv1alpha1.Restore{}
 		if err := cli.Get(reqCtx.Ctx, client.ObjectKey{Name: restoreName, Namespace: opsRes.Cluster.Namespace}, restore); err != nil {
 			return nil, restoreName, client.IgnoreNotFound(err)
@@ -240,7 +241,7 @@ func (inPlaceHelper *inplaceRebuildHelper) createPrepareDataRestore(reqCtx intct
 
 func (inPlaceHelper *inplaceRebuildHelper) buildRestoreMetaObject(opsRequest *opsv1alpha1.OpsRequest, restoreName string) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
-		Name:      restoreName,
+		Name:      constant.ShortenKubeName(restoreName, constant.KubeNameMaxLength),
 		Namespace: opsRequest.Namespace,
 		Labels: map[string]string{
 			constant.OpsRequestNameLabelKey:      opsRequest.Name,

--- a/pkg/operations/rebuild_restore_name_test.go
+++ b/pkg/operations/rebuild_restore_name_test.go
@@ -1,3 +1,22 @@
+/*
+Copyright (C) 2022-2025 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 package operations
 
 import (

--- a/pkg/operations/rebuild_restore_name_test.go
+++ b/pkg/operations/rebuild_restore_name_test.go
@@ -1,0 +1,26 @@
+package operations
+
+import (
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	opsv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+)
+
+func TestBuildRestoreMetaObjectShortensName(t *testing.T) {
+	helper := &inplaceRebuildHelper{}
+	opsRequest := &opsv1alpha1.OpsRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rebuild-ops",
+			Namespace: "default",
+		},
+	}
+
+	meta := helper.buildRestoreMetaObject(opsRequest, strings.Repeat("rebuild-restore-", 5))
+	if len(meta.Name) > constant.KubeNameMaxLength {
+		t.Fatalf("restore name length = %d, want <= %d: %s", len(meta.Name), constant.KubeNameMaxLength, meta.Name)
+	}
+}


### PR DESCRIPTION
## Summary
- shorten generated Restore resource names so restore labels can keep using the exact restore name without truncation
- shorten restore-derived PVC and volume names to stay within Kubernetes name limits
- keep shared service/headless service naming unchanged; long-name handling stays in restore-private derived names instead of the public service naming rule
- reuse the same deterministic `prefix + fnv32a hash` helper for restore-derived names that need shortening

## Scope
- restore-name shortening now happens at the Restore object creation sites instead of truncating `dataprotection.kubeblocks.io/restore`
- restore-related PVC/volume names reuse the same helper to stay within the 63-char limit
- service/headless service names still follow the existing `cluster + comp + service` convention
- `pkg/constant/pattern.go` now only provides shared shortening helpers reused by restore-derived names; it no longer changes service-name generation

## Validation
- `go test ./pkg/constant -count=1`
- `go test ./pkg/controller/plan -run TestGetRestoreObjectMetaShortensName -count=1` (blocked locally: missing generated `mock_client` types in `pkg/testutil/k8s`)
- `go test ./pkg/operations -run TestBuildRestoreMetaObjectShortensName -count=1` (blocked locally: missing generated `mock_client` types in `pkg/testutil/k8s`)

Closes #10148

Supersedes #10149 because the previous PR head branch name failed repo branch naming policy.