### PR TITLE
fix: skip switchover for config hash marker updates

### DIFF
--- a/pkg/controller/instance/in_place_update_utils.go
+++ b/pkg/controller/instance/in_place_update_utils.go
@@ -247,6 +247,14 @@ func equalBasicInPlaceFields(old, new *corev1.Pod) bool {
 	return true
 }
 
+func configHashOnlyInPlaceUpdate(old, new *corev1.Pod) bool {
+	oldCopy := old.DeepCopy()
+	newCopy := new.DeepCopy()
+	delete(oldCopy.Annotations, constant.CMInsConfigurationHashLabelKey)
+	delete(newCopy.Annotations, constant.CMInsConfigurationHashLabelKey)
+	return equalBasicInPlaceFields(oldCopy, newCopy) && equalResourcesInPlaceFields(oldCopy, newCopy)
+}
+
 // equalResourcesInPlaceFields checks if the desired values of pod resources are equal to their current actual values.
 // If they are equal, it returns true. Containers in 'old' that are not recognized (they may have been injected by external mutating admission webhooks)
 // will not participate in the comparison.

--- a/pkg/controller/instance/reconciler_update.go
+++ b/pkg/controller/instance/reconciler_update.go
@@ -164,8 +164,10 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 			if !equalResourcesInPlaceFields(pod, newPod) && supportResizeSubResource {
 				err = tree.Update(newMergedPod, kubebuilderx.WithSubResource("resize"))
 			} else {
-				if err = r.switchover(tree, inst, newMergedPod.(*corev1.Pod)); err != nil {
-					return kubebuilderx.Continue, err
+				if !configHashOnlyInPlaceUpdate(pod, newPod) {
+					if err = r.switchover(tree, inst, newMergedPod.(*corev1.Pod)); err != nil {
+						return kubebuilderx.Continue, err
+					}
 				}
 				err = tree.Update(newMergedPod)
 			}

--- a/pkg/controller/instance/utils_test.go
+++ b/pkg/controller/instance/utils_test.go
@@ -22,6 +22,7 @@ package instance
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
@@ -48,6 +49,35 @@ func TestConfigsToUpdateTreatsNilAndEmptyConfigHashAsEqual(t *testing.T) {
 	}
 	if len(toUpdate) != 0 {
 		t.Fatalf("expected no config drift, got %#v", toUpdate)
+	}
+}
+
+func TestConfigHashOnlyInPlaceUpdate(t *testing.T) {
+	oldPod := builder.NewPodBuilder("default", "valkey-0").
+		AddAnnotations("kept", "value").
+		SetContainers([]corev1.Container{{Name: "valkey", Image: "valkey:9"}}).
+		GetObject()
+	if err := configsToPod([]workloads.ConfigTemplate{{
+		Name:       "valkey-replication-config",
+		ConfigHash: ptr.To("old-hash"),
+	}}, oldPod); err != nil {
+		t.Fatalf("configsToPod() error = %v", err)
+	}
+
+	newPod := oldPod.DeepCopy()
+	if err := configsToPod([]workloads.ConfigTemplate{{
+		Name:       "valkey-replication-config",
+		ConfigHash: ptr.To("new-hash"),
+	}}, newPod); err != nil {
+		t.Fatalf("configsToPod() error = %v", err)
+	}
+	if !configHashOnlyInPlaceUpdate(oldPod, newPod) {
+		t.Fatalf("expected config hash only update")
+	}
+
+	newPod.Labels = map[string]string{"extra": "label"}
+	if configHashOnlyInPlaceUpdate(oldPod, newPod) {
+		t.Fatalf("expected non-config label update not to be config hash only")
 	}
 }
 

--- a/pkg/controller/instanceset/in_place_update_util.go
+++ b/pkg/controller/instanceset/in_place_update_util.go
@@ -256,6 +256,14 @@ func equalBasicInPlaceFields(old, new *corev1.Pod) bool {
 	return true
 }
 
