### PR TITLE
fix(dataprotection): release restore-manager sidecar in ClusterRestore manual Populate path

### DIFF
--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -226,6 +226,22 @@ func (r *VolumePopulatorReconciler) Populate(reqCtx intctrlutil.RequestCtx, pvc 
 			return err
 		}
 
+		// 2.5. Release the `restore-manager` sidecar for any Pod whose
+		// `restore` container has terminated. The populate Pod template
+		// pairs a one-shot `restore` data-mover container with a sleep-loop
+		// `restore-manager` sidecar that exits only when a stop annotation
+		// is set on the Pod. Without this release the Pod stays in Running
+		// after `restore` finishes, the owning Job never reaches Complete,
+		// and the volume populator framework cannot rebind the populator
+		// PVC's PV. The helper only patches an annotation; it does not
+		// touch RestoreManager.Status, so it is safe to invoke from
+		// callers that build a transient RestoreManager without a
+		// persisted Restore CR. Cross-Job coordinated stop semantics, if
+		// any, remain with the caller that owns the broader reconcile.
+		if err := restoreMgr.ReleaseManagerSidecarIfRestoreTerminated(reqCtx.Ctx, jobs[0]); err != nil {
+			return err
+		}
+
 		// 3. check if jobs are finished.
 		isCompleted, _, errMsg := utils.IsJobFinished(jobs[0])
 		if !isCompleted {

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -256,6 +256,132 @@ var _ = Describe("Volume Populator Controller test", func() {
 
 			})
 
+			// These tests pin the wiring of
+			// RestoreManager.ReleaseManagerSidecarIfRestoreTerminated into
+			// VolumePopulator.Populate's step 2.5 (between CreateJobsIfNotExist
+			// and IsJobFinished). They drive Populate through the normal
+			// controller reconcile loop so a missing call site shows up as a
+			// missing annotation, not as a passing helper-level test.
+			runPopulateAndExpectAnnotation := func(
+				volumeBinding storagev1.VolumeBindingMode,
+				restoreState corev1.ContainerState,
+				preExistingAnnotation bool,
+				expectAnnotation bool,
+			) {
+				pvc := initResources(volumeBinding, false, true)
+				pvcKey := client.ObjectKeyFromObject(pvc)
+
+				if volumeBinding == storagev1.VolumeBindingWaitForFirstConsumer {
+					Eventually(testapps.CheckObj(&testCtx, pvcKey, func(g Gomega, tmpPVC *corev1.PersistentVolumeClaim) {
+						g.Expect(len(tmpPVC.Status.Conditions)).Should(Equal(0))
+					})).Should(Succeed())
+				}
+
+				By("mock pvc has selected the node")
+				Expect(testapps.ChangeObj(&testCtx, pvc, func(claim *corev1.PersistentVolumeClaim) {
+					if claim.Annotations == nil {
+						claim.Annotations = map[string]string{}
+					}
+					claim.Annotations[AnnSelectedNode] = "test-node"
+				})).Should(Succeed())
+
+				By("wait for populator job to be created")
+				populatePVCName := getPopulatePVCName(pvc.UID)
+				jobList := &batchv1.JobList{}
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.List(ctx, jobList,
+						client.MatchingLabels{dprestore.DataProtectionPopulatePVCLabelKey: populatePVCName},
+						client.InNamespace(testCtx.DefaultNamespace))).Should(Succeed())
+					g.Expect(jobList.Items).Should(HaveLen(1))
+				}).Should(Succeed())
+				job := &jobList.Items[0]
+
+				By("inject a Pod owned by the job with the desired restore container state")
+				podAnnotations := map[string]string{}
+				if preExistingAnnotation {
+					podAnnotations[dprestore.DataProtectionStopRestoreManagerAnnotationKey] = "true"
+				}
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      job.Name + "-rocco-pod",
+						Namespace: job.Namespace,
+						Labels: map[string]string{
+							"job-name": job.Name,
+						},
+						Annotations: podAnnotations,
+					},
+					Spec: corev1.PodSpec{
+						RestartPolicy: corev1.RestartPolicyNever,
+						Containers: []corev1.Container{
+							{Name: dprestore.Restore, Image: "busybox"},
+							{Name: "restore-manager", Image: "busybox"},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, pod)).Should(Succeed())
+				pod.Status.ContainerStatuses = []corev1.ContainerStatus{
+					{Name: dprestore.Restore, State: restoreState},
+					{Name: "restore-manager", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+				}
+				Expect(k8sClient.Status().Update(ctx, pod)).Should(Succeed())
+
+				By("nudge PVC to trigger another reconcile cycle")
+				Expect(testapps.ChangeObj(&testCtx, pvc, func(claim *corev1.PersistentVolumeClaim) {
+					if claim.Annotations == nil {
+						claim.Annotations = map[string]string{}
+					}
+					claim.Annotations["dataprotection.kubeblocks.io/rocco-test-nudge"] = "1"
+				})).Should(Succeed())
+
+				By("assert annotation outcome via the reconcile loop")
+				podKey := client.ObjectKeyFromObject(pod)
+				if expectAnnotation {
+					Eventually(testapps.CheckObj(&testCtx, podKey, func(g Gomega, p *corev1.Pod) {
+						g.Expect(p.Annotations).Should(HaveKeyWithValue(
+							dprestore.DataProtectionStopRestoreManagerAnnotationKey, "true"))
+					})).Should(Succeed())
+				} else {
+					Consistently(testapps.CheckObj(&testCtx, podKey, func(g Gomega, p *corev1.Pod) {
+						g.Expect(p.Annotations).ShouldNot(HaveKey(
+							dprestore.DataProtectionStopRestoreManagerAnnotationKey))
+					}), "5s", "1s").Should(Succeed())
+				}
+
+				By("clean up Pod ahead of next test")
+				Expect(k8sClient.Delete(ctx, pod)).Should(Succeed())
+			}
+
+			It("VolumePopulator.Populate wires the sidecar release when restore container Terminated Exit 0", func() {
+				runPopulateAndExpectAnnotation(
+					storagev1.VolumeBindingImmediate,
+					corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 0, Reason: "Completed"}},
+					false,
+					true,
+				)
+			})
+
+			It("VolumePopulator.Populate does not release the sidecar while restore container is still Running", func() {
+				runPopulateAndExpectAnnotation(
+					storagev1.VolumeBindingImmediate,
+					corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+					false,
+					false,
+				)
+			})
+
+			It("VolumePopulator.Populate is idempotent when the sidecar stop annotation is already present", func() {
+				// The Restore CR controller's CheckJobsDone path may have
+				// already patched this annotation; calling Populate again
+				// from the standalone watcher must not surface an error and
+				// must not flap the annotation value.
+				runPopulateAndExpectAnnotation(
+					storagev1.VolumeBindingImmediate,
+					corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 0, Reason: "Completed"}},
+					true,
+					true,
+				)
+			})
+
 		})
 	})
 })

