### PR TITLE
fix: add @iecQuantity CUE attribute alongside @k8sResource

### DIFF
--- a/pkg/parameters/validate/cue_util.go
+++ b/pkg/parameters/validate/cue_util.go
@@ -43,6 +43,7 @@ const (
 	K8SQuantityType         CueType = "quantity"
 	ClassicStorageType      CueType = "storage"
 	ClassicTimeDurationType CueType = "timeDuration"
+	IECQuantityType         CueType = "iecQuantity"
 )
 
 // CueValidate validates cue file

--- a/pkg/parameters/validate/cue_visitor.go
+++ b/pkg/parameters/validate/cue_visitor.go
@@ -160,6 +160,8 @@ func transNumberOrBoolType(t CueType, obj reflect.Value, fn util.UpdateFn, expan
 		return processTypeTrans[int64](obj, handleK8sQuantityType, fn, trimString, true)
 	case ClassicStorageType:
 		return processTypeTrans[int64](obj, handleClassicStorageType(expand), fn, trimString, true)
+	case IECQuantityType:
+		return processTypeTrans[int64](obj, handleIECQuantityType, fn, trimString, true)
 	case ClassicTimeDurationType:
 		return processTypeTrans[int64](obj, handleClassicTimeDurationType(expand), fn, trimString, true)
 	case StringType:

--- a/pkg/parameters/validate/cuelang_expansion.go
+++ b/pkg/parameters/validate/cuelang_expansion.go
@@ -35,6 +35,7 @@ const (
 	k8sResourceAttr          = "k8sResource"
 	attrQuantityValue        = "quantity"
 	storeResourceAttr        = "storeResource"
+	iecQuantityAttr          = "iecQuantity"
 	timeDurationResourceAttr = "timeDurationResource"
 	// attrStorageValue         = "storage"
 	// attrTimeDurationValue    = "timeDuration"
@@ -102,6 +103,8 @@ func processCueIntegerExpansion(x cue.Value) (CueType, string) {
 			return K8SQuantityType, ""
 		case storeResourceAttr:
 			return ClassicStorageType, attr.Contents()
+		case iecQuantityAttr:
+			return IECQuantityType, ""
 		case timeDurationResourceAttr:
 			return ClassicTimeDurationType, attr.Contents()
 		}
@@ -115,6 +118,17 @@ func handleK8sQuantityType(s string) (int64, error) {
 		return 0, err
 	}
 	return quantity.Value(), nil
+}
+
+func handleIECQuantityType(s string) (int64, error) {
+	if !isAllNumber(s) {
+		// IEC 80000-13 requires explicit 'B' suffix (e.g. "256MB", "256MiB").
+		if !strings.HasSuffix(s, "B") && !strings.HasSuffix(s, "b") {
+			return 0, core.MakeError("require explicit byte-unit suffixing[%s]", s)
+		}
+		s = s[:len(s)-1]
+	}
+	return handleK8sQuantityType(s)
 }
 
 func parseDigitNumber(s string) int {

--- a/pkg/parameters/validate/cuelang_expansion.go
+++ b/pkg/parameters/validate/cuelang_expansion.go
@@ -123,7 +123,7 @@ func handleK8sQuantityType(s string) (int64, error) {
 func handleIECQuantityType(s string) (int64, error) {
 	if !isAllNumber(s) {
 		// IEC 80000-13 requires explicit 'B' suffix (e.g. "256MB", "256MiB").
-		if !strings.HasSuffix(s, "B") && !strings.HasSuffix(s, "b") {
+		if !strings.HasSuffix(s, "B") {
 			return 0, core.MakeError("require explicit byte-unit suffixing[%s]", s)
 		}
 		s = s[:len(s)-1]


### PR DESCRIPTION
## Summary
- Add `@iecQuantity` CUE attribute supporting IEC 80000-13 compliant byte-unit suffixes (`MB`, `MiB`, `GB`, `GiB`, etc.)
- Enforces explicit `B` suffix for consistency
- Reuses `resource.ParseQuantity` internally for correct decimal (1000) vs binary (1024) distinction

## Test plan
- [ ] `256MB` / `256MiB` / `256GB` / `256GiB` / `256KiB` — valid
- [ ] `256` (no unit) — valid
- [ ] `256M` / `256Mi` — rejected (missing `B`)

Closes #10213

🤖 Generated with [Claude Code](https://claude.com/claude-code)