### PR TITLE
fix(operations): preserve rebuild helper PV identity when reverting reclaim policy

### DIFF
--- a/pkg/operations/rebuild_instance_inplace.go
+++ b/pkg/operations/rebuild_instance_inplace.go
@@ -677,13 +677,12 @@ func (inPlaceHelper *inplaceRebuildHelper) revertReclaimPolicy(reqCtx intctrluti
 		}
 		pv.Spec.PersistentVolumeReclaimPolicy = corev1.PersistentVolumeReclaimPolicy(reclaimPolicy)
 	}
-	if pv.Annotations != nil {
-		delete(pv.Annotations, rebuildFromAnnotation)
-		delete(pv.Annotations, sourcePVReclaimPolicyAnnotation)
-	}
-	if pv.Labels != nil {
-		delete(pv.Labels, rebuildTmpPVCNameLabel)
-	}
+	// Preserve the rebuild identity metadata (rebuildFromAnnotation,
+	// sourcePVReclaimPolicyAnnotation, rebuildTmpPVCNameLabel) on the PV
+	// so that a later re-entry on this OpsRequest can still resolve the
+	// restored PV via the tmp PVC label. Clearing them eagerly here
+	// caused getRestoredPV to return a Fatal error when the tmp PVC was
+	// cleaned up between reconciles.
 	return cli.Patch(reqCtx.Ctx, pv, patch)
 }
 

--- a/pkg/operations/rebuild_instance_test.go
+++ b/pkg/operations/rebuild_instance_test.go
@@ -495,6 +495,48 @@ var _ = Describe("OpsUtil functions", func() {
 			Expect(sourcePVC.Spec.VolumeName).Should(ContainSubstring("restored-pv-"))
 		})
 
