### PR TITLE
chore(instanceset): backport V(1) diagnostic logs for alignment reconcile decisions

### DIFF
--- a/pkg/controller/instanceset/alignment_log.go
+++ b/pkg/controller/instanceset/alignment_log.go
@@ -1,0 +1,124 @@
+/*
+Copyright (C) 2022-2025 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package instanceset
+
+import (
+	"fmt"
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+)
+
+// alignment_log.go contains deterministic formatting helpers used by the
+// instance alignment reconciler to emit V(1) instrumentation logs. The
+// helpers intentionally produce compact, lossy summaries (no labels,
+// annotations, or full spec/status content) so that enabling V(1) verbosity
+// does not produce unbounded log size and does not leak arbitrary metadata.
+
+// formatPodSnapshot returns a single compact summary line for a Pod. It is
+// nil-safe: when pod is nil the result is "name=<name> oldPodFound=false",
+// allowing the caller to emit a clear "we expected an old pod here but the
+// map lookup returned nil" signal.
+//
+// The format is intentionally key=value separated by single spaces so that
+// the resulting log argument is one line per pod.
+func formatPodSnapshot(name string, pod *corev1.Pod, minReadySeconds int32) string {
+	if pod == nil {
+		return fmt.Sprintf("name=%s oldPodFound=false", name)
+	}
+	dts := ""
+	if pod.DeletionTimestamp != nil {
+		dts = pod.DeletionTimestamp.UTC().Format("2006-01-02T15:04:05Z")
+	}
+	return fmt.Sprintf(
+		"name=%s uid=%s phase=%s deletionTimestamp=%s ownerRef=%s ready=%t available=%t",
+		name,
+		string(pod.UID),
+		string(pod.Status.Phase),
+		dts,
+		formatPodOwnerRef(pod.OwnerReferences),
+		intctrlutil.IsPodReady(pod),
+		intctrlutil.IsPodAvailable(pod, minReadySeconds),
+	)
+}
+
+// formatPodOwnerRef returns a compact owner-reference summary. The controller
+// owner (Controller=true) is preferred when present; if no owner is set the
+// result is "<none>"; otherwise the first reference is reported. Only
+// kind/name/uid/controller-flag are included by design - additional fields
+// (apiVersion, blockOwnerDeletion) are dropped to keep the summary short.
+func formatPodOwnerRef(refs []metav1.OwnerReference) string {
+	if len(refs) == 0 {
+		return "<none>"
+	}
+	for i := range refs {
+		ref := &refs[i]
+		if ref.Controller != nil && *ref.Controller {
+			return fmt.Sprintf("%s/%s/%s/controller=true", ref.Kind, ref.Name, string(ref.UID))
+		}
+	}
+	ref := refs[0]
+	return fmt.Sprintf("%s/%s/%s/controller=false", ref.Kind, ref.Name, string(ref.UID))
+}
+
+// formatOldInstanceMapSnapshot returns a deterministic, name-sorted slice of
+// compact pod summary strings for use in V(1) instrumentation logs. Each
+// element is the output of formatPodSnapshot for one pod in oldInstanceMap.
+// The slice ordering is by ascending name so that log diffs across reconciles
+// are stable and grep-friendly.
+func formatOldInstanceMapSnapshot(oldInstanceMap map[string]*corev1.Pod, minReadySeconds int32) []string {
+	names := make([]string, 0, len(oldInstanceMap))
+	for name := range oldInstanceMap {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]string, 0, len(names))
+	for _, name := range names {
+		out = append(out, formatPodSnapshot(name, oldInstanceMap[name], minReadySeconds))
+	}
+	return out
+}
+
+// formatNameSetSnapshot returns a deterministic map view of the four name
+// sets used by the alignment loop. Each value is a sorted slice of names; an
+// empty set is rendered as an empty (non-nil) slice. Callers pass the four
+// sets as separate keyed entries so that the resulting structured log keys
+// are stable.
+func formatNameSetSnapshot(oldNameSet, newNameSet, createNameSet, deleteNameSet sets.Set[string]) map[string][]string {
+	return map[string][]string{
+		"oldNameSet":    sortedNamesFromSet(oldNameSet),
+		"newNameSet":    sortedNamesFromSet(newNameSet),
+		"createNameSet": sortedNamesFromSet(createNameSet),
+		"deleteNameSet": sortedNamesFromSet(deleteNameSet),
+	}
+}
+
+func sortedNamesFromSet(s sets.Set[string]) []string {
+	if s.Len() == 0 {
+		return []string{}
+	}
+	out := s.UnsortedList()
+	sort.Strings(out)
+	return out
+}

--- a/pkg/controller/instanceset/alignment_log_test.go
+++ b/pkg/controller/instanceset/alignment_log_test.go
@@ -1,0 +1,247 @@
+/*
+Copyright (C) 2022-2025 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package instanceset
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// These tests cover the deterministic formatting helpers used by the
+// alignment reconciler V(1) instrumentation. They intentionally exercise
+// the formatters directly rather than capturing controller log output, so
+// the assertions are stable and do not depend on logger plumbing.
+
+func TestFormatPodSnapshot_NilPod(t *testing.T) {
+	got := formatPodSnapshot("foo-0", nil, 0)
+	want := "name=foo-0 oldPodFound=false"
+	if got != want {
+		t.Fatalf("nil pod: got %q want %q", got, want)
+	}
+}
+
+func TestFormatPodSnapshot_TerminatingPod(t *testing.T) {
+	truth := true
+	dts := metav1.NewTime(time.Date(2026, 5, 14, 22, 33, 36, 0, time.UTC))
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "foo-0",
+			UID:               "11111111-2222-3333-4444-555555555555",
+			DeletionTimestamp: &dts,
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "InstanceSet", Name: "foo", UID: "aaa", Controller: &truth},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:               corev1.PodReady,
+					Status:             corev1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(time.Date(2026, 5, 14, 22, 30, 0, 0, time.UTC)),
+				},
+			},
+		},
+	}
+	got := formatPodSnapshot("foo-0", pod, 0)
+	// A pod with a DeletionTimestamp is "terminating": IsPodReady and
+	// IsPodAvailable both return false even though the Ready condition is
+	// True. This distinction is critical for diagnosing recovery delays
+	// where the API object survives past the user-perceived deletion.
+	want := "name=foo-0 uid=11111111-2222-3333-4444-555555555555 phase=Running deletionTimestamp=2026-05-14T22:33:36Z ownerRef=InstanceSet/foo/aaa/controller=true ready=false available=false"
+	if got != want {
+		t.Fatalf("terminating pod: got %q want %q", got, want)
+	}
+}
+
+func TestFormatPodSnapshot_HealthyPod(t *testing.T) {
+	truth := true
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo-0",
+			UID:  "uid-healthy",
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "InstanceSet", Name: "foo", UID: "aaa", Controller: &truth},
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{
+				{
+					Type:               corev1.PodReady,
+					Status:             corev1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(time.Now().Add(-time.Hour)),
+				},
+			},
+		},
+	}
+	got := formatPodSnapshot("foo-0", pod, 0)
+	want := "name=foo-0 uid=uid-healthy phase=Running deletionTimestamp= ownerRef=InstanceSet/foo/aaa/controller=true ready=true available=true"
+	if got != want {
+		t.Fatalf("healthy pod: got %q want %q", got, want)
+	}
+}
+
+func TestFormatPodOwnerRef_None(t *testing.T) {
+	got := formatPodOwnerRef(nil)
+	if got != "<none>" {
+		t.Fatalf("nil refs: got %q want <none>", got)
+	}
+	got = formatPodOwnerRef([]metav1.OwnerReference{})
+	if got != "<none>" {
+		t.Fatalf("empty refs: got %q want <none>", got)
+	}
+}
+
+func TestFormatPodOwnerRef_ControllerPreferred(t *testing.T) {
+	f := false
+	truth := true
+	refs := []metav1.OwnerReference{
+		{Kind: "Other", Name: "x", UID: "y", Controller: &f},
+		{Kind: "InstanceSet", Name: "foo", UID: "aaa", Controller: &truth},
+	}
+	got := formatPodOwnerRef(refs)
+	want := "InstanceSet/foo/aaa/controller=true"
+	if got != want {
+		t.Fatalf("controller-preferred: got %q want %q", got, want)
+	}
+}
+
+func TestFormatPodOwnerRef_NoControllerFallback(t *testing.T) {
+	f := false
+	refs := []metav1.OwnerReference{
+		{Kind: "Other", Name: "x", UID: "y", Controller: &f},
+	}
+	got := formatPodOwnerRef(refs)
+	want := "Other/x/y/controller=false"
+	if got != want {
+		t.Fatalf("no-controller fallback: got %q want %q", got, want)
+	}
+}
+
+func TestFormatPodOwnerRef_NilControllerFlag(t *testing.T) {
+	refs := []metav1.OwnerReference{
+		{Kind: "Other", Name: "x", UID: "y"},
+	}
+	got := formatPodOwnerRef(refs)
+	// nil Controller pointer is treated as not-controller; we still report
+	// the first owner with controller=false.
+	want := "Other/x/y/controller=false"
+	if got != want {
+		t.Fatalf("nil controller flag: got %q want %q", got, want)
+	}
+}
+
+func TestFormatOldInstanceMapSnapshot_SortedByName(t *testing.T) {
+	pods := map[string]*corev1.Pod{
+		"foo-2": {ObjectMeta: metav1.ObjectMeta{Name: "foo-2", UID: "uid-2"}},
+		"foo-0": {ObjectMeta: metav1.ObjectMeta{Name: "foo-0", UID: "uid-0"}},
+		"foo-1": {ObjectMeta: metav1.ObjectMeta{Name: "foo-1", UID: "uid-1"}},
+	}
+	got := formatOldInstanceMapSnapshot(pods, 0)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 entries, got %d: %v", len(got), got)
+	}
+	wantOrder := []string{"foo-0", "foo-1", "foo-2"}
+	for i, name := range wantOrder {
+		prefix := "name=" + name + " "
+		if !strings.HasPrefix(got[i], prefix) {
+			t.Fatalf("entry %d: expected prefix %q, got %q", i, prefix, got[i])
+		}
+	}
+}
+
+func TestFormatOldInstanceMapSnapshot_EmptyMap(t *testing.T) {
+	got := formatOldInstanceMapSnapshot(map[string]*corev1.Pod{}, 0)
+	if len(got) != 0 {
+		t.Fatalf("empty map: expected empty slice, got %v", got)
+	}
+}
+
+func TestFormatOldInstanceMapSnapshot_NilPodEntry(t *testing.T) {
+	// A nil pod value in the map (theoretically unreachable, but the
+	// formatter is defensive) renders as the nil-safe form so a "we expected
+	// an old pod here but got nil" case is distinguishable.
+	pods := map[string]*corev1.Pod{
+		"foo-0": nil,
+	}
+	got := formatOldInstanceMapSnapshot(pods, 0)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entry, got %v", got)
+	}
+	want := "name=foo-0 oldPodFound=false"
+	if got[0] != want {
+		t.Fatalf("nil entry: got %q want %q", got[0], want)
+	}
+}
+
+func TestFormatNameSetSnapshot(t *testing.T) {
+	oldSet := sets.New[string]("foo-0", "foo-1", "foo-2")
+	newSet := sets.New[string]("foo-0", "foo-1", "foo-3")
+	createSet := newSet.Difference(oldSet)
+	deleteSet := oldSet.Difference(newSet)
+	got := formatNameSetSnapshot(oldSet, newSet, createSet, deleteSet)
+
+	cases := map[string][]string{
+		"oldNameSet":    {"foo-0", "foo-1", "foo-2"},
+		"newNameSet":    {"foo-0", "foo-1", "foo-3"},
+		"createNameSet": {"foo-3"},
+		"deleteNameSet": {"foo-2"},
+	}
+	for key, want := range cases {
+		if !equalStringSlices(got[key], want) {
+			t.Fatalf("key %s: got %v want %v", key, got[key], want)
+		}
+	}
+}
+
+func TestFormatNameSetSnapshot_EmptySets(t *testing.T) {
+	empty := sets.New[string]()
+	got := formatNameSetSnapshot(empty, empty, empty, empty)
+	for _, key := range []string{"oldNameSet", "newNameSet", "createNameSet", "deleteNameSet"} {
+		v, ok := got[key]
+		if !ok {
+			t.Fatalf("missing key %s", key)
+		}
+		if v == nil {
+			t.Fatalf("key %s: expected non-nil empty slice, got nil", key)
+		}
+		if len(v) != 0 {
+			t.Fatalf("key %s: expected empty slice, got %v", key, v)
+		}
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/controller/instanceset/reconciler_instance_alignment.go
+++ b/pkg/controller/instanceset/reconciler_instance_alignment.go
@@ -87,6 +87,18 @@ func (r *instanceAlignmentReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (
 	createNameSet := newNameSet.Difference(oldNameSet)
 	deleteNameSet := oldNameSet.Difference(newNameSet)
 
+	// instrumentation: emit a compact, deterministic snapshot of the old pods
+	// observed by this reconcile pass. Logged at V(1) so it does not appear in
+	// the default INFO stream. The `namespace` and `instanceSet` keys are
+	// emitted as separate structured fields so log consumers can filter by
+	// (namespace, instanceSet) without parsing a combined "ns/name" string.
+	tree.Logger.V(1).Info(
+		"alignment: oldInstance snapshot",
+		"namespace", its.Namespace,
+		"instanceSet", its.Name,
+		"oldPods", formatOldInstanceMapSnapshot(oldInstanceMap, its.Spec.MinReadySeconds),
+	)
+
 	// default OrderedReady policy
 	isOrderedReady := true
 	concurrency := 0
@@ -98,6 +110,23 @@ func (r *instanceAlignmentReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (
 		isOrderedReady = false
 	}
 	// TODO(free6om): handle BestEffortParallel: always keep the majority available.
+
+	// instrumentation: emit the four name sets used by the alignment loop plus
+	// the policy/concurrency context. Logged at V(1).
+	{
+		setSnapshot := formatNameSetSnapshot(oldNameSet, newNameSet, createNameSet, deleteNameSet)
+		tree.Logger.V(1).Info(
+			"alignment: nameSet snapshot",
+			"namespace", its.Namespace,
+			"instanceSet", its.Name,
+			"podManagementPolicy", string(its.Spec.PodManagementPolicy),
+			"concurrencyInit", concurrency,
+			"oldNameSet", setSnapshot["oldNameSet"],
+			"newNameSet", setSnapshot["newNameSet"],
+			"createNameSet", setSnapshot["createNameSet"],
+			"deleteNameSet", setSnapshot["deleteNameSet"],
+		)
+	}
 
 	// 3. handle alignment (create new instances and delete useless instances)
 	// create new instances
@@ -124,13 +153,75 @@ func (r *instanceAlignmentReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (
 	for i, name := range newNameList {
 		if _, ok := createNameSet[name]; !ok {
 			currentAlignedNameList = append(currentAlignedNameList, name)
+			// instrumentation: this desired name already has a corresponding
+			// pod in oldInstanceMap, so the alignment loop reuses the existing
+			// instance instead of creating a new one. Logged at V(1) with a
+			// nil-safe pod snapshot so the "expected old pod but got nil" case
+			// is distinguishable from the normal reuse case via the
+			// `oldPodFound=false` field rendered by formatPodSnapshot.
+			// `namespace`, `instanceSet`, `podName`, and `podUID` are emitted
+			// as separate structured fields so log consumers can filter by
+			// (namespace, instanceSet, podName/uid) without parsing the
+			// embedded snapshot string.
+			existing := oldInstanceMap[name]
+			var podUID string
+			if existing != nil {
+				podUID = string(existing.UID)
+			}
+			tree.Logger.V(1).Info(
+				"alignment: reuse-existing-instance",
+				"namespace", its.Namespace,
+				"instanceSet", its.Name,
+				"podName", name,
+				"podUID", podUID,
+				"podSnapshot", formatPodSnapshot(name, existing, its.Spec.MinReadySeconds),
+			)
 			continue
 		}
 		if !isOrderedReady && concurrency <= 0 {
+			// instrumentation: parallel pod-management has exhausted its
+			// per-reconcile concurrency budget, so no more new pods will be
+			// created in this pass. Logged at V(1). `podName` carries the
+			// desired name that did NOT get created in this pass so callers
+			// can filter on the blocked pod even though no pod object yet
+			// exists; `podUID` is empty because the pod has not been
+			// constructed.
+			tree.Logger.V(1).Info(
+				"alignment: stop-create-loop",
+				"namespace", its.Namespace,
+				"instanceSet", its.Name,
+				"reason", "concurrency-exhausted",
+				"podName", name,
+				"podUID", "",
+				"podManagementPolicy", string(its.Spec.PodManagementPolicy),
+				"concurrency", concurrency,
+				"currentIndex", i,
+				"totalNameCount", len(newNameList),
+			)
 			break
 		}
 		predecessor := getPredecessor(i)
 		if isOrderedReady && predecessor != nil && !intctrlutil.IsPodAvailable(predecessor, its.Spec.MinReadySeconds) {
+			// instrumentation: ordered pod-management is waiting for the
+			// previous-ordinal pod to become Available before it will create
+			// the next pod. Logged at V(1). The predecessor snapshot is
+			// nil-safe; in this branch predecessor is guaranteed non-nil by
+			// the guard above but formatPodSnapshot still handles nil for
+			// defensive reasons. `predecessorPodUID` is emitted as a separate
+			// structured field for filtering.
+			tree.Logger.V(1).Info(
+				"alignment: stop-create-loop",
+				"namespace", its.Namespace,
+				"instanceSet", its.Name,
+				"reason", "predecessor-not-available",
+				"podName", name,
+				"podUID", "",
+				"podManagementPolicy", "OrderedReady",
+				"currentIndex", i,
+				"predecessorPodName", predecessor.Name,
+				"predecessorPodUID", string(predecessor.UID),
+				"predecessorSnapshot", formatPodSnapshot(predecessor.Name, predecessor, its.Spec.MinReadySeconds),
+			)
 			break
 		}
 		inst, err := buildInstanceByTemplate(name, nameToTemplateMap[name], its, "")


### PR DESCRIPTION
## Scope

Scope: diagnostic/logging only.

This backport only carries the V(1) diagnostic logs from PR #10236 to `release-1.0` so a patch image can collect evidence from the target run. It does not change lifecycle, queueing, retry, status, or reconciliation behavior. It is not a root-cause fix and should not be treated as a release gate fix.

## Summary

Backport PR #10236 to `release-1.0`.

Original on `main`: <https://github.com/apecloud/kubeblocks/pull/10236>

Adds 5 V(1) instrumentation log points to the InstanceSet alignment reconcile path, plus the `alignment_log.go` helper file that builds compact snapshots of the old-instance map, name sets, and reuse/break decisions. Behavior is otherwise unchanged.

## What changed

This backport is a cherry-pick of the main commit `be47e417` with one small compatibility fix for release-1.0:

- `pkg/controller/instanceset/alignment_log.go`: new file, the 3 helper formatters.
- `pkg/controller/instanceset/alignment_log_test.go`: new file, 12 deterministic unit tests.
- `pkg/controller/instanceset/reconciler_instance_alignment.go`: 5 V(1) instrumentation log calls; one log key (`stopRequested`) is **dropped** here because `InstanceSetSpec.Stop` and the helper `isStopRequested` do not exist on release-1.0. The other four log calls are identical to main.

## Verification

- `go build ./pkg/controller/instanceset/...` clean on release-1.0 head + this commit.
- `go test ./pkg/controller/instanceset -run TestFormat -count=1` passes.

## Relationship to main PR

- Main PR is still open and awaiting non-author maintainer review.
- This backport carries the same instrumentation behavior to `release-1.0` for OB patch image builds (Mia's longrun verbose log collection in particular).
- Once main lands, both branches will carry equivalent log calls (with the noted `stopRequested` field skipped on release-1.0).

## Backport target

- release-1.0: this PR
- release-1.1: TODO — needs separate evaluation; field-availability check the same as here.

## Diff stats

- 3 files changed, +462 / 0

