### PR TITLE
fix(parameters): fail invalid component parameter desired values

### DIFF
--- a/controllers/parameters/componentparameter_controller_test.go
+++ b/controllers/parameters/componentparameter_controller_test.go
@@ -176,6 +176,35 @@ var _ = Describe("ComponentParameter Controller", func() {
 			})).Should(Succeed())
 		})
 
+		It("should fail when desired parameters violate ParametersDefinition schema", func() {
+			_, _, _, _, _ = mockReconcileResource()
+
+			cfgKey := client.ObjectKey{
+				Namespace: testCtx.DefaultNamespace,
+				Name:      core.GenerateComponentConfigurationName(clusterName, defaultCompName),
+			}
+			Eventually(testapps.CheckObj(&testCtx, cfgKey, func(g Gomega, cfg *parametersv1alpha1.ComponentParameter) {
+				g.Expect(cfg.Status.Phase).Should(BeEquivalentTo(parametersv1alpha1.CFinishedPhase))
+			})).Should(Succeed())
+
+			By("write an invalid desired parameter directly to ComponentParameter")
+			Eventually(testapps.GetAndChangeObj(&testCtx, cfgKey, func(cfg *parametersv1alpha1.ComponentParameter) {
+				cfg.Spec.Desired = &parametersv1alpha1.ParameterInputs{
+					Assignments: map[string]*string{
+						"max_connections": cfgutil.ToPointer("0"),
+					},
+				}
+			})).Should(Succeed())
+
+			By("verify ComponentParameter fails closed instead of finishing the change")
+			Eventually(testapps.CheckObj(&testCtx, cfgKey, func(g Gomega, cfg *parametersv1alpha1.ComponentParameter) {
+				g.Expect(cfg.Status.ObservedGeneration).Should(Equal(cfg.Generation))
+				g.Expect(cfg.Status.Phase).Should(BeEquivalentTo(parametersv1alpha1.CMergeFailedPhase))
+				g.Expect(cfg.Status.Message).Should(ContainSubstring("max_connections"))
+				g.Expect(cfg.Status.Message).Should(ContainSubstring("invalid"))
+			})).Should(Succeed())
+		})
+
 		It("should project init first and let desired override it", func() {
 			_, _, _, _, _ = mockReconcileResource()
 

--- a/pkg/operations/reconfigure.go
+++ b/pkg/operations/reconfigure.go
@@ -24,16 +24,20 @@ import (
 	"fmt"
 	"time"
 
+	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	opsv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
 	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/common"
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/sharding"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	parameters "github.com/apecloud/kubeblocks/pkg/parameters"
 	parameterscore "github.com/apecloud/kubeblocks/pkg/parameters/core"
+	"github.com/apecloud/kubeblocks/pkg/parameters/openapi"
 )
 
 type reconfigureAction struct {
@@ -57,6 +61,9 @@ var noRequeueAfter time.Duration = 0
 
 // ActionStartedCondition the started condition when handle the reconfiguring request.
 func (r *reconfigureAction) ActionStartedCondition(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes *OpsResource) (*metav1.Condition, error) {
+	if err := r.validateReconfigures(reqCtx.Ctx, cli, opsRes.Cluster, opsRes.OpsRequest.Spec.Reconfigures); err != nil {
+		return nil, err
+	}
 	return opsv1alpha1.NewReconfigureCondition(opsRes.OpsRequest), nil
 }
 
@@ -144,6 +151,9 @@ func (r *reconfigureAction) applyReconfigureToParameters(reqCtx intctrlutil.Requ
 	if err != nil {
 		return err
 	}
+	if err := r.validateReconfigureParameters(reqCtx.Ctx, cli, cluster, reconfigure); err != nil {
+		return err
+	}
 	patch := client.MergeFrom(compParam.DeepCopy())
 	if compParam.Spec.Desired == nil {
 		compParam.Spec.Desired = &parametersv1alpha1.ParameterInputs{}
@@ -160,6 +170,130 @@ func (r *reconfigureAction) applyReconfigureToParameters(reqCtx intctrlutil.Requ
 		return err
 	}
 	return nil
+}
+
+func (r *reconfigureAction) validateReconfigures(ctx context.Context, cli client.Client, cluster *appsv1.Cluster, reconfigures []opsv1alpha1.Reconfigure) error {
+	for _, reconfigure := range reconfigures {
+		if err := r.validateReconfigureParameters(ctx, cli, cluster, reconfigure); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *reconfigureAction) validateReconfigureParameters(ctx context.Context, cli client.Client, cluster *appsv1.Cluster, reconfigure opsv1alpha1.Reconfigure) error {
+	if len(reconfigure.Parameters) == 0 {
+		return nil
+	}
+	compDefName, err := r.resolveComponentDefinitionName(ctx, cli, cluster, reconfigure.ComponentName)
+	if err != nil {
+		return err
+	}
+	if compDefName == "" {
+		return nil
+	}
+	compDef, err := component.GetCompDefByName(ctx, cli, compDefName)
+	if err != nil {
+		return err
+	}
+	_, paramsDefs, err := parameters.ResolveCmpdParametersDefs(ctx, cli, compDef)
+	if err != nil {
+		return err
+	}
+	if !hasParameterSchema(paramsDefs) {
+		return nil
+	}
+	assignments := make(parametersv1alpha1.ComponentParameters, len(reconfigure.Parameters))
+	for _, param := range reconfigure.Parameters {
+		assignments[param.Key] = param.Value
+	}
+	if err := validateParameterAssignments(assignments, paramsDefs); err != nil {
+		return intctrlutil.NewFatalError(fmt.Sprintf("invalid reconfigure request for component %s: %s", reconfigure.ComponentName, err.Error()))
+	}
+	return nil
+}
+
+func (r *reconfigureAction) resolveComponentDefinitionName(ctx context.Context, cli client.Reader, cluster *appsv1.Cluster, compName string) (string, error) {
+	if compSpec := cluster.Spec.GetComponentByName(compName); compSpec != nil {
+		if compSpec.ComponentDef != "" {
+			return compSpec.ComponentDef, nil
+		}
+		return r.resolveComponentDefinitionNameFromComponent(ctx, cli, cluster, compName)
+	}
+	if shardingSpec := cluster.Spec.GetShardingByName(compName); shardingSpec != nil {
+		if shardingSpec.Template.ComponentDef != "" {
+			return shardingSpec.Template.ComponentDef, nil
+		}
+		comps, err := sharding.ListShardingComponents(ctx, cli, cluster, compName)
+		if err != nil {
+			return "", err
+		}
+		if len(comps) == 0 {
+			return "", fmt.Errorf("no component found for sharding %s", compName)
+		}
+		return comps[0].Spec.CompDef, nil
+	}
+	return "", intctrlutil.NewErrorf(intctrlutil.ErrorTypeFatal, "component not found: %s", compName)
+}
+
+func (r *reconfigureAction) resolveComponentDefinitionNameFromComponent(ctx context.Context, cli client.Reader, cluster *appsv1.Cluster, compName string) (string, error) {
+	comp, err := component.GetComponentByName(ctx, cli, cluster.Namespace, component.FullName(cluster.Name, compName))
+	if err != nil {
+		return "", err
+	}
+	return comp.Spec.CompDef, nil
+}
+
+func hasParameterSchema(paramsDefs []*parametersv1alpha1.ParametersDefinition) bool {
+	for _, paramsDef := range paramsDefs {
+		if paramsDef != nil && paramsDef.Spec.ParametersSchema != nil && paramsDef.Spec.ParametersSchema.SchemaInJSON != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func validateParameterAssignments(assignments parametersv1alpha1.ComponentParameters, paramsDefs []*parametersv1alpha1.ParametersDefinition) error {
+	for key, value := range assignments {
+		paramSchema, ok := findParameterSchema(paramsDefs, key)
+		if !ok {
+			return fmt.Errorf("parameter %s not found in parameters schema", key)
+		}
+		if value == nil {
+			continue
+		}
+		schema := &apiext.JSONSchemaProps{
+			Type: "object",
+			Properties: map[string]apiext.JSONSchemaProps{
+				key: paramSchema,
+			},
+		}
+		typedValue, err := common.ConvertStringToInterfaceBySchemaType(schema, map[string]string{key: *value})
+		if err != nil {
+			return fmt.Errorf("parameter %s value %q is invalid: %w", key, *value, err)
+		}
+		if err := common.ValidateDataWithSchema(schema, typedValue); err != nil {
+			return fmt.Errorf("parameter %s value %q is invalid: %w", key, *value, err)
+		}
+	}
+	return nil
+}
+
+func findParameterSchema(paramsDefs []*parametersv1alpha1.ParametersDefinition, key string) (apiext.JSONSchemaProps, bool) {
+	for _, paramsDef := range paramsDefs {
+		if paramsDef == nil || paramsDef.Spec.ParametersSchema == nil || paramsDef.Spec.ParametersSchema.SchemaInJSON == nil {
+			continue
+		}
+		specSchema, ok := paramsDef.Spec.ParametersSchema.SchemaInJSON.Properties[openapi.DefaultSchemaName]
+		if !ok {
+			continue
+		}
+		flattenedSchema := openapi.FlattenSchema(specSchema)
+		if schema, ok := parameters.FindParameterSchema(flattenedSchema.Properties, key); ok {
+			return schema, true
+		}
+	}
+	return apiext.JSONSchemaProps{}, false
 }
 
 func (r *reconfigureAction) resolveReconfigureComponents(ctx context.Context, reader client.Reader, cluster *appsv1.Cluster, compName string) ([]string, error) {

--- a/pkg/operations/reconfigure.go
+++ b/pkg/operations/reconfigure.go
@@ -21,7 +21,6 @@ package operations
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -34,7 +33,6 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/sharding"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
-	parameters "github.com/apecloud/kubeblocks/pkg/parameters"
 	parameterscore "github.com/apecloud/kubeblocks/pkg/parameters/core"
 )
 
@@ -59,9 +57,6 @@ var noRequeueAfter time.Duration = 0
 
 // ActionStartedCondition the started condition when handle the reconfiguring request.
 func (r *reconfigureAction) ActionStartedCondition(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes *OpsResource) (*metav1.Condition, error) {
-	if err := r.validateReconfigures(reqCtx.Ctx, cli, opsRes.Cluster, opsRes.OpsRequest.Spec.Reconfigures); err != nil {
-		return nil, err
-	}
 	return opsv1alpha1.NewReconfigureCondition(opsRes.OpsRequest), nil
 }
 
@@ -149,9 +144,6 @@ func (r *reconfigureAction) applyReconfigureToParameters(reqCtx intctrlutil.Requ
 	if err != nil {
 		return err
 	}
-	if err := r.validateReconfigureParameters(reqCtx.Ctx, cli, cluster, reconfigure); err != nil {
-		return err
-	}
 	patch := client.MergeFrom(compParam.DeepCopy())
 	if compParam.Spec.Desired == nil {
 		compParam.Spec.Desired = &parametersv1alpha1.ParameterInputs{}
@@ -164,41 +156,7 @@ func (r *reconfigureAction) applyReconfigureToParameters(reqCtx intctrlutil.Requ
 			compParam.Spec.Desired.Assignments[param.Key] = param.Value
 		}
 	}
-	if err := cli.Patch(reqCtx.Ctx, compParam, patch); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (r *reconfigureAction) validateReconfigures(ctx context.Context, cli client.Client, cluster *appsv1.Cluster, reconfigures []opsv1alpha1.Reconfigure) error {
-	for _, reconfigure := range reconfigures {
-		if err := r.validateReconfigureParameters(ctx, cli, cluster, reconfigure); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (r *reconfigureAction) validateReconfigureParameters(ctx context.Context, cli client.Client, cluster *appsv1.Cluster, reconfigure opsv1alpha1.Reconfigure) error {
-	if len(reconfigure.Parameters) == 0 {
-		return nil
-	}
-	assignments := make(parametersv1alpha1.ComponentParameters, len(reconfigure.Parameters))
-	for _, param := range reconfigure.Parameters {
-		assignments[param.Key] = param.Value
-	}
-	if err := parameters.ValidateComponentParameterAssignmentsForCluster(ctx, cli, cluster, reconfigure.ComponentName, assignments); err != nil {
-		var validationErr *parameters.AssignmentValidationError
-		if errors.As(err, &validationErr) {
-			return intctrlutil.NewFatalError(fmt.Sprintf("invalid reconfigure request for component %s: %s", reconfigure.ComponentName, err.Error()))
-		}
-		var targetNotFoundErr *parameters.AssignmentTargetNotFoundError
-		if errors.As(err, &targetNotFoundErr) {
-			return intctrlutil.NewFatalError(fmt.Sprintf("invalid reconfigure request: %s", err.Error()))
-		}
-		return err
-	}
-	return nil
+	return cli.Patch(reqCtx.Ctx, compParam, patch)
 }
 
 func (r *reconfigureAction) resolveReconfigureComponents(ctx context.Context, reader client.Reader, cluster *appsv1.Cluster, compName string) ([]string, error) {

--- a/pkg/operations/reconfigure.go
+++ b/pkg/operations/reconfigure.go
@@ -21,6 +21,7 @@ package operations
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -182,60 +183,22 @@ func (r *reconfigureAction) validateReconfigureParameters(ctx context.Context, c
 	if len(reconfigure.Parameters) == 0 {
 		return nil
 	}
-	compDefName, err := r.resolveComponentDefinitionName(ctx, cli, cluster, reconfigure.ComponentName)
-	if err != nil {
-		return err
-	}
-	if compDefName == "" {
-		return nil
-	}
-	compDef, err := component.GetCompDefByName(ctx, cli, compDefName)
-	if err != nil {
-		return err
-	}
-	_, paramsDefs, err := parameters.ResolveCmpdParametersDefs(ctx, cli, compDef)
-	if err != nil {
-		return err
-	}
 	assignments := make(parametersv1alpha1.ComponentParameters, len(reconfigure.Parameters))
 	for _, param := range reconfigure.Parameters {
 		assignments[param.Key] = param.Value
 	}
-	if err := parameters.ValidateComponentParameterAssignments(assignments, paramsDefs); err != nil {
-		return intctrlutil.NewFatalError(fmt.Sprintf("invalid reconfigure request for component %s: %s", reconfigure.ComponentName, err.Error()))
+	if err := parameters.ValidateComponentParameterAssignmentsForCluster(ctx, cli, cluster, reconfigure.ComponentName, assignments); err != nil {
+		var validationErr *parameters.AssignmentValidationError
+		if errors.As(err, &validationErr) {
+			return intctrlutil.NewFatalError(fmt.Sprintf("invalid reconfigure request for component %s: %s", reconfigure.ComponentName, err.Error()))
+		}
+		var targetNotFoundErr *parameters.AssignmentTargetNotFoundError
+		if errors.As(err, &targetNotFoundErr) {
+			return intctrlutil.NewFatalError(fmt.Sprintf("invalid reconfigure request: %s", err.Error()))
+		}
+		return err
 	}
 	return nil
-}
-
-func (r *reconfigureAction) resolveComponentDefinitionName(ctx context.Context, cli client.Reader, cluster *appsv1.Cluster, compName string) (string, error) {
-	if compSpec := cluster.Spec.GetComponentByName(compName); compSpec != nil {
-		if compSpec.ComponentDef != "" {
-			return compSpec.ComponentDef, nil
-		}
-		return r.resolveComponentDefinitionNameFromComponent(ctx, cli, cluster, compName)
-	}
-	if shardingSpec := cluster.Spec.GetShardingByName(compName); shardingSpec != nil {
-		if shardingSpec.Template.ComponentDef != "" {
-			return shardingSpec.Template.ComponentDef, nil
-		}
-		comps, err := sharding.ListShardingComponents(ctx, cli, cluster, compName)
-		if err != nil {
-			return "", err
-		}
-		if len(comps) == 0 {
-			return "", fmt.Errorf("no component found for sharding %s", compName)
-		}
-		return comps[0].Spec.CompDef, nil
-	}
-	return "", intctrlutil.NewErrorf(intctrlutil.ErrorTypeFatal, "component not found: %s", compName)
-}
-
-func (r *reconfigureAction) resolveComponentDefinitionNameFromComponent(ctx context.Context, cli client.Reader, cluster *appsv1.Cluster, compName string) (string, error) {
-	comp, err := component.GetComponentByName(ctx, cli, cluster.Namespace, component.FullName(cluster.Name, compName))
-	if err != nil {
-		return "", err
-	}
-	return comp.Spec.CompDef, nil
 }
 
 func (r *reconfigureAction) resolveReconfigureComponents(ctx context.Context, reader client.Reader, cluster *appsv1.Cluster, compName string) ([]string, error) {

--- a/pkg/operations/reconfigure.go
+++ b/pkg/operations/reconfigure.go
@@ -24,20 +24,17 @@ import (
 	"fmt"
 	"time"
 
-	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	opsv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
 	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
-	"github.com/apecloud/kubeblocks/pkg/common"
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/sharding"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	parameters "github.com/apecloud/kubeblocks/pkg/parameters"
 	parameterscore "github.com/apecloud/kubeblocks/pkg/parameters/core"
-	"github.com/apecloud/kubeblocks/pkg/parameters/openapi"
 )
 
 type reconfigureAction struct {
@@ -200,14 +197,11 @@ func (r *reconfigureAction) validateReconfigureParameters(ctx context.Context, c
 	if err != nil {
 		return err
 	}
-	if !hasParameterSchema(paramsDefs) {
-		return nil
-	}
 	assignments := make(parametersv1alpha1.ComponentParameters, len(reconfigure.Parameters))
 	for _, param := range reconfigure.Parameters {
 		assignments[param.Key] = param.Value
 	}
-	if err := validateParameterAssignments(assignments, paramsDefs); err != nil {
+	if err := parameters.ValidateComponentParameterAssignments(assignments, paramsDefs); err != nil {
 		return intctrlutil.NewFatalError(fmt.Sprintf("invalid reconfigure request for component %s: %s", reconfigure.ComponentName, err.Error()))
 	}
 	return nil
@@ -242,58 +236,6 @@ func (r *reconfigureAction) resolveComponentDefinitionNameFromComponent(ctx cont
 		return "", err
 	}
 	return comp.Spec.CompDef, nil
-}
-
-func hasParameterSchema(paramsDefs []*parametersv1alpha1.ParametersDefinition) bool {
-	for _, paramsDef := range paramsDefs {
-		if paramsDef != nil && paramsDef.Spec.ParametersSchema != nil && paramsDef.Spec.ParametersSchema.SchemaInJSON != nil {
-			return true
-		}
-	}
-	return false
-}
-
-func validateParameterAssignments(assignments parametersv1alpha1.ComponentParameters, paramsDefs []*parametersv1alpha1.ParametersDefinition) error {
-	for key, value := range assignments {
-		paramSchema, ok := findParameterSchema(paramsDefs, key)
-		if !ok {
-			return fmt.Errorf("parameter %s not found in parameters schema", key)
-		}
-		if value == nil {
-			continue
-		}
-		schema := &apiext.JSONSchemaProps{
-			Type: "object",
-			Properties: map[string]apiext.JSONSchemaProps{
-				key: paramSchema,
-			},
-		}
-		typedValue, err := common.ConvertStringToInterfaceBySchemaType(schema, map[string]string{key: *value})
-		if err != nil {
-			return fmt.Errorf("parameter %s value %q is invalid: %w", key, *value, err)
-		}
-		if err := common.ValidateDataWithSchema(schema, typedValue); err != nil {
-			return fmt.Errorf("parameter %s value %q is invalid: %w", key, *value, err)
-		}
-	}
-	return nil
-}
-
-func findParameterSchema(paramsDefs []*parametersv1alpha1.ParametersDefinition, key string) (apiext.JSONSchemaProps, bool) {
-	for _, paramsDef := range paramsDefs {
-		if paramsDef == nil || paramsDef.Spec.ParametersSchema == nil || paramsDef.Spec.ParametersSchema.SchemaInJSON == nil {
-			continue
-		}
-		specSchema, ok := paramsDef.Spec.ParametersSchema.SchemaInJSON.Properties[openapi.DefaultSchemaName]
-		if !ok {
-			continue
-		}
-		flattenedSchema := openapi.FlattenSchema(specSchema)
-		if schema, ok := parameters.FindParameterSchema(flattenedSchema.Properties, key); ok {
-			return schema, true
-		}
-	}
-	return apiext.JSONSchemaProps{}, false
 }
 
 func (r *reconfigureAction) resolveReconfigureComponents(ctx context.Context, reader client.Reader, cluster *appsv1.Cluster, compName string) ([]string, error) {

--- a/pkg/operations/reconfigure_test.go
+++ b/pkg/operations/reconfigure_test.go
@@ -24,6 +24,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -199,6 +201,71 @@ parameter: {
 			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsSucceedPhase))
 
 			Expect(err).Should(BeNil())
+		})
+
+		It("rejects parameter values outside ParametersDefinition schema", func() {
+			By("init operations resources ")
+			reqCtx := intctrlutil.RequestCtx{Ctx: ctx}
+			opsRes, _, _ := initOperationsResources(compDefName, clusterName)
+
+			By("prepare parameter schema and component parameter")
+			paramsDef := testparameters.NewParametersDefinitionFactory("valkey-params-" + randomStr).
+				SetComponentDefinition(compDefName).
+				SetTemplateName("valkey-config").
+				SetConfigFile("valkey.conf").
+				SetFileFormatConfig(parametersv1alpha1.FileFormatConfig{Format: parametersv1alpha1.RedisCfg}).
+				Schema(`
+parameter: {
+  "maxmemory-samples"?: int & >=1 & <=10
+  "maxmemory-policy"?: string & "noeviction" | "allkeys-lru" | "volatile-lru"
+}`).
+				Create(&testCtx).
+				GetObject()
+			Expect(testapps.ChangeObjStatus(&testCtx, paramsDef, func() {
+				paramsDef.Status.Phase = parametersv1alpha1.PDAvailablePhase
+			})).Should(Succeed())
+
+			componentParameter := builder.NewComponentParameterBuilder(testCtx.DefaultNamespace, parameterscore.GenerateComponentConfigurationName(clusterName, defaultCompName)).
+				AddLabelsInMap(constant.GetCompLabelsWithDef(clusterName, defaultCompName, compDefName)).
+				SetClusterName(clusterName).
+				SetCompName(defaultCompName).
+				GetObject()
+			Expect(testCtx.CreateObj(ctx, componentParameter)).Should(Succeed())
+
+			By("create an invalid reconfigure opsRequest")
+			ops := testops.NewOpsRequestObj("invalid-reconfigure-"+randomStr, testCtx.DefaultNamespace,
+				clusterName, opsv1alpha1.ReconfiguringType)
+			ops.Spec.Reconfigures = []opsv1alpha1.Reconfigure{
+				{
+					ComponentOps: opsv1alpha1.ComponentOps{ComponentName: defaultCompName},
+					Parameters: []opsv1alpha1.ParameterPair{
+						{
+							Key:   "maxmemory-samples",
+							Value: pointer.String("0"),
+						},
+					},
+				},
+			}
+			opsRes.OpsRequest = testops.CreateOpsRequest(ctx, testCtx, ops)
+
+			By("reject the ops before marking validation passed or writing invalid desired assignments")
+			Expect(opsutil.UpdateClusterOpsAnnotations(ctx, k8sClient, opsRes.Cluster, nil)).Should(Succeed())
+
+			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsPendingPhase
+			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest), func(g Gomega, fetched *opsv1alpha1.OpsRequest) {
+				g.Expect(fetched.Status.Phase).Should(Equal(opsv1alpha1.OpsFailedPhase))
+				condition := meta.FindStatusCondition(fetched.Status.Conditions, opsv1alpha1.ConditionTypeValidated)
+				g.Expect(condition).ShouldNot(BeNil())
+				g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
+				g.Expect(condition.Message).Should(ContainSubstring("maxmemory-samples"))
+				g.Expect(condition.Message).Should(ContainSubstring("invalid"))
+			})).Should(Succeed())
+
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(componentParameter), func(g Gomega, cp *parametersv1alpha1.ComponentParameter) {
+				g.Expect(cp.Spec.Desired).Should(BeNil())
+			})).Should(Succeed())
 		})
 	})
 })

--- a/pkg/operations/reconfigure_test.go
+++ b/pkg/operations/reconfigure_test.go
@@ -25,7 +25,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -203,27 +202,10 @@ parameter: {
 			Expect(err).Should(BeNil())
 		})
 
-		It("rejects parameter values outside ParametersDefinition schema", func() {
+		It("propagates ComponentParameter merge failure", func() {
 			By("init operations resources ")
 			reqCtx := intctrlutil.RequestCtx{Ctx: ctx}
 			opsRes, _, _ := initOperationsResources(compDefName, clusterName)
-
-			By("prepare parameter schema and component parameter")
-			paramsDef := testparameters.NewParametersDefinitionFactory("valkey-params-" + randomStr).
-				SetComponentDefinition(compDefName).
-				SetTemplateName("valkey-config").
-				SetConfigFile("valkey.conf").
-				SetFileFormatConfig(parametersv1alpha1.FileFormatConfig{Format: parametersv1alpha1.RedisCfg}).
-				Schema(`
-parameter: {
-  "maxmemory-samples"?: int & >=1 & <=10
-  "maxmemory-policy"?: string & "noeviction" | "allkeys-lru" | "volatile-lru"
-}`).
-				Create(&testCtx).
-				GetObject()
-			Expect(testapps.ChangeObjStatus(&testCtx, paramsDef, func() {
-				paramsDef.Status.Phase = parametersv1alpha1.PDAvailablePhase
-			})).Should(Succeed())
 
 			componentParameter := builder.NewComponentParameterBuilder(testCtx.DefaultNamespace, parameterscore.GenerateComponentConfigurationName(clusterName, defaultCompName)).
 				AddLabelsInMap(constant.GetCompLabelsWithDef(clusterName, defaultCompName, compDefName)).
@@ -232,8 +214,8 @@ parameter: {
 				GetObject()
 			Expect(testCtx.CreateObj(ctx, componentParameter)).Should(Succeed())
 
-			By("create an invalid reconfigure opsRequest")
-			ops := testops.NewOpsRequestObj("invalid-reconfigure-"+randomStr, testCtx.DefaultNamespace,
+			By("create a reconfigure opsRequest")
+			ops := testops.NewOpsRequestObj("failed-reconfigure-"+randomStr, testCtx.DefaultNamespace,
 				clusterName, opsv1alpha1.ReconfiguringType)
 			ops.Spec.Reconfigures = []opsv1alpha1.Reconfigure{
 				{
@@ -248,23 +230,38 @@ parameter: {
 			}
 			opsRes.OpsRequest = testops.CreateOpsRequest(ctx, testCtx, ops)
 
-			By("reject the ops before marking validation passed or writing invalid desired assignments")
+			By("write desired parameters through the ops path")
 			Expect(opsutil.UpdateClusterOpsAnnotations(ctx, k8sClient, opsRes.Cluster, nil)).Should(Succeed())
 
 			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsPendingPhase
 			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)
 			Expect(err).ShouldNot(HaveOccurred())
-			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest), func(g Gomega, fetched *opsv1alpha1.OpsRequest) {
-				g.Expect(fetched.Status.Phase).Should(Equal(opsv1alpha1.OpsFailedPhase))
-				condition := meta.FindStatusCondition(fetched.Status.Conditions, opsv1alpha1.ConditionTypeValidated)
-				g.Expect(condition).ShouldNot(BeNil())
-				g.Expect(condition.Status).Should(Equal(metav1.ConditionFalse))
-				g.Expect(condition.Message).Should(ContainSubstring("maxmemory-samples"))
-				g.Expect(condition.Message).Should(ContainSubstring("invalid"))
+			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsCreatingPhase))
+			_, err = GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(componentParameter), func(g Gomega, cp *parametersv1alpha1.ComponentParameter) {
+				g.Expect(cp.Spec.Desired).ShouldNot(BeNil())
+				g.Expect(cp.Spec.Desired.Assignments).Should(HaveKeyWithValue("maxmemory-samples", pointer.String("0")))
 			})).Should(Succeed())
 
-			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(componentParameter), func(g Gomega, cp *parametersv1alpha1.ComponentParameter) {
-				g.Expect(cp.Spec.Desired).Should(BeNil())
+			By("surface the ComponentParameter failure back to the opsRequest")
+			Expect(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKeyFromObject(componentParameter), func(cp *parametersv1alpha1.ComponentParameter) {
+				cp.Status.ObservedGeneration = cp.Generation
+				cp.Status.Phase = parametersv1alpha1.CMergeFailedPhase
+				cp.Status.Message = "parameter maxmemory-samples value \"0\" is invalid"
+				cp.Status.ConfigurationItemStatus = []parametersv1alpha1.ConfigTemplateItemDetailStatus{{
+					Name:  cp.Spec.ConfigItemDetails[0].Name,
+					Phase: parametersv1alpha1.CMergeFailedPhase,
+				}}
+			})()).Should(Succeed())
+			Expect(testCtx.Cli.Get(ctx, client.ObjectKeyFromObject(opsRes.OpsRequest), opsRes.OpsRequest)).Should(Succeed())
+			_, err = GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest), func(g Gomega, fetched *opsv1alpha1.OpsRequest) {
+				g.Expect(fetched.Status.Phase).Should(Equal(opsv1alpha1.OpsFailedPhase))
+				condition := meta.FindStatusCondition(fetched.Status.Conditions, opsv1alpha1.ConditionTypeFailed)
+				g.Expect(condition).ShouldNot(BeNil())
+				g.Expect(condition.Message).Should(ContainSubstring("maxmemory-samples"))
 			})).Should(Succeed())
 		})
 	})

