### PR TITLE
chore: skip switchover for safe metadata-only in-place updates

### DIFF
--- a/pkg/controller/instance/in_place_update_utils.go
+++ b/pkg/controller/instance/in_place_update_utils.go
@@ -247,12 +247,42 @@ func equalBasicInPlaceFields(old, new *corev1.Pod) bool {
 	return true
 }
 
-func configHashOnlyInPlaceUpdate(old, new *corev1.Pod) bool {
+// safeMetadataOnlyInPlaceUpdate returns true when the only difference between
+// old and new is a Pod metadata patch (annotations and/or labels) that has no
+// effect on the running database process or availability. In that case the
+// caller can skip the lifecycle switchover that is normally invoked before an
+// in-place pod update.
+//
+// Specifically, it returns true if and only if:
+//   - old and new are otherwise equal when annotations and labels are ignored
+//     (basic spec fields + container resources match)
+//   - metadata has actually changed (do not vacuously skip switchover when
+//     there is no real diff)
+//   - the annotation diff does not include constant.RestartAnnotationKey, the
+//     explicit restart trigger which always implies a process restart
+//
+// Label changes are allowed because pure label patches do not restart the
+// container, do not change the spec, and do not touch the database process.
+// Service-selector routing impact is a network-layer concern and is not
+// resolved by invoking lifecycle switchover. Role-label patches are likewise
+// state synchronization, not a trigger for additional switchover.
+func safeMetadataOnlyInPlaceUpdate(old, new *corev1.Pod) bool {
 	oldCopy := old.DeepCopy()
 	newCopy := new.DeepCopy()
-	delete(oldCopy.Annotations, constant.CMInsConfigurationHashLabelKey)
-	delete(newCopy.Annotations, constant.CMInsConfigurationHashLabelKey)
-	return equalBasicInPlaceFields(oldCopy, newCopy) && equalResourcesInPlaceFields(oldCopy, newCopy)
+	oldCopy.Annotations = nil
+	newCopy.Annotations = nil
+	oldCopy.Labels = nil
+	newCopy.Labels = nil
+	if !equalBasicInPlaceFields(oldCopy, newCopy) || !equalResourcesInPlaceFields(oldCopy, newCopy) {
+		return false
+	}
+	if equalField(old.Annotations, new.Annotations) && equalField(old.Labels, new.Labels) {
+		return false
+	}
+	if !equalField(old.Annotations[constant.RestartAnnotationKey], new.Annotations[constant.RestartAnnotationKey]) {
+		return false
+	}
+	return true
 }
 
 // equalResourcesInPlaceFields checks if the desired values of pod resources are equal to their current actual values.

--- a/pkg/controller/instance/in_place_update_utils.go
+++ b/pkg/controller/instance/in_place_update_utils.go
@@ -247,6 +247,14 @@ func equalBasicInPlaceFields(old, new *corev1.Pod) bool {
 	return true
 }
 
+func configHashOnlyInPlaceUpdate(old, new *corev1.Pod) bool {
+	oldCopy := old.DeepCopy()
+	newCopy := new.DeepCopy()
+	delete(oldCopy.Annotations, constant.CMInsConfigurationHashLabelKey)
+	delete(newCopy.Annotations, constant.CMInsConfigurationHashLabelKey)
+	return equalBasicInPlaceFields(oldCopy, newCopy) && equalResourcesInPlaceFields(oldCopy, newCopy)
+}
+
 // equalResourcesInPlaceFields checks if the desired values of pod resources are equal to their current actual values.
 // If they are equal, it returns true. Containers in 'old' that are not recognized (they may have been injected by external mutating admission webhooks)
 // will not participate in the comparison.

--- a/pkg/controller/instance/reconciler_update.go
+++ b/pkg/controller/instance/reconciler_update.go
@@ -164,8 +164,10 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 			if !equalResourcesInPlaceFields(pod, newPod) && supportResizeSubResource {
 				err = tree.Update(newMergedPod, kubebuilderx.WithSubResource("resize"))
 			} else {
-				if err = r.switchover(tree, inst, newMergedPod.(*corev1.Pod)); err != nil {
-					return kubebuilderx.Continue, err
+				if !configHashOnlyInPlaceUpdate(pod, newPod) {
+					if err = r.switchover(tree, inst, newMergedPod.(*corev1.Pod)); err != nil {
+						return kubebuilderx.Continue, err
+					}
 				}
 				err = tree.Update(newMergedPod)
 			}

--- a/pkg/controller/instance/reconciler_update.go
+++ b/pkg/controller/instance/reconciler_update.go
@@ -164,7 +164,7 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 			if !equalResourcesInPlaceFields(pod, newPod) && supportResizeSubResource {
 				err = tree.Update(newMergedPod, kubebuilderx.WithSubResource("resize"))
 			} else {
-				if !configHashOnlyInPlaceUpdate(pod, newPod) {
+				if !safeMetadataOnlyInPlaceUpdate(pod, newPod) {
 					if err = r.switchover(tree, inst, newMergedPod.(*corev1.Pod)); err != nil {
 						return kubebuilderx.Continue, err
 					}

--- a/pkg/controller/instance/utils.go
+++ b/pkg/controller/instance/utils.go
@@ -436,7 +436,11 @@ func copyAndMerge(oldObj, newObj client.Object) client.Object {
 	}
 }
 
-func newLifecycleAction(inst *workloads.Instance, pods []*corev1.Pod, pod *corev1.Pod) (lifecycle.Lifecycle, error) {
+// newLifecycleAction is a package-level variable so tests can substitute a
+// spy implementation to assert call-site behavior (e.g., that switchover is
+// not invoked when an in-place update is metadata-only). Production behavior
+// is unchanged.
+var newLifecycleAction = func(inst *workloads.Instance, pods []*corev1.Pod, pod *corev1.Pod) (lifecycle.Lifecycle, error) {
 	var (
 		clusterName      = inst.Labels[constant.AppInstanceLabelKey]
 		compName         = inst.Labels[constant.KBAppComponentLabelKey]

--- a/pkg/controller/instance/utils_test.go
+++ b/pkg/controller/instance/utils_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/builder"
 )
 
@@ -53,73 +54,111 @@ func TestConfigsToUpdateTreatsNilAndEmptyConfigHashAsEqual(t *testing.T) {
 	}
 }
 
-func TestConfigHashOnlyInPlaceUpdate(t *testing.T) {
-	oldPod := builder.NewPodBuilder("default", "valkey-0").
+func TestSafeMetadataOnlyInPlaceUpdate(t *testing.T) {
+	basePod := builder.NewPodBuilder("default", "valkey-0").
 		AddAnnotations("kept", "value").
+		AddLabels("app", "valkey").
 		SetContainers([]corev1.Container{{Name: "valkey", Image: "valkey:9"}}).
 		GetObject()
 	if err := configsToPod([]workloads.ConfigTemplate{{
 		Name:       "valkey-replication-config",
 		ConfigHash: ptr.To("old-hash"),
-	}}, oldPod); err != nil {
+	}}, basePod); err != nil {
 		t.Fatalf("configsToPod() error = %v", err)
 	}
 
-	newPod := oldPod.DeepCopy()
-	if err := configsToPod([]workloads.ConfigTemplate{{
-		Name:       "valkey-replication-config",
-		ConfigHash: ptr.To("new-hash"),
-	}}, newPod); err != nil {
-		t.Fatalf("configsToPod() error = %v", err)
-	}
-	if !configHashOnlyInPlaceUpdate(oldPod, newPod) {
-		t.Fatalf("expected config hash only update")
-	}
-
-	newConfigHashPod := func(t *testing.T) *corev1.Pod {
-		t.Helper()
-		pod := oldPod.DeepCopy()
-		if err := configsToPod([]workloads.ConfigTemplate{{
-			Name:       "valkey-replication-config",
-			ConfigHash: ptr.To("new-hash"),
-		}}, pod); err != nil {
-			t.Fatalf("configsToPod() error = %v", err)
-		}
-		return pod
-	}
-
-	cases := []struct {
+	positiveCases := []struct {
 		name   string
 		mutate func(*corev1.Pod)
 	}{{
-		name: "label",
+		name: "config-hash annotation patch",
 		mutate: func(pod *corev1.Pod) {
-			pod.Labels = map[string]string{"extra": "label"}
+			if err := configsToPod([]workloads.ConfigTemplate{{
+				Name:       "valkey-replication-config",
+				ConfigHash: ptr.To("new-hash"),
+			}}, pod); err != nil {
+				t.Fatalf("configsToPod() error = %v", err)
+			}
 		},
 	}, {
-		name: "non config-hash annotation",
+		name: "non-restart annotation added",
 		mutate: func(pod *corev1.Pod) {
-			pod.Annotations["other"] = "changed"
+			pod.Annotations["custom"] = "value"
 		},
 	}, {
-		name: "container image",
+		name: "non-restart annotation value changed",
+		mutate: func(pod *corev1.Pod) {
+			pod.Annotations["kept"] = "changed"
+		},
+	}, {
+		name: "label added",
+		mutate: func(pod *corev1.Pod) {
+			pod.Labels["extra"] = "value"
+		},
+	}, {
+		name: "label value changed",
+		mutate: func(pod *corev1.Pod) {
+			pod.Labels["app"] = "valkey-renamed"
+		},
+	}, {
+		name: "role label state synchronization",
+		mutate: func(pod *corev1.Pod) {
+			pod.Labels[constant.RoleLabelKey] = "primary"
+		},
+	}}
+	for _, tc := range positiveCases {
+		t.Run("skip switchover when "+tc.name, func(t *testing.T) {
+			newPod := basePod.DeepCopy()
+			tc.mutate(newPod)
+			if !safeMetadataOnlyInPlaceUpdate(basePod, newPod) {
+				t.Fatalf("expected %s to be a safe metadata-only update", tc.name)
+			}
+		})
+	}
+
+	negativeCases := []struct {
+		name   string
+		mutate func(*corev1.Pod)
+	}{{
+		name: "no diff",
+		mutate: func(pod *corev1.Pod) {},
+	}, {
+		name: "restart annotation added",
+		mutate: func(pod *corev1.Pod) {
+			pod.Annotations[constant.RestartAnnotationKey] = "2026-05-19T14:00:00Z"
+		},
+	}, {
+		name: "restart annotation value changed",
+		mutate: func(pod *corev1.Pod) {
+			if pod.Annotations == nil {
+				pod.Annotations = map[string]string{}
+			}
+			pod.Annotations[constant.RestartAnnotationKey] = "next"
+		},
+	}, {
+		name: "container image changed",
 		mutate: func(pod *corev1.Pod) {
 			pod.Spec.Containers[0].Image = "valkey:10"
 		},
 	}, {
-		name: "container resources",
+		name: "container resources changed",
 		mutate: func(pod *corev1.Pod) {
 			pod.Spec.Containers[0].Resources.Requests = corev1.ResourceList{
 				corev1.ResourceCPU: resource.MustParse("1"),
 			}
 		},
+	}, {
+		name: "container env added",
+		mutate: func(pod *corev1.Pod) {
+			pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, corev1.EnvVar{Name: "EXTRA", Value: "v"})
+		},
 	}}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			pod := newConfigHashPod(t)
-			tc.mutate(pod)
-			if configHashOnlyInPlaceUpdate(oldPod, pod) {
-				t.Fatalf("expected %s update not to be config hash only", tc.name)
+	for _, tc := range negativeCases {
+		t.Run("invoke switchover when "+tc.name, func(t *testing.T) {
+			newPod := basePod.DeepCopy()
+			tc.mutate(newPod)
+			if safeMetadataOnlyInPlaceUpdate(basePod, newPod) {
+				t.Fatalf("expected %s not to be a safe metadata-only update", tc.name)
 			}
 		})
 	}

--- a/pkg/controller/instance/utils_test.go
+++ b/pkg/controller/instance/utils_test.go
@@ -22,6 +22,7 @@ package instance
 import (
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
@@ -48,6 +49,35 @@ func TestConfigsToUpdateTreatsNilAndEmptyConfigHashAsEqual(t *testing.T) {
 	}
 	if len(toUpdate) != 0 {
 		t.Fatalf("expected no config drift, got %#v", toUpdate)
+	}
+}
+
+func TestConfigHashOnlyInPlaceUpdate(t *testing.T) {
+	oldPod := builder.NewPodBuilder("default", "valkey-0").
+		AddAnnotations("kept", "value").
+		SetContainers([]corev1.Container{{Name: "valkey", Image: "valkey:9"}}).
+		GetObject()
+	if err := configsToPod([]workloads.ConfigTemplate{{
+		Name:       "valkey-replication-config",
+		ConfigHash: ptr.To("old-hash"),
+	}}, oldPod); err != nil {
+		t.Fatalf("configsToPod() error = %v", err)
+	}
+
+	newPod := oldPod.DeepCopy()
+	if err := configsToPod([]workloads.ConfigTemplate{{
+		Name:       "valkey-replication-config",
+		ConfigHash: ptr.To("new-hash"),
+	}}, newPod); err != nil {
+		t.Fatalf("configsToPod() error = %v", err)
+	}
+	if !configHashOnlyInPlaceUpdate(oldPod, newPod) {
+		t.Fatalf("expected config hash only update")
+	}
+
+	newPod.Labels = map[string]string{"extra": "label"}
+	if configHashOnlyInPlaceUpdate(oldPod, newPod) {
+		t.Fatalf("expected non-config label update not to be config hash only")
 	}
 }
 

--- a/pkg/controller/instance/utils_test.go
+++ b/pkg/controller/instance/utils_test.go
@@ -120,7 +120,7 @@ func TestSafeMetadataOnlyInPlaceUpdate(t *testing.T) {
 		name   string
 		mutate func(*corev1.Pod)
 	}{{
-		name: "no diff",
+		name:   "no diff",
 		mutate: func(pod *corev1.Pod) {},
 	}, {
 		name: "restart annotation added",

--- a/pkg/controller/instance/utils_test.go
+++ b/pkg/controller/instance/utils_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/ptr"
 
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
@@ -75,9 +76,52 @@ func TestConfigHashOnlyInPlaceUpdate(t *testing.T) {
 		t.Fatalf("expected config hash only update")
 	}
 
-	newPod.Labels = map[string]string{"extra": "label"}
-	if configHashOnlyInPlaceUpdate(oldPod, newPod) {
-		t.Fatalf("expected non-config label update not to be config hash only")
+	newConfigHashPod := func(t *testing.T) *corev1.Pod {
+		t.Helper()
+		pod := oldPod.DeepCopy()
+		if err := configsToPod([]workloads.ConfigTemplate{{
+			Name:       "valkey-replication-config",
+			ConfigHash: ptr.To("new-hash"),
+		}}, pod); err != nil {
+			t.Fatalf("configsToPod() error = %v", err)
+		}
+		return pod
+	}
+
+	cases := []struct {
+		name   string
+		mutate func(*corev1.Pod)
+	}{{
+		name: "label",
+		mutate: func(pod *corev1.Pod) {
+			pod.Labels = map[string]string{"extra": "label"}
+		},
+	}, {
+		name: "non config-hash annotation",
+		mutate: func(pod *corev1.Pod) {
+			pod.Annotations["other"] = "changed"
+		},
+	}, {
+		name: "container image",
+		mutate: func(pod *corev1.Pod) {
+			pod.Spec.Containers[0].Image = "valkey:10"
+		},
+	}, {
+		name: "container resources",
+		mutate: func(pod *corev1.Pod) {
+			pod.Spec.Containers[0].Resources.Requests = corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("1"),
+			}
+		},
+	}}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pod := newConfigHashPod(t)
+			tc.mutate(pod)
+			if configHashOnlyInPlaceUpdate(oldPod, pod) {
+				t.Fatalf("expected %s update not to be config hash only", tc.name)
+			}
+		})
 	}
 }
 

--- a/pkg/controller/instanceset/in_place_update_util.go
+++ b/pkg/controller/instanceset/in_place_update_util.go
@@ -256,6 +256,14 @@ func equalBasicInPlaceFields(old, new *corev1.Pod) bool {
 	return true
 }
 
+func configHashOnlyInPlaceUpdate(old, new *corev1.Pod) bool {
+	oldCopy := old.DeepCopy()
+	newCopy := new.DeepCopy()
+	delete(oldCopy.Annotations, constant.CMInsConfigurationHashLabelKey)
+	delete(newCopy.Annotations, constant.CMInsConfigurationHashLabelKey)
+	return equalBasicInPlaceFields(oldCopy, newCopy) && equalResourcesInPlaceFields(oldCopy, newCopy)
+}
+
 // equalResourcesInPlaceFields checks if the desired values of pod resources are equal to their current actual values.
 // If they are equal, it returns true. Containers in 'old' that are not recognized (they may have been injected by external mutating admission webhooks)
 // will not participate in the comparison.

--- a/pkg/controller/instanceset/in_place_update_util.go
+++ b/pkg/controller/instanceset/in_place_update_util.go
@@ -256,12 +256,42 @@ func equalBasicInPlaceFields(old, new *corev1.Pod) bool {
 	return true
 }
 
-func configHashOnlyInPlaceUpdate(old, new *corev1.Pod) bool {
+// safeMetadataOnlyInPlaceUpdate returns true when the only difference between
+// old and new is a Pod metadata patch (annotations and/or labels) that has no
+// effect on the running database process or availability. In that case the
+// caller can skip the lifecycle switchover that is normally invoked before an
+// in-place pod update.
+//
+// Specifically, it returns true if and only if:
+//   - old and new are otherwise equal when annotations and labels are ignored
+//     (basic spec fields + container resources match)
+//   - metadata has actually changed (do not vacuously skip switchover when
+//     there is no real diff)
+//   - the annotation diff does not include constant.RestartAnnotationKey, the
+//     explicit restart trigger which always implies a process restart
+//
+// Label changes are allowed because pure label patches do not restart the
+// container, do not change the spec, and do not touch the database process.
+// Service-selector routing impact is a network-layer concern and is not
+// resolved by invoking lifecycle switchover. Role-label patches are likewise
+// state synchronization, not a trigger for additional switchover.
+func safeMetadataOnlyInPlaceUpdate(old, new *corev1.Pod) bool {
 	oldCopy := old.DeepCopy()
 	newCopy := new.DeepCopy()
-	delete(oldCopy.Annotations, constant.CMInsConfigurationHashLabelKey)
-	delete(newCopy.Annotations, constant.CMInsConfigurationHashLabelKey)
-	return equalBasicInPlaceFields(oldCopy, newCopy) && equalResourcesInPlaceFields(oldCopy, newCopy)
+	oldCopy.Annotations = nil
+	newCopy.Annotations = nil
+	oldCopy.Labels = nil
+	newCopy.Labels = nil
+	if !equalBasicInPlaceFields(oldCopy, newCopy) || !equalResourcesInPlaceFields(oldCopy, newCopy) {
+		return false
+	}
+	if equalField(old.Annotations, new.Annotations) && equalField(old.Labels, new.Labels) {
+		return false
+	}
+	if !equalField(old.Annotations[constant.RestartAnnotationKey], new.Annotations[constant.RestartAnnotationKey]) {
+		return false
+	}
+	return true
 }
 
 // equalResourcesInPlaceFields checks if the desired values of pod resources are equal to their current actual values.

--- a/pkg/controller/instanceset/instance_util_test.go
+++ b/pkg/controller/instanceset/instance_util_test.go
@@ -120,6 +120,27 @@ var _ = Describe("instance util test", func() {
 			Expect(toUpdate).Should(HaveLen(1))
 			Expect(toUpdate[0].Name).Should(Equal("valkey-replication-config"))
 		})
+
+		It("identifies config hash annotation only in-place updates", func() {
+			oldPod := builder.NewPodBuilder(namespace, name+"-0").
+				AddAnnotations("kept", "value").
+				SetContainers(template.Spec.Containers).
+				GetObject()
+			Expect(configsToPod([]workloads.ConfigTemplate{{
+				Name:       "valkey-replication-config",
+				ConfigHash: ptr.To("old-hash"),
+			}}, oldPod)).Should(Succeed())
+
+			newPod := oldPod.DeepCopy()
+			Expect(configsToPod([]workloads.ConfigTemplate{{
+				Name:       "valkey-replication-config",
+				ConfigHash: ptr.To("new-hash"),
+			}}, newPod)).Should(Succeed())
+			Expect(configHashOnlyInPlaceUpdate(oldPod, newPod)).Should(BeTrue())
+
+			newPod.Labels = map[string]string{"extra": "label"}
+			Expect(configHashOnlyInPlaceUpdate(oldPod, newPod)).Should(BeFalse())
+		})
 	})
 
 	Context("buildInstancePodByTemplate", func() {

--- a/pkg/controller/instanceset/instance_util_test.go
+++ b/pkg/controller/instanceset/instance_util_test.go
@@ -138,8 +138,47 @@ var _ = Describe("instance util test", func() {
 			}}, newPod)).Should(Succeed())
 			Expect(configHashOnlyInPlaceUpdate(oldPod, newPod)).Should(BeTrue())
 
-			newPod.Labels = map[string]string{"extra": "label"}
-			Expect(configHashOnlyInPlaceUpdate(oldPod, newPod)).Should(BeFalse())
+			newConfigHashPod := func() *corev1.Pod {
+				pod := oldPod.DeepCopy()
+				Expect(configsToPod([]workloads.ConfigTemplate{{
+					Name:       "valkey-replication-config",
+					ConfigHash: ptr.To("new-hash"),
+				}}, pod)).Should(Succeed())
+				return pod
+			}
+
+			cases := []struct {
+				name   string
+				mutate func(*corev1.Pod)
+			}{{
+				name: "label",
+				mutate: func(pod *corev1.Pod) {
+					pod.Labels = map[string]string{"extra": "label"}
+				},
+			}, {
+				name: "non config-hash annotation",
+				mutate: func(pod *corev1.Pod) {
+					pod.Annotations["other"] = "changed"
+				},
+			}, {
+				name: "container image",
+				mutate: func(pod *corev1.Pod) {
+					pod.Spec.Containers[0].Image = "valkey:10"
+				},
+			}, {
+				name: "container resources",
+				mutate: func(pod *corev1.Pod) {
+					pod.Spec.Containers[0].Resources.Requests = corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("1"),
+					}
+				},
+			}}
+			for _, tc := range cases {
+				By("rejecting " + tc.name + " as config-hash-only")
+				pod := newConfigHashPod()
+				tc.mutate(pod)
+				Expect(configHashOnlyInPlaceUpdate(oldPod, pod)).Should(BeFalse())
+			}
 		})
 	})
 

