### PR TITLE
chore: use kubeblocks.fullname for upgrade hook deployment lookup

### DIFF
--- a/deploy/helm/templates/kubeblocks-upgrade-hook.yaml
+++ b/deploy/helm/templates/kubeblocks-upgrade-hook.yaml
@@ -35,7 +35,7 @@ spec:
             - -c
             - |
               set -e
-              kb_json=$(kubectl get deployments.apps -n {{ .Release.Namespace }} {{ .Release.Name }} -ojson )
+              kb_json=$(kubectl get deployments.apps -n {{ .Release.Namespace }} {{ include "kubeblocks.fullname" . }} -ojson )
               version=$(echo $kb_json | jq '.metadata.labels["app.kubernetes.io/version"]' | tr -d '"')
               echo "Current KubeBlocks Version: $version"
               if echo "$version" | grep -q '^0\.'; then


### PR DESCRIPTION
## Summary

- The pre-upgrade hook job looks up the KubeBlocks Deployment by \`.Release.Name\`, but the Deployment is named via the \`kubeblocks.fullname\` helper which expands to \`<release>-kubeblocks\` unless the release name already contains \`kubeblocks\`.
- When the release name is anything that doesn't contain \`kubeblocks\` (e.g. \`kb\`), the hook lookup targets \`kb\` while the actual Deployment is \`kb-kubeblocks\`, so the hook fails with NotFound and blocks helm upgrade.
- Replaces \`.Release.Name\` with the \`kubeblocks.fullname\` include so the hook lookup matches the Deployment template's actual rendered name for any release name.

## Reproduction

\`\`\`
helm install kb deploy/helm                # Deployment kb-kubeblocks is created
helm upgrade  kb deploy/helm --set ...     # pre-upgrade hook job kubectl get deployments.apps -n kb-system kb -> NotFound, job fails 3/1
\`\`\`

## Verification

\`\`\`
helm template kb         deploy/helm --is-upgrade   # renders: kubectl get deployments.apps -n default kb-kubeblocks
helm template kubeblocks deploy/helm --is-upgrade   # renders: kubectl get deployments.apps -n default kubeblocks
\`\`\`

Both match what the Deployment template renders.

## Test plan

- [ ] \`helm template\` renders the expected Deployment name for release names \`kb\` and \`kubeblocks\`
- [ ] \`helm upgrade kb deploy/helm\` succeeds against a cluster where KB was installed as release \`kb\` (the pre-upgrade hook job no longer fails NotFound)