### PR TITLE
fix(component): honor image pull policy for kbagent

### DIFF
--- a/pkg/controller/component/kbagent.go
+++ b/pkg/controller/component/kbagent.go
@@ -134,11 +134,12 @@ func buildKBAgentContainer(synthesizedComp *SynthesizedComponent) error {
 	if err != nil {
 		return err
 	}
+	imagePullPolicy := kbAgentImagePullPolicy()
 
 	newContainer := func(name string, f func(*builder.ContainerBuilder) error) (*corev1.Container, error) {
 		b := builder.NewContainerBuilder(name).
 			SetImage(viper.GetString(constant.KBToolsImage)).
-			SetImagePullPolicy(corev1.PullIfNotPresent).
+			SetImagePullPolicy(imagePullPolicy).
 			AddCommands(kbAgentCommand).
 			AddEnv(mergedActionEnv4KBAgent(synthesizedComp)...).
 			AddEnv(envVars...).
@@ -462,7 +463,7 @@ func handleCustomImageNContainerDefined(synthesizedComp *SynthesizedComponent, c
 		// init-container to copy binaries to the shared mount point /kubeblocks
 		initContainer := builder.NewContainerBuilder(kbagent.InitContainerName).
 			SetImage(viper.GetString(constant.KBToolsImage)).
-			SetImagePullPolicy(corev1.PullIfNotPresent).
+			SetImagePullPolicy(kbAgentImagePullPolicy()).
 			AddCommands([]string{"cp", "-r", kbAgentCommand, kbAgentSharedMountPath + "/"}...).
 			AddVolumeMounts(sharedVolumeMount).
 			GetObject()
@@ -483,6 +484,13 @@ func handleCustomImageNContainerDefined(synthesizedComp *SynthesizedComponent, c
 	}
 
 	return nil
+}
+
+func kbAgentImagePullPolicy() corev1.PullPolicy {
+	if policy := corev1.PullPolicy(viper.GetString(constant.KBImagePullPolicy)); policy != "" {
+		return policy
+	}
+	return corev1.PullIfNotPresent
 }
 
 func customExecActionImageNContainer(synthesizedComp *SynthesizedComponent) (string, *corev1.Container, error) {

--- a/pkg/controller/component/kbagent_test.go
+++ b/pkg/controller/component/kbagent_test.go
@@ -320,6 +320,26 @@ var _ = Describe("kb-agent", func() {
 			Expect(c.VolumeMounts[0]).Should(Equal(roleLabelVolumeMount))
 		})
 
+		It("uses configured image pull policy", func() {
+			previous := viperx.GetString(constant.KBImagePullPolicy)
+			viperx.Set(constant.KBImagePullPolicy, string(corev1.PullNever))
+			DeferCleanup(func() {
+				viperx.Set(constant.KBImagePullPolicy, previous)
+			})
+			synthesizedComp.LifecycleActions.PostProvision.Exec.Image = "custom-action-image"
+
+			err := buildKBAgentContainer(synthesizedComp)
+			Expect(err).Should(BeNil())
+
+			c := kbAgentContainer()
+			Expect(c).ShouldNot(BeNil())
+			Expect(c.ImagePullPolicy).Should(Equal(corev1.PullNever))
+
+			ic := kbAgentInitContainer()
+			Expect(ic).ShouldNot(BeNil())
+			Expect(ic.ImagePullPolicy).Should(Equal(corev1.PullNever))
+		})
+
 		It("custom container - volume mounts", func() {
 			synthesizedComp.PodSpec.Containers[0].VolumeMounts = []corev1.VolumeMount{
 				{

--- a/pkg/controller/component/kbagent_unit_test.go
+++ b/pkg/controller/component/kbagent_unit_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package component
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/kbagent"
+	"github.com/apecloud/kubeblocks/pkg/viperx"
+)
+
+func TestBuildKBAgentContainerUsesConfiguredImagePullPolicy(t *testing.T) {
+	previous := viperx.GetString(constant.KBImagePullPolicy)
+	viperx.Set(constant.KBImagePullPolicy, string(corev1.PullNever))
+	t.Cleanup(func() {
+		viperx.Set(constant.KBImagePullPolicy, previous)
+	})
+
+	synthesizedComp := &SynthesizedComponent{
+		PodSpec: &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "mysql",
+				Image: "mysql:8.0",
+			}},
+		},
+		LifecycleActions: SynthesizedLifecycleActions{
+			ComponentLifecycleActions: &appsv1.ComponentLifecycleActions{
+				PostProvision: &appsv1.Action{
+					Exec: &appsv1.ExecAction{
+						Image:   "custom-action-image",
+						Command: []string{"echo", "hello"},
+					},
+				},
+			},
+		},
+	}
+
+	if err := buildKBAgentContainer(synthesizedComp); err != nil {
+		t.Fatalf("buildKBAgentContainer() error = %v", err)
+	}
+
+	var agent, initAgent *corev1.Container
+	for i := range synthesizedComp.PodSpec.Containers {
+		if synthesizedComp.PodSpec.Containers[i].Name == kbagent.ContainerName {
+			agent = &synthesizedComp.PodSpec.Containers[i]
+			break
+		}
+	}
+	for i := range synthesizedComp.PodSpec.InitContainers {
+		if synthesizedComp.PodSpec.InitContainers[i].Name == kbagent.InitContainerName {
+			initAgent = &synthesizedComp.PodSpec.InitContainers[i]
+			break
+		}
+	}
+	if agent == nil {
+		t.Fatalf("kbagent container not found")
+	}
+	if agent.ImagePullPolicy != corev1.PullNever {
+		t.Fatalf("kbagent imagePullPolicy = %q, want %q", agent.ImagePullPolicy, corev1.PullNever)
+	}
+	if initAgent == nil {
+		t.Fatalf("init-kbagent container not found")
+	}
+	if initAgent.ImagePullPolicy != corev1.PullNever {
+		t.Fatalf("init-kbagent imagePullPolicy = %q, want %q", initAgent.ImagePullPolicy, corev1.PullNever)
+	}
+}


### PR DESCRIPTION
## Summary
- make component kbagent and init-kbagent honor `KUBEBLOCKS_IMAGE_PULL_POLICY`
- keep the previous default by falling back to `IfNotPresent` when the config is empty
- add focused unit coverage for the main kbagent container and the init-kbagent path

## Scope
This only changes the component controller kbagent injection path. Existing DataProtection, custom Ops, and other job paths that already read `KBImagePullPolicy` are unchanged.

The empty-config fallback to `IfNotPresent` is deliberate backward compatibility with the previous hardcoded component kbagent behavior. It differs from some job paths that leave an empty pull policy for Kubernetes defaults, but avoids changing component kbagent behavior when `KUBEBLOCKS_IMAGE_PULL_POLICY` is not set.

## Validation
- `go test ./pkg/controller/component -run TestBuildKBAgentContainerUsesConfiguredImagePullPolicy -count=1`
- `go test -c ./pkg/controller/component`
- `git diff --check`

Local Ginkgo/envtest execution is not counted as passed because this machine is missing `/usr/local/kubebuilder/bin/etcd`; CI should provide that coverage.

## Context
MariaDB T6 validation hit a repeated kbagent tools image tag-alias trap while the KubeBlocks deployment had `KUBEBLOCKS_IMAGE_PULL_POLICY=Never`. The controller component path still injected kbagent with hardcoded `IfNotPresent`, so pod image resolution could re-enter the registry path.