### PR TITLE
fix(instanceset): digest-pinned image match falls back to status.ImageID

### DIFF
--- a/pkg/controller/instance/utils.go
+++ b/pkg/controller/instance/utils.go
@@ -125,9 +125,18 @@ func isImageMatched(pod *corev1.Pod) bool {
 		// More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodStatus
 		specName, specTag, specDigest := imageSplit(specImage)
 		statusName, statusTag, statusDigest := imageSplit(statusImage)
-		// if digest presents in spec, it must be same in status
+		// if digest presents in spec, it must be same in status.
+		// status.Image may not carry the digest (kubelet often reports the
+		// image as a tag form), so fall back to status.ImageID, which is
+		// the canonical hash of the actually loaded image. This keeps the
+		// digest-pinned spec match working when the kubelet only surfaces
+		// a tag in status.Image.
 		if len(specDigest) != 0 && specDigest != statusDigest {
-			return false
+			statusImageID := pod.Status.ContainerStatuses[index].ImageID
+			_, _, idDigest := imageSplit(statusImageID)
+			if specDigest != idDigest {
+				return false
+			}
 		}
 		// if tag presents in spec, it must be same in status
 		if len(specTag) != 0 && specTag != statusTag {

--- a/pkg/controller/instance/utils_test.go
+++ b/pkg/controller/instance/utils_test.go
@@ -22,11 +22,86 @@ package instance
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	"github.com/apecloud/kubeblocks/pkg/controller/builder"
 )
+
+const (
+	testImageDigestA = "sha256:abc1234567890abcdef1234567890abcdef1234567890abcdef1234567890abc"
+	testImageDigestB = "sha256:def0000000000000000000000000000000000000000000000000000000000000"
+)
+
+func TestIsImageMatchedDigestPinnedFallsBackToImageID(t *testing.T) {
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "main",
+				Image: "apecloud/kubeblocks@" + testImageDigestA,
+			}},
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:    "main",
+				Image:   "apecloud/kubeblocks:1.0.3-beta.7",
+				ImageID: "docker.io/apecloud/kubeblocks@" + testImageDigestA,
+			}},
+		},
+	}
+	if !isImageMatched(pod) {
+		t.Fatalf("expected digest-pinned spec to match via status.ImageID when status.Image lacks digest")
+	}
+}
+
+func TestIsImageMatchedDigestPinnedRejectsOnImageIDMismatch(t *testing.T) {
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "main",
+				Image: "apecloud/kubeblocks@" + testImageDigestA,
+			}},
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:    "main",
+				Image:   "apecloud/kubeblocks:1.0.3-beta.7",
+				ImageID: "docker.io/apecloud/kubeblocks@" + testImageDigestB,
+			}},
+		},
+	}
+	if isImageMatched(pod) {
+		t.Fatalf("expected digest-pinned spec to reject when status.ImageID digest does not match")
+	}
+}
+
+func TestIsImageMatchedTagOnlySpecKeepsStrictTagComparison(t *testing.T) {
+	// Tag-only spec must continue to enforce strict status.Image tag match
+	// even when status.ImageID carries a non-empty digest. The ImageID
+	// fallback is intentionally limited to digest-pinned specs; tag-only
+	// specs cannot be resolved to a digest at the controller level, so a
+	// status tag drift must still surface as a non-match (otherwise a
+	// pending image upgrade would be misreported as already realized).
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "main",
+				Image: "apecloud/kubeblocks:1.0.3-beta.7",
+			}},
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:    "main",
+				Image:   "apecloud/kubeblocks:1.0.3-beta.6",
+				ImageID: "docker.io/apecloud/kubeblocks@" + testImageDigestA,
+			}},
+		},
+	}
+	if isImageMatched(pod) {
+		t.Fatalf("expected tag-only spec to reject when status.Image tag differs, ignoring status.ImageID")
+	}
+}
 
 func TestConfigsToUpdateTreatsNilAndEmptyConfigHashAsEqual(t *testing.T) {
 	inst := builder.NewInstanceBuilder("default", "valkey-0").

--- a/pkg/controller/instanceset/instance_util.go
+++ b/pkg/controller/instanceset/instance_util.go
@@ -178,9 +178,18 @@ func isImageMatched(pod *corev1.Pod) bool {
 		// More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodStatus
 		specName, specTag, specDigest := imageSplit(specImage)
 		statusName, statusTag, statusDigest := imageSplit(statusImage)
-		// if digest presents in spec, it must be same in status
+		// if digest presents in spec, it must be same in status.
+		// status.Image may not carry the digest (kubelet often reports the
+		// image as a tag form), so fall back to status.ImageID, which is
+		// the canonical hash of the actually loaded image. This keeps the
+		// digest-pinned spec match working when the kubelet only surfaces
+		// a tag in status.Image.
 		if len(specDigest) != 0 && specDigest != statusDigest {
-			return false
+			statusImageID := pod.Status.ContainerStatuses[index].ImageID
+			_, _, idDigest := imageSplit(statusImageID)
+			if specDigest != idDigest {
+				return false
+			}
 		}
 		// if tag presents in spec, it must be same in status
 		if len(specTag) != 0 && specTag != statusTag {

--- a/pkg/controller/instanceset/instance_util_test.go
+++ b/pkg/controller/instanceset/instance_util_test.go
@@ -518,6 +518,38 @@ var _ = Describe("instance util test", func() {
 				Image: "apecloud.com/nginx",
 			}}
 			Expect(isImageMatched(pod)).Should(BeTrue())
+
+			By("digest-pinned spec matches via status.ImageID when status.Image carries no digest")
+			pod.Spec.Containers = []corev1.Container{{
+				Name:  name,
+				Image: "apecloud/kubeblocks@sha256:abc1234567890abcdef1234567890abcdef1234567890abcdef1234567890abc",
+			}}
+			pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+				Name:    name,
+				Image:   "apecloud/kubeblocks:1.0.3-beta.7",
+				ImageID: "docker.io/apecloud/kubeblocks@sha256:abc1234567890abcdef1234567890abcdef1234567890abcdef1234567890abc",
+			}}
+			Expect(isImageMatched(pod)).Should(BeTrue())
+
+			By("digest-pinned spec rejects when status.ImageID digest is different")
+			pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+				Name:    name,
+				Image:   "apecloud/kubeblocks:1.0.3-beta.7",
+				ImageID: "docker.io/apecloud/kubeblocks@sha256:def0000000000000000000000000000000000000000000000000000000000000",
+			}}
+			Expect(isImageMatched(pod)).Should(BeFalse())
+
+			By("tag-only spec keeps strict tag match (no ImageID fallback for tag-only)")
+			pod.Spec.Containers = []corev1.Container{{
+				Name:  name,
+				Image: "apecloud/kubeblocks:1.0.3-beta.7",
+			}}
+			pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+				Name:    name,
+				Image:   "apecloud/kubeblocks:1.0.3-beta.6",
+				ImageID: "docker.io/apecloud/kubeblocks@sha256:abc1234567890abcdef1234567890abcdef1234567890abcdef1234567890abc",
+			}}
+			Expect(isImageMatched(pod)).Should(BeFalse())
 		})
 	})
 


