### PR TITLE
fix(instanceset): guard plain exclusive role events

### DIFF
--- a/pkg/controller/instanceset/pod_role_event_handler.go
+++ b/pkg/controller/instanceset/pod_role_event_handler.go
@@ -142,10 +142,10 @@ func handleRoleChangedEvent(cli client.Client, reqCtx intctrlutil.RequestCtx, _ 
 		reqCtx.Log.Info("probe event failed", "message", message.Message)
 		return "", nil
 	}
-	role := strings.ToLower(message.Role)
-
-	snapshot := parseGlobalRoleSnapshot(role, event)
+	snapshot, authoritative := parseGlobalRoleSnapshot(message.Role, event)
+	role := ""
 	for _, pair := range snapshot.PodRoleNamePairs {
+		role = strings.ToLower(pair.RoleName)
 		podName := types.NamespacedName{
 			Namespace: event.InvolvedObject.Namespace,
 			Name:      pair.PodName,
@@ -175,9 +175,9 @@ func handleRoleChangedEvent(cli client.Client, reqCtx intctrlutil.RequestCtx, _ 
 		if err := cli.Get(reqCtx.Ctx, types.NamespacedName{Namespace: pod.Namespace, Name: name}, its); err != nil {
 			return "", err
 		}
-		reqCtx.Log.Info("handle role change event", "pod", pod.Name, "role", role, "originalRole", message.OriginalRole)
+		reqCtx.Log.Info("handle role change event", "pod", pod.Name, "role", pair.RoleName, "originalRole", message.OriginalRole)
 
-		if err := updatePodRoleLabel(cli, reqCtx, *its, pod, pair.RoleName, snapshot.Version); err != nil {
+		if err := updatePodRoleLabel(cli, reqCtx, *its, pod, pair.RoleName, snapshot.Version, authoritative); err != nil {
 			return "", err
 		}
 	}
@@ -196,19 +196,19 @@ func checkStaleLastSnapshotVersion(version string, pod *corev1.Pod) bool {
 	return false
 }
 
-func parseGlobalRoleSnapshot(role string, event *corev1.Event) *common.GlobalRoleSnapshot {
+func parseGlobalRoleSnapshot(role string, event *corev1.Event) (*common.GlobalRoleSnapshot, bool) {
 	snapshot := &common.GlobalRoleSnapshot{}
 	if err := json.Unmarshal([]byte(role), snapshot); err == nil {
-		return snapshot
+		return snapshot, true
 	}
 	snapshot.Version = strconv.FormatInt(event.EventTime.UnixMicro(), 10)
 	pair := common.PodRoleNamePair{
 		PodName:  event.InvolvedObject.Name,
-		RoleName: role,
+		RoleName: strings.ToLower(role),
 		PodUID:   string(event.InvolvedObject.UID),
 	}
 	snapshot.PodRoleNamePairs = append(snapshot.PodRoleNamePairs, pair)
-	return snapshot
+	return snapshot, false
 }
 
 // parseProbeEventMessage parses probe event message.
@@ -244,13 +244,24 @@ func parseProbeEventMessage(reqCtx intctrlutil.RequestCtx, event *corev1.Event) 
 }
 
 func updatePodRoleLabel(cli client.Client, reqCtx intctrlutil.RequestCtx, its workloads.InstanceSet,
-	pod *corev1.Pod, roleName string, version string) error {
+	pod *corev1.Pod, roleName string, version string, authoritative bool) error {
 	var (
 		ctx                = reqCtx.Ctx
 		roleMap            = composeRoleMap(its)
 		normalizedRoleName = strings.ToLower(roleName)
 		role, defined      = roleMap[normalizedRoleName]
 	)
+	if defined && role.IsExclusive && !authoritative {
+		allowed, err := canApplyPlainExclusiveRole(cli, reqCtx, its, pod, normalizedRoleName)
+		if err != nil {
+			return err
+		}
+		if !allowed {
+			reqCtx.Log.Info("skip plain per-pod exclusive role promotion because another active holder exists",
+				"pod", pod.Name, "role", normalizedRoleName)
+			return nil
+		}
+	}
 	// update pod role label
 	newPod := pod.DeepCopy()
 	if defined {
@@ -270,6 +281,22 @@ func updatePodRoleLabel(cli client.Client, reqCtx intctrlutil.RequestCtx, its wo
 		return removeExclusiveRoleLabels(cli, reqCtx, its, pod.Name, normalizedRoleName, version)
 	}
 	return nil
+}
+
+func canApplyPlainExclusiveRole(cli client.Client, reqCtx intctrlutil.RequestCtx, its workloads.InstanceSet, pod *corev1.Pod, roleName string) (bool, error) {
+	labels := getMatchLabels(its.Name)
+	labels[RoleLabelKey] = roleName
+	var pods corev1.PodList
+	if err := cli.List(reqCtx.Ctx, &pods, client.InNamespace(its.Namespace), client.MatchingLabels(labels)); err != nil {
+		return false, err
+	}
+	for _, holder := range pods.Items {
+		if holder.Name == pod.Name || holder.DeletionTimestamp != nil {
+			continue
+		}
+		return false, nil
+	}
+	return true, nil
 }
 
 func removeExclusiveRoleLabels(cli client.Client, reqCtx intctrlutil.RequestCtx, its workloads.InstanceSet, newPodName, roleName, version string) error {

--- a/pkg/controller/instanceset/pod_role_event_handler_plain_test.go
+++ b/pkg/controller/instanceset/pod_role_event_handler_plain_test.go
@@ -1,0 +1,260 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package instanceset
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+)
+
+func TestHandleRoleChangedEventPlainExclusiveRole(t *testing.T) {
+	tests := []struct {
+		name                 string
+		role                 string
+		pods                 []*corev1.Pod
+		targetPod            string
+		wantRoles            map[string]string
+		wantTargetAnnotation string
+	}{
+		{
+			name:                 "bootstraps exclusive role when no active holder exists",
+			role:                 "leader",
+			pods:                 []*corev1.Pod{testRolePod("foo-0", "uid-0", "follower", nil)},
+			targetPod:            "foo-0",
+			wantRoles:            map[string]string{"foo-0": "leader"},
+			wantTargetAnnotation: "200000000",
+		},
+		{
+			name:                 "demotes the current exclusive holder through a plain non-exclusive role event",
+			role:                 "follower",
+			pods:                 []*corev1.Pod{testRolePod("foo-0", "uid-0", "leader", nil)},
+			targetPod:            "foo-0",
+			wantRoles:            map[string]string{"foo-0": "follower"},
+			wantTargetAnnotation: "200000000",
+		},
+		{
+			name: "does not promote a plain exclusive role event when another active holder exists",
+			role: "leader",
+			pods: []*corev1.Pod{
+				testRolePod("foo-0", "uid-0", "leader", map[string]string{
+					constant.LastRoleSnapshotVersionAnnotationKey: "100",
+				}),
+				testRolePod("foo-2", "uid-2", "follower", map[string]string{
+					constant.LastRoleSnapshotVersionAnnotationKey: "100",
+				}),
+			},
+			targetPod:            "foo-2",
+			wantRoles:            map[string]string{"foo-0": "leader", "foo-2": "follower"},
+			wantTargetAnnotation: "100",
+		},
+		{
+			name: "does not use a plain exclusive role event to clean up another active holder",
+			role: "leader",
+			pods: []*corev1.Pod{
+				testRolePod("foo-0", "uid-0", "leader", map[string]string{
+					constant.LastRoleSnapshotVersionAnnotationKey: "100",
+				}),
+				testRolePod("foo-2", "uid-2", "leader", map[string]string{
+					constant.LastRoleSnapshotVersionAnnotationKey: "100",
+				}),
+			},
+			targetPod:            "foo-0",
+			wantRoles:            map[string]string{"foo-0": "leader", "foo-2": "leader"},
+			wantTargetAnnotation: "100",
+		},
+		{
+			name: "allows plain exclusive promotion when the only other holder is terminating",
+			role: "leader",
+			pods: []*corev1.Pod{
+				testRolePod("foo-0", "uid-0", "leader", nil, testRolePodDeleting()),
+				testRolePod("foo-2", "uid-2", "follower", nil),
+			},
+			targetPod:            "foo-2",
+			wantRoles:            map[string]string{"foo-0": "", "foo-2": "leader"},
+			wantTargetAnnotation: "200000000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cli := testRoleClient(t, testRoleInstanceSet(), tt.pods...)
+			target := findTestRolePod(t, tt.pods, tt.targetPod)
+			event := testRoleEvent(t, target, tt.role)
+
+			if _, err := handleRoleChangedEvent(cli, testRoleRequestCtx(), nil, event); err != nil {
+				t.Fatalf("handle role event: %v", err)
+			}
+
+			for podName, wantRole := range tt.wantRoles {
+				got := &corev1.Pod{}
+				if err := cli.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: podName}, got); err != nil {
+					t.Fatalf("get pod %s: %v", podName, err)
+				}
+				if got.Labels[RoleLabelKey] != wantRole {
+					t.Fatalf("pod %s role = %q, want %q", podName, got.Labels[RoleLabelKey], wantRole)
+				}
+			}
+
+			gotTarget := &corev1.Pod{}
+			if err := cli.Get(context.Background(), types.NamespacedName{Namespace: namespace, Name: tt.targetPod}, gotTarget); err != nil {
+				t.Fatalf("get target pod %s: %v", tt.targetPod, err)
+			}
+			if gotTarget.Annotations[constant.LastRoleSnapshotVersionAnnotationKey] != tt.wantTargetAnnotation {
+				t.Fatalf("target pod annotation = %q, want %q",
+					gotTarget.Annotations[constant.LastRoleSnapshotVersionAnnotationKey], tt.wantTargetAnnotation)
+			}
+		})
+	}
+}
+
+func testRoleClient(t *testing.T, its *workloads.InstanceSet, pods ...*corev1.Pod) client.Client {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	if err := workloads.AddToScheme(scheme); err != nil {
+		t.Fatalf("add workloads scheme: %v", err)
+	}
+
+	objects := make([]client.Object, 0, len(pods)+1)
+	objects = append(objects, its)
+	for _, pod := range pods {
+		objects = append(objects, pod)
+	}
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+}
+
+func testRoleInstanceSet() *workloads.InstanceSet {
+	return &workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: workloads.InstanceSetSpec{
+			Roles: []workloads.ReplicaRole{
+				{
+					Name:                 "leader",
+					ParticipatesInQuorum: true,
+					UpdatePriority:       5,
+					IsExclusive:          true,
+				},
+				{
+					Name:                 "follower",
+					ParticipatesInQuorum: true,
+					UpdatePriority:       3,
+				},
+			},
+		},
+	}
+}
+
+func testRolePod(podName, podUID, role string, annotations map[string]string, opts ...func(*corev1.Pod)) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   namespace,
+			Name:        podName,
+			UID:         types.UID(podUID),
+			Labels:      testRolePodLabels(role),
+			Annotations: annotations,
+		},
+	}
+	for _, opt := range opts {
+		opt(pod)
+	}
+	return pod
+}
+
+func testRolePodDeleting() func(*corev1.Pod) {
+	return func(pod *corev1.Pod) {
+		now := metav1.NewTime(time.Unix(100, 0))
+		pod.DeletionTimestamp = &now
+		pod.Finalizers = []string{"keep-terminating-state"}
+	}
+}
+
+func testRolePodLabels(role string) map[string]string {
+	return map[string]string{
+		constant.AppManagedByLabelKey: constant.AppName,
+		WorkloadsManagedByLabelKey:    workloads.InstanceSetKind,
+		WorkloadsInstanceLabelKey:     name,
+		RoleLabelKey:                  role,
+	}
+}
+
+func findTestRolePod(t *testing.T, pods []*corev1.Pod, podName string) *corev1.Pod {
+	t.Helper()
+	for _, pod := range pods {
+		if pod.Name == podName {
+			return pod
+		}
+	}
+	t.Fatalf("pod %s not found", podName)
+	return nil
+}
+
+func testRoleEvent(t *testing.T, pod *corev1.Pod, role string) *corev1.Event {
+	t.Helper()
+	message, err := json.Marshal(probeMessage{
+		Event: successEvent,
+		Role:  role,
+	})
+	if err != nil {
+		t.Fatalf("marshal probe message: %v", err)
+	}
+	return &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      pod.Name + ".role",
+		},
+		InvolvedObject: corev1.ObjectReference{
+			APIVersion: "v1",
+			Kind:       "Pod",
+			Namespace:  namespace,
+			Name:       pod.Name,
+			UID:        pod.UID,
+			FieldPath:  lorryEventFieldPath,
+		},
+		Reason:    checkRoleOperation,
+		Message:   string(message),
+		EventTime: metav1.NewMicroTime(time.Unix(200, 0)),
+	}
+}
+
+func testRoleRequestCtx() intctrlutil.RequestCtx {
+	return intctrlutil.RequestCtx{
+		Ctx: context.Background(),
+		Log: logf.FromContext(context.Background()),
+	}
+}

