### PR TITLE
chore: bump Go toolchain to 1.25.10 and add apk upgrade for trivy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ mod-vendor: module ## Run go mod vendor against go modules.
 
 .PHONY: module
 module: ## Run go mod tidy->verify against go modules.
-	$(GO) mod tidy -compat=1.24
+	$(GO) mod tidy -compat=1.25
 	$(GO) mod verify
 
 TEST_PACKAGES ?= ./pkg/... ./apis/... ./controllers/... ./cmd/...
@@ -298,7 +298,7 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 
 .PHONY: reviewable
 reviewable: generate build-checks test check-license-header ## Run code checks to proceed with PR reviews.
-	$(GO) mod tidy -compat=1.23
+	$(GO) mod tidy -compat=1.25
 
 .PHONY: check-diff
 check-diff: reviewable ## Run git code diff checker.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # Build the manager binary
 ARG DIST_IMG=gcr.io/distroless/static:nonroot
 
-ARG GO_VERSION=1.24.11-alpine
+ARG GO_VERSION=1.25.10-alpine
 
 FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} AS builder
 

--- a/docker/Dockerfile-charts
+++ b/docker/Dockerfile-charts
@@ -10,5 +10,7 @@ RUN bash /tmp/fetch-all-helm-charts.sh deploy/helm /tmp/charts
 
 FROM docker.io/alpine:3.22 AS dist
 
+RUN apk upgrade --no-cache
+
 COPY --from=builder /tmp/charts /charts
 USER 65532:65532

--- a/docker/Dockerfile-dataprotection
+++ b/docker/Dockerfile-dataprotection
@@ -1,7 +1,7 @@
 # Build the dataprotection binary
 ARG DIST_IMG=gcr.io/distroless/static:nonroot
 
-ARG GO_VERSION=1.24.11-alpine
+ARG GO_VERSION=1.25.10-alpine
 
 FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} AS builder
 

--- a/docker/Dockerfile-tools
+++ b/docker/Dockerfile-tools
@@ -11,7 +11,7 @@
 #TARGETARCH - Architecture from --platform, e.g. arm64
 #TARGETVARIANT - used to set target ARM variant, e.g. v7
 
-ARG GO_VERSION=1.24.11-alpine
+ARG GO_VERSION=1.25.10-alpine
 
 FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} AS builder
 ARG TARGETOS
@@ -58,6 +58,7 @@ ARG APK_MIRROR
 # install tools via apk
 ENV APK_MIRROR=${APK_MIRROR}
 RUN if [ -n "${APK_MIRROR}" ]; then sed -i "s/dl-cdn.alpinelinux.org/${APK_MIRROR}/g" /etc/apk/repositories; fi
+RUN apk upgrade --no-cache
 # curl is used to send certain requests, such as reload in config-manager.
 RUN apk add --no-cache curl kubectl helm jq --allow-untrusted \
     && rm -rf /var/cache/apk/*

--- a/docker/Dockerfile-ubi
+++ b/docker/Dockerfile-ubi
@@ -1,7 +1,7 @@
 # Build the manager binary
 ARG DIST_IMG=registry.access.redhat.com/ubi9:9.7
 
-ARG GO_VERSION=1.24.11-alpine
+ARG GO_VERSION=1.25.10-alpine
 
 FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} AS builder
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/apecloud/kubeblocks
 
-go 1.24.0
+go 1.25
 
-toolchain go1.24.11
+toolchain go1.25.10
 
 require (
 	cuelang.org/go v0.8.0


### PR DESCRIPTION
- Bump Go version from 1.24.11 to 1.25.10 across Dockerfiles and go.mod
- Update go.mod go directive to 1.25
- Update Makefile go mod tidy compat to 1.25
- Add apk upgrade --no-cache in Dockerfile-charts and Dockerfile-tools