### PR TITLE
fix: correct typos and grammar errors in error messages and comments

### DIFF
--- a/pkg/common/openapiv3schema.go
+++ b/pkg/common/openapiv3schema.go
@@ -57,8 +57,8 @@ func ValidateDataWithSchema(openAPIV3Schema *apiextensionsv1.JSONSchemaProps, da
 func ConvertStringToInterfaceBySchemaType(openAPIV3Schema *apiextensionsv1.JSONSchemaProps, input map[string]string) (map[string]interface{}, error) {
 	out := map[string]interface{}{}
 	properties := openAPIV3Schema.Properties
-	covertError := func(key string, err error) error {
-		return fmt.Errorf(`covert "%s" failed: %s`, key, err.Error())
+	convertError := func(key string, err error) error {
+		return fmt.Errorf(`convert "%s" failed: %s`, key, err.Error())
 	}
 	var err error
 	for k, v := range input {
@@ -80,7 +80,7 @@ func ConvertStringToInterfaceBySchemaType(openAPIV3Schema *apiextensionsv1.JSONS
 			out[k] = v
 		}
 		if err != nil {
-			return nil, covertError(k, err)
+			return nil, convertError(k, err)
 		}
 	}
 	return out, nil

--- a/pkg/controller/component/available.go
+++ b/pkg/controller/component/available.go
@@ -501,7 +501,7 @@ func (h *AvailableEventHandler) evalActionEvent(assertion appsv1.ActionAssertion
 	}
 	if assertion.Stdout != nil {
 		if assertion.Stdout.EqualTo != nil && !bytes.Equal(event.Stdout, []byte(*assertion.Stdout.EqualTo)) {
-			return false, fmt.Sprintf("probe stdout is not match: %s", prefix16(*assertion.Stdout.EqualTo))
+			return false, fmt.Sprintf("probe stdout does not match: %s", prefix16(*assertion.Stdout.EqualTo))
 		}
 		if assertion.Stdout.Contains != nil && !bytes.Contains(event.Stdout, []byte(*assertion.Stdout.Contains)) {
 			return false, fmt.Sprintf("probe stdout does not contain: %s", prefix16(*assertion.Stdout.Contains))
@@ -509,7 +509,7 @@ func (h *AvailableEventHandler) evalActionEvent(assertion appsv1.ActionAssertion
 	}
 	if assertion.Stderr != nil {
 		if assertion.Stderr.EqualTo != nil && !bytes.Equal(event.Stderr, []byte(*assertion.Stderr.EqualTo)) {
-			return false, fmt.Sprintf("probe stderr is not match: %s", prefix16(*assertion.Stderr.EqualTo))
+			return false, fmt.Sprintf("probe stderr does not match: %s", prefix16(*assertion.Stderr.EqualTo))
 		}
 		if assertion.Stderr.Contains != nil && !bytes.Contains(event.Stderr, []byte(*assertion.Stderr.Contains)) {
 			return false, fmt.Sprintf("probe stderr does not contain: %s", prefix16(*assertion.Stderr.Contains))

--- a/pkg/controller/component/service_reference.go
+++ b/pkg/controller/component/service_reference.go
@@ -295,7 +295,7 @@ func handleServiceRefFromServiceDescriptor(ctx context.Context, cli client.Reade
 
 	match := verifyServiceKindAndVersion(*serviceDescriptor, serviceRefDecl.ServiceRefDeclarationSpecs...)
 	if !match {
-		return nil, fmt.Errorf("service descriptor %s kind or version is not match with service reference declaration %s", serviceDescriptor.Name, serviceRefDecl.Name)
+		return nil, fmt.Errorf("service descriptor %s kind or version does not match service reference declaration %s", serviceDescriptor.Name, serviceRefDecl.Name)
 	}
 	return serviceDescriptor, nil
 }

--- a/pkg/controller/instancetemplate/validation.go
+++ b/pkg/controller/instancetemplate/validation.go
@@ -27,7 +27,7 @@ import (
 func ValidateInstanceTemplates(its *workloads.InstanceSet, tree *kubebuilderx.ObjectTree) error {
 	instancesCompressed, err := findTemplateObject(its, tree)
 	if err != nil {
-		return fmt.Errorf("failed to find compreesssed template: %w", err)
+		return fmt.Errorf("failed to find compressed template: %w", err)
 	}
 
 	instanceTemplates := getInstanceTemplates(its.Spec.Instances, instancesCompressed)
@@ -45,9 +45,9 @@ func ValidateInstanceTemplates(its *workloads.InstanceSet, tree *kubebuilderx.Ob
 		}
 		templateNames.Insert(template.Name)
 	}
-	// sum of spec.templates[*].replicas should not greater than spec.replicas
+	// sum of spec.templates[*].replicas should not be greater than spec.replicas
 	if replicasInTemplates > *its.Spec.Replicas {
-		err = fmt.Errorf("total replicas in instances(%d) should not greater than replicas in spec(%d)", replicasInTemplates, *its.Spec.Replicas)
+		err = fmt.Errorf("total replicas in instances(%d) should not be greater than replicas in spec(%d)", replicasInTemplates, *its.Spec.Replicas)
 		return err
 	}
 

--- a/pkg/controller/instancetemplate/validation_test.go
+++ b/pkg/controller/instancetemplate/validation_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Validation", func() {
 			tree := &kubebuilderx.ObjectTree{}
 			err := ValidateInstanceTemplates(its, tree)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("total replicas in instances(4) should not greater than replicas in spec(3)"))
+			Expect(err.Error()).To(ContainSubstring("total replicas in instances(4) should not be greater than replicas in spec(3)"))
 		})
 
 		It("should fail validation when total replicas restricted by ordinals do not equal to spec.replicas", func() {
@@ -139,7 +139,7 @@ var _ = Describe("Validation", func() {
 			tree := &kubebuilderx.ObjectTree{}
 			err := ValidateInstanceTemplates(its, tree)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("total replicas in instances(4) should not greater than replicas in spec(3)"))
+			Expect(err.Error()).To(ContainSubstring("total replicas in instances(4) should not be greater than replicas in spec(3)"))
 		})
 	})
 })

--- a/pkg/controller/lifecycle/errors.go
+++ b/pkg/controller/lifecycle/errors.go
@@ -26,7 +26,7 @@ import (
 var (
 	ErrActionNotDefined     = errors.New("action is not defined")
 	ErrActionNotImplemented = errors.New("action is not implemented")
-	ErrPreconditionFailed   = errors.New("action precondition is not matched")
+	ErrPreconditionFailed   = errors.New("action precondition is not met")
 	ErrActionInProgress     = errors.New("action is in progress")
 	ErrActionBusy           = errors.New("action is busy")
 	ErrActionTimedOut       = errors.New("action timed-out")

--- a/pkg/controller/lifecycle/lifecycle_test.go
+++ b/pkg/controller/lifecycle/lifecycle_test.go
@@ -483,7 +483,7 @@ var _ = Describe("lifecycle", func() {
 
 			err = lifecycle.PostProvision(ctx, reader, nil)
 			Expect(err).ShouldNot(BeNil())
-			Expect(err.Error()).Should(ContainSubstring("action precondition is not matched"))
+			Expect(err.Error()).Should(ContainSubstring("action precondition is not met"))
 		})
 
 		It("precondition - object selector", func() {
@@ -576,7 +576,7 @@ var _ = Describe("lifecycle", func() {
 				PreConditionObjectSelector: labels,
 			}, "custom-action", customAction, nil)
 			Expect(err).ShouldNot(BeNil())
-			Expect(err.Error()).Should(ContainSubstring("action precondition is not matched"))
+			Expect(err.Error()).Should(ContainSubstring("action precondition is not met"))
 		})
 
 		It("pod selector - any", func() {

--- a/pkg/operations/custom.go
+++ b/pkg/operations/custom.go
@@ -155,11 +155,11 @@ func (c CustomOpsHandler) checkExpression(reqCtx intctrlutil.RequestCtx,
 		return err
 	}
 	for _, comp := range comps {
-		params, err := covertParametersToMap(reqCtx.Ctx, cli, compCustomItem.Parameters, opsRes.OpsRequest.Namespace)
+		params, err := convertParametersToMap(reqCtx.Ctx, cli, compCustomItem.Parameters, opsRes.OpsRequest.Namespace)
 		if err != nil {
 			return err
 		}
-		// get the built-in objects and covert the json tag
+		// get the built-in objects and convert the json tag
 		getBuiltInObjs := func() (map[string]interface{}, error) {
 			b, err := json.Marshal(map[string]interface{}{
 				"cluster":    opsRes.Cluster,
@@ -236,7 +236,7 @@ func (c CustomOpsHandler) initCompActionStatusAndPreCheck(reqCtx intctrlutil.Req
 	return 0, true
 }
 
-func covertParametersToMap(ctx context.Context,
+func convertParametersToMap(ctx context.Context,
 	cli client.Client,
 	parameters []opsv1alpha1.Parameter,
 	opsNamespace string) (map[string]string, error) {
@@ -326,11 +326,11 @@ func initOpsDefAndValidate(reqCtx intctrlutil.RequestCtx,
 	for _, v := range customSpec.CustomOpsComponents {
 		// 1. validate OpenApV3Schema
 		if parametersSchema != nil {
-			paramsMap, err := covertParametersToMap(reqCtx.Ctx, cli, v.Parameters, opsRes.OpsRequest.Namespace)
+			paramsMap, err := convertParametersToMap(reqCtx.Ctx, cli, v.Parameters, opsRes.OpsRequest.Namespace)
 			if err != nil {
 				return err
 			}
-			// covert to type map[string]interface{}
+			// convert to type map[string]interface{}
 			params, err := common.ConvertStringToInterfaceBySchemaType(parametersSchema.OpenAPIV3Schema, paramsMap)
 			if err != nil {
 				return intctrlutil.NewFatalError(err.Error())

--- a/pkg/operations/horizontal_scaling.go
+++ b/pkg/operations/horizontal_scaling.go
@@ -133,7 +133,7 @@ func (hs horizontalScalingOpsHandler) Action(reqCtx intctrlutil.RequestCtx, cli 
 			insReplicas += v.GetReplicas()
 		}
 		if insReplicas > replicas {
-			errMsg := fmt.Sprintf(`the total number of replicas for the instance template can not greater than the number of replicas for component "%s" after horizontally scaling`,
+			errMsg := fmt.Sprintf(`the total number of replicas for the instance template cannot be greater than the number of replicas for component "%s" after horizontally scaling`,
 				horizontalScaling.ComponentName)
 			return intctrlutil.NewFatalError(errMsg)
 		}


### PR DESCRIPTION
## Summary

Fix various typos and grammar errors across error messages, comments, and function names.

### Typos Fixed
- `compreesssed` → `compressed` in `pkg/controller/instancetemplate/validation.go`
- `covert` → `convert` in `pkg/common/openapiv3schema.go` and `pkg/operations/custom.go` (including function name `covertParametersToMap` → `convertParametersToMap`)

### Grammar Fixed
- `"is not match"` → `"does not match"` in `pkg/controller/component/available.go` and `pkg/controller/component/service_reference.go`
- `"should not greater than"` → `"should not be greater than"` in `pkg/controller/instancetemplate/validation.go`
- `"can not greater than"` → `"cannot be greater than"` in `pkg/operations/horizontal_scaling.go`
- `"is not matched"` → `"is not met"` in `pkg/controller/lifecycle/errors.go`

### Test Updates
- Updated test expectations in `validation_test.go` and `lifecycle_test.go` to match corrected error strings

### Files Changed (9)
- `pkg/common/openapiv3schema.go`
- `pkg/controller/component/available.go`
- `pkg/controller/component/service_reference.go`
- `pkg/controller/instancetemplate/validation.go`
- `pkg/controller/instancetemplate/validation_test.go`
- `pkg/controller/lifecycle/errors.go`
- `pkg/controller/lifecycle/lifecycle_test.go`
- `pkg/operations/custom.go`
- `pkg/operations/horizontal_scaling.go`