--- a/pkg/dataprotection/restore/manager.go
+++ b/pkg/dataprotection/restore/manager.go
@@ -886,6 +886,55 @@ func (r *RestoreManager) CheckIfRestoreContainerTerminated(job *batchv1.Job) (no
 	return normalTerminated, nil
 }
 
+// ReleaseManagerSidecarIfRestoreTerminated patches the stop annotation on
+// every Pod of the given Job whose `restore` container has reached the
+// Terminated state, regardless of exit code. This lets the `restore-manager`
+// sidecar exit so the Pod can transition to Succeeded (on Exit 0) or Failed
+// (on Exit != 0); without this the Pod stays in Running forever and the
+// owning Job never reaches Complete, which blocks the K8s volume populator
+// framework from rebinding the populator PVC's PV to the user PVC.
+//
+// Pods that are still Running their `restore` container, or that have a
+// non-zero DeletionTimestamp (already terminating), are left untouched; the
+// caller revisits them on the next reconcile.
+//
+// This helper does NOT write to r.Restore.Status; the only side effect is a
+// Pod annotation Patch. It is therefore safe to call from code paths that
+// invoke VolumePopulator.Populate with an in-memory RestoreManager that does
+// not own a persisted Restore CR. Cross-Job coordinated stop semantics, when
+// required, remain the responsibility of the caller that owns the broader
+// reconcile (e.g. the Restore CR controller's CheckJobsDone path).
+func (r *RestoreManager) ReleaseManagerSidecarIfRestoreTerminated(ctx context.Context, job *batchv1.Job) error {
+	podList, err := utils.GetAssociatedPodsOfJob(ctx, r.Client, job.Namespace, job.Name)
+	if err != nil {
+		return err
+	}
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if !pod.DeletionTimestamp.IsZero() {
+			// Pod is terminating; leave Kubernetes GC to drive lifecycle.
+			continue
+		}
+		restoreTerminated := false
+		for _, cs := range pod.Status.ContainerStatuses {
+			if cs.Name != Restore {
+				continue
+			}
+			if cs.State.Terminated != nil {
+				restoreTerminated = true
+			}
+			break
+		}
+		if !restoreTerminated {
+			continue
+		}
+		if err := r.StopManagerContainer(pod); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // StopManagerContainerByJob stops the `restore manager` containers by the job.
 func (r *RestoreManager) StopManagerContainerByJob(job *batchv1.Job) error {
 	podList, err := utils.GetAssociatedPodsOfJob(context.Background(), r.Client, job.Namespace, job.Name)

--- a/pkg/dataprotection/restore/manager_test.go
+++ b/pkg/dataprotection/restore/manager_test.go
@@ -528,6 +528,173 @@ var _ = Describe("RestoreManager Test", func() {
 				})
 			})
 		})
