### PR TITLE
fix(dataprotection): expose StorageClass NotFound on ClusterRestore status

### DIFF
--- a/controllers/dataprotection/clusterrestore_controller.go
+++ b/controllers/dataprotection/clusterrestore_controller.go
@@ -23,6 +23,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -53,6 +55,26 @@ const (
 	backupDataSourceRestoreLabelCluster   = "dataprotection.kubeblocks.io/target-cluster"
 	backupDataSourceRestoreLabelComponent = "dataprotection.kubeblocks.io/target-component"
 	backupDataSourceRestoreLabelBackup    = "dataprotection.kubeblocks.io/source-backup"
+
+	// reasonWaitingForStorageClass marks the ClusterRestore.status Ready
+	// condition while a referenced StorageClass is missing from the API
+	// surface and the controller is bounded-retrying for it to appear.
+	reasonWaitingForStorageClass = "WaitingForStorageClass"
+	// reasonStorageClassMissing marks the ClusterRestore.status Ready condition
+	// after the bounded retry window elapses without the StorageClass becoming
+	// visible. The phase is escalated to Failed alongside this reason.
+	reasonStorageClassMissing = "StorageClassMissing"
+
+	// storageClassWaitTimeout is the bounded window during which a missing
+	// StorageClass keeps ClusterRestore in Restoring/WaitingForStorageClass.
+	// After this elapses the condition is escalated to Failed/StorageClassMissing.
+	// Chosen to give 2-3x typical fresh-vcluster sync settling time (~1-2min)
+	// before declaring the StorageClass actually absent.
+	storageClassWaitTimeout = 5 * time.Minute
+	// storageClassRequeueAfter is the requeue cadence while waiting; gives the
+	// caller a predictable, log-visible retry beat instead of relying on the
+	// controller-runtime exponential default.
+	storageClassRequeueAfter = 30 * time.Second
 )
 
 // ClusterRestoreReconciler reconciles ClusterRestore orchestration sessions.
@@ -244,6 +266,9 @@ func (r *ClusterRestoreReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				return intctrlutil.RequeueWithError(err, reqCtx.Log, "")
 			}
 			if err = r.volumePopulator().Populate(reqCtx, item.pvc, restoreMgr); err != nil {
+				if scErr, ok := dprestore.IsStorageClassNotFoundError(err); ok {
+					return r.handleStorageClassNotFound(reqCtx, clusterRestore, scErr, targetRef, item.pvc)
+				}
 				if intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal) {
 					_ = r.patchClusterRestoreStatus(reqCtx, clusterRestore, dpv1alpha1.ClusterRestorePhaseFailed, metav1.ConditionFalse, "Failed", err.Error(), targetRef)
 					r.Recorder.Event(clusterRestore, corev1.EventTypeWarning, dprestore.ReasonRestoreFailed, err.Error())
@@ -1158,6 +1183,107 @@ func (r *ClusterRestoreReconciler) patchClusterRestoreStatus(reqCtx intctrlutil.
 		LastTransitionTime: metav1.Now(),
 	})
 	return r.Client.Status().Patch(reqCtx.Ctx, latest, patch)
