### PR TITLE
docs: replace Slack invite with Discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ KubeCon 2024 in HongKong from 21-23 August 2024: [KuaiShou's 100% Resource Utili
 
 If you have any questions, you can reach out to us through:
 
-- KubeBlocks [Slack Channel](https://join.slack.com/t/kubeblockshq/shared_invite/zt-3u7x3hvky-sNWWCp3ljL8oBNzoaxBEmw)
+- KubeBlocks [Discord Channel](https://discord.gg/UKHQEhxaTd)
 - KubeBlocks GitHub [Discussions](https://github.com/apecloud/kubeblocks/discussions)
 - KubeBlocks Wechat Account:
 


### PR DESCRIPTION
## Background

Per request, this PR replaces the Slack invite in the `apecloud/kubeblocks` README with the Discord invite: <https://discord.gg/UKHQEhxaTd>.

## Changes

- Change the Community contact link in `README.md` from `Slack Channel` to `Discord Channel`.
- Replace the Slack invite URL with <https://discord.gg/UKHQEhxaTd>.

## Validation

- `rg -n "join\.slack|kubeblockshq|shared_invite|Slack Channel|Slack Community|Join KubeBlocks on Slack|KubeBlocks Slack|slack channel" .` has no matches.
- `git diff --check` passes.