+		It("preserves rebuild identity metadata when reverting the reclaim policy", func() {
+			reqCtx := intctrlutil.RequestCtx{Ctx: testCtx.Ctx}
+			opsRequestName := "rebuild-reclaim-revert-" + testCtx.GetRandomStr()
+			tmpPVCName := "rebuild-tmp-" + testCtx.GetRandomStr()
+			pvName := "restored-pv-" + testCtx.GetRandomStr()
+			pv := testapps.NewPersistentVolumeFactory(testCtx.DefaultNamespace, pvName, tmpPVCName).
+				SetStorage("20Gi").
+				Create(&testCtx).
+				GetObject()
+			Expect(testapps.ChangeObj(&testCtx, pv, func(p *corev1.PersistentVolume) {
+				if p.Labels == nil {
+					p.Labels = map[string]string{}
+				}
+				p.Labels[rebuildTmpPVCNameLabel] = tmpPVCName
+				if p.Annotations == nil {
+					p.Annotations = map[string]string{}
+				}
+				p.Annotations[rebuildFromAnnotation] = opsRequestName
+				p.Annotations[sourcePVReclaimPolicyAnnotation] = string(corev1.PersistentVolumeReclaimDelete)
+				p.Spec.PersistentVolumeReclaimPolicy = corev1.PersistentVolumeReclaimRetain
+			})).Should(Succeed())
+			Expect(testapps.ChangeObjStatus(&testCtx, pv, func() {
+				pv.Status.Phase = corev1.VolumeBound
+			})).Should(Succeed())
+
+			helper := &inplaceRebuildHelper{}
+			Expect(helper.revertReclaimPolicy(reqCtx, k8sClient, pv)).Should(Succeed())
+
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(pv), func(g Gomega, p *corev1.PersistentVolume) {
+				// Reclaim policy must be reverted to the value recorded in
+				// sourcePVReclaimPolicyAnnotation.
+				g.Expect(p.Spec.PersistentVolumeReclaimPolicy).Should(Equal(corev1.PersistentVolumeReclaimDelete))
+				// Rebuild identity metadata must be preserved so a later
+				// re-entry can still resolve the restored PV by its tmp
+				// PVC label even after the tmp PVC itself has been cleaned
+				// up.
+				g.Expect(p.Labels).Should(HaveKeyWithValue(rebuildTmpPVCNameLabel, tmpPVCName))
+				g.Expect(p.Annotations).Should(HaveKeyWithValue(rebuildFromAnnotation, opsRequestName))
+				g.Expect(p.Annotations).Should(HaveKeyWithValue(sourcePVReclaimPolicyAnnotation, string(corev1.PersistentVolumeReclaimDelete)))
+			})).Should(Succeed())
+		})
+
 		testRebuildInstanceWithBackup := func(ignoreRoleCheck bool) {
 			By("init operation resources and backup")
 			actionSet := testapps.CreateCustomizedObj(&testCtx, "backup/actionset.yaml",


### PR DESCRIPTION
## Summary

`revertReclaimPolicy` reverted the helper PV's reclaim policy to the
value recorded in `sourcePVReclaimPolicyAnnotation` and at the same
time cleared the rebuild identity metadata (`rebuildFromAnnotation`,
`sourcePVReclaimPolicyAnnotation` and the `rebuildTmpPVCNameLabel`
label).

If the tmp PVC was cleaned up between reconciles, the next re-entry on
the same OpsRequest then called `getRestoredPV`, which falls back to a
label-list lookup by `rebuildTmpPVCNameLabel` when the tmp PVC's
`Spec.VolumeName` is empty. With the label already cleared, the list
returned zero items and `getRestoredPV` raised:

```
NewFatalError(fmt.Sprintf(`can not found the pv by the pvc "%s"`, tmpPVC.Name))
```

That collapsed the OpsRequest to a terminal failure even though the
underlying restored PV still existed in the cluster.

This PR keeps the rebuild identity metadata on the PV so a later
re-entry can still resolve the restored PV via the tmp PVC label. The
reclaim policy is still reverted to its original value.

## Test plan

Added a narrow regression test in `pkg/operations/rebuild_instance_test.go`
that exercises `revertReclaimPolicy` directly:

- [x] Create a PV with the three rebuild identity metadata fields set
  and `PersistentVolumeReclaimPolicy=Retain`, `Status.Phase=Bound`.
- [x] Call `inplaceRebuildHelper.revertReclaimPolicy`.
- [x] Assert the PV's reclaim policy is reverted to the value recorded
  in `sourcePVReclaimPolicyAnnotation`.
- [x] Assert `rebuildFromAnnotation`, `sourcePVReclaimPolicyAnnotation`
  and `rebuildTmpPVCNameLabel` are all preserved on the PV after the
  revert.

Local verification:

- Focused: `go test ./pkg/operations -run TestAPIs -ginkgo.focus="preserves rebuild identity metadata" -count=1`
  is green, stable across N=3 independent runs.
- Rebuild-related Ginkgo specs: `go test ./pkg/operations -run TestAPIs -ginkgo.focus="Rebuild|rebuild|revert|identity|pre-bind|volumeName"`
  returns `8 Passed | 0 Failed | 76 Skipped`.
- Full envtest: `go test ./pkg/operations -run TestAPIs -count=1` is
  green (~36s).
- `go vet ./pkg/operations/...` clean.
- `gofmt -d` clean; `git diff --check` clean.

## Scope and boundaries

- **Strict scope**: only changes `revertReclaimPolicy` in
  `pkg/operations/rebuild_instance_inplace.go`. The 3-line "delete
  rebuild identity metadata" block is replaced with a comment that
  records why the metadata is preserved.
- Does NOT change:
  - The reclaim-policy revert behaviour itself; the PV's reclaim
    policy is still set back to the value in
    `sourcePVReclaimPolicyAnnotation`.
  - `getRestoredPV` or its label-list fallback.
  - The rebuild source-PVC reconcile flow, the success guard, or the
    cleanup ordering more broadly.
  - Any other ops handler or OpsRequest type.
- Existing protections are preserved: `rebuildFromAnnotation` owner
  mismatch still produces a Fatal error in
  `rebuildSourcePVCsAndRecreateInstance`; `failIfSourcePVCBoundToOtherActiveRebuildPV`
  is untouched.

## Out of scope

- Any broader rework of the rebuild success path or the OpsRequest
  ReconcileAction observation chain.
- Any change to the tmp PVC cleanup logic.
- Any change to other OpsRequest handlers.