### PR TITLE
fix(component): skip pre-terminate when owned pods are gone

### DIFF
--- a/controllers/apps/component/transformer_component_pre_terminate.go
+++ b/controllers/apps/component/transformer_component_pre_terminate.go
@@ -145,29 +145,32 @@ func (t *componentPreTerminateTransformer) markPreTerminateDone(transCtx *compon
 }
 
 func (t *componentPreTerminateTransformer) preTerminate(transCtx *componentTransformContext, compDef *appsv1.ComponentDefinition) error {
-	lfa, err := t.lifecycleAction4Component(transCtx, compDef)
+	lfa, hasPods, err := t.lifecycleAction4Component(transCtx, compDef)
 	if err != nil {
 		return err
+	}
+	if !hasPods {
+		return nil
 	}
 	return lfa.PreTerminate(transCtx.Context, transCtx.Client, nil)
 }
 
-func (t *componentPreTerminateTransformer) lifecycleAction4Component(transCtx *componentTransformContext, compDef *appsv1.ComponentDefinition) (lifecycle.Lifecycle, error) {
+func (t *componentPreTerminateTransformer) lifecycleAction4Component(transCtx *componentTransformContext, compDef *appsv1.ComponentDefinition) (lifecycle.Lifecycle, bool, error) {
 	synthesizedComp, err1 := t.synthesizedComponent(transCtx, compDef)
 	if err1 != nil {
-		return nil, err1
+		return nil, false, err1
 	}
 	pods, err2 := component.ListOwnedPods(transCtx.Context, transCtx.Client,
 		synthesizedComp.Namespace, synthesizedComp.ClusterName, synthesizedComp.Name)
 	if err2 != nil {
-		return nil, err2
+		return nil, false, err2
 	}
 	if len(pods) == 0 {
-		// TODO: (good-first-issue) we should handle the case that the component has no pods
-		return nil, fmt.Errorf("has no pods to running the pre-terminate action")
+		return nil, false, nil
 	}
-	return lifecycle.New(synthesizedComp.Namespace, synthesizedComp.ClusterName, synthesizedComp.Name,
+	lfa, err := lifecycle.New(synthesizedComp.Namespace, synthesizedComp.ClusterName, synthesizedComp.Name,
 		synthesizedComp.LifecycleActions.ComponentLifecycleActions, synthesizedComp.TemplateVars, nil, pods)
+	return lfa, true, err
 }
 
 func (t *componentPreTerminateTransformer) synthesizedComponent(transCtx *componentTransformContext, compDef *appsv1.ComponentDefinition) (*component.SynthesizedComponent, error) {

--- a/controllers/apps/component/transformer_component_pre_terminate_test.go
+++ b/controllers/apps/component/transformer_component_pre_terminate_test.go
@@ -173,11 +173,12 @@ var _ = Describe("pre-terminate transformer test", func() {
 			Expect(preTerminated).Should(BeTrue())
 		})
 
-		It("no pods error", func() {
+		It("marks pre-terminate done when owned pods are already gone", func() {
 			transformer := &componentPreTerminateTransformer{}
 			err := transformer.Transform(transCtx, dag)
 			Expect(err).ShouldNot(BeNil())
-			Expect(err.Error()).Should(ContainSubstring("has no pods to running the pre-terminate action"))
+			Expect(err.Error()).Should(ContainSubstring("requeue to waiting for pre-terminate annotation to be set"))
+			Expect(transCtx.Component.Annotations).Should(HaveKey(kbCompPreTerminateDoneKey))
 		})
 
 		It("not-defined", func() {


### PR DESCRIPTION
## Current Review Note

This PR is back in draft. The current implementation changes the `preTerminate` API boundary by treating `owned Pods == 0` as completed pre-terminate, which can make a required pre-delete action implicit/best-effort. Do not review or merge this version as-is.

Next step: rework the proposal so normal Component deletion does not silently bypass `preTerminate`. Either keep cleanup unblocking behind the existing explicit `apps.kubeblocks.io/skip-pre-terminate=true` signal, or introduce a clearly scoped cleanup-only mechanism with tests that prove normal deletion still preserves `preTerminate` semantics.

## Summary

- Treat a deleting Component with a defined `preTerminate` action but no remaining owned Pods as a no-op pre-terminate case.
- Keep the existing pre-terminate completion flow: mark `kubeblocks.io/pre-terminate-done`, requeue, then allow the Component finalizer path to remove the finalizer naturally.
- Preserve the non-empty Pod path so kbagent `preTerminate` execution keeps the existing behavior.

## Why

Cleanup can reach a state where the Component is still deleting but its owned Pods are already gone. In that state there is no Pod left to run the pre-terminate action, and returning `has no pods to running the pre-terminate action` can keep the Component finalizer from converging.

Normal Component-controller-owned deletion is expected to run `preTerminate` before the component deletion transformer removes workloads. This PR is not claiming that Pods should normally disappear before `preTerminate`. It covers cleanup / namespace deletion / external deletion states where Pods may already be gone while the Component finalizer is still present. If Pods disappear before `preTerminate` in a normal non-cleanup Component deletion path, that should be investigated separately as a delete-ordering or owner-chain issue.

## Validation

- RED before implementation: focused spec failed with `has no pods to running the pre-terminate action`.
- GREEN focused validation: focused component pre-terminate specs PASS, 2/2 specs.
- Package validation: `go test ./controllers/apps/component -count=1 -v` PASS, 119/120 specs with the existing restore pending spec.
- Compile: `go test -c ./controllers/apps/component` PASS.
- `git diff --check` PASS.

## Boundary

This is a controller cleanup-convergence fix. It handles the terminal state where no owned Pod remains as the pre-terminate execution target. It does not classify the root cause of Pod disappearance, does not change the product verdict of any Redis runtime test run, and does not replace runtime cleanup evidence.