### PR TITLE
fix(controller): patch CR metadata without owning spec (release-1.0)

### DIFF
--- a/controllers/apps/componentversion_controller.go
+++ b/controllers/apps/componentversion_controller.go
@@ -265,8 +265,9 @@ func (r *ComponentVersionReconciler) supportedServiceVersions(compVersion *appsv
 	return strings.Join(versions, ",") // TODO(API): service versions length
 }
 
-func (r *ComponentVersionReconciler) updateSupportedCompDefLabels(cli client.Client, rctx intctrlutil.RequestCtx,
+func (r *ComponentVersionReconciler) updateSupportedCompDefLabels(cli client.Writer, rctx intctrlutil.RequestCtx,
 	compVersion *appsv1.ComponentVersion, releaseToCompDefinitions map[string]map[string]*appsv1.ComponentDefinition) error {
+	patch := client.MergeFrom(compVersion.DeepCopy())
 	if compVersion.Annotations == nil {
 		compVersion.Annotations = make(map[string]string)
 	}
@@ -294,7 +295,7 @@ func (r *ComponentVersionReconciler) updateSupportedCompDefLabels(cli client.Cli
 	}
 	compVersion.Labels = labels
 	compVersion.Annotations[compatibleDefinitionsKey] = strings.Join(labelKeys, ",")
-	return cli.Update(rctx.Ctx, compVersion)
+	return cli.Patch(rctx.Ctx, compVersion, patch)
 }
 
 func (r *ComponentVersionReconciler) validate(compVersion *appsv1.ComponentVersion,

--- a/controllers/apps/componentversion_controller_test.go
+++ b/controllers/apps/componentversion_controller_test.go
@@ -20,20 +20,115 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package apps
 
 import (
+	"context"
 	"strings"
+	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	"github.com/apecloud/kubeblocks/pkg/generics"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
 )
+
+type componentVersionPatchWriter struct {
+	patchCalls  int
+	updateCalls int
+	patchData   []byte
+}
+
+func (w *componentVersionPatchWriter) Create(context.Context, client.Object, ...client.CreateOption) error {
+	return nil
+}
+
+func (w *componentVersionPatchWriter) Delete(context.Context, client.Object, ...client.DeleteOption) error {
+	return nil
+}
+
+func (w *componentVersionPatchWriter) Update(context.Context, client.Object, ...client.UpdateOption) error {
+	w.updateCalls++
+	return nil
+}
+
+func (w *componentVersionPatchWriter) Patch(_ context.Context, obj client.Object, patch client.Patch, _ ...client.PatchOption) error {
+	var err error
+	w.patchCalls++
+	w.patchData, err = patch.Data(obj)
+	return err
+}
+
+func (w *componentVersionPatchWriter) DeleteAllOf(context.Context, client.Object, ...client.DeleteAllOfOption) error {
+	return nil
+}
+
+func TestComponentVersionSupportedCompDefLabelsUsesMetadataPatch(t *testing.T) {
+	compVersion := &appsv1.ComponentVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mssql",
+			Labels: map[string]string{
+				"old-comp-def": "old-comp-def",
+				"chart-label":  "keep",
+			},
+			Annotations: map[string]string{
+				compatibleDefinitionsKey: "old-comp-def",
+			},
+		},
+		Spec: appsv1.ComponentVersionSpec{
+			Releases: []appsv1.ComponentVersionRelease{{
+				Name:           "mssql-2022",
+				ServiceVersion: "16.0.0",
+				Images: map[string]string{
+					"mssql": "mssql:old",
+				},
+			}},
+		},
+	}
+	writer := &componentVersionPatchWriter{}
+	releaseToCompDefinitions := map[string]map[string]*appsv1.ComponentDefinition{
+		"mssql-2022": {
+			"mssql-new": {ObjectMeta: metav1.ObjectMeta{Name: "mssql-new"}},
+		},
+	}
+
+	err := (&ComponentVersionReconciler{}).updateSupportedCompDefLabels(writer,
+		intctrlutil.RequestCtx{Ctx: context.Background()}, compVersion, releaseToCompDefinitions)
+	if err != nil {
+		t.Fatalf("updateSupportedCompDefLabels returned error: %v", err)
+	}
+	if writer.patchCalls != 1 {
+		t.Fatalf("expected one patch, got %d", writer.patchCalls)
+	}
+	if writer.updateCalls != 0 {
+		t.Fatalf("expected no whole-object update, got %d", writer.updateCalls)
+	}
+	if got := compVersion.Labels["mssql-new"]; got != "mssql-new" {
+		t.Fatalf("expected new compatible label, got %q", got)
+	}
+	if got := compVersion.Labels["chart-label"]; got != "keep" {
+		t.Fatalf("expected existing chart label to be preserved, got %q", got)
+	}
+	if _, ok := compVersion.Labels["old-comp-def"]; ok {
+		t.Fatalf("expected old compatible label to be removed")
+	}
+	if got := compVersion.Annotations[compatibleDefinitionsKey]; got != "mssql-new" {
+		t.Fatalf("expected compatible definitions annotation to be updated, got %q", got)
+	}
+	patchData := string(writer.patchData)
+	if !strings.Contains(patchData, `"metadata"`) {
+		t.Fatalf("expected metadata patch, got %s", patchData)
+	}
+	if strings.Contains(patchData, `"spec"`) {
+		t.Fatalf("metadata patch must not include spec, got %s", patchData)
+	}
+}
 
 var _ = Describe("ComponentVersion Controller", func() {
 	var (

--- a/pkg/controllerutil/controller_common.go
+++ b/pkg/controllerutil/controller_common.go
@@ -109,7 +109,8 @@ func Requeue(logger logr.Logger, msg string, keysAndValues ...interface{}) (reco
 }
 
 // HandleCRDeletion handles CR deletion, adds finalizer if found a non-deleting object and removes finalizer during
-// deletion process. Passes optional 'deletionHandler' func for external dependency deletion. Returns Result pointer
+// deletion process. It patches only finalizer metadata so chart-owned spec fields keep their field ownership.
+// Passes optional 'deletionHandler' func for external dependency deletion. Returns Result pointer
 // if required to return out of outer 'Reconcile' reconciliation loop.
 func HandleCRDeletion(reqCtx RequestCtx,
 	r client.Writer,
@@ -122,8 +123,9 @@ func HandleCRDeletion(reqCtx RequestCtx,
 		// then add the finalizer and update the object. This is equivalent to
 		// registering our finalizer.
 		if !controllerutil.ContainsFinalizer(cr, finalizer) {
+			patch := client.MergeFrom(cr.DeepCopyObject().(client.Object))
 			controllerutil.AddFinalizer(cr, finalizer)
-			if err := r.Update(reqCtx.Ctx, cr); err != nil {
+			if err := r.Patch(reqCtx.Ctx, cr, patch); err != nil {
 				return ResultToP(CheckedRequeueWithError(err, reqCtx.Log, ""))
 			}
 		}
@@ -160,8 +162,9 @@ func HandleCRDeletion(reqCtx RequestCtx,
 				}
 			}
 			// remove our finalizer from the list and update it.
+			patch := client.MergeFrom(cr.DeepCopyObject().(client.Object))
 			if controllerutil.RemoveFinalizer(cr, finalizer) {
-				if err := r.Update(reqCtx.Ctx, cr); err != nil {
+				if err := r.Patch(reqCtx.Ctx, cr, patch); err != nil {
 					return ResultToP(CheckedRequeueWithError(err, reqCtx.Log, ""))
 				}
 				// record resources deleted event

--- a/pkg/controllerutil/controller_common_test.go
+++ b/pkg/controllerutil/controller_common_test.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -43,6 +44,36 @@ import (
 )
 
 var tlog = ctrl.Log.WithName("controller_testing")
+
+type patchRecordingWriter struct {
+	patchCalls  int
+	updateCalls int
+	patchData   []byte
+}
+
+func (w *patchRecordingWriter) Create(context.Context, client.Object, ...client.CreateOption) error {
+	return nil
+}
+
+func (w *patchRecordingWriter) Delete(context.Context, client.Object, ...client.DeleteOption) error {
+	return nil
+}
+
+func (w *patchRecordingWriter) Update(context.Context, client.Object, ...client.UpdateOption) error {
+	w.updateCalls++
+	return nil
+}
+
+func (w *patchRecordingWriter) Patch(_ context.Context, obj client.Object, patch client.Patch, _ ...client.PatchOption) error {
+	var err error
+	w.patchCalls++
+	w.patchData, err = patch.Data(obj)
+	return err
+}
+
+func (w *patchRecordingWriter) DeleteAllOf(context.Context, client.Object, ...client.DeleteAllOfOption) error {
+	return nil
+}
 
 func TestRequeueWithError(t *testing.T) {
 	_, err := CheckedRequeueWithError(errors.New("test error"), tlog, "test")
@@ -113,6 +144,67 @@ func TestResultToP(t *testing.T) {
 	res, _ := ResultToP(reconcile.Result{}, nil)
 	if reflect.ValueOf(res).Kind() != reflect.Ptr {
 		t.Error("Expect to get a pointer type, got:", reflect.ValueOf(res).Kind())
+	}
+}
+
+func TestHandleCRDeletionPatchesFinalizerMetadata(t *testing.T) {
+	const finalizer = "finalizer/protection"
+	reqCtx := RequestCtx{Ctx: context.Background(), Log: tlog}
+
+	t.Run("add finalizer", func(t *testing.T) {
+		writer := &patchRecordingWriter{}
+		obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm"}}
+
+		res, err := HandleCRDeletion(reqCtx, writer, obj, finalizer, nil)
+		if err != nil {
+			t.Fatalf("HandleCRDeletion returned error: %v", err)
+		}
+		if res != nil {
+			t.Fatalf("expected no reconcile result, got %v", res)
+		}
+		if writer.patchCalls != 1 || writer.updateCalls != 0 {
+			t.Fatalf("expected one patch and no update, got patch=%d update=%d", writer.patchCalls, writer.updateCalls)
+		}
+		assertMetadataOnlyPatch(t, writer.patchData)
+		if !controllerutil.ContainsFinalizer(obj, finalizer) {
+			t.Fatalf("expected finalizer %q to be added", finalizer)
+		}
+	})
+
+	t.Run("remove finalizer", func(t *testing.T) {
+		writer := &patchRecordingWriter{}
+		now := metav1.Now()
+		obj := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+			Name:              "cm",
+			Finalizers:        []string{finalizer},
+			DeletionTimestamp: &now,
+		}}
+
+		res, err := HandleCRDeletion(reqCtx, writer, obj, finalizer, nil)
+		if err != nil {
+			t.Fatalf("HandleCRDeletion returned error: %v", err)
+		}
+		if res == nil {
+			t.Fatalf("expected reconciled result")
+		}
+		if writer.patchCalls != 1 || writer.updateCalls != 0 {
+			t.Fatalf("expected one patch and no update, got patch=%d update=%d", writer.patchCalls, writer.updateCalls)
+		}
+		assertMetadataOnlyPatch(t, writer.patchData)
+		if controllerutil.ContainsFinalizer(obj, finalizer) {
+			t.Fatalf("expected finalizer %q to be removed", finalizer)
+		}
+	})
+}
+
+func assertMetadataOnlyPatch(t *testing.T, data []byte) {
+	t.Helper()
+	patchData := string(data)
+	if !strings.Contains(patchData, `"metadata"`) {
+		t.Fatalf("expected metadata patch, got %s", patchData)
+	}
+	if strings.Contains(patchData, `"spec"`) {
+		t.Fatalf("metadata patch must not include spec, got %s", patchData)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Backport the metadata-only patch behavior from #10264 to `release-1.0`.
- Replace whole-object `Update` calls in finalizer handling with metadata-only merge patches.
- Replace `ComponentVersion` supported ComponentDefinition metadata updates with a metadata-only merge patch.

## Context
SQL Server addon in-place upgrade can fail with server-side apply field ownership conflicts after the controller reconciles chart-rendered definition objects. The conflicting fields are chart-owned spec fields, but whole-object controller updates can make apiserver managedFields record them under the `kubeblocks` manager.

This backport keeps controller writes scoped to metadata when the controller only changes finalizers, labels, or annotations. It preserves chart ownership of rendered spec fields during Helm upgrades.

## Validation
- `go test ./pkg/controllerutil -run TestHandleCRDeletionPatchesFinalizerMetadata -count=1 -v`
- `go test ./controllers/apps -run TestComponentVersionSupportedCompDefLabelsUsesMetadataPatch -count=1 -v`
- `go test -c ./controllers/apps`
- `go test -c ./pkg/controllerutil`
- `git diff --check`

## Boundary
This PR is a release-1.0 backport of #10264. Live Helm in-place upgrade validation for the SQL Server addon will be run with a release-1.0 patch image after this PR head is available.
