### PR TITLE
fix(instanceset): normalize absent config hash in configsToUpdate

### DIFF
--- a/pkg/controller/instanceset/instance_util.go
+++ b/pkg/controller/instanceset/instance_util.go
@@ -718,7 +718,7 @@ func configsToUpdate(its *workloads.InstanceSet, pod *corev1.Pod) ([]workloads.C
 		idx := slices.IndexFunc(configs, func(cfg workloads.ConfigTemplate) bool {
 			return cfg.Name == config.Name
 		})
-		if idx < 0 || !ptr.Equal(config.ConfigHash, configs[idx].ConfigHash) {
+		if idx < 0 || ptr.Deref(config.ConfigHash, "") != ptr.Deref(configs[idx].ConfigHash, "") {
 			toUpdate = append(toUpdate, its.Spec.Configs[i])
 		}
 	}

--- a/pkg/controller/instanceset/instance_util_test.go
+++ b/pkg/controller/instanceset/instance_util_test.go
@@ -30,9 +30,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/builder"
 	"github.com/apecloud/kubeblocks/pkg/controller/instancetemplate"
@@ -79,6 +81,44 @@ var _ = Describe("instance util test", func() {
 			revision := "revision"
 			pod = builder.NewPodBuilder(namespace, name).AddControllerRevisionHashLabel(revision).GetObject()
 			Expect(getPodRevision(pod)).Should(Equal(revision))
+		})
+	})
+
+	Context("configsToUpdate", func() {
+		It("treats nil and empty config hash as equal", func() {
+			its := builder.NewInstanceSetBuilder(namespace, name).
+				SetConfigs([]workloads.ConfigTemplate{{
+					Name: "valkey-replication-config",
+				}}).
+				GetObject()
+			pod := builder.NewPodBuilder(namespace, name+"-0").GetObject()
+			Expect(configsToPod([]workloads.ConfigTemplate{{
+				Name:       "valkey-replication-config",
+				ConfigHash: ptr.To(""),
+			}}, pod)).Should(Succeed())
+
+			toUpdate, err := configsToUpdate(its, pod)
+			Expect(err).Should(BeNil())
+			Expect(toUpdate).Should(BeEmpty())
+		})
+
+		It("still reports real config hash mismatch", func() {
+			its := builder.NewInstanceSetBuilder(namespace, name).
+				SetConfigs([]workloads.ConfigTemplate{{
+					Name:       "valkey-replication-config",
+					ConfigHash: ptr.To("desired-hash"),
+				}}).
+				GetObject()
+			pod := builder.NewPodBuilder(namespace, name+"-0").GetObject()
+			Expect(configsToPod([]workloads.ConfigTemplate{{
+				Name:       "valkey-replication-config",
+				ConfigHash: ptr.To(""),
+			}}, pod)).Should(Succeed())
+
+			toUpdate, err := configsToUpdate(its, pod)
+			Expect(err).Should(BeNil())
+			Expect(toUpdate).Should(HaveLen(1))
+			Expect(toUpdate[0].Name).Should(Equal("valkey-replication-config"))
 		})
 	})
 


### PR DESCRIPTION
## Summary

This change normalizes absent config hashes in `InstanceSet` config comparison so that `nil` and `""` are treated as the same value.

In the failing restart path we analyzed, an `externalManaged` config could legitimately keep `configHash=nil` in `InstanceSet.spec.configs`, while `configsToPod()` serialized the same absent-hash semantics into the pod annotation as `""`. The old `configsToUpdate(...)` comparison did not normalize these equivalent representations first, so it reported false drift.

That false drift could feed the restart path as:

- `configsToUpdate != 0`
- `updatePolicy = noOps`
- `allUpdated = false`

Under a tight restart quota, that was enough to block later pods from progressing.

Closes #10160

## Test background / reproduction context

This bug was found and validated during focused Valkey restart verification.

- Trigger background: `externalManaged` `valkey-replication-config` legitimately carried no concrete hash, so the desired spec kept `configHash=nil` while the pod annotation stored the same absent-hash semantics as `""`.
- Symptom: the Valkey restart `OpsRequest` previously got stuck at `Running 1/3`; only `valkey-2` completed while `valkey-0/1` did not continue.
- Why it blocked: the controller mis-detected `nil` vs `""` as config drift, which fed the false-drift path into `noOps + allUpdated=false`, and under `unavailableQuota=1` that blocked later pod restart progress.
- Boundary: Valkey is the trigger and validation context, but the fix remains a generic `InstanceSet configsToUpdate(...)` controller fix rather than a Valkey-specific special case.

## Changes

- normalize `configHash` values before comparison in `pkg/controller/instanceset/instance_util.go`
- add unit coverage for:
  - `nil` vs `""` not being treated as drift
  - real hash mismatches still being treated as drift

## Validation

- `go test ./pkg/controller/instanceset/...`
- frozen Valkey failing baseline: restart progressed from `Running 1/3` to `Succeed 3/3`
- clean Valkey restart rerun: restart also completed as `Succeed 3/3`, with controller logs no longer showing the old bad path

## Out of Scope

- the broader `noOps + allUpdated=false -> updatingPods++` quota-accounting follow-up is not included in this PR