--- a/pkg/controller/instanceset/instance_util_test.go
+++ b/pkg/controller/instanceset/instance_util_test.go
@@ -121,63 +121,103 @@ var _ = Describe("instance util test", func() {
 			Expect(toUpdate[0].Name).Should(Equal("valkey-replication-config"))
 		})
 
-		It("identifies config hash annotation only in-place updates", func() {
-			oldPod := builder.NewPodBuilder(namespace, name+"-0").
+		It("identifies safe metadata-only in-place updates per process-impact semantic", func() {
+			basePod := builder.NewPodBuilder(namespace, name+"-0").
 				AddAnnotations("kept", "value").
+				AddLabels("app", "valkey").
 				SetContainers(template.Spec.Containers).
 				GetObject()
 			Expect(configsToPod([]workloads.ConfigTemplate{{
 				Name:       "valkey-replication-config",
 				ConfigHash: ptr.To("old-hash"),
-			}}, oldPod)).Should(Succeed())
+			}}, basePod)).Should(Succeed())
 
-			newPod := oldPod.DeepCopy()
-			Expect(configsToPod([]workloads.ConfigTemplate{{
-				Name:       "valkey-replication-config",
-				ConfigHash: ptr.To("new-hash"),
-			}}, newPod)).Should(Succeed())
-			Expect(configHashOnlyInPlaceUpdate(oldPod, newPod)).Should(BeTrue())
-
-			newConfigHashPod := func() *corev1.Pod {
-				pod := oldPod.DeepCopy()
-				Expect(configsToPod([]workloads.ConfigTemplate{{
-					Name:       "valkey-replication-config",
-					ConfigHash: ptr.To("new-hash"),
-				}}, pod)).Should(Succeed())
-				return pod
-			}
-
-			cases := []struct {
+			positiveCases := []struct {
 				name   string
 				mutate func(*corev1.Pod)
 			}{{
-				name: "label",
+				name: "config-hash annotation patch",
 				mutate: func(pod *corev1.Pod) {
-					pod.Labels = map[string]string{"extra": "label"}
+					Expect(configsToPod([]workloads.ConfigTemplate{{
+						Name:       "valkey-replication-config",
+						ConfigHash: ptr.To("new-hash"),
+					}}, pod)).Should(Succeed())
 				},
 			}, {
-				name: "non config-hash annotation",
+				name: "non-restart annotation added",
 				mutate: func(pod *corev1.Pod) {
-					pod.Annotations["other"] = "changed"
+					pod.Annotations["custom"] = "value"
 				},
 			}, {
-				name: "container image",
+				name: "non-restart annotation value changed",
+				mutate: func(pod *corev1.Pod) {
+					pod.Annotations["kept"] = "changed"
+				},
+			}, {
+				name: "label added",
+				mutate: func(pod *corev1.Pod) {
+					pod.Labels["extra"] = "value"
+				},
+			}, {
+				name: "label value changed",
+				mutate: func(pod *corev1.Pod) {
+					pod.Labels["app"] = "valkey-renamed"
+				},
+			}, {
+				name: "role label state synchronization",
+				mutate: func(pod *corev1.Pod) {
+					pod.Labels[constant.RoleLabelKey] = "primary"
+				},
+			}}
+			for _, tc := range positiveCases {
+				By("skipping switchover when " + tc.name)
+				newPod := basePod.DeepCopy()
+				tc.mutate(newPod)
+				Expect(safeMetadataOnlyInPlaceUpdate(basePod, newPod)).Should(BeTrue())
+			}
+
+			negativeCases := []struct {
+				name   string
+				mutate func(*corev1.Pod)
+			}{{
+				name:   "no diff",
+				mutate: func(pod *corev1.Pod) {},
+			}, {
+				name: "restart annotation added",
+				mutate: func(pod *corev1.Pod) {
+					pod.Annotations[constant.RestartAnnotationKey] = "2026-05-19T14:00:00Z"
+				},
+			}, {
+				name: "restart annotation value changed",
+				mutate: func(pod *corev1.Pod) {
+					if pod.Annotations == nil {
+						pod.Annotations = map[string]string{}
+					}
+					pod.Annotations[constant.RestartAnnotationKey] = "next"
+				},
+			}, {
+				name: "container image changed",
 				mutate: func(pod *corev1.Pod) {
 					pod.Spec.Containers[0].Image = "valkey:10"
 				},
 			}, {
-				name: "container resources",
+				name: "container resources changed",
 				mutate: func(pod *corev1.Pod) {
 					pod.Spec.Containers[0].Resources.Requests = corev1.ResourceList{
 						corev1.ResourceCPU: resource.MustParse("1"),
 					}
 				},
+			}, {
+				name: "container env added",
+				mutate: func(pod *corev1.Pod) {
+					pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, corev1.EnvVar{Name: "EXTRA", Value: "v"})
+				},
 			}}
