### PR TITLE
chore: fix release-1.0 golangci-lint toolchain

### DIFF
--- a/.github/workflows/cicd-pull-request.yml
+++ b/.github/workflows/cicd-pull-request.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Install golangci-lint
         if: matrix.ops == 'lint'
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.5
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.8.0
 
       - name: make ${{ matrix.ops }}
         run: |

--- a/.github/workflows/cicd-push.yml
+++ b/.github/workflows/cicd-push.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Install golangci-lint
         if: matrix.ops == 'lint'
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.5
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.8.0
 
       - name: make ${{ matrix.ops }}
         run: |

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install golangci-lint
         if: matrix.ops == 'lint'
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.5
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.8.0
 
       - name: make ${{ matrix.ops }}
         run: |

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,52 +1,49 @@
-# options for analysis running
+version: "2"
 run:
-  # default concurrency is a available CPU number
   concurrency: 4
-
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
-  deadline: 15m
-
   timeout: 30m
-
-issues:
-  exclude-files:
-    - "^zz_generated.*"
-
-#  build-tags:
-#    - containers_image_openpgp
-
 output:
-  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
   formats:
-    - format: colored-line-number
+    text:
       path: stdout
-
-  # print lines of code with issue, default is true
-  print-issued-lines: true
-
-  # print linter name in the end of issue text, default is true
-  print-linter-name: true
-
-# check available linters @ https://golangci-lint.run/usage/linters/
+      print-linter-name: true
+      print-issued-lines: true
 linters:
-  disable-all: true
-  enable: # please keep this alphabetized
-  # - gocyclo
-    - loggercheck
+  default: none
+  enable:
     - errcheck
     - gocritic
-    # - goconst
-    - goimports
-    - gofmt  # We enable this as well as goimports for its simplify mode.
-    - gosimple
     - govet
     - ineffassign
-    - typecheck
+    - loggercheck
     - misspell
     - nakedret
     - unconvert
     - unused
-
-linters-settings:
-  errcheck:
-    check-blank: false # to keep `_ = viper.BindPFlag(...)` from throwing errors
+  settings:
+    errcheck:
+      check-blank: false
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - gocritic
+        text: "deprecatedComment"
+      - linters:
+          - govet
+        text: "hostport"
+    paths:
+      - ^zz_generated.*
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - ^zz_generated.*

--- a/Makefile
+++ b/Makefile
@@ -383,7 +383,7 @@ controller-gen: $(LOCALBIN) ## Download controller-gen locally if necessary.
 envtest: $(LOCALBIN) ## Download envtest-setup locally if necessary.
 	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest,$(ENVTEST_VERSION))
 
-GOLANGCILINT_VERSION = v1.64.8
+GOLANGCILINT_VERSION = v2.8.0
 GOLANGCILINT = $(LOCALBIN)/golangci-lint-$(GOLANGCILINT_VERSION)
 .PHONY: golangci-lint-bin
 golangci-lint-bin: $(LOCALBIN) ## Download golangci-lint locally if necessary.
@@ -394,10 +394,17 @@ golangci-lint-bin: $(LOCALBIN) ## Download golangci-lint locally if necessary.
 	}
 
 STATICCHECK_VERSION = v0.6.1
+STATICCHECK_GOTOOLCHAIN ?= go1.25.10
 STATICCHECK = $(LOCALBIN)/staticcheck-$(STATICCHECK_VERSION)
 .PHONY: staticcheck-bin
 staticcheck-bin: $(LOCALBIN) ## Download staticcheck locally if necessary.
-	$(call go-install-tool,$(STATICCHECK),honnef.co/go/tools/cmd/staticcheck,$(STATICCHECK_VERSION))
+	@[ -f $(STATICCHECK) ] || { \
+	set -e; \
+	package=honnef.co/go/tools/cmd/staticcheck@$(STATICCHECK_VERSION) ;\
+	echo "Installing $${package} with $(STATICCHECK_GOTOOLCHAIN)" ;\
+	GOBIN=$(LOCALBIN) GOTOOLCHAIN=$(STATICCHECK_GOTOOLCHAIN) go install $${package} ;\
+	mv "$$(echo "$(STATICCHECK)" | sed "s/-$(STATICCHECK_VERSION)$$//")" $(STATICCHECK) ;\
+	}
 
 GOIMPORTS_VERSION = v0.34.0
 GOIMPORTS = $(LOCALBIN)/goimports-$(GOIMPORTS_VERSION)

--- a/pkg/operations/vertical_scaling_test.go
+++ b/pkg/operations/vertical_scaling_test.go
@@ -402,10 +402,6 @@ var _ = Describe("verticalScalingHandler resource match contract", func() {
 		}
 	}
 
