### PR TITLE
fix(operations): close RebuildInstance PVC handoff race (backport #10191 to release-1.0)

### DIFF
--- a/pkg/operations/rebuild_instance_inplace.go
+++ b/pkg/operations/rebuild_instance_inplace.go
@@ -24,8 +24,10 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/kubectl/pkg/util/podutils"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -349,75 +351,159 @@ func (inPlaceHelper *inplaceRebuildHelper) rebuildSourcePVCsAndRecreateInstance(
 	cli client.Client,
 	opsRequest *opsv1alpha1.OpsRequest,
 	progressDetail *opsv1alpha1.ProgressStatusDetail) error {
-	for sourcePVCName, v := range inPlaceHelper.pvcMap {
-		tmpPVC := &corev1.PersistentVolumeClaim{}
-		_ = cli.Get(reqCtx.Ctx, types.NamespacedName{Name: v.Name, Namespace: v.Namespace}, tmpPVC)
-		if tmpPVC.UID == "" {
-			// if the tmp pvc not exists in k8s, replace with the built pvc.
-			tmpPVC = v
+	itsName := constant.GenerateWorkloadNamePattern(inPlaceHelper.synthesizedComp.ClusterName, inPlaceHelper.synthesizedComp.Name)
+
+	needDeleteTargetPod := false
+	waitingForSourcePVC := false
+	for sourcePVCName, builtTmpPVC := range inPlaceHelper.pvcMap {
+		tmpPVC, err := inPlaceHelper.getLiveTmpPVCOrBuilt(reqCtx, cli, builtTmpPVC)
+		if err != nil {
+			return err
 		}
-		// 1. get the restored pv
 		pv, err := inPlaceHelper.getRestoredPV(reqCtx, cli, tmpPVC)
 		if err != nil {
 			return err
 		}
-		sourcePvc := &corev1.PersistentVolumeClaim{}
-		if err = cli.Get(reqCtx.Ctx, types.NamespacedName{Name: sourcePVCName, Namespace: tmpPVC.Namespace}, sourcePvc); err != nil {
-			// if not exists, wait for the pvc to recreate by external controller.
+		sourcePVC, err := inPlaceHelper.getSourcePVC(reqCtx, cli, sourcePVCName, tmpPVC.Namespace)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				waitingForSourcePVC = true
+				continue
+			}
 			return err
 		}
 		if _, ok := pv.Annotations[rebuildFromAnnotation]; !ok {
 			if pv.Labels[rebuildTmpPVCNameLabel] != tmpPVC.Name {
-				// 2. retain and label the pv with 'rebuildTmpPVCNameLabel'
-				if err = inPlaceHelper.retainAndAnnotatePV(reqCtx, cli, opsRequest.Name, pv, tmpPVC, sourcePvc); err != nil {
+				if err = inPlaceHelper.retainAndAnnotatePV(reqCtx, cli, opsRequest.Name, pv, tmpPVC, sourcePVC); err != nil {
 					return err
 				}
 			}
+		} else if pv.Annotations[rebuildFromAnnotation] != opsRequest.Name {
+			return intctrlutil.NewFatalError(fmt.Sprintf(`the pv "%s" is rebuilt by another OpsRequest "%s"`, pv.Name, pv.Annotations[rebuildFromAnnotation]))
 		}
-		// 3. cleanup the tmp pvc firstly.
-		if err = inPlaceHelper.cleanupTmpPVC(reqCtx, cli, tmpPVC); err != nil {
+		if err = inPlaceHelper.preBindPVToSourcePVC(reqCtx, cli, pv, tmpPVC, sourcePVCName, sourcePVC); err != nil {
 			return err
 		}
-		// set volumeName to tmp pvc, it will be used when recreating the source pvc.
-		tmpPVC.Spec.VolumeName = pv.Name
-		// 4. recreate the source pvc.
-		if err = inPlaceHelper.recreateSourcePVC(reqCtx, cli, tmpPVC, sourcePvc, opsRequest.Name); err != nil {
-			return err
+		if sourcePVC.DeletionTimestamp != nil {
+			waitingForSourcePVC = true
+			if err := inPlaceHelper.removePVCFinalizer(reqCtx, cli, sourcePVC); err != nil {
+				return err
+			}
+			continue
+		}
+		if sourcePVC.Spec.VolumeName == pv.Name {
+			if err := inPlaceHelper.cleanupTmpPVC(reqCtx, cli, tmpPVC); err != nil {
+				return err
+			}
+			latestPV := &corev1.PersistentVolume{}
+			if err := cli.Get(reqCtx.Ctx, types.NamespacedName{Name: pv.Name}, latestPV); err != nil {
+				return err
+			}
+			if err := inPlaceHelper.revertReclaimPolicy(reqCtx, cli, latestPV); err != nil {
+				return err
+			}
+			continue
 		}
 
-		// 5. rebound the pv to the source pvc.
-		if err = inPlaceHelper.reboundPV(reqCtx, cli, sourcePvc, pv, opsRequest.Name); err != nil {
+		waitingForSourcePVC = true
+		if sourcePVC.Spec.VolumeName == "" {
+			if err := inPlaceHelper.setSourcePVCVolumeNameForRebuild(reqCtx, cli, sourcePVC, pv.Name); err != nil {
+				return err
+			}
+		} else {
+			if err := inPlaceHelper.failIfSourcePVCBoundToOtherActiveRebuildPV(reqCtx, cli, opsRequest, sourcePVC, pv); err != nil {
+				return err
+			}
+			needDeleteTargetPod = true
+			if err := inPlaceHelper.deleteSourcePVCForRebuild(reqCtx, cli, sourcePVC); err != nil {
+				return err
+			}
+		}
+	}
+	if needDeleteTargetPod {
+		if err := inPlaceHelper.setInstanceNodeSelectorForRebuild(reqCtx, cli, itsName); err != nil {
 			return err
 		}
-		// 6. revert the reclaim policy of the pv.
-		if err = inPlaceHelper.revertReclaimPolicy(reqCtx, cli, pv); err != nil {
+		if err := inPlaceHelper.deleteTargetPodForRebuild(reqCtx, cli, opsRequest); err != nil {
 			return err
 		}
 	}
-	// update progress message and recreate the target instance by deleting it.
+	if waitingForSourcePVC {
+		progressDetail.Message = "Waiting for source PVCs to bind restored PVs"
+		return nil
+	}
+
 	progressDetail.Message = waitingForInstanceReadyMessage
+	return nil
+}
+
+func (inPlaceHelper *inplaceRebuildHelper) deleteTargetPodForRebuild(reqCtx intctrlutil.RequestCtx,
+	cli client.Client,
+	opsRequest *opsv1alpha1.OpsRequest) error {
 	var options []client.DeleteOption
 	if opsRequest.Spec.Force {
 		options = append(options, client.GracePeriodSeconds(0))
 	}
+	return client.IgnoreNotFound(intctrlutil.BackgroundDeleteObject(cli, reqCtx.Ctx, inPlaceHelper.targetPod, options...))
+}
 
-	if inPlaceHelper.instance.TargetNodeName != "" {
-		// under the circumstance of using cloud disks, need to set node selector again to make sure pod
-		// goes to the specified node
+func (inPlaceHelper *inplaceRebuildHelper) setSourcePVCVolumeNameForRebuild(reqCtx intctrlutil.RequestCtx,
+	cli client.Client,
+	sourcePVC *corev1.PersistentVolumeClaim,
+	pvName string) error {
+	patch := client.MergeFrom(sourcePVC.DeepCopy())
+	// Bind the replacement PVC that InstanceSet just created to the restored PV.
+	// If it has already bound to another PV, the caller deletes it and waits for
+	// a fresh PVC instead of changing an immutable bound claim.
+	sourcePVC.Spec.VolumeName = pvName
+	return cli.Patch(reqCtx.Ctx, sourcePVC, patch)
+}
+
+func (inPlaceHelper *inplaceRebuildHelper) setInstanceNodeSelectorForRebuild(reqCtx intctrlutil.RequestCtx,
+	cli client.Client,
+	itsName string) error {
+	if inPlaceHelper.instance.TargetNodeName == "" {
+		return nil
+	}
+	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		its := &workloads.InstanceSet{}
-		itsName := constant.GenerateWorkloadNamePattern(inPlaceHelper.synthesizedComp.ClusterName, inPlaceHelper.synthesizedComp.Name)
 		if err := cli.Get(reqCtx.Ctx, types.NamespacedName{Name: itsName, Namespace: inPlaceHelper.synthesizedComp.Namespace}, its); err != nil {
 			return err
 		}
+		patch := client.MergeFrom(its.DeepCopy())
+		// If the rebuilt instance targets a node, ask InstanceSet to apply that node selector when it recreates the pod.
 		if err := instanceset.MergeNodeSelectorOnceAnnotation(its, map[string]string{inPlaceHelper.targetPod.Name: inPlaceHelper.instance.TargetNodeName}); err != nil {
 			return err
 		}
-		if err := cli.Update(reqCtx.Ctx, its); err != nil {
-			return err
-		}
+		return cli.Patch(reqCtx.Ctx, its, patch)
+	}); err != nil {
+		return err
 	}
+	return nil
+}
 
-	return intctrlutil.BackgroundDeleteObject(cli, reqCtx.Ctx, inPlaceHelper.targetPod, options...)
+func (inPlaceHelper *inplaceRebuildHelper) getLiveTmpPVCOrBuilt(reqCtx intctrlutil.RequestCtx,
+	cli client.Client,
+	builtTmpPVC *corev1.PersistentVolumeClaim) (*corev1.PersistentVolumeClaim, error) {
+	tmpPVC := &corev1.PersistentVolumeClaim{}
+	if err := cli.Get(reqCtx.Ctx, types.NamespacedName{Name: builtTmpPVC.Name, Namespace: builtTmpPVC.Namespace}, tmpPVC); err != nil {
+		if apierrors.IsNotFound(err) {
+			return builtTmpPVC, nil
+		}
+		return nil, err
+	}
+	return tmpPVC, nil
+}
+
+func (inPlaceHelper *inplaceRebuildHelper) getSourcePVC(reqCtx intctrlutil.RequestCtx,
+	cli client.Client,
+	name string,
+	namespace string) (*corev1.PersistentVolumeClaim, error) {
+	sourcePVC := &corev1.PersistentVolumeClaim{}
+	if err := cli.Get(reqCtx.Ctx, types.NamespacedName{Name: name, Namespace: namespace}, sourcePVC); err != nil {
+		return nil, err
+	}
+	return sourcePVC, nil
 }
 
 func (inPlaceHelper *inplaceRebuildHelper) getRestoredPV(reqCtx intctrlutil.RequestCtx,
@@ -452,7 +538,7 @@ func (inPlaceHelper *inplaceRebuildHelper) retainAndAnnotatePV(reqCtx intctrluti
 	patchPV := client.MergeFrom(pv.DeepCopy())
 	// Examine the claimRef for the PV and see if it's bound to the correct PVC
 	claimRef := pv.Spec.ClaimRef
-	if claimRef != nil && claimRef.Name != tmpPVC.Name || claimRef.Namespace != tmpPVC.Namespace {
+	if claimRef != nil && (claimRef.Name != tmpPVC.Name || claimRef.Namespace != tmpPVC.Namespace) {
 		return intctrlutil.NewFatalError(fmt.Sprintf(`the pv "%s" is not bound by the pvc "%s"`, pv.Name, tmpPVC.Name))
 	}
 	// 1. retain and label the pv
@@ -479,6 +565,80 @@ func (inPlaceHelper *inplaceRebuildHelper) retainAndAnnotatePV(reqCtx intctrluti
 	return cli.Patch(reqCtx.Ctx, pv, patchPV)
 }
 
+func (inPlaceHelper *inplaceRebuildHelper) preBindPVToSourcePVC(reqCtx intctrlutil.RequestCtx,
+	cli client.Client,
+	pv *corev1.PersistentVolume,
+	tmpPVC *corev1.PersistentVolumeClaim,
+	sourcePVCName string,
+	sourcePVC *corev1.PersistentVolumeClaim) error {
+	uid := types.UID("")
+	if sourcePVC.Spec.VolumeName == "" || sourcePVC.Spec.VolumeName == pv.Name {
+		uid = sourcePVC.UID
+	}
+	claimRef := pv.Spec.ClaimRef
+	if claimRef != nil &&
+		claimRef.Name == sourcePVCName &&
+		claimRef.Namespace == tmpPVC.Namespace &&
+		claimRef.UID == uid &&
+		claimRef.APIVersion == "v1" &&
+		claimRef.Kind == "PersistentVolumeClaim" {
+		return nil
+	}
+	if claimRef != nil &&
+		(claimRef.Name != tmpPVC.Name || claimRef.Namespace != tmpPVC.Namespace) &&
+		(claimRef.Name != sourcePVCName || claimRef.Namespace != tmpPVC.Namespace) {
+		return intctrlutil.NewFatalError(fmt.Sprintf(`the pv "%s" is not owned by the rebuild pvc "%s"`, pv.Name, tmpPVC.Name))
+	}
+	patchPV := client.MergeFrom(pv.DeepCopy())
+	// Reserve the restored PV for the current source PVC object. If InstanceSet
+	// recreates that PVC later, this check will run again and update the UID.
+	pv.Spec.ClaimRef = &corev1.ObjectReference{
+		APIVersion: "v1",
+		Kind:       "PersistentVolumeClaim",
+		Namespace:  tmpPVC.Namespace,
+		Name:       sourcePVCName,
+		UID:        uid,
+	}
+	return cli.Patch(reqCtx.Ctx, pv, patchPV)
+}
+
+func (inPlaceHelper *inplaceRebuildHelper) failIfSourcePVCBoundToOtherActiveRebuildPV(reqCtx intctrlutil.RequestCtx,
+	cli client.Client,
+	opsRequest *opsv1alpha1.OpsRequest,
+	sourcePVC *corev1.PersistentVolumeClaim,
+	restoredPV *corev1.PersistentVolume) error {
+	if sourcePVC.Spec.VolumeName == "" || sourcePVC.Spec.VolumeName == restoredPV.Name {
+		return nil
+	}
+	sourcePV := &corev1.PersistentVolume{}
+	if err := cli.Get(reqCtx.Ctx, types.NamespacedName{Name: sourcePVC.Spec.VolumeName}, sourcePV); err != nil {
+		return err
+	}
+	if sourcePV.Annotations == nil {
+		return nil
+	}
+	ownerName := sourcePV.Annotations[rebuildFromAnnotation]
+	if ownerName == "" || ownerName == opsRequest.Name {
+		return nil
+	}
+	claimRef := sourcePV.Spec.ClaimRef
+	if claimRef == nil || claimRef.Name != sourcePVC.Name || claimRef.Namespace != sourcePVC.Namespace {
+		return nil
+	}
+	owner := &opsv1alpha1.OpsRequest{}
+	if err := cli.Get(reqCtx.Ctx, types.NamespacedName{Name: ownerName, Namespace: opsRequest.Namespace}, owner); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	if owner.IsComplete() {
+		return nil
+	}
+	return intctrlutil.NewFatalError(fmt.Sprintf(`the source pvc "%s" is already bound to pv "%s" restored by OpsRequest "%s"`,
+		sourcePVC.Name, sourcePV.Name, ownerName))
+}
+
 func (inPlaceHelper *inplaceRebuildHelper) cleanupTmpPVC(reqCtx intctrlutil.RequestCtx,
 	cli client.Client,
 	tmpPVC *corev1.PersistentVolumeClaim) error {
@@ -492,72 +652,37 @@ func (inPlaceHelper *inplaceRebuildHelper) cleanupTmpPVC(reqCtx intctrlutil.Requ
 	return inPlaceHelper.removePVCFinalizer(reqCtx, cli, tmpPVC)
 }
 
-// recreateSourcePVC recreates the source pvc to bound the restored pv.
-func (inPlaceHelper *inplaceRebuildHelper) recreateSourcePVC(reqCtx intctrlutil.RequestCtx,
+func (inPlaceHelper *inplaceRebuildHelper) deleteSourcePVCForRebuild(reqCtx intctrlutil.RequestCtx,
 	cli client.Client,
-	tmpPVC,
-	sourcePvc *corev1.PersistentVolumeClaim,
-	opsRequestName string) error {
-
-	// if the pvc is rebuilt by current opsRequest, return.
-	if sourcePvc.Annotations[rebuildFromAnnotation] == opsRequestName {
+	sourcePVC *corev1.PersistentVolumeClaim) error {
+	if sourcePVC.DeletionTimestamp != nil {
 		return nil
 	}
-	// 1. merge the labels of the source pvc.
-	intctrlutil.MergeMetadataMapInplace(sourcePvc.Labels, &tmpPVC.Labels)
-	// 2. delete the old pvc
-	if err := intctrlutil.BackgroundDeleteObject(cli, reqCtx.Ctx, sourcePvc); err != nil {
+	// Remove the old source PVC name. InstanceSet will recreate it from the normal volumeClaimTemplate.
+	if err := intctrlutil.BackgroundDeleteObject(cli, reqCtx.Ctx, sourcePVC); err != nil {
 		return err
 	}
-	if err := inPlaceHelper.removePVCFinalizer(reqCtx, cli, sourcePvc); err != nil {
-		return err
-	}
-
-	// 3. recreate the pvc with restored PV.
-	newPVC := &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        sourcePvc.Name,
-			Namespace:   tmpPVC.Namespace,
-			Labels:      tmpPVC.Labels,
-			Annotations: sourcePvc.Annotations,
-		},
-		Spec: tmpPVC.Spec,
-	}
-	// merge the annotations of the source pvc.
-	if newPVC.Annotations == nil {
-		newPVC.Annotations = map[string]string{}
-	}
-	newPVC.Annotations[rebuildFromAnnotation] = opsRequestName
-	return cli.Create(reqCtx.Ctx, newPVC)
-}
-
-// reboundPV rebounds the PV to the source PVC if it is bound to another PVC.
-func (inPlaceHelper *inplaceRebuildHelper) reboundPV(reqCtx intctrlutil.RequestCtx,
-	cli client.Client,
-	sourcePvc *corev1.PersistentVolumeClaim,
-	pv *corev1.PersistentVolume,
-	opsRequestName string) error {
-	// if the pvc is not rebuilt by current opsRequest, return.
-	if sourcePvc.Annotations[rebuildFromAnnotation] != opsRequestName {
-		return nil
-	}
-	if pv.Spec.ClaimRef == nil || pv.Spec.ClaimRef.UID == sourcePvc.UID {
-		return nil
-	}
-	pv.Spec.ClaimRef = nil
-	return cli.Update(reqCtx.Ctx, pv)
+	return inPlaceHelper.removePVCFinalizer(reqCtx, cli, sourcePVC)
 }
 
 func (inPlaceHelper *inplaceRebuildHelper) revertReclaimPolicy(reqCtx intctrlutil.RequestCtx,
 	cli client.Client, pv *corev1.PersistentVolume) error {
-	if string(pv.Spec.PersistentVolumeReclaimPolicy) == pv.Annotations[sourcePVReclaimPolicyAnnotation] {
-		return nil
+	reclaimPolicy := pv.Annotations[sourcePVReclaimPolicyAnnotation]
+	patch := client.MergeFrom(pv.DeepCopy())
+	if reclaimPolicy != "" && string(pv.Spec.PersistentVolumeReclaimPolicy) != reclaimPolicy {
+		if pv.Status.Phase != corev1.VolumeBound {
+			return intctrlutil.NewErrorf(intctrlutil.ErrorTypeNeedWaiting, `wait for the PV "%s" to be bound`, pv.GetName())
+		}
+		pv.Spec.PersistentVolumeReclaimPolicy = corev1.PersistentVolumeReclaimPolicy(reclaimPolicy)
 	}
-	if pv.Status.Phase != corev1.VolumeBound {
-		return intctrlutil.NewErrorf(intctrlutil.ErrorTypeNeedWaiting, `wait for the PV "%s" to be bound`, pv.GetName())
+	if pv.Annotations != nil {
+		delete(pv.Annotations, rebuildFromAnnotation)
+		delete(pv.Annotations, sourcePVReclaimPolicyAnnotation)
 	}
-	pv.Spec.PersistentVolumeReclaimPolicy = corev1.PersistentVolumeReclaimPolicy(pv.Annotations[sourcePVReclaimPolicyAnnotation])
-	return cli.Update(reqCtx.Ctx, pv)
+	if pv.Labels != nil {
+		delete(pv.Labels, rebuildTmpPVCNameLabel)
+	}
+	return cli.Patch(reqCtx.Ctx, pv, patch)
 }
 
 func (inPlaceHelper *inplaceRebuildHelper) removePVCFinalizer(reqCtx intctrlutil.RequestCtx,
@@ -596,7 +721,10 @@ func getPVCMapAndVolumes(opsRes *OpsResource,
 	for i, vct := range synthesizedComp.VolumeClaimTemplates {
 		sourcePVCName := volumePVCMap[vct.Name]
 		if sourcePVCName == "" {
-			return nil, nil, nil, intctrlutil.NewFatalError("")
+			// release-1.0 backport: ComposePVCName helper is part of PR #9355 (volumes sharing among instances)
+			// which has not been backported to release-1.0. PVCNamePrefixAnnotationKey is also unset on this
+			// release line, so the helper's fallback is equivalent to the simple "<template>-<pod>" naming.
+			sourcePVCName = fmt.Sprintf("%s-%s", vct.Name, targetPod.Name)
 		}
 		pvcLabels := getWellKnownLabels(synthesizedComp)
 		tmpPVC := &corev1.PersistentVolumeClaim{

--- a/pkg/operations/rebuild_instance_test.go
+++ b/pkg/operations/rebuild_instance_test.go
@@ -27,7 +27,9 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
@@ -219,43 +221,143 @@ var _ = Describe("OpsUtil functions", func() {
 			// fake the pvs and bound them to the tmp pvcs
 			pvs := fakeTmpPVCBoundPV(pvcList)
 
-			_, _ = GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
-			for i := range pvs {
-				Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(pvs[i]), func(g Gomega, pv *corev1.PersistentVolume) {
-					g.Expect(pv.Spec.ClaimRef).Should(BeNil())
-					g.Expect(pv.Spec.PersistentVolumeReclaimPolicy).Should(Equal(corev1.PersistentVolumeReclaimDelete))
+			sourcePVCTemplateList := &corev1.PersistentVolumeClaimList{}
+			Expect(k8sClient.List(ctx, sourcePVCTemplateList,
+				client.MatchingLabels{constant.KBAppComponentLabelKey: defaultCompName},
+				client.InNamespace(opsRes.OpsRequest.Namespace))).Should(Succeed())
+			sourcePVCTemplates := map[string]*corev1.PersistentVolumeClaim{}
+			for i := range sourcePVCTemplateList.Items {
+				pvc := sourcePVCTemplateList.Items[i].DeepCopy()
+				if _, ok := pvc.Annotations[rebuildFromAnnotation]; ok {
+					continue
+				}
+				sourcePVCTemplates[pvc.Name] = pvc
+			}
+			sourcePVCToPV := map[string]string{}
+			sourcePVCToTmpPVC := map[string]string{}
+			Eventually(func(g Gomega) {
+				_, err := GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
+				g.Expect(err).Should(Succeed())
+				sourcePVCToPV = map[string]string{}
+				sourcePVCToTmpPVC = map[string]string{}
+				for i := range pvs {
+					pv := &corev1.PersistentVolume{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pvs[i]), pv)).Should(Succeed())
+					g.Expect(pv.Spec.ClaimRef).ShouldNot(BeNil())
+					g.Expect(pv.Spec.PersistentVolumeReclaimPolicy).Should(Equal(corev1.PersistentVolumeReclaimRetain))
 					g.Expect(pv.Annotations[rebuildFromAnnotation]).Should(Equal(opsRes.OpsRequest.Name))
-				}))
+					sourcePVCToPV[pv.Spec.ClaimRef.Name] = pv.Name
+					sourcePVCToTmpPVC[pv.Spec.ClaimRef.Name] = pv.Labels[rebuildTmpPVCNameLabel]
+				}
+				g.Expect(sourcePVCToPV).Should(HaveLen(rebuildInstanceCount))
+			}).Should(Succeed())
+			for _, ins := range opsRes.OpsRequest.Spec.RebuildFrom[0].Instances {
+				pod := &corev1.Pod{}
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: ins.Name, Namespace: opsRes.OpsRequest.Namespace}, pod)
+				Expect(client.IgnoreNotFound(err)).Should(Succeed())
+				if err == nil {
+					Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, pod))).Should(Succeed())
+				}
 			}
 
-			Expect(k8sClient.List(ctx, pvcList, client.MatchingLabels{constant.KBAppComponentLabelKey: defaultCompName}, client.InNamespace(opsRes.OpsRequest.Namespace))).Should(Succeed())
-			By("mock the restored pvs are bound")
-			for i := range pvs {
-				Expect(testapps.ChangeObjStatus(&testCtx, pvs[i], func() {
-					pvs[i].Status.Phase = corev1.VolumeBound
+			for sourcePVCName := range sourcePVCToPV {
+				Eventually(func(g Gomega) {
+					pvc := &corev1.PersistentVolumeClaim{}
+					err := k8sClient.Get(ctx, client.ObjectKey{Name: sourcePVCName, Namespace: opsRes.OpsRequest.Namespace}, pvc)
+					g.Expect(apierrors.IsNotFound(err)).Should(BeTrue())
+				}).Should(Succeed())
+			}
+
+			initInstanceSetPods(ctx, k8sClient, opsRes)
+			By("expect rebuild to wait while InstanceSet has not recreated the source PVCs")
+			_, err := GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
+			Expect(err).Should(Succeed())
+			for _, detail := range opsRes.OpsRequest.Status.Components[defaultCompName].ProgressDetails {
+				Expect(detail.Message).Should(Equal("Waiting for source PVCs to bind restored PVs"))
+			}
+
+			for sourcePVCName := range sourcePVCToPV {
+				sourcePVCTemplate := sourcePVCTemplates[sourcePVCName]
+				Expect(sourcePVCTemplate).ShouldNot(BeNil())
+				recreatedSourcePVC := sourcePVCTemplate.DeepCopy()
+				recreatedSourcePVC.ResourceVersion = ""
+				recreatedSourcePVC.UID = ""
+				recreatedSourcePVC.CreationTimestamp = metav1.Time{}
+				recreatedSourcePVC.DeletionTimestamp = nil
+				recreatedSourcePVC.ManagedFields = nil
+				recreatedSourcePVC.Finalizers = nil
+				recreatedSourcePVC.Spec.VolumeName = ""
+				Expect(k8sClient.Create(ctx, recreatedSourcePVC)).Should(Succeed())
+			}
+
+			Eventually(func(g Gomega) {
+				_, err := GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
+				g.Expect(err).Should(Succeed())
+				for sourcePVCName, pvName := range sourcePVCToPV {
+					pvc := &corev1.PersistentVolumeClaim{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: sourcePVCName, Namespace: opsRes.OpsRequest.Namespace}, pvc)).Should(Succeed())
+					g.Expect(pvc.Spec.VolumeName).Should(Equal(pvName))
+					pv := &corev1.PersistentVolume{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: pvName}, pv)).Should(Succeed())
+					g.Expect(pv.Spec.ClaimRef).ShouldNot(BeNil())
+					g.Expect(pv.Spec.ClaimRef.Name).Should(Equal(sourcePVCName))
+					g.Expect(pv.Spec.ClaimRef.UID).Should(Equal(pvc.UID))
+				}
+			}).Should(Succeed())
+
+			By("mock the source pvcs are bound to the restored pvs")
+			for sourcePVCName, pvName := range sourcePVCToPV {
+				pvc := &corev1.PersistentVolumeClaim{}
+				Expect(k8sClient.Get(ctx, client.ObjectKey{Name: sourcePVCName, Namespace: opsRes.OpsRequest.Namespace}, pvc)).Should(Succeed())
+				Expect(testapps.ChangeObj(&testCtx, pvc, func(p *corev1.PersistentVolumeClaim) {
+					p.Spec.VolumeName = pvName
+				})).Should(Succeed())
+				Expect(testapps.ChangeObjStatus(&testCtx, pvc, func() {
+					pvc.Status.Phase = corev1.ClaimBound
+				})).Should(Succeed())
+				pv := &corev1.PersistentVolume{}
+				Expect(k8sClient.Get(ctx, client.ObjectKey{Name: pvName}, pv)).Should(Succeed())
+				Expect(testapps.ChangeObjStatus(&testCtx, pv, func() {
+					pv.Status.Phase = corev1.VolumeBound
 				})).Should(Succeed())
 			}
-			// reconcile again to revert the reclaim policy
-			_, _ = GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
+			_, err = GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
+			Expect(err).Should(Succeed())
 
 			Expect(k8sClient.List(ctx, pvcList, client.MatchingLabels{constant.KBAppComponentLabelKey: defaultCompName}, client.InNamespace(opsRes.OpsRequest.Namespace))).Should(Succeed())
 			reCreatePVCCount := 0
 			for i := range pvcList.Items {
 				pvc := &pvcList.Items[i]
-				rebuildFrom, ok := pvc.Annotations[rebuildFromAnnotation]
+				pvName, ok := sourcePVCToPV[pvc.Name]
 				if !ok {
 					continue
 				}
 				reCreatePVCCount += 1
-				Expect(rebuildFrom).Should(Equal(opsRes.OpsRequest.Name))
-				Expect(pvc.Spec.VolumeName).Should(ContainSubstring("-pv"))
+				Expect(pvc.Spec.VolumeName).Should(Equal(pvName))
+				Expect(testapps.ChangeObj(&testCtx, pvc, func(p *corev1.PersistentVolumeClaim) {
+					if p.Labels == nil {
+						p.Labels = map[string]string{}
+					}
+					p.Labels[testCtx.TestObjLabelKey] = "true"
+					p.Finalizers = nil
+				})).Should(Succeed())
 			}
 			Expect(reCreatePVCCount).Should(Equal(rebuildInstanceCount))
 			By("expect to revert the reclaim policy to Delete")
 			for i := range pvs {
 				Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(pvs[i]), func(g Gomega, pv *corev1.PersistentVolume) {
 					g.Expect(pv.Spec.PersistentVolumeReclaimPolicy).Should(Equal(corev1.PersistentVolumeReclaimDelete))
+					g.Expect(pv.Annotations).ShouldNot(HaveKey(rebuildFromAnnotation))
+					g.Expect(pv.Annotations).ShouldNot(HaveKey(sourcePVReclaimPolicyAnnotation))
+					g.Expect(pv.Labels).ShouldNot(HaveKey(rebuildTmpPVCNameLabel))
 				}))
+			}
+			for _, tmpPVCName := range sourcePVCToTmpPVC {
+				Eventually(func(g Gomega) {
+					tmpPVC := &corev1.PersistentVolumeClaim{}
+					err := k8sClient.Get(ctx, client.ObjectKey{Name: tmpPVCName, Namespace: opsRes.OpsRequest.Namespace}, tmpPVC)
+					g.Expect(apierrors.IsNotFound(err)).Should(BeTrue())
+				}).Should(Succeed())
 			}
 		}
 
@@ -338,6 +440,59 @@ var _ = Describe("OpsUtil functions", func() {
 				g.Expect(mapping).To(HaveKeyWithValue(podPrefix+"-0", targetNodeName))
 				g.Expect(mapping).To(HaveKeyWithValue(podPrefix+"-1", targetNodeName))
 			})).Should(Succeed())
+		})
+
+		It("pre-binds restored PV claimRef to the source PVC", func() {
+			reqCtx := intctrlutil.RequestCtx{Ctx: testCtx.Ctx}
+			sourcePVCName := "data-rebuild-source-" + testCtx.GetRandomStr()
+			tmpPVC := testapps.NewPersistentVolumeClaimFactory(testCtx.DefaultNamespace, "rebuild-tmp-"+testCtx.GetRandomStr(), clusterName, defaultCompName, testapps.DataVolumeName).
+				SetStorage("20Gi").
+				Create(&testCtx).
+				GetObject()
+			sourcePVC := testapps.NewPersistentVolumeClaimFactory(testCtx.DefaultNamespace, sourcePVCName, clusterName, defaultCompName, testapps.DataVolumeName).
+				SetStorage("20Gi").
+				Create(&testCtx).
+				GetObject()
+			pv := testapps.NewPersistentVolumeFactory(tmpPVC.Namespace, "restored-pv-"+testCtx.GetRandomStr(), tmpPVC.Name).
+				SetStorage("20Gi").
+				SetClaimRef(tmpPVC).
+				Create(&testCtx).
+				GetObject()
+
+			helper := &inplaceRebuildHelper{}
+			Expect(helper.preBindPVToSourcePVC(reqCtx, k8sClient, pv, tmpPVC, sourcePVCName, sourcePVC)).Should(Succeed())
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pv), pv)).Should(Succeed())
+			Expect(pv.Spec.ClaimRef.Name).Should(Equal(sourcePVCName))
+			Expect(pv.Spec.ClaimRef.Namespace).Should(Equal(testCtx.DefaultNamespace))
+			Expect(pv.Spec.ClaimRef.UID).Should(Equal(sourcePVC.UID))
+
+			wrongBoundSourcePVC := sourcePVC.DeepCopy()
+			wrongBoundSourcePVC.Spec.VolumeName = "old-source-pv"
+			Expect(helper.preBindPVToSourcePVC(reqCtx, k8sClient, pv, tmpPVC, sourcePVCName, wrongBoundSourcePVC)).Should(Succeed())
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pv), pv)).Should(Succeed())
+			Expect(pv.Spec.ClaimRef.Name).Should(Equal(sourcePVCName))
+			Expect(pv.Spec.ClaimRef.Namespace).Should(Equal(testCtx.DefaultNamespace))
+			Expect(pv.Spec.ClaimRef.UID).Should(BeEmpty())
+
+			recreatedSourcePVC := sourcePVC.DeepCopy()
+			recreatedSourcePVC.UID = types.UID("recreated-source-pvc")
+			Expect(helper.preBindPVToSourcePVC(reqCtx, k8sClient, pv, tmpPVC, sourcePVCName, recreatedSourcePVC)).Should(Succeed())
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pv), pv)).Should(Succeed())
+			Expect(pv.Spec.ClaimRef.UID).Should(Equal(recreatedSourcePVC.UID))
+		})
+
+		It("sets volumeName on an unbound replacement source PVC", func() {
+			reqCtx := intctrlutil.RequestCtx{Ctx: testCtx.Ctx}
+			sourcePVC := testapps.NewPersistentVolumeClaimFactory(testCtx.DefaultNamespace, "data-rebuild-unbound-"+testCtx.GetRandomStr(), clusterName, defaultCompName, testapps.DataVolumeName).
+				SetStorage("20Gi").
+				Create(&testCtx).
+				GetObject()
+
+			helper := &inplaceRebuildHelper{}
+			Expect(helper.setSourcePVCVolumeNameForRebuild(reqCtx, k8sClient, sourcePVC, "restored-pv-"+testCtx.GetRandomStr())).Should(Succeed())
+
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sourcePVC), sourcePVC)).Should(Succeed())
+			Expect(sourcePVC.Spec.VolumeName).Should(ContainSubstring("restored-pv-"))
 		})
 
 		testRebuildInstanceWithBackup := func(ignoreRoleCheck bool) {


### PR DESCRIPTION
## Summary

Backport of PR #10191 (merged to main at `7852fcddb`) onto `release-1.0` so the next 1.0.3 beta image can include the RebuildInstance PVC handoff race fix.

## Why

`apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com/apecloud/kubeblocks:1.0.3-beta.6` (image build `2026-05-11T01:01:57Z`) predates PR #10191's merge (`2026-05-11T08:19:17Z`) by ~7 hours, so addon teams running on the 1.0.3 line do not yet have this fix.

## Minimal adaptation

A direct cherry-pick of `7852fcddb` introduces a call to `intctrlutil.ComposePVCName`, which is part of PR #9355 (volumes sharing among different instances) and has not been backported to release-1.0. This PR replaces the helper call with the equivalent inline naming:

```go
sourcePVCName = fmt.Sprintf("%s-%s", vct.Name, targetPod.Name)
```

On release-1.0, `constant.PVCNamePrefixAnnotationKey` is not set on volume claim templates, so the helper's annotation branch (added by PR #9355) never fires; the inline simple naming is behaviorally equivalent.

No other source modifications were made beyond what PR #10191 carried.

## Test plan

- [x] `go build ./pkg/operations/...`
- [x] `KUBEBUILDER_ASSETS=$(setup-envtest use 1.26.1 -p path) go test ./pkg/operations -run TestAPIs -count=1 -timeout 5m` PASS (37s).
- [x] `git diff --check origin/release-1.0..HEAD`.
- [ ] Release maintainer: cut a new `1.0.3-beta.7` image after merge so addon teams on the 1.0.3 line get the fix.

## Boundaries (explicit)

- This backport does **not** claim release-readiness for any addon or for KubeBlocks.
- This backport **only** carries the RebuildInstance PVC handoff race fix; no other PRs are bundled.
- PR #9355 (volumes sharing) is **not** backported by this PR.
- No new code paths are added beyond #10191's already-accepted scope.