+
+		Context("ReleaseManagerSidecarIfRestoreTerminated", func() {
+			// These tests pin the single-Job VolumePopulator contract: when the
+			// `restore` container of a populator Pod reaches Terminated, the
+			// helper patches the stop annotation so the `restore-manager`
+			// sidecar can exit. The helper must NOT touch Restore.Status, so
+			// it is safe for callers that build a transient RestoreManager
+			// without a persisted Restore CR (e.g. ClusterRestoreReconciler's
+			// manual VolumePopulator.Populate invocation). Cross-Job
+			// coordinated stop semantics remain with the Restore CR
+			// controller's CheckJobsDone path and are exercised separately.
+			var (
+				restoreMGR *RestoreManager
+				job        *batchv1.Job
+			)
+
+			newPopulatePod := func(name string, restoreState corev1.ContainerState) *corev1.Pod {
+				return &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: testCtx.DefaultNamespace,
+						Labels: map[string]string{
+							"job-name": job.Name,
+						},
+					},
+					Spec: corev1.PodSpec{
+						RestartPolicy: corev1.RestartPolicyNever,
+						Containers: []corev1.Container{
+							{Name: Restore, Image: "busybox"},
+							{Name: "restore-manager", Image: "busybox"},
+						},
+					},
+				}
+			}
+
+			applyPodStatus := func(pod *corev1.Pod, restoreState corev1.ContainerState) {
+				pod.Status.ContainerStatuses = []corev1.ContainerStatus{
+					{Name: Restore, State: restoreState},
+					{Name: "restore-manager", State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+				}
+			}
+
+			BeforeEach(func() {
+				restoreMGR = NewRestoreManager(&dpv1alpha1.Restore{
+					ObjectMeta: metav1.ObjectMeta{Namespace: testCtx.DefaultNamespace, Name: "rocco-rm-test"},
+				}, recorder, k8sClient.Scheme(), k8sClient)
+				job = &batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testCtx.DefaultNamespace,
+						Name:      "rocco-rm-test-job",
+					},
+					Spec: batchv1.JobSpec{
+						Template: corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								RestartPolicy: corev1.RestartPolicyNever,
+								Containers:    []corev1.Container{{Name: Restore, Image: "busybox"}},
+							},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, job)).Should(Succeed())
+			})
+
+			It("patches stop annotation when restore container Terminated Exit 0", func() {
+				pod := newPopulatePod("rocco-rm-pod-exit0", corev1.ContainerState{})
+				Expect(k8sClient.Create(ctx, pod)).Should(Succeed())
+				applyPodStatus(pod, corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{ExitCode: 0, Reason: "Completed"},
+				})
+				Expect(k8sClient.Status().Update(ctx, pod)).Should(Succeed())
+
+				Expect(restoreMGR.ReleaseManagerSidecarIfRestoreTerminated(ctx, job)).Should(Succeed())
+
+				latest := &corev1.Pod{}
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), latest)).Should(Succeed())
+				Expect(latest.Annotations).Should(HaveKeyWithValue(
+					DataProtectionStopRestoreManagerAnnotationKey, "true"))
+			})
+
+			It("patches stop annotation when restore container Terminated Exit non-zero", func() {
+				pod := newPopulatePod("rocco-rm-pod-exit1", corev1.ContainerState{})
+				Expect(k8sClient.Create(ctx, pod)).Should(Succeed())
+				applyPodStatus(pod, corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, Reason: "Error"},
+				})
+				Expect(k8sClient.Status().Update(ctx, pod)).Should(Succeed())
+
+				Expect(restoreMGR.ReleaseManagerSidecarIfRestoreTerminated(ctx, job)).Should(Succeed())
+
+				latest := &corev1.Pod{}
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), latest)).Should(Succeed())
+				// Non-zero exit must still release the sidecar so the Job can
+				// transition to Failed via its own BackoffLimit / completion
+				// state — leaving the sidecar Running on a failed restore
+				// stalls the Job same way as a successful one.
+				Expect(latest.Annotations).Should(HaveKeyWithValue(
+					DataProtectionStopRestoreManagerAnnotationKey, "true"))
+			})
+
+			It("leaves Pod untouched when restore container is still Running", func() {
+				pod := newPopulatePod("rocco-rm-pod-running", corev1.ContainerState{})
+				Expect(k8sClient.Create(ctx, pod)).Should(Succeed())
+				applyPodStatus(pod, corev1.ContainerState{Running: &corev1.ContainerStateRunning{}})
+				Expect(k8sClient.Status().Update(ctx, pod)).Should(Succeed())
+
+				Expect(restoreMGR.ReleaseManagerSidecarIfRestoreTerminated(ctx, job)).Should(Succeed())
+
+				latest := &corev1.Pod{}
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), latest)).Should(Succeed())
+				Expect(latest.Annotations).ShouldNot(HaveKey(
+					DataProtectionStopRestoreManagerAnnotationKey))
+			})
+
+			It("skips Pods that are already terminating", func() {
+				pod := newPopulatePod("rocco-rm-pod-terminating", corev1.ContainerState{})
+				pod.Finalizers = []string{"dataprotection.kubeblocks.io/test-finalizer"}
+				Expect(k8sClient.Create(ctx, pod)).Should(Succeed())
+				applyPodStatus(pod, corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{ExitCode: 0, Reason: "Completed"},
+				})
+				Expect(k8sClient.Status().Update(ctx, pod)).Should(Succeed())
+				// Delete to set DeletionTimestamp; the finalizer keeps the
+				// Pod visible to the helper's List call so we can assert the
+				// terminating branch is actually exercised.
+				Expect(k8sClient.Delete(ctx, pod)).Should(Succeed())
+				latest := &corev1.Pod{}
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), latest)).Should(Succeed())
+					g.Expect(latest.DeletionTimestamp.IsZero()).Should(BeFalse())
+				}).Should(Succeed())
+
+				Expect(restoreMGR.ReleaseManagerSidecarIfRestoreTerminated(ctx, job)).Should(Succeed())
+
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), latest)).Should(Succeed())
+				Expect(latest.Annotations).ShouldNot(HaveKey(
+					DataProtectionStopRestoreManagerAnnotationKey))
+
+				// Clean up the finalizer so the Pod can be removed.
+				Expect(testapps.ChangeObj(&testCtx, latest, func(p *corev1.Pod) {
+					p.Finalizers = nil
+				})).Should(Succeed())
+			})
+
+			It("is a no-op when the Job has no associated Pods", func() {
+				Expect(restoreMGR.ReleaseManagerSidecarIfRestoreTerminated(ctx, job)).Should(Succeed())
+			})
+
+			It("is idempotent for already-stopped sidecars (regression for Restore CR path)", func() {
+				pod := newPopulatePod("rocco-rm-pod-already", corev1.ContainerState{})
+				pod.Annotations = map[string]string{
+					DataProtectionStopRestoreManagerAnnotationKey: "true",
+				}
+				Expect(k8sClient.Create(ctx, pod)).Should(Succeed())
+				applyPodStatus(pod, corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{ExitCode: 0, Reason: "Completed"},
+				})
+				Expect(k8sClient.Status().Update(ctx, pod)).Should(Succeed())
+				before := &corev1.Pod{}
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), before)).Should(Succeed())
+
+				Expect(restoreMGR.ReleaseManagerSidecarIfRestoreTerminated(ctx, job)).Should(Succeed())
+
+				after := &corev1.Pod{}
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), after)).Should(Succeed())
+				Expect(after.ResourceVersion).Should(Equal(before.ResourceVersion))
+			})
+		})
 	})
 
 })


