### PR TITLE
chore(parameters): reject immutable parameter updates

### DIFF
--- a/apis/apps/v1alpha1/configconstraint_types.go
+++ b/apis/apps/v1alpha1/configconstraint_types.go
@@ -139,7 +139,7 @@ type ConfigConstraintSpec struct {
 	DynamicParameters []string `json:"dynamicParameters,omitempty"`
 
 	// Lists the parameters that cannot be modified once set.
-	// Attempting to change any of these parameters will be ignored.
+	// Attempts to change any of these parameters are rejected during configuration merge and surface as a merge failure.
 	//
 	// +listType=set
 	// +optional

--- a/apis/apps/v1beta1/configconstraint_types.go
+++ b/apis/apps/v1beta1/configconstraint_types.go
@@ -110,7 +110,7 @@ type ConfigConstraintSpec struct {
 	DynamicParameters []string `json:"dynamicParameters,omitempty"`
 
 	// Lists the parameters that cannot be modified once set.
-	// Attempting to change any of these parameters will be ignored.
+	// Attempts to change any of these parameters are rejected during configuration merge and surface as a merge failure.
 	//
 	// +listType=set
 	// +optional

--- a/apis/parameters/v1alpha1/parametersdefinition_types.go
+++ b/apis/parameters/v1alpha1/parametersdefinition_types.go
@@ -153,7 +153,7 @@ type ParametersDefinitionSpec struct {
 	DynamicParameters []string `json:"dynamicParameters,omitempty"`
 
 	// Lists the parameters that cannot be modified once set.
-	// Attempting to change any of these parameters will be ignored.
+	// Attempts to change any of these parameters are rejected during configuration merge and surface as a merge failure.
 	//
 	// +listType=set
 	// +optional

--- a/config/crd/bases/apps.kubeblocks.io_configconstraints.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_configconstraints.yaml
@@ -302,7 +302,7 @@ spec:
               immutableParameters:
                 description: |-
                   Lists the parameters that cannot be modified once set.
-                  Attempting to change any of these parameters will be ignored.
+                  Attempts to change any of these parameters are rejected during configuration merge and surface as a merge failure.
                 items:
                   type: string
                 type: array
@@ -1010,7 +1010,7 @@ spec:
               immutableParameters:
                 description: |-
                   Lists the parameters that cannot be modified once set.
-                  Attempting to change any of these parameters will be ignored.
+                  Attempts to change any of these parameters are rejected during configuration merge and surface as a merge failure.
                 items:
                   type: string
                 type: array

--- a/config/crd/bases/parameters.kubeblocks.io_parametersdefinitions.yaml
+++ b/config/crd/bases/parameters.kubeblocks.io_parametersdefinitions.yaml
@@ -141,7 +141,7 @@ spec:
               immutableParameters:
                 description: |-
                   Lists the parameters that cannot be modified once set.
-                  Attempting to change any of these parameters will be ignored.
+                  Attempts to change any of these parameters are rejected during configuration merge and surface as a merge failure.
                 items:
                   type: string
                 type: array

--- a/deploy/helm/crds/apps.kubeblocks.io_configconstraints.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_configconstraints.yaml
@@ -302,7 +302,7 @@ spec:
               immutableParameters:
                 description: |-
                   Lists the parameters that cannot be modified once set.
-                  Attempting to change any of these parameters will be ignored.
+                  Attempts to change any of these parameters are rejected during configuration merge and surface as a merge failure.
                 items:
                   type: string
                 type: array
@@ -1010,7 +1010,7 @@ spec:
               immutableParameters:
                 description: |-
                   Lists the parameters that cannot be modified once set.
-                  Attempting to change any of these parameters will be ignored.
+                  Attempts to change any of these parameters are rejected during configuration merge and surface as a merge failure.
                 items:
                   type: string
                 type: array

--- a/deploy/helm/crds/parameters.kubeblocks.io_parametersdefinitions.yaml
+++ b/deploy/helm/crds/parameters.kubeblocks.io_parametersdefinitions.yaml
@@ -141,7 +141,7 @@ spec:
               immutableParameters:
                 description: |-
                   Lists the parameters that cannot be modified once set.
-                  Attempting to change any of these parameters will be ignored.
+                  Attempts to change any of these parameters are rejected during configuration merge and surface as a merge failure.
                 items:
                   type: string
                 type: array

--- a/docs/developer_docs/api-reference/cluster.md
+++ b/docs/developer_docs/api-reference/cluster.md
@@ -16238,7 +16238,7 @@ Modifications to these parameters trigger a configuration reload without requiri
 <td>
 <em>(Optional)</em>
 <p>Lists the parameters that cannot be modified once set.
-Attempting to change any of these parameters will be ignored.</p>
+Attempts to change any of these parameters are rejected during configuration merge and surface as a merge failure.</p>
 </td>
 </tr>
 <tr>
@@ -23223,7 +23223,7 @@ Modifications to these parameters trigger a configuration reload without requiri
 <td>
 <em>(Optional)</em>
 <p>Lists the parameters that cannot be modified once set.
-Attempting to change any of these parameters will be ignored.</p>
+Attempts to change any of these parameters are rejected during configuration merge and surface as a merge failure.</p>
 </td>
 </tr>
 <tr>
@@ -31003,7 +31003,7 @@ Modifications to these parameters trigger a configuration reload without requiri
 <td>
 <em>(Optional)</em>
 <p>Lists the parameters that cannot be modified once set.
-Attempting to change any of these parameters will be ignored.</p>
+Attempts to change any of these parameters are rejected during configuration merge and surface as a merge failure.</p>
 </td>
 </tr>
 <tr>
@@ -31296,7 +31296,7 @@ Modifications to these parameters trigger a configuration reload without requiri
 <td>
 <em>(Optional)</em>
 <p>Lists the parameters that cannot be modified once set.
-Attempting to change any of these parameters will be ignored.</p>
+Attempts to change any of these parameters are rejected during configuration merge and surface as a merge failure.</p>
 </td>
 </tr>
 <tr>

--- a/docs/developer_docs/api-reference/parameters.md
+++ b/docs/developer_docs/api-reference/parameters.md
@@ -813,7 +813,7 @@ Modifications to these parameters trigger a configuration reload without requiri
 <td>
 <em>(Optional)</em>
 <p>Lists the parameters that cannot be modified once set.
-Attempting to change any of these parameters will be ignored.</p>
+Attempts to change any of these parameters are rejected during configuration merge and surface as a merge failure.</p>
 </td>
 </tr>
 </tbody>
@@ -3053,7 +3053,7 @@ Modifications to these parameters trigger a configuration reload without requiri
 <td>
 <em>(Optional)</em>
 <p>Lists the parameters that cannot be modified once set.
-Attempting to change any of these parameters will be ignored.</p>
+Attempts to change any of these parameters are rejected during configuration merge and surface as a merge failure.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/parameters/config_util.go
+++ b/pkg/parameters/config_util.go
@@ -80,7 +80,10 @@ func MergeAndValidateConfigs(baseConfigs map[string]string,
 
 	// merge param to config file
 	for _, params := range updatedParams {
-		validUpdatedParameters := filterImmutableParameters(params.UpdatedParams, params.Key, paramsDefs)
+		validUpdatedParameters, err := filterImmutableParameters(params.UpdatedParams, params.Key, paramsDefs)
+		if err != nil {
+			return nil, err
+		}
 		if len(validUpdatedParameters) == 0 {
 			continue
 		}
@@ -192,20 +195,21 @@ func resolveParametersDef(paramsDefs []*parametersv1alpha1.ParametersDefinition,
 	return nil
 }
 
-func filterImmutableParameters(parameters map[string]any, fileName string, paramsDefs []*parametersv1alpha1.ParametersDefinition) map[string]any {
+func filterImmutableParameters(parameters map[string]any, fileName string, paramsDefs []*parametersv1alpha1.ParametersDefinition) (map[string]any, error) {
 	paramsDef := resolveParametersDef(paramsDefs, fileName)
 	if paramsDef == nil || len(paramsDef.Spec.ImmutableParameters) == 0 {
-		return parameters
+		return parameters, nil
 	}
 
 	immutableParams := paramsDef.Spec.ImmutableParameters
 	validParameters := make(map[string]any, len(parameters))
 	for key, val := range parameters {
-		if !slices.Contains(immutableParams, key) {
-			validParameters[key] = val
+		if slices.Contains(immutableParams, key) {
+			return nil, fmt.Errorf("immutable parameter %s cannot be modified", key)
 		}
+		validParameters[key] = val
 	}
-	return validParameters
+	return validParameters, nil
 }
 
 func ResolveCmpdParametersDefs(ctx context.Context, reader client.Reader, cmpd *appsv1.ComponentDefinition) ([]parametersv1alpha1.ComponentConfigDescription, []*parametersv1alpha1.ParametersDefinition, error) {

--- a/pkg/parameters/config_util.go
+++ b/pkg/parameters/config_util.go
@@ -277,6 +277,15 @@ func parseFileParameters(name, content string, formatConfig *parametersv1alpha1.
 	if err != nil {
 		return nil, err
 	}
+	if configObject == nil {
+		// core.FromConfigObject returns nil when the requested sub-section is
+		// absent (e.g., the INI [section] header is missing or has been
+		// removed in the content payload). Treat as an empty parameter map
+		// so the caller's diff sees this as "all keys in that section
+		// removed" and rejects immutable removals, instead of nil-deref
+		// panicking on GetAllParameters below.
+		return map[string]interface{}{}, nil
+	}
 	return configObject.GetAllParameters(), nil
 }
 

--- a/pkg/parameters/config_util.go
+++ b/pkg/parameters/config_util.go
@@ -230,8 +230,8 @@ func filterImmutableParameters(parameters map[string]any, fileName string, param
 // will.
 //
 // Fail-safe: when a file *does* have immutable-parameter candidates but the
-// parser cannot be applied — missing FileFormatConfig in configDescs, or
-// parse error on base/merged content — the operation is rejected rather
+// parser cannot be applied -- missing FileFormatConfig in configDescs, or
+// parse error on base/merged content -- the operation is rejected rather
 // than silently allowed. Otherwise an unknown-format file would let
 // immutable parameter changes leak through this guard.
 func validateImmutableContentChanges(

--- a/pkg/parameters/config_util.go
+++ b/pkg/parameters/config_util.go
@@ -212,6 +212,74 @@ func filterImmutableParameters(parameters map[string]any, fileName string, param
 	return validParameters, nil
 }
 
+// validateImmutableContentChanges rejects raw-content updates that would
+// modify (add, remove, or change) any immutable parameter declared on the
+// file's ParametersDefinition.
+//
+// Scope: only files present in updatedFiles are inspected. Files outside that
+// set are untouched by this call.
+//
+// Skip rule: if a file has no ParametersDefinition match, or its
+// ParametersDefinition declares no immutable parameters, the file is skipped
+// entirely. This preserves backward-compatible behavior for content updates on
+// files that have no immutable-parameter contract.
+//
+// Diff is computed on parsed parameter maps via the file's FileFormatConfig,
+// not on raw text. Pure format changes (whitespace, comment order, blank
+// lines) therefore do not trip the check; only a semantic parameter delta
+// will.
+//
+// Fail-safe: when a file *does* have immutable-parameter candidates but the
+// parser cannot be applied — missing FileFormatConfig in configDescs, or
+// parse error on base/merged content — the operation is rejected rather
+// than silently allowed. Otherwise an unknown-format file would let
+// immutable parameter changes leak through this guard.
+func validateImmutableContentChanges(
+	base map[string]string,
+	merged map[string]string,
+	updatedFiles map[string]string,
+	paramsDefs []*parametersv1alpha1.ParametersDefinition,
+	configDescs []parametersv1alpha1.ComponentConfigDescription,
+) error {
+	for fileName := range updatedFiles {
+		paramsDef := resolveParametersDef(paramsDefs, fileName)
+		if paramsDef == nil || len(paramsDef.Spec.ImmutableParameters) == 0 {
+			continue
+		}
+		formatConfig := core.ResolveConfigFormat(configDescs, fileName)
+		if formatConfig == nil {
+			return fmt.Errorf("cannot validate immutable parameters for file %q: missing file format config", fileName)
+		}
+		baseParams, err := parseFileParameters(fileName, base[fileName], formatConfig)
+		if err != nil {
+			return fmt.Errorf("failed to parse base content of file %q for immutable validation: %w", fileName, err)
+		}
+		mergedParams, err := parseFileParameters(fileName, merged[fileName], formatConfig)
+		if err != nil {
+			return fmt.Errorf("failed to parse merged content of file %q for immutable validation: %w", fileName, err)
+		}
+		for _, immutableKey := range paramsDef.Spec.ImmutableParameters {
+			baseVal, baseOK := baseParams[immutableKey]
+			mergedVal, mergedOK := mergedParams[immutableKey]
+			if baseOK != mergedOK {
+				return fmt.Errorf("immutable parameter %s cannot be modified (file %q)", immutableKey, fileName)
+			}
+			if baseOK && !reflect.DeepEqual(baseVal, mergedVal) {
+				return fmt.Errorf("immutable parameter %s cannot be modified (file %q)", immutableKey, fileName)
+			}
+		}
+	}
+	return nil
+}
+
+func parseFileParameters(name, content string, formatConfig *parametersv1alpha1.FileFormatConfig) (map[string]interface{}, error) {
+	configObject, err := core.FromConfigObject(name, content, formatConfig)
+	if err != nil {
+		return nil, err
+	}
+	return configObject.GetAllParameters(), nil
+}
+
 func ResolveCmpdParametersDefs(ctx context.Context, reader client.Reader, cmpd *appsv1.ComponentDefinition) ([]parametersv1alpha1.ComponentConfigDescription, []*parametersv1alpha1.ParametersDefinition, error) {
 	paramsDefList := &parametersv1alpha1.ParametersDefinitionList{}
 	if err := reader.List(ctx, paramsDefList); err != nil {

--- a/pkg/parameters/config_util_test.go
+++ b/pkg/parameters/config_util_test.go
@@ -762,9 +762,10 @@ func Test_filterImmutableParameters(t *testing.T) {
 		immutableParams []string
 	}
 	tests := []struct {
-		name string
-		args args
-		want map[string]any
+		name    string
+		args    args
+		want    map[string]any
+		wantErr bool
 	}{{
 		name: "test",
 		args: args{
@@ -786,9 +787,7 @@ func Test_filterImmutableParameters(t *testing.T) {
 			},
 			immutableParams: []string{"a", "d"},
 		},
-		want: map[string]any{
-			"c": "d",
-		},
+		wantErr: true,
 	}, {
 		name: "test",
 		args: args{
@@ -806,7 +805,15 @@ func Test_filterImmutableParameters(t *testing.T) {
 					ImmutableParameters: tt.args.immutableParams,
 				},
 			}}
-			if got := filterImmutableParameters(tt.args.parameters, "test", paramsDefs); !reflect.DeepEqual(got, tt.want) {
+			got, err := filterImmutableParameters(tt.args.parameters, "test", paramsDefs)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("filterImmutableParameters() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("filterImmutableParameters() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/parameters/patch_merger.go
+++ b/pkg/parameters/patch_merger.go
@@ -66,6 +66,14 @@ func mergeUpdatedParams(base map[string]string,
 	// merge updated files into configmap
 	if len(updatedFiles) != 0 {
 		updatedConfig = core.MergeUpdatedConfig(base, updatedFiles)
+		// Reject content-level updates that would alter any immutable parameter.
+		// MergeUpdatedConfig substitutes whole file contents key-by-key, so without
+		// this guard a user submitting raw file content could bypass the
+		// parameter-level immutable check performed below by
+		// MergeAndValidateConfigs/filterImmutableParameters.
+		if err := validateImmutableContentChanges(base, updatedConfig, updatedFiles, paramsDefs, configDescs); err != nil {
+			return nil, err
+		}
 	}
 	if len(configDescs) == 0 {
 		return updatedConfig, nil

--- a/pkg/parameters/patch_merger.go
+++ b/pkg/parameters/patch_merger.go
@@ -21,7 +21,6 @@ package parameters
 
 import (
 	"fmt"
-	"slices"
 
 	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/parameters/core"
@@ -109,7 +108,7 @@ func mergeUnmanagedUpdates(base map[string]string,
 			if err != nil {
 				return nil, err
 			}
-			if err := rejectImmutableUnmanagedUpdates(file, sectionUpdate.Updates, paramsDefs); err != nil {
+			if err := rejectImmutableUnmanagedUpdates(file, fileFormat, sectionUpdate, paramsDefs); err != nil {
 				return nil, err
 			}
 			normalizedUpdates, err := normalizeUnmanagedParameterUpdates(sectionUpdate.Updates)
@@ -135,19 +134,41 @@ func mergeUnmanagedUpdates(base map[string]string,
 
 func rejectImmutableUnmanagedUpdates(
 	fileName string,
-	updates []parametersv1alpha1.ParameterUpdate,
+	fileFormat *parametersv1alpha1.FileFormatConfig,
+	sectionUpdate parametersv1alpha1.UnmanagedParameterSectionUpdate,
 	paramsDefs []*parametersv1alpha1.ParametersDefinition,
 ) error {
 	paramsDef := resolveParametersDef(paramsDefs, fileName)
 	if paramsDef == nil || len(paramsDef.Spec.ImmutableParameters) == 0 {
 		return nil
 	}
-	for _, update := range updates {
-		if slices.Contains(paramsDef.Spec.ImmutableParameters, update.Key) {
+	if !unmanagedUpdateTargetsManagedScope(fileFormat, sectionUpdate.Section) {
+		return nil
+	}
+	immutableParams := make(map[string]struct{}, len(paramsDef.Spec.ImmutableParameters))
+	for _, immutableParam := range paramsDef.Spec.ImmutableParameters {
+		immutableParams[immutableParam] = struct{}{}
+	}
+	for _, update := range sectionUpdate.Updates {
+		if _, ok := immutableParams[update.Key]; ok {
 			return fmt.Errorf("immutable parameter %s cannot be modified (file %q)", update.Key, fileName)
 		}
 	}
 	return nil
+}
+
+func unmanagedUpdateTargetsManagedScope(fileFormat *parametersv1alpha1.FileFormatConfig, section *string) bool {
+	if fileFormat == nil || fileFormat.Format != parametersv1alpha1.Ini {
+		return true
+	}
+	managedSection := ""
+	if fileFormat.IniConfig != nil {
+		managedSection = fileFormat.IniConfig.SectionName
+	}
+	if section == nil {
+		return true
+	}
+	return *section == managedSection
 }
 
 func resolveUnmanagedFormatConfig(base *parametersv1alpha1.FileFormatConfig, section *string) (*parametersv1alpha1.FileFormatConfig, error) {

--- a/pkg/parameters/patch_merger.go
+++ b/pkg/parameters/patch_merger.go
@@ -21,6 +21,7 @@ package parameters
 
 import (
 	"fmt"
+	"slices"
 
 	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/parameters/core"
@@ -82,11 +83,12 @@ func mergeUpdatedParams(base map[string]string,
 	if err != nil {
 		return nil, err
 	}
-	return mergeUnmanagedUpdates(updatedConfig, unmanagedUpdatedByFiles, configDescs)
+	return mergeUnmanagedUpdates(updatedConfig, unmanagedUpdatedByFiles, paramsDefs, configDescs)
 }
 
 func mergeUnmanagedUpdates(base map[string]string,
 	unmanagedUpdatedByFiles map[string][]parametersv1alpha1.UnmanagedParameterSectionUpdate,
+	paramsDefs []*parametersv1alpha1.ParametersDefinition,
 	configDescs []parametersv1alpha1.ComponentConfigDescription) (map[string]string, error) {
 	if len(unmanagedUpdatedByFiles) == 0 {
 		return base, nil
@@ -107,6 +109,9 @@ func mergeUnmanagedUpdates(base map[string]string,
 			if err != nil {
 				return nil, err
 			}
+			if err := rejectImmutableUnmanagedUpdates(file, sectionUpdate.Updates, paramsDefs); err != nil {
+				return nil, err
+			}
 			normalizedUpdates, err := normalizeUnmanagedParameterUpdates(sectionUpdate.Updates)
 			if err != nil {
 				return nil, err
@@ -118,7 +123,31 @@ func mergeUnmanagedUpdates(base map[string]string,
 		}
 		updatedConfig[file] = next
 	}
+	updatedFiles := make(map[string]string, len(unmanagedUpdatedByFiles))
+	for file := range unmanagedUpdatedByFiles {
+		updatedFiles[file] = updatedConfig[file]
+	}
+	if err := validateImmutableContentChanges(base, updatedConfig, updatedFiles, paramsDefs, configDescs); err != nil {
+		return nil, err
+	}
 	return updatedConfig, nil
+}
+
+func rejectImmutableUnmanagedUpdates(
+	fileName string,
+	updates []parametersv1alpha1.ParameterUpdate,
+	paramsDefs []*parametersv1alpha1.ParametersDefinition,
+) error {
+	paramsDef := resolveParametersDef(paramsDefs, fileName)
+	if paramsDef == nil || len(paramsDef.Spec.ImmutableParameters) == 0 {
+		return nil
+	}
+	for _, update := range updates {
+		if slices.Contains(paramsDef.Spec.ImmutableParameters, update.Key) {
+			return fmt.Errorf("immutable parameter %s cannot be modified (file %q)", update.Key, fileName)
+		}
+	}
+	return nil
 }
 
 func resolveUnmanagedFormatConfig(base *parametersv1alpha1.FileFormatConfig, section *string) (*parametersv1alpha1.FileFormatConfig, error) {

--- a/pkg/parameters/patch_merger_test.go
+++ b/pkg/parameters/patch_merger_test.go
@@ -75,3 +75,207 @@ func TestDoMergeAppliesUnmanagedUpdatesAfterContentAndParameters(t *testing.T) {
 func strPtr(v string) *string {
 	return &v
 }
+
+// The following tests cover the content-path immutable guard added in
+// validateImmutableContentChanges. Each case constructs a base ConfigMap +
+// ParametersInFile content patch and asserts whether DoMerge accepts or
+// rejects the result.
+//
+// Coverage matrix:
+//   - content modifies an immutable parameter   -> reject
+//   - content adds an immutable parameter       -> reject
+//   - content removes an immutable parameter    -> reject
+//   - content only reorders / re-formats        -> accept (no误伤)
+//   - file has no immutable candidate, missing
+//     FileFormatConfig                          -> accept (no兼容性回归)
+//   - file has immutable candidate but missing
+//     FileFormatConfig                          -> reject (fail-safe)
+
+func iniConfigDescsForMyCnf() []parametersv1alpha1.ComponentConfigDescription {
+	return []parametersv1alpha1.ComponentConfigDescription{{
+		Name:         "my.cnf",
+		TemplateName: "mysql-config",
+		FileFormatConfig: &parametersv1alpha1.FileFormatConfig{
+			Format: parametersv1alpha1.Ini,
+			FormatterAction: parametersv1alpha1.FormatterAction{
+				IniConfig: &parametersv1alpha1.IniConfig{SectionName: "mysqld"},
+			},
+		},
+	}}
+}
+
+func paramsDefsWithImmutable(immutable []string) []*parametersv1alpha1.ParametersDefinition {
+	return []*parametersv1alpha1.ParametersDefinition{{
+		Spec: parametersv1alpha1.ParametersDefinitionSpec{
+			FileName:            "my.cnf",
+			ImmutableParameters: immutable,
+		},
+	}}
+}
+
+func TestDoMergeRejectsContentModifyingImmutableParameter(t *testing.T) {
+	base := map[string]string{
+		"my.cnf": "[mysqld]\ngtid_mode=OFF\nmax_connections=1000\n",
+	}
+	patch := map[string]parametersv1alpha1.ParametersInFile{
+		"my.cnf": {
+			Content: strPtr("[mysqld]\ngtid_mode=ON\nmax_connections=1000\n"),
+		},
+	}
+	configDescs := iniConfigDescsForMyCnf()
+	paramsDefs := paramsDefsWithImmutable([]string{"gtid_mode"})
+
+	_, err := DoMerge(base, patch, paramsDefs, configDescs)
+	if err == nil {
+		t.Fatalf("expected immutable parameter modification via content to be rejected, got nil error")
+	}
+	if !strings.Contains(err.Error(), "gtid_mode") {
+		t.Fatalf("expected error to mention immutable parameter gtid_mode, got %q", err.Error())
+	}
+}
+
+func TestDoMergeRejectsContentAddingImmutableParameter(t *testing.T) {
+	base := map[string]string{
+		"my.cnf": "[mysqld]\nmax_connections=1000\n",
+	}
+	patch := map[string]parametersv1alpha1.ParametersInFile{
+		"my.cnf": {
+			Content: strPtr("[mysqld]\nmax_connections=1000\ngtid_mode=ON\n"),
+		},
+	}
+	configDescs := iniConfigDescsForMyCnf()
+	paramsDefs := paramsDefsWithImmutable([]string{"gtid_mode"})
+
+	_, err := DoMerge(base, patch, paramsDefs, configDescs)
+	if err == nil {
+		t.Fatalf("expected immutable parameter addition via content to be rejected, got nil error")
+	}
+	if !strings.Contains(err.Error(), "gtid_mode") {
+		t.Fatalf("expected error to mention immutable parameter gtid_mode, got %q", err.Error())
+	}
+}
+
+func TestDoMergeRejectsContentRemovingImmutableParameter(t *testing.T) {
+	base := map[string]string{
+		"my.cnf": "[mysqld]\ngtid_mode=OFF\nmax_connections=1000\n",
+	}
+	patch := map[string]parametersv1alpha1.ParametersInFile{
+		"my.cnf": {
+			Content: strPtr("[mysqld]\nmax_connections=1000\n"),
+		},
+	}
+	configDescs := iniConfigDescsForMyCnf()
+	paramsDefs := paramsDefsWithImmutable([]string{"gtid_mode"})
+
+	_, err := DoMerge(base, patch, paramsDefs, configDescs)
+	if err == nil {
+		t.Fatalf("expected immutable parameter removal via content to be rejected, got nil error")
+	}
+	if !strings.Contains(err.Error(), "gtid_mode") {
+		t.Fatalf("expected error to mention immutable parameter gtid_mode, got %q", err.Error())
+	}
+}
+
+func TestDoMergeAcceptsContentWithOnlyFormatChange(t *testing.T) {
+	base := map[string]string{
+		"my.cnf": "[mysqld]\ngtid_mode=OFF\nmax_connections=1000\n",
+	}
+	// Same semantic content, just reordered and with an added blank line.
+	// Must not be flagged as an immutable change because the parsed parameter
+	// map for gtid_mode is unchanged.
+	patch := map[string]parametersv1alpha1.ParametersInFile{
+		"my.cnf": {
+			Content: strPtr("[mysqld]\n\nmax_connections=1000\ngtid_mode=OFF\n"),
+		},
+	}
+	configDescs := iniConfigDescsForMyCnf()
+	paramsDefs := paramsDefsWithImmutable([]string{"gtid_mode"})
+
+	if _, err := DoMerge(base, patch, paramsDefs, configDescs); err != nil {
+		t.Fatalf("expected format-only content change to be accepted, got error %v", err)
+	}
+}
+
+func TestDoMergeAcceptsContentWithMutableChangeAndFormatNoiseWhileImmutableUnchanged(t *testing.T) {
+	// Realistic MySQL-style fixture covering the joint case the guard must
+	// accept:
+	//   1) format noise — comment rewrites, extra blank lines, `key=value`
+	//      vs `key = value` spacing — must NOT trip the immutable check;
+	//   2) a mutable parameter (max_connections) changes value — that is
+	//      explicitly allowed because it is not in ImmutableParameters;
+	//   3) the immutable parameter (gtid_mode) keeps the same parsed value
+	//      across base and patch, so the guard must let the merge through.
+	//
+	// Together these confirm the guard only triggers on immutable-parameter
+	// semantic delta and ignores everything else.
+	base := map[string]string{
+		"my.cnf": "" +
+			"# header comment\n" +
+			"[mysqld]\n" +
+			"gtid_mode=OFF\n" +
+			"max_connections=1000\n" +
+			"# inline comment\n" +
+			"slow_query_log=ON\n",
+	}
+	patch := map[string]parametersv1alpha1.ParametersInFile{
+		"my.cnf": {
+			Content: strPtr("" +
+				"# rewritten header\n" +
+				"\n" +
+				"[mysqld]\n" +
+				"\n" +
+				"# reordered block\n" +
+				"slow_query_log = ON\n" +
+				"max_connections = 2000\n" +
+				"gtid_mode = OFF\n"),
+		},
+	}
+	configDescs := iniConfigDescsForMyCnf()
+	paramsDefs := paramsDefsWithImmutable([]string{"gtid_mode"})
+
+	if _, err := DoMerge(base, patch, paramsDefs, configDescs); err != nil {
+		t.Fatalf("expected realistic format/whitespace/comment noise without immutable-parameter change to be accepted, got error %v", err)
+	}
+}
+
+func TestDoMergeAcceptsContentOnFileWithoutImmutableCandidate(t *testing.T) {
+	// File has no ParametersDefinition entry, and the content payload uses an
+	// arbitrary format with no FileFormatConfig registered. The guard must
+	// stay out of the way: there is no immutable contract to protect on this
+	// file, so a missing parser must not block a benign content update.
+	base := map[string]string{
+		"custom.conf": "key1=value1\n",
+	}
+	patch := map[string]parametersv1alpha1.ParametersInFile{
+		"custom.conf": {
+			Content: strPtr("key1=value1\nkey2=value2\n"),
+		},
+	}
+
+	if _, err := DoMerge(base, patch, nil, nil); err != nil {
+		t.Fatalf("expected content update on file without immutable candidate to be accepted even without parser, got error %v", err)
+	}
+}
+
+func TestDoMergeRejectsContentWhenImmutableDeclaredButFormatMissing(t *testing.T) {
+	// File has an immutable parameter declared but no FileFormatConfig is
+	// available. Fail-safe: reject rather than silently allow because the
+	// guard cannot verify whether the content change touched gtid_mode.
+	base := map[string]string{
+		"my.cnf": "[mysqld]\ngtid_mode=OFF\n",
+	}
+	patch := map[string]parametersv1alpha1.ParametersInFile{
+		"my.cnf": {
+			Content: strPtr("[mysqld]\ngtid_mode=OFF\nmax_connections=1000\n"),
+		},
+	}
+	paramsDefs := paramsDefsWithImmutable([]string{"gtid_mode"})
+
+	_, err := DoMerge(base, patch, paramsDefs, nil)
+	if err == nil {
+		t.Fatalf("expected fail-safe rejection when immutable parameter declared but file format config is missing, got nil error")
+	}
+	if !strings.Contains(err.Error(), "missing file format config") {
+		t.Fatalf("expected error to mention missing file format config, got %q", err.Error())
+	}
+}

--- a/pkg/parameters/patch_merger_test.go
+++ b/pkg/parameters/patch_merger_test.go
@@ -126,6 +126,36 @@ func TestDoMergeRejectsUnmanagedUpdateRemovingImmutableParameter(t *testing.T) {
 	}
 }
 
+func TestDoMergeAcceptsUnmanagedUpdateWithImmutableKeyInDifferentSection(t *testing.T) {
+	base := map[string]string{
+		"my.cnf": "[mysqld]\ngtid_mode=OFF\nmax_connections=1000\n\n[client]\ngtid_mode=OFF\n",
+	}
+	patch := map[string]parametersv1alpha1.ParametersInFile{
+		"my.cnf": {
+			UnmanagedUpdates: []parametersv1alpha1.UnmanagedParameterSectionUpdate{{
+				Section: strPtr("client"),
+				Updates: []parametersv1alpha1.ParameterUpdate{
+					{Type: parametersv1alpha1.ParameterUpdateSet, Key: "gtid_mode", Value: strPtr("ON")},
+				},
+			}},
+		},
+	}
+	configDescs := iniConfigDescsForMyCnf()
+	paramsDefs := paramsDefsWithImmutable([]string{"gtid_mode"})
+
+	got, err := DoMerge(base, patch, paramsDefs, configDescs)
+	if err != nil {
+		t.Fatalf("expected unmanaged update in a different INI section to be accepted, got error %v", err)
+	}
+	content := got["my.cnf"]
+	if !strings.Contains(content, "[mysqld]\ngtid_mode=OFF") {
+		t.Fatalf("expected managed mysqld gtid_mode to stay unchanged, got %q", content)
+	}
+	if !strings.Contains(content, "[client]\ngtid_mode=ON") {
+		t.Fatalf("expected client section gtid_mode to be updated, got %q", content)
+	}
+}
+
 func strPtr(v string) *string {
 	return &v
 }

--- a/pkg/parameters/patch_merger_test.go
+++ b/pkg/parameters/patch_merger_test.go
@@ -85,9 +85,9 @@ func strPtr(v string) *string {
 //   - content modifies an immutable parameter   -> reject
 //   - content adds an immutable parameter       -> reject
 //   - content removes an immutable parameter    -> reject
-//   - content only reorders / re-formats        -> accept (no误伤)
+//   - content only reorders / re-formats        -> accept (no false positive)
 //   - file has no immutable candidate, missing
-//     FileFormatConfig                          -> accept (no兼容性回归)
+//     FileFormatConfig                          -> accept (no backward-compat regression)
 //   - file has immutable candidate but missing
 //     FileFormatConfig                          -> reject (fail-safe)
 
@@ -199,9 +199,9 @@ func TestDoMergeAcceptsContentWithOnlyFormatChange(t *testing.T) {
 func TestDoMergeAcceptsContentWithMutableChangeAndFormatNoiseWhileImmutableUnchanged(t *testing.T) {
 	// Realistic MySQL-style fixture covering the joint case the guard must
 	// accept:
-	//   1) format noise — comment rewrites, extra blank lines, `key=value`
-	//      vs `key = value` spacing — must NOT trip the immutable check;
-	//   2) a mutable parameter (max_connections) changes value — that is
+	//   1) format noise -- comment rewrites, extra blank lines, `key=value`
+	//      vs `key = value` spacing -- must NOT trip the immutable check;
+	//   2) a mutable parameter (max_connections) changes value -- that is
 	//      explicitly allowed because it is not in ImmutableParameters;
 	//   3) the immutable parameter (gtid_mode) keeps the same parsed value
 	//      across base and patch, so the guard must let the merge through.

--- a/pkg/parameters/patch_merger_test.go
+++ b/pkg/parameters/patch_merger_test.go
@@ -56,7 +56,9 @@ func TestDoMergeAppliesUnmanagedUpdatesAfterContentAndParameters(t *testing.T) {
 		},
 	}}
 
-	got, err := DoMerge(base, patch, nil, configDescs)
+	paramsDefs := paramsDefsWithImmutable([]string{"gtid_mode"})
+
+	got, err := DoMerge(base, patch, paramsDefs, configDescs)
 	if err != nil {
 		t.Fatalf("DoMerge() error = %v", err)
 	}
@@ -69,6 +71,58 @@ func TestDoMergeAppliesUnmanagedUpdatesAfterContentAndParameters(t *testing.T) {
 	}
 	if !strings.Contains(content, "gtid_mode=OFF") {
 		t.Fatalf("expected unrelated config to remain after merge, got %q", content)
+	}
+}
+
+func TestDoMergeRejectsUnmanagedUpdateSettingImmutableParameter(t *testing.T) {
+	base := map[string]string{
+		"my.cnf": "[mysqld]\ngtid_mode=OFF\nmax_connections=1000\n",
+	}
+	patch := map[string]parametersv1alpha1.ParametersInFile{
+		"my.cnf": {
+			UnmanagedUpdates: []parametersv1alpha1.UnmanagedParameterSectionUpdate{{
+				Section: strPtr("mysqld"),
+				Updates: []parametersv1alpha1.ParameterUpdate{
+					{Type: parametersv1alpha1.ParameterUpdateSet, Key: "gtid_mode", Value: strPtr("ON")},
+				},
+			}},
+		},
+	}
+	configDescs := iniConfigDescsForMyCnf()
+	paramsDefs := paramsDefsWithImmutable([]string{"gtid_mode"})
+
+	_, err := DoMerge(base, patch, paramsDefs, configDescs)
+	if err == nil {
+		t.Fatalf("expected immutable parameter modification via unmanaged update to be rejected, got nil error")
+	}
+	if !strings.Contains(err.Error(), "gtid_mode") {
+		t.Fatalf("expected error to mention immutable parameter gtid_mode, got %q", err.Error())
+	}
+}
+
+func TestDoMergeRejectsUnmanagedUpdateRemovingImmutableParameter(t *testing.T) {
+	base := map[string]string{
+		"my.cnf": "[mysqld]\ngtid_mode=OFF\nmax_connections=1000\n",
+	}
+	patch := map[string]parametersv1alpha1.ParametersInFile{
+		"my.cnf": {
+			UnmanagedUpdates: []parametersv1alpha1.UnmanagedParameterSectionUpdate{{
+				Section: strPtr("mysqld"),
+				Updates: []parametersv1alpha1.ParameterUpdate{
+					{Type: parametersv1alpha1.ParameterUpdateRemove, Key: "gtid_mode"},
+				},
+			}},
+		},
+	}
+	configDescs := iniConfigDescsForMyCnf()
+	paramsDefs := paramsDefsWithImmutable([]string{"gtid_mode"})
+
+	_, err := DoMerge(base, patch, paramsDefs, configDescs)
+	if err == nil {
+		t.Fatalf("expected immutable parameter removal via unmanaged update to be rejected, got nil error")
+	}
+	if !strings.Contains(err.Error(), "gtid_mode") {
+		t.Fatalf("expected error to mention immutable parameter gtid_mode, got %q", err.Error())
 	}
 }
 

--- a/pkg/parameters/patch_merger_test.go
+++ b/pkg/parameters/patch_merger_test.go
@@ -257,6 +257,33 @@ func TestDoMergeAcceptsContentOnFileWithoutImmutableCandidate(t *testing.T) {
 	}
 }
 
+func TestDoMergeRejectsContentRemovingEntireSectionContainingImmutableParameter(t *testing.T) {
+	// Regression for the nil-deref panic introduced by core.FromConfigObject
+	// returning nil when an INI sub-section is absent. The content payload
+	// drops the entire [mysqld] section that contains the immutable
+	// parameter gtid_mode; the guard must reject the change (immutable
+	// removed) instead of panicking on GetAllParameters of a nil
+	// ConfigObject.
+	base := map[string]string{
+		"my.cnf": "[mysqld]\ngtid_mode=OFF\nmax_connections=1000\n",
+	}
+	patch := map[string]parametersv1alpha1.ParametersInFile{
+		"my.cnf": {
+			Content: strPtr("[other]\nfoo=bar\n"),
+		},
+	}
+	configDescs := iniConfigDescsForMyCnf()
+	paramsDefs := paramsDefsWithImmutable([]string{"gtid_mode"})
+
+	_, err := DoMerge(base, patch, paramsDefs, configDescs)
+	if err == nil {
+		t.Fatalf("expected immutable parameter removal via whole-section deletion to be rejected, got nil error")
+	}
+	if !strings.Contains(err.Error(), "gtid_mode") {
+		t.Fatalf("expected error to mention immutable parameter gtid_mode, got %q", err.Error())
+	}
+}
+
 func TestDoMergeRejectsContentWhenImmutableDeclaredButFormatMissing(t *testing.T) {
 	// File has an immutable parameter declared but no FileFormatConfig is
 	// available. Fail-safe: reject rather than silently allow because the

--- a/pkg/unstructured/viper_wrap.go
+++ b/pkg/unstructured/viper_wrap.go
@@ -62,8 +62,18 @@ func (v *viperWrap) RemoveKey(key string) error {
 }
 
 func (v *viperWrap) SubConfig(key string) ConfigObject {
+	sub := v.Sub(key)
+	if sub == nil {
+		// Stay consistent with the other ConfigObject implementations
+		// (properties / redis / xml / yaml) which return nil when the
+		// requested sub-section is absent. Returning a non-nil wrapper
+		// around a nil viper would panic on later AllKeys / AllSettings
+		// calls; the existing nil-check in pkg/configuration/core/config.go
+		// already expects nil for absent sections.
+		return nil
+	}
 	return &viperWrap{
-		Viper:  v.Sub(key),
+		Viper:  sub,
 		format: v.format,
 	}
 }


### PR DESCRIPTION
## Summary

Main-branch port of release-1.0 PR #10204. Rejects updates to parameters listed in `ParametersDefinition.spec.immutableParameters`, covering both update entry points:

- **Structured `ParametersInFile.Parameters` path**: `filterImmutableParameters` returns an explicit error instead of silently filtering immutable keys.
- **Raw `ParametersInFile.Content` path**: new `validateImmutableContentChanges` helper parses base and merged content via each file's `FileFormatConfig`, rejects add / remove / modify of any immutable parameter, and ignores formatting-only changes.

The two-entry-point scope matches PR #10204 on release-1.0 so the behavior stays consistent across main and release-1.0. (The earlier split into separate PRs #10237 / #10242 was unintentional and is now folded into this single PR; #10242 will be closed.)

## Architectural placement (post #10254)

PR #10254 (merged 2026-05-19) restructured the validation flow so that `ClassifyComponentParameters` and `DoMerge` are now invoked inside the **ComponentParameter controller** (`controllers/parameters/componentparameter_controller_utils.go:122-141`), processing `ComponentParameter.Spec.Desired`. The error path is `intctrlutil.NewErrorf(intctrlutil.ErrorTypeFatal, ...)` → `CMergeFailedPhase`.

This PR lifts both immutable-parameter rejections along the same call chain:

```
ComponentParameter controller
  → ClassifyComponentParameters
    → ValidateComponentParameterAssignments (schema check, from #10254)
  → DoMerge
    → mergeUpdatedParams
      → validateImmutableContentChanges (this PR, Content path) → error → ErrorTypeFatal → CMergeFailedPhase
      → MergeAndValidateConfigs
        → filterImmutableParameters (this PR, Parameters path) → error → ErrorTypeFatal → CMergeFailedPhase
```

All three checks (schema, content-level immutable, parameter-level immutable) sit at the layer that owns `ComponentParameter.Spec.Desired` state. Any future writer of `Spec.Desired` (Parameter CR, OpsRequest reconfigure, direct edit) goes through the same gate.

## Evidence

- Observed scene: an immutable negative gate run had the OpsRequest reach `Succeeded` while `ComponentParameter` desired one value and the rendered pod configs stayed on the previous value. Reconfigure status reported "no config modified / skip reconfigure".
- Static path matches the scene: `filterImmutableParameters` silently dropped immutable keys, producing a no-op patch that finished as Succeeded. The Content path had no immutable check at all, allowing the same bypass via raw file content.

## What changed

- `pkg/parameters/config_util.go`: `filterImmutableParameters` returns `(map[string]any, error)` and rejects any immutable key with `fmt.Errorf("immutable parameter %s cannot be modified", key)`. The single caller in `MergeAndValidateConfigs` surfaces the error.
- `pkg/parameters/config_util_test.go`: the rejection case now expects `wantErr=true` rather than a filtered map.
- `pkg/parameters/patch_merger.go`: invoke `validateImmutableContentChanges` from `mergeUpdatedParams` after `MergeUpdatedConfig`.
- `pkg/parameters/patch_merger_test.go`: 7 new cases covering modify / add / remove of immutable parameter on raw content, format-only changes (no false flag), mutable change with format noise, content on file without immutable candidate, and fail-safe when immutable declared but format missing.
- `pkg/unstructured/viper_wrap.go`: support nil-safe access for `viperWrap.SubConfig` so the new check does not panic when a patch removes an INI sub-section entirely (Leon's review comment on the earlier #10242 split).

## Helper contract for `validateImmutableContentChanges`

- Only inspects files present in the current update set (no scan of unchanged files).
- Skips files whose `ParametersDefinition` has no immutable-parameter contract, so benign content updates to ordinary files are not affected.
- Parses base and merged content using each file's `FileFormatConfig` and compares the parsed parameter map. Format-only changes (whitespace, comment order, blank lines, `key=value` vs `key = value` spacing) are not flagged.
- Rejects add, remove, and modify of any immutable parameter.
- Fails safe when an immutable-parameter candidate is declared on the file but no parser is available (`FileFormatConfig` missing or parse error), so an unknown-format file cannot become a silent bypass.

## Verification

- `go build ./pkg/parameters/...` and `./pkg/unstructured/...`
- `go test ./pkg/parameters -run 'Test_filterImmutableParameters|TestDoMerge' -count=1 -v` (plain Go tests, 7 new content-path cases plus the existing structured-path case all PASS)
- `go test ./pkg/unstructured -count=1` PASS
- `git diff --check origin/main...HEAD` clean
- Commit attribution scan clean

## Diff stats

5 files changed, +351 / -14.

## Relationship to #10204 and #10242

- PR #10204 (release-1.0, merged) is the equivalent release-1.0 PR. Same five files (under pre-#9846 paths), same two-entry-point scope.
- PR #10242 (main, to be closed) contained the Content-path subset before this fold-up; its three commits are now part of this PR's history. Closing #10242 preserves the review trail; this PR is the authoritative landing target.