### PR TITLE
fix(instanceset): compare digest image IDs

### DIFF
--- a/pkg/controller/instanceset/instance_util.go
+++ b/pkg/controller/instanceset/instance_util.go
@@ -186,14 +186,14 @@ func isImageMatched(pod *corev1.Pod) bool {
 		// Image in status may not match the image used in the PodSpec.
 		// More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodStatus
 		specName, specTag, specDigest := imageSplit(specImage)
-		statusName, statusTag, statusDigest := imageSplit(statusImage)
 		_, _, statusImageIDDigest := imageSplit(status.ImageID)
-		// If the spec is digest-pinned, accept the pulled digest from either
-		// status.image or status.imageID. Do not use imageID for tag-only specs:
-		// mutable tags must still match status.image by tag.
-		if len(specDigest) != 0 && specDigest != statusDigest && specDigest != statusImageIDDigest {
-			return false
+		if len(specDigest) != 0 {
+			if specDigest != statusImageIDDigest {
+				return false
+			}
+			continue
 		}
+		statusName, statusTag, _ := imageSplit(statusImage)
 		// if tag presents in spec, it must be same in status
 		if len(specTag) != 0 && specTag != statusTag {
 			return false

--- a/pkg/controller/instanceset/instance_util.go
+++ b/pkg/controller/instanceset/instance_util.go
@@ -181,13 +181,15 @@ func isImageMatched(pod *corev1.Pod) bool {
 			continue
 		}
 		specImage := container.Image
-		statusImage := pod.Status.ContainerStatuses[index].Image
+		status := pod.Status.ContainerStatuses[index]
+		statusImage := status.Image
 		// Image in status may not match the image used in the PodSpec.
 		// More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodStatus
 		specName, specTag, specDigest := imageSplit(specImage)
 		statusName, statusTag, statusDigest := imageSplit(statusImage)
+		_, _, statusImageIDDigest := imageSplit(status.ImageID)
 		// if digest presents in spec, it must be same in status
-		if len(specDigest) != 0 && specDigest != statusDigest {
+		if len(specDigest) != 0 && specDigest != statusDigest && specDigest != statusImageIDDigest {
 			return false
 		}
 		// if tag presents in spec, it must be same in status

--- a/pkg/controller/instanceset/instance_util.go
+++ b/pkg/controller/instanceset/instance_util.go
@@ -182,18 +182,17 @@ func isImageMatched(pod *corev1.Pod) bool {
 		}
 		specImage := container.Image
 		status := pod.Status.ContainerStatuses[index]
-		statusImage := status.Image
 		// Image in status may not match the image used in the PodSpec.
 		// More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodStatus
 		specName, specTag, specDigest := imageSplit(specImage)
-		_, _, statusImageIDDigest := imageSplit(status.ImageID)
+		_, _, statusDigest := imageSplit(status.ImageID)
 		if len(specDigest) != 0 {
-			if specDigest != statusImageIDDigest {
+			if specDigest != statusDigest {
 				return false
 			}
 			continue
 		}
-		statusName, statusTag, _ := imageSplit(statusImage)
+		statusName, statusTag, _ := imageSplit(status.Image)
 		// if tag presents in spec, it must be same in status
 		if len(specTag) != 0 && specTag != statusTag {
 			return false

--- a/pkg/controller/instanceset/instance_util.go
+++ b/pkg/controller/instanceset/instance_util.go
@@ -188,7 +188,9 @@ func isImageMatched(pod *corev1.Pod) bool {
 		specName, specTag, specDigest := imageSplit(specImage)
 		statusName, statusTag, statusDigest := imageSplit(statusImage)
 		_, _, statusImageIDDigest := imageSplit(status.ImageID)
-		// if digest presents in spec, it must be same in status
+		// If the spec is digest-pinned, accept the pulled digest from either
+		// status.image or status.imageID. Do not use imageID for tag-only specs:
+		// mutable tags must still match status.image by tag.
 		if len(specDigest) != 0 && specDigest != statusDigest && specDigest != statusImageIDDigest {
 			return false
 		}

--- a/pkg/controller/instanceset/instance_util_test.go
+++ b/pkg/controller/instanceset/instance_util_test.go
@@ -932,6 +932,18 @@ var _ = Describe("instance util test", func() {
 			}}
 			Expect(isImageMatched(pod)).Should(BeTrue())
 
+			By("spec: mutable tag, status image: different tag, status imageID: digest")
+			pod.Spec.Containers = []corev1.Container{{
+				Name:  name,
+				Image: "docker.io/nginx:1.0.0",
+			}}
+			pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+				Name:    name,
+				Image:   "docker.io/nginx:latest",
+				ImageID: "docker.io/nginx@sha256:0f37a86c04f8",
+			}}
+			Expect(isImageMatched(pod)).Should(BeFalse())
+
 			By("digest not matches")
 			pod.Spec.Containers = []corev1.Container{{
 				Name:  name,

--- a/pkg/controller/instanceset/instance_util_test.go
+++ b/pkg/controller/instanceset/instance_util_test.go
@@ -920,6 +920,18 @@ var _ = Describe("instance util test", func() {
 			}}
 			Expect(isImageMatched(pod)).Should(BeTrue())
 
+			By("spec: digest, status image: tag, status imageID: digest")
+			pod.Spec.Containers = []corev1.Container{{
+				Name:  name,
+				Image: "docker.io/nginx@sha256:0f37a86c04f8",
+			}}
+			pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+				Name:    name,
+				Image:   "docker.io/nginx:latest",
+				ImageID: "docker.io/nginx@sha256:0f37a86c04f8",
+			}}
+			Expect(isImageMatched(pod)).Should(BeTrue())
+
 			By("digest not matches")
 			pod.Spec.Containers = []corev1.Container{{
 				Name:  name,

--- a/pkg/controller/instanceset/instance_util_test.go
+++ b/pkg/controller/instanceset/instance_util_test.go
@@ -932,6 +932,22 @@ var _ = Describe("instance util test", func() {
 			}}
 			Expect(isImageMatched(pod)).Should(BeTrue())
 
+			By("spec: digest, status image: local image ID, status imageID: digest")
+			pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+				Name:    name,
+				Image:   "sha256:runtime-local-image-id",
+				ImageID: "docker.io/nginx@sha256:0f37a86c04f8",
+			}}
+			Expect(isImageMatched(pod)).Should(BeTrue())
+
+			By("spec: digest, status image: matching digest, status imageID: different digest")
+			pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+				Name:    name,
+				Image:   "docker.io/nginx@sha256:0f37a86c04f8",
+				ImageID: "docker.io/nginx@sha256:different",
+			}}
+			Expect(isImageMatched(pod)).Should(BeFalse())
+
 			By("spec: mutable tag, status image: different tag, status imageID: digest")
 			pod.Spec.Containers = []corev1.Container{{
 				Name:  name,
@@ -949,12 +965,22 @@ var _ = Describe("instance util test", func() {
 				Name:  name,
 				Image: "nginx:latest@xxxxxxxxx",
 			}}
+			pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+				Name:    name,
+				Image:   "nginx:latest@xxxxxxxxx",
+				ImageID: "docker.io/nginx@sha256:0f37a86c04f8",
+			}}
 			Expect(isImageMatched(pod)).Should(BeFalse())
 
-			By("tag not matches")
+			By("tag not matches for tag-only spec")
 			pod.Spec.Containers = []corev1.Container{{
 				Name:  name,
-				Image: "nginx:xxxx@0f37a86c04f8",
+				Image: "nginx:xxxx",
+			}}
+			pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+				Name:    name,
+				Image:   "docker.io/nginx:latest",
+				ImageID: "docker.io/nginx@sha256:0f37a86c04f8",
 			}}
 			Expect(isImageMatched(pod)).Should(BeFalse())
 


### PR DESCRIPTION
## Summary

Fix InstanceSet image matching for digest-pinned Pod specs by comparing the PodSpec digest with the digest from `status.containerStatuses[].imageID`.

## Necessity evidence

In the SQL Server 2025 `mssqlsoak25d` retained scene, the key containers had this shape:

- Pod spec image: `repo/mssql@sha256:...`
- `status.containerStatuses[].image`: `repo/mssql:2025-latest`
- `status.containerStatuses[].imageID`: `repo/mssql@sha256:...`
- container Ready: `true`

InstanceSet only increments `readyReplicas` when `isImageMatched(pod) && PodReady`. With digest-pinned specs, comparing only `status.image` can therefore treat a Ready Pod as image-mismatched and keep `readyReplicas` / `availableReplicas` at 0.

## Fix

When the spec image has a digest, compare that digest only with the digest parsed from `status.imageID`.

`status.image` is intentionally ignored in the digest-pinned branch because runtimes may report it as a tag or as a local image ID such as `sha256:...`. The digest already identifies the image content, so matching it through `status.imageID` is the stable contract.

When the spec image has no digest, the existing mutable tag behavior is unchanged: name and tag are still matched through `status.image`, and `status.imageID` is not used to accept a tag mismatch.

## Safety boundary

- Digest-pinned specs: use spec digest vs. `status.imageID` digest only.
- Tag-only specs: keep comparing against `status.image` by name/tag.
- No API, CRD, or reconcile flow change beyond InstanceSet image-match judgment.

## Verification

- `go test ./pkg/controller/instanceset -count=1`
- `git diff --check`

Added/updated test coverage:

- digest-pinned spec passes when `status.image` is a tag and `status.imageID` has the matching digest
- digest-pinned spec passes when `status.image` is a local runtime image ID and `status.imageID` has the matching digest
- digest-pinned spec fails when `status.image` has the matching digest but `status.imageID` has a different digest
- mutable tag spec still fails when `status.image` has a different tag, even if `status.imageID` has a digest

## Contributor note

Ava provided the SQL Server retained-scene evidence, implementation context, and review-follow-up context. Commit metadata uses Wei Cao <cyg.cao@gmail.com>.
