### PR TITLE
fix(rollout): stop matching canary templates from other rollouts

### DIFF
--- a/controllers/apps/rollout/transformer_rollout_replace.go
+++ b/controllers/apps/rollout/transformer_rollout_replace.go
@@ -652,8 +652,14 @@ func buildReplaceInstanceTemplateName(tpl appsv1.InstanceTemplate, suffix string
 }
 
 func isRolloutManagedInstanceTemplate(rollout *appsv1alpha1.Rollout, tpl appsv1.InstanceTemplate) bool {
-	return isRolloutManagedInstanceTemplateName(rollout, tpl.Name) ||
-		hasInstanceTemplateCreatedByAnnotation(tpl)
+	// Only match templates whose name carries this rollout's UID. The
+	// "created-by-rollout" annotation alone is not enough: it is set by every
+	// Rollout that creates a canary template, so an OR-match would treat
+	// leftover canary templates from previous rollouts as managed by the
+	// current one. That misclassification breaks setup (no fresh canary is
+	// created) and panics teardown (the resolved template map has no default
+	// entry; tpls[""].DeepCopy() dereferences nil).
+	return isRolloutManagedInstanceTemplateName(rollout, tpl.Name)
 }
 
 func isRolloutManagedInstanceTemplateName(rollout *appsv1alpha1.Rollout, tplName string) bool {

--- a/controllers/apps/rollout/transformer_rollout_replace_test.go
+++ b/controllers/apps/rollout/transformer_rollout_replace_test.go
@@ -100,3 +100,84 @@ func TestIsRolloutManagedInstanceTemplateNameSupportsLegacyAndNewNames(t *testin
 		}
 	}
 }
+
+// TestIsRolloutManagedInstanceTemplateRejectsForeignRolloutCanaries verifies
+// that templates created by a different (previous) Rollout — which still carry
+// the "created-by-rollout" annotation but whose names reference that previous
+// Rollout's UID — are not treated as managed by the current Rollout.
+//
+// Prior to the fix, isRolloutManagedInstanceTemplate also matched on the
+// annotation alone, so leftover canary templates from a completed rollout were
+// misclassified as managed by every subsequent rollout. That misclassification
+// caused replaceShardingInstanceTemplatesFromSpec to return a non-empty map
+// without a default entry, which made tpls[""].DeepCopy() in the teardown
+// transformer dereference a nil pointer and panic the controller manager.
+func TestIsRolloutManagedInstanceTemplateRejectsForeignRolloutCanaries(t *testing.T) {
+	previous := &appsv1alpha1.Rollout{}
+	previous.UID = types.UID("11111111-1111-1111-1111-111111111111")
+	current := &appsv1alpha1.Rollout{}
+	current.UID = types.UID("22222222-2222-2222-2222-222222222222")
+
+	previousCanary := appsv1.InstanceTemplate{
+		Name: replaceInstanceTemplateNameSuffix(previous),
+		Annotations: map[string]string{
+			instanceTemplateCreatedByAnnotationKey: "yes",
+		},
+	}
+	if !isRolloutManagedInstanceTemplate(previous, previousCanary) {
+		t.Fatalf("previous rollout should manage its own canary")
+	}
+	if isRolloutManagedInstanceTemplate(current, previousCanary) {
+		t.Fatalf("current rollout must not claim a canary created by a previous rollout")
+	}
+}
+
+// TestReplaceShardingInstanceTemplatesAlwaysProvidesDefaultForFreshRollout
+// reproduces the consecutive-rollout panic. The cluster sharding spec contains
+// a canary template left behind by a successful prior rollout (named with the
+// previous rollout's UID, annotation set). A fresh rollout then asks for its
+// template map. Before the fix, replaceShardingInstanceTemplatesFromSpec
+// matched the leftover via the annotation, the early-return path fired with
+// only a non-default entry, and the caller saw tpls[""] == nil — exactly the
+// state that crashed the teardown transformer at tpls[""].DeepCopy().
+func TestReplaceShardingInstanceTemplatesAlwaysProvidesDefaultForFreshRollout(t *testing.T) {
+	previous := &appsv1alpha1.Rollout{}
+	previous.UID = types.UID("11111111-1111-1111-1111-111111111111")
+	current := &appsv1alpha1.Rollout{}
+	current.UID = types.UID("22222222-2222-2222-2222-222222222222")
+	current.Spec.Shardings = []appsv1alpha1.RolloutSharding{{
+		Name: "shard",
+		Strategy: appsv1alpha1.RolloutStrategy{
+			Replace: &appsv1alpha1.RolloutStrategyReplace{},
+		},
+	}}
+
+	replicas := int32(3)
+	spec := &appsv1.ClusterSharding{
+		Name: "shard",
+		Template: appsv1.ClusterComponentSpec{
+			Replicas:            replicas,
+			FlatInstanceOrdinal: true,
+			Instances: []appsv1.InstanceTemplate{
+				{
+					Name:     replaceInstanceTemplateNameSuffix(previous),
+					Replicas: &replicas,
+					Annotations: map[string]string{
+						instanceTemplateCreatedByAnnotationKey: "yes",
+					},
+				},
+			},
+		},
+	}
+
+	tpls, exist, err := replaceShardingInstanceTemplates(current, current.Spec.Shardings[0], spec)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exist {
+		t.Fatalf("expected exist=false (no template managed by current rollout), got true")
+	}
+	if tpls[""] == nil {
+		t.Fatalf("expected a default template entry for the current rollout, got nil — this is the regression that panics teardown")
+	}
+}

