### PR TITLE
fix(operations): respect explicit zero requests in vertical scaling

### DIFF
--- a/pkg/operations/vertical_scaling.go
+++ b/pkg/operations/vertical_scaling.go
@@ -200,8 +200,11 @@ func (vs verticalScalingHandler) podApplyCompOps(
 			vsResources.Requests = corev1.ResourceList{}
 		}
 		for resName, resValue := range vsResources.Limits {
-			requestResource := vsResources.Requests[resName]
-			if requestResource.IsZero() {
+			// Only default a request value to the matching limit when the caller
+			// omitted the request key entirely. An explicit zero value is a valid
+			// Pod spec and must be compared as a literal zero, not silently
+			// promoted to the limit value.
+			if _, ok := vsResources.Requests[resName]; !ok {
 				vsResources.Requests[resName] = resValue
 			}
 			if !resValue.Equal(podResources.Limits[resName]) {

--- a/pkg/operations/vertical_scaling_test.go
+++ b/pkg/operations/vertical_scaling_test.go
@@ -366,3 +366,109 @@ var _ = Describe("VerticalScaling OpsRequest", func() {
 		})
 	})
 })
+
+var _ = Describe("verticalScalingHandler resource match contract", func() {
+	// These tests pin the contract that podApplyCompOps must use when comparing
+	// a Pod's actual container resources against the target requirements declared
+	// in a VerticalScaling spec. They distinguish two distinct intents that the
+	// previous implementation collapsed into a single state:
+	//   1) the caller omitted a request key entirely (defaulting it to the limit
+	//      value matches the apiserver behaviour for an absent request);
+	//   2) the caller explicitly set the request value to zero (which is a valid
+	//      Pod spec and must be compared as a literal zero, not silently
+	//      promoted to the limit value).
+	const (
+		clusterCompName = "c1"
+		podName         = "pod-0"
+		containerName   = "main"
+	)
+
+	vs := verticalScalingHandler{}
+
+	makePod := func(limits, requests corev1.ResourceList) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: podName},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: containerName,
+						Resources: corev1.ResourceRequirements{
+							Limits:   limits,
+							Requests: requests,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	makeInstance := func(pod *corev1.Pod) Instance {
+		return &defaultInstance{name: podName, componentName: clusterCompName, pod: pod}
+	}
+
+	makePgRes := func(target corev1.ResourceRequirements) *progressResource {
+		return &progressResource{
+			updatedPodSet:    map[string]string{podName: constant.EmptyInsTemplateName},
+			clusterComponent: &appsv1.ClusterComponentSpec{Name: clusterCompName},
+			compOps: opsv1alpha1.VerticalScaling{
+				ComponentOps:         opsv1alpha1.ComponentOps{ComponentName: clusterCompName},
+				ResourceRequirements: target,
+			},
+		}
+	}
+
+	ops := &opsv1alpha1.OpsRequest{}
+
+	It("treats an explicit requests=0 with limits>0 as a match when the Pod actual has the same explicit zero request", func() {
+		target := corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("0"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+		}
+		pod := makePod(target.Limits.DeepCopy(), target.Requests.DeepCopy())
+		Expect(vs.podApplyCompOps(ops, makeInstance(pod), makePgRes(target))).Should(BeTrue())
+	})
+
+	It("defaults an absent request key to its limit value when comparing", func() {
+		target := corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+			Requests: corev1.ResourceList{
+				// cpu key is intentionally absent here.
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+		}
+		podRequests := corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: resource.MustParse("2Gi"),
+		}
+		pod := makePod(target.Limits.DeepCopy(), podRequests)
+		Expect(vs.podApplyCompOps(ops, makeInstance(pod), makePgRes(target))).Should(BeTrue())
+	})
+
+	It("returns false when the Pod's actual requests differ from the target", func() {
+		target := corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+		}
+		podRequests := corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("300m"),
+			corev1.ResourceMemory: resource.MustParse("2Gi"),
+		}
+		pod := makePod(target.Limits.DeepCopy(), podRequests)
+		Expect(vs.podApplyCompOps(ops, makeInstance(pod), makePgRes(target))).Should(BeFalse())
+	})
+})


### PR DESCRIPTION
## Summary

VerticalScaling's `podApplyCompOps` decides whether a Pod's actual
container resources match the target by walking the OpsRequest's
declared `Limits` and `Requests`. The previous implementation used
`IsZero()` on the result of a map index lookup to decide whether to
default a request value to the matching limit:

```go
for resName, resValue := range vsResources.Limits {
    requestResource := vsResources.Requests[resName]
    if requestResource.IsZero() {
        vsResources.Requests[resName] = resValue
    }
    ...
}
```

Indexing a missing key in a Go map returns the zero value, so
`IsZero()` cannot distinguish two distinct caller intents:

- the request key was omitted entirely (apiserver defaults the request
  to the limit for absent keys, so the check-side promotion is
  correct);
- the request key was present with an explicit zero value (a valid Pod
  spec; the Pod actually runs with request 0 and the check must
  compare 0).

When the OpsRequest spec set an explicit `requests.cpu=0` with
`limits.cpu=1`, the check silently promoted the explicit zero to the
limit value and then compared the promoted `1` against the Pod's
actual explicit `0`. The comparison never matched, so
`progressDetails` for every Pod stayed at `Processing`. After the data
plane fully converged the cluster also went idle, so no further events
re-triggered the OpsRequest reconciler. The OpsRequest stayed in phase
`Running` with `progress: 0/N` indefinitely.

This PR keeps the existing "only limits supplied → default request to
limit" behaviour by using the two-value map index form. The check now
defaults a request only when the request key is absent; an explicit
zero is compared literally.

```go
for resName, resValue := range vsResources.Limits {
    if _, ok := vsResources.Requests[resName]; !ok {
        vsResources.Requests[resName] = resValue
    }
    ...
}
```

## Test plan

Added the `verticalScalingHandler resource match contract` Describe in
`pkg/operations/vertical_scaling_test.go`. Tests call
`podApplyCompOps` directly with in-memory `defaultInstance` /
`progressResource` / `OpsRequest` fixtures (no Cluster / OpsManager /
envtest harness needed for the contract):

- [x] explicit `requests.cpu=0` with `limits.cpu=1`, Pod actual same:
  pre-fix RED, post-fix GREEN. Pins the new contract.
- [x] absent request cpu key with `limits.cpu=1`, Pod actual
  `requests.cpu=1`: GREEN both before and after the fix. Protects the
  existing default-to-limit behaviour.
- [x] explicit `requests.cpu=500m` with Pod actual `requests.cpu=300m`:
  GREEN both before and after the fix. Protects the regular mismatch
  path.

Local verification:

- Focused: `go test ./pkg/operations/ -run TestAPIs -ginkgo.focus="resource match contract" -count=1`
  returns `3 Passed | 0 Failed | 0 Pending | 83 Skipped`, stable across
  N=3 independent runs after the fix; pre-fix the first spec is RED and
  the other two are GREEN.
- VerticalScaling-related: `go test ./pkg/operations/ -run TestAPIs -ginkgo.focus="VerticalScaling|vertical|resource match"`
  returns `10 Passed | 0 Failed` (7 pre-existing + 3 new).
- Full package: `go test ./pkg/operations/ -run TestAPIs -count=1` is
  green (~36s).
- `gofmt -d` clean; `git diff --check` clean.
- `go vet` could not complete locally because the `testutil/k8s/mocks`
  generated file is not committed and the `go generate` mock fixture is
  a pre-existing environment requirement unrelated to this change.

## Scope and boundaries

- **Strict scope**: only changes the resource-match decision inside
  `matchResources` in `pkg/operations/vertical_scaling.go::podApplyCompOps`.
  Does NOT change:
  - Kubernetes default resource semantics (apiserver-side request /
    limit defaulting is untouched).
  - The Action write path (`compSpec.Resources` is still set verbatim
    from spec).
  - Validation / admission policy on `requests` / `limits` values.
  - Watch / re-enqueue / `progressDetails` reporter / status update
    paths.
- Does NOT address the broader question of whether VerticalScaling's
  reconciler should requeue without an external trigger after the
  cluster reaches steady state. With this fix, the resource match
  returns true correctly so no further events are needed; if a similar
  stall pattern appears in a case where the match returns true, that's
  a separate watch / requeue audit.
- Similar `IsZero()`-on-map-result patterns may exist in other ops
  handlers (`horizontal_scaling.go`, etc.). This PR does NOT scan or
  modify them; tracked as a follow-up audit item to avoid widening the
  blast radius beyond VerticalScaling.

## Out of scope

- Any change to the apply path or to validation of `requests` /
  `limits` values.
- Any audit or change of other ops handlers' resource-match logic.
- Any change to the VerticalScaling watch / requeue / reporter chain.