-			for _, tc := range cases {
-				By("rejecting " + tc.name + " as config-hash-only")
-				pod := newConfigHashPod()
-				tc.mutate(pod)
-				Expect(configHashOnlyInPlaceUpdate(oldPod, pod)).Should(BeFalse())
+			for _, tc := range negativeCases {
+				By("invoking switchover when " + tc.name)
+				newPod := basePod.DeepCopy()
+				tc.mutate(newPod)
+				Expect(safeMetadataOnlyInPlaceUpdate(basePod, newPod)).Should(BeFalse())
 			}
 		})
 	})

--- a/pkg/controller/instanceset/reconciler_update.go
+++ b/pkg/controller/instanceset/reconciler_update.go
@@ -193,7 +193,7 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 			if !equalResourcesInPlaceFields(pod, newPod) && supportResizeSubResource {
 				err = tree.Update(newMergedPod, kubebuilderx.WithSubResource("resize"))
 			} else {
-				if !configHashOnlyInPlaceUpdate(pod, newPod) {
+				if !safeMetadataOnlyInPlaceUpdate(pod, newPod) {
 					if err = r.switchover(tree, its, newMergedPod.(*corev1.Pod)); err != nil {
 						return kubebuilderx.Continue, err
 					}

--- a/pkg/controller/instanceset/reconciler_update.go
+++ b/pkg/controller/instanceset/reconciler_update.go
@@ -193,8 +193,10 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 			if !equalResourcesInPlaceFields(pod, newPod) && supportResizeSubResource {
 				err = tree.Update(newMergedPod, kubebuilderx.WithSubResource("resize"))
 			} else {
-				if err = r.switchover(tree, its, newMergedPod.(*corev1.Pod)); err != nil {
-					return kubebuilderx.Continue, err
+				if !configHashOnlyInPlaceUpdate(pod, newPod) {
+					if err = r.switchover(tree, its, newMergedPod.(*corev1.Pod)); err != nil {
+						return kubebuilderx.Continue, err
+					}
 				}
 				err = tree.Update(newMergedPod)
 			}

--- a/pkg/controller/instanceset/reconciler_update_test.go
+++ b/pkg/controller/instanceset/reconciler_update_test.go
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package instanceset
 
 import (
+	"context"
 	"slices"
 	"time"
 
@@ -39,6 +40,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/builder"
 	"github.com/apecloud/kubeblocks/pkg/controller/kubebuilderx"
+	"github.com/apecloud/kubeblocks/pkg/controller/lifecycle"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
@@ -410,5 +412,124 @@ var _ = Describe("update reconciler test", func() {
 		It("inplace updates pod resource using resize subresource", func() {
 			testInplacePodVerticalScaling(true)
 		})
+
+		It("patches pod without calling switchover for metadata-only in-place updates", func() {
+			// This test exercises the Reconcile call site (not just the
+			// safeMetadataOnlyInPlaceUpdate helper) to assert the contract
+			// from PR #10252: when the only difference between the existing
+			// pod and the rebuilt pod is non-restart metadata, the pod is
+			// patched but the switchover lifecycle action must not be
+			// invoked.
+			origSupportResize := intctrlutil.SupportResizeSubResource
+			intctrlutil.SupportResizeSubResource = func() (bool, error) { return false, nil }
+			defer func() { intctrlutil.SupportResizeSubResource = origSupportResize }()
+
+			spy := &lifecycleCallSpy{}
+			origNewLifecycleAction := newLifecycleAction
+			newLifecycleAction = func(_ *workloads.InstanceSet, _ *kubebuilderx.ObjectTree, _ *corev1.Pod) (lifecycle.Lifecycle, error) {
+				return spy, nil
+			}
+			defer func() { newLifecycleAction = origNewLifecycleAction }()
+
+			tree := kubebuilderx.NewObjectTree()
+			its.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+			its.Spec.Replicas = ptr.To[int32](1)
+			its.Spec.PodUpdatePolicy = kbappsv1.PreferInPlacePodUpdatePolicyType
+			// Configure a switchover action so r.switchover would invoke
+			// newLifecycleAction (and thus the spy) if the gate did not
+			// suppress it.
+			its.Spec.LifecycleActions = &workloads.LifecycleActions{
+				Switchover: &kbappsv1.Action{
+					Exec: &kbappsv1.ExecAction{Command: []string{"true"}},
+				},
+			}
+			tree.SetRoot(its)
+
+			// Run the revision pipeline against the original template so the
+			// generated pod's controller-revision label matches
+			// its.Status.UpdateRevisions. This avoids the revision-mismatch
+			// branch in getPodUpdatePolicy that would force recreatePolicy.
+			prepareForUpdate(tree)
+
+			pods := tree.List(&corev1.Pod{})
+			Expect(pods).Should(HaveLen(1))
+			pod := pods[0].(*corev1.Pod)
+			pod.Status.Phase = corev1.PodRunning
+			pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
+				Type:               corev1.PodReady,
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: metav1.NewTime(time.Now().Add(-1 * minReadySeconds * time.Second)),
+			})
+
+			// Mutate the template AFTER prepareForUpdate so the rebuilt pod
+			// differs from the existing pod only in the config-hash
+			// annotation. its.Status.UpdateRevisions is no longer
+			// recomputed, so the pod's revision still matches and the
+			// reconciler enters the in-place branch via basicUpdate=true.
+			if its.Spec.Template.ObjectMeta.Annotations == nil {
+				its.Spec.Template.ObjectMeta.Annotations = map[string]string{}
+			}
+			its.Spec.Template.ObjectMeta.Annotations[constant.CMInsConfigurationHashLabelKey] = "new-hash"
+
+			reconciler = NewUpdateReconciler()
+			res, err := reconciler.Reconcile(tree)
+			Expect(err).Should(BeNil())
+			Expect(res).Should(Equal(kubebuilderx.Continue))
+
+			postPods := tree.List(&corev1.Pod{})
+			Expect(postPods).Should(HaveLen(1),
+				"pod should be in-place updated, not deleted/recreated")
+			updatedPod := postPods[0].(*corev1.Pod)
+			Expect(updatedPod.Annotations).Should(HaveKeyWithValue(constant.CMInsConfigurationHashLabelKey, "new-hash"),
+				"pod should be patched with the new config-hash annotation even though switchover is skipped")
+			Expect(spy.switchoverCalls).Should(Equal(0),
+				"switchover must not be invoked when only the config-hash annotation differs")
+		})
 	})
 })
+
+// lifecycleCallSpy is a test double for lifecycle.Lifecycle used to assert
+// that switchover is or is not invoked during reconciliation. Methods that
+// the call-site tests do not exercise return nil to satisfy the interface.
+type lifecycleCallSpy struct {
+	switchoverCalls  int
+	reconfigureCalls int
+}
+
+func (s *lifecycleCallSpy) PostProvision(_ context.Context, _ client.Reader, _ *lifecycle.Options) error {
+	return nil
+}
+
+func (s *lifecycleCallSpy) PreTerminate(_ context.Context, _ client.Reader, _ *lifecycle.Options) error {
+	return nil
+}
+
+func (s *lifecycleCallSpy) RoleProbe(_ context.Context, _ client.Reader, _ *lifecycle.Options) ([]byte, error) {
+	return nil, nil
+}
+
+func (s *lifecycleCallSpy) Switchover(_ context.Context, _ client.Reader, _ *lifecycle.Options, _ string) error {
+	s.switchoverCalls++
+	return nil
+}
+
+func (s *lifecycleCallSpy) MemberJoin(_ context.Context, _ client.Reader, _ *lifecycle.Options) error {
+	return nil
+}
+
+func (s *lifecycleCallSpy) MemberLeave(_ context.Context, _ client.Reader, _ *lifecycle.Options) error {
+	return nil
+}
+
+func (s *lifecycleCallSpy) Reconfigure(_ context.Context, _ client.Reader, _ *lifecycle.Options, _ map[string]string) error {
+	s.reconfigureCalls++
+	return nil
+}
+
+func (s *lifecycleCallSpy) AccountProvision(_ context.Context, _ client.Reader, _ *lifecycle.Options, _, _, _ string) error {
+	return nil
+}
+
+func (s *lifecycleCallSpy) UserDefined(_ context.Context, _ client.Reader, _ *lifecycle.Options, _ string, _ *kbappsv1.Action, _ map[string]string) error {
+	return nil
+}

--- a/pkg/controller/instanceset/utils.go
+++ b/pkg/controller/instanceset/utils.go
@@ -204,7 +204,11 @@ func getMemberUpdateStrategy(its *workloads.InstanceSet) workloads.MemberUpdateS
 	return updateStrategy
 }
 
