### PR TITLE
fix: add shell-safe aliases for lifecycle action parameters

### DIFF
--- a/pkg/controller/lifecycle/kbagent.go
+++ b/pkg/controller/lifecycle/kbagent.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"strings"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -303,7 +304,44 @@ func (a *kbagent) parameters(ctx context.Context, cli client.Reader, lfa lifecyc
 			m[k] = v
 		}
 	}
+	addShellSafeParameterAliases(m)
 	return m, nil
+}
+
+func addShellSafeParameterAliases(m map[string]string) {
+	for k, v := range m {
+		alias := shellSafeParameterAlias(k)
+		if alias == "" || alias == k {
+			continue
+		}
+		if existing, ok := m[alias]; !ok || existing == "" {
+			m[alias] = v
+		}
+	}
+}
+
+func shellSafeParameterAlias(name string) string {
+	if name == "" {
+		return ""
+	}
+	var b strings.Builder
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+			b.WriteByte(c - 'a' + 'A')
+		case c >= 'A' && c <= 'Z':
+			b.WriteByte(c)
+		case c >= '0' && c <= '9':
+			if b.Len() == 0 {
+				b.WriteByte('_')
+			}
+			b.WriteByte(c)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
 }
 
 func (a *kbagent) templateVarsParameters() (map[string]string, error) {

--- a/pkg/controller/lifecycle/kbagent_parameters_test.go
+++ b/pkg/controller/lifecycle/kbagent_parameters_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright (C) 2022-2025 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package lifecycle
+
+import "testing"
+
+func TestAddShellSafeParameterAliasesPreservesRawParameter(t *testing.T) {
+	parameters := map[string]string{
+		"maxmemory-policy": "allkeys-lru",
+	}
+
+	addShellSafeParameterAliases(parameters)
+
+	if got := parameters["maxmemory-policy"]; got != "allkeys-lru" {
+		t.Fatalf("raw parameter changed, got %q", got)
+	}
+	if got := parameters["MAXMEMORY_POLICY"]; got != "allkeys-lru" {
+		t.Fatalf("shell-safe alias mismatch, got %q", got)
+	}
+}
+
+func TestAddShellSafeParameterAliasesFillsEmptyAlias(t *testing.T) {
+	parameters := map[string]string{
+		"maxmemory-policy": "allkeys-lru",
+		"MAXMEMORY_POLICY": "",
+	}
+
+	addShellSafeParameterAliases(parameters)
+
+	if got := parameters["MAXMEMORY_POLICY"]; got != "allkeys-lru" {
+		t.Fatalf("empty shell-safe alias should be filled from raw parameter, got %q", got)
+	}
+}
+
+func TestAddShellSafeParameterAliasesKeepsExplicitAlias(t *testing.T) {
+	parameters := map[string]string{
+		"maxmemory-policy": "allkeys-lru",
+		"MAXMEMORY_POLICY": "volatile-lru",
+	}
+
+	addShellSafeParameterAliases(parameters)
+
+	if got := parameters["MAXMEMORY_POLICY"]; got != "volatile-lru" {
+		t.Fatalf("non-empty explicit alias should be preserved, got %q", got)
+	}
+}
+
+func TestShellSafeParameterAlias(t *testing.T) {
+	tests := map[string]string{
+		"maxmemory-policy": "MAXMEMORY_POLICY",
+		"foo.bar-baz":      "FOO_BAR_BAZ",
+		"1st-param":        "_1ST_PARAM",
+		"ALREADY_SAFE":     "ALREADY_SAFE",
+	}
+	for input, expected := range tests {
+		if got := shellSafeParameterAlias(input); got != expected {
+			t.Fatalf("shellSafeParameterAlias(%q)=%q, want %q", input, got, expected)
+		}
+	}
+}


### PR DESCRIPTION
## What this PR does

Adds shell-safe aliases for lifecycle action parameters generated for kbagent actions.

For a raw parameter such as:

```text
maxmemory-policy=allkeys-lru
```

KubeBlocks now also provides:

```text
MAXMEMORY_POLICY=allkeys-lru
```

The original raw key is preserved for compatibility. Existing non-empty explicit aliases are not overwritten.

Fixes #10180.

## Why

Addon action scripts commonly consume parameters through shell environments. Raw config parameter names can include characters such as `-` or `.`, which are not safe shell variable identifiers. Providing an explicit shell-safe alias makes the action parameter contract reliable without requiring every addon to depend on raw-key environment behavior.

This was needed by Valkey R08a `maxmemory-policy` dynamic reconfigure. The addon still needs to fan out the action to all Valkey pods because `CONFIG SET maxmemory-policy` is not automatically replicated across the topology.

## Validation

Controller unit test:

```text
go test ./pkg/controller/lifecycle -run 'TestAddShellSafeParameterAliases|TestShellSafeParameterAlias' -count=1
```

Valkey repeated R08a-only product-gate validation with this controller alias gate and addon fan-out passed 3 consecutive samples:

```text
controller image: apecloud/kubeblocks:release-1.1-controller-side-alias-20260426-195333
imageID: sha256:bc6246f747c9f7d4c42fee842e38393e28e4c9f4c177914292582e2217fcc221
addon: kb-addon-valkey revision 55
addon shape: targetPodSelector: All=yes, runtime closure check=no, rendered fallback=no
artifact root: /tmp/valkey-alias-fanout-no-runtime-closure-repeated-000106
```

| Round | Sample | OpsRequest | ComponentParameter | Pre runtime | Post-immediate runtime | Post-settle(60s) runtime |
|---|---|---|---|---|---|---|
| 1 | `valkey-178-r1-000106 / vlk-v178-r1-000106` | `Succeed` | `Finished` | `3/3 volatile-lru` | `3/3 allkeys-lru` | `3/3 allkeys-lru` |
| 2 | `valkey-178-r2-000703 / vlk-v178-r2-000703` | `Succeed` | `Finished` | `3/3 volatile-lru` | `3/3 allkeys-lru` | `3/3 allkeys-lru` |
| 3 | `valkey-178-r3-001126 / vlk-v178-r3-001126` | `Succeed` | `Finished` | `3/3 volatile-lru` | `3/3 allkeys-lru` | `3/3 allkeys-lru` |

Scope note: this PR fixes the controller-side action parameter contract. Engine-specific addon fan-out remains addon responsibility.
