### PR TITLE
fix(parameters): backfill absent externalManaged config hash

### DIFF
--- a/controllers/parameters/parametertemplateextension_controller.go
+++ b/controllers/parameters/parametertemplateextension_controller.go
@@ -37,6 +37,7 @@ import (
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
 	componentctrl "github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
@@ -124,6 +125,7 @@ func updateConfigsForComponent(reqCtx intctrlutil.RequestCtx, reader client.Clie
 		config.ConfigMap = &corev1.ConfigMapVolumeSource{
 			LocalObjectReference: corev1.LocalObjectReference{Name: cm.Name},
 		}
+		backfillAbsentConfigHash(config, &cm)
 		return nil
 	}
 	defaultExternalManagedHandle := func(compSpec *appsv1.ComponentSpec, tpl *appsv1.ComponentFileTemplate) error {
@@ -161,6 +163,17 @@ func updateConfigsForComponent(reqCtx intctrlutil.RequestCtx, reader client.Clie
 		}
 	}
 	return nil
+}
+
+func backfillAbsentConfigHash(config *appsv1.ClusterComponentConfig, cm *corev1.ConfigMap) {
+	if pointer.StringDeref(config.ConfigHash, "") != "" || cm == nil {
+		return
+	}
+	hash := cm.Labels[constant.CMInsConfigurationHashLabelKey]
+	if hash == "" {
+		return
+	}
+	config.ConfigHash = pointer.String(hash)
 }
 
 func updateConfigsForParameterTemplate(reqCtx intctrlutil.RequestCtx, reader client.Client, component *appsv1.Component) (*appsv1.Component, error) {

--- a/controllers/parameters/parametertemplateextension_controller_test.go
+++ b/controllers/parameters/parametertemplateextension_controller_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,6 +49,31 @@ var _ = Describe("ParameterExtension Controller", func() {
 		return nil
 	}
 
+	It("should only backfill absent config hash from rendered ConfigMap labels", func() {
+		hash := "rendered-hash"
+		rendered := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					constant.CMInsConfigurationHashLabelKey: hash,
+				},
+			},
+		}
+
+		absent := &appsv1.ClusterComponentConfig{}
+		backfillAbsentConfigHash(absent, rendered)
+		Expect(absent.ConfigHash).ShouldNot(BeNil())
+		Expect(*absent.ConfigHash).Should(Equal(hash))
+
+		preset := &appsv1.ClusterComponentConfig{ConfigHash: pointer.String("preset-hash")}
+		backfillAbsentConfigHash(preset, rendered)
+		Expect(preset.ConfigHash).ShouldNot(BeNil())
+		Expect(*preset.ConfigHash).Should(Equal("preset-hash"))
+
+		missing := &appsv1.ClusterComponentConfig{}
+		backfillAbsentConfigHash(missing, &corev1.ConfigMap{})
+		Expect(missing.ConfigHash).Should(BeNil())
+	})
+
 	Context("When updating cluster configs", func() {
 		BeforeEach(cleanEnv)
 
@@ -58,6 +84,7 @@ var _ = Describe("ParameterExtension Controller", func() {
 
 			By("check cm resource")
 			Eventually(testapps.CheckObjExists(&testCtx, client.ObjectKey{Name: configcore.GetComponentCfgName(clusterObj.Name, defaultCompName, configSpecName), Namespace: clusterObj.Namespace}, &corev1.ConfigMap{}, true)).Should(Succeed())
+			expectedHash := waitRenderedConfigHash(clusterObj.Namespace, clusterObj.Name, defaultCompName, configSpecName)
 
 			By("set external managed")
 			Eventually(testapps.GetAndChangeObj(&testCtx, client.ObjectKeyFromObject(compObj), func(comp *appsv1.Component) {
@@ -73,6 +100,8 @@ var _ = Describe("ParameterExtension Controller", func() {
 				g.Expect(config).ShouldNot(BeNil())
 				g.Expect(config.ConfigMap).ShouldNot(BeNil())
 				g.Expect(config.ConfigMap.Name).Should(BeEquivalentTo(configcore.GetComponentCfgName(clusterName, defaultCompName, configSpecName)))
+				g.Expect(config.ConfigHash).ShouldNot(BeNil())
+				g.Expect(*config.ConfigHash).Should(Equal(expectedHash))
 			})).Should(Succeed())
 		})
 


### PR DESCRIPTION
Fixes #10167

## Summary

This follow-up patch backfills an absent `ConfigHash` for `externalManaged` configs in `ParameterTemplateExtension`.

Today `ParameterTemplateExtension` already resolves the rendered ConfigMap and backfills `component.spec.configs[].configMap`, but it does not carry the rendered ConfigMap hash back into `component.spec.configs[].configHash`. That leaves the desired spec incomplete on the initial external-managed path even though the rendered ConfigMap already has a real hash.

This patch keeps the fix narrow:

- backfill `ConfigHash` only when it is absent (`nil` or empty)
- read the hash from the rendered ConfigMap label `config.kubeblocks.io/config-hash`
- do not overwrite an existing non-empty `ConfigHash`
- do not add a transformer-layer fallback in this PR


## Flow

```text
ComponentParameter
  renders the externalManaged config
  creates the rendered ConfigMap
  rendered ConfigMap already has hash: config.kubeblocks.io/config-hash
        |
        |  This PR backfills the missing metadata here:
        |  when writing the ConfigMap reference back to Component.spec.configs,
        |  also write the hash back to Component.spec.configs[].configHash.
        v
Component.spec.configs
  Before: name + configMap, but configHash is absent
  After:  name + configMap + configHash
        |
        v
InstanceSet.spec.configs / Pod annotation
  Later controllers use this desired state to compare config consistency.
```

In short, this PR records the already-computed rendered ConfigMap fingerprint into the desired spec. It complements `#10163`: `#10163` improves downstream controller robustness for absent-hash representations, while this PR improves upstream desired-state completeness for the initial `externalManaged` path.

## Why Here

`ParameterTemplateExtension` is already the place where the rendered ConfigMap is read and the `ConfigMap` reference is written back into `Component.spec.configs`. Adding the initial hash backfill here keeps the desired spec complete at the source instead of pushing this responsibility down to workload transform.

## Changes

- `controllers/parameters/parametertemplateextension_controller.go`
  - backfill absent `ConfigHash` from the rendered ConfigMap label during external-managed config update
- `controllers/parameters/parametertemplateextension_controller_test.go`
  - add helper-level coverage for:
    - absent hash is backfilled from rendered ConfigMap labels
    - existing non-empty hash is not overwritten
    - missing label keeps the hash absent
  - add controller-level coverage that external-managed config reconciliation now writes the rendered hash into `Component.spec.configs[].configHash`

## Validation

```bash
KUBEBUILDER_ASSETS="$(./bin/setup-envtest-release-0.21 use 1.26.1 -p path)" \
go test ./controllers/parameters -count=1 -- -ginkgo.focus='ParameterExtension Controller'
```

## Out of Scope

- transformer fallback for `externalManaged && configHash == nil`
- continuous mirroring of live rendered hash back into desired spec after initial backfill
- `#10163` controller absent-hash compatibility fix