### PR DESCRIPTION
Fixes #10208. Stacks on top of #10192 (`support/dp-restore-api-decoupling`).

## Summary

`ClusterRestoreReconciler` (introduced by #10192) drives `VolumePopulator.Populate` directly for Backup-dataSource PVCs without owning a persisted `Restore` CR. The populate Pod template pairs a one-shot `restore` data-mover container with a sleep-loop `restore-manager` sidecar that exits only when `dataprotection.kubeblocks.io/stop-restore-manager=true` is patched onto the Pod. The `Restore` CR controller patches that annotation via `RestoreManager.CheckJobsDone`; the ClusterRestore manual path never reaches `CheckJobsDone`, so the sidecar lingers indefinitely. The populate Pod stays in `Running`, the Job never reaches `Complete`, and the Kubernetes volume populator framework cannot rebind the populator PVC's PV onto the restore PVC — the ClusterRestore reconcile loop then loops on `pvc.Spec.VolumeName == ""` forever.

## Scope and boundaries

- **What this PR is**: the per-Job `VolumePopulator.Populate` contract is taught to release its own sidecar once the `restore` container has terminated. Patch-version-only fix.
- **What this PR is not**:
  - Does **not** touch `controllers/dataprotection/clusterrestore_controller.go` production code.
  - Does **not** change the `Restore` CR controller's coordinated stop semantics (`CheckJobsDone -> StopManagerContainerByJob`); the new helper is invoked only from `VolumePopulator.Populate`.
  - Does **not** subsume case-001 (`#10207`, `WaitingForStorageClass` status contract) or 1328 (`cipher: message authentication failed`, routed separately) or case-003 (`#10205`, external delete Job TTL).
  - Does **not** claim Valkey / SQL Server / Oracle release-readiness; this is controller-side contract only.

## Stacked dependency

- Base: `support/dp-restore-api-decoupling` (PR #10192 head).
- This PR must not merge into `main` ahead of #10192. After #10192 merges, this branch needs to be rebased onto the new base and re-verified before continuing the release flow.

## Implementation

- `pkg/dataprotection/restore/manager.go` (new helper, +49 LoC):
  - `func (r *RestoreManager) ReleaseManagerSidecarIfRestoreTerminated(ctx context.Context, job *batchv1.Job) error`
  - Lists Pods of the Job. For each Pod with a non-zero `DeletionTimestamp`, skip and let Kubernetes GC drive the lifecycle. Otherwise, look at the `restore` container status: if it has a `Terminated` state (regardless of exit code), call the existing `StopManagerContainer`, which patches the annotation and is already idempotent against an already-set value. Pods still Running their `restore` container are left for the next reconcile.
  - The helper does **not** write `RestoreManager.Restore.Status`; the only side effect is a Pod annotation Patch. It is therefore safe to call from any caller that constructs a transient `RestoreManager` in memory without a persisted `Restore` CR.
- `controllers/dataprotection/volumepopulator_controller.go` (wiring, +16 LoC):
  - Invokes `ReleaseManagerSidecarIfRestoreTerminated` in `Populate` between `CreateJobsIfNotExist` and the `IsJobFinished` check. The rebind step still gates on Job completion in a subsequent reconcile, so this PR is a one-line behaviour change at the boundary that already controls Job lifecycle.

## Test coverage

- `pkg/dataprotection/restore/manager_test.go` (+167 LoC): six unit tests pinning the helper contract directly — Terminated Exit 0 patches, Terminated Exit non-zero patches, still-Running leaves untouched, terminating Pod is skipped, no associated Pods is a no-op, already-stopped sidecars are idempotent (regression for the `Restore` CR coordinated stop path coexisting).
- `controllers/dataprotection/volumepopulator_controller_test.go` (+126 LoC): three wiring tests driving `Populate` through the full controller reconcile loop and asserting the annotation outcome based on Pod container state — so a future refactor that drops the helper invocation fails loudly rather than silently regressing the populator deadlock.
- Local verification with `setup-envtest` Kubernetes 1.26.1 envtest binaries:
  - [x] `go build ./pkg/dataprotection/restore/... ./controllers/dataprotection/...`
  - [x] `go test ./pkg/dataprotection/restore -run TestAction`
  - [x] `go test ./controllers/dataprotection -run TestAPIs --ginkgo.focus="VolumePopulator"`
  - [x] `git diff --check`

## Manual validation plan (post-CI)

This PR is patch-version-only. Manual verification will be reported separately on the merged commit. The intended verification matrix:

- Fresh vcluster, SC pre-applied (so the `WaitingForStorageClass` path is not exercised), `ClusterRestore` with a Backup-dataSource (`Backup`-kind `dataSourceRef`), no persisted `Restore` CR.
- Assert: populate Pod's `restore` container reaches `Terminated` `Exit 0`, the helper patches the stop annotation, the Pod transitions to `Succeeded`, the owning Job reaches `Complete`, and the user restore PVC's `Spec.VolumeName` is set by the populator framework.
- Negative: when the `restore` container exits non-zero, the Job still progresses to `Failed` via its BackoffLimit; the sidecar is not what stalls it.

## Reviewers

Reviewers from the controller pair and the originating addon teams will inspect on top of CI.