--- a/pkg/operations/reconfigure_test.go
+++ b/pkg/operations/reconfigure_test.go
@@ -250,7 +250,7 @@ parameter: {
 				cp.Status.Phase = parametersv1alpha1.CMergeFailedPhase
 				cp.Status.Message = "parameter maxmemory-samples value \"0\" is invalid"
 				cp.Status.ConfigurationItemStatus = []parametersv1alpha1.ConfigTemplateItemDetailStatus{{
-					Name:  cp.Spec.ConfigItemDetails[0].Name,
+					Name:  "mysql-config",
 					Phase: parametersv1alpha1.CMergeFailedPhase,
 				}}
 			})()).Should(Succeed())

--- a/pkg/operations/reconfigure_unit_test.go
+++ b/pkg/operations/reconfigure_unit_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package operations
+
+import (
+	"testing"
+
+	"k8s.io/utils/pointer"
+
+	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
+	testparameters "github.com/apecloud/kubeblocks/pkg/testutil/parameters"
+)
+
+func TestValidateParameterAssignments(t *testing.T) {
+	paramsDef := testparameters.NewParametersDefinitionFactory("valkey-params").
+		SetTemplateName("valkey-config").
+		SetConfigFile("valkey.conf").
+		SetFileFormatConfig(parametersv1alpha1.FileFormatConfig{Format: parametersv1alpha1.RedisCfg}).
+		Schema(`
+parameter: {
+  "maxmemory-samples"?: int & >=1 & <=10
+  "maxmemory-policy"?: string & "noeviction" | "allkeys-lru" | "volatile-lru"
+}`).
+		GetObject()
+
+	tests := []struct {
+		name        string
+		assignments parametersv1alpha1.ComponentParameters
+		wantErr     bool
+	}{
+		{
+			name: "valid integer and enum",
+			assignments: parametersv1alpha1.ComponentParameters{
+				"maxmemory-samples": pointer.String("5"),
+				"maxmemory-policy":  pointer.String("volatile-lru"),
+			},
+		},
+		{
+			name: "reject integer below minimum",
+			assignments: parametersv1alpha1.ComponentParameters{
+				"maxmemory-samples": pointer.String("0"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "reject integer above maximum",
+			assignments: parametersv1alpha1.ComponentParameters{
+				"maxmemory-samples": pointer.String("11"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "reject integer parse error",
+			assignments: parametersv1alpha1.ComponentParameters{
+				"maxmemory-samples": pointer.String("not-an-int"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "reject enum miss",
+			assignments: parametersv1alpha1.ComponentParameters{
+				"maxmemory-policy": pointer.String("definitely-not-a-policy"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "reject unknown parameter when schema exists",
+			assignments: parametersv1alpha1.ComponentParameters{
+				"not-a-real-parameter": pointer.String("1"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "allow deletion for known parameter",
+			assignments: parametersv1alpha1.ComponentParameters{
+				"maxmemory-samples": nil,
+			},
+		},
+		{
+			name: "reject deletion for unknown parameter",
+			assignments: parametersv1alpha1.ComponentParameters{
+				"not-a-real-parameter": nil,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateParameterAssignments(tt.assignments, []*parametersv1alpha1.ParametersDefinition{paramsDef})
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected validation error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no validation error, got %v", err)
+			}
+		})
+	}
+}

--- a/pkg/parameters/parameter_assignment.go
+++ b/pkg/parameters/parameter_assignment.go
@@ -20,14 +20,64 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package parameters
 
 import (
+	"context"
 	"fmt"
 
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/common"
+	"github.com/apecloud/kubeblocks/pkg/controller/component"
+	"github.com/apecloud/kubeblocks/pkg/controller/sharding"
 	"github.com/apecloud/kubeblocks/pkg/parameters/openapi"
 )
+
+type AssignmentValidationError struct {
+	Err error
+}
+
+func (e *AssignmentValidationError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *AssignmentValidationError) Unwrap() error {
+	return e.Err
+}
+
+type AssignmentTargetNotFoundError struct {
+	ComponentName string
+}
+
+func (e *AssignmentTargetNotFoundError) Error() string {
+	return fmt.Sprintf("component not found: %s", e.ComponentName)
+}
+
+// ValidateComponentParameterAssignmentsForCluster resolves the component's ParametersDefinition
+// and validates assignments at the parameters layer.
+func ValidateComponentParameterAssignmentsForCluster(ctx context.Context, reader client.Reader,
+	cluster *appsv1.Cluster, componentName string, assignments parametersv1alpha1.ComponentParameters) error {
+	if len(assignments) == 0 {
+		return nil
+	}
+	compDefName, err := resolveComponentDefinitionName(ctx, reader, cluster, componentName)
+	if err != nil {
+		return err
+	}
+	compDef, err := component.GetCompDefByName(ctx, reader, compDefName)
+	if err != nil {
+		return err
+	}
+	_, paramsDefs, err := ResolveCmpdParametersDefs(ctx, reader, compDef)
+	if err != nil {
+		return err
+	}
+	if err := ValidateComponentParameterAssignments(assignments, paramsDefs); err != nil {
+		return &AssignmentValidationError{Err: err}
+	}
+	return nil
+}
 
 // ValidateComponentParameterAssignments validates parameter assignments when the component
 // has ParametersDefinition JSON schema. Components without schema keep legacy behavior.
@@ -85,4 +135,41 @@ func findParameterSchema(paramsDefs []*parametersv1alpha1.ParametersDefinition, 
 		}
 	}
 	return apiext.JSONSchemaProps{}, false
+}
+
+func resolveComponentDefinitionName(ctx context.Context, reader client.Reader, cluster *appsv1.Cluster, componentName string) (string, error) {
+	if compSpec := cluster.Spec.GetComponentByName(componentName); compSpec != nil {
+		if compSpec.ComponentDef != "" {
+			return compSpec.ComponentDef, nil
+		}
+		return resolveComponentDefinitionNameFromComponent(ctx, reader, cluster, componentName)
+	}
+	if shardingSpec := cluster.Spec.GetShardingByName(componentName); shardingSpec != nil {
+		if shardingSpec.Template.ComponentDef != "" {
+			return shardingSpec.Template.ComponentDef, nil
+		}
+		comps, err := sharding.ListShardingComponents(ctx, reader, cluster, componentName)
+		if err != nil {
+			return "", err
+		}
+		if len(comps) == 0 {
+			return "", fmt.Errorf("no component found for sharding %s", componentName)
+		}
+		if comps[0].Spec.CompDef == "" {
+			return "", fmt.Errorf("component definition is empty for sharding %s", componentName)
+		}
+		return comps[0].Spec.CompDef, nil
+	}
+	return "", &AssignmentTargetNotFoundError{ComponentName: componentName}
+}
+
+func resolveComponentDefinitionNameFromComponent(ctx context.Context, reader client.Reader, cluster *appsv1.Cluster, componentName string) (string, error) {
+	comp, err := component.GetComponentByName(ctx, reader, cluster.Namespace, component.FullName(cluster.Name, componentName))
+	if err != nil {
+		return "", err
+	}
+	if comp.Spec.CompDef == "" {
+		return "", fmt.Errorf("component definition is empty for component %s", componentName)
+	}
+	return comp.Spec.CompDef, nil
 }

--- a/pkg/parameters/parameter_assignment.go
+++ b/pkg/parameters/parameter_assignment.go
@@ -1,0 +1,88 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package parameters
+
+import (
+	"fmt"
+
+	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/common"
+	"github.com/apecloud/kubeblocks/pkg/parameters/openapi"
+)
+
+// ValidateComponentParameterAssignments validates parameter assignments when the component
+// has ParametersDefinition JSON schema. Components without schema keep legacy behavior.
+func ValidateComponentParameterAssignments(assignments parametersv1alpha1.ComponentParameters,
+	paramsDefs []*parametersv1alpha1.ParametersDefinition) error {
+	if !hasParameterSchema(paramsDefs) {
+		return nil
+	}
+	for key, value := range assignments {
+		paramSchema, ok := findParameterSchema(paramsDefs, key)
+		if !ok {
+			return fmt.Errorf("parameter %s not found in parameters schema", key)
+		}
+		if value == nil {
+			continue
+		}
+		schema := &apiext.JSONSchemaProps{
+			Type: "object",
+			Properties: map[string]apiext.JSONSchemaProps{
+				key: paramSchema,
+			},
+		}
+		typedValue, err := common.ConvertStringToInterfaceBySchemaType(schema, map[string]string{key: *value})
+		if err != nil {
+			return fmt.Errorf("parameter %s value %q is invalid: %w", key, *value, err)
+		}
+		if err := common.ValidateDataWithSchema(schema, typedValue); err != nil {
+			return fmt.Errorf("parameter %s value %q is invalid: %w", key, *value, err)
+		}
+	}
+	return nil
+}
+
+func hasParameterSchema(paramsDefs []*parametersv1alpha1.ParametersDefinition) bool {
+	for _, paramsDef := range paramsDefs {
+		if paramsDef != nil && paramsDef.Spec.ParametersSchema != nil && paramsDef.Spec.ParametersSchema.SchemaInJSON != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func findParameterSchema(paramsDefs []*parametersv1alpha1.ParametersDefinition, key string) (apiext.JSONSchemaProps, bool) {
+	for _, paramsDef := range paramsDefs {
+		if paramsDef == nil || paramsDef.Spec.ParametersSchema == nil || paramsDef.Spec.ParametersSchema.SchemaInJSON == nil {
+			continue
+		}
+		specSchema, ok := paramsDef.Spec.ParametersSchema.SchemaInJSON.Properties[openapi.DefaultSchemaName]
+		if !ok {
+			continue
+		}
+		flattenedSchema := openapi.FlattenSchema(specSchema)
+		if schema, ok := FindParameterSchema(flattenedSchema.Properties, key); ok {
+			return schema, true
+		}
+	}
+	return apiext.JSONSchemaProps{}, false
+}

--- a/pkg/parameters/parameter_assignment.go
+++ b/pkg/parameters/parameter_assignment.go
@@ -20,64 +20,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package parameters
 
 import (
-	"context"
 	"fmt"
 
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/common"
-	"github.com/apecloud/kubeblocks/pkg/controller/component"
-	"github.com/apecloud/kubeblocks/pkg/controller/sharding"
 	"github.com/apecloud/kubeblocks/pkg/parameters/openapi"
 )
-
-type AssignmentValidationError struct {
-	Err error
-}
-
-func (e *AssignmentValidationError) Error() string {
-	return e.Err.Error()
-}
-
-func (e *AssignmentValidationError) Unwrap() error {
-	return e.Err
-}
-
-type AssignmentTargetNotFoundError struct {
-	ComponentName string
-}
-
-func (e *AssignmentTargetNotFoundError) Error() string {
-	return fmt.Sprintf("component not found: %s", e.ComponentName)
-}
-
-// ValidateComponentParameterAssignmentsForCluster resolves the component's ParametersDefinition
-// and validates assignments at the parameters layer.
-func ValidateComponentParameterAssignmentsForCluster(ctx context.Context, reader client.Reader,
-	cluster *appsv1.Cluster, componentName string, assignments parametersv1alpha1.ComponentParameters) error {
-	if len(assignments) == 0 {
-		return nil
-	}
-	compDefName, err := resolveComponentDefinitionName(ctx, reader, cluster, componentName)
-	if err != nil {
-		return err
-	}
-	compDef, err := component.GetCompDefByName(ctx, reader, compDefName)
-	if err != nil {
-		return err
-	}
-	_, paramsDefs, err := ResolveCmpdParametersDefs(ctx, reader, compDef)
-	if err != nil {
-		return err
-	}
-	if err := ValidateComponentParameterAssignments(assignments, paramsDefs); err != nil {
-		return &AssignmentValidationError{Err: err}
-	}
-	return nil
-}
 
 // ValidateComponentParameterAssignments validates parameter assignments when the component
 // has ParametersDefinition JSON schema. Components without schema keep legacy behavior.
@@ -135,41 +85,4 @@ func findParameterSchema(paramsDefs []*parametersv1alpha1.ParametersDefinition, 
 		}
 	}
 	return apiext.JSONSchemaProps{}, false
-}
-
-func resolveComponentDefinitionName(ctx context.Context, reader client.Reader, cluster *appsv1.Cluster, componentName string) (string, error) {
-	if compSpec := cluster.Spec.GetComponentByName(componentName); compSpec != nil {
-		if compSpec.ComponentDef != "" {
-			return compSpec.ComponentDef, nil
-		}
-		return resolveComponentDefinitionNameFromComponent(ctx, reader, cluster, componentName)
-	}
-	if shardingSpec := cluster.Spec.GetShardingByName(componentName); shardingSpec != nil {
-		if shardingSpec.Template.ComponentDef != "" {
-			return shardingSpec.Template.ComponentDef, nil
-		}
-		comps, err := sharding.ListShardingComponents(ctx, reader, cluster, componentName)
-		if err != nil {
-			return "", err
-		}
-		if len(comps) == 0 {
-			return "", fmt.Errorf("no component found for sharding %s", componentName)
-		}
-		if comps[0].Spec.CompDef == "" {
-			return "", fmt.Errorf("component definition is empty for sharding %s", componentName)
-		}
-		return comps[0].Spec.CompDef, nil
-	}
-	return "", &AssignmentTargetNotFoundError{ComponentName: componentName}
-}
-
-func resolveComponentDefinitionNameFromComponent(ctx context.Context, reader client.Reader, cluster *appsv1.Cluster, componentName string) (string, error) {
-	comp, err := component.GetComponentByName(ctx, reader, cluster.Namespace, component.FullName(cluster.Name, componentName))
-	if err != nil {
-		return "", err
-	}
-	if comp.Spec.CompDef == "" {
-		return "", fmt.Errorf("component definition is empty for component %s", componentName)
-	}
-	return comp.Spec.CompDef, nil
 }

--- a/pkg/parameters/parameter_assignment_test.go
+++ b/pkg/parameters/parameter_assignment_test.go
@@ -17,7 +17,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-package operations
+package parameters
 
 import (
 	"testing"
@@ -28,7 +28,7 @@ import (
 	testparameters "github.com/apecloud/kubeblocks/pkg/testutil/parameters"
 )
 
-func TestValidateParameterAssignments(t *testing.T) {
+func TestValidateComponentParameterAssignments(t *testing.T) {
 	paramsDef := testparameters.NewParametersDefinitionFactory("valkey-params").
 		SetTemplateName("valkey-config").
 		SetConfigFile("valkey.conf").
@@ -104,7 +104,7 @@ parameter: {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateParameterAssignments(tt.assignments, []*parametersv1alpha1.ParametersDefinition{paramsDef})
+			err := ValidateComponentParameterAssignments(tt.assignments, []*parametersv1alpha1.ParametersDefinition{paramsDef})
 			if tt.wantErr && err == nil {
 				t.Fatalf("expected validation error")
 			}

--- a/pkg/parameters/parameter_utils.go
+++ b/pkg/parameters/parameter_utils.go
@@ -95,6 +95,9 @@ func ClassifyComponentParameters(parameters parametersv1alpha1.ComponentParamete
 	if !hasValidParametersDefinition(parametersDefs) {
 		return transformDefaultParameters(parameters, configs)
 	}
+	if err := ValidateComponentParameterAssignments(parameters, parametersDefs); err != nil {
+		return nil, err
+	}
 
 	classifyParams := make(map[string]map[string]*parametersv1alpha1.ParametersInFile, len(templates))
 	parametersMap, err := resolveSchemaFromParametersDefinition(parametersDefs, templates, tpls)

--- a/pkg/parameters/validate/config_validate.go
+++ b/pkg/parameters/validate/config_validate.go
@@ -21,12 +21,9 @@ package validate
 
 import (
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	"k8s.io/kube-openapi/pkg/validation/errors"
-	kubeopenapispec "k8s.io/kube-openapi/pkg/validation/spec"
-	"k8s.io/kube-openapi/pkg/validation/strfmt"
-	"k8s.io/kube-openapi/pkg/validation/validate"
 
 	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/common"
 	"github.com/apecloud/kubeblocks/pkg/parameters/core"
 )
 
@@ -59,13 +56,11 @@ func (s *schemaValidator) Validate(content string) error {
 	var err error
 	var parameters map[string]interface{}
 
-	openAPITypes := &kubeopenapispec.Schema{}
-	validator := validate.NewSchemaValidator(openAPITypes, nil, "", strfmt.Default)
 	if parameters, err = LoadConfigObjectFromContent(s.cfgType, content); err != nil {
 		return err
 	}
-	if res := validator.Validate(parameters); res.HasErrors() {
-		return core.WrapError(errors.CompositeValidationError(res.Errors...), "failed to schema validate for config file")
+	if err = common.ValidateDataWithSchema(s.schema, parameters); err != nil {
+		return core.WrapError(err, "failed to schema validate for config file")
 	}
 	return nil
 }

--- a/pkg/parameters/validate/config_validate_test.go
+++ b/pkg/parameters/validate/config_validate_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
 	"github.com/apecloud/kubeblocks/test/testdata"
@@ -165,4 +166,24 @@ func TestSchemaValidatorWithOpenSchema(t *testing.T) {
 			require.Equal(t, tt.err, validator.Validate(fromTestData(tt.args.configFile)))
 		})
 	}
+}
+
+func TestSchemaValidatorUsesSchemaInJSON(t *testing.T) {
+	minimum := float64(1)
+	maximum := float64(10)
+	validator := NewConfigValidator(&parametersv1alpha1.ParametersSchema{
+		SchemaInJSON: &apiext.JSONSchemaProps{
+			Type: "object",
+			Properties: map[string]apiext.JSONSchemaProps{
+				"maxmemory-samples": {
+					Type:    "integer",
+					Minimum: &minimum,
+					Maximum: &maximum,
+				},
+			},
+		},
+	}, &parametersv1alpha1.FileFormatConfig{Format: parametersv1alpha1.YAML})
+
+	require.NoError(t, validator.Validate("maxmemory-samples: 5"))
+	require.ErrorContains(t, validator.Validate("maxmemory-samples: 0"), "failed to schema validate for config file")
 }

--- a/pkg/parameters/validate/config_validate_test.go
+++ b/pkg/parameters/validate/config_validate_test.go
@@ -27,6 +27,7 @@ import (
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/parameters/openapi"
 	"github.com/apecloud/kubeblocks/test/testdata"
 )
 
@@ -158,6 +159,9 @@ func TestSchemaValidatorWithOpenSchema(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			configSchema := newFakeConfigSchema(tt.args.cueFile)
+			schema, err := openapi.GenerateOpenAPISchema(configSchema.CUE, tt.args.SchemaTypeName)
+			require.NoError(t, err)
+			configSchema.SchemaInJSON = schema
 			validator := &schemaValidator{
 				typeName: tt.args.SchemaTypeName,
 				cfgType:  tt.args.format,


### PR DESCRIPTION
## Problem
A user can submit an invalid Reconfigure request and see it reported as successful even though the database never applied the requested value.

One observed Valkey case:
- `maxmemory-samples=0`, while the ParametersDefinition allows only `1..10`
- `maxmemory-policy=definitely-not-a-policy`, while the ParametersDefinition allows only a fixed enum
- the database kept the old values: `maxmemory-samples=5` and `maxmemory-policy=volatile-lru`
- the control plane still marked the OpsRequest as `Succeed` and ComponentParameter as `Finished`

This creates a dangerous false success: users and tests see "parameter change succeeded", but the database is not running with the requested target state.

## Summary
- make the ComponentParameter processing path fail closed when `Spec.Desired` violates a ParametersDefinition JSON schema
- keep Reconfigure Ops on the existing status path: it observes ComponentParameter failure and reports the OpsRequest as failed
- fix `SchemaInJSON` config validation so the schema validator actually validates against the provided schema
- keep legacy/no-schema addons on the previous behavior when no JSON schema is available

## Scope
This is a Configure/Parameters fix. The root protection is in the ComponentParameter/parameters chain, not an Ops precheck.

When a ParametersDefinition JSON schema is available, invalid desired parameters now fail closed for:
- unknown parameter keys
- integer parse errors
- numeric range violations
- enum violations

Known parameter deletion with a nil value remains allowed; unknown deletion is rejected.

## Validation
- `go test ./pkg/parameters/validate -run TestSchemaValidatorUsesSchemaInJSON -count=1 -v`
- `go test ./pkg/parameters -run TestValidateComponentParameterAssignments -count=1 -v`
- `go test -c ./pkg/parameters/validate`
- `go test -c ./pkg/parameters`
- `go test -c ./controllers/parameters`
- `go test -c ./pkg/operations`
- `git diff --check`

Local envtest/Ginkgo execution is not counted because this workstation does not have `/usr/local/kubebuilder/bin/etcd`; the focused Ginkgo spec is included for CI/envtest coverage.