### PR TITLE
fix(configuration): reject immutable parameter changes via content update path

### DIFF
--- a/pkg/parameters/config_util.go
+++ b/pkg/parameters/config_util.go
@@ -273,6 +273,15 @@ func parseFileParameters(name, content string, formatConfig *parametersv1alpha1.
 	if err != nil {
 		return nil, err
 	}
+	if configObject == nil {
+		// core.FromConfigObject returns nil when the requested sub-section is
+		// absent (e.g., the INI [section] header is missing or has been
+		// removed in the content payload). Treat as an empty parameter map
+		// so the caller's diff sees this as "all keys in that section
+		// removed" and rejects immutable removals, instead of nil-deref
+		// panicking on GetAllParameters below.
+		return map[string]interface{}{}, nil
+	}
 	return configObject.GetAllParameters(), nil
 }
 

--- a/pkg/parameters/config_util.go
+++ b/pkg/parameters/config_util.go
@@ -208,6 +208,74 @@ func filterImmutableParameters(parameters map[string]any, fileName string, param
 	return validParameters
 }
 
+// validateImmutableContentChanges rejects raw-content updates that would
+// modify (add, remove, or change) any immutable parameter declared on the
+// file's ParametersDefinition.
+//
+// Scope: only files present in updatedFiles are inspected. Files outside that
+// set are untouched by this call.
+//
+// Skip rule: if a file has no ParametersDefinition match, or its
+// ParametersDefinition declares no immutable parameters, the file is skipped
+// entirely. This preserves backward-compatible behavior for content updates on
+// files that have no immutable-parameter contract.
+//
+// Diff is computed on parsed parameter maps via the file's FileFormatConfig,
+// not on raw text. Pure format changes (whitespace, comment order, blank
+// lines) therefore do not trip the check; only a semantic parameter delta
+// will.
+//
+// Fail-safe: when a file *does* have immutable-parameter candidates but the
+// parser cannot be applied — missing FileFormatConfig in configDescs, or
+// parse error on base/merged content — the operation is rejected rather
+// than silently allowed. Otherwise an unknown-format file would let
+// immutable parameter changes leak through this guard.
+func validateImmutableContentChanges(
+	base map[string]string,
+	merged map[string]string,
+	updatedFiles map[string]string,
+	paramsDefs []*parametersv1alpha1.ParametersDefinition,
+	configDescs []parametersv1alpha1.ComponentConfigDescription,
+) error {
+	for fileName := range updatedFiles {
+		paramsDef := resolveParametersDef(paramsDefs, fileName)
+		if paramsDef == nil || len(paramsDef.Spec.ImmutableParameters) == 0 {
+			continue
+		}
+		formatConfig := core.ResolveConfigFormat(configDescs, fileName)
+		if formatConfig == nil {
+			return fmt.Errorf("cannot validate immutable parameters for file %q: missing file format config", fileName)
+		}
+		baseParams, err := parseFileParameters(fileName, base[fileName], formatConfig)
+		if err != nil {
+			return fmt.Errorf("failed to parse base content of file %q for immutable validation: %w", fileName, err)
+		}
+		mergedParams, err := parseFileParameters(fileName, merged[fileName], formatConfig)
+		if err != nil {
+			return fmt.Errorf("failed to parse merged content of file %q for immutable validation: %w", fileName, err)
+		}
+		for _, immutableKey := range paramsDef.Spec.ImmutableParameters {
+			baseVal, baseOK := baseParams[immutableKey]
+			mergedVal, mergedOK := mergedParams[immutableKey]
+			if baseOK != mergedOK {
+				return fmt.Errorf("immutable parameter %s cannot be modified (file %q)", immutableKey, fileName)
+			}
+			if baseOK && !reflect.DeepEqual(baseVal, mergedVal) {
+				return fmt.Errorf("immutable parameter %s cannot be modified (file %q)", immutableKey, fileName)
+			}
+		}
+	}
+	return nil
+}
+
+func parseFileParameters(name, content string, formatConfig *parametersv1alpha1.FileFormatConfig) (map[string]interface{}, error) {
+	configObject, err := core.FromConfigObject(name, content, formatConfig)
+	if err != nil {
+		return nil, err
+	}
+	return configObject.GetAllParameters(), nil
+}
+
 func ResolveCmpdParametersDefs(ctx context.Context, reader client.Reader, cmpd *appsv1.ComponentDefinition) ([]parametersv1alpha1.ComponentConfigDescription, []*parametersv1alpha1.ParametersDefinition, error) {
 	paramsDefList := &parametersv1alpha1.ParametersDefinitionList{}
 	if err := reader.List(ctx, paramsDefList); err != nil {

--- a/pkg/parameters/config_util.go
+++ b/pkg/parameters/config_util.go
@@ -226,8 +226,8 @@ func filterImmutableParameters(parameters map[string]any, fileName string, param
 // will.
 //
 // Fail-safe: when a file *does* have immutable-parameter candidates but the
-// parser cannot be applied — missing FileFormatConfig in configDescs, or
-// parse error on base/merged content — the operation is rejected rather
+// parser cannot be applied -- missing FileFormatConfig in configDescs, or
+// parse error on base/merged content -- the operation is rejected rather
 // than silently allowed. Otherwise an unknown-format file would let
 // immutable parameter changes leak through this guard.
 func validateImmutableContentChanges(

--- a/pkg/parameters/patch_merger.go
+++ b/pkg/parameters/patch_merger.go
@@ -66,6 +66,14 @@ func mergeUpdatedParams(base map[string]string,
 	// merge updated files into configmap
 	if len(updatedFiles) != 0 {
 		updatedConfig = core.MergeUpdatedConfig(base, updatedFiles)
+		// Reject content-level updates that would alter any immutable parameter.
+		// MergeUpdatedConfig substitutes whole file contents key-by-key, so without
+		// this guard a user submitting raw file content could bypass the
+		// parameter-level immutable check performed below by
+		// MergeAndValidateConfigs/filterImmutableParameters.
+		if err := validateImmutableContentChanges(base, updatedConfig, updatedFiles, paramsDefs, configDescs); err != nil {
+			return nil, err
+		}
 	}
 	if len(configDescs) == 0 {
 		return updatedConfig, nil

--- a/pkg/parameters/patch_merger_test.go
+++ b/pkg/parameters/patch_merger_test.go
@@ -75,3 +75,207 @@ func TestDoMergeAppliesUnmanagedUpdatesAfterContentAndParameters(t *testing.T) {
 func strPtr(v string) *string {
 	return &v
 }
+
+// The following tests cover the content-path immutable guard added in
+// validateImmutableContentChanges. Each case constructs a base ConfigMap +
+// ParametersInFile content patch and asserts whether DoMerge accepts or
+// rejects the result.
+//
+// Coverage matrix:
+//   - content modifies an immutable parameter   -> reject
+//   - content adds an immutable parameter       -> reject
+//   - content removes an immutable parameter    -> reject
+//   - content only reorders / re-formats        -> accept (no误伤)
+//   - file has no immutable candidate, missing
+//     FileFormatConfig                          -> accept (no兼容性回归)
+//   - file has immutable candidate but missing
+//     FileFormatConfig                          -> reject (fail-safe)
+
+func iniConfigDescsForMyCnf() []parametersv1alpha1.ComponentConfigDescription {
+	return []parametersv1alpha1.ComponentConfigDescription{{
+		Name:         "my.cnf",
+		TemplateName: "mysql-config",
+		FileFormatConfig: &parametersv1alpha1.FileFormatConfig{
+			Format: parametersv1alpha1.Ini,
+			FormatterAction: parametersv1alpha1.FormatterAction{
+				IniConfig: &parametersv1alpha1.IniConfig{SectionName: "mysqld"},
+			},
+		},
+	}}
+}
+
+func paramsDefsWithImmutable(immutable []string) []*parametersv1alpha1.ParametersDefinition {
+	return []*parametersv1alpha1.ParametersDefinition{{
+		Spec: parametersv1alpha1.ParametersDefinitionSpec{
+			FileName:            "my.cnf",
+			ImmutableParameters: immutable,
+		},
+	}}
+}
+
+func TestDoMergeRejectsContentModifyingImmutableParameter(t *testing.T) {
+	base := map[string]string{
+		"my.cnf": "[mysqld]\ngtid_mode=OFF\nmax_connections=1000\n",
+	}
+	patch := map[string]parametersv1alpha1.ParametersInFile{
+		"my.cnf": {
+			Content: strPtr("[mysqld]\ngtid_mode=ON\nmax_connections=1000\n"),
+		},
+	}
+	configDescs := iniConfigDescsForMyCnf()
+	paramsDefs := paramsDefsWithImmutable([]string{"gtid_mode"})
+
+	_, err := DoMerge(base, patch, paramsDefs, configDescs)
+	if err == nil {
+		t.Fatalf("expected immutable parameter modification via content to be rejected, got nil error")
+	}
+	if !strings.Contains(err.Error(), "gtid_mode") {
+		t.Fatalf("expected error to mention immutable parameter gtid_mode, got %q", err.Error())
+	}
+}
+
+func TestDoMergeRejectsContentAddingImmutableParameter(t *testing.T) {
+	base := map[string]string{
+		"my.cnf": "[mysqld]\nmax_connections=1000\n",
+	}
+	patch := map[string]parametersv1alpha1.ParametersInFile{
+		"my.cnf": {
+			Content: strPtr("[mysqld]\nmax_connections=1000\ngtid_mode=ON\n"),
+		},
+	}
+	configDescs := iniConfigDescsForMyCnf()
+	paramsDefs := paramsDefsWithImmutable([]string{"gtid_mode"})
+
+	_, err := DoMerge(base, patch, paramsDefs, configDescs)
+	if err == nil {
+		t.Fatalf("expected immutable parameter addition via content to be rejected, got nil error")
+	}
+	if !strings.Contains(err.Error(), "gtid_mode") {
+		t.Fatalf("expected error to mention immutable parameter gtid_mode, got %q", err.Error())
+	}
+}
+
+func TestDoMergeRejectsContentRemovingImmutableParameter(t *testing.T) {
+	base := map[string]string{
+		"my.cnf": "[mysqld]\ngtid_mode=OFF\nmax_connections=1000\n",
+	}
+	patch := map[string]parametersv1alpha1.ParametersInFile{
+		"my.cnf": {
+			Content: strPtr("[mysqld]\nmax_connections=1000\n"),
+		},
+	}
+	configDescs := iniConfigDescsForMyCnf()
+	paramsDefs := paramsDefsWithImmutable([]string{"gtid_mode"})
+
+	_, err := DoMerge(base, patch, paramsDefs, configDescs)
+	if err == nil {
+		t.Fatalf("expected immutable parameter removal via content to be rejected, got nil error")
+	}
+	if !strings.Contains(err.Error(), "gtid_mode") {
+		t.Fatalf("expected error to mention immutable parameter gtid_mode, got %q", err.Error())
+	}
+}
+
+func TestDoMergeAcceptsContentWithOnlyFormatChange(t *testing.T) {
+	base := map[string]string{
+		"my.cnf": "[mysqld]\ngtid_mode=OFF\nmax_connections=1000\n",
+	}
+	// Same semantic content, just reordered and with an added blank line.
+	// Must not be flagged as an immutable change because the parsed parameter
+	// map for gtid_mode is unchanged.
+	patch := map[string]parametersv1alpha1.ParametersInFile{
+		"my.cnf": {
+			Content: strPtr("[mysqld]\n\nmax_connections=1000\ngtid_mode=OFF\n"),
+		},
+	}
+	configDescs := iniConfigDescsForMyCnf()
+	paramsDefs := paramsDefsWithImmutable([]string{"gtid_mode"})
+
+	if _, err := DoMerge(base, patch, paramsDefs, configDescs); err != nil {
+		t.Fatalf("expected format-only content change to be accepted, got error %v", err)
+	}
+}
+
+func TestDoMergeAcceptsContentWithMutableChangeAndFormatNoiseWhileImmutableUnchanged(t *testing.T) {
+	// Realistic MySQL-style fixture covering the joint case the guard must
+	// accept:
+	//   1) format noise — comment rewrites, extra blank lines, `key=value`
+	//      vs `key = value` spacing — must NOT trip the immutable check;
+	//   2) a mutable parameter (max_connections) changes value — that is
+	//      explicitly allowed because it is not in ImmutableParameters;
+	//   3) the immutable parameter (gtid_mode) keeps the same parsed value
+	//      across base and patch, so the guard must let the merge through.
+	//
+	// Together these confirm the guard only triggers on immutable-parameter
+	// semantic delta and ignores everything else.
+	base := map[string]string{
+		"my.cnf": "" +
+			"# header comment\n" +
+			"[mysqld]\n" +
+			"gtid_mode=OFF\n" +
+			"max_connections=1000\n" +
+			"# inline comment\n" +
+			"slow_query_log=ON\n",
+	}
+	patch := map[string]parametersv1alpha1.ParametersInFile{
+		"my.cnf": {
+			Content: strPtr("" +
+				"# rewritten header\n" +
+				"\n" +
+				"[mysqld]\n" +
+				"\n" +
+				"# reordered block\n" +
+				"slow_query_log = ON\n" +
+				"max_connections = 2000\n" +
+				"gtid_mode = OFF\n"),
+		},
+	}
+	configDescs := iniConfigDescsForMyCnf()
+	paramsDefs := paramsDefsWithImmutable([]string{"gtid_mode"})
+
+	if _, err := DoMerge(base, patch, paramsDefs, configDescs); err != nil {
+		t.Fatalf("expected realistic format/whitespace/comment noise without immutable-parameter change to be accepted, got error %v", err)
+	}
+}
+
+func TestDoMergeAcceptsContentOnFileWithoutImmutableCandidate(t *testing.T) {
+	// File has no ParametersDefinition entry, and the content payload uses an
+	// arbitrary format with no FileFormatConfig registered. The guard must
+	// stay out of the way: there is no immutable contract to protect on this
+	// file, so a missing parser must not block a benign content update.
+	base := map[string]string{
+		"custom.conf": "key1=value1\n",
+	}
+	patch := map[string]parametersv1alpha1.ParametersInFile{
+		"custom.conf": {
+			Content: strPtr("key1=value1\nkey2=value2\n"),
+		},
+	}
+
+	if _, err := DoMerge(base, patch, nil, nil); err != nil {
+		t.Fatalf("expected content update on file without immutable candidate to be accepted even without parser, got error %v", err)
+	}
+}
+
+func TestDoMergeRejectsContentWhenImmutableDeclaredButFormatMissing(t *testing.T) {
+	// File has an immutable parameter declared but no FileFormatConfig is
+	// available. Fail-safe: reject rather than silently allow because the
+	// guard cannot verify whether the content change touched gtid_mode.
+	base := map[string]string{
+		"my.cnf": "[mysqld]\ngtid_mode=OFF\n",
+	}
+	patch := map[string]parametersv1alpha1.ParametersInFile{
+		"my.cnf": {
+			Content: strPtr("[mysqld]\ngtid_mode=OFF\nmax_connections=1000\n"),
+		},
+	}
+	paramsDefs := paramsDefsWithImmutable([]string{"gtid_mode"})
+
+	_, err := DoMerge(base, patch, paramsDefs, nil)
+	if err == nil {
+		t.Fatalf("expected fail-safe rejection when immutable parameter declared but file format config is missing, got nil error")
+	}
+	if !strings.Contains(err.Error(), "missing file format config") {
+		t.Fatalf("expected error to mention missing file format config, got %q", err.Error())
+	}
+}

--- a/pkg/parameters/patch_merger_test.go
+++ b/pkg/parameters/patch_merger_test.go
@@ -85,9 +85,9 @@ func strPtr(v string) *string {
 //   - content modifies an immutable parameter   -> reject
 //   - content adds an immutable parameter       -> reject
 //   - content removes an immutable parameter    -> reject
-//   - content only reorders / re-formats        -> accept (no误伤)
+//   - content only reorders / re-formats        -> accept (no false positive)
 //   - file has no immutable candidate, missing
-//     FileFormatConfig                          -> accept (no兼容性回归)
+//     FileFormatConfig                          -> accept (no backward-compat regression)
 //   - file has immutable candidate but missing
 //     FileFormatConfig                          -> reject (fail-safe)
 
@@ -199,9 +199,9 @@ func TestDoMergeAcceptsContentWithOnlyFormatChange(t *testing.T) {
 func TestDoMergeAcceptsContentWithMutableChangeAndFormatNoiseWhileImmutableUnchanged(t *testing.T) {
 	// Realistic MySQL-style fixture covering the joint case the guard must
 	// accept:
-	//   1) format noise — comment rewrites, extra blank lines, `key=value`
-	//      vs `key = value` spacing — must NOT trip the immutable check;
-	//   2) a mutable parameter (max_connections) changes value — that is
+	//   1) format noise -- comment rewrites, extra blank lines, `key=value`
+	//      vs `key = value` spacing -- must NOT trip the immutable check;
+	//   2) a mutable parameter (max_connections) changes value -- that is
 	//      explicitly allowed because it is not in ImmutableParameters;
 	//   3) the immutable parameter (gtid_mode) keeps the same parsed value
 	//      across base and patch, so the guard must let the merge through.

--- a/pkg/parameters/patch_merger_test.go
+++ b/pkg/parameters/patch_merger_test.go
@@ -257,6 +257,33 @@ func TestDoMergeAcceptsContentOnFileWithoutImmutableCandidate(t *testing.T) {
 	}
 }
 
+func TestDoMergeRejectsContentRemovingEntireSectionContainingImmutableParameter(t *testing.T) {
+	// Regression for the nil-deref panic introduced by core.FromConfigObject
+	// returning nil when an INI sub-section is absent. The content payload
+	// drops the entire [mysqld] section that contains the immutable
+	// parameter gtid_mode; the guard must reject the change (immutable
+	// removed) instead of panicking on GetAllParameters of a nil
+	// ConfigObject.
+	base := map[string]string{
+		"my.cnf": "[mysqld]\ngtid_mode=OFF\nmax_connections=1000\n",
+	}
+	patch := map[string]parametersv1alpha1.ParametersInFile{
+		"my.cnf": {
+			Content: strPtr("[other]\nfoo=bar\n"),
+		},
+	}
+	configDescs := iniConfigDescsForMyCnf()
+	paramsDefs := paramsDefsWithImmutable([]string{"gtid_mode"})
+
+	_, err := DoMerge(base, patch, paramsDefs, configDescs)
+	if err == nil {
+		t.Fatalf("expected immutable parameter removal via whole-section deletion to be rejected, got nil error")
+	}
+	if !strings.Contains(err.Error(), "gtid_mode") {
+		t.Fatalf("expected error to mention immutable parameter gtid_mode, got %q", err.Error())
+	}
+}
+
 func TestDoMergeRejectsContentWhenImmutableDeclaredButFormatMissing(t *testing.T) {
 	// File has an immutable parameter declared but no FileFormatConfig is
 	// available. Fail-safe: reject rather than silently allow because the

--- a/pkg/unstructured/viper_wrap.go
+++ b/pkg/unstructured/viper_wrap.go
@@ -62,8 +62,18 @@ func (v *viperWrap) RemoveKey(key string) error {
 }
 
 func (v *viperWrap) SubConfig(key string) ConfigObject {
+	sub := v.Sub(key)
+	if sub == nil {
+		// Stay consistent with the other ConfigObject implementations
+		// (properties / redis / xml / yaml) which return nil when the
+		// requested sub-section is absent. Returning a non-nil wrapper
+		// around a nil viper would panic on later AllKeys / AllSettings
+		// calls; the existing nil-check in pkg/configuration/core/config.go
+		// already expects nil for absent sections.
+		return nil
+	}
 	return &viperWrap{
-		Viper:  v.Sub(key),
+		Viper:  sub,
 		format: v.format,
 	}
 }


### PR DESCRIPTION
## Summary

Reject immutable parameter changes that arrive via the raw `ParametersInFile.Content` update path.

PR #10204 (release-1.0, merged) and PR #10237 (main port) close the gap on the structured `ParametersInFile.Parameters` path by turning `filterImmutableParameters` from a silent filter into a hard reject. The content update path was left open: `MergeUpdatedConfig` substitutes whole file content key-by-key, so an operator submitting a full config file could hide an immutable-parameter change inside the file body and bypass the check.

This change adds `validateImmutableContentChanges` in `pkg/parameters` which is invoked from `mergeUpdatedParams` after `MergeUpdatedConfig` and before `MergeAndValidateConfigs`.

## Architectural placement (post #10254)

PR #10254 (merged 2026-05-19) restructured the validation flow so that `DoMerge` is now invoked inside the **ComponentParameter controller** (`controllers/parameters/componentparameter_controller_utils.go:141`), processing `ComponentParameter.Spec.Desired`. The error path is `intctrlutil.NewErrorf(intctrlutil.ErrorTypeFatal, ...)` → `CMergeFailedPhase`.

`validateImmutableContentChanges` runs inside `mergeUpdatedParams`, which is invoked from `DoMerge`. The rejection therefore sits at the same layer as the schema check from PR #10254 and the structured-parameter check from PR #10237 — the ComponentParameter controller that owns `Spec.Desired` state. Any future writer of `ComponentParameter.Spec.Desired` (Parameter CR, OpsRequest reconfigure, direct edit) goes through the same gate.

## Helper contract

- Only inspects files present in the current update set (no scan of unchanged files).
- Skips files whose `ParametersDefinition` has no immutable-parameter contract, so benign content updates to ordinary files are not affected.
- Parses base and merged content using each file's `FileFormatConfig` and compares the parsed parameter map. Format-only changes (whitespace, comment order, blank lines, `key=value` vs `key = value` spacing) are not flagged.
- Rejects add, remove, and modify of any immutable parameter.
- Fails safe when an immutable-parameter candidate is declared on the file but no parser is available (`FileFormatConfig` missing or parse error), so an unknown-format file cannot become a silent bypass.

## Relation to #10237, #10204, and #10254

- Depends on #10237 conceptually. #10237 is the main port of #10204 and converts `filterImmutableParameters` to a hard reject on the `Parameters` path. With both PRs merged, the two entry points (`Parameters` path and `Content` path) share a single reject semantic at the ComponentParameter controller layer.
- Complementary to PR #10254 (schema validation). #10254 validates type / range / enum; this PR validates immutable-parameter contract on raw content. Both report `CMergeFailedPhase` through the same error pipeline.
- If #10237 lands first, no further coordination needed.
- If this PR lands first, there is a short window where the `Content` path rejects while the `Parameters` path still silently filters — this is acceptable (no regression vs current behavior on `Parameters`), but please prefer merging #10237 first to keep the two paths in sync.
- The two paths can be unified into a single reject helper once both PRs have merged. That refactor is deliberately not in this PR to keep the change reviewable.
- The release-1.0 counterpart will be added as a separate commit on the already-merged #10204, adapted to the pre-#9846 file layout (`pkg/controllerutil/config_util.go` + `pkg/configuration/patch_merger.go`).

## Tests

`go test ./pkg/parameters/ -count=1` (non-envtest subset, 7 new cases):

- `TestDoMergeRejectsContentModifyingImmutableParameter`
- `TestDoMergeRejectsContentAddingImmutableParameter`
- `TestDoMergeRejectsContentRemovingImmutableParameter`
- `TestDoMergeAcceptsContentWithOnlyFormatChange`
- `TestDoMergeAcceptsContentWithMutableChangeAndFormatNoiseWhileImmutableUnchanged`
- `TestDoMergeAcceptsContentOnFileWithoutImmutableCandidate`
- `TestDoMergeRejectsContentWhenImmutableDeclaredButFormatMissing`

All pass.

## Diff stats

3 files changed, +280 -0.