-	makeInstance := func(pod *corev1.Pod) Instance {
-		return &defaultInstance{name: podName, componentName: clusterCompName, pod: pod}
-	}
-
 	makePgRes := func(target corev1.ResourceRequirements) *progressResource {
 		return &progressResource{
 			updatedPodSet:    map[string]string{podName: constant.EmptyInsTemplateName},
@@ -431,7 +427,7 @@ var _ = Describe("verticalScalingHandler resource match contract", func() {
 			},
 		}
 		pod := makePod(target.Limits.DeepCopy(), target.Requests.DeepCopy())
-		Expect(vs.podApplyCompOps(ops, makeInstance(pod), makePgRes(target))).Should(BeTrue())
+		Expect(vs.podApplyCompOps(ops, pod, makePgRes(target))).Should(BeTrue())
 	})
 
 	It("defaults an absent request key to its limit value when comparing", func() {
@@ -450,7 +446,7 @@ var _ = Describe("verticalScalingHandler resource match contract", func() {
 			corev1.ResourceMemory: resource.MustParse("2Gi"),
 		}
 		pod := makePod(target.Limits.DeepCopy(), podRequests)
-		Expect(vs.podApplyCompOps(ops, makeInstance(pod), makePgRes(target))).Should(BeTrue())
+		Expect(vs.podApplyCompOps(ops, pod, makePgRes(target))).Should(BeTrue())
 	})
 
 	It("returns false when the Pod's actual requests differ from the target", func() {
@@ -469,6 +465,6 @@ var _ = Describe("verticalScalingHandler resource match contract", func() {
 			corev1.ResourceMemory: resource.MustParse("2Gi"),
 		}
 		pod := makePod(target.Limits.DeepCopy(), podRequests)
-		Expect(vs.podApplyCompOps(ops, makeInstance(pod), makePgRes(target))).Should(BeFalse())
+		Expect(vs.podApplyCompOps(ops, pod, makePgRes(target))).Should(BeFalse())
 	})
 })


### PR DESCRIPTION
## Summary

This PR fixes the release-1.0 CI toolchain after the branch moved to Go 1.25.10.

It keeps the scope to CI/tooling only:

1. Bumps release-1.0 `GOLANGCILINT_VERSION` from `v1.64.8` to `v2.8.0`.
2. Migrates `.golangci.yaml` to the golangci-lint v2 schema while keeping the release-1.0 lint scope narrow.
3. Keeps the workflow runner Go version at `1.24` so the existing `controller-gen v0.14.0` generate/manifests path remains stable.
4. Builds the `staticcheck v0.6.1` binary with `GOTOOLCHAIN=go1.25.10`, so staticcheck itself can analyze the Go 1.25.10 module.
5. Aligns `vertical_scaling_test.go` with the release-1.0 `podApplyCompOps(*corev1.Pod, ...)` signature instead of backporting the larger main-branch `Instance/defaultInstance` abstraction.
6. Updates the golangci-lint installer in the precheck/release-test workflows to `v2.8.0`.

This does not change controller behavior and does not attempt to fix #10204, #10247, or other business PRs directly. It only unblocks the shared release-1.0 CI toolchain.

## Why this shape

The first CI attempt proved that globally switching workflow `GO_VERSION` to Go 1.25.10 breaks `controller-gen v0.14.0` during `generate`:

```text
# golang.org/x/tools/internal/tokeninternal
invalid array length -delta * delta
```

So this PR avoids upgrading `controller-gen` or changing generated manifests. Instead, it keeps generate/manifests on the existing workflow runner setup and narrows Go 1.25.10 usage to the tool that needs it: staticcheck.

## Validation

Local checks run:

```text
make generate
make manifests
make golangci-lint
make staticcheck
go test -c ./pkg/operations
ruby YAML parse for the three touched workflow files
git diff --check
```

Also verified the rebuilt local staticcheck binary was built with Go 1.25.10:

```text
go version -m bin/staticcheck-v0.6.1
# bin/staticcheck-v0.6.1: go1.25.10
```

Note: on a reused local worktree, delete `bin/staticcheck-v0.6.1` before rerunning `make staticcheck-bin` if the binary was previously built with Go 1.24. CI fresh runners are not affected by this local cache boundary.

## Review notes

Rocco reviewed the initial CI-toolchain diff before push. Rocco and Edward reviewed the workflow/toolchain scope. After CI showed the `controller-gen` failure, Rocco reviewed the narrowed staticcheck-only toolchain fix and agreed it is preferable to upgrading `controller-gen` in this PR.