### PR DESCRIPTION
## Summary

Fall back to `pod.status.containerStatuses[*].ImageID` when matching a digest-pinned `pod.spec.containers[*].Image` against a status that does not include the digest on `.Image`.

The kubelet often reports the running container image in tag form on `status.Image` (no `@sha256:…` suffix), while the canonical hash of the actually loaded image lives on `status.ImageID`. When the spec carries a digest pin, the current `isImageMatched` declares the image mismatched even if the pod is provably running the right image — its hash is just sitting on `ImageID` rather than `Image`.

This change consults `status.ImageID` as a second source for the digest when the digest cannot be matched from `status.Image`. The behavior for tag-only specs is intentionally unchanged: a controller cannot resolve a spec tag to a digest at runtime, so any tag drift on `status.Image` must continue to surface as a non-match, otherwise a pending image upgrade would be misreported as already realized.

## Scope

Narrow:

- **In scope:** digest-pinned spec → use `status.ImageID` as a fallback source for the digest.
- **Out of scope:** tag-only specs (kept strict). Sideload paths whose chart still uses a tag (and where containerd tag aliasing makes `status.Image` show a different tag than the spec tag) are not the target of this PR — the operational guidance is to either use a digest-pinned spec or drop the conflicting tag alias on the sideloaded image. That guidance will be sedimented in `kubeblocks-addon-docs`.

## Changes

- `pkg/controller/instanceset/instance_util.go`: digest-pinned branch now consults `status.ImageID` when the spec digest cannot be matched from `status.Image`.
- `pkg/controller/instance/utils.go`: same change applied to the sibling copy so the two controllers keep an aligned `isImageMatched` contract.

## Tests

- `pkg/controller/instance/utils_test.go`:
  - `TestIsImageMatchedDigestPinnedFallsBackToImageID` — digest-pinned spec + status.Image without digest + matching status.ImageID → match.
  - `TestIsImageMatchedDigestPinnedRejectsOnImageIDMismatch` — digest-pinned spec + non-matching status.ImageID → reject.
  - `TestIsImageMatchedTagOnlySpecKeepsStrictTagComparison` — tag-only spec + status.Image with a different tag + non-empty status.ImageID → still reject.
- `pkg/controller/instanceset/instance_util_test.go`: `Context("isImageMatched")` gains three new `By` sub-cases covering the same three scenarios.

Locally:

```
go test -count=1 ./pkg/controller/instance/ -run TestIsImageMatched
go test -count=1 ./pkg/controller/instanceset/ -run TestAPIs
```

both pass on `a375e107a + this commit`.

## Diff stats

4 files changed, +129 -4.
