### PR TITLE
fix(dataprotection): allow empty string for optional name patterns (#10232)

### DIFF
--- a/apis/dataprotection/v1alpha1/backuppolicy_types.go
+++ b/apis/dataprotection/v1alpha1/backuppolicy_types.go
@@ -26,8 +26,9 @@ import (
 type BackupPolicySpec struct {
 	// Specifies the name of BackupRepo where the backup data will be stored.
 	// If not set, data will be stored in the default backup repository.
+	// An empty string is treated the same as the field being unset.
 	//
-	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
+	// +kubebuilder:validation:Pattern:=`^([a-z0-9]([a-z0-9\.\-]*[a-z0-9])?)?$`
 	// +optional
 	BackupRepoName *string `json:"backupRepoName,omitempty"`
 
@@ -232,9 +233,10 @@ type BackupMethod struct {
 	Name string `json:"name"`
 
 	// The name of the compatible full backup method, used by incremental backups.
+	// An empty string is treated the same as the field being unset.
 	//
 	// +optional
-	// +kubebuilder:validation:Pattern:=`^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$`
+	// +kubebuilder:validation:Pattern:=`^([a-z0-9]([a-z0-9\.\-]*[a-z0-9])?)?$`
 	CompatibleMethod string `json:"compatibleMethod,omitempty"`
 
 	// Specifies whether to take snapshots of persistent volumes. If true,

--- a/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -74,9 +74,10 @@ spec:
                         will use the CSI volume snapshotter to create the snapshot.
                       type: string
                     compatibleMethod:
-                      description: The name of the compatible full backup method,
-                        used by incremental backups.
-                      pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                      description: |-
+                        The name of the compatible full backup method, used by incremental backups.
+                        An empty string is treated the same as the field being unset.
+                      pattern: ^([a-z0-9]([a-z0-9\.\-]*[a-z0-9])?)?$
                       type: string
                     env:
                       description: Specifies the environment variables for the backup
@@ -811,7 +812,8 @@ spec:
                 description: |-
                   Specifies the name of BackupRepo where the backup data will be stored.
                   If not set, data will be stored in the default backup repository.
-                pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                  An empty string is treated the same as the field being unset.
+                pattern: ^([a-z0-9]([a-z0-9\.\-]*[a-z0-9])?)?$
                 type: string
               encryptionConfig:
                 description: |-

--- a/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
@@ -296,9 +296,10 @@ spec:
                       will use the CSI volume snapshotter to create the snapshot.
                     type: string
                   compatibleMethod:
-                    description: The name of the compatible full backup method, used
-                      by incremental backups.
-                    pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                    description: |-
+                      The name of the compatible full backup method, used by incremental backups.
+                      An empty string is treated the same as the field being unset.
+                    pattern: ^([a-z0-9]([a-z0-9\.\-]*[a-z0-9])?)?$
                     type: string
                   env:
                     description: Specifies the environment variables for the backup

--- a/controllers/dataprotection/backuppolicy_controller_test.go
+++ b/controllers/dataprotection/backuppolicy_controller_test.go
@@ -23,6 +23,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -119,6 +121,75 @@ var _ = Describe("BackupPolicy Controller test", func() {
 				func(g Gomega, bp *dpv1alpha1.BackupPolicy) {
 					g.Expect(bp.Status.Phase).Should(BeEquivalentTo(dpv1alpha1.AvailablePhase))
 				})).Should(Succeed())
+		})
+	})
+
+	Context("CRD schema validation for optional name patterns (#10232)", func() {
+		It("accepts empty string for spec.backupRepoName", func() {
+			By("creating a BackupPolicy with backupRepoName set to empty string")
+			emptyRepo := ""
+			bp := &dpv1alpha1.BackupPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bp-empty-repo",
+					Namespace: testCtx.DefaultNamespace,
+				},
+				Spec: dpv1alpha1.BackupPolicySpec{
+					BackupRepoName: &emptyRepo,
+					Target: &dpv1alpha1.BackupTarget{
+						PodSelector: &dpv1alpha1.PodSelector{
+							LabelSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									constant.AppInstanceLabelKey: testdp.ClusterName,
+								},
+							},
+						},
+					},
+					BackupMethods: []dpv1alpha1.BackupMethod{
+						{
+							Name:            testdp.BackupMethodName,
+							SnapshotVolumes: ptr.To(false),
+							ActionSetName:   testdp.ActionSetName,
+						},
+					},
+				},
+			}
+			Expect(testCtx.Cli.Create(testCtx.Ctx, bp)).Should(Succeed())
+		})
+
+		It("accepts empty string for spec.backupMethods[].compatibleMethod", func() {
+			By("creating a BackupPolicy with compatibleMethod literally serialized as empty string")
+			// CompatibleMethod has json:"compatibleMethod,omitempty" so a typed
+			// client would strip the empty value before it reaches the API server.
+			// Use an unstructured resource to send the field on the wire and
+			// exercise the OpenAPI pattern validator.
+			bp := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": dpv1alpha1.GroupVersion.String(),
+					"kind":       "BackupPolicy",
+					"metadata": map[string]interface{}{
+						"name":      "bp-empty-compatible",
+						"namespace": testCtx.DefaultNamespace,
+					},
+					"spec": map[string]interface{}{
+						"target": map[string]interface{}{
+							"podSelector": map[string]interface{}{
+								"matchLabels": map[string]interface{}{
+									constant.AppInstanceLabelKey: testdp.ClusterName,
+								},
+							},
+						},
+						"backupMethods": []interface{}{
+							map[string]interface{}{
+								"name":             testdp.BackupMethodName,
+								"snapshotVolumes":  false,
+								"actionSetName":    testdp.ActionSetName,
+								"compatibleMethod": "",
+							},
+						},
+					},
+				},
+			}
+			Expect(testCtx.Cli.Create(testCtx.Ctx, bp)).Should(Succeed())
 		})
 	})
 })

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -74,9 +74,10 @@ spec:
                         will use the CSI volume snapshotter to create the snapshot.
                       type: string
                     compatibleMethod:
