### PR TITLE
chore(operations): make restore ops failure gate restore-aware

### DIFF
--- a/pkg/operations/restore.go
+++ b/pkg/operations/restore.go
@@ -160,7 +160,7 @@ func (r RestoreOpsHandler) ReconcileAction(reqCtx intctrlutil.RequestCtx, cli cl
 	if cluster.Spec.Restore == nil {
 		return opsv1alpha1.OpsFailedPhase, 0, fmt.Errorf("restore failed: target cluster %s/%s has no restore intent", cluster.Namespace, cluster.Name)
 	}
-	if cluster.Status.Phase == appsv1.FailedClusterPhase || cluster.IsDeleting() {
+	if cluster.IsDeleting() {
 		return opsv1alpha1.OpsFailedPhase, 0, fmt.Errorf("restore failed")
 	}
 	restoreCond := meta.FindStatusCondition(cluster.Status.Conditions, appsv1.ConditionTypeRestore)
@@ -169,6 +169,9 @@ func (r RestoreOpsHandler) ReconcileAction(reqCtx intctrlutil.RequestCtx, cli cl
 	}
 	if restoreCond.Status == metav1.ConditionFalse {
 		return opsv1alpha1.OpsFailedPhase, 0, fmt.Errorf("restore failed: %s", restoreCond.Message)
+	}
+	if cluster.Status.Phase == appsv1.FailedClusterPhase {
+		return opsv1alpha1.OpsFailedPhase, 0, fmt.Errorf("restore failed")
 	}
 	if cluster.Status.Phase != appsv1.RunningClusterPhase {
 		return opsv1alpha1.OpsRunningPhase, 0, nil

--- a/pkg/operations/restore_test.go
+++ b/pkg/operations/restore_test.go
@@ -221,10 +221,12 @@ var _ = Describe("Restore OpsRequest", func() {
 		Expect(phase).Should(Equal(opsv1alpha1.OpsFailedPhase))
 	})
 
-	It("fails when target Cluster failed before restore condition is reported", func() {
+	It("fails when target Cluster is deleting", func() {
 		opsRequest := createRestoreOpsObj(restoreClusterName, restoreOpsName, backupName)
-		targetCluster := newRestoreTargetClusterWithoutRestoreCondition(opsRequest.Namespace, restoreClusterName, appsv1.FailedClusterPhase)
+		targetCluster := newRestoreTargetCluster(opsRequest.Namespace, restoreClusterName, appsv1.FailedClusterPhase, metav1.ConditionUnknown)
 		markRestoreClusterWithOps(targetCluster, opsRequest)
+		targetCluster.Finalizers = []string{"test-finalizer"}
+		targetCluster.DeletionTimestamp = &metav1.Time{Time: time.Now()}
 		cli := newRestoreOpsFakeClient(opsRequest, targetCluster)
 
 		phase, _, err := restoreHandler.ReconcileAction(reqCtx, cli, &OpsResource{OpsRequest: opsRequest})
@@ -233,7 +235,19 @@ var _ = Describe("Restore OpsRequest", func() {
 		Expect(phase).Should(Equal(opsv1alpha1.OpsFailedPhase))
 	})
 
-	It("fails when target Cluster failed while restore condition is unknown", func() {
+	It("keeps running when target Cluster failed before restore condition is reported", func() {
+		opsRequest := createRestoreOpsObj(restoreClusterName, restoreOpsName, backupName)
+		targetCluster := newRestoreTargetClusterWithoutRestoreCondition(opsRequest.Namespace, restoreClusterName, appsv1.FailedClusterPhase)
+		markRestoreClusterWithOps(targetCluster, opsRequest)
+		cli := newRestoreOpsFakeClient(opsRequest, targetCluster)
+
+		phase, _, err := restoreHandler.ReconcileAction(reqCtx, cli, &OpsResource{OpsRequest: opsRequest})
+
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(phase).Should(Equal(opsv1alpha1.OpsRunningPhase))
+	})
+
+	It("keeps running when target Cluster failed while restore condition is unknown", func() {
 		opsRequest := createRestoreOpsObj(restoreClusterName, restoreOpsName, backupName)
 		targetCluster := newRestoreTargetCluster(opsRequest.Namespace, restoreClusterName, appsv1.FailedClusterPhase, metav1.ConditionUnknown)
 		markRestoreClusterWithOps(targetCluster, opsRequest)
@@ -241,8 +255,8 @@ var _ = Describe("Restore OpsRequest", func() {
 
 		phase, _, err := restoreHandler.ReconcileAction(reqCtx, cli, &OpsResource{OpsRequest: opsRequest})
 
-		Expect(err).Should(HaveOccurred())
-		Expect(phase).Should(Equal(opsv1alpha1.OpsFailedPhase))
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(phase).Should(Equal(opsv1alpha1.OpsRunningPhase))
 	})
 
 	It("fails when target Cluster is not visible", func() {


### PR DESCRIPTION
## Summary

Re-evaluated this PR after `main` switched restore OpsRequest handling to the Cluster restore API.

The old implementation in this PR listed Restore CRs directly. That is no longer the right shape because current `main` projects restore progress through `Cluster.status.conditions[type=Restore]`.

This update keeps the new Cluster-restore contract and changes only the terminal failure gate:

- target Cluster is deleting: restore OpsRequest fails.
- `Restore` condition is missing or `Unknown`: restore OpsRequest stays `Running`, even if `Cluster.status.phase` is briefly `Failed`.
- `Restore` condition is `False`: restore OpsRequest fails with the restore condition message.
- `Restore` condition is `True` and Cluster is still `Failed`: restore OpsRequest fails.
- `Restore` condition is `True` and Cluster is not yet `Running`: restore OpsRequest stays `Running`.
- `Restore` condition is `True` and Cluster is `Running`: restore OpsRequest succeeds.

This avoids terminally failing a restore OpsRequest on a single transient Cluster `Failed` snapshot while restore status is still unresolved, without reintroducing the old Restore-CR lookup.

## Test plan

Updated `pkg/operations/restore_test.go`:

- `Cluster Failed` before `Restore` condition is reported -> OpsRequest remains `Running`.
- `Cluster Failed` while `Restore` condition is `Unknown` -> OpsRequest remains `Running`.
- target Cluster deleting -> OpsRequest still fails.
- existing `Restore=True + Cluster Failed` failure behavior is preserved.

Local verification:

- `make test-go-generate`: PASS.
- `go test -c ./pkg/operations`: PASS.
- `git diff --check`: PASS.
- Focused `go test ./pkg/operations -run TestAPIs -ginkgo.focus "Restore OpsRequest" -count=1`: blocked locally before running specs because `/usr/local/kubebuilder/bin/etcd` is missing on this machine.

## Scope and boundaries

- Scope is only restore OpsRequest terminal failure gating on current `main`.
- No direct Restore CR list/filter logic remains.
- No DataProtection controller behavior is changed.
- Full envtest result must come from CI or a machine with kubebuilder test binaries installed.
