### PR TITLE
fix(component): wait for parameter config backfill

### DIFF
--- a/controllers/apps/component/transformer_component_template.go
+++ b/controllers/apps/component/transformer_component_template.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/Masterminds/sprig/v3"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -38,7 +39,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	appsutil "github.com/apecloud/kubeblocks/controllers/apps/util"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/builder"
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
@@ -46,6 +49,8 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/lifecycle"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	parameters "github.com/apecloud/kubeblocks/pkg/parameters"
+	configcore "github.com/apecloud/kubeblocks/pkg/parameters/core"
 )
 
 const (
@@ -113,10 +118,100 @@ func (t *componentFileTemplateTransformer) instanceAssistantObject(transCtx *com
 func (t *componentFileTemplateTransformer) precheck(transCtx *componentTransformContext) error {
 	for _, tpl := range transCtx.SynthesizeComponent.FileTemplates {
 		if len(tpl.Template) == 0 {
+			waiting, err := t.waitingForParameterBackfill(transCtx, tpl)
+			if err != nil {
+				return err
+			}
+			if waiting {
+				return intctrlutil.NewRequeueError(appsutil.RequeueDuration,
+					fmt.Sprintf("waiting for parameters controller to backfill config template: %s", tpl.Name))
+			}
 			return fmt.Errorf("config/script template has no template specified: %s", tpl.Name)
 		}
 	}
 	return nil
+}
+
+func (t *componentFileTemplateTransformer) waitingForParameterBackfill(
+	transCtx *componentTransformContext,
+	tpl component.SynthesizedFileTemplate) (bool, error) {
+	if !isExternalManaged(tpl) {
+		return false, nil
+	}
+
+	clusterName, err := component.GetClusterName(transCtx.Component)
+	if err != nil {
+		return false, err
+	}
+	componentName, err := component.ShortName(clusterName, transCtx.Component.Name)
+	if err != nil {
+		return false, err
+	}
+
+	parameter := &parametersv1alpha1.ComponentParameter{}
+	parameterKey := types.NamespacedName{
+		Namespace: transCtx.Component.Namespace,
+		Name:      configcore.GenerateComponentConfigurationName(clusterName, componentName),
+	}
+	if err := transCtx.Client.Get(transCtx.Context, parameterKey, parameter); err != nil {
+		if apierrors.IsNotFound(err) {
+			return t.parameterBackfillExpected(transCtx, tpl)
+		}
+		return false, err
+	}
+
+	for _, item := range parameter.Spec.ConfigItemDetails {
+		if item.ConfigSpec == nil {
+			continue
+		}
+		if item.ConfigSpec.Name == tpl.Name && !ptr.Deref(item.ConfigSpec.ExternalManaged, false) {
+			return false, nil
+		}
+		if item.ConfigSpec.Name == tpl.Name && ptr.Deref(item.ConfigSpec.ExternalManaged, false) {
+			status := parameters.GetItemStatus(&parameter.Status, tpl.Name)
+			if status != nil {
+				if parameters.IsFailedPhase(status.Phase) {
+					return false, fmt.Errorf("parameters controller failed to backfill config template %s: %s",
+						tpl.Name, ptr.Deref(status.Message, ""))
+				}
+			}
+			if parameters.IsFailedPhase(parameter.Status.Phase) {
+				return false, fmt.Errorf("componentParameter %s failed to backfill config template %s: %s",
+					parameter.Name, tpl.Name, parameter.Status.Message)
+			}
+			return true, nil
+		}
+	}
+	if parameters.IsFailedPhase(parameter.Status.Phase) {
+		expected, err := t.parameterBackfillExpected(transCtx, tpl)
+		if err != nil {
+			return false, err
+		}
+		if expected {
+			return false, fmt.Errorf("componentParameter %s failed to backfill config template %s: %s",
+				parameter.Name, tpl.Name, parameter.Status.Message)
+		}
+		return false, nil
+	}
+	return t.parameterBackfillExpected(transCtx, tpl)
+}
+
+func (t *componentFileTemplateTransformer) parameterBackfillExpected(
+	transCtx *componentTransformContext,
+	tpl component.SynthesizedFileTemplate) (bool, error) {
+	if transCtx.CompDef == nil {
+		return false, nil
+	}
+	configs, _, err := parameters.ResolveCmpdParametersDefs(transCtx.Context, transCtx.Client, transCtx.CompDef)
+	if err != nil {
+		return false, err
+	}
+	for _, config := range parameters.ResolveParameterTemplate(transCtx.CompDef.Spec, configs) {
+		if config.Name == tpl.Name {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (t *componentFileTemplateTransformer) handleTemplateObjectChanges(transCtx *componentTransformContext,

--- a/controllers/apps/component/transformer_component_template_test.go
+++ b/controllers/apps/component/transformer_component_template_test.go
@@ -31,12 +31,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	appsutil "github.com/apecloud/kubeblocks/controllers/apps/util"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	configcore "github.com/apecloud/kubeblocks/pkg/parameters/core"
 )
 
 var _ = Describe("file templates transformer test", func() {
@@ -226,6 +229,28 @@ var _ = Describe("file templates transformer test", func() {
 		}))
 	}
 
+	claimServerConfByParametersDefinition := func() {
+		transCtx.CompDef.Spec.Configs = []appsv1.ComponentFileTemplate{
+			{
+				Name:            "serverConf",
+				Template:        serverConfCM.Name,
+				ExternalManaged: ptr.To(true),
+			},
+		}
+		reader.Objects = append(reader.Objects, &parametersv1alpha1.ParametersDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: "server-conf-params"},
+			Spec: parametersv1alpha1.ParametersDefinitionSpec{
+				ComponentDef: compDefName,
+				TemplateName: serverConfCM.Name,
+				FileName:     "server.conf",
+				FileFormatConfig: &parametersv1alpha1.FileFormatConfig{
+					Format: parametersv1alpha1.Properties,
+				},
+			},
+			Status: parametersv1alpha1.ParametersDefinitionStatus{Phase: parametersv1alpha1.PDAvailablePhase},
+		})
+	}
+
 	// checkEnvWithAction := func(action string) {
 	//	podSpec := transCtx.SynthesizeComponent.PodSpec
 	//	for _, c := range podSpec.Containers {
@@ -326,6 +351,256 @@ var _ = Describe("file templates transformer test", func() {
 			err := transformer.Transform(transCtx, dag)
 			Expect(err).ShouldNot(BeNil())
 			Expect(err.Error()).Should(ContainSubstring("config/script template has no template specified"))
+		})
+
+		It("external managed - w/o template waits when parameters controller claimed the config", func() {
+			transCtx.SynthesizeComponent.FileTemplates[1].Template = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].Namespace = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].ExternalManaged = ptr.To(true)
+			reader.Objects = append(reader.Objects, &parametersv1alpha1.ComponentParameter{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testCtx.DefaultNamespace,
+					Name:      configcore.GenerateComponentConfigurationName(clusterName, compName),
+				},
+				Spec: parametersv1alpha1.ComponentParameterSpec{
+					ClusterName:   clusterName,
+					ComponentName: compName,
+					ConfigItemDetails: []parametersv1alpha1.ConfigTemplateItemDetail{
+						{
+							Name: "serverConf",
+							ConfigSpec: &appsv1.ComponentFileTemplate{
+								Name:            "serverConf",
+								ExternalManaged: ptr.To(true),
+							},
+						},
+					},
+				},
+			})
+
+			transformer := &componentFileTemplateTransformer{}
+			err := transformer.Transform(transCtx, dag)
+			Expect(err).ShouldNot(BeNil())
+			Expect(intctrlutil.IsRequeueError(err)).Should(BeTrue())
+			Expect(err.Error()).Should(ContainSubstring("waiting for parameters controller to backfill config template: serverConf"))
+			Expect(err.Error()).ShouldNot(ContainSubstring("config/script template has no template specified"))
+		})
+
+		It("external managed - w/o template waits when parameters definition claims the config before component parameter exists", func() {
+			transCtx.SynthesizeComponent.FileTemplates[1].Template = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].Namespace = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].ExternalManaged = ptr.To(true)
+			claimServerConfByParametersDefinition()
+
+			transformer := &componentFileTemplateTransformer{}
+			err := transformer.Transform(transCtx, dag)
+			Expect(err).ShouldNot(BeNil())
+			Expect(intctrlutil.IsRequeueError(err)).Should(BeTrue())
+			Expect(err.Error()).Should(ContainSubstring("waiting for parameters controller to backfill config template: serverConf"))
+			Expect(err.Error()).ShouldNot(ContainSubstring("config/script template has no template specified"))
+		})
+
+		It("external managed - w/o template waits when parameter details are not filled yet but parameters definition claims the config", func() {
+			transCtx.SynthesizeComponent.FileTemplates[1].Template = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].Namespace = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].ExternalManaged = ptr.To(true)
+			claimServerConfByParametersDefinition()
+			reader.Objects = append(reader.Objects, &parametersv1alpha1.ComponentParameter{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testCtx.DefaultNamespace,
+					Name:      configcore.GenerateComponentConfigurationName(clusterName, compName),
+				},
+				Spec: parametersv1alpha1.ComponentParameterSpec{
+					ClusterName:   clusterName,
+					ComponentName: compName,
+				},
+			})
+
+			transformer := &componentFileTemplateTransformer{}
+			err := transformer.Transform(transCtx, dag)
+			Expect(err).ShouldNot(BeNil())
+			Expect(intctrlutil.IsRequeueError(err)).Should(BeTrue())
+			Expect(err.Error()).Should(ContainSubstring("waiting for parameters controller to backfill config template: serverConf"))
+			Expect(err.Error()).ShouldNot(ContainSubstring("config/script template has no template specified"))
+		})
+
+		It("external managed - w/o template still fails when parameters controller did not claim the config", func() {
+			transCtx.SynthesizeComponent.FileTemplates[1].Template = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].Namespace = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].ExternalManaged = ptr.To(true)
+			reader.Objects = append(reader.Objects, &parametersv1alpha1.ComponentParameter{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testCtx.DefaultNamespace,
+					Name:      configcore.GenerateComponentConfigurationName(clusterName, compName),
+				},
+				Spec: parametersv1alpha1.ComponentParameterSpec{
+					ClusterName:   clusterName,
+					ComponentName: compName,
+					ConfigItemDetails: []parametersv1alpha1.ConfigTemplateItemDetail{
+						{
+							Name: "otherConf",
+							ConfigSpec: &appsv1.ComponentFileTemplate{
+								Name:            "otherConf",
+								ExternalManaged: ptr.To(true),
+							},
+						},
+					},
+				},
+			})
+
+			transformer := &componentFileTemplateTransformer{}
+			err := transformer.Transform(transCtx, dag)
+			Expect(err).ShouldNot(BeNil())
+			Expect(intctrlutil.IsRequeueError(err)).Should(BeFalse())
+			Expect(err.Error()).Should(ContainSubstring("config/script template has no template specified"))
+		})
+
+		It("external managed - w/o template still fails when matched parameter config is not external managed", func() {
+			transCtx.SynthesizeComponent.FileTemplates[1].Template = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].Namespace = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].ExternalManaged = ptr.To(true)
+			reader.Objects = append(reader.Objects, &parametersv1alpha1.ComponentParameter{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testCtx.DefaultNamespace,
+					Name:      configcore.GenerateComponentConfigurationName(clusterName, compName),
+				},
+				Spec: parametersv1alpha1.ComponentParameterSpec{
+					ClusterName:   clusterName,
+					ComponentName: compName,
+					ConfigItemDetails: []parametersv1alpha1.ConfigTemplateItemDetail{
+						{
+							Name: "serverConf",
+							ConfigSpec: &appsv1.ComponentFileTemplate{
+								Name:            "serverConf",
+								ExternalManaged: ptr.To(false),
+							},
+						},
+					},
+				},
+			})
+
+			transformer := &componentFileTemplateTransformer{}
+			err := transformer.Transform(transCtx, dag)
+			Expect(err).ShouldNot(BeNil())
+			Expect(intctrlutil.IsRequeueError(err)).Should(BeFalse())
+			Expect(err.Error()).Should(ContainSubstring("config/script template has no template specified"))
+		})
+
+		It("external managed - w/o template fails loudly when claimed parameter config failed", func() {
+			transCtx.SynthesizeComponent.FileTemplates[1].Template = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].Namespace = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].ExternalManaged = ptr.To(true)
+			message := "render failed"
+			reader.Objects = append(reader.Objects, &parametersv1alpha1.ComponentParameter{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testCtx.DefaultNamespace,
+					Name:      configcore.GenerateComponentConfigurationName(clusterName, compName),
+				},
+				Spec: parametersv1alpha1.ComponentParameterSpec{
+					ClusterName:   clusterName,
+					ComponentName: compName,
+					ConfigItemDetails: []parametersv1alpha1.ConfigTemplateItemDetail{
+						{
+							Name: "serverConf",
+							ConfigSpec: &appsv1.ComponentFileTemplate{
+								Name:            "serverConf",
+								ExternalManaged: ptr.To(true),
+							},
+						},
+					},
+				},
+				Status: parametersv1alpha1.ComponentParameterStatus{
+					ConfigurationItemStatus: []parametersv1alpha1.ConfigTemplateItemDetailStatus{
+						{
+							Name:    "serverConf",
+							Phase:   parametersv1alpha1.CMergeFailedPhase,
+							Message: &message,
+						},
+					},
+				},
+			})
+
+			transformer := &componentFileTemplateTransformer{}
+			err := transformer.Transform(transCtx, dag)
+			Expect(err).ShouldNot(BeNil())
+			Expect(intctrlutil.IsRequeueError(err)).Should(BeFalse())
+			Expect(err.Error()).Should(ContainSubstring("parameters controller failed to backfill config template serverConf: render failed"))
+		})
+
+		It("external managed - w/o template fails loudly when component parameter aggregate status failed", func() {
+			transCtx.SynthesizeComponent.FileTemplates[1].Template = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].Namespace = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].ExternalManaged = ptr.To(true)
+			reader.Objects = append(reader.Objects, &parametersv1alpha1.ComponentParameter{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testCtx.DefaultNamespace,
+					Name:      configcore.GenerateComponentConfigurationName(clusterName, compName),
+				},
+				Spec: parametersv1alpha1.ComponentParameterSpec{
+					ClusterName:   clusterName,
+					ComponentName: compName,
+					ConfigItemDetails: []parametersv1alpha1.ConfigTemplateItemDetail{
+						{
+							Name: "serverConf",
+							ConfigSpec: &appsv1.ComponentFileTemplate{
+								Name:            "serverConf",
+								ExternalManaged: ptr.To(true),
+							},
+						},
+					},
+				},
+				Status: parametersv1alpha1.ComponentParameterStatus{
+					Phase:   parametersv1alpha1.CMergeFailedPhase,
+					Message: "aggregate render failed",
+				},
+			})
+
+			transformer := &componentFileTemplateTransformer{}
+			err := transformer.Transform(transCtx, dag)
+			Expect(err).ShouldNot(BeNil())
+			Expect(intctrlutil.IsRequeueError(err)).Should(BeFalse())
+			Expect(err.Error()).Should(ContainSubstring("componentParameter " + configcore.GenerateComponentConfigurationName(clusterName, compName) + " failed to backfill config template serverConf: aggregate render failed"))
+		})
+
+		It("external managed - w/o template fails loudly when component parameter aggregate status failed with partial item status", func() {
+			transCtx.SynthesizeComponent.FileTemplates[1].Template = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].Namespace = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].ExternalManaged = ptr.To(true)
+			reader.Objects = append(reader.Objects, &parametersv1alpha1.ComponentParameter{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testCtx.DefaultNamespace,
+					Name:      configcore.GenerateComponentConfigurationName(clusterName, compName),
+				},
+				Spec: parametersv1alpha1.ComponentParameterSpec{
+					ClusterName:   clusterName,
+					ComponentName: compName,
+					ConfigItemDetails: []parametersv1alpha1.ConfigTemplateItemDetail{
+						{
+							Name: "otherConf",
+							ConfigSpec: &appsv1.ComponentFileTemplate{
+								Name:            "otherConf",
+								ExternalManaged: ptr.To(true),
+							},
+						},
+					},
+				},
+				Status: parametersv1alpha1.ComponentParameterStatus{
+					Phase:   parametersv1alpha1.CFailedAndPausePhase,
+					Message: "aggregate paused",
+					ConfigurationItemStatus: []parametersv1alpha1.ConfigTemplateItemDetailStatus{
+						{
+							Name:  "otherConf",
+							Phase: parametersv1alpha1.CFinishedPhase,
+						},
+					},
+				},
+			})
+			claimServerConfByParametersDefinition()
+
+			transformer := &componentFileTemplateTransformer{}
+			err := transformer.Transform(transCtx, dag)
+			Expect(err).ShouldNot(BeNil())
+			Expect(intctrlutil.IsRequeueError(err)).Should(BeFalse())
+			Expect(err.Error()).Should(ContainSubstring("componentParameter " + configcore.GenerateComponentConfigurationName(clusterName, compName) + " failed to backfill config template serverConf: aggregate paused"))
 		})
 	})
 })

