### PR TITLE
fix(instanceset): block stale plain role events

### DIFF
--- a/pkg/controller/instanceset/pod_role_event_handler.go
+++ b/pkg/controller/instanceset/pod_role_event_handler.go
@@ -131,10 +131,16 @@ func handleRoleChangedEvent(cli client.Client, reqCtx intctrlutil.RequestCtx, ev
 // stale role event will be ignored.
 func checkStaleLastRoleEventVersion(version string, pod *corev1.Pod) bool {
 	lastRoleEventVersion, ok := pod.Annotations[constant.LastRoleEventVersionAnnotationKey]
-	if ok {
-		if version <= lastRoleEventVersion && !strings.Contains(lastRoleEventVersion, ":") {
-			return true
-		}
+	if !ok {
+		return false
+	}
+	// Plain role events use EventTime as a numeric version. They must not
+	// supersede a non-plain version already recorded on the Pod.
+	if strings.Contains(lastRoleEventVersion, ":") && !strings.Contains(version, ":") {
+		return true
+	}
+	if version <= lastRoleEventVersion && !strings.Contains(lastRoleEventVersion, ":") {
+		return true
 	}
 	return false
 }

--- a/pkg/controller/instanceset/pod_role_event_handler_test.go
+++ b/pkg/controller/instanceset/pod_role_event_handler_test.go
@@ -23,17 +23,22 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/golang/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/builder"
+	"github.com/apecloud/kubeblocks/pkg/controller/model"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	"github.com/apecloud/kubeblocks/pkg/kbagent/proto"
 )
@@ -345,6 +350,116 @@ var _ = Describe("pod role label event handler test", func() {
 				}).Times(1)
 
 			Expect(handler.Handle(cli, reqCtx, nil, event)).Should(Succeed())
+		})
+
+		Context("Bug B stale plain per-pod role event", func() {
+			const (
+				primaryRole   = "primary"
+				secondaryRole = "secondary"
+				// A ":" event version exercises the stale-check carve-out for
+				// non-plain versions while the plain Event still uses EventTime.
+				authoritativeRoleEventVersion = "term:10:gen:20"
+				stalePlainEventTimeMicros     = int64(200)
+			)
+
+			newExclusiveRole := func() workloads.ReplicaRole {
+				return workloads.ReplicaRole{
+					Name:                 primaryRole,
+					ParticipatesInQuorum: true,
+					UpdatePriority:       5,
+					IsExclusive:          true,
+				}
+			}
+
+			newInstanceSet := func(role workloads.ReplicaRole) *workloads.InstanceSet {
+				return &workloads.InstanceSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      name,
+					},
+					Spec: workloads.InstanceSetSpec{
+						Roles: []workloads.ReplicaRole{role},
+					},
+				}
+			}
+
+			newRolefulPod := func(ordinal int, uid types.UID, role string) *corev1.Pod {
+				return builder.NewPodBuilder(namespace, getPodName(name, ordinal)).
+					SetUID(uid).
+					AddLabels(constant.AppManagedByLabelKey, constant.AppName).
+					AddLabels(WorkloadsManagedByLabelKey, workloads.InstanceSetKind).
+					AddLabels(WorkloadsInstanceLabelKey, name).
+					AddLabels(RoleLabelKey, role).
+					AddAnnotations(constant.LastRoleEventVersionAnnotationKey, authoritativeRoleEventVersion).
+					GetObject()
+			}
+
+			newPlainRoleProbeEvent := func(pod *corev1.Pod, roleName string) *corev1.Event {
+				message, err := json.Marshal(proto.ProbeEvent{
+					Probe:   "roleProbe",
+					Code:    0,
+					Output:  []byte(roleName),
+					Message: "mock role probe event",
+				})
+				Expect(err).ShouldNot(HaveOccurred())
+				event := builder.NewEventBuilder(namespace, "bug-b-stale-plain-role").
+					SetInvolvedObject(corev1.ObjectReference{
+						APIVersion: "v1",
+						Kind:       "Pod",
+						Namespace:  pod.Namespace,
+						Name:       pod.Name,
+						UID:        pod.UID,
+						FieldPath:  proto.ProbeEventFieldPath,
+					}).
+					SetReason("roleProbe").
+					SetMessage(string(message)).
+					SetReportingController(proto.ProbeEventReportingController).
+					SetEventTime(metav1.MicroTime{Time: time.Unix(0, stalePlainEventTimeMicros*int64(time.Microsecond))}).
+					GetObject()
+				event.Count = 2
+				return event
+			}
+
+			newBugBScenario := func() (client.Client, *corev1.Pod, *corev1.Pod) {
+				role := newExclusiveRole()
+				its := newInstanceSet(role)
+				candidate := newRolefulPod(0, types.UID("candidate-pod-uid"), secondaryRole)
+				holder := newRolefulPod(1, types.UID("holder-pod-uid"), primaryRole)
+				event := newPlainRoleProbeEvent(candidate, primaryRole)
+				cli := fake.NewClientBuilder().
+					WithScheme(model.GetScheme()).
+					WithObjects(its, candidate, holder, event).
+					Build()
+				reqCtx := intctrlutil.RequestCtx{
+					Ctx: ctx,
+					Log: logger,
+				}
+				handler := &PodRoleEventHandler{}
+				Expect(handler.Handle(cli, reqCtx, nil, event)).Should(Succeed())
+				return cli, candidate, holder
+			}
+
+			// This RED abstracts the shared Bug B contract: a plain per-pod old fact
+			// must not acquire an exclusive role or evict the current holder by using
+			// a fresh EventTime alone. A failing Go test demonstrates a controller
+			// contract gap; it does not independently prove the live root cause final.
+			It("should not promote the event pod from a stale plain per-pod exclusive role event", func() {
+				cli, candidate, _ := newBugBScenario()
+				gotCandidate := &corev1.Pod{}
+				Expect(cli.Get(ctx, client.ObjectKeyFromObject(candidate), gotCandidate)).Should(Succeed())
+				Expect(gotCandidate.Labels[RoleLabelKey]).Should(Equal(secondaryRole))
+				Expect(gotCandidate.Annotations[constant.LastRoleEventVersionAnnotationKey]).
+					Should(Equal(authoritativeRoleEventVersion))
+			})
+
+			It("should not evict the existing exclusive role holder from a stale plain per-pod event", func() {
+				cli, _, holder := newBugBScenario()
+				gotHolder := &corev1.Pod{}
+				Expect(cli.Get(ctx, client.ObjectKeyFromObject(holder), gotHolder)).Should(Succeed())
+				Expect(gotHolder.Labels[RoleLabelKey]).Should(Equal(primaryRole))
+				Expect(gotHolder.Annotations[constant.LastRoleEventVersionAnnotationKey]).
+					Should(Equal(authoritativeRoleEventVersion))
+			})
 		})
 	})
 })