--- a/pkg/controller/instanceset/pod_role_event_handler_test.go
+++ b/pkg/controller/instanceset/pod_role_event_handler_test.go
@@ -21,6 +21,7 @@ package instanceset
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -32,6 +33,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/common"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/builder"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
@@ -213,7 +215,7 @@ var _ = Describe("pod role label event handler test", func() {
 			handler = &PodRoleEventHandler{}
 		})
 
-		It("should remove exclusive role labels from other pods when a new pod claims exclusive role", func() {
+		It("should remove exclusive role labels from other pods for an authoritative global role snapshot", func() {
 			// Create an exclusive role
 			exclusiveRole := workloads.ReplicaRole{
 				Name:                 "leader",
@@ -222,7 +224,23 @@ var _ = Describe("pod role label event handler test", func() {
 				IsExclusive:          true, // Exclusive role
 			}
 
-			// Create an event for the new pod claiming the exclusive role
+			// An authoritative GlobalRoleSnapshot JSON message declares the
+			// new exclusive holder. Only this path retains the authority to
+			// remove the old holders' labels; a plain per-pod role string
+			// must NOT trigger removeExclusiveRoleLabels (see "exclusive
+			// role - plain per-pod path" tests below).
+			snapshot := common.GlobalRoleSnapshot{
+				Version: "term-1",
+				PodRoleNamePairs: []common.PodRoleNamePair{
+					{
+						PodName:  pod.Name,
+						RoleName: exclusiveRole.Name,
+						PodUID:   string(pod.UID),
+					},
+				},
+			}
+			snapshotJSON, err := json.Marshal(snapshot)
+			Expect(err).ShouldNot(HaveOccurred())
 			objectRef := corev1.ObjectReference{
 				APIVersion: "v1",
 				Kind:       "Pod",
@@ -231,11 +249,15 @@ var _ = Describe("pod role label event handler test", func() {
 				UID:        pod.UID,
 				FieldPath:  lorryEventFieldPath,
 			}
-			message := fmt.Sprintf("Readiness probe failed: error: health rpc failed: rpc error: code = Unknown desc = {\"event\":\"Success\",\"originalRole\":\"\",\"role\":\"%s\"}", exclusiveRole.Name)
+			eventMessage, err := json.Marshal(probeMessage{
+				Event: successEvent,
+				Role:  string(snapshotJSON),
+			})
+			Expect(err).ShouldNot(HaveOccurred())
 			event := builder.NewEventBuilder(namespace, "foo").
 				SetInvolvedObject(objectRef).
 				SetReason(checkRoleOperation).
-				SetMessage(message).
+				SetMessage(string(eventMessage)).
 				GetObject()
 
 			// Mock other pods with the same exclusive role label


### PR DESCRIPTION
## Summary

- parse `GlobalRoleSnapshot` role payloads before normalizing plain role names
- keep exclusive-holder cleanup on the authoritative global snapshot path only
- block plain per-pod exclusive role events from promoting themselves when another active holder already owns that role
- add focused fake-client coverage for plain bootstrap, demotion, blocked promotion, self-holder no-cleanup, and terminating-holder boundaries

## Validation

- `go test ./pkg/controller/instanceset -run TestHandleRoleChangedEventPlainExclusiveRole -count=3`
- `for i in 1 2 3; do go test ./pkg/controller/instanceset -run TestAPIs -count=1 -ginkgo.focus='exclusive role'; done`
- `go test ./pkg/controller/instanceset -count=1`
- `go test ./controllers/k8score ./controllers/workloads -run '^$' -count=0`
- `git diff --check`

`controllers/k8score` and `controllers/workloads` full envtest suites were not counted locally because `/usr/local/kubebuilder/bin/etcd` is unavailable on this machine.

## Boundary

A plain per-pod role event is still allowed to set an exclusive role when no other active holder exists. It is not allowed to remove or replace an existing active holder. Authoritative `GlobalRoleSnapshot` events keep the existing ability to move exclusive holder labels.