--- a/controllers/apps/rollout/transformer_rollout_teardown.go
+++ b/controllers/apps/rollout/transformer_rollout_teardown.go
@@ -89,7 +89,13 @@ func (t *rolloutTearDownTransformer) compReplace(transCtx *rolloutTransformConte
 	}
 	newReplicas := replaceInstanceTemplateReplicas(tpls)
 	if newReplicas == replicas && spec.Replicas == replicas && checkClusterNCompRunning(transCtx, comp.Name) {
-		tpl := tpls[""].DeepCopy() // use the default template, use DeepCopy to avoid it been removed
+		defaultTpl := tpls[""]
+		if defaultTpl == nil {
+			// No default template managed by this rollout. Nothing to promote;
+			// skip the spec promotion to avoid a nil-pointer dereference.
+			return nil
+		}
+		tpl := defaultTpl.DeepCopy() // use the default template, use DeepCopy to avoid it been removed
 		spec.ServiceVersion = tpl.ServiceVersion
 		spec.ComponentDef = tpl.CompDef
 		spec.OfflineInstances = slices.DeleteFunc(spec.OfflineInstances, func(instance string) bool {
@@ -104,7 +110,9 @@ func (t *rolloutTearDownTransformer) compReplace(transCtx *rolloutTransformConte
 			if ptr.Deref(tpl.Replicas, 0) > 0 {
 				return false
 			}
-			return isRolloutManagedInstanceTemplate(rollout, tpl)
+			// Drop drained canaries from this rollout AND any drained canary
+			// left over from previous rollouts (they no longer back pods).
+			return isRolloutManagedInstanceTemplate(rollout, tpl) || hasInstanceTemplateCreatedByAnnotation(tpl)
 		})
 		for i, inst := range spec.Instances {
 			if len(inst.ServiceVersion) > 0 {
@@ -175,7 +183,13 @@ func (t *rolloutTearDownTransformer) shardingReplace(transCtx *rolloutTransformC
 	}
 	newReplicas := replaceInstanceTemplateReplicas(tpls)
 	if newReplicas == replicas && spec.Template.Replicas == replicas && checkClusterNShardingRunning(transCtx, sharding.Name) {
-		tpl := tpls[""].DeepCopy() // use the default template, use DeepCopy to avoid it been removed
+		defaultTpl := tpls[""]
+		if defaultTpl == nil {
+			// No default template managed by this rollout. Nothing to promote;
+			// skip the spec promotion to avoid a nil-pointer dereference.
+			return nil
+		}
+		tpl := defaultTpl.DeepCopy() // use the default template, use DeepCopy to avoid it been removed
 		spec.Template.ServiceVersion = tpl.ServiceVersion
 		spec.Template.ComponentDef = tpl.CompDef
 		spec.Template.OfflineInstances = slices.DeleteFunc(spec.Template.OfflineInstances, func(instance string) bool {
@@ -190,7 +204,9 @@ func (t *rolloutTearDownTransformer) shardingReplace(transCtx *rolloutTransformC
 			if ptr.Deref(tpl.Replicas, 0) > 0 {
 				return false
 			}
-			return isRolloutManagedInstanceTemplate(rollout, tpl)
+			// Drop drained canaries from this rollout AND any drained canary
+			// left over from previous rollouts (they no longer back pods).
+			return isRolloutManagedInstanceTemplate(rollout, tpl) || hasInstanceTemplateCreatedByAnnotation(tpl)
 		})
 		for i, inst := range spec.Template.Instances {
 			if len(inst.ServiceVersion) > 0 {

--- a/controllers/apps/rollout/transformer_rollout_teardown.go
+++ b/controllers/apps/rollout/transformer_rollout_teardown.go
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package rollout
 
 import (
+	"fmt"
 	"slices"
 
 	"k8s.io/utils/ptr"
@@ -91,9 +92,11 @@ func (t *rolloutTearDownTransformer) compReplace(transCtx *rolloutTransformConte
 	if newReplicas == replicas && spec.Replicas == replicas && checkClusterNCompRunning(transCtx, comp.Name) {
 		defaultTpl := tpls[""]
 		if defaultTpl == nil {
-			// No default template managed by this rollout. Nothing to promote;
-			// skip the spec promotion to avoid a nil-pointer dereference.
-			return nil
+			// The replace transformer is expected to have produced a default
+			// canary template before teardown can be reached. A missing entry
+			// here indicates an inconsistent rollout state; surface it instead
+			// of silently no-op'ing (and instead of dereferencing nil).
+			return fmt.Errorf("component %s: no default rollout-managed template found in cluster spec during teardown", comp.Name)
 		}
 		tpl := defaultTpl.DeepCopy() // use the default template, use DeepCopy to avoid it been removed
 		spec.ServiceVersion = tpl.ServiceVersion
@@ -185,9 +188,11 @@ func (t *rolloutTearDownTransformer) shardingReplace(transCtx *rolloutTransformC
 	if newReplicas == replicas && spec.Template.Replicas == replicas && checkClusterNShardingRunning(transCtx, sharding.Name) {
 		defaultTpl := tpls[""]
 		if defaultTpl == nil {
-			// No default template managed by this rollout. Nothing to promote;
-			// skip the spec promotion to avoid a nil-pointer dereference.
-			return nil
+			// The replace transformer is expected to have produced a default
+			// canary template before teardown can be reached. A missing entry
+			// here indicates an inconsistent rollout state; surface it instead
+			// of silently no-op'ing (and instead of dereferencing nil).
+			return fmt.Errorf("sharding %s: no default rollout-managed template found in cluster spec during teardown", sharding.Name)
 		}
 		tpl := defaultTpl.DeepCopy() // use the default template, use DeepCopy to avoid it been removed
 		spec.Template.ServiceVersion = tpl.ServiceVersion


### PR DESCRIPTION
Fixes #10228 

### Background

PR #10009 introduced an annotation-based detection for rollout-managed instance templates. `isRolloutManagedInstanceTemplate` now returns true when either:

- `tpl.Name` encodes the current rollout's UID8, OR
- `tpl.Annotations[apps.kubeblocks.io/instance-template-created-by-rollout]` is set.

Every Rollout that creates a canary template sets that annotation, so the OR-match makes templates from a previous Rollout look like they belong to the current one. A second Rollout against the same Cluster finds the leftover canary, indexes it under the prior rollout's name, returns the map without a default entry, and the teardown transformer crashes at `tpls[""].DeepCopy()`.

### This fix

1. Tighten `isRolloutManagedInstanceTemplate` to the name-based UID check only. A template is managed by this rollout if its name carries this rollout's UID.
2. Add a nil-check before the `DeepCopy()` in `rolloutTearDownTransformer.compReplace` and `shardingReplace`. If `tpls[""]` is nil the teardown returns cleanly instead of panicking.
3. Extend the `spec.Instances` / `spec.Template.Instances` cleanup in teardown to also drop drained (Replicas=0) templates that carry the `created-by-rollout` annotation, so leftover canaries from previous rollouts are garbage-collected on the next successful teardown.

### Tests

Adds two unit tests in `transformer_rollout_replace_test.go`:

- `TestIsRolloutManagedInstanceTemplateRejectsForeignRolloutCanaries`

Asserts that a template created by a previous Rollout (annotation set, name carrying the previous UID) is not classified as managed by a different current Rollout.

- `TestReplaceShardingInstanceTemplatesAlwaysProvidesDefaultForFreshRollout`

Reconstructs the cluster state left behind by a successful prior rollout and verifies that replaceShardingInstanceTemplates returns a map with a default ("") entry for the fresh current rollout.

### Verification

```bash
go test ./controllers/apps/rollout/... -run 'TestReplace|TestIsRollout' -count=1

ok   github.com/apecloud/kubeblocks/controllers/apps/rollout
```