-                      description: The name of the compatible full backup method,
-                        used by incremental backups.
-                      pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                      description: |-
+                        The name of the compatible full backup method, used by incremental backups.
+                        An empty string is treated the same as the field being unset.
+                      pattern: ^([a-z0-9]([a-z0-9\.\-]*[a-z0-9])?)?$
                       type: string
                     env:
                       description: Specifies the environment variables for the backup
@@ -811,7 +812,8 @@ spec:
                 description: |-
                   Specifies the name of BackupRepo where the backup data will be stored.
                   If not set, data will be stored in the default backup repository.
-                pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                  An empty string is treated the same as the field being unset.
+                pattern: ^([a-z0-9]([a-z0-9\.\-]*[a-z0-9])?)?$
                 type: string
               encryptionConfig:
                 description: |-

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
@@ -296,9 +296,10 @@ spec:
                       will use the CSI volume snapshotter to create the snapshot.
                     type: string
                   compatibleMethod:
-                    description: The name of the compatible full backup method, used
-                      by incremental backups.
-                    pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
+                    description: |-
+                      The name of the compatible full backup method, used by incremental backups.
+                      An empty string is treated the same as the field being unset.
+                    pattern: ^([a-z0-9]([a-z0-9\.\-]*[a-z0-9])?)?$
                     type: string
                   env:
                     description: Specifies the environment variables for the backup


### PR DESCRIPTION
## What does this PR do?

Closes #10232.

`BackupPolicy.spec.backupRepoName` and `BackupMethod.compatibleMethod` are both documented as optional, and the controller already treats an unset value as "use the default". The OpenAPI `pattern` validator on those fields, however, rejects an empty string:

```
The BackupPolicy "t" is invalid: spec.backupRepoName: Invalid value: "":
  spec.backupRepoName in body should match '^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?\$'
```

This is a footgun for templated authoring (Helm / Kustomize / scripted generation) where rendering an empty string for an unset config value is natural: `backupRepoName: ""` is rejected, while omitting the key entirely is accepted, even though the controller treats the two as equivalent. The internal `MockBackupPolicyFactory.SetBackupRepoName` already silently coerces `""` to nil, which is further evidence the empty-string case is meant to be a no-op.

## How does this PR fix it?

Wrap the existing pattern in an optional group on the two optional fields so it also matches an empty string:

```
^([a-z0-9]([a-z0-9\.\-]*[a-z0-9])?)?\$
```

Required-name patterns elsewhere (`BackupMethod.name`, `ConnectionCredential.secretName`) are left untouched.

Files changed:
- `apis/dataprotection/v1alpha1/backuppolicy_types.go` — relax 2 `+kubebuilder:validation:Pattern` annotations
- `config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml`, `...backups.yaml` — `make manifests` regenerated output
- `deploy/helm/crds/...` — same files, helm-chart copies
- `controllers/dataprotection/backuppolicy_controller_test.go` — 2 envtest specs

## How is this tested?

Added 2 envtest specs in `backuppolicy_controller_test.go`:
- `accepts empty string for spec.backupRepoName` — typed client (field is `*string`, so `&""` reaches the wire).
- `accepts empty string for spec.backupMethods[].compatibleMethod` — uses `unstructured.Unstructured` because the typed field has `json:"...,omitempty"` and would otherwise be stripped on the client side before reaching the API server.

Both specs **fail** on the previous CRD schema (422 from the API server matching the issue's exact error message) and **pass** after this fix. Verified locally with `make envtest` + `go test -short ./controllers/dataprotection/... --ginkgo.focus="CRD schema validation for optional name patterns"`.

## Backward compatibility

This change only **relaxes** validation; existing valid `BackupPolicy` resources remain valid. No controller logic changed.

---
Assisted-by: Claude Code