### PR TITLE
chore(ops): centralize OpsRequest condition reason literals and fix message typos

### DIFF
--- a/apis/operations/v1alpha1/opsrequest_conditions.go
+++ b/apis/operations/v1alpha1/opsrequest_conditions.go
@@ -58,6 +58,28 @@ const (
 	ReasonOpsCancelFailed       = "CancelFailed"
 	ReasonOpsCancelSucceed      = "CancelSucceed"
 	ReasonOpsCancelByController = "CancelByController"
+
+	// reasons emitted by NewXxxCondition constructors below. These were
+	// previously inline string literals; centralized here so consumers
+	// (Console, tests, lint analyzers in OPS-S1 Slice E) have a single
+	// authoritative source. String values MUST remain stable — see
+	// TestReasonConstantsStringDrift.
+	ReasonValidateOpsRequestPassed        = "ValidateOpsRequestPassed"
+	ReasonOpsRequestProcessedSuccessfully = "OpsRequestProcessedSuccessfully"
+	ReasonRestartStarted                  = "RestartStarted"
+	ReasonStartToRebuildInstances         = "StartToRebuildInstances"
+	ReasonSwitchoverStarted               = "SwitchoverStarted"
+	ReasonVerticalScalingStarted          = "VerticalScalingStarted"
+	ReasonHorizontalScalingStarted        = "HorizontalScalingStarted"
+	ReasonVolumeExpansionStarted          = "VolumeExpansionStarted"
+	ReasonExposeStarted                   = "ExposeStarted"
+	ReasonVersionUpgradeStarted           = "VersionUpgradeStarted"
+	ReasonStopStarted                     = "StopStarted"
+	ReasonStartCluster                    = "StartCluster"
+	ReasonReconfigureStarted              = "ReconfigureStarted"
+	ReasonReconfigureFailed               = "ReconfigureFailed"
+	ReasonBackupStarted                   = "BackupStarted"
+	ReasonRestoreStarted                  = "RestoreStarted"
 )
 
 func (r *OpsRequest) SetStatusCondition(condition metav1.Condition) {
@@ -130,7 +152,7 @@ func NewValidatePassedCondition(opsRequestName string) *metav1.Condition {
 	return &metav1.Condition{
 		Type:               ConditionTypeValidated,
 		Status:             metav1.ConditionTrue,
-		Reason:             "ValidateOpsRequestPassed",
+		Reason:             ReasonValidateOpsRequestPassed,
 		LastTransitionTime: metav1.Now(),
 		Message:            fmt.Sprintf("OpsRequest: %s is validated", opsRequestName),
 	}
@@ -167,7 +189,7 @@ func NewSucceedCondition(ops *OpsRequest) *metav1.Condition {
 	return &metav1.Condition{
 		Type:               ConditionTypeSucceed,
 		Status:             metav1.ConditionTrue,
-		Reason:             "OpsRequestProcessedSuccessfully",
+		Reason:             ReasonOpsRequestProcessedSuccessfully,
 		LastTransitionTime: metav1.Now(),
 		Message: fmt.Sprintf("Successfully processed the OpsRequest: %s in Cluster: %s",
 			ops.Name, ops.Spec.GetClusterName()),
@@ -179,7 +201,7 @@ func NewRestartingCondition(ops *OpsRequest) *metav1.Condition {
 	return &metav1.Condition{
 		Type:               ConditionTypeRestarting,
 		Status:             metav1.ConditionTrue,
-		Reason:             "RestartStarted",
+		Reason:             ReasonRestartStarted,
 		LastTransitionTime: metav1.Now(),
 		Message:            fmt.Sprintf("Start to restart database in Cluster: %s", ops.Spec.GetClusterName()),
 	}
@@ -190,7 +212,7 @@ func NewInstancesRebuildingCondition(ops *OpsRequest) *metav1.Condition {
 	return &metav1.Condition{
 		Type:               ConditionTypeInstanceRebuilding,
 		Status:             metav1.ConditionTrue,
-		Reason:             "StartToRebuildInstances",
+		Reason:             ReasonStartToRebuildInstances,
 		LastTransitionTime: metav1.Now(),
 		Message:            fmt.Sprintf("Start to rebuild the instances in Cluster: %s", ops.Spec.GetClusterName()),
 	}
@@ -201,7 +223,7 @@ func NewSwitchoveringCondition(generation int64, message string) *metav1.Conditi
 	return &metav1.Condition{
 		Type:               ConditionTypeSwitchover,
 		Status:             metav1.ConditionTrue,
-		Reason:             "SwitchoverStarted",
+		Reason:             ReasonSwitchoverStarted,
 		LastTransitionTime: metav1.Now(),
 		Message:            message,
 		ObservedGeneration: generation,
@@ -213,7 +235,7 @@ func NewVerticalScalingCondition(ops *OpsRequest) *metav1.Condition {
 	return &metav1.Condition{
 		Type:               ConditionTypeVerticalScaling,
 		Status:             metav1.ConditionTrue,
-		Reason:             "VerticalScalingStarted",
+		Reason:             ReasonVerticalScalingStarted,
 		LastTransitionTime: metav1.Now(),
 		Message:            fmt.Sprintf("Start to vertical scale resources in Cluster: %s", ops.Spec.GetClusterName()),
 	}
@@ -224,7 +246,7 @@ func NewHorizontalScalingCondition(ops *OpsRequest) *metav1.Condition {
 	return &metav1.Condition{
 		Type:               ConditionTypeHorizontalScaling,
 		Status:             metav1.ConditionTrue,
-		Reason:             "HorizontalScalingStarted",
+		Reason:             ReasonHorizontalScalingStarted,
 		LastTransitionTime: metav1.Now(),
 		Message:            fmt.Sprintf("Start to horizontal scale replicas in Cluster: %s", ops.Spec.GetClusterName()),
 	}
@@ -235,7 +257,7 @@ func NewVolumeExpandingCondition(ops *OpsRequest) *metav1.Condition {
 	return &metav1.Condition{
 		Type:               ConditionTypeVolumeExpanding,
 		Status:             metav1.ConditionTrue,
-		Reason:             "VolumeExpansionStarted",
+		Reason:             ReasonVolumeExpansionStarted,
 		LastTransitionTime: metav1.Now(),
 		Message:            fmt.Sprintf("Start to expand the volumes in Cluster: %s", ops.Spec.GetClusterName()),
 	}
@@ -245,7 +267,7 @@ func NewExposingCondition(ops *OpsRequest) *metav1.Condition {
 	return &metav1.Condition{
 		Type:               ConditionTypeExpose,
 		Status:             metav1.ConditionTrue,
-		Reason:             "ExposeStarted",
+		Reason:             ReasonExposeStarted,
 		LastTransitionTime: metav1.Now(),
 		Message:            fmt.Sprintf("Start to expose the services in Cluster: %s", ops.Spec.GetClusterName()),
 	}
@@ -256,7 +278,7 @@ func NewUpgradingCondition(ops *OpsRequest) *metav1.Condition {
 	return &metav1.Condition{
 		Type:               ConditionTypeVersionUpgrading,
 		Status:             metav1.ConditionTrue,
-		Reason:             "VersionUpgradeStarted",
+		Reason:             ReasonVersionUpgradeStarted,
 		LastTransitionTime: metav1.Now(),
 		Message:            fmt.Sprintf("Start to upgrade the version in Cluster: %s", ops.Spec.GetClusterName()),
 	}
@@ -267,7 +289,7 @@ func NewStopCondition(ops *OpsRequest) *metav1.Condition {
 	return &metav1.Condition{
 		Type:               ConditionTypeStop,
 		Status:             metav1.ConditionTrue,
-		Reason:             "StopStarted",
+		Reason:             ReasonStopStarted,
 		LastTransitionTime: metav1.Now(),
 		Message:            fmt.Sprintf("Start to stop the Cluster: %s", ops.Spec.GetClusterName()),
 	}
@@ -278,7 +300,7 @@ func NewStartCondition(ops *OpsRequest) *metav1.Condition {
 	return &metav1.Condition{
 		Type:               ConditionTypeStart,
 		Status:             metav1.ConditionTrue,
-		Reason:             "StartCluster",
+		Reason:             ReasonStartCluster,
 		LastTransitionTime: metav1.Now(),
 		Message:            fmt.Sprintf("Start the Cluster: %s", ops.Spec.GetClusterName()),
 	}
@@ -289,7 +311,7 @@ func NewReconfigureCondition(ops *OpsRequest) *metav1.Condition {
 	return &metav1.Condition{
 		Type:               ConditionTypeReconfigure,
 		Status:             metav1.ConditionTrue,
-		Reason:             "ReconfigureStarted",
+		Reason:             ReasonReconfigureStarted,
 		LastTransitionTime: metav1.Now(),
 		Message: fmt.Sprintf("Start to reconfigure in Cluster: %s, Component: %s",
 			ops.Spec.GetClusterName(),
@@ -338,7 +360,7 @@ func NewReconfigureFailedCondition(ops *OpsRequest, err error) *metav1.Condition
 	return &metav1.Condition{
 		Type:               appsv1alpha1.ReasonReconfigureFailed,
 		Status:             metav1.ConditionFalse,
-		Reason:             "ReconfigureFailed",
+		Reason:             ReasonReconfigureFailed,
 		LastTransitionTime: metav1.Now(),
 		Message:            msg,
 	}
@@ -349,7 +371,7 @@ func NewBackupCondition(ops *OpsRequest) *metav1.Condition {
 	return &metav1.Condition{
 		Type:               ConditionTypeBackup,
 		Status:             metav1.ConditionTrue,
-		Reason:             "BackupStarted",
+		Reason:             ReasonBackupStarted,
 		LastTransitionTime: metav1.Now(),
 		Message:            fmt.Sprintf("Start to backup the Cluster: %s", ops.Spec.GetClusterName()),
 	}
@@ -360,7 +382,7 @@ func NewRestoreCondition(ops *OpsRequest) *metav1.Condition {
 	return &metav1.Condition{
 		Type:               ConditionTypeBackup,
 		Status:             metav1.ConditionTrue,
-		Reason:             "RestoreStarted",
+		Reason:             ReasonRestoreStarted,
 		LastTransitionTime: metav1.Now(),
 		Message:            fmt.Sprintf("Start to restore the Cluster: %s", ops.Spec.GetClusterName()),
 	}

--- a/apis/operations/v1alpha1/opsrequest_conditions_test.go
+++ b/apis/operations/v1alpha1/opsrequest_conditions_test.go
@@ -63,6 +63,96 @@ func TestNewAllCondition(t *testing.T) {
 	NewReconfigureRunningCondition(opsRequest, appsv1alpha1.ReasonReconfigureRunning, "for_test", "")
 }
 
+// TestReasonConstantsStringDrift pins the literal value of every Reason
+// constant emitted by the NewXxxCondition constructors. Console, Slock task
+// templates, fixtures, and the upcoming OPS-S1 reasoncatalog registry all
+// match on the string value, not the Go identifier, so a silent rename
+// would break consumers without a compile-time signal.
+//
+// Slice A intentionally only centralizes existing inline literals and does
+// NOT introduce the 9 OPS-S1 anchor reasons. Anchors land in Slice B with
+// their own catalog and tests.
+func TestReasonConstantsStringDrift(t *testing.T) {
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		// pre-existing constants — pinned for completeness
+		{"ReasonClusterPhaseMismatch", ReasonClusterPhaseMismatch, "ClusterPhaseMismatch"},
+		{"ReasonOpsTypeNotSupported", ReasonOpsTypeNotSupported, "OpsTypeNotSupported"},
+		{"ReasonValidateFailed", ReasonValidateFailed, "ValidateFailed"},
+		{"ReasonClusterNotFound", ReasonClusterNotFound, "ClusterNotFound"},
+		{"ReasonOpsRequestFailed", ReasonOpsRequestFailed, "OpsRequestFailed"},
+		{"ReasonOpsCanceling", ReasonOpsCanceling, "Canceling"},
+		{"ReasonOpsCancelFailed", ReasonOpsCancelFailed, "CancelFailed"},
+		{"ReasonOpsCancelSucceed", ReasonOpsCancelSucceed, "CancelSucceed"},
+		{"ReasonOpsCancelByController", ReasonOpsCancelByController, "CancelByController"},
+
+		// constants centralized in Slice A — values must equal the
+		// previously inline string literal, no behavior change allowed.
+		{"ReasonValidateOpsRequestPassed", ReasonValidateOpsRequestPassed, "ValidateOpsRequestPassed"},
+		{"ReasonOpsRequestProcessedSuccessfully", ReasonOpsRequestProcessedSuccessfully, "OpsRequestProcessedSuccessfully"},
+		{"ReasonRestartStarted", ReasonRestartStarted, "RestartStarted"},
+		{"ReasonStartToRebuildInstances", ReasonStartToRebuildInstances, "StartToRebuildInstances"},
+		{"ReasonSwitchoverStarted", ReasonSwitchoverStarted, "SwitchoverStarted"},
+		{"ReasonVerticalScalingStarted", ReasonVerticalScalingStarted, "VerticalScalingStarted"},
+		{"ReasonHorizontalScalingStarted", ReasonHorizontalScalingStarted, "HorizontalScalingStarted"},
+		{"ReasonVolumeExpansionStarted", ReasonVolumeExpansionStarted, "VolumeExpansionStarted"},
+		{"ReasonExposeStarted", ReasonExposeStarted, "ExposeStarted"},
+		{"ReasonVersionUpgradeStarted", ReasonVersionUpgradeStarted, "VersionUpgradeStarted"},
+		{"ReasonStopStarted", ReasonStopStarted, "StopStarted"},
+		{"ReasonStartCluster", ReasonStartCluster, "StartCluster"},
+		{"ReasonReconfigureStarted", ReasonReconfigureStarted, "ReconfigureStarted"},
+		{"ReasonReconfigureFailed", ReasonReconfigureFailed, "ReconfigureFailed"},
+		{"ReasonBackupStarted", ReasonBackupStarted, "BackupStarted"},
+		{"ReasonRestoreStarted", ReasonRestoreStarted, "RestoreStarted"},
+	}
+	for _, tc := range cases {
+		if tc.got != tc.want {
+			t.Errorf("Reason constant %s drifted: got %q, want %q (consumer match would break)", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+// TestNewConditionReasonsMatchConstants verifies that the constructors
+// in opsrequest_conditions.go set Condition.Reason to the centralized
+// constants we just defined. Defends against an accidental in-place
+// edit that re-introduces an inline string and silently drifts from the
+// constant.
+func TestNewConditionReasonsMatchConstants(t *testing.T) {
+	opsRequest := createTestOpsRequest("mysql-test", "mysql-restart", RestartType)
+	opsRequest.Spec.Reconfigures = []Reconfigure{{ComponentOps: ComponentOps{ComponentName: "testReconfiguring"}}}
+
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"NewValidatePassedCondition", NewValidatePassedCondition(opsRequest.Name).Reason, ReasonValidateOpsRequestPassed},
+		{"NewSucceedCondition", NewSucceedCondition(opsRequest).Reason, ReasonOpsRequestProcessedSuccessfully},
+		{"NewRestartingCondition", NewRestartingCondition(opsRequest).Reason, ReasonRestartStarted},
+		{"NewInstancesRebuildingCondition", NewInstancesRebuildingCondition(opsRequest).Reason, ReasonStartToRebuildInstances},
+		{"NewSwitchoveringCondition", NewSwitchoveringCondition(0, "test").Reason, ReasonSwitchoverStarted},
+		{"NewVerticalScalingCondition", NewVerticalScalingCondition(opsRequest).Reason, ReasonVerticalScalingStarted},
+		{"NewHorizontalScalingCondition", NewHorizontalScalingCondition(opsRequest).Reason, ReasonHorizontalScalingStarted},
+		{"NewVolumeExpandingCondition", NewVolumeExpandingCondition(opsRequest).Reason, ReasonVolumeExpansionStarted},
+		{"NewExposingCondition", NewExposingCondition(opsRequest).Reason, ReasonExposeStarted},
+		{"NewUpgradingCondition", NewUpgradingCondition(opsRequest).Reason, ReasonVersionUpgradeStarted},
+		{"NewStopCondition", NewStopCondition(opsRequest).Reason, ReasonStopStarted},
+		{"NewStartCondition", NewStartCondition(opsRequest).Reason, ReasonStartCluster},
+		{"NewReconfigureCondition", NewReconfigureCondition(opsRequest).Reason, ReasonReconfigureStarted},
+		{"NewReconfigureFailedCondition", NewReconfigureFailedCondition(opsRequest, nil).Reason, ReasonReconfigureFailed},
+		{"NewBackupCondition", NewBackupCondition(opsRequest).Reason, ReasonBackupStarted},
+		{"NewRestoreCondition", NewRestoreCondition(opsRequest).Reason, ReasonRestoreStarted},
+	}
+	for _, tc := range cases {
+		if tc.got != tc.want {
+			t.Errorf("%s emitted Reason %q, want %q", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
 func TestSetStatusCondition(t *testing.T) {
 	opsRequest := createTestOpsRequest("mysql-test", "mysql-restart", RestartType)
 	progressingCondition := NewVerticalScalingCondition(opsRequest)

--- a/pkg/operations/custom.go
+++ b/pkg/operations/custom.go
@@ -302,7 +302,7 @@ func validateAndGetCompSpec(cluster *appsv1.Cluster, opsDef *opsv1alpha1.OpsDefi
 	}
 	shardingSpec := cluster.Spec.GetShardingByName(componentName)
 	if shardingSpec == nil {
-		return nil, intctrlutil.NewFatalError(fmt.Sprintf(`cannot found the component "%s" in cluster "%s"`, componentName, cluster.Name))
+		return nil, intctrlutil.NewFatalError(fmt.Sprintf(`cannot find the component "%s" in cluster "%s"`, componentName, cluster.Name))
 	}
 	if len(opsDef.Spec.PodInfoExtractors) == 0 {
 		return nil, intctrlutil.NewFatalError(fmt.Sprintf(`podInfoExtractors cannot be empty in opsDef "%s" when the component "%s" is a shard component`, opsDef.Name, componentName))

--- a/pkg/operations/rebuild_instance.go
+++ b/pkg/operations/rebuild_instance.go
@@ -109,7 +109,7 @@ func (r rebuildInstanceOpsHandler) Action(reqCtx intctrlutil.RequestCtx, cli cli
 			}
 			roleAware := len(synthesizedComp.Roles) > 0
 			if !opsRes.OpsRequest.Spec.Force && targetInstance.IsAvailable(synthesizedComp.MinReadySeconds, roleAware) {
-				return intctrlutil.NewFatalError(fmt.Sprintf(`instance "%s" is availabled, can not rebuild it`, ins.Name))
+				return intctrlutil.NewFatalError(fmt.Sprintf(`instance "%s" is available, can not rebuild it`, ins.Name))
 			}
 			instanceNames = append(instanceNames, ins.Name)
 		}
@@ -488,7 +488,7 @@ func (r rebuildInstanceOpsHandler) checkProgressForScalingOutPods(reqCtx intctrl
 		progressDetail := r.getInstanceProgressDetail(*compStatus, instance.Name)
 		scalingOutPodName := r.getScalingOutPodNameFromMessage(progressDetail.Message)
 		if _, ok := currPodSet[scalingOutPodName]; !ok {
-			return 0, 0, nil, intctrlutil.NewFatalError(fmt.Sprintf(`the replicas of the component "%s" has been modifeied by another operation`, compSpec.Name))
+			return 0, 0, nil, intctrlutil.NewFatalError(fmt.Sprintf(`the replicas of the component "%s" has been modified by another operation`, compSpec.Name))
 		}
 		scaledOutInstance, err := runtime.GetInstance(opsRes.Cluster.Namespace, opsRes.Cluster.Name, compSpec.Name, scalingOutPodName)
 		if err != nil {


### PR DESCRIPTION
## Summary

No behavior change. Centralizes the inline Reason string literals in `apis/operations/v1alpha1/opsrequest_conditions.go` into named constants in the same file, and corrects three user-visible message typos in `pkg/operations`.

This is the first slice of the OpsRequest status reason model work; it intentionally adds nothing else (no new vocabulary, no catalog/registry, no phase changes, no evidence backfill). Subsequent slices will introduce the structured anchor reasons and the catalog on top of these constants.

## What changed

### Reason constants centralized

The `NewXxxCondition` constructors previously set `Condition.Reason` to inline string literals (e.g. `"VolumeExpansionStarted"`). The literal values are unchanged; they are now declared once in the existing constants block and referenced from each constructor. 16 new exported constants:

| Constant | Value |
|---|---|
| `ReasonValidateOpsRequestPassed` | `ValidateOpsRequestPassed` |
| `ReasonOpsRequestProcessedSuccessfully` | `OpsRequestProcessedSuccessfully` |
| `ReasonRestartStarted` | `RestartStarted` |
| `ReasonStartToRebuildInstances` | `StartToRebuildInstances` |
| `ReasonSwitchoverStarted` | `SwitchoverStarted` |
| `ReasonVerticalScalingStarted` | `VerticalScalingStarted` |
| `ReasonHorizontalScalingStarted` | `HorizontalScalingStarted` |
| `ReasonVolumeExpansionStarted` | `VolumeExpansionStarted` |
| `ReasonExposeStarted` | `ExposeStarted` |
| `ReasonVersionUpgradeStarted` | `VersionUpgradeStarted` |
| `ReasonStopStarted` | `StopStarted` |
| `ReasonStartCluster` | `StartCluster` |
| `ReasonReconfigureStarted` | `ReconfigureStarted` |
| `ReasonReconfigureFailed` | `ReconfigureFailed` |
| `ReasonBackupStarted` | `BackupStarted` |
| `ReasonRestoreStarted` | `RestoreStarted` |

### Typo fixes (English grammar in user-visible failure messages)

| File:Line | Before | After |
|---|---|---|
| `pkg/operations/rebuild_instance.go:112` | `instance "%s" is availabled, can not rebuild it` | `instance "%s" is available, can not rebuild it` |
| `pkg/operations/rebuild_instance.go:491` | `the replicas of the component "%s" has been modifeied by another operation` | `the replicas of the component "%s" has been modified by another operation` |
| `pkg/operations/custom.go:305` | `cannot found the component "%s" in cluster "%s"` | `cannot find the component "%s" in cluster "%s"` |

These messages are surfaced via `intctrlutil.NewFatalError` and end up in `OpsRequest.status` and reconciler logs, so they are externally visible.

### New tests

- `TestReasonConstantsStringDrift` pins the literal value of every Reason constant. A silent rename or string change fails the test, defending consumers that match on the Reason string value rather than the Go identifier.
- `TestNewConditionReasonsMatchConstants` verifies that each `NewXxxCondition` constructor returns a Condition whose `Reason` equals the centralized constant. Defends against an accidental in-place edit that re-introduces an inline string literal.

## Test plan

- [x] `go test ./apis/operations/v1alpha1/...` (4 tests, including the two new ones) — passes
- [x] `go test ./pkg/operations/util/...` — passes (8.8s)
- [x] `go test ./pkg/operations/...` (full Ginkgo suite, envtest 1.26.1) — passes (28.8s)
- [x] `go test ./controllers/operations/...` — passes (17.9s)
- [x] `go vet ./apis/operations/v1alpha1/... ./pkg/operations/...` — clean
- [x] Repo-wide search for the three typo tokens (`modifeied`, `availabled`, `cannot found`) returns zero matches after this change.

## Out of scope (subsequent slices)

- Adding new structured anchor reasons (e.g. for queue-blocked, precheck-failed, pod/job-failed, kbagent-action-failed, dependent-operation-failed, timeout-waiting-for-ready). These are introduced in a follow-up alongside a new reason catalog/registry file.
- Phase change for queue-full handling (currently `Failed`; tracked separately).
- Evidence backfill at terse-message paths (`backup.go`, `restore.go`, `rebuild_instance_inplace.go`, `ops_manager.go`).
- A `make verify` lint analyzer enforcing registered reasons and required evidence.