+}
+
+// patchClusterRestoreReadyConditionAt is a variant of patchClusterRestoreStatus
+// that lets callers supply an explicit LastTransitionTime for the Ready
+// condition. It is used by the WaitingForStorageClass branch so the original
+// wait-start time survives across reconciles, regardless of whether the
+// condition.Status changes between calls. (meta.SetStatusCondition only
+// preserves LastTransitionTime when Status is unchanged, which is the wrong
+// semantics for tracking a bounded wait window keyed by Reason.)
+func (r *ClusterRestoreReconciler) patchClusterRestoreReadyConditionAt(reqCtx intctrlutil.RequestCtx, clusterRestore *dpv1alpha1.ClusterRestore, phase dpv1alpha1.ClusterRestorePhase, status metav1.ConditionStatus, reason, message string, targetRef *dpv1alpha1.ClusterRestoreTargetClusterRef, transitionTime metav1.Time) error {
+	latest := &dpv1alpha1.ClusterRestore{}
+	if err := r.Client.Get(reqCtx.Ctx, client.ObjectKeyFromObject(clusterRestore), latest); err != nil {
+		return err
+	}
+	patch := client.MergeFrom(latest.DeepCopy())
+	latest.Status.Phase = phase
+	latest.Status.ObservedGeneration = latest.Generation
+	if targetRef != nil {
+		latest.Status.TargetClusterRef = targetRef
+	}
+	cond := metav1.Condition{
+		Type:               dpv1alpha1.ClusterRestoreReadyCondition,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: latest.Generation,
+		LastTransitionTime: transitionTime,
+	}
+	replaced := false
+	for i := range latest.Status.Conditions {
+		if latest.Status.Conditions[i].Type == cond.Type {
+			latest.Status.Conditions[i] = cond
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		latest.Status.Conditions = append(latest.Status.Conditions, cond)
+	}
+	return r.Client.Status().Patch(reqCtx.Ctx, latest, patch)
+}
+
+// handleStorageClassNotFound translates a *dprestore.StorageClassNotFoundError
+// returned by VolumePopulator.Populate into a user-facing condition on
+// ClusterRestore.status. While within storageClassWaitTimeout, the condition
+// is set to Restoring/WaitingForStorageClass with a stable LastTransitionTime
+// (the wait-start), and the Reconcile is requeued after storageClassRequeueAfter.
+// Once elapsed time crosses the bound, the phase is escalated to Failed with
+// reason StorageClassMissing and a Warning event.
+func (r *ClusterRestoreReconciler) handleStorageClassNotFound(reqCtx intctrlutil.RequestCtx, clusterRestore *dpv1alpha1.ClusterRestore, scErr *dprestore.StorageClassNotFoundError, targetRef *dpv1alpha1.ClusterRestoreTargetClusterRef, pvc *corev1.PersistentVolumeClaim) (ctrl.Result, error) {
+	now := metav1.Now()
+	waitingMsg := storageClassWaitingMessage(clusterRestore, scErr.Name, pvc)
+	waitStart := now
+	if existing := meta.FindStatusCondition(clusterRestore.Status.Conditions, dpv1alpha1.ClusterRestoreReadyCondition); isSameStorageClassWait(existing, clusterRestore, scErr.Name) {
+		if !existing.LastTransitionTime.IsZero() {
+			waitStart = existing.LastTransitionTime
+		}
+	}
+	elapsed := now.Sub(waitStart.Time)
+
+	if elapsed >= storageClassWaitTimeout {
+		failedMsg := fmt.Sprintf(
+			"StorageClass %q not found after %s; please create the StorageClass and re-apply ClusterRestore %s/%s",
+			scErr.Name, storageClassWaitTimeout, clusterRestore.Namespace, clusterRestore.Name,
+		)
+		if err := r.patchClusterRestoreStatus(reqCtx, clusterRestore,
+			dpv1alpha1.ClusterRestorePhaseFailed, metav1.ConditionFalse,
+			reasonStorageClassMissing, failedMsg, targetRef); err != nil {
+			return intctrlutil.RequeueWithError(err, reqCtx.Log, "")
+		}
+		r.Recorder.Event(clusterRestore, corev1.EventTypeWarning, dprestore.ReasonRestoreFailed, failedMsg)
+		return intctrlutil.Reconciled()
+	}
+
+	if err := r.patchClusterRestoreReadyConditionAt(reqCtx, clusterRestore,
+		dpv1alpha1.ClusterRestorePhaseRestoring, metav1.ConditionFalse,
+		reasonWaitingForStorageClass, waitingMsg, targetRef, waitStart); err != nil {
+		return intctrlutil.RequeueWithError(err, reqCtx.Log, "")
+	}
+	return ctrl.Result{RequeueAfter: storageClassRequeueAfter}, nil
+}
+
+func isSameStorageClassWait(cond *metav1.Condition, clusterRestore *dpv1alpha1.ClusterRestore, storageClassName string) bool {
+	return cond != nil &&
+		cond.Reason == reasonWaitingForStorageClass &&
+		strings.HasPrefix(cond.Message, storageClassWaitingPrefix(clusterRestore, storageClassName))
+}
+
+func storageClassWaitingPrefix(clusterRestore *dpv1alpha1.ClusterRestore, storageClassName string) string {
+	return fmt.Sprintf("StorageClass %q not found for ClusterRestore %s/%s", storageClassName, clusterRestore.Namespace, clusterRestore.Name)
+}
+
+func storageClassWaitingMessage(clusterRestore *dpv1alpha1.ClusterRestore, storageClassName string, pvc *corev1.PersistentVolumeClaim) string {
+	pvcRef := ""
+	if pvc != nil {
+		pvcRef = fmt.Sprintf(" (target PVC %s/%s)", pvc.Namespace, pvc.Name)
+	}
+	return fmt.Sprintf(
+		"%s%s; waiting for sync (timeout %s); to fix: pre-create or sync the StorageClass into the cluster",
+		storageClassWaitingPrefix(clusterRestore, storageClassName), pvcRef, storageClassWaitTimeout,
+	)
 }
 
 func clusterRestoreTargetRef(cluster *appsv1.Cluster) *dpv1alpha1.ClusterRestoreTargetClusterRef {

--- a/controllers/dataprotection/clusterrestore_controller_test.go
+++ b/controllers/dataprotection/clusterrestore_controller_test.go
@@ -22,9 +22,12 @@ package dataprotection
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -267,6 +270,541 @@ func TestClusterRestoreBuildsTargetClusterFromTemplate(t *testing.T) {
 	if vct.Annotations[dptypes.SourceTargetNameAnnotationKey] != "mysql" ||
 		vct.Annotations[dptypes.VolumeSourceAnnotationKey] != "data" {
 		t.Fatalf("unexpected restore annotations: %#v", vct.Annotations)
+	}
+}
+
+func TestVolumePopulatorWaitForPVCSelectedNodeReturnsStorageClassSentinel(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := storagev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+		Scheme: scheme,
+	}
+	storageClassName := "missing-sc"
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "restore-pvc", Namespace: "default"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &storageClassName,
+		},
+	}
+
+	wait, nodeName, err := reconciler.waitForPVCSelectedNode(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc)
+
+	if wait {
+		t.Fatal("expected missing StorageClass to stop waiting and return an error")
+	}
+	if nodeName != "" {
+		t.Fatalf("nodeName = %q, want empty", nodeName)
+	}
+	scErr, ok := dprestore.IsStorageClassNotFoundError(err)
+	if !ok || scErr == nil {
+		t.Fatalf("expected StorageClassNotFoundError, got %T: %v", err, err)
+	}
+	if scErr.Name != storageClassName {
+		t.Fatalf("StorageClassNotFoundError.Name = %q, want %q", scErr.Name, storageClassName)
+	}
+}
+
+func TestVolumePopulatorWaitForPVCSelectedNodePropagatesOtherStorageClassGetErrors(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := storagev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	rawErr := apierrors.NewForbidden(schema.GroupResource{Group: storagev1.GroupName, Resource: "storageclasses"}, "blocked-sc", nil)
+	reconciler := &VolumePopulatorReconciler{
+		Client: storageClassGetErrorClient{
+			Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+			err:    rawErr,
+		},
+		Scheme: scheme,
+	}
+	storageClassName := "blocked-sc"
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "restore-pvc", Namespace: "default"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &storageClassName,
+		},
+	}
+
+	wait, nodeName, err := reconciler.waitForPVCSelectedNode(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc)
+
+	if wait {
+		t.Fatal("expected raw StorageClass GET error to stop waiting and return the error")
+	}
+	if nodeName != "" {
+		t.Fatalf("nodeName = %q, want empty", nodeName)
+	}
+	if err != rawErr {
+		t.Fatalf("err = %v, want raw error %v", err, rawErr)
+	}
+	if scErr, ok := dprestore.IsStorageClassNotFoundError(err); ok || scErr != nil {
+		t.Fatalf("raw GET error must not match StorageClassNotFoundError, got (%v, %v)", scErr, ok)
+	}
+}
+
+type storageClassGetErrorClient struct {
+	client.Client
+	err error
+}
+
+func (c storageClassGetErrorClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if _, ok := obj.(*storagev1.StorageClass); ok {
+		return c.err
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func TestClusterRestoreHandlesStorageClassNotFoundWithinBoundedWindow(t *testing.T) {
+	scheme := newClusterRestoreUnitScheme(t)
+	clusterRestore := newStorageClassTestClusterRestore()
+	targetRef := &dpv1alpha1.ClusterRestoreTargetClusterRef{
+		Name:      "target-cluster",
+		Namespace: "default",
+		UID:       types.UID("target-cluster-uid"),
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&dpv1alpha1.ClusterRestore{}).
+		WithObjects(clusterRestore).
+		Build()
+	reconciler := &ClusterRestoreReconciler{
+		Client:   cli,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(8),
+	}
+	pvc := newStorageClassTestPVC()
+
+	result, err := reconciler.handleStorageClassNotFound(
+		intctrlutil.RequestCtx{Ctx: context.Background()},
+		clusterRestore,
+		&dprestore.StorageClassNotFoundError{Name: "missing-sc"},
+		targetRef,
+		pvc,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.RequeueAfter != storageClassRequeueAfter {
+		t.Fatalf("RequeueAfter = %s, want %s", result.RequeueAfter, storageClassRequeueAfter)
+	}
+
+	latest := &dpv1alpha1.ClusterRestore{}
+	if err = cli.Get(context.Background(), client.ObjectKeyFromObject(clusterRestore), latest); err != nil {
+		t.Fatal(err)
+	}
+	if latest.Status.Phase != dpv1alpha1.ClusterRestorePhaseRestoring {
+		t.Fatalf("phase = %q, want %q", latest.Status.Phase, dpv1alpha1.ClusterRestorePhaseRestoring)
+	}
+	if latest.Status.TargetClusterRef == nil || latest.Status.TargetClusterRef.Name != targetRef.Name {
+		t.Fatalf("target ref not preserved: %#v", latest.Status.TargetClusterRef)
+	}
+	cond := meta.FindStatusCondition(latest.Status.Conditions, dpv1alpha1.ClusterRestoreReadyCondition)
+	if cond == nil {
+		t.Fatalf("Ready condition missing: %#v", latest.Status.Conditions)
+	}
+	if other := meta.FindStatusCondition(latest.Status.Conditions, "OtherControllerCondition"); other == nil || other.Reason != "KeepMe" {
+		t.Fatalf("expected unrelated conditions to be preserved, got %#v", latest.Status.Conditions)
+	}
+	if cond.Status != metav1.ConditionFalse ||
+		cond.Reason != reasonWaitingForStorageClass ||
+		cond.ObservedGeneration != latest.Generation {
+		t.Fatalf("unexpected Ready condition: %#v", cond)
+	}
+	if cond.LastTransitionTime.IsZero() {
+		t.Fatalf("expected LastTransitionTime to mark wait start: %#v", cond)
+	}
+	assertContainsAll(t, cond.Message,
+		`StorageClass "missing-sc" not found`,
+		"ClusterRestore default/restore-session",
+		"target PVC default/data-target-cluster-mysql-0",
+		"pre-create or sync the StorageClass",
+	)
+}
+
+func TestClusterRestoreKeepsStorageClassWaitStartAcrossRetries(t *testing.T) {
+	scheme := newClusterRestoreUnitScheme(t)
+	waitStart := metav1.NewTime(time.Now().Add(-2 * time.Minute).Truncate(time.Second))
+	clusterRestore := newStorageClassTestClusterRestore()
+	pvc := newStorageClassTestPVC()
+	clusterRestore.Status.Conditions = []metav1.Condition{{
+		Type:               dpv1alpha1.ClusterRestoreReadyCondition,
+		Status:             metav1.ConditionFalse,
+		Reason:             reasonWaitingForStorageClass,
+		Message:            storageClassWaitingMessage(clusterRestore, "missing-sc", pvc),
+		ObservedGeneration: clusterRestore.Generation,
+		LastTransitionTime: waitStart,
+	}, {
+		Type:               "OtherControllerCondition",
+		Status:             metav1.ConditionTrue,
+		Reason:             "KeepMe",
+		Message:            "owned by another status writer",
+		ObservedGeneration: 1,
+		LastTransitionTime: metav1.NewTime(time.Now().Add(-time.Minute).Truncate(time.Second)),
+	}}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&dpv1alpha1.ClusterRestore{}).
+		WithObjects(clusterRestore).
+		Build()
+	reconciler := &ClusterRestoreReconciler{
+		Client:   cli,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(8),
+	}
+
+	result, err := reconciler.handleStorageClassNotFound(
+		intctrlutil.RequestCtx{Ctx: context.Background()},
+		clusterRestore,
+		&dprestore.StorageClassNotFoundError{Name: "missing-sc"},
+		clusterRestoreTargetRef(&appsv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "target-cluster", Namespace: "default", UID: types.UID("target-cluster-uid")}}),
+		pvc,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.RequeueAfter != storageClassRequeueAfter {
+		t.Fatalf("RequeueAfter = %s, want %s", result.RequeueAfter, storageClassRequeueAfter)
+	}
+
+	latest := &dpv1alpha1.ClusterRestore{}
+	if err = cli.Get(context.Background(), client.ObjectKeyFromObject(clusterRestore), latest); err != nil {
+		t.Fatal(err)
+	}
+	cond := meta.FindStatusCondition(latest.Status.Conditions, dpv1alpha1.ClusterRestoreReadyCondition)
+	if cond == nil {
+		t.Fatalf("Ready condition missing: %#v", latest.Status.Conditions)
+	}
+	if !cond.LastTransitionTime.Time.Equal(waitStart.Time) {
+		t.Fatalf("LastTransitionTime = %s, want original wait start %s", cond.LastTransitionTime.Time, waitStart.Time)
+	}
+	if cond.Reason != reasonWaitingForStorageClass {
+		t.Fatalf("Reason = %q, want %q", cond.Reason, reasonWaitingForStorageClass)
+	}
+	if other := meta.FindStatusCondition(latest.Status.Conditions, "OtherControllerCondition"); other == nil || other.Reason != "KeepMe" {
+		t.Fatalf("expected unrelated conditions to be preserved, got %#v", latest.Status.Conditions)
+	}
+}
+
+func TestClusterRestoreResetsStorageClassWaitStartForDifferentMissingStorageClass(t *testing.T) {
+	scheme := newClusterRestoreUnitScheme(t)
+	previousWaitStart := metav1.NewTime(time.Now().Add(-storageClassWaitTimeout - time.Minute).Truncate(time.Second))
+	clusterRestore := newStorageClassTestClusterRestore()
+	previousPVC := newStorageClassTestPVC()
+	clusterRestore.Status.Conditions = []metav1.Condition{{
+		Type:               dpv1alpha1.ClusterRestoreReadyCondition,
+		Status:             metav1.ConditionFalse,
+		Reason:             reasonWaitingForStorageClass,
+		Message:            storageClassWaitingMessage(clusterRestore, "old-missing-sc", previousPVC),
+		ObservedGeneration: clusterRestore.Generation,
+		LastTransitionTime: previousWaitStart,
+	}}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&dpv1alpha1.ClusterRestore{}).
+		WithObjects(clusterRestore).
+		Build()
+	reconciler := &ClusterRestoreReconciler{
+		Client:   cli,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(8),
+	}
+
+	result, err := reconciler.handleStorageClassNotFound(
+		intctrlutil.RequestCtx{Ctx: context.Background()},
+		clusterRestore,
+		&dprestore.StorageClassNotFoundError{Name: "new-missing-sc"},
+		clusterRestoreTargetRef(&appsv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "target-cluster", Namespace: "default", UID: types.UID("target-cluster-uid")}}),
+		previousPVC,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.RequeueAfter != storageClassRequeueAfter {
+		t.Fatalf("RequeueAfter = %s, want %s", result.RequeueAfter, storageClassRequeueAfter)
+	}
+
+	latest := &dpv1alpha1.ClusterRestore{}
+	if err = cli.Get(context.Background(), client.ObjectKeyFromObject(clusterRestore), latest); err != nil {
+		t.Fatal(err)
+	}
+	cond := meta.FindStatusCondition(latest.Status.Conditions, dpv1alpha1.ClusterRestoreReadyCondition)
+	if cond == nil {
+		t.Fatalf("Ready condition missing: %#v", latest.Status.Conditions)
+	}
+	if cond.Reason != reasonWaitingForStorageClass {
+		t.Fatalf("Reason = %q, want %q", cond.Reason, reasonWaitingForStorageClass)
+	}
+	if !cond.LastTransitionTime.After(previousWaitStart.Time) {
+		t.Fatalf("LastTransitionTime = %s, should reset after previous wait start %s", cond.LastTransitionTime.Time, previousWaitStart.Time)
+	}
+	assertContainsAll(t, cond.Message, `StorageClass "new-missing-sc" not found`)
+}
+
+func TestClusterRestoreKeepsStorageClassWaitStartForSameStorageClassAcrossDifferentPVCs(t *testing.T) {
+	scheme := newClusterRestoreUnitScheme(t)
+	waitStart := metav1.NewTime(time.Now().Add(-2 * time.Minute).Truncate(time.Second))
+	clusterRestore := newStorageClassTestClusterRestore()
+	previousPVC := newStorageClassTestPVC()
+	currentPVC := newStorageClassTestPVC()
+	currentPVC.Name = "data-target-cluster-mysql-1"
+	clusterRestore.Status.Conditions = []metav1.Condition{{
+		Type:               dpv1alpha1.ClusterRestoreReadyCondition,
+		Status:             metav1.ConditionFalse,
+		Reason:             reasonWaitingForStorageClass,
+		Message:            storageClassWaitingMessage(clusterRestore, "missing-sc", previousPVC),
+		ObservedGeneration: clusterRestore.Generation,
+		LastTransitionTime: waitStart,
+	}}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&dpv1alpha1.ClusterRestore{}).
+		WithObjects(clusterRestore).
+		Build()
+	reconciler := &ClusterRestoreReconciler{
+		Client:   cli,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(8),
+	}
+
+	result, err := reconciler.handleStorageClassNotFound(
+		intctrlutil.RequestCtx{Ctx: context.Background()},
+		clusterRestore,
+		&dprestore.StorageClassNotFoundError{Name: "missing-sc"},
+		clusterRestoreTargetRef(&appsv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "target-cluster", Namespace: "default", UID: types.UID("target-cluster-uid")}}),
+		currentPVC,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.RequeueAfter != storageClassRequeueAfter {
+		t.Fatalf("RequeueAfter = %s, want %s", result.RequeueAfter, storageClassRequeueAfter)
+	}
+
+	latest := &dpv1alpha1.ClusterRestore{}
+	if err = cli.Get(context.Background(), client.ObjectKeyFromObject(clusterRestore), latest); err != nil {
+		t.Fatal(err)
+	}
+	cond := meta.FindStatusCondition(latest.Status.Conditions, dpv1alpha1.ClusterRestoreReadyCondition)
+	if cond == nil {
+		t.Fatalf("Ready condition missing: %#v", latest.Status.Conditions)
+	}
+	if !cond.LastTransitionTime.Time.Equal(waitStart.Time) {
+		t.Fatalf("LastTransitionTime = %s, want original wait start %s", cond.LastTransitionTime.Time, waitStart.Time)
+	}
+	assertContainsAll(t, cond.Message,
+		`StorageClass "missing-sc" not found`,
+		"target PVC default/data-target-cluster-mysql-1",
+	)
+}
+
+func TestClusterRestoreResetsStorageClassWaitStartForDifferentClusterRestore(t *testing.T) {
+	scheme := newClusterRestoreUnitScheme(t)
+	previousWaitStart := metav1.NewTime(time.Now().Add(-storageClassWaitTimeout - time.Minute).Truncate(time.Second))
+	clusterRestore := newStorageClassTestClusterRestore()
+	otherClusterRestore := clusterRestore.DeepCopy()
+	otherClusterRestore.Name = "other-restore-session"
+	pvc := newStorageClassTestPVC()
+	clusterRestore.Status.Conditions = []metav1.Condition{{
+		Type:               dpv1alpha1.ClusterRestoreReadyCondition,
+		Status:             metav1.ConditionFalse,
+		Reason:             reasonWaitingForStorageClass,
+		Message:            storageClassWaitingMessage(otherClusterRestore, "missing-sc", pvc),
+		ObservedGeneration: clusterRestore.Generation,
+		LastTransitionTime: previousWaitStart,
+	}}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&dpv1alpha1.ClusterRestore{}).
+		WithObjects(clusterRestore).
+		Build()
+	reconciler := &ClusterRestoreReconciler{
+		Client:   cli,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(8),
+	}
+
+	result, err := reconciler.handleStorageClassNotFound(
+		intctrlutil.RequestCtx{Ctx: context.Background()},
+		clusterRestore,
+		&dprestore.StorageClassNotFoundError{Name: "missing-sc"},
+		clusterRestoreTargetRef(&appsv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "target-cluster", Namespace: "default", UID: types.UID("target-cluster-uid")}}),
+		pvc,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.RequeueAfter != storageClassRequeueAfter {
+		t.Fatalf("RequeueAfter = %s, want %s", result.RequeueAfter, storageClassRequeueAfter)
+	}
+
+	latest := &dpv1alpha1.ClusterRestore{}
+	if err = cli.Get(context.Background(), client.ObjectKeyFromObject(clusterRestore), latest); err != nil {
+		t.Fatal(err)
+	}
+	cond := meta.FindStatusCondition(latest.Status.Conditions, dpv1alpha1.ClusterRestoreReadyCondition)
+	if cond == nil {
+		t.Fatalf("Ready condition missing: %#v", latest.Status.Conditions)
+	}
+	if !cond.LastTransitionTime.After(previousWaitStart.Time) {
+		t.Fatalf("LastTransitionTime = %s, should reset after previous wait start %s", cond.LastTransitionTime.Time, previousWaitStart.Time)
+	}
+	assertContainsAll(t, cond.Message,
+		`StorageClass "missing-sc" not found`,
+		"ClusterRestore default/restore-session",
+	)
+}
+
+func TestClusterRestoreFailsStorageClassNotFoundAfterBoundedWindow(t *testing.T) {
+	scheme := newClusterRestoreUnitScheme(t)
+	waitStart := metav1.NewTime(time.Now().Add(-storageClassWaitTimeout - time.Second).Truncate(time.Second))
+	clusterRestore := newStorageClassTestClusterRestore()
+	pvc := newStorageClassTestPVC()
+	clusterRestore.Status.Conditions = []metav1.Condition{{
+		Type:               dpv1alpha1.ClusterRestoreReadyCondition,
+		Status:             metav1.ConditionFalse,
+		Reason:             reasonWaitingForStorageClass,
+		Message:            storageClassWaitingMessage(clusterRestore, "missing-sc", pvc),
+		ObservedGeneration: clusterRestore.Generation,
+		LastTransitionTime: waitStart,
+	}, {
+		Type:               "OtherControllerCondition",
+		Status:             metav1.ConditionTrue,
+		Reason:             "KeepMe",
+		Message:            "owned by another status writer",
+		ObservedGeneration: 1,
+		LastTransitionTime: metav1.NewTime(time.Now().Add(-time.Minute).Truncate(time.Second)),
+	}}
+	recorder := record.NewFakeRecorder(8)
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&dpv1alpha1.ClusterRestore{}).
+		WithObjects(clusterRestore).
+		Build()
+	reconciler := &ClusterRestoreReconciler{
+		Client:   cli,
+		Scheme:   scheme,
+		Recorder: recorder,
+	}
+
+	result, err := reconciler.handleStorageClassNotFound(
+		intctrlutil.RequestCtx{Ctx: context.Background()},
+		clusterRestore,
+		&dprestore.StorageClassNotFoundError{Name: "missing-sc"},
+		clusterRestoreTargetRef(&appsv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "target-cluster", Namespace: "default", UID: types.UID("target-cluster-uid")}}),
+		pvc,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != (ctrl.Result{}) {
+		t.Fatalf("result = %#v, want reconciled empty result", result)
+	}
+
+	latest := &dpv1alpha1.ClusterRestore{}
+	if err = cli.Get(context.Background(), client.ObjectKeyFromObject(clusterRestore), latest); err != nil {
+		t.Fatal(err)
+	}
+	if latest.Status.Phase != dpv1alpha1.ClusterRestorePhaseFailed {
+		t.Fatalf("phase = %q, want %q", latest.Status.Phase, dpv1alpha1.ClusterRestorePhaseFailed)
+	}
+	cond := meta.FindStatusCondition(latest.Status.Conditions, dpv1alpha1.ClusterRestoreReadyCondition)
+	if cond == nil {
+		t.Fatalf("Ready condition missing: %#v", latest.Status.Conditions)
+	}
+	if other := meta.FindStatusCondition(latest.Status.Conditions, "OtherControllerCondition"); other == nil || other.Reason != "KeepMe" {
+		t.Fatalf("expected unrelated conditions to be preserved, got %#v", latest.Status.Conditions)
+	}
+	if cond.Reason != reasonStorageClassMissing || cond.Status != metav1.ConditionFalse {
+		t.Fatalf("unexpected Ready condition: %#v", cond)
+	}
+	assertContainsAll(t, cond.Message,
+		`StorageClass "missing-sc" not found after 5m0s`,
+		"re-apply ClusterRestore default/restore-session",
+	)
+
+	select {
+	case event := <-recorder.Events:
+		assertContainsAll(t, event,
+			corev1.EventTypeWarning,
+			dprestore.ReasonRestoreFailed,
+			`StorageClass "missing-sc" not found after 5m0s`,
+		)
+	default:
+		t.Fatal("expected Warning event for bounded StorageClass wait timeout")
+	}
+}
+
+func newClusterRestoreUnitScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := dpv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	return scheme
+}
+
+func newStorageClassTestClusterRestore() *dpv1alpha1.ClusterRestore {
+	return &dpv1alpha1.ClusterRestore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "restore-session",
+			Namespace:  "default",
+			UID:        types.UID("restore-session-uid"),
+			Generation: 2,
+		},
+		Spec: dpv1alpha1.ClusterRestoreSpec{
+			TargetClusterName: "target-cluster",
+			BackupRef:         dpv1alpha1.ClusterRestoreBackupRef{Name: "backup", Namespace: "default"},
+		},
+		Status: dpv1alpha1.ClusterRestoreStatus{
+			Phase: dpv1alpha1.ClusterRestorePhaseRestoring,
+			Conditions: []metav1.Condition{{
+				Type:               "OtherControllerCondition",
+				Status:             metav1.ConditionTrue,
+				Reason:             "KeepMe",
+				Message:            "owned by another status writer",
+				ObservedGeneration: 1,
+				LastTransitionTime: metav1.NewTime(time.Now().Add(-time.Minute).Truncate(time.Second)),
+			}},
+		},
+	}
+}
+
+func newStorageClassTestPVC() *corev1.PersistentVolumeClaim {
+	storageClassName := "missing-sc"
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "data-target-cluster-mysql-0",
+			Namespace: "default",
+			Annotations: map[string]string{
+				dptypes.VolumeSourceAnnotationKey: "data",
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &storageClassName,
+		},
+	}
+}
+
+func assertContainsAll(t *testing.T, got string, wantSubstrings ...string) {
+	t.Helper()
+	for _, want := range wantSubstrings {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q to contain %q", got, want)
+		}
 	}
 }
 

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -309,6 +309,14 @@ func (r *VolumePopulatorReconciler) waitForPVCSelectedNode(reqCtx intctrlutil.Re
 		storageClassName := *pvc.Spec.StorageClassName
 		storageClass := &storagev1.StorageClass{}
 		if err := r.Client.Get(reqCtx.Ctx, types.NamespacedName{Name: storageClassName}, storageClass); err != nil {
+			// Distinguish NotFound so callers (notably ClusterRestoreReconciler,
+			// which invokes Populate directly for Backup-dataSource PVCs) can
+			// translate the case into a user-facing WaitingForStorageClass
+			// condition with a bounded retry window. Other GET errors keep the
+			// existing raw-error contract.
+			if apierrors.IsNotFound(err) {
+				return false, nodeName, &dprestore.StorageClassNotFoundError{Name: storageClassName}
+			}
 			return false, nodeName, err
 		}
 

--- a/pkg/dataprotection/restore/errors.go
+++ b/pkg/dataprotection/restore/errors.go
@@ -1,0 +1,57 @@
+/*
+Copyright (C) 2022-2025 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package restore
+
+import (
+	"errors"
+	"fmt"
+)
+
+// StorageClassNotFoundError signals that a referenced StorageClass cannot be
+// resolved at the time the data-protection restore path attempts to read it.
+//
+// This typed error is returned by helpers in the data-protection restore path
+// (e.g. VolumePopulator.waitForPVCSelectedNode) when a StorageClass GET fails
+// with apierrors.NotFound. Callers, for example ClusterRestoreReconciler,
+// use IsStorageClassNotFoundError to translate this case into a user-facing
+// condition (WaitingForStorageClass) with a bounded retry window before
+// escalating to Failed/StorageClassMissing. Other GET errors continue to
+// propagate as raw errors and rely on controller-runtime default retry.
+type StorageClassNotFoundError struct {
+	// Name is the StorageClass that the helper attempted to GET.
+	Name string
+}
+
+// Error implements the error interface. Format intentionally mirrors the
+// kube-apiserver NotFound message so existing log output stays human-readable.
+func (e *StorageClassNotFoundError) Error() string {
+	return fmt.Sprintf("StorageClass %q not found", e.Name)
+}
+
+// IsStorageClassNotFoundError reports whether err (or any error it wraps)
+// is a *StorageClassNotFoundError, returning the embedded sentinel so the
+// caller can read Name. Returns (nil, false) when err does not carry one.
+func IsStorageClassNotFoundError(err error) (*StorageClassNotFoundError, bool) {
+	var scErr *StorageClassNotFoundError
+	if errors.As(err, &scErr) {
+		return scErr, true
+	}
+	return nil, false
+}

--- a/pkg/dataprotection/restore/errors_test.go
+++ b/pkg/dataprotection/restore/errors_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright (C) 2022-2025 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package restore
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// Minimal red-tests pinning the *StorageClassNotFoundError contract used by
+// VolumePopulator.waitForPVCSelectedNode to signal a missing StorageClass and
+// by ClusterRestoreReconciler to translate that case into a user-facing
+// WaitingForStorageClass condition. Caller-side reconcile behaviour, bounded
+// timeout, and Warning event coverage live with the ClusterRestore tests; this
+// file only locks the sentinel surface.
+
+func TestStorageClassNotFoundError_Error(t *testing.T) {
+	err := &StorageClassNotFoundError{Name: "apelocal-hostpath-data"}
+	got := err.Error()
+	want := `StorageClass "apelocal-hostpath-data" not found`
+	if got != want {
+		t.Fatalf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestIsStorageClassNotFoundError(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		if scErr, ok := IsStorageClassNotFoundError(nil); ok || scErr != nil {
+			t.Fatalf("nil err should not match, got (%v, %v)", scErr, ok)
+		}
+	})
+
+	t.Run("plain other error", func(t *testing.T) {
+		if scErr, ok := IsStorageClassNotFoundError(errors.New("boom")); ok || scErr != nil {
+			t.Fatalf("plain error should not match, got (%v, %v)", scErr, ok)
+		}
+	})
+
+	t.Run("direct sentinel", func(t *testing.T) {
+		direct := &StorageClassNotFoundError{Name: "sc-x"}
+		scErr, ok := IsStorageClassNotFoundError(direct)
+		if !ok || scErr == nil {
+			t.Fatalf("direct sentinel should match, got (%v, %v)", scErr, ok)
+		}
+		if scErr.Name != "sc-x" {
+			t.Fatalf("scErr.Name = %q, want %q", scErr.Name, "sc-x")
+		}
+	})
+
+	t.Run("wrapped sentinel via fmt.Errorf %w", func(t *testing.T) {
+		wrapped := fmt.Errorf("populate failed: %w", &StorageClassNotFoundError{Name: "sc-y"})
+		scErr, ok := IsStorageClassNotFoundError(wrapped)
+		if !ok || scErr == nil {
+			t.Fatalf("wrapped sentinel should match via errors.As, got (%v, %v)", scErr, ok)
+		}
+		if scErr.Name != "sc-y" {
+			t.Fatalf("scErr.Name = %q, want %q", scErr.Name, "sc-y")
+		}
+	})
+}


### PR DESCRIPTION
Fixes #10206. Stacked on top of #10192 (`support/dp-restore-api-decoupling`).

## Summary

- Translate `StorageClass NotFound` from `VolumePopulator.waitForPVCSelectedNode` into a typed sentinel `*StorageClassNotFoundError` in the `pkg/dataprotection/restore` package.
- In `ClusterRestoreReconciler.Reconcile`, intercept the sentinel returned by the direct `VolumePopulator.Populate` call (used for Backup-dataSource PVCs) and translate it into a user-facing `ClusterRestore.status` condition: `Restoring / WaitingForStorageClass` within a 5-minute bounded window (requeued every 30s, with a stable `LastTransitionTime`), then `Failed / StorageClassMissing` plus a Warning event after the window.
- Other StorageClass GET errors (Forbidden, Conflict, etc.) keep the existing raw-error contract.

## Scope and boundaries

- This PR is intentionally narrow: it only changes the `ClusterRestoreReconciler` call path that invokes `VolumePopulator.Populate` directly. The standalone `VolumePopulator` reconcile path (PVC-driven via watch) is **not** changed; it keeps its current `RecorderEventAndRequeue` behaviour. Adopting the same sentinel there can happen in a separate PR.
- **No CRD schema changes**, no `dpv1alpha1` API field changes, no release-notes-level contract changes. The only externally observable additions are two new `condition.Reason` strings (`WaitingForStorageClass`, `StorageClassMissing`) on the existing `Ready` condition.
- Related but **not in this PR**: a separate `cipher: message authentication failed` failure observed on an unrelated sample is being routed independently and is **not** part of this PR's validation scope.

## Implementation

- `pkg/dataprotection/restore/errors.go` (new, 57 LoC): `*StorageClassNotFoundError{Name string}` typed sentinel + `IsStorageClassNotFoundError(err)` helper using `errors.As`.
- `controllers/dataprotection/volumepopulator_controller.go` (+8): `waitForPVCSelectedNode` wraps `apierrors.IsNotFound` from the SC GET into the sentinel; other GET errors propagate raw.
- `controllers/dataprotection/clusterrestore_controller.go` (+126): new constants `reasonWaitingForStorageClass`, `reasonStorageClassMissing`, `storageClassWaitTimeout = 5 * time.Minute`, `storageClassRequeueAfter = 30 * time.Second`. New helpers `handleStorageClassNotFound` (bounded retry then escalate) and `patchClusterRestoreReadyConditionAt` (variant of `patchClusterRestoreStatus` that lets the caller supply an explicit `LastTransitionTime`, so the wait-start survives across reconciles whose Status does not change).
- `pkg/dataprotection/restore/errors_test.go` (new, 78): sentinel surface - Error string format, IsStorageClassNotFoundError direct match, plain-error rejection, wrapped-error match via `errors.As`.
- `controllers/dataprotection/clusterrestore_controller_test.go` (+538): caller-side reconcile coverage.

## Test plan

- [x] `go build ./pkg/dataprotection/restore/ ./controllers/dataprotection/`
- [x] `go test ./pkg/dataprotection/restore -run 'Test(StorageClass|IsStorageClass)' -count=1`
- [x] `go test ./controllers/dataprotection -run 'Test(VolumePopulatorWaitForPVCSelectedNode|ClusterRestoreHandlesStorageClassNotFound|ClusterRestoreKeepsStorageClassWaitStart|ClusterRestoreKeepsStorageClassWaitStartForSameStorageClassAcrossDifferentPVCs|ClusterRestoreResetsStorageClassWaitStart|ClusterRestoreFailsStorageClassNotFound)' -count=1`
- [x] `go test ./controllers/dataprotection -run 'TestClusterRestore' -count=1` (no regressions)
- [x] `git diff --check`

Test cases cover:

- StorageClass NotFound returns a typed sentinel; Forbidden / other GET errors propagate raw.
- First NotFound reconcile writes `Restoring / WaitingForStorageClass` + `RequeueAfter=30s` with a fresh `LastTransitionTime`.
- Repeated NotFound reconciles for the same missing StorageClass target keep the original `LastTransitionTime` (so the wait-start does not slide).
- The same missing StorageClass across different target PVCs keeps `LastTransitionTime`, so multi-PVC restores do not slide the 5-minute wait window.
- A different missing StorageClass target resets `LastTransitionTime`, avoiding premature timeout across unrelated missing-SC waits.
- A different ClusterRestore does not reuse another ClusterRestore's wait-start.
- After 5 minutes elapsed, the controller escalates to `Failed / StorageClassMissing` and emits a Warning event.
- Unrelated conditions (`OtherControllerCondition`) are preserved across the wait, retry, and timeout branches.

## Manual validation plan (post-merge)

The fresh-vcluster takeover sample that triggered this issue is held for re-run against the patched binary; the validation will be reported as a `patch-version-only` result for this PR (not a Valkey product release-readiness signal).