+func configHashOnlyInPlaceUpdate(old, new *corev1.Pod) bool {
+	oldCopy := old.DeepCopy()
+	newCopy := new.DeepCopy()
+	delete(oldCopy.Annotations, constant.CMInsConfigurationHashLabelKey)
+	delete(newCopy.Annotations, constant.CMInsConfigurationHashLabelKey)
+	return equalBasicInPlaceFields(oldCopy, newCopy) && equalResourcesInPlaceFields(oldCopy, newCopy)
+}
+
 // equalResourcesInPlaceFields checks if the desired values of pod resources are equal to their current actual values.
 // If they are equal, it returns true. Containers in 'old' that are not recognized (they may have been injected by external mutating admission webhooks)
 // will not participate in the comparison.

--- a/pkg/controller/instanceset/instance_util_test.go
+++ b/pkg/controller/instanceset/instance_util_test.go
@@ -120,6 +120,27 @@ var _ = Describe("instance util test", func() {
 			Expect(toUpdate).Should(HaveLen(1))
 			Expect(toUpdate[0].Name).Should(Equal("valkey-replication-config"))
 		})
+
+		It("identifies config hash annotation only in-place updates", func() {
+			oldPod := builder.NewPodBuilder(namespace, name+"-0").
+				AddAnnotations("kept", "value").
+				SetContainers(template.Spec.Containers).
+				GetObject()
+			Expect(configsToPod([]workloads.ConfigTemplate{{
+				Name:       "valkey-replication-config",
+				ConfigHash: ptr.To("old-hash"),
+			}}, oldPod)).Should(Succeed())
+
+			newPod := oldPod.DeepCopy()
+			Expect(configsToPod([]workloads.ConfigTemplate{{
+				Name:       "valkey-replication-config",
+				ConfigHash: ptr.To("new-hash"),
+			}}, newPod)).Should(Succeed())
+			Expect(configHashOnlyInPlaceUpdate(oldPod, newPod)).Should(BeTrue())
+
+			newPod.Labels = map[string]string{"extra": "label"}
+			Expect(configHashOnlyInPlaceUpdate(oldPod, newPod)).Should(BeFalse())
+		})
 	})
 
 	Context("buildInstancePodByTemplate", func() {

--- a/pkg/controller/instanceset/reconciler_update.go
+++ b/pkg/controller/instanceset/reconciler_update.go
@@ -193,8 +193,10 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 			if !equalResourcesInPlaceFields(pod, newPod) && supportResizeSubResource {
 				err = tree.Update(newMergedPod, kubebuilderx.WithSubResource("resize"))
 			} else {
-				if err = r.switchover(tree, its, newMergedPod.(*corev1.Pod)); err != nil {
-					return kubebuilderx.Continue, err
+				if !configHashOnlyInPlaceUpdate(pod, newPod) {
+					if err = r.switchover(tree, its, newMergedPod.(*corev1.Pod)); err != nil {
+						return kubebuilderx.Continue, err
+					}
 				}
 				err = tree.Update(newMergedPod)
 			}


### PR DESCRIPTION
## Summary
- skip lifecycle switchover when an in-place pod update only changes the config-hash annotation
- apply the guard in both InstanceSet and Instance update paths
- add unit coverage for config-hash-only metadata updates

## Why
After syncReload succeeds, the controller updates `config.kubeblocks.io/config-hash` on pods to mark the applied config. That metadata-only marker update was going through the generic in-place update path, which can call lifecycle switchover before updating pod metadata. For Valkey R08a, this caused unnecessary switchover calls and transient topology drift even though pod spec/data path did not require role movement.

## Verification
- `go test ./pkg/controller/instanceset ./pkg/controller/instance -count=1`

## Runtime validation
Bob reproduced the residual signal 2/2 after the configSpec-source fix: `syncReload` with no pod recreate, but each data pod saw `reconfigure -> switchover` and transient multi-master. After this fix, a fresh Valkey R08a retest showed controller switchover grep 0, all data-pod kbagent switchover grep 0, and post/settle topology stayed single-primary.

---

_(Re-opened from #10185 with renamed branch to satisfy KB CI's branch-name pattern requirement: `feature/|bugfix/|release/|hotfix/|support/|releasing/|dependabot/`. Original `fix/...` prefix didn't match. Content is identical — same commit `7685fa973`.)_