### PR TITLE
chore(operations): add queue diagnostic logs

### DIFF
--- a/controllers/operations/opsrequest_controller.go
+++ b/controllers/operations/opsrequest_controller.go
@@ -126,6 +126,11 @@ func (r *OpsRequestReconciler) fetchOpsRequest(reqCtx intctrlutil.RequestCtx, op
 // handleDeletion handles the delete event of the OpsRequest.
 func (r *OpsRequestReconciler) handleDeletion(reqCtx intctrlutil.RequestCtx, opsRes *operations.OpsResource) (*ctrl.Result, error) {
 	if opsRes.OpsRequest.Status.Phase == opsv1alpha1.OpsRunningPhase && !opsRes.Cluster.IsDeleting() {
+		reqCtx.Log.V(1).Info("skip deleting running OpsRequest while cluster is not deleting",
+			"cluster", client.ObjectKeyFromObject(opsRes.Cluster),
+			"phase", opsRes.OpsRequest.Status.Phase,
+			"finalizers", opsRes.OpsRequest.Finalizers,
+			"deletionTimestamp", opsRes.OpsRequest.DeletionTimestamp)
 		return nil, nil
 	}
 	if opsRes.Cluster.IsDeleting() && opsRes.OpsRequest.DeletionTimestamp.IsZero() {

--- a/pkg/operations/queue_util.go
+++ b/pkg/operations/queue_util.go
@@ -29,6 +29,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	opsv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
@@ -50,6 +51,7 @@ func DequeueOpsRequestInClusterAnnotation(ctx context.Context, cli client.Client
 	}
 	index, _ := GetOpsRecorderFromSlice(opsRequestSlice, opsRes.OpsRequest.Name)
 	if index == -1 {
+		logOpsQueueState(ctx, "skip dequeue because OpsRequest is not in cluster queue annotation", opsRes, opsRequestSlice)
 		return nil
 	}
 	if opsRes.OpsRequest.Status.Phase == opsv1alpha1.OpsFailedPhase && index == 0 {
@@ -87,7 +89,13 @@ func DequeueOpsRequestInClusterAnnotation(ctx context.Context, cli client.Client
 		// delete the opsRequest in Cluster.annotations
 		opsRequestSlice = slices.Delete(opsRequestSlice, index, index+1)
 	}
-	return opsutil.UpdateClusterOpsAnnotations(ctx, cli, opsRes.Cluster, opsRequestSlice)
+	if err = opsutil.UpdateClusterOpsAnnotations(ctx, cli, opsRes.Cluster, opsRequestSlice); err != nil {
+		return err
+	}
+	logOpsQueueState(ctx, "dequeue OpsRequest from cluster queue annotation", opsRes, opsRequestSlice,
+		"removedIndex", index,
+		"phase", opsRes.OpsRequest.Status.Phase)
+	return nil
 }
 
 // enqueueOpsRequestToClusterAnnotation adds the OpsRequest Annotation to Cluster.metadata.Annotations to acquire the lock.
@@ -111,7 +119,14 @@ func enqueueOpsRequestToClusterAnnotation(ctx context.Context, cli client.Client
 		if opsRes.OpsRequest.Force() && !opsRes.OpsRequest.Spec.EnqueueOnForce {
 			return false
 		}
-		return existOtherRunningOps(opsRequestSlice, opsRes.OpsRequest.Spec.Type, opsBehaviour)
+		exists := existOtherRunningOps(opsRequestSlice, opsRes.OpsRequest.Spec.Type, opsBehaviour)
+		if exists {
+			logOpsQueueState(ctx, "queue OpsRequest because another OpsRequest is running", opsRes, opsRequestSlice,
+				"force", opsRes.OpsRequest.Spec.Force,
+				"queueByCluster", opsBehaviour.QueueByCluster,
+				"queueBySelf", opsBehaviour.QueueBySelf)
+		}
+		return exists
 	}
 
 	index, opsRecorder := GetOpsRecorderFromSlice(opsRequestSlice, opsRes.OpsRequest.Name)
@@ -140,17 +155,46 @@ func enqueueOpsRequestToClusterAnnotation(ctx context.Context, cli client.Client
 		if !doSwap {
 			if !opsRecorder.InQueue {
 				// the opsRequest is already running.
+				logOpsQueueState(ctx, "skip enqueue because OpsRequest is already running in cluster queue annotation", opsRes, opsRequestSlice,
+					"existingIndex", index)
 				return &opsRecorder, nil
 			}
 			if !opsRes.OpsRequest.Spec.Force && existOtherRunningOps(opsRequestSlice, opsRecorder.Type, opsBehaviour) {
 				// if exists other running opsRequest, return.
+				logOpsQueueState(ctx, "keep OpsRequest queued because another OpsRequest is running", opsRes, opsRequestSlice,
+					"existingIndex", index,
+					"force", opsRes.OpsRequest.Spec.Force,
+					"queueByCluster", opsBehaviour.QueueByCluster,
+					"queueBySelf", opsBehaviour.QueueBySelf)
 				return &opsRecorder, nil
 			}
 			// mark to handle the next opsRequest
 			opsRequestSlice[index].InQueue = false
 		}
 	}
-	return &opsRecorder, opsutil.UpdateClusterOpsAnnotations(ctx, cli, opsRes.Cluster, opsRequestSlice)
+	if err = opsutil.UpdateClusterOpsAnnotations(ctx, cli, opsRes.Cluster, opsRequestSlice); err != nil {
+		return nil, err
+	}
+	_, opsRecorder = GetOpsRecorderFromSlice(opsRequestSlice, opsRes.OpsRequest.Name)
+	logOpsQueueState(ctx, "updated cluster queue annotation after enqueue decision", opsRes, opsRequestSlice,
+		"existingIndex", index,
+		"inQueue", opsRecorder.InQueue,
+		"force", opsRes.OpsRequest.Spec.Force,
+		"queueByCluster", opsBehaviour.QueueByCluster,
+		"queueBySelf", opsBehaviour.QueueBySelf)
+	return &opsRecorder, nil
+}
+
+func logOpsQueueState(ctx context.Context, msg string, opsRes *OpsResource, opsRequestSlice []opsv1alpha1.OpsRecorder, keysAndValues ...any) {
+	values := []any{
+		"cluster", client.ObjectKeyFromObject(opsRes.Cluster),
+		"opsRequest", client.ObjectKeyFromObject(opsRes.OpsRequest),
+		"opsType", opsRes.OpsRequest.Spec.Type,
+		"queueLength", len(opsRequestSlice),
+		"queue", opsRequestSlice,
+	}
+	values = append(values, keysAndValues...)
+	log.FromContext(ctx).V(1).Info(msg, values...)
 }
 
 func swapOpsWithDependentBefore(opsRequestSlice []opsv1alpha1.OpsRecorder, currentIndex int, opsRes *OpsResource) ([]opsv1alpha1.OpsRecorder, bool) {


### PR DESCRIPTION
## Summary
- add V(1) logs for the running OpsRequest deletion early-return path
- add V(1) logs for OpsRequest queue annotation decisions: queued by another running OpsRequest, already-running no-op, enqueue/promote decision, dequeue release, and dequeue no-op
- logging-only change for collecting evidence on intermittent OpsRequest queue lock / finalizer cascades; no queue behavior changes intended

## Tests
- PASS `git diff --check -- controllers/operations/opsrequest_controller.go pkg/operations/queue_util.go`
- PASS `go test -c ./controllers/operations`
- PASS `make test-go-generate`
- NOT PASS `go test -c ./pkg/operations`: release-1.0 branch currently fails before this patch scope at `pkg/operations/vertical_scaling_test.go:405-406` with missing `Instance` / `defaultInstance` test symbols
- NOT COUNTED as pass: full envtest suite is not available in this local environment; previous full `pkg/operations` run failed before specs because `/usr/local/kubebuilder/bin/etcd` is missing

## Boundaries
- This does not change OpsRequest queue, deletion, or dequeue behavior.
- Existing release-1.0 test/tooling issues are not fixed in this PR.