-func newLifecycleAction(its *workloads.InstanceSet, tree *kubebuilderx.ObjectTree, pod *corev1.Pod) (lifecycle.Lifecycle, error) {
+// newLifecycleAction is a package-level variable so tests can substitute a
+// spy implementation to assert call-site behavior (e.g., that switchover is
+// not invoked when an in-place update is metadata-only). Production behavior
+// is unchanged.
+var newLifecycleAction = func(its *workloads.InstanceSet, tree *kubebuilderx.ObjectTree, pod *corev1.Pod) (lifecycle.Lifecycle, error) {
 	var (
 		clusterName      = its.Labels[constant.AppInstanceLabelKey]
 		compName         = its.Labels[constant.KBAppComponentLabelKey]


### PR DESCRIPTION
## Problem

The KubeBlocks controller calls a lifecycle switchover before every in-place pod update. The intent is "if we are about to make a change that affects the database process or availability on this pod, migrate the primary role away first." The previous logic invoked switchover whenever it detected any pod-spec or pod-metadata difference, including pure metadata patches that have no effect on the running process.

Field example: when Valkey or MariaDB applies a dynamic parameter change, the controller updates `config.kubeblocks.io/config-hash` on the pod as a configuration version marker. That update does not restart the container, does not change the spec, and does not touch the database process. But the previous logic still invoked switchover, migrating the primary away before patching the annotation. Both Valkey R08a and MariaDB T6 alpha.85 observed this misfire.

If left unfixed, every configuration synchronization triggers an unnecessary primary-replica switchover plus extra latency. During reconfigure scenarios this amplifies the blast radius (for example a switchover happening mid-reconfigure can confuse role decisions downstream).

## Scope

Replace the previous `configHashOnlyInPlaceUpdate` helper with `safeMetadataOnlyInPlaceUpdate(old, new *corev1.Pod) bool`. The caller skips switchover only when **all** of the following hold:

- After ignoring annotations and labels on both sides, basic in-place fields (containers / tolerations / initContainers / activeDeadlineSeconds) and container resource requests/limits are equal.
- The metadata (annotations + labels) has actually changed; the helper refuses to vacuously skip switchover when there is no real diff.
- The annotation diff does not include `kubeblocks.io/restart`, which is the explicit restart trigger and must always invoke switchover.

Implementation, identical in both packages:
- `pkg/controller/instance/in_place_update_utils.go`
- `pkg/controller/instanceset/in_place_update_util.go`

Call sites, in the in-place update branch only; the recreate branch keeps the original switchover behavior:
- `pkg/controller/instance/reconciler_update.go`
- `pkg/controller/instanceset/reconciler_update.go`

## Why

The new boundary matches the semantic that switchover should fire only for changes that can affect the database process or availability:

- **Pure annotation patch**: does not restart the container, does not change the spec, does not touch the database process. No switchover needed.
- **Pure label patch (including role label)**: control-plane state synchronization, does not touch the process. Even when a label change influences a Service selector, that is a network-layer concern; invoking switchover does not resolve a routing problem. Role-label patches are after-the-fact state recording and should not trigger an additional switchover.
- **`kubeblocks.io/restart` annotation change**: an explicit restart trigger; switchover is still required.
- **Any spec change** (container image / env / command / args / VolumeMounts / resources / tolerations / initContainers / activeDeadlineSeconds): affects the process or scheduling. Switchover is still required.
- **Recreate path is unchanged**: recreating the pod inherently interrupts the process, so switchover is still invoked.

Boundary notes:
- The helper allows **any** label change rather than maintaining a per-key allowlist. This follows the first-principle rule (a pure label patch does not affect the process), not the conservative fallback of "deny every label that has not been proven safe."
- The fix does not introduce a new selector or role contract check. Selector and role safety should be enforced by the InstanceSet template contract, not by the switchover hook.

## Verification

- `go test ./pkg/controller/instance -run TestSafeMetadataOnlyInPlaceUpdate -count=1 -v`: 12 subtests all PASS
- `go test ./pkg/controller/instanceset -ginkgo.focus="identifies safe metadata-only" -count=1`: PASS
- `go test ./pkg/controller/instanceset -ginkgo.focus="patches pod without calling switchover for metadata-only in-place updates" -count=1`: PASS (new call-site Reconcile test)
- `go test -c ./pkg/controller/instance` + `go test -c ./pkg/controller/instanceset`: PASS
- `go test ./pkg/controller/instance ./pkg/controller/instanceset -count=1`: PASS (full touched packages)
- `go vet ./pkg/controller/instance ./pkg/controller/instanceset`: PASS
- `git diff --check`: PASS
- `gofmt -l`: clean

Test coverage:
- **Helper-level (positive, skip switchover)**: config-hash annotation change / non-restart annotation added / non-restart annotation value changed / label added / label value changed / role label state synchronization
- **Helper-level (negative, still invoke switchover)**: no diff / restart annotation added / restart annotation value changed / container image changed / container resources changed / container env changed
- **Call-site Reconcile-level**: asserts that when only `config.kubeblocks.io/config-hash` differs between the existing pod and the rebuilt pod, the pod is patched in-place AND the switchover lifecycle action is not invoked (`its.Spec.LifecycleActions.Switchover` is configured non-nil, so the assertion differentiates from the short-circuit case).

## Patch Identity Boundary

The PR history preserves five commits, each with a distinct runtime evidence anchor:

- `83c684357` (v1 production): the original config-hash-only helper. Valkey r15-patch round-1 (70min, N=1) and MariaDB T6 alpha.85 N=1 evidence are anchored to this commit.
- `1c8723184` (v2 test-only follow-up): adds negative test coverage; production code is identical to `83c684357`. MariaDB alpha.88 N=1 evidence is also anchored to this commit.
- `89c4e3c35` (v3 production rework): **production behavior changed** from config-hash-only to metadata-only excluding restart. The earlier evidence (Valkey r15-patch round-1, MariaDB alpha.85, MariaDB alpha.88) only validates the old helper and **does not extend to the new helper**.
- `821ba4f48` (v3.1 style-only follow-up): a single-line gofmt struct alignment; production behavior is equivalent to `89c4e3c35`.
- `8ee04938c` (v3.2 test + testability hook follow-up, current head): adds a Reconcile-level call-site Ginkgo test, plus converts `newLifecycleAction` in both packages from a function to a package-level variable so the test can substitute a spy. Production behavior is equivalent to `89c4e3c35`.

Before merge, the current head must be rebuilt as a patch image and re-tested. The runtime four-field provenance (source commit + image tag + live pod imageID + controller pod startTime) must record the actual built SHA (currently `8ee04938c`, production behavior equivalent to `89c4e3c35`).

## Related

- Continues the fix direction from stale #10188, with the design boundary tightened from config-hash-only (workaround) to process-impact-only (root-cause).
- Each iteration is recorded as a follow-up commit rather than an amend, so the patch identity anchors (`83c684357` and `89c4e3c35`) are preserved for historical patch-image evidence to remain traceable.