### PR TITLE
chore: reject negative retention periods

### DIFF
--- a/apis/apps/v1/retention_period.go
+++ b/apis/apps/v1/retention_period.go
@@ -122,14 +122,10 @@ func (r RetentionPeriod) nextNumber(input string) (num int, rest string, err err
 		return 0, "", nil
 	}
 
-	var (
-		n        string
-		negative bool
-	)
+	var n string
 
 	if input[0] == '-' {
-		negative = true
-		input = input[1:]
+		return 0, input, errInvalidDuration
 	}
 
 	for i, s := range input {
@@ -150,8 +146,5 @@ func (r RetentionPeriod) nextNumber(input string) (num int, rest string, err err
 		return 0, input, err
 	}
 
-	if negative {
-		num = -num
-	}
 	return num, rest, nil
 }

--- a/apis/apps/v1/retention_period_test.go
+++ b/apis/apps/v1/retention_period_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package v1
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRetentionPeriodToDuration(t *testing.T) {
+	tests := []struct {
+		name    string
+		period  RetentionPeriod
+		want    time.Duration
+		wantErr bool
+	}{
+		{
+			name:   "empty period",
+			period: "",
+			want:   0,
+		},
+		{
+			name:   "combined units",
+			period: "1y2mo3w4d5h6m",
+			want:   (365*24*time.Hour + 2*30*24*time.Hour + 3*7*24*time.Hour + 4*24*time.Hour + 5*time.Hour + 6*time.Minute),
+		},
+		{
+			name:    "negative days",
+			period:  "-1d",
+			wantErr: true,
+		},
+		{
+			name:    "negative unit in combined period",
+			period:  "1d-2h",
+			wantErr: true,
+		},
+		{
+			name:    "unit without number",
+			period:  "1dh",
+			wantErr: true,
+		},
+		{
+			name:    "number without unit",
+			period:  "1d2",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.period.ToDuration()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("expected %s, got %s", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Small parser papercut

`retentionPeriod` is a plain CRD string, and the parser accepted negative units. So `-1d` or `1d-2h` could pass `ToDuration()` and later produce past expiration / negative TTL math. not great.

Repro:
```sh
go test ./apis/apps/v1 -run TestRetentionPeriodToDuration
```
Before this patch the negative cases fail. After it, they pass.

Checked:
```sh
go test ./apis/apps/v1
KUBEBUILDER_ASSETS="$(./bin/setup-envtest-release-0.21 use 1.26.1 -p path)" go test ./pkg/dataprotection/backup
KUBEBUILDER_ASSETS="$(./bin/setup-envtest-release-0.21 use 1.26.1 -p path)" go test ./pkg/operations -run "Backup|Test"
```

No cloud quota weirdness here; this is just user-provided API input, so the edge case is reachable.