--- a/controllers/apps/util/mock_reader.go
+++ b/controllers/apps/util/mock_reader.go
@@ -38,6 +38,9 @@ func (r *MockReader) Get(ctx context.Context, key client.ObjectKey, obj client.O
 	for _, o := range r.Objects {
 		// ignore the GVK check
 		if client.ObjectKeyFromObject(o) == key {
+			if !reflect.TypeOf(o).Elem().AssignableTo(reflect.TypeOf(obj).Elem()) {
+				continue
+			}
 			reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(o).Elem())
 			return nil
 		}


### PR DESCRIPTION
## Summary

Fixes the follow-up pre-backfill window after #10267.

When a Component config is `externalManaged=true` and owned by the parameters chain, the Component controller may reconcile before ParameterTemplateExtension has backfilled the rendered runtime ConfigMap into `Component.spec.configs[].configMap`. In that short window the synthesized file template has an empty `Template`, and the current precheck emits `config/script template has no template specified` as a build error even though the parameters controller is about to fill it.

This change makes that state explicitly waitable:
- if the config is claimed by `ComponentParameter.spec.configItemDetails`, requeue instead of emitting the build error;
- if the ComponentParameter is not created yet, or its details are not filled yet, use `ParametersDefinition.templateName` + `ResolveParameterTemplate` to decide whether the config is expected to be backfilled;
- if the parameters chain has failed, fail loudly instead of waiting forever;
- keep unclaimed configs and non-externalManaged configs on the existing fail-loudly path.

## Contract

The intended behavior is:
- PD claimed + runtime CM not backfilled yet: requeue, no component build ERROR.
- CP NotFound or CP details empty but PD claims this config: requeue.
- CP item status failed: fail loudly with the item error.
- CP aggregate status `MergeFailed` / `FailedAndPause` and no more specific item failure: fail loudly with the ComponentParameter name and aggregate message.
- No PD/CP claim, or matching config is not external-managed: keep the existing `config/script template has no template specified` error.

This PR is stacked on #10267. It depends on #10267's parameter-template matching fix and does not independently fix the SQL Server B-lane without that helper change. It does not change the `externalManaged` contract or the parameter template matching rules.

## Verification

- `KUBEBUILDER_ASSETS="$(./bin/setup-envtest-release-0.21 use 1.26.1 -p path)" go test ./controllers/apps/component -count=1 -v`
  - PASS: 127/128 specs; 1 pending is existing `transformer_component_restore_test.go:245 restore component from backup`.
- `go test ./controllers/apps/util -count=1`
- `go test -c ./controllers/apps/component`
- `KUBEBUILDER_ASSETS="$(./bin/setup-envtest-release-0.21 use 1.26.1 -p path)" go test ./pkg/parameters -count=1`
- `git diff --check`

Runtime validation expected from the SQL Server B-lane patch image:
- V1-V5 from #10267 still pass.
- New V6: the pre-backfill transient `config/script template has no template specified` ERROR no longer appears while the parameters chain is converging.
- Component and Cluster have no `Failed` condition, and the SQL Server pod reaches Running/Ready.