### PR TITLE
fix(parameters): preserve single-line comments in redis config after Update

### DIFF
--- a/pkg/unstructured/lexer.go
+++ b/pkg/unstructured/lexer.go
@@ -77,7 +77,7 @@ func (l *Lexer) appendValidParameter(param Item, fromNo int) {
 }
 
 func (l *Lexer) addParameterComments(param *Item, start, end int) {
-	if start+1 >= end {
+	if start >= end {
 		return
 	}
 	param.Comments = l.lines[start:end]

--- a/pkg/unstructured/redis_config_test.go
+++ b/pkg/unstructured/redis_config_test.go
@@ -192,6 +192,22 @@ zset-max-listpack-value 64`
 		updated: map[string]interface{}{
 			"zset-max-listpack-entries": 128,
 		},
+	}, {
+		name: "single_line_comment_preserved_after_update",
+		input: `port 6379
+maxmemory 100mb
+# maxmemory-policy controls eviction behavior
+maxmemory-policy volatile-lru
+timeout 0`,
+		want: `port 6379
+maxmemory 100mb
+# maxmemory-policy controls eviction behavior
+maxmemory-policy allkeys-lru
+timeout 300`,
+		updated: map[string]interface{}{
+			"maxmemory-policy": "allkeys-lru",
+			"timeout":          300,
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Title

fix(parameters): preserve single-line comments in redis config after Update

## Summary

Fix an off-by-one bug in `Lexer.addParameterComments` that silently drops single-line comments during redis.conf parsing and update.

## Bug Description

### Root Cause

`pkg/unstructured/lexer.go` line 80:

```go
// Before (buggy)
func (l *Lexer) addParameterComments(param *Item, start, end int) {
    if start+1 >= end {  // requires at least 2 comment lines
        return
    }
    param.Comments = l.lines[start:end]
}
```

The condition `start+1 >= end` is equivalent to `end - start <= 1`, meaning comments are only retained when there are **2 or more** consecutive comment lines above a parameter. A single comment line (the most common pattern in redis.conf) is silently dropped.

### How Load works

During `Lexer.Load`, each parameter line is parsed and passed to `appendValidParameter(param, lastScanNo)`. Inside `appendValidParameter`, it calls:

```go
l.addParameterComments(&newItem, fromNo+1, param.LineNo)
```

Where `fromNo` is the line number of the **previous** parameter. For a config like:

```
line 0: port 6379
line 1: maxmemory 100mb
line 2: # some comment          ← single-line comment
line 3: timeout 0
```

When processing `timeout` (line 3), the call is `addParameterComments(&newItem, 2, 3)` — meaning `start=2, end=3`. The slice `l.lines[2:3]` = `["# some comment"]` is a valid single comment.

But the guard `start+1 >= end` evaluates to `2+1 >= 3` → `3 >= 3` → `true`, so it **returns early** and the comment is never attached.

### Reproduction

Given this redis.conf:

```
port 6379
maxmemory 100mb
# maxmemory-policy controls eviction behavior
maxmemory-policy volatile-lru
timeout 0
```

After `LoadConfig` + `Update("maxmemory-policy", "allkeys-lru")` + `Marshal()`:

```
port 6379
maxmemory 100mb
maxmemory-policy allkeys-lru    ← comment is GONE
timeout 0
```

Expected:

```
port 6379
maxmemory 100mb
# maxmemory-policy controls eviction behavior
maxmemory-policy allkeys-lru    ← comment preserved
timeout 0
```

### Why existing tests didn't catch it

The existing `TestRedisConfig_Marshal` test uses a `commentsConfig` fixture where every parameter has a **multi-line** comment block (3+ lines each). Multi-line comments satisfy `start+1 >= end` as false (e.g. `start=5, end=12` → `6 >= 12` is false), so they are correctly retained. Single-line comments were never tested.

### Impact

- Affects all redis.conf files with single-line comments (which is the standard convention — every parameter typically has one `#` comment above it)
- Comments are lost after any `Update` + `Marshal` cycle, meaning config file regeneration silently strips documentation
- Other config formats using the same FSM Lexer are similarly affected

## Fix

Change `start+1 >= end` to `start >= end` in `Lexer.addParameterComments`.

```go
// After (fixed)
func (l *Lexer) addParameterComments(param *Item, start, end int) {
    if start >= end {
        return
    }
    param.Comments = l.lines[start:end]
}
```

This is a 1-character fix. The semantics change from "skip if fewer than 2 comment lines" to "skip if no comment lines", which is the correct boundary.

## Test

Added regression test `single_line_comment_preserved_after_update` in `redis_config_test.go` that:

1. Loads a config with a single-line comment above `maxmemory-policy`
2. Updates `maxmemory-policy` and `timeout` to new values
3. Asserts the single-line comment is preserved in `Marshal()` output

The test **fails** on the old code and **passes** on the fix. All existing tests continue to pass.

## Changes

- `pkg/unstructured/lexer.go`: Fix off-by-one in `addParameterComments`
- `pkg/unstructured/redis_config_test.go`: Add single-line comment regression test

