### PR TITLE
fix(dataprotection): shorten backup policy derived names

### DIFF
--- a/controllers/dataprotection/backuppolicydriver_controller.go
+++ b/controllers/dataprotection/backuppolicydriver_controller.go
@@ -737,12 +737,12 @@ func (r *backupPolicyAndScheduleBuilder) buildTargetPodLabels(role string, fullC
 
 // generateBackupPolicyName generates the backup policy name which is created from backup policy template.
 func generateBackupPolicyName(clusterName, componentName string) string {
-	return fmt.Sprintf("%s-%s-backup-policy", clusterName, componentName)
+	return constant.ShortenKubeName(fmt.Sprintf("%s-%s-backup-policy", clusterName, componentName), constant.KubeNameMaxLength)
 }
 
 // generateBackupScheduleName generates the backup schedule name which is created from backup policy template.
 func generateBackupScheduleName(clusterName, componentName string) string {
-	return fmt.Sprintf("%s-%s-backup-schedule", clusterName, componentName)
+	return constant.ShortenKubeName(fmt.Sprintf("%s-%s-backup-schedule", clusterName, componentName), constant.KubeNameMaxLength)
 }
 
 func buildBackupPathPrefix(cluster *appsv1.Cluster, compName string) string {

--- a/controllers/dataprotection/backuppolicydriver_controller_test.go
+++ b/controllers/dataprotection/backuppolicydriver_controller_test.go
@@ -21,6 +21,7 @@ package dataprotection
 
 import (
 	"slices"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -99,6 +100,31 @@ var _ = Describe("BackupPolicyDriver Controller test", func() {
 	})
 
 	Context("expect to create a backup policy", func() {
+		It("shortens overlength backup policy and schedule names", func() {
+			clusterName := strings.Repeat("c", 41)
+			componentName := strings.Repeat("d", 9)
+
+			backupPolicyName := generateBackupPolicyName(clusterName, componentName)
+			backupScheduleName := generateBackupScheduleName(clusterName, componentName)
+
+			Expect(len(backupPolicyName)).To(BeNumerically("<=", constant.KubeNameMaxLength))
+			Expect(len(backupScheduleName)).To(BeNumerically("<=", constant.KubeNameMaxLength))
+			Expect(backupPolicyName).NotTo(Equal(backupScheduleName))
+
+			backupPolicyName2 := generateBackupPolicyName(clusterName[:40]+"e", componentName)
+			backupScheduleName2 := generateBackupScheduleName(clusterName[:40]+"e", componentName)
+			Expect(len(backupPolicyName2)).To(BeNumerically("<=", constant.KubeNameMaxLength))
+			Expect(len(backupScheduleName2)).To(BeNumerically("<=", constant.KubeNameMaxLength))
+			Expect(backupPolicyName2).NotTo(Equal(backupPolicyName))
+			Expect(backupScheduleName2).NotTo(Equal(backupScheduleName))
+		})
+
+		It("keeps existing short backup policy and schedule names", func() {
+			Expect(generateBackupPolicyName(clusterName, defaultCompName)).
+				To(Equal("test-cluster-test-backup-policy"))
+			Expect(generateBackupScheduleName(clusterName, defaultCompName)).
+				To(Equal("test-cluster-test-backup-schedule"))
+		})
 
 		It("test backup policy for a general cluster", func() {
 			By("creating a cluster")


### PR DESCRIPTION
## Summary

- Shorten generated BackupPolicy and BackupSchedule names with `constant.ShortenKubeName`.
- Preserve existing short-name output for normal cluster/component names.
- Add focused coverage for overlength backup policy/schedule names and collision avoidance on different long inputs.

## Motivation

OceanBase Restore long-name validation for #10266 reached patch-image scoped PASS on the 70-character live path, but the strongest 74-character attempt exposed an earlier Kubernetes name-length blocker before the Restore path could run:

- generated BackupPolicy name: `<restore>-<component>-backup-policy` can reach 65 chars;
- generated BackupSchedule name: `<restore>-<component>-backup-schedule` can reach 67 chars.

These names are DataProtection-derived resources, not OceanBase-specific resources, so the name hardening should live in the controller helper that generates them.

## Validation

- `go generate ./pkg/testutil/k8s/mocks`
- `KUBEBUILDER_ASSETS="$(/Users/wei/ApeCloud/kubeblocks/bin/setup-envtest-release-0.21 use 1.26.1 -p path)" go test ./controllers/dataprotection -run 'TestAPIs/BackupPolicyDriver' -count=1 -v` PASS, 130/130 specs
- `go test -c ./controllers/dataprotection` PASS
- `KUBEBUILDER_ASSETS="$(/Users/wei/ApeCloud/kubeblocks/bin/setup-envtest-release-0.21 use 1.26.1 -p path)" go test ./pkg/dataprotection/restore -count=1` PASS
- `git diff --check` PASS

## Boundary

This PR only hardens generated BackupPolicy/BackupSchedule names. It does not change the #10266 Restore prepareData/postReady name-shortening path and does not claim release-ready validation. The affected addon team still needs a patch-image sideload run for the 74-character long-name lane.
