### PR TITLE
fix: allow stop before post-provision completes

### DIFF
--- a/controllers/apps/component/transformer_component_post_provision.go
+++ b/controllers/apps/component/transformer_component_post_provision.go
@@ -50,6 +50,9 @@ func (t *componentPostProvisionTransformer) Transform(ctx graph.TransformContext
 		synthesizedComp.LifecycleActions.PostProvision == nil {
 		return nil
 	}
+	if isCompStopped(synthesizedComp) {
+		return nil
+	}
 
 	if checkPostProvisionDone(transCtx) {
 		return nil

--- a/controllers/apps/component/transformer_component_post_provision_test.go
+++ b/controllers/apps/component/transformer_component_post_provision_test.go
@@ -180,5 +180,16 @@ var _ = Describe("post-provision transformer test", func() {
 			Expect(err).ShouldNot(BeNil())
 			Expect(err.Error()).Should(ContainSubstring("has no pods to running the post-provision action"))
 		})
+
+		It("skips post-provision when component is stopping", func() {
+			comp.Spec.Stop = ptr.To(true)
+			synthesizeComponent, err := component.BuildSynthesizedComponent(ctx, reader, compDef, comp)
+			Expect(err).To(BeNil())
+			transCtx.SynthesizeComponent = synthesizeComponent
+
+			transformer := &componentPostProvisionTransformer{}
+			err = transformer.Transform(transCtx, dag)
+			Expect(err).Should(BeNil())
+		})
 	})
 })

--- a/controllers/apps/component/transformer_component_status.go
+++ b/controllers/apps/component/transformer_component_status.go
@@ -164,7 +164,7 @@ func (t *componentStatusTransformer) reconcileStatus(transCtx *componentTransfor
 	switch {
 	case isDeleting:
 		t.setComponentStatusPhase(transCtx, appsv1.DeletingComponentPhase, nil, "component is Deleting")
-	case stopped && (hasRunningPods || !checkPostProvisionDone(transCtx)):
+	case stopped && hasRunningPods:
 		t.setComponentStatusPhase(transCtx, appsv1.StoppingComponentPhase, nil, "component is Stopping")
 	case stopped:
 		t.setComponentStatusPhase(transCtx, appsv1.StoppedComponentPhase, nil, "component is Stopped")

--- a/controllers/apps/component/transformer_component_workload.go
+++ b/controllers/apps/component/transformer_component_workload.go
@@ -193,7 +193,7 @@ func (t *componentWorkloadTransformer) handleWorkloadStartNStop(transCtx *compon
 		runningITSCopy.Annotations[constant.KubeBlocksGenerationKey] = (*protoITS).Annotations[constant.KubeBlocksGenerationKey]
 		*protoITS = runningITSCopy
 	}
-	if stop && checkPostProvisionDone(transCtx) {
+	if stop {
 		(*protoITS).Spec.Stop = ptr.To(true)
 	}
 	if start {

--- a/controllers/apps/component/transformer_component_workload_test.go
+++ b/controllers/apps/component/transformer_component_workload_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/golang/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
@@ -106,6 +107,37 @@ var _ = Describe("Component Workload Operations Test", func() {
 
 		graphCli := model.NewGraphClient(reader)
 		dag = newDAG(graphCli, comp)
+	})
+
+	Context("Start and Stop Operations", func() {
+		It("should stop workload before post-provision is completed", func() {
+			runningITS := testapps.NewInstanceSetFactory(testCtx.DefaultNamespace,
+				constant.GenerateClusterComponentName(clusterName, compName), clusterName, compName).
+				SetReplicas(1).
+				GetObject()
+			runningITS.Annotations = map[string]string{}
+			protoITS := runningITS.DeepCopy()
+			protoITS.Annotations[constant.KubeBlocksGenerationKey] = "2"
+
+			synthesizeComp.Stop = ptr.To(true)
+			synthesizeComp.Generation = "2"
+			synthesizeComp.LifecycleActions = component.SynthesizedLifecycleActions{
+				ComponentLifecycleActions: &appsv1.ComponentLifecycleActions{
+					PostProvision: testapps.NewLifecycleAction("post-provision"),
+				},
+			}
+			transCtx := &componentTransformContext{
+				Component:           comp,
+				SynthesizeComponent: synthesizeComp,
+			}
+
+			start, stop := (&componentWorkloadTransformer{}).handleWorkloadStartNStop(transCtx, synthesizeComp, runningITS, &protoITS)
+
+			Expect(start).Should(BeFalse())
+			Expect(stop).Should(BeTrue())
+			Expect(ptr.Deref(protoITS.Spec.Stop, false)).Should(BeTrue())
+			Expect(protoITS.Annotations[constant.KubeBlocksGenerationKey]).Should(Equal("2"))
+		})
 	})
 
 	Context("Member Leave Operations", func() {


### PR DESCRIPTION
Fixes #9543

Summary:
- let component stop set InstanceSet.spec.stop even when postProvision has not completed
- skip postProvision while a component is stopping
- mark stopped components as Stopped once pods are gone instead of waiting on postProvision annotation

Validation:
- go test ./controllers/apps/component -run '^$'

Note:
- go test ./controllers/apps/component was attempted, but envtest could not start because /usr/local/kubebuilder/bin/etcd is not installed in this local environment.