### PR DESCRIPTION
## Summary
- Rebased on `origin/main` after #10273 cleaned kbagent role event handling.
- Adds RED coverage for a stale plain kbagent role event on an exclusive role.
- Blocks plain EventTime-derived versions from superseding a non-plain role-event version already recorded on the Pod.
- Keeps the two expectations separate: the event pod must not acquire `primary`, and the existing holder must not lose `primary`.

## Boundary
- This is a controller contract fix for stale plain role events.
- The Go test demonstrates and closes this controller contract gap. It is not a live root-cause-final claim and it is not release-ready evidence.
- After #10273, the current handler consumes kbagent `proto.ProbeEvent` output and records `LastRoleEventVersionAnnotationKey`; this PR only changes the stale-version guard for that existing annotation.
- The new guard only fires when the Pod already has a non-plain role-event version. If an addon emits only plain-string role events and no non-plain version is recorded, this PR alone does not close that live path.

## Validation
- RED baseline after rebase: `go test ./pkg/controller/instanceset -run TestAPIs -ginkgo.focus 'Bug B stale plain per-pod role event' -count=1 -v` failed as expected on commit `56e021f30`:
  - `should not promote the event pod...`: actual `primary`, expected `secondary`.
  - `should not evict the existing exclusive role holder...`: actual empty role, expected `primary`.
- GREEN after implementation on commit `332f4d721`: `go test ./pkg/controller/instanceset -run TestAPIs -ginkgo.focus 'Bug B stale plain per-pod role event' -count=1 -v` PASS, 2/2.
- Package validation: `go test ./pkg/controller/instanceset -count=1` PASS.
- `git diff --check origin/main...HEAD` PASS.
- Submission check: commits `origin/main..HEAD` are clean for generated/AI attribution; pushed with `--force-with-lease`.

## Review Notes
- The explanatory non-plain role-event version comment is kept with the RED case.
- Rebase conflict with #10273 was resolved by adapting the RED test to the current kbagent event schema and the renamed role-event annotation constant.
