### PR TITLE
test(dataprotection): add envtest coverage for ClusterRestore StorageClass missing

### DIFF
--- a/controllers/dataprotection/clusterrestore_controller.go
+++ b/controllers/dataprotection/clusterrestore_controller.go
@@ -23,6 +23,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -53,6 +55,26 @@ const (
 	backupDataSourceRestoreLabelCluster   = "dataprotection.kubeblocks.io/target-cluster"
 	backupDataSourceRestoreLabelComponent = "dataprotection.kubeblocks.io/target-component"
 	backupDataSourceRestoreLabelBackup    = "dataprotection.kubeblocks.io/source-backup"
+
+	// reasonWaitingForStorageClass marks the ClusterRestore.status Ready
+	// condition while a referenced StorageClass is missing from the API
+	// surface and the controller is bounded-retrying for it to appear.
+	reasonWaitingForStorageClass = "WaitingForStorageClass"
+	// reasonStorageClassMissing marks the ClusterRestore.status Ready condition
+	// after the bounded retry window elapses without the StorageClass becoming
+	// visible. The phase is escalated to Failed alongside this reason.
+	reasonStorageClassMissing = "StorageClassMissing"
+
+	// storageClassWaitTimeout is the bounded window during which a missing
+	// StorageClass keeps ClusterRestore in Restoring/WaitingForStorageClass.
+	// After this elapses the condition is escalated to Failed/StorageClassMissing.
+	// Chosen to give 2-3x typical fresh-vcluster sync settling time (~1-2min)
+	// before declaring the StorageClass actually absent.
+	storageClassWaitTimeout = 5 * time.Minute
+	// storageClassRequeueAfter is the requeue cadence while waiting; gives the
+	// caller a predictable, log-visible retry beat instead of relying on the
+	// controller-runtime exponential default.
+	storageClassRequeueAfter = 30 * time.Second
 )
 
 // ClusterRestoreReconciler reconciles ClusterRestore orchestration sessions.
@@ -244,6 +266,9 @@ func (r *ClusterRestoreReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				return intctrlutil.RequeueWithError(err, reqCtx.Log, "")
 			}
 			if err = r.volumePopulator().Populate(reqCtx, item.pvc, restoreMgr); err != nil {
+				if scErr, ok := dprestore.IsStorageClassNotFoundError(err); ok {
+					return r.handleStorageClassNotFound(reqCtx, clusterRestore, scErr, targetRef, item.pvc)
+				}
 				if intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal) {
 					_ = r.patchClusterRestoreStatus(reqCtx, clusterRestore, dpv1alpha1.ClusterRestorePhaseFailed, metav1.ConditionFalse, "Failed", err.Error(), targetRef)
 					r.Recorder.Event(clusterRestore, corev1.EventTypeWarning, dprestore.ReasonRestoreFailed, err.Error())
@@ -1158,6 +1183,107 @@ func (r *ClusterRestoreReconciler) patchClusterRestoreStatus(reqCtx intctrlutil.
 		LastTransitionTime: metav1.Now(),
 	})
 	return r.Client.Status().Patch(reqCtx.Ctx, latest, patch)
+}
+
+// patchClusterRestoreReadyConditionAt is a variant of patchClusterRestoreStatus
+// that lets callers supply an explicit LastTransitionTime for the Ready
+// condition. It is used by the WaitingForStorageClass branch so the original
+// wait-start time survives across reconciles, regardless of whether the
+// condition.Status changes between calls. (meta.SetStatusCondition only
+// preserves LastTransitionTime when Status is unchanged, which is the wrong
+// semantics for tracking a bounded wait window keyed by Reason.)
+func (r *ClusterRestoreReconciler) patchClusterRestoreReadyConditionAt(reqCtx intctrlutil.RequestCtx, clusterRestore *dpv1alpha1.ClusterRestore, phase dpv1alpha1.ClusterRestorePhase, status metav1.ConditionStatus, reason, message string, targetRef *dpv1alpha1.ClusterRestoreTargetClusterRef, transitionTime metav1.Time) error {
+	latest := &dpv1alpha1.ClusterRestore{}
+	if err := r.Client.Get(reqCtx.Ctx, client.ObjectKeyFromObject(clusterRestore), latest); err != nil {
+		return err
+	}
+	patch := client.MergeFrom(latest.DeepCopy())
+	latest.Status.Phase = phase
+	latest.Status.ObservedGeneration = latest.Generation
+	if targetRef != nil {
+		latest.Status.TargetClusterRef = targetRef
+	}
+	cond := metav1.Condition{
+		Type:               dpv1alpha1.ClusterRestoreReadyCondition,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: latest.Generation,
+		LastTransitionTime: transitionTime,
+	}
+	replaced := false
+	for i := range latest.Status.Conditions {
+		if latest.Status.Conditions[i].Type == cond.Type {
+			latest.Status.Conditions[i] = cond
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		latest.Status.Conditions = append(latest.Status.Conditions, cond)
+	}
+	return r.Client.Status().Patch(reqCtx.Ctx, latest, patch)
+}
+
+// handleStorageClassNotFound translates a *dprestore.StorageClassNotFoundError
+// returned by VolumePopulator.Populate into a user-facing condition on
+// ClusterRestore.status. While within storageClassWaitTimeout, the condition
+// is set to Restoring/WaitingForStorageClass with a stable LastTransitionTime
+// (the wait-start), and the Reconcile is requeued after storageClassRequeueAfter.
+// Once elapsed time crosses the bound, the phase is escalated to Failed with
+// reason StorageClassMissing and a Warning event.
+func (r *ClusterRestoreReconciler) handleStorageClassNotFound(reqCtx intctrlutil.RequestCtx, clusterRestore *dpv1alpha1.ClusterRestore, scErr *dprestore.StorageClassNotFoundError, targetRef *dpv1alpha1.ClusterRestoreTargetClusterRef, pvc *corev1.PersistentVolumeClaim) (ctrl.Result, error) {
+	now := metav1.Now()
+	waitingMsg := storageClassWaitingMessage(clusterRestore, scErr.Name, pvc)
+	waitStart := now
+	if existing := meta.FindStatusCondition(clusterRestore.Status.Conditions, dpv1alpha1.ClusterRestoreReadyCondition); isSameStorageClassWait(existing, clusterRestore, scErr.Name) {
+		if !existing.LastTransitionTime.IsZero() {
+			waitStart = existing.LastTransitionTime
+		}
+	}
+	elapsed := now.Sub(waitStart.Time)
+
+	if elapsed >= storageClassWaitTimeout {
+		failedMsg := fmt.Sprintf(
+			"StorageClass %q not found after %s; please create the StorageClass and re-apply ClusterRestore %s/%s",
+			scErr.Name, storageClassWaitTimeout, clusterRestore.Namespace, clusterRestore.Name,
+		)
+		if err := r.patchClusterRestoreStatus(reqCtx, clusterRestore,
+			dpv1alpha1.ClusterRestorePhaseFailed, metav1.ConditionFalse,
+			reasonStorageClassMissing, failedMsg, targetRef); err != nil {
+			return intctrlutil.RequeueWithError(err, reqCtx.Log, "")
+		}
+		r.Recorder.Event(clusterRestore, corev1.EventTypeWarning, dprestore.ReasonRestoreFailed, failedMsg)
+		return intctrlutil.Reconciled()
+	}
+
+	if err := r.patchClusterRestoreReadyConditionAt(reqCtx, clusterRestore,
+		dpv1alpha1.ClusterRestorePhaseRestoring, metav1.ConditionFalse,
+		reasonWaitingForStorageClass, waitingMsg, targetRef, waitStart); err != nil {
+		return intctrlutil.RequeueWithError(err, reqCtx.Log, "")
+	}
+	return ctrl.Result{RequeueAfter: storageClassRequeueAfter}, nil
+}
+
+func isSameStorageClassWait(cond *metav1.Condition, clusterRestore *dpv1alpha1.ClusterRestore, storageClassName string) bool {
+	return cond != nil &&
+		cond.Reason == reasonWaitingForStorageClass &&
+		strings.HasPrefix(cond.Message, storageClassWaitingPrefix(clusterRestore, storageClassName))
+}
+
+func storageClassWaitingPrefix(clusterRestore *dpv1alpha1.ClusterRestore, storageClassName string) string {
+	return fmt.Sprintf("StorageClass %q not found for ClusterRestore %s/%s", storageClassName, clusterRestore.Namespace, clusterRestore.Name)
+}
+
+func storageClassWaitingMessage(clusterRestore *dpv1alpha1.ClusterRestore, storageClassName string, pvc *corev1.PersistentVolumeClaim) string {
+	pvcRef := ""
+	if pvc != nil {
+		pvcRef = fmt.Sprintf(" (target PVC %s/%s)", pvc.Namespace, pvc.Name)
+	}
+	return fmt.Sprintf(
+		"%s%s; waiting for sync (timeout %s); to fix: pre-create or sync the StorageClass into the cluster",
+		storageClassWaitingPrefix(clusterRestore, storageClassName), pvcRef, storageClassWaitTimeout,
+	)
 }
 
 func clusterRestoreTargetRef(cluster *appsv1.Cluster) *dpv1alpha1.ClusterRestoreTargetClusterRef {

--- a/controllers/dataprotection/clusterrestore_controller_storageclass_envtest_test.go
+++ b/controllers/dataprotection/clusterrestore_controller_storageclass_envtest_test.go
@@ -1,0 +1,326 @@
+/*
+Copyright (C) 2022-2025 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package dataprotection
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	dprestore "github.com/apecloud/kubeblocks/pkg/dataprotection/restore"
+	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
+)
+
+// These envtest specs guard the persistence-layer slice of
+// handleStorageClassNotFound that the fake.Client unit tests cannot
+// validate: real Status subresource Patch via API server, metav1.Time
+// serialization round-trip for LastTransitionTime, and event delivery
+// through a real EventRecorder. The matrix of reason/message values is
+// already covered by the fake.Client tests in
+// clusterrestore_controller_test.go; specs here intentionally only
+// exercise the bounded-window escalation outcome (Phase=Failed terminal)
+// so the BeforeSuite-registered ClusterRestoreReconciler stays quiet
+// (early return on terminal phase) and does not race with the spec.
+var _ = Describe("ClusterRestore StorageClass missing envtest", func() {
+	const (
+		envtestStorageClassName    = "envtest-missing-sc"
+		envtestTargetClusterName   = "envtest-target-cluster"
+		envtestTargetClusterUID    = types.UID("envtest-target-cluster-uid")
+		envtestSourceBackupName    = "envtest-backup"
+		envtestSourceBackupNS      = "envtest-backup-ns"
+		envtestPVCName             = "data-envtest-target-cluster-mysql-0"
+		envtestEventDrainTimeout   = 2 * time.Second
+	)
+
+	var (
+		nsName     string
+		recorder   *record.FakeRecorder
+		reconciler *ClusterRestoreReconciler
+	)
+
+	newClusterRestore := func(name string) *dpv1alpha1.ClusterRestore {
+		return &dpv1alpha1.ClusterRestore{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: nsName,
+			},
+			Spec: dpv1alpha1.ClusterRestoreSpec{
+				TargetClusterName: envtestTargetClusterName,
+				BackupRef: dpv1alpha1.ClusterRestoreBackupRef{
+					Name:      envtestSourceBackupName,
+					Namespace: envtestSourceBackupNS,
+				},
+			},
+		}
+	}
+
+	newPVC := func() *corev1.PersistentVolumeClaim {
+		sc := envtestStorageClassName
+		return &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      envtestPVCName,
+				Namespace: nsName,
+				Annotations: map[string]string{
+					dptypes.VolumeSourceAnnotationKey: "data",
+				},
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				StorageClassName: &sc,
+			},
+		}
+	}
+
+	targetRef := func() *dpv1alpha1.ClusterRestoreTargetClusterRef {
+		return &dpv1alpha1.ClusterRestoreTargetClusterRef{
+			Name:      envtestTargetClusterName,
+			Namespace: nsName,
+			UID:       envtestTargetClusterUID,
+		}
+	}
+
+	// seedClusterRestore creates the ClusterRestore, then waits for the
+	// BeforeSuite-registered ClusterRestoreReconciler to settle on
+	// terminal Phase=Failed (the Backup the spec references does not
+	// exist, so getAndValidateBackup returns NewFatalError and the
+	// manager's reconciler patches Phase=Failed exactly once). After
+	// that the manager early-returns on every subsequent enqueue
+	// (terminal phase guard at the top of Reconcile), and the spec is
+	// safe to overwrite Status.Conditions / TargetClusterRef without a
+	// race. Phase stays Failed through the spec's call to
+	// handleStorageClassNotFound, which patches Phase=Failed again
+	// (idempotent).
+	seedClusterRestore := func(name string, conditions []metav1.Condition) *dpv1alpha1.ClusterRestore {
+		cr := newClusterRestore(name)
+		Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+		// Wait for manager's terminal settle. This is bounded
+		// by getAndValidateBackup -> NewFatalError -> Phase=Failed.
+		Eventually(func(g Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cr), cr)).To(Succeed())
+			g.Expect(cr.Status.Phase).To(Equal(dpv1alpha1.ClusterRestorePhaseFailed))
+		}, 10*time.Second, 100*time.Millisecond).Should(Succeed(), "manager-side reconciler did not settle on terminal Phase=Failed")
+		// Now overwrite the seeded Status.Conditions for the spec under
+		// test. Phase stays Failed; manager continues to early-return.
+		patch := client.MergeFrom(cr.DeepCopy())
+		cr.Status.Conditions = conditions
+		cr.Status.TargetClusterRef = targetRef()
+		Expect(k8sClient.Status().Patch(ctx, cr, patch)).To(Succeed())
+		// Re-fetch so the spec sees the post-patch resourceVersion and
+		// the persisted condition list.
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cr), cr)).To(Succeed())
+		return cr
+	}
+
+	BeforeEach(func() {
+		nsName = fmt.Sprintf("dp-cr-sc-envtest-%d", time.Now().UnixNano())
+		Expect(k8sClient.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: nsName},
+		})).To(Succeed())
+		recorder = record.NewFakeRecorder(8)
+		reconciler = &ClusterRestoreReconciler{
+			Client:   k8sClient,
+			Scheme:   k8sManager.GetScheme(),
+			Recorder: recorder,
+		}
+	})
+
+	AfterEach(func() {
+		// Best-effort cleanup; envtest namespaces stay around but the
+		// resources inside them do not leak across specs because spec
+		// fixtures are name-prefixed by ns.
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
+		_ = k8sClient.Delete(ctx, ns)
+	})
+
+	It("escalates to Failed/StorageClassMissing via real Status subresource and emits Warning event after the bounded wait window elapses", func() {
+		crName := "envtest-escalate-after-window"
+		// Pre-seed an existing WaitingForStorageClass condition whose
+		// LastTransitionTime is past the 5-minute timeout. The
+		// function must read this LTT through real API server
+		// serialization (not in-memory) and use it to compute elapsed.
+		// If LTT serialization is broken, elapsed would default to 0
+		// and the function would NOT escalate, so the Failed/
+		// StorageClassMissing outcome is itself proof that LTT
+		// round-trip works.
+		waitStart := metav1.NewTime(time.Now().Add(-storageClassWaitTimeout - time.Second).Truncate(time.Second))
+		cr := seedClusterRestore(crName, []metav1.Condition{
+			{
+				Type:               dpv1alpha1.ClusterRestoreReadyCondition,
+				Status:             metav1.ConditionFalse,
+				Reason:             reasonWaitingForStorageClass,
+				Message:            storageClassWaitingMessage(newClusterRestore(crName), envtestStorageClassName, newPVC()),
+				ObservedGeneration: 1,
+				LastTransitionTime: waitStart,
+			},
+		})
+
+		result, err := reconciler.handleStorageClassNotFound(
+			intctrlutil.RequestCtx{Ctx: ctx},
+			cr,
+			&dprestore.StorageClassNotFoundError{Name: envtestStorageClassName},
+			targetRef(),
+			newPVC(),
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeZero(), "escalated branch should reconcile to terminal, not requeue")
+
+		// Read back through the API server (real Status subresource path)
+		// to confirm what was actually persisted, not the in-memory
+		// reconciler-local copy.
+		latest := &dpv1alpha1.ClusterRestore{}
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cr), latest)).To(Succeed())
+		Expect(latest.Status.Phase).To(Equal(dpv1alpha1.ClusterRestorePhaseFailed))
+		Expect(latest.Status.TargetClusterRef).NotTo(BeNil())
+		Expect(latest.Status.TargetClusterRef.Name).To(Equal(envtestTargetClusterName))
+
+		cond := meta.FindStatusCondition(latest.Status.Conditions, dpv1alpha1.ClusterRestoreReadyCondition)
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+		Expect(cond.Reason).To(Equal(reasonStorageClassMissing))
+		Expect(cond.Message).To(ContainSubstring(envtestStorageClassName))
+		Expect(cond.Message).To(ContainSubstring(fmt.Sprintf("after %s", storageClassWaitTimeout)))
+		Expect(cond.Message).To(ContainSubstring(fmt.Sprintf("re-apply ClusterRestore %s/%s", nsName, crName)))
+
+		// Bounded drain so async event delivery does not flake the
+		// assertion. Single Warning event is the contract.
+		evt, ok := drainSingleEvent(recorder, envtestEventDrainTimeout)
+		Expect(ok).To(BeTrue(), "expected a single Warning event for StorageClassMissing escalation")
+		Expect(evt).To(ContainSubstring(corev1.EventTypeWarning))
+		Expect(evt).To(ContainSubstring(dprestore.ReasonRestoreFailed))
+		Expect(evt).To(ContainSubstring(envtestStorageClassName))
+	})
+
+	It("preserves unrelated Status conditions through the real API server when escalating to StorageClassMissing", func() {
+		crName := "envtest-preserve-unrelated"
+		waitStart := metav1.NewTime(time.Now().Add(-storageClassWaitTimeout - 5*time.Second).Truncate(time.Second))
+		unrelatedLTT := metav1.NewTime(time.Now().Add(-time.Minute).Truncate(time.Second))
+		cr := seedClusterRestore(crName, []metav1.Condition{
+			{
+				Type:               dpv1alpha1.ClusterRestoreReadyCondition,
+				Status:             metav1.ConditionFalse,
+				Reason:             reasonWaitingForStorageClass,
+				Message:            storageClassWaitingMessage(newClusterRestore(crName), envtestStorageClassName, newPVC()),
+				ObservedGeneration: 1,
+				LastTransitionTime: waitStart,
+			},
+			{
+				Type:               "OtherControllerCondition",
+				Status:             metav1.ConditionTrue,
+				Reason:             "KeepMe",
+				Message:            "owned by another status writer",
+				ObservedGeneration: 1,
+				LastTransitionTime: unrelatedLTT,
+			},
+		})
+
+		_, err := reconciler.handleStorageClassNotFound(
+			intctrlutil.RequestCtx{Ctx: ctx},
+			cr,
+			&dprestore.StorageClassNotFoundError{Name: envtestStorageClassName},
+			targetRef(),
+			newPVC(),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		latest := &dpv1alpha1.ClusterRestore{}
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cr), latest)).To(Succeed())
+
+		ready := meta.FindStatusCondition(latest.Status.Conditions, dpv1alpha1.ClusterRestoreReadyCondition)
+		Expect(ready).NotTo(BeNil())
+		Expect(ready.Reason).To(Equal(reasonStorageClassMissing))
+
+		other := meta.FindStatusCondition(latest.Status.Conditions, "OtherControllerCondition")
+		Expect(other).NotTo(BeNil(), "unrelated condition must survive Status patch through real API server")
+		Expect(other.Reason).To(Equal("KeepMe"))
+		Expect(other.Status).To(Equal(metav1.ConditionTrue))
+		// metav1.Time has second precision, so an exact wall-clock
+		// equality check survives the API server round-trip.
+		Expect(other.LastTransitionTime.Time.Equal(unrelatedLTT.Time)).To(BeTrue(),
+			"unrelated condition LastTransitionTime must round-trip through API server unchanged")
+
+		// Drain to keep the recorder buffer clean for downstream specs.
+		_, _ = drainSingleEvent(recorder, envtestEventDrainTimeout)
+	})
+
+	It("propagates the missing StorageClass identifier and ClusterRestore identity through real API server serialization", func() {
+		crName := "envtest-message-identity"
+		waitStart := metav1.NewTime(time.Now().Add(-storageClassWaitTimeout - 10*time.Second).Truncate(time.Second))
+		cr := seedClusterRestore(crName, []metav1.Condition{
+			{
+				Type:               dpv1alpha1.ClusterRestoreReadyCondition,
+				Status:             metav1.ConditionFalse,
+				Reason:             reasonWaitingForStorageClass,
+				Message:            storageClassWaitingMessage(newClusterRestore(crName), envtestStorageClassName, newPVC()),
+				ObservedGeneration: 1,
+				LastTransitionTime: waitStart,
+			},
+		})
+
+		_, err := reconciler.handleStorageClassNotFound(
+			intctrlutil.RequestCtx{Ctx: ctx},
+			cr,
+			&dprestore.StorageClassNotFoundError{Name: envtestStorageClassName},
+			targetRef(),
+			newPVC(),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		latest := &dpv1alpha1.ClusterRestore{}
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(cr), latest)).To(Succeed())
+		cond := meta.FindStatusCondition(latest.Status.Conditions, dpv1alpha1.ClusterRestoreReadyCondition)
+		Expect(cond).NotTo(BeNil())
+		Expect(cond.Reason).To(Equal(reasonStorageClassMissing))
+		// Contract substrings: caller can grep the failure message
+		// to identify (a) which StorageClass is missing and (b) which
+		// ClusterRestore needs to be re-applied. Message rendering goes
+		// through API server serialization in this assertion path.
+		Expect(cond.Message).To(ContainSubstring(fmt.Sprintf(`StorageClass %q not found`, envtestStorageClassName)))
+		Expect(cond.Message).To(ContainSubstring(fmt.Sprintf("ClusterRestore %s/%s", nsName, crName)))
+
+		evt, ok := drainSingleEvent(recorder, envtestEventDrainTimeout)
+		Expect(ok).To(BeTrue())
+		Expect(evt).To(ContainSubstring(envtestStorageClassName))
+		Expect(evt).To(ContainSubstring(corev1.EventTypeWarning))
+	})
+})
+
+// drainSingleEvent reads exactly one event from a FakeRecorder with a
+// bounded timeout, so the assertion does not hang on async event
+// delivery and does not flake on under-counted buffers. Returns the
+// event string and ok=true if one event was received within timeout.
+func drainSingleEvent(recorder *record.FakeRecorder, timeout time.Duration) (string, bool) {
+	select {
+	case evt := <-recorder.Events:
+		return strings.TrimSpace(evt), true
+	case <-time.After(timeout):
+		return "", false
+	}
+}

--- a/controllers/dataprotection/clusterrestore_controller_storageclass_envtest_test.go
+++ b/controllers/dataprotection/clusterrestore_controller_storageclass_envtest_test.go
@@ -52,13 +52,13 @@ import (
 // (early return on terminal phase) and does not race with the spec.
 var _ = Describe("ClusterRestore StorageClass missing envtest", func() {
 	const (
-		envtestStorageClassName    = "envtest-missing-sc"
-		envtestTargetClusterName   = "envtest-target-cluster"
-		envtestTargetClusterUID    = types.UID("envtest-target-cluster-uid")
-		envtestSourceBackupName    = "envtest-backup"
-		envtestSourceBackupNS      = "envtest-backup-ns"
-		envtestPVCName             = "data-envtest-target-cluster-mysql-0"
-		envtestEventDrainTimeout   = 2 * time.Second
+		envtestStorageClassName  = "envtest-missing-sc"
+		envtestTargetClusterName = "envtest-target-cluster"
+		envtestTargetClusterUID  = types.UID("envtest-target-cluster-uid")
+		envtestSourceBackupName  = "envtest-backup"
+		envtestSourceBackupNS    = "envtest-backup-ns"
+		envtestPVCName           = "data-envtest-target-cluster-mysql-0"
+		envtestEventDrainTimeout = 2 * time.Second
 	)
 
 	var (

--- a/controllers/dataprotection/clusterrestore_controller_test.go
+++ b/controllers/dataprotection/clusterrestore_controller_test.go
@@ -22,9 +22,12 @@ package dataprotection
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -267,6 +270,541 @@ func TestClusterRestoreBuildsTargetClusterFromTemplate(t *testing.T) {
 	if vct.Annotations[dptypes.SourceTargetNameAnnotationKey] != "mysql" ||
 		vct.Annotations[dptypes.VolumeSourceAnnotationKey] != "data" {
 		t.Fatalf("unexpected restore annotations: %#v", vct.Annotations)
+	}
+}
+
+func TestVolumePopulatorWaitForPVCSelectedNodeReturnsStorageClassSentinel(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := storagev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+		Scheme: scheme,
+	}
+	storageClassName := "missing-sc"
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "restore-pvc", Namespace: "default"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &storageClassName,
+		},
+	}
+
+	wait, nodeName, err := reconciler.waitForPVCSelectedNode(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc)
+
+	if wait {
+		t.Fatal("expected missing StorageClass to stop waiting and return an error")
+	}
+	if nodeName != "" {
+		t.Fatalf("nodeName = %q, want empty", nodeName)
+	}
+	scErr, ok := dprestore.IsStorageClassNotFoundError(err)
+	if !ok || scErr == nil {
+		t.Fatalf("expected StorageClassNotFoundError, got %T: %v", err, err)
+	}
+	if scErr.Name != storageClassName {
+		t.Fatalf("StorageClassNotFoundError.Name = %q, want %q", scErr.Name, storageClassName)
+	}
+}
+
+func TestVolumePopulatorWaitForPVCSelectedNodePropagatesOtherStorageClassGetErrors(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := storagev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	rawErr := apierrors.NewForbidden(schema.GroupResource{Group: storagev1.GroupName, Resource: "storageclasses"}, "blocked-sc", nil)
+	reconciler := &VolumePopulatorReconciler{
+		Client: storageClassGetErrorClient{
+			Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+			err:    rawErr,
+		},
+		Scheme: scheme,
+	}
+	storageClassName := "blocked-sc"
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "restore-pvc", Namespace: "default"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &storageClassName,
+		},
+	}
+
+	wait, nodeName, err := reconciler.waitForPVCSelectedNode(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc)
+
+	if wait {
+		t.Fatal("expected raw StorageClass GET error to stop waiting and return the error")
+	}
+	if nodeName != "" {
+		t.Fatalf("nodeName = %q, want empty", nodeName)
+	}
+	if err != rawErr {
+		t.Fatalf("err = %v, want raw error %v", err, rawErr)
+	}
+	if scErr, ok := dprestore.IsStorageClassNotFoundError(err); ok || scErr != nil {
+		t.Fatalf("raw GET error must not match StorageClassNotFoundError, got (%v, %v)", scErr, ok)
+	}
+}
+
+type storageClassGetErrorClient struct {
+	client.Client
+	err error
+}
+
+func (c storageClassGetErrorClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if _, ok := obj.(*storagev1.StorageClass); ok {
+		return c.err
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func TestClusterRestoreHandlesStorageClassNotFoundWithinBoundedWindow(t *testing.T) {
+	scheme := newClusterRestoreUnitScheme(t)
+	clusterRestore := newStorageClassTestClusterRestore()
+	targetRef := &dpv1alpha1.ClusterRestoreTargetClusterRef{
+		Name:      "target-cluster",
+		Namespace: "default",
+		UID:       types.UID("target-cluster-uid"),
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&dpv1alpha1.ClusterRestore{}).
+		WithObjects(clusterRestore).
+		Build()
+	reconciler := &ClusterRestoreReconciler{
+		Client:   cli,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(8),
+	}
+	pvc := newStorageClassTestPVC()
+
+	result, err := reconciler.handleStorageClassNotFound(
+		intctrlutil.RequestCtx{Ctx: context.Background()},
+		clusterRestore,
+		&dprestore.StorageClassNotFoundError{Name: "missing-sc"},
+		targetRef,
+		pvc,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.RequeueAfter != storageClassRequeueAfter {
+		t.Fatalf("RequeueAfter = %s, want %s", result.RequeueAfter, storageClassRequeueAfter)
+	}
+
+	latest := &dpv1alpha1.ClusterRestore{}
+	if err = cli.Get(context.Background(), client.ObjectKeyFromObject(clusterRestore), latest); err != nil {
+		t.Fatal(err)
+	}
+	if latest.Status.Phase != dpv1alpha1.ClusterRestorePhaseRestoring {
+		t.Fatalf("phase = %q, want %q", latest.Status.Phase, dpv1alpha1.ClusterRestorePhaseRestoring)
+	}
+	if latest.Status.TargetClusterRef == nil || latest.Status.TargetClusterRef.Name != targetRef.Name {
+		t.Fatalf("target ref not preserved: %#v", latest.Status.TargetClusterRef)
+	}
+	cond := meta.FindStatusCondition(latest.Status.Conditions, dpv1alpha1.ClusterRestoreReadyCondition)
+	if cond == nil {
+		t.Fatalf("Ready condition missing: %#v", latest.Status.Conditions)
+	}
+	if other := meta.FindStatusCondition(latest.Status.Conditions, "OtherControllerCondition"); other == nil || other.Reason != "KeepMe" {
+		t.Fatalf("expected unrelated conditions to be preserved, got %#v", latest.Status.Conditions)
+	}
+	if cond.Status != metav1.ConditionFalse ||
+		cond.Reason != reasonWaitingForStorageClass ||
+		cond.ObservedGeneration != latest.Generation {
+		t.Fatalf("unexpected Ready condition: %#v", cond)
+	}
+	if cond.LastTransitionTime.IsZero() {
+		t.Fatalf("expected LastTransitionTime to mark wait start: %#v", cond)
+	}
+	assertContainsAll(t, cond.Message,
+		`StorageClass "missing-sc" not found`,
+		"ClusterRestore default/restore-session",
+		"target PVC default/data-target-cluster-mysql-0",
+		"pre-create or sync the StorageClass",
+	)
+}
+
+func TestClusterRestoreKeepsStorageClassWaitStartAcrossRetries(t *testing.T) {
+	scheme := newClusterRestoreUnitScheme(t)
+	waitStart := metav1.NewTime(time.Now().Add(-2 * time.Minute).Truncate(time.Second))
+	clusterRestore := newStorageClassTestClusterRestore()
+	pvc := newStorageClassTestPVC()
+	clusterRestore.Status.Conditions = []metav1.Condition{{
+		Type:               dpv1alpha1.ClusterRestoreReadyCondition,
+		Status:             metav1.ConditionFalse,
+		Reason:             reasonWaitingForStorageClass,
+		Message:            storageClassWaitingMessage(clusterRestore, "missing-sc", pvc),
+		ObservedGeneration: clusterRestore.Generation,
+		LastTransitionTime: waitStart,
+	}, {
+		Type:               "OtherControllerCondition",
+		Status:             metav1.ConditionTrue,
+		Reason:             "KeepMe",
+		Message:            "owned by another status writer",
+		ObservedGeneration: 1,
+		LastTransitionTime: metav1.NewTime(time.Now().Add(-time.Minute).Truncate(time.Second)),
+	}}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&dpv1alpha1.ClusterRestore{}).
+		WithObjects(clusterRestore).
+		Build()
+	reconciler := &ClusterRestoreReconciler{
+		Client:   cli,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(8),
+	}
+
+	result, err := reconciler.handleStorageClassNotFound(
+		intctrlutil.RequestCtx{Ctx: context.Background()},
+		clusterRestore,
+		&dprestore.StorageClassNotFoundError{Name: "missing-sc"},
+		clusterRestoreTargetRef(&appsv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "target-cluster", Namespace: "default", UID: types.UID("target-cluster-uid")}}),
+		pvc,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.RequeueAfter != storageClassRequeueAfter {
+		t.Fatalf("RequeueAfter = %s, want %s", result.RequeueAfter, storageClassRequeueAfter)
+	}
+
+	latest := &dpv1alpha1.ClusterRestore{}
+	if err = cli.Get(context.Background(), client.ObjectKeyFromObject(clusterRestore), latest); err != nil {
+		t.Fatal(err)
+	}
+	cond := meta.FindStatusCondition(latest.Status.Conditions, dpv1alpha1.ClusterRestoreReadyCondition)
+	if cond == nil {
+		t.Fatalf("Ready condition missing: %#v", latest.Status.Conditions)
+	}
+	if !cond.LastTransitionTime.Time.Equal(waitStart.Time) {
+		t.Fatalf("LastTransitionTime = %s, want original wait start %s", cond.LastTransitionTime.Time, waitStart.Time)
+	}
+	if cond.Reason != reasonWaitingForStorageClass {
+		t.Fatalf("Reason = %q, want %q", cond.Reason, reasonWaitingForStorageClass)
+	}
+	if other := meta.FindStatusCondition(latest.Status.Conditions, "OtherControllerCondition"); other == nil || other.Reason != "KeepMe" {
+		t.Fatalf("expected unrelated conditions to be preserved, got %#v", latest.Status.Conditions)
+	}
+}
+
+func TestClusterRestoreResetsStorageClassWaitStartForDifferentMissingStorageClass(t *testing.T) {
+	scheme := newClusterRestoreUnitScheme(t)
+	previousWaitStart := metav1.NewTime(time.Now().Add(-storageClassWaitTimeout - time.Minute).Truncate(time.Second))
+	clusterRestore := newStorageClassTestClusterRestore()
+	previousPVC := newStorageClassTestPVC()
+	clusterRestore.Status.Conditions = []metav1.Condition{{
+		Type:               dpv1alpha1.ClusterRestoreReadyCondition,
+		Status:             metav1.ConditionFalse,
+		Reason:             reasonWaitingForStorageClass,
+		Message:            storageClassWaitingMessage(clusterRestore, "old-missing-sc", previousPVC),
+		ObservedGeneration: clusterRestore.Generation,
+		LastTransitionTime: previousWaitStart,
+	}}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&dpv1alpha1.ClusterRestore{}).
+		WithObjects(clusterRestore).
+		Build()
+	reconciler := &ClusterRestoreReconciler{
+		Client:   cli,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(8),
+	}
+
+	result, err := reconciler.handleStorageClassNotFound(
+		intctrlutil.RequestCtx{Ctx: context.Background()},
+		clusterRestore,
+		&dprestore.StorageClassNotFoundError{Name: "new-missing-sc"},
+		clusterRestoreTargetRef(&appsv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "target-cluster", Namespace: "default", UID: types.UID("target-cluster-uid")}}),
+		previousPVC,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.RequeueAfter != storageClassRequeueAfter {
+		t.Fatalf("RequeueAfter = %s, want %s", result.RequeueAfter, storageClassRequeueAfter)
+	}
+
+	latest := &dpv1alpha1.ClusterRestore{}
+	if err = cli.Get(context.Background(), client.ObjectKeyFromObject(clusterRestore), latest); err != nil {
+		t.Fatal(err)
+	}
+	cond := meta.FindStatusCondition(latest.Status.Conditions, dpv1alpha1.ClusterRestoreReadyCondition)
+	if cond == nil {
+		t.Fatalf("Ready condition missing: %#v", latest.Status.Conditions)
+	}
+	if cond.Reason != reasonWaitingForStorageClass {
+		t.Fatalf("Reason = %q, want %q", cond.Reason, reasonWaitingForStorageClass)
+	}
+	if !cond.LastTransitionTime.After(previousWaitStart.Time) {
+		t.Fatalf("LastTransitionTime = %s, should reset after previous wait start %s", cond.LastTransitionTime.Time, previousWaitStart.Time)
+	}
+	assertContainsAll(t, cond.Message, `StorageClass "new-missing-sc" not found`)
+}
+
+func TestClusterRestoreKeepsStorageClassWaitStartForSameStorageClassAcrossDifferentPVCs(t *testing.T) {
+	scheme := newClusterRestoreUnitScheme(t)
+	waitStart := metav1.NewTime(time.Now().Add(-2 * time.Minute).Truncate(time.Second))
+	clusterRestore := newStorageClassTestClusterRestore()
+	previousPVC := newStorageClassTestPVC()
+	currentPVC := newStorageClassTestPVC()
+	currentPVC.Name = "data-target-cluster-mysql-1"
+	clusterRestore.Status.Conditions = []metav1.Condition{{
+		Type:               dpv1alpha1.ClusterRestoreReadyCondition,
+		Status:             metav1.ConditionFalse,
+		Reason:             reasonWaitingForStorageClass,
+		Message:            storageClassWaitingMessage(clusterRestore, "missing-sc", previousPVC),
+		ObservedGeneration: clusterRestore.Generation,
+		LastTransitionTime: waitStart,
+	}}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&dpv1alpha1.ClusterRestore{}).
+		WithObjects(clusterRestore).
+		Build()
+	reconciler := &ClusterRestoreReconciler{
+		Client:   cli,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(8),
+	}
+
+	result, err := reconciler.handleStorageClassNotFound(
+		intctrlutil.RequestCtx{Ctx: context.Background()},
+		clusterRestore,
+		&dprestore.StorageClassNotFoundError{Name: "missing-sc"},
+		clusterRestoreTargetRef(&appsv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "target-cluster", Namespace: "default", UID: types.UID("target-cluster-uid")}}),
+		currentPVC,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.RequeueAfter != storageClassRequeueAfter {
+		t.Fatalf("RequeueAfter = %s, want %s", result.RequeueAfter, storageClassRequeueAfter)
+	}
+
+	latest := &dpv1alpha1.ClusterRestore{}
+	if err = cli.Get(context.Background(), client.ObjectKeyFromObject(clusterRestore), latest); err != nil {
+		t.Fatal(err)
+	}
+	cond := meta.FindStatusCondition(latest.Status.Conditions, dpv1alpha1.ClusterRestoreReadyCondition)
+	if cond == nil {
+		t.Fatalf("Ready condition missing: %#v", latest.Status.Conditions)
+	}
+	if !cond.LastTransitionTime.Time.Equal(waitStart.Time) {
+		t.Fatalf("LastTransitionTime = %s, want original wait start %s", cond.LastTransitionTime.Time, waitStart.Time)
+	}
+	assertContainsAll(t, cond.Message,
+		`StorageClass "missing-sc" not found`,
+		"target PVC default/data-target-cluster-mysql-1",
+	)
+}
+
+func TestClusterRestoreResetsStorageClassWaitStartForDifferentClusterRestore(t *testing.T) {
+	scheme := newClusterRestoreUnitScheme(t)
+	previousWaitStart := metav1.NewTime(time.Now().Add(-storageClassWaitTimeout - time.Minute).Truncate(time.Second))
+	clusterRestore := newStorageClassTestClusterRestore()
+	otherClusterRestore := clusterRestore.DeepCopy()
+	otherClusterRestore.Name = "other-restore-session"
+	pvc := newStorageClassTestPVC()
+	clusterRestore.Status.Conditions = []metav1.Condition{{
+		Type:               dpv1alpha1.ClusterRestoreReadyCondition,
+		Status:             metav1.ConditionFalse,
+		Reason:             reasonWaitingForStorageClass,
+		Message:            storageClassWaitingMessage(otherClusterRestore, "missing-sc", pvc),
+		ObservedGeneration: clusterRestore.Generation,
+		LastTransitionTime: previousWaitStart,
+	}}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&dpv1alpha1.ClusterRestore{}).
+		WithObjects(clusterRestore).
+		Build()
+	reconciler := &ClusterRestoreReconciler{
+		Client:   cli,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(8),
+	}
+
+	result, err := reconciler.handleStorageClassNotFound(
+		intctrlutil.RequestCtx{Ctx: context.Background()},
+		clusterRestore,
+		&dprestore.StorageClassNotFoundError{Name: "missing-sc"},
+		clusterRestoreTargetRef(&appsv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "target-cluster", Namespace: "default", UID: types.UID("target-cluster-uid")}}),
+		pvc,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.RequeueAfter != storageClassRequeueAfter {
+		t.Fatalf("RequeueAfter = %s, want %s", result.RequeueAfter, storageClassRequeueAfter)
+	}
+
+	latest := &dpv1alpha1.ClusterRestore{}
+	if err = cli.Get(context.Background(), client.ObjectKeyFromObject(clusterRestore), latest); err != nil {
+		t.Fatal(err)
+	}
+	cond := meta.FindStatusCondition(latest.Status.Conditions, dpv1alpha1.ClusterRestoreReadyCondition)
+	if cond == nil {
+		t.Fatalf("Ready condition missing: %#v", latest.Status.Conditions)
+	}
+	if !cond.LastTransitionTime.After(previousWaitStart.Time) {
+		t.Fatalf("LastTransitionTime = %s, should reset after previous wait start %s", cond.LastTransitionTime.Time, previousWaitStart.Time)
+	}
+	assertContainsAll(t, cond.Message,
+		`StorageClass "missing-sc" not found`,
+		"ClusterRestore default/restore-session",
+	)
+}
+
+func TestClusterRestoreFailsStorageClassNotFoundAfterBoundedWindow(t *testing.T) {
+	scheme := newClusterRestoreUnitScheme(t)
+	waitStart := metav1.NewTime(time.Now().Add(-storageClassWaitTimeout - time.Second).Truncate(time.Second))
+	clusterRestore := newStorageClassTestClusterRestore()
+	pvc := newStorageClassTestPVC()
+	clusterRestore.Status.Conditions = []metav1.Condition{{
+		Type:               dpv1alpha1.ClusterRestoreReadyCondition,
+		Status:             metav1.ConditionFalse,
+		Reason:             reasonWaitingForStorageClass,
+		Message:            storageClassWaitingMessage(clusterRestore, "missing-sc", pvc),
+		ObservedGeneration: clusterRestore.Generation,
+		LastTransitionTime: waitStart,
+	}, {
+		Type:               "OtherControllerCondition",
+		Status:             metav1.ConditionTrue,
+		Reason:             "KeepMe",
+		Message:            "owned by another status writer",
+		ObservedGeneration: 1,
+		LastTransitionTime: metav1.NewTime(time.Now().Add(-time.Minute).Truncate(time.Second)),
+	}}
+	recorder := record.NewFakeRecorder(8)
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&dpv1alpha1.ClusterRestore{}).
+		WithObjects(clusterRestore).
+		Build()
+	reconciler := &ClusterRestoreReconciler{
+		Client:   cli,
+		Scheme:   scheme,
+		Recorder: recorder,
+	}
+
+	result, err := reconciler.handleStorageClassNotFound(
+		intctrlutil.RequestCtx{Ctx: context.Background()},
+		clusterRestore,
+		&dprestore.StorageClassNotFoundError{Name: "missing-sc"},
+		clusterRestoreTargetRef(&appsv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "target-cluster", Namespace: "default", UID: types.UID("target-cluster-uid")}}),
+		pvc,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != (ctrl.Result{}) {
+		t.Fatalf("result = %#v, want reconciled empty result", result)
+	}
+
+	latest := &dpv1alpha1.ClusterRestore{}
+	if err = cli.Get(context.Background(), client.ObjectKeyFromObject(clusterRestore), latest); err != nil {
+		t.Fatal(err)
+	}
+	if latest.Status.Phase != dpv1alpha1.ClusterRestorePhaseFailed {
+		t.Fatalf("phase = %q, want %q", latest.Status.Phase, dpv1alpha1.ClusterRestorePhaseFailed)
+	}
+	cond := meta.FindStatusCondition(latest.Status.Conditions, dpv1alpha1.ClusterRestoreReadyCondition)
+	if cond == nil {
+		t.Fatalf("Ready condition missing: %#v", latest.Status.Conditions)
+	}
+	if other := meta.FindStatusCondition(latest.Status.Conditions, "OtherControllerCondition"); other == nil || other.Reason != "KeepMe" {
+		t.Fatalf("expected unrelated conditions to be preserved, got %#v", latest.Status.Conditions)
+	}
+	if cond.Reason != reasonStorageClassMissing || cond.Status != metav1.ConditionFalse {
+		t.Fatalf("unexpected Ready condition: %#v", cond)
+	}
+	assertContainsAll(t, cond.Message,
+		`StorageClass "missing-sc" not found after 5m0s`,
+		"re-apply ClusterRestore default/restore-session",
+	)
+
+	select {
+	case event := <-recorder.Events:
+		assertContainsAll(t, event,
+			corev1.EventTypeWarning,
+			dprestore.ReasonRestoreFailed,
+			`StorageClass "missing-sc" not found after 5m0s`,
+		)
+	default:
+		t.Fatal("expected Warning event for bounded StorageClass wait timeout")
+	}
+}
+
+func newClusterRestoreUnitScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := dpv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	return scheme
+}
+
+func newStorageClassTestClusterRestore() *dpv1alpha1.ClusterRestore {
+	return &dpv1alpha1.ClusterRestore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "restore-session",
+			Namespace:  "default",
+			UID:        types.UID("restore-session-uid"),
+			Generation: 2,
+		},
+		Spec: dpv1alpha1.ClusterRestoreSpec{
+			TargetClusterName: "target-cluster",
+			BackupRef:         dpv1alpha1.ClusterRestoreBackupRef{Name: "backup", Namespace: "default"},
+		},
+		Status: dpv1alpha1.ClusterRestoreStatus{
+			Phase: dpv1alpha1.ClusterRestorePhaseRestoring,
+			Conditions: []metav1.Condition{{
+				Type:               "OtherControllerCondition",
+				Status:             metav1.ConditionTrue,
+				Reason:             "KeepMe",
+				Message:            "owned by another status writer",
+				ObservedGeneration: 1,
+				LastTransitionTime: metav1.NewTime(time.Now().Add(-time.Minute).Truncate(time.Second)),
+			}},
+		},
+	}
+}
+
+func newStorageClassTestPVC() *corev1.PersistentVolumeClaim {
+	storageClassName := "missing-sc"
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "data-target-cluster-mysql-0",
+			Namespace: "default",
+			Annotations: map[string]string{
+				dptypes.VolumeSourceAnnotationKey: "data",
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			StorageClassName: &storageClassName,
+		},
+	}
+}
+
+func assertContainsAll(t *testing.T, got string, wantSubstrings ...string) {
+	t.Helper()
+	for _, want := range wantSubstrings {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected %q to contain %q", got, want)
+		}
 	}
 }
 

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -309,6 +309,14 @@ func (r *VolumePopulatorReconciler) waitForPVCSelectedNode(reqCtx intctrlutil.Re
 		storageClassName := *pvc.Spec.StorageClassName
 		storageClass := &storagev1.StorageClass{}
 		if err := r.Client.Get(reqCtx.Ctx, types.NamespacedName{Name: storageClassName}, storageClass); err != nil {
+			// Distinguish NotFound so callers (notably ClusterRestoreReconciler,
+			// which invokes Populate directly for Backup-dataSource PVCs) can
+			// translate the case into a user-facing WaitingForStorageClass
+			// condition with a bounded retry window. Other GET errors keep the
+			// existing raw-error contract.
+			if apierrors.IsNotFound(err) {
+				return false, nodeName, &dprestore.StorageClassNotFoundError{Name: storageClassName}
+			}
 			return false, nodeName, err
 		}
 

--- a/pkg/dataprotection/restore/errors.go
+++ b/pkg/dataprotection/restore/errors.go
@@ -1,0 +1,57 @@
+/*
+Copyright (C) 2022-2025 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package restore
+
+import (
+	"errors"
+	"fmt"
+)
+
+// StorageClassNotFoundError signals that a referenced StorageClass cannot be
+// resolved at the time the data-protection restore path attempts to read it.
+//
+// This typed error is returned by helpers in the data-protection restore path
+// (e.g. VolumePopulator.waitForPVCSelectedNode) when a StorageClass GET fails
+// with apierrors.NotFound. Callers, for example ClusterRestoreReconciler,
+// use IsStorageClassNotFoundError to translate this case into a user-facing
+// condition (WaitingForStorageClass) with a bounded retry window before
+// escalating to Failed/StorageClassMissing. Other GET errors continue to
+// propagate as raw errors and rely on controller-runtime default retry.
+type StorageClassNotFoundError struct {
+	// Name is the StorageClass that the helper attempted to GET.
+	Name string
+}
+
+// Error implements the error interface. Format intentionally mirrors the
+// kube-apiserver NotFound message so existing log output stays human-readable.
+func (e *StorageClassNotFoundError) Error() string {
+	return fmt.Sprintf("StorageClass %q not found", e.Name)
+}
+
+// IsStorageClassNotFoundError reports whether err (or any error it wraps)
+// is a *StorageClassNotFoundError, returning the embedded sentinel so the
+// caller can read Name. Returns (nil, false) when err does not carry one.
+func IsStorageClassNotFoundError(err error) (*StorageClassNotFoundError, bool) {
+	var scErr *StorageClassNotFoundError
+	if errors.As(err, &scErr) {
+		return scErr, true
+	}
+	return nil, false
+}

--- a/pkg/dataprotection/restore/errors_test.go
+++ b/pkg/dataprotection/restore/errors_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright (C) 2022-2025 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package restore
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// Minimal red-tests pinning the *StorageClassNotFoundError contract used by
+// VolumePopulator.waitForPVCSelectedNode to signal a missing StorageClass and
+// by ClusterRestoreReconciler to translate that case into a user-facing
+// WaitingForStorageClass condition. Caller-side reconcile behaviour, bounded
+// timeout, and Warning event coverage live with the ClusterRestore tests; this
+// file only locks the sentinel surface.
+
+func TestStorageClassNotFoundError_Error(t *testing.T) {
+	err := &StorageClassNotFoundError{Name: "apelocal-hostpath-data"}
+	got := err.Error()
+	want := `StorageClass "apelocal-hostpath-data" not found`
+	if got != want {
+		t.Fatalf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestIsStorageClassNotFoundError(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		if scErr, ok := IsStorageClassNotFoundError(nil); ok || scErr != nil {
+			t.Fatalf("nil err should not match, got (%v, %v)", scErr, ok)
+		}
+	})
+
+	t.Run("plain other error", func(t *testing.T) {
+		if scErr, ok := IsStorageClassNotFoundError(errors.New("boom")); ok || scErr != nil {
+			t.Fatalf("plain error should not match, got (%v, %v)", scErr, ok)
+		}
+	})
+
+	t.Run("direct sentinel", func(t *testing.T) {
+		direct := &StorageClassNotFoundError{Name: "sc-x"}
+		scErr, ok := IsStorageClassNotFoundError(direct)
+		if !ok || scErr == nil {
+			t.Fatalf("direct sentinel should match, got (%v, %v)", scErr, ok)
+		}
+		if scErr.Name != "sc-x" {
+			t.Fatalf("scErr.Name = %q, want %q", scErr.Name, "sc-x")
+		}
+	})
+
+	t.Run("wrapped sentinel via fmt.Errorf %w", func(t *testing.T) {
+		wrapped := fmt.Errorf("populate failed: %w", &StorageClassNotFoundError{Name: "sc-y"})
+		scErr, ok := IsStorageClassNotFoundError(wrapped)
+		if !ok || scErr == nil {
+			t.Fatalf("wrapped sentinel should match via errors.As, got (%v, %v)", scErr, ok)
+		}
+		if scErr.Name != "sc-y" {
+			t.Fatalf("scErr.Name = %q, want %q", scErr.Name, "sc-y")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

This is a **test-coverage follow-up** to PR #10207. It adds three Ginkgo envtest specs that exercise the persistence-layer slice of `ClusterRestoreReconciler.handleStorageClassNotFound` that the existing fake-client unit tests in `clusterrestore_controller_test.go` cannot validate:

* real Status subresource Patch round-trip via the API server
* `metav1.Time` (LastTransitionTime) serialization preservation
* Warning event delivery through a real EventRecorder

## Boundary — what this PR is NOT

* Does **not** modify any production code path in `controllers/dataprotection/clusterrestore_controller.go`, `controllers/dataprotection/volumepopulator_controller.go`, or `pkg/dataprotection/restore/`. Diff is test-only.
* Does **not** change the `D2 patch-version` conclusion locked on PR #10207. The reason / message matrix for `handleStorageClassNotFound` is already covered by the fake-client unit tests in `clusterrestore_controller_test.go`; this PR adds only the envtest integration coverage that complements the existing matrix, not replaces it.
* Is **not** release-ready evidence. It is envtest integration coverage. Patch-version validation continues per the existing chain on #10207.
* Does **not** subsume case-002 (#10208 / PR #10209) populate-path lifecycle or case-003 (#10204 / PR #10205) external delete Job TTL.

## Scope of the new envtest specs

The new file `controllers/dataprotection/clusterrestore_controller_storageclass_envtest_test.go` adds three `It` specs, all of which exercise the bounded-window escalation outcome (Phase=Failed terminal) so the BeforeSuite-registered `ClusterRestoreReconciler` stays quiet (early return on terminal phase) and does not race with the spec:

1. **escalates to Failed/StorageClassMissing via real Status subresource and emits Warning event after the bounded wait window elapses** — proves the function correctly reads the seeded `LastTransitionTime` back through the real API server (otherwise elapsed would default to 0 and not escalate), and that the resulting Warning event is delivered via a real EventRecorder.
2. **preserves unrelated Status conditions through the real API server when escalating to StorageClassMissing** — proves the Status subresource Patch only modifies the `Ready` condition and that an unrelated condition's `LastTransitionTime` survives the round-trip unchanged.
3. **propagates the missing StorageClass identifier and ClusterRestore identity through real API server serialization** — proves the failure message rendering (StorageClass name + `ClusterRestore namespace/name`) survives serialization through the Status subresource.

## Manager-race avoidance

Specs construct an independent `ClusterRestoreReconciler` (suite k8sClient + suite manager scheme + per-spec `record.FakeRecorder`) and call `handleStorageClassNotFound` directly. The seed helper waits for the BeforeSuite-registered manager-side reconciler to settle on terminal `Phase=Failed` (`getAndValidateBackup -> NewFatalError -> Phase=Failed`) before overwriting `Status.Conditions`; `Phase` stays `Failed` through the spec's call so the manager-side reconciler early-returns on every subsequent enqueue. Assertions read state back through `k8sClient.Get` — never the in-memory copy.

Event drain is bounded (2 s timeout via `select`) so async event delivery does not flake the assertion.

## Local validation

* envtest 1.30.0 focused (3 specs): GREEN 10.5 s
* envtest 1.30.0 full `controllers/dataprotection` (124 specs): GREEN 44.6 s — no breakage of existing specs
* envtest 1.26.1 focused (3 specs): GREEN 9.9 s (Edward independent rerun)
* envtest 1.26.1 full: GREEN 46.4 s (Edward independent rerun)
* `go vet ./controllers/dataprotection ./pkg/dataprotection/restore` clean
* `git diff --check` clean

```
export KUBEBUILDER_ASSETS="/path/to/setup-envtest/k8s/1.30.0-darwin-arm64"
go test ./controllers/dataprotection -run TestAPIs --ginkgo.focus="ClusterRestore StorageClass missing envtest" -count=1 -timeout=180s
```

## Reviewers

XP design contract review (8 classes) accepted by the controller pair.
