### PR TITLE
chore(parameters): log reconfigure ConfigMap predicate skips

### DIFF
--- a/controllers/parameters/reconfigure_controller.go
+++ b/controllers/parameters/reconfigure_controller.go
@@ -108,6 +108,8 @@ func (r *ReconfigureReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	reqCtx.Log = reqCtx.Log.
 		WithValues("ClusterName", config.Labels[constant.AppInstanceLabelKey]).
 		WithValues("ComponentName", config.Labels[constant.KBAppComponentLabelKey])
+	reqCtx.Log.V(1).Info("reconcile reconfigure ConfigMap",
+		"ConfigurationRevision", config.Annotations[constant.ConfigurationRevision])
 
 	isAppliedConfigs, err := checkAndApplyConfigsChanged(r.Client, reqCtx, config)
 	if err != nil {
@@ -148,23 +150,37 @@ func (r *ReconfigureReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func checkConfigurationObject(object client.Object) bool {
+	ok, reason := checkConfigurationObjectWithReason(object)
+	if !ok {
+		log.Log.WithName("ReconfigureRequestPredicate").V(1).Info("skip reconfigure ConfigMap",
+			"ConfigMap", client.ObjectKeyFromObject(object),
+			"reason", reason)
+	}
+	return ok
+}
+
+func checkConfigurationObjectWithReason(object client.Object) (bool, string) {
 	labels := object.GetLabels()
 	if len(labels) == 0 {
-		return false
+		return false, "missing labels"
 	}
 
 	for _, label := range reconfigureRequiredLabels {
 		if _, ok := labels[label]; !ok {
-			return false
+			return false, fmt.Sprintf("missing required label %s", label)
 		}
 	}
 
 	// reconfigure ConfigMap for db instance
 	if ins, ok := labels[constant.CMConfigurationTypeLabelKey]; !ok || ins != constant.ConfigInstanceType {
-		return false
+		return false, fmt.Sprintf("configuration type is %q, want %q", ins, constant.ConfigInstanceType)
 	}
 
-	return checkEnableCfgUpgrade(object)
+	if !checkEnableCfgUpgrade(object) {
+		return false, fmt.Sprintf("%s=true", constant.DisableUpgradeInsConfigurationAnnotationKey)
+	}
+
+	return true, ""
 }
 
 func (r *ReconfigureReconciler) getConfigSpec(reqCtx intctrlutil.RequestCtx, cm *corev1.ConfigMap) (*appsv1.ComponentFileTemplate, error) {

--- a/controllers/parameters/reconfigure_predicate_test.go
+++ b/controllers/parameters/reconfigure_predicate_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package parameters
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/apecloud/kubeblocks/pkg/constant"
+)
+
+func TestCheckConfigurationObjectWithReason(t *testing.T) {
+	requiredLabels := map[string]string{
+		constant.AppInstanceLabelKey:                 "cluster",
+		constant.KBAppComponentLabelKey:              "mysql",
+		constant.CMConfigurationTemplateNameLabelKey: "mysql-config",
+		constant.CMConfigurationSpecProviderLabelKey: "mysql-config",
+		constant.CMConfigurationTypeLabelKey:         constant.ConfigInstanceType,
+	}
+
+	tests := []struct {
+		name         string
+		mutate       func(*corev1.ConfigMap)
+		wantOK       bool
+		wantReasonIn string
+	}{
+		{
+			name:         "missing labels",
+			mutate:       func(cm *corev1.ConfigMap) { cm.Labels = nil },
+			wantReasonIn: "missing labels",
+		},
+		{
+			name: "missing required label",
+			mutate: func(cm *corev1.ConfigMap) {
+				delete(cm.Labels, constant.CMConfigurationTemplateNameLabelKey)
+			},
+			wantReasonIn: constant.CMConfigurationTemplateNameLabelKey,
+		},
+		{
+			name: "wrong configuration type",
+			mutate: func(cm *corev1.ConfigMap) {
+				cm.Labels[constant.CMConfigurationTypeLabelKey] = "template"
+			},
+			wantReasonIn: constant.ConfigInstanceType,
+		},
+		{
+			name: "disabled",
+			mutate: func(cm *corev1.ConfigMap) {
+				cm.Annotations = map[string]string{
+					constant.DisableUpgradeInsConfigurationAnnotationKey: "true",
+				}
+			},
+			wantReasonIn: constant.DisableUpgradeInsConfigurationAnnotationKey,
+		},
+		{
+			name: "valid",
+			mutate: func(cm *corev1.ConfigMap) {
+				cm.Annotations = map[string]string{
+					constant.DisableUpgradeInsConfigurationAnnotationKey: "false",
+				}
+			},
+			wantOK: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "config",
+					Namespace: "default",
+					Labels:    map[string]string{},
+				},
+			}
+			for k, v := range requiredLabels {
+				cm.Labels[k] = v
+			}
+			if tt.mutate != nil {
+				tt.mutate(cm)
+			}
+
+			gotOK, gotReason := checkConfigurationObjectWithReason(cm)
+			if gotOK != tt.wantOK {
+				t.Fatalf("expected ok=%v, got %v, reason=%q", tt.wantOK, gotOK, gotReason)
+			}
+			if !tt.wantOK && !strings.Contains(gotReason, tt.wantReasonIn) {
+				t.Fatalf("expected reason to contain %q, got %q", tt.wantReasonIn, gotReason)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does

Adds V(1) diagnostic logs to the reconfigure ConfigMap path:

- logs when a ConfigMap reaches `ReconfigureReconciler`, including `ConfigurationRevision`
- logs why `checkConfigurationObject()` filters a ConfigMap before reconcile
- keeps the existing predicate boolean behavior unchanged
- adds focused coverage for the predicate reasons

## Why

When a reconfigure request has already produced a new ConfigMap revision but the revision result is not written back, current logs do not distinguish:

- the ConfigMap update was never observed by the reconfigure controller
- the ConfigMap was filtered by labels or `disable-reconfigure`
- the ConfigMap entered reconcile but failed later while writing the revision result

These logs are V(1) diagnostics. They are intended for fresh repro / debug runs and can be filtered by logger or ConfigMap name; they are not normal business logs.

## Tests

```text
go test ./controllers/parameters -run TestCheckConfigurationObjectWithReason -count=1
go test ./controllers/parameters -run 'TestCheckConfigurationObjectWithReason|TestValidateLegacyReloadActionSupport|TestNeedRestartAllowsTemplateReconfigure|TestResolveReconfigurePolicy' -count=1
git diff --check HEAD^ HEAD
```
