### PR TITLE
fix(controller): gate kbagent roleProbe by engine-authoritative version

### DIFF
--- a/controllers/k8score/event_controller.go
+++ b/controllers/k8score/event_controller.go
@@ -36,6 +36,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/instanceset"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	"github.com/apecloud/kubeblocks/pkg/kbagent/proto"
 	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
 
@@ -74,6 +75,17 @@ func (r *EventReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	event := &corev1.Event{}
 	if err := r.Client.Get(ctx, req.NamespacedName, event); err != nil {
 		return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "getEventError")
+	}
+
+	// kbagent roleProbe events are owned by InstanceEventReconciler in
+	// controllers/workloads, which applies the engine-authoritative
+	// kb-role-version staleness gate. EventReconciler must not handle them
+	// here. In particular it must not mark them with the shared
+	// `kubeblocks.io/event-handled` annotation, because InstanceEventReconciler
+	// checks the same annotation as its outer guard and would silently drop
+	// the event if it found it already marked.
+	if isKBAgentRoleProbeEvent(event) {
+		return intctrlutil.Reconciled()
 	}
 
 	if r.isEventHandled(event) {
@@ -123,4 +135,10 @@ func (r *EventReconciler) eventHandled(ctx context.Context, event *corev1.Event)
 	}
 	event.Annotations[eventHandledAnnotationKey] = fmt.Sprintf("%d", event.Count)
 	return r.Client.Patch(ctx, event, patch)
+}
+
+func isKBAgentRoleProbeEvent(event *corev1.Event) bool {
+	return event.ReportingController == proto.ProbeEventReportingController &&
+		event.Reason == "roleProbe" &&
+		event.InvolvedObject.FieldPath == proto.ProbeEventFieldPath
 }

--- a/controllers/k8score/event_controller_kbagent_skip_test.go
+++ b/controllers/k8score/event_controller_kbagent_skip_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package k8score
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/apecloud/kubeblocks/pkg/kbagent/proto"
+)
+
+// EventReconciler must skip kbagent roleProbe events at the outer guard so
+// the shared `kubeblocks.io/event-handled` annotation is not stamped. The
+// downstream InstanceEventReconciler uses the same annotation as its outer
+// short-circuit, so stamping it here would silently drop every kbagent
+// roleProbe event the EventReconciler instance processes first.
+func TestIsKBAgentRoleProbeEventMatchesKBAgentSourcedRoleProbe(t *testing.T) {
+	event := &corev1.Event{
+		Reason:              "roleProbe",
+		ReportingController: proto.ProbeEventReportingController,
+		InvolvedObject: corev1.ObjectReference{
+			Kind:      "Pod",
+			Name:      "pod-0",
+			Namespace: "ns",
+			FieldPath: proto.ProbeEventFieldPath,
+		},
+	}
+	if !isKBAgentRoleProbeEvent(event) {
+		t.Fatalf("expected kbagent roleProbe event to be recognised")
+	}
+}
+
+func TestIsKBAgentRoleProbeEventRejectsWrongReason(t *testing.T) {
+	event := &corev1.Event{
+		Reason:              "availableProbe",
+		ReportingController: proto.ProbeEventReportingController,
+		InvolvedObject:      corev1.ObjectReference{FieldPath: proto.ProbeEventFieldPath},
+	}
+	if isKBAgentRoleProbeEvent(event) {
+		t.Fatalf("availableProbe must not be classified as kbagent roleProbe")
+	}
+}
+
+func TestIsKBAgentRoleProbeEventRejectsWrongReportingController(t *testing.T) {
+	event := &corev1.Event{
+		Reason:              "roleProbe",
+		ReportingController: "some-other-controller",
+		InvolvedObject:      corev1.ObjectReference{FieldPath: proto.ProbeEventFieldPath},
+	}
+	if isKBAgentRoleProbeEvent(event) {
+		t.Fatalf("non-kbagent reporting controller must not be classified as kbagent roleProbe")
+	}
+}
+
+func TestIsKBAgentRoleProbeEventRejectsWrongFieldPath(t *testing.T) {
+	event := &corev1.Event{
+		Reason:              "roleProbe",
+		ReportingController: proto.ProbeEventReportingController,
+		InvolvedObject:      corev1.ObjectReference{FieldPath: "spec.containers{some-other}"},
+	}
+	if isKBAgentRoleProbeEvent(event) {
+		t.Fatalf("non-kbagent involvedObject FieldPath must not be classified")
+	}
+}

--- a/controllers/k8score/event_controller_test.go
+++ b/controllers/k8score/event_controller_test.go
@@ -22,7 +22,6 @@ package k8score
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -61,16 +60,9 @@ var _ = Describe("Event Controller", func() {
 		testapps.ClearResources(&testCtx, generics.PodSignature, inNS, ml)
 	}
 
-	const (
-		// roleChangedAnnotKey is used to mark the role change event has been handled.
-		roleChangedAnnotKey = "role.kubeblocks.io/event-handled"
-	)
-
 	var (
-		beforeLastTS = time.Date(2021, time.January, 1, 12, 0, 0, 0, time.UTC)
-		initLastTS   = time.Date(2022, time.January, 1, 12, 0, 0, 0, time.UTC)
-		afterLastTS  = time.Date(2023, time.January, 1, 12, 0, 0, 0, time.UTC)
-		eventSeq     = 0
+		initLastTS = time.Date(2022, time.January, 1, 12, 0, 0, 0, time.UTC)
+		eventSeq   = 0
 	)
 
 	createRoleChangedEvent := func(podName, role string, podUid types.UID) *corev1.Event {
@@ -123,7 +115,16 @@ var _ = Describe("Event Controller", func() {
 	AfterEach(cleanEnv)
 
 	Context("When receiving role changed event", func() {
-		It("should handle it properly", func() {
+		// kbagent roleProbe events are owned by InstanceEventReconciler in
+		// controllers/workloads since the multi-cluster Instance API refactor
+		// (#9697). EventReconciler skips them at the outer guard so the
+		// shared kubeblocks.io/event-handled annotation is not stamped here;
+		// otherwise InstanceEventReconciler's outer short-circuit would see
+		// the event already handled and silently drop it. Pod role label
+		// writes for these events are now exclusively the responsibility of
+		// InstanceEventReconciler and its engine-authoritative staleness
+		// gate (covered by controllers/workloads tests).
+		It("should skip kbagent roleProbe events without writing the pod role label or marking the event handled", func() {
 			By("create cluster & compdef")
 			compDefName := "test-compdef"
 			clusterName := "test-cluster"
@@ -157,6 +158,7 @@ var _ = Describe("Event Controller", func() {
 					},
 				}
 			})()).Should(Succeed())
+
 			By("create involved pod")
 			var uid types.UID
 			podName := fmt.Sprintf("%s-%d", itsName, 0)
@@ -174,9 +176,8 @@ var _ = Describe("Event Controller", func() {
 			}).Should(Succeed())
 			Expect(uid).ShouldNot(BeNil())
 
-			By("send role changed event")
-			role := "leader"
-			sndEvent := createRoleChangedEvent(podName, role, uid)
+			By("send a kbagent roleProbe event")
+			sndEvent := createRoleChangedEvent(podName, "leader", uid)
 			Expect(testCtx.CreateObj(ctx, sndEvent)).Should(Succeed())
 			Eventually(func() string {
 				event := &corev1.Event{}
@@ -189,63 +190,24 @@ var _ = Describe("Event Controller", func() {
 				return event.InvolvedObject.Name
 			}).Should(Equal(sndEvent.InvolvedObject.Name))
 
-			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(pod), func(g Gomega, p *corev1.Pod) {
+			By("the pod role label and last-role-snapshot-version annotation must stay untouched")
+			Consistently(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(pod), func(g Gomega, p *corev1.Pod) {
 				g.Expect(p).ShouldNot(BeNil())
-				g.Expect(p.Labels).ShouldNot(BeNil())
-				g.Expect(p.Labels[constant.RoleLabelKey]).Should(Equal(role))
-				g.Expect(p.Annotations[constant.LastRoleEventVersionAnnotationKey]).Should(Equal(strconv.FormatInt(sndEvent.EventTime.UnixMicro(), 10)))
-			})).Should(Succeed())
+				if p.Labels != nil {
+					g.Expect(p.Labels).ShouldNot(HaveKey(constant.RoleLabelKey))
+				}
+				if p.Annotations != nil {
+					g.Expect(p.Annotations).ShouldNot(HaveKey(constant.LastRoleEventVersionAnnotationKey))
+				}
+			}), 2*time.Second, 200*time.Millisecond).Should(Succeed())
 
-			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(sndEvent), func(g Gomega, e *corev1.Event) {
+			By("the event must not be stamped with the EventReconciler handled annotation")
+			Consistently(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(sndEvent), func(g Gomega, e *corev1.Event) {
 				g.Expect(e).ShouldNot(BeNil())
-				g.Expect(e.Annotations).ShouldNot(BeNil())
-				g.Expect(e.Annotations[roleChangedAnnotKey]).Should(Equal("count-0"))
-			})).Should(Succeed())
-
-			By("send role changed event with beforeLastTS earlier than pod last role changes event timestamp annotation should not be update successfully")
-			role = "follower"
-			sndInvalidEvent := createRoleChangedEvent(podName, role, uid)
-			sndInvalidEvent.EventTime = metav1.NewMicroTime(beforeLastTS)
-			Expect(testCtx.CreateObj(ctx, sndInvalidEvent)).Should(Succeed())
-			Eventually(func() string {
-				event := &corev1.Event{}
-				if err := k8sClient.Get(ctx, types.NamespacedName{
-					Namespace: sndInvalidEvent.Namespace,
-					Name:      sndInvalidEvent.Name,
-				}, event); err != nil {
-					return err.Error()
+				if e.Annotations != nil {
+					g.Expect(e.Annotations).ShouldNot(HaveKey(eventHandledAnnotationKey))
 				}
-				return event.InvolvedObject.Name
-			}).Should(Equal(sndInvalidEvent.InvolvedObject.Name))
-			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(pod), func(g Gomega, p *corev1.Pod) {
-				g.Expect(p).ShouldNot(BeNil())
-				g.Expect(p.Labels).ShouldNot(BeNil())
-				g.Expect(p.Labels[constant.RoleLabelKey]).ShouldNot(Equal(role))
-				g.Expect(p.Annotations[constant.LastRoleEventVersionAnnotationKey]).ShouldNot(Equal(strconv.FormatInt(sndInvalidEvent.EventTime.UnixMicro(), 10)))
-			})).Should(Succeed())
-
-			By("send role changed event with afterLastTS later than pod last role changes event timestamp annotation should be update successfully")
-			role = "follower"
-			sndValidEvent := createRoleChangedEvent(podName, role, uid)
-			sndValidEvent.LastTimestamp = metav1.NewTime(afterLastTS)
-			sndValidEvent.EventTime = metav1.NewMicroTime(afterLastTS)
-			Expect(testCtx.CreateObj(ctx, sndValidEvent)).Should(Succeed())
-			Eventually(func() string {
-				event := &corev1.Event{}
-				if err := k8sClient.Get(ctx, types.NamespacedName{
-					Namespace: sndValidEvent.Namespace,
-					Name:      sndValidEvent.Name,
-				}, event); err != nil {
-					return err.Error()
-				}
-				return event.InvolvedObject.Name
-			}).Should(Equal(sndValidEvent.InvolvedObject.Name))
-			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(pod), func(g Gomega, p *corev1.Pod) {
-				g.Expect(p).ShouldNot(BeNil())
-				g.Expect(p.Labels).ShouldNot(BeNil())
-				g.Expect(p.Labels[constant.RoleLabelKey]).Should(Equal(role))
-				g.Expect(p.Annotations[constant.LastRoleEventVersionAnnotationKey]).Should(Equal(strconv.FormatInt(sndValidEvent.LastTimestamp.UnixMicro(), 10)))
-			})).Should(Succeed())
+			}), 2*time.Second, 200*time.Millisecond).Should(Succeed())
 		})
 	})
 })

--- a/controllers/workloads/instance_event_controller.go
+++ b/controllers/workloads/instance_event_controller.go
@@ -161,16 +161,22 @@ func (r *InstanceEventReconciler) handleRoleChangedEvent(ctx context.Context, lo
 	if err := r.updatePodRoleLabel(ctx, pod, parsed.role, newAnnotation); err != nil {
 		return err
 	}
-	return r.cleanupExclusiveRolePeers(ctx, logger, pod, parsed, newAnnotation)
+	return r.cleanupExclusiveRolePeers(ctx, logger, pod, parsed, event.EventTime.UnixMicro())
 }
 
 // cleanupExclusiveRolePeers removes the role label from any other Pod in the
 // same InstanceSet that still carries an exclusive role label this event just
 // claimed. The peer cleanup honours the same engine-version staleness gate as
 // the primary update: a peer whose annotation already records a newer engine
-// version is left alone, so a stale primary event cannot strip the label from
-// a freshly-promoted peer that has already advanced past it.
-func (r *InstanceEventReconciler) cleanupExclusiveRolePeers(ctx context.Context, logger logr.Logger, newPod *corev1.Pod, parsed roleProbeOutput, newAnnotation string) error {
+// version (or, in the legacy path, a later EventTime) is left alone, so a
+// stale primary event cannot strip the label from a freshly-promoted peer
+// that has already advanced past it.
+//
+// `eventTimeMicros` is the source event's EventTime in micros; the legacy
+// path uses it as the comparison key against the peer's bare-EventTime
+// annotation. Passing it through (instead of a hard-coded 0) keeps the
+// version state consistent across the primary update and the peer cleanup.
+func (r *InstanceEventReconciler) cleanupExclusiveRolePeers(ctx context.Context, logger logr.Logger, newPod *corev1.Pod, parsed roleProbeOutput, eventTimeMicros int64) error {
 	if parsed.role == "" {
 		return nil
 	}
@@ -214,9 +220,10 @@ func (r *InstanceEventReconciler) cleanupExclusiveRolePeers(ctx context.Context,
 			lastPeerAnnotation = peer.Annotations[constant.LastRoleEventVersionAnnotationKey]
 		}
 		// Reuse the same gate: only strip the peer's label if this event is
-		// actually newer than what the peer already recorded. Otherwise we
-		// might race-strip a peer that has already advanced its own version.
-		decision, peerNewAnnotation := checkRoleProbeStale(parsed, lastPeerAnnotation, 0)
+		// actually newer than what the peer already recorded. Legacy events
+		// rely on eventTimeMicros to do the comparison; engine events use
+		// parsed.version internally and ignore the EventTime argument.
+		decision, peerNewAnnotation := checkRoleProbeStale(parsed, lastPeerAnnotation, eventTimeMicros)
 		if decision != roleProbeGateAccept {
 			logger.Info("skip exclusive role label cleanup; peer annotation is not older than this event",
 				"newPod", newPod.Name, "peer", peer.Name, "lastPeerAnnotation", lastPeerAnnotation)
@@ -229,9 +236,6 @@ func (r *InstanceEventReconciler) cleanupExclusiveRolePeers(ctx context.Context,
 		logger.Info("removed exclusive role label from peer",
 			"newPod", newPod.Name, "peer", peer.Name, "role", parsed.role)
 	}
-	// newAnnotation is unused here; it is passed to keep the call-site
-	// explicit that the gate already advanced the primary pod's annotation.
-	_ = newAnnotation
 	return errors.Join(errs...)
 }
 

--- a/controllers/workloads/instance_event_controller.go
+++ b/controllers/workloads/instance_event_controller.go
@@ -219,17 +219,18 @@ func (r *InstanceEventReconciler) cleanupExclusiveRolePeers(ctx context.Context,
 		if peer.Annotations != nil {
 			lastPeerAnnotation = peer.Annotations[constant.LastRoleEventVersionAnnotationKey]
 		}
-		// Reuse the same gate: only strip the peer's label if this event is
-		// actually newer than what the peer already recorded. Legacy events
-		// rely on eventTimeMicros to do the comparison; engine events use
-		// parsed.version internally and ignore the EventTime argument.
-		decision, peerNewAnnotation := checkRoleProbeStale(parsed, lastPeerAnnotation, eventTimeMicros)
+		// Reuse the same gate to decide whether the new event is newer than
+		// what the peer already recorded; the returned annotation value is
+		// intentionally discarded here (see stripExclusiveRoleLabel below).
+		// Legacy events rely on eventTimeMicros to do the comparison; engine
+		// events use parsed.version internally and ignore EventTime.
+		decision, _ := checkRoleProbeStale(parsed, lastPeerAnnotation, eventTimeMicros)
 		if decision != roleProbeGateAccept {
 			logger.Info("skip exclusive role label cleanup; peer annotation is not older than this event",
 				"newPod", newPod.Name, "peer", peer.Name, "lastPeerAnnotation", lastPeerAnnotation)
 			continue
 		}
-		if err := r.stripExclusiveRoleLabel(ctx, peer, peerNewAnnotation); err != nil {
+		if err := r.stripExclusiveRoleLabel(ctx, peer); err != nil {
 			errs = append(errs, err)
 			continue
 		}
@@ -239,18 +240,26 @@ func (r *InstanceEventReconciler) cleanupExclusiveRolePeers(ctx context.Context,
 	return errors.Join(errs...)
 }
 
-func (r *InstanceEventReconciler) stripExclusiveRoleLabel(ctx context.Context, peer *corev1.Pod, peerNewAnnotation string) error {
-	newPeer := peer.DeepCopy()
-	delete(newPeer.Labels, constant.RoleLabelKey)
-	if peerNewAnnotation != "" {
-		if newPeer.Annotations == nil {
-			newPeer.Annotations = make(map[string]string)
-		}
-		newPeer.Annotations[constant.LastRoleEventVersionAnnotationKey] = peerNewAnnotation
-	}
-	if reflect.DeepEqual(newPeer.Labels, peer.Labels) && reflect.DeepEqual(newPeer.Annotations, peer.Annotations) {
+// stripExclusiveRoleLabel deletes the exclusive role label from a peer but
+// deliberately leaves LastRoleEventVersionAnnotationKey untouched.
+//
+// That annotation represents the last roleProbe event the peer's *own*
+// kbagent emitted. Stamping it with the new primary's engine version (which
+// did not originate from this peer's kbagent) would let the strict-newer
+// gate later reject a legitimate event from the peer at the same engine
+// epoch — for example after failover the demoted pod's next event is
+// `secondary <same-epoch>`, and the gate would treat it as stale because
+// the peer's annotation was already advanced by the cleanup step.
+//
+// Strict-newer is intentionally preserved on the gate itself; loosening it
+// to "equal version, different role" would re-open the silent same-epoch
+// stale-primary write-back the gate is supposed to close.
+func (r *InstanceEventReconciler) stripExclusiveRoleLabel(ctx context.Context, peer *corev1.Pod) error {
+	if _, has := peer.Labels[constant.RoleLabelKey]; !has {
 		return nil
 	}
+	newPeer := peer.DeepCopy()
+	delete(newPeer.Labels, constant.RoleLabelKey)
 	return r.Client.Update(ctx, newPeer)
 }
 

--- a/controllers/workloads/instance_event_controller.go
+++ b/controllers/workloads/instance_event_controller.go
@@ -22,12 +22,14 @@ package workloads
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -36,7 +38,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	workloadsv1 "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/instanceset"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	"github.com/apecloud/kubeblocks/pkg/kbagent/proto"
 	viper "github.com/apecloud/kubeblocks/pkg/viperx"
@@ -154,7 +158,96 @@ func (r *InstanceEventReconciler) handleRoleChangedEvent(ctx context.Context, lo
 	}
 	logger.Info("handle role change event",
 		"pod", pod.Name, "role", parsed.role, "mode", parsed.mode, "version", parsed.version)
-	return r.updatePodRoleLabel(ctx, pod, parsed.role, newAnnotation)
+	if err := r.updatePodRoleLabel(ctx, pod, parsed.role, newAnnotation); err != nil {
+		return err
+	}
+	return r.cleanupExclusiveRolePeers(ctx, logger, pod, parsed, newAnnotation)
+}
+
+// cleanupExclusiveRolePeers removes the role label from any other Pod in the
+// same InstanceSet that still carries an exclusive role label this event just
+// claimed. The peer cleanup honours the same engine-version staleness gate as
+// the primary update: a peer whose annotation already records a newer engine
+// version is left alone, so a stale primary event cannot strip the label from
+// a freshly-promoted peer that has already advanced past it.
+func (r *InstanceEventReconciler) cleanupExclusiveRolePeers(ctx context.Context, logger logr.Logger, newPod *corev1.Pod, parsed roleProbeOutput, newAnnotation string) error {
+	if parsed.role == "" {
+		return nil
+	}
+	itsName, ok := newPod.Labels[instanceset.WorkloadsInstanceLabelKey]
+	if !ok || itsName == "" {
+		return nil
+	}
+	its := &workloadsv1.InstanceSet{}
+	itsKey := types.NamespacedName{Namespace: newPod.Namespace, Name: itsName}
+	if err := r.Client.Get(ctx, itsKey, its); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	exclusive := false
+	for _, role := range its.Spec.Roles {
+		if strings.EqualFold(role.Name, parsed.role) && role.IsExclusive {
+			exclusive = true
+			break
+		}
+	}
+	if !exclusive {
+		return nil
+	}
+
+	labels := instanceset.GetMatchLabels(its.Name)
+	labels[constant.RoleLabelKey] = parsed.role
+	var pods corev1.PodList
+	if err := r.Client.List(ctx, &pods, client.InNamespace(its.Namespace), client.MatchingLabels(labels)); err != nil {
+		return err
+	}
+	var errs []error
+	for i := range pods.Items {
+		peer := &pods.Items[i]
+		if peer.Name == newPod.Name {
+			continue
+		}
+		lastPeerAnnotation := ""
+		if peer.Annotations != nil {
+			lastPeerAnnotation = peer.Annotations[constant.LastRoleEventVersionAnnotationKey]
+		}
+		// Reuse the same gate: only strip the peer's label if this event is
+		// actually newer than what the peer already recorded. Otherwise we
+		// might race-strip a peer that has already advanced its own version.
+		decision, peerNewAnnotation := checkRoleProbeStale(parsed, lastPeerAnnotation, 0)
+		if decision != roleProbeGateAccept {
+			logger.Info("skip exclusive role label cleanup; peer annotation is not older than this event",
+				"newPod", newPod.Name, "peer", peer.Name, "lastPeerAnnotation", lastPeerAnnotation)
+			continue
+		}
+		if err := r.stripExclusiveRoleLabel(ctx, peer, peerNewAnnotation); err != nil {
+			errs = append(errs, err)
+			continue
+		}
+		logger.Info("removed exclusive role label from peer",
+			"newPod", newPod.Name, "peer", peer.Name, "role", parsed.role)
+	}
+	// newAnnotation is unused here; it is passed to keep the call-site
+	// explicit that the gate already advanced the primary pod's annotation.
+	_ = newAnnotation
+	return errors.Join(errs...)
+}
+
+func (r *InstanceEventReconciler) stripExclusiveRoleLabel(ctx context.Context, peer *corev1.Pod, peerNewAnnotation string) error {
+	newPeer := peer.DeepCopy()
+	delete(newPeer.Labels, constant.RoleLabelKey)
+	if peerNewAnnotation != "" {
+		if newPeer.Annotations == nil {
+			newPeer.Annotations = make(map[string]string)
+		}
+		newPeer.Annotations[constant.LastRoleEventVersionAnnotationKey] = peerNewAnnotation
+	}
+	if reflect.DeepEqual(newPeer.Labels, peer.Labels) && reflect.DeepEqual(newPeer.Annotations, peer.Annotations) {
+		return nil
+	}
+	return r.Client.Update(ctx, newPeer)
 }
 
 func (r *InstanceEventReconciler) updatePodRoleLabel(ctx context.Context, pod *corev1.Pod, roleName, newAnnotation string) error {

--- a/controllers/workloads/instance_event_controller.go
+++ b/controllers/workloads/instance_event_controller.go
@@ -135,12 +135,29 @@ func (r *InstanceEventReconciler) handleRoleChangedEvent(ctx context.Context, lo
 		return nil
 	}
 
-	role := strings.ToLower(string(probeEvent.Output))
-	logger.Info("handle role change event", "pod", pod.Name, "role", role)
-	return r.updatePodRoleLabel(ctx, pod, role)
+	parsed := parseRoleProbeOutput(probeEvent.Output)
+	lastAnnotation := ""
+	if pod.Annotations != nil {
+		lastAnnotation = pod.Annotations[constant.LastRoleEventVersionAnnotationKey]
+	}
+	decision, newAnnotation := checkRoleProbeStale(parsed, lastAnnotation, event.EventTime.UnixMicro())
+	switch decision {
+	case roleProbeGateRejectStale:
+		logger.Info("stale role probe event rejected by version gate",
+			"pod", pod.Name, "role", parsed.role, "mode", parsed.mode,
+			"newVersion", parsed.version, "lastAnnotation", lastAnnotation)
+		return nil
+	case roleProbeGateRejectMalformed:
+		logger.Info("malformed kb-role-version line rejected; addon attempted new contract but emitted an unparseable trailer",
+			"pod", pod.Name, "role", parsed.role, "rawOutput", string(probeEvent.Output))
+		return nil
+	}
+	logger.Info("handle role change event",
+		"pod", pod.Name, "role", parsed.role, "mode", parsed.mode, "version", parsed.version)
+	return r.updatePodRoleLabel(ctx, pod, parsed.role, newAnnotation)
 }
 
-func (r *InstanceEventReconciler) updatePodRoleLabel(ctx context.Context, pod *corev1.Pod, roleName string) error {
+func (r *InstanceEventReconciler) updatePodRoleLabel(ctx context.Context, pod *corev1.Pod, roleName, newAnnotation string) error {
 	newPod := pod.DeepCopy()
 	if len(roleName) == 0 {
 		delete(newPod.Labels, constant.RoleLabelKey)
@@ -150,7 +167,13 @@ func (r *InstanceEventReconciler) updatePodRoleLabel(ctx context.Context, pod *c
 		}
 		newPod.Labels[constant.RoleLabelKey] = roleName
 	}
-	if reflect.DeepEqual(newPod.Labels, pod.Labels) {
+	if newAnnotation != "" {
+		if newPod.Annotations == nil {
+			newPod.Annotations = make(map[string]string)
+		}
+		newPod.Annotations[constant.LastRoleEventVersionAnnotationKey] = newAnnotation
+	}
+	if reflect.DeepEqual(newPod.Labels, pod.Labels) && reflect.DeepEqual(newPod.Annotations, pod.Annotations) {
 		return nil
 	}
 	return r.Client.Update(ctx, newPod)

--- a/controllers/workloads/instance_event_controller_cleanup_test.go
+++ b/controllers/workloads/instance_event_controller_cleanup_test.go
@@ -84,23 +84,25 @@ func newCleanupPod(namespace, name, itsName, role, annotation string) *corev1.Po
 }
 
 // Legacy event whose EventTime is strictly newer than a peer's bare-EventTime
-// annotation must strip the peer's exclusive role label and advance the peer
-// annotation to the source event's EventTime micros. The previous
-// implementation hard-coded the legacy comparison EventTime to 0, which made
-// every legacy peer cleanup look stale.
-func TestCleanupExclusiveRolePeersLegacyEventAdvancesOlderPeer(t *testing.T) {
+// annotation must strip the peer's exclusive role label but leave the peer's
+// own LastRoleEventVersionAnnotationKey untouched. The annotation belongs to
+// the peer's own kbagent stream; cleanup must not advance it on the peer's
+// behalf or the peer's next legitimate event at the same epoch would be
+// rejected as stale.
+func TestCleanupExclusiveRolePeersLegacyEventStripsLabelOfOlderPeerWithoutAdvancingAnnotation(t *testing.T) {
 	scheme := newCleanupScheme(t)
 	const (
-		ns        = "default"
-		itsName   = "redis-0"
-		newPod    = "redis-0-0"
-		peerName  = "redis-0-1"
-		roleName  = "primary"
-		newMicros = int64(1779550700000000)
+		ns          = "default"
+		itsName     = "redis-0"
+		newPod      = "redis-0-0"
+		peerName    = "redis-0-1"
+		roleName    = "primary"
+		newMicros   = int64(1779550700000000)
+		peerAnnotIn = "1779550500000000"
 	)
 	its := newCleanupInstanceSet(ns, itsName, roleName)
 	newPodObj := newCleanupPod(ns, newPod, itsName, roleName, fmt.Sprintf("%d", newMicros))
-	peer := newCleanupPod(ns, peerName, itsName, roleName, "1779550500000000") // older EventTime
+	peer := newCleanupPod(ns, peerName, itsName, roleName, peerAnnotIn) // older EventTime
 	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(its, newPodObj, peer).Build()
 
 	r := &InstanceEventReconciler{Client: cli, Scheme: scheme}
@@ -115,9 +117,8 @@ func TestCleanupExclusiveRolePeersLegacyEventAdvancesOlderPeer(t *testing.T) {
 	if _, ok := updated.Labels[constant.RoleLabelKey]; ok {
 		t.Fatalf("peer role label still present after legacy cleanup: %v", updated.Labels)
 	}
-	want := fmt.Sprintf("%d", newMicros)
-	if got := updated.Annotations[constant.LastRoleEventVersionAnnotationKey]; got != want {
-		t.Fatalf("peer annotation = %q, want %q", got, want)
+	if got := updated.Annotations[constant.LastRoleEventVersionAnnotationKey]; got != peerAnnotIn {
+		t.Fatalf("peer annotation = %q, want %q (unchanged)", got, peerAnnotIn)
 	}
 }
 
@@ -158,22 +159,23 @@ func TestCleanupExclusiveRolePeersLegacyEventDoesNotStripNewerPeer(t *testing.T)
 }
 
 // Engine event whose version is strictly larger than a peer's engine
-// annotation must strip the peer and advance the peer annotation to the new
-// engine version.
-func TestCleanupExclusiveRolePeersEngineEventAdvancesOlderPeer(t *testing.T) {
+// annotation must strip the peer's exclusive role label without advancing
+// the peer's own annotation. The same rule as the legacy case applies: the
+// annotation belongs to the peer's own roleProbe event stream.
+func TestCleanupExclusiveRolePeersEngineEventStripsLabelOfOlderPeerWithoutAdvancingAnnotation(t *testing.T) {
 	scheme := newCleanupScheme(t)
 	const (
-		ns         = "default"
-		itsName    = "redis-0"
-		newPod     = "redis-0-0"
-		peerName   = "redis-0-1"
-		roleName   = "primary"
-		newVersion = uint64(20)
-		peerAnnot  = "engine:10"
+		ns          = "default"
+		itsName     = "redis-0"
+		newPod      = "redis-0-0"
+		peerName    = "redis-0-1"
+		roleName    = "primary"
+		newVersion  = uint64(20)
+		peerAnnotIn = "engine:10"
 	)
 	its := newCleanupInstanceSet(ns, itsName, roleName)
 	newPodObj := newCleanupPod(ns, newPod, itsName, roleName, fmt.Sprintf("engine:%d", newVersion))
-	peer := newCleanupPod(ns, peerName, itsName, roleName, peerAnnot)
+	peer := newCleanupPod(ns, peerName, itsName, roleName, peerAnnotIn)
 	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(its, newPodObj, peer).Build()
 
 	r := &InstanceEventReconciler{Client: cli, Scheme: scheme}
@@ -188,8 +190,63 @@ func TestCleanupExclusiveRolePeersEngineEventAdvancesOlderPeer(t *testing.T) {
 	if _, ok := updated.Labels[constant.RoleLabelKey]; ok {
 		t.Fatalf("peer role label still present after engine cleanup: %v", updated.Labels)
 	}
-	if got := updated.Annotations[constant.LastRoleEventVersionAnnotationKey]; got != fmt.Sprintf("engine:%d", newVersion) {
-		t.Fatalf("peer annotation = %q, want %q", got, fmt.Sprintf("engine:%d", newVersion))
+	if got := updated.Annotations[constant.LastRoleEventVersionAnnotationKey]; got != peerAnnotIn {
+		t.Fatalf("peer annotation = %q, want %q (unchanged)", got, peerAnnotIn)
+	}
+}
+
+// Regression for the bug Alice's V1 surfaced: after cleanup strips the old
+// primary's label, the old primary's own next roleProbe event at the same
+// engine epoch (e.g. "secondary 1" arriving right after a new primary was
+// claimed at version 1) must be accepted by handleRoleChangedEvent and
+// install the correct label, because the cleanup step did not silently
+// advance the peer's annotation.
+func TestCleanupExclusiveRolePeersThenDemotedPeerAcceptsItsOwnEvent(t *testing.T) {
+	scheme := newCleanupScheme(t)
+	const (
+		ns          = "default"
+		itsName     = "redis-0"
+		newPod      = "redis-0-0"
+		peerName    = "redis-0-1"
+		roleName    = "primary"
+		newVersion  = uint64(1)
+		peerAnnotIn = "engine:0" // peer's previous accepted event at the earlier epoch
+	)
+	its := newCleanupInstanceSet(ns, itsName, roleName)
+	newPodObj := newCleanupPod(ns, newPod, itsName, roleName, fmt.Sprintf("engine:%d", newVersion))
+	peer := newCleanupPod(ns, peerName, itsName, roleName, peerAnnotIn)
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(its, newPodObj, peer).Build()
+
+	r := &InstanceEventReconciler{Client: cli, Scheme: scheme}
+	parsed := roleProbeOutput{role: roleName, version: newVersion, mode: roleProbeVersionModeEngine}
+	if err := r.cleanupExclusiveRolePeers(context.Background(), logr.Discard(), newPodObj, parsed, 0); err != nil {
+		t.Fatalf("cleanupExclusiveRolePeers err = %v", err)
+	}
+
+	// Simulate the peer's own kbagent emitting its post-failover event
+	// "secondary 1" — same engine epoch as the cleanup-driving event, but
+	// from the peer's own roleProbe stream. Without the annotation-stamp
+	// fix this would be silently rejected as stale and the peer would stay
+	// label-less.
+	peerCurrent := &corev1.Pod{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: peerName}, peerCurrent); err != nil {
+		t.Fatalf("get peer pod: %v", err)
+	}
+	peerLastAnnotation := ""
+	if peerCurrent.Annotations != nil {
+		peerLastAnnotation = peerCurrent.Annotations[constant.LastRoleEventVersionAnnotationKey]
+	}
+	if peerLastAnnotation != peerAnnotIn {
+		t.Fatalf("precondition: peer annotation should be unchanged after cleanup, got %q want %q", peerLastAnnotation, peerAnnotIn)
+	}
+
+	peerParsed := roleProbeOutput{role: "secondary", version: newVersion, mode: roleProbeVersionModeEngine}
+	decision, peerNewAnnotation := checkRoleProbeStale(peerParsed, peerLastAnnotation, 0)
+	if decision != roleProbeGateAccept {
+		t.Fatalf("peer's own post-failover secondary event must be accepted; decision = %d, want Accept (peer annotation was not advanced by cleanup)", decision)
+	}
+	if peerNewAnnotation != fmt.Sprintf("engine:%d", newVersion) {
+		t.Fatalf("peer's post-failover annotation should advance to engine:%d, got %q", newVersion, peerNewAnnotation)
 	}
 }
 

--- a/controllers/workloads/instance_event_controller_cleanup_test.go
+++ b/controllers/workloads/instance_event_controller_cleanup_test.go
@@ -1,0 +1,264 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package workloads
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	workloadsv1 "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/instanceset"
+)
+
+func newCleanupScheme(t *testing.T) *k8sruntime.Scheme {
+	scheme := k8sruntime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("add client-go scheme: %v", err)
+	}
+	if err := workloadsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add workloads scheme: %v", err)
+	}
+	return scheme
+}
+
+func newCleanupInstanceSet(namespace, name, exclusiveRole string) *workloadsv1.InstanceSet {
+	return &workloadsv1.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: workloadsv1.InstanceSetSpec{
+			Roles: []workloadsv1.ReplicaRole{
+				{Name: exclusiveRole, ParticipatesInQuorum: true, UpdatePriority: 5, IsExclusive: true},
+				{Name: "secondary", ParticipatesInQuorum: true, UpdatePriority: 3},
+			},
+		},
+	}
+}
+
+func newCleanupPod(namespace, name, itsName, role, annotation string) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Labels: map[string]string{
+				constant.AppManagedByLabelKey:          constant.AppName,
+				instanceset.WorkloadsManagedByLabelKey: workloadsv1.InstanceSetKind,
+				instanceset.WorkloadsInstanceLabelKey:  itsName,
+			},
+		},
+	}
+	if role != "" {
+		pod.Labels[constant.RoleLabelKey] = role
+	}
+	if annotation != "" {
+		pod.Annotations = map[string]string{
+			constant.LastRoleEventVersionAnnotationKey: annotation,
+		}
+	}
+	return pod
+}
+
+// Legacy event whose EventTime is strictly newer than a peer's bare-EventTime
+// annotation must strip the peer's exclusive role label and advance the peer
+// annotation to the source event's EventTime micros. The previous
+// implementation hard-coded the legacy comparison EventTime to 0, which made
+// every legacy peer cleanup look stale.
+func TestCleanupExclusiveRolePeersLegacyEventAdvancesOlderPeer(t *testing.T) {
+	scheme := newCleanupScheme(t)
+	const (
+		ns        = "default"
+		itsName   = "redis-0"
+		newPod    = "redis-0-0"
+		peerName  = "redis-0-1"
+		roleName  = "primary"
+		newMicros = int64(1779550700000000)
+	)
+	its := newCleanupInstanceSet(ns, itsName, roleName)
+	newPodObj := newCleanupPod(ns, newPod, itsName, roleName, fmt.Sprintf("%d", newMicros))
+	peer := newCleanupPod(ns, peerName, itsName, roleName, "1779550500000000") // older EventTime
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(its, newPodObj, peer).Build()
+
+	r := &InstanceEventReconciler{Client: cli, Scheme: scheme}
+	parsed := roleProbeOutput{role: roleName, mode: roleProbeVersionModeNone}
+	if err := r.cleanupExclusiveRolePeers(context.Background(), logr.Discard(), newPodObj, parsed, newMicros); err != nil {
+		t.Fatalf("cleanupExclusiveRolePeers err = %v", err)
+	}
+	updated := &corev1.Pod{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: peerName}, updated); err != nil {
+		t.Fatalf("get peer pod: %v", err)
+	}
+	if _, ok := updated.Labels[constant.RoleLabelKey]; ok {
+		t.Fatalf("peer role label still present after legacy cleanup: %v", updated.Labels)
+	}
+	want := fmt.Sprintf("%d", newMicros)
+	if got := updated.Annotations[constant.LastRoleEventVersionAnnotationKey]; got != want {
+		t.Fatalf("peer annotation = %q, want %q", got, want)
+	}
+}
+
+// Legacy event whose EventTime is older than a peer's bare-EventTime
+// annotation must leave the peer alone (no label strip, no annotation
+// rewrite), preserving the peer's recorded state.
+func TestCleanupExclusiveRolePeersLegacyEventDoesNotStripNewerPeer(t *testing.T) {
+	scheme := newCleanupScheme(t)
+	const (
+		ns        = "default"
+		itsName   = "redis-0"
+		newPod    = "redis-0-0"
+		peerName  = "redis-0-1"
+		roleName  = "primary"
+		newMicros = int64(1779550500000000)
+		peerAnnot = "1779550700000000"
+	)
+	its := newCleanupInstanceSet(ns, itsName, roleName)
+	newPodObj := newCleanupPod(ns, newPod, itsName, roleName, fmt.Sprintf("%d", newMicros))
+	peer := newCleanupPod(ns, peerName, itsName, roleName, peerAnnot)
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(its, newPodObj, peer).Build()
+
+	r := &InstanceEventReconciler{Client: cli, Scheme: scheme}
+	parsed := roleProbeOutput{role: roleName, mode: roleProbeVersionModeNone}
+	if err := r.cleanupExclusiveRolePeers(context.Background(), logr.Discard(), newPodObj, parsed, newMicros); err != nil {
+		t.Fatalf("cleanupExclusiveRolePeers err = %v", err)
+	}
+	updated := &corev1.Pod{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: peerName}, updated); err != nil {
+		t.Fatalf("get peer pod: %v", err)
+	}
+	if got, ok := updated.Labels[constant.RoleLabelKey]; !ok || got != roleName {
+		t.Fatalf("peer role label was stripped or changed: %v", updated.Labels)
+	}
+	if got := updated.Annotations[constant.LastRoleEventVersionAnnotationKey]; got != peerAnnot {
+		t.Fatalf("peer annotation = %q, want %q (unchanged)", got, peerAnnot)
+	}
+}
+
+// Engine event whose version is strictly larger than a peer's engine
+// annotation must strip the peer and advance the peer annotation to the new
+// engine version.
+func TestCleanupExclusiveRolePeersEngineEventAdvancesOlderPeer(t *testing.T) {
+	scheme := newCleanupScheme(t)
+	const (
+		ns         = "default"
+		itsName    = "redis-0"
+		newPod     = "redis-0-0"
+		peerName   = "redis-0-1"
+		roleName   = "primary"
+		newVersion = uint64(20)
+		peerAnnot  = "engine:10"
+	)
+	its := newCleanupInstanceSet(ns, itsName, roleName)
+	newPodObj := newCleanupPod(ns, newPod, itsName, roleName, fmt.Sprintf("engine:%d", newVersion))
+	peer := newCleanupPod(ns, peerName, itsName, roleName, peerAnnot)
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(its, newPodObj, peer).Build()
+
+	r := &InstanceEventReconciler{Client: cli, Scheme: scheme}
+	parsed := roleProbeOutput{role: roleName, version: newVersion, mode: roleProbeVersionModeEngine}
+	if err := r.cleanupExclusiveRolePeers(context.Background(), logr.Discard(), newPodObj, parsed, 0); err != nil {
+		t.Fatalf("cleanupExclusiveRolePeers err = %v", err)
+	}
+	updated := &corev1.Pod{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: peerName}, updated); err != nil {
+		t.Fatalf("get peer pod: %v", err)
+	}
+	if _, ok := updated.Labels[constant.RoleLabelKey]; ok {
+		t.Fatalf("peer role label still present after engine cleanup: %v", updated.Labels)
+	}
+	if got := updated.Annotations[constant.LastRoleEventVersionAnnotationKey]; got != fmt.Sprintf("engine:%d", newVersion) {
+		t.Fatalf("peer annotation = %q, want %q", got, fmt.Sprintf("engine:%d", newVersion))
+	}
+}
+
+// Engine event whose version is smaller than a peer's engine annotation must
+// leave the peer's exclusive role label intact, even though the new event was
+// itself accepted on a different Pod.
+func TestCleanupExclusiveRolePeersEngineEventDoesNotStripNewerPeer(t *testing.T) {
+	scheme := newCleanupScheme(t)
+	const (
+		ns         = "default"
+		itsName    = "redis-0"
+		newPod     = "redis-0-0"
+		peerName   = "redis-0-1"
+		roleName   = "primary"
+		newVersion = uint64(10)
+		peerAnnot  = "engine:20"
+	)
+	its := newCleanupInstanceSet(ns, itsName, roleName)
+	newPodObj := newCleanupPod(ns, newPod, itsName, roleName, fmt.Sprintf("engine:%d", newVersion))
+	peer := newCleanupPod(ns, peerName, itsName, roleName, peerAnnot)
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(its, newPodObj, peer).Build()
+
+	r := &InstanceEventReconciler{Client: cli, Scheme: scheme}
+	parsed := roleProbeOutput{role: roleName, version: newVersion, mode: roleProbeVersionModeEngine}
+	if err := r.cleanupExclusiveRolePeers(context.Background(), logr.Discard(), newPodObj, parsed, 0); err != nil {
+		t.Fatalf("cleanupExclusiveRolePeers err = %v", err)
+	}
+	updated := &corev1.Pod{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: peerName}, updated); err != nil {
+		t.Fatalf("get peer pod: %v", err)
+	}
+	if got, ok := updated.Labels[constant.RoleLabelKey]; !ok || got != roleName {
+		t.Fatalf("peer role label was stripped: %v", updated.Labels)
+	}
+	if got := updated.Annotations[constant.LastRoleEventVersionAnnotationKey]; got != peerAnnot {
+		t.Fatalf("peer annotation = %q, want %q (unchanged)", got, peerAnnot)
+	}
+}
+
+// Non-exclusive role events must not touch peers regardless of version.
+func TestCleanupExclusiveRolePeersNonExclusiveRoleSkipsPeer(t *testing.T) {
+	scheme := newCleanupScheme(t)
+	const (
+		ns         = "default"
+		itsName    = "redis-0"
+		newPod     = "redis-0-0"
+		peerName   = "redis-0-1"
+		roleName   = "secondary"
+		newVersion = uint64(20)
+	)
+	its := newCleanupInstanceSet(ns, itsName, "primary") // secondary is not exclusive in this matrix
+	newPodObj := newCleanupPod(ns, newPod, itsName, roleName, fmt.Sprintf("engine:%d", newVersion))
+	peer := newCleanupPod(ns, peerName, itsName, roleName, "engine:10")
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(its, newPodObj, peer).Build()
+
+	r := &InstanceEventReconciler{Client: cli, Scheme: scheme}
+	parsed := roleProbeOutput{role: roleName, version: newVersion, mode: roleProbeVersionModeEngine}
+	if err := r.cleanupExclusiveRolePeers(context.Background(), logr.Discard(), newPodObj, parsed, 0); err != nil {
+		t.Fatalf("cleanupExclusiveRolePeers err = %v", err)
+	}
+	updated := &corev1.Pod{}
+	if err := cli.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: peerName}, updated); err != nil {
+		t.Fatalf("get peer pod: %v", err)
+	}
+	if got, ok := updated.Labels[constant.RoleLabelKey]; !ok || got != roleName {
+		t.Fatalf("peer role label changed for non-exclusive role: %v", updated.Labels)
+	}
+	want := "engine:10"
+	if got := updated.Annotations[constant.LastRoleEventVersionAnnotationKey]; got != want {
+		t.Fatalf("peer annotation = %q, want %q (unchanged)", got, want)
+	}
+}

--- a/controllers/workloads/instance_event_controller_helper.go
+++ b/controllers/workloads/instance_event_controller_helper.go
@@ -30,28 +30,22 @@ import (
 type roleProbeVersionMode int
 
 const (
-	// roleProbeVersionModeNone means the stdout carries only the role name on
-	// its first line, with no kb-role-version trailer. This is the legacy
-	// addon contract; the staleness gate falls back to EventTime.
+	// roleProbeVersionModeNone means the stdout carries only a single
+	// whitespace-separated token (the role name). This is the legacy addon
+	// contract; the staleness gate falls back to EventTime.
 	roleProbeVersionModeNone roleProbeVersionMode = iota
 
-	// roleProbeVersionModeEngine means the stdout carries exactly one
-	// `kb-role-version=<uint64>` trailer line and the value parses cleanly.
-	// The staleness gate uses the engine-authoritative version.
+	// roleProbeVersionModeEngine means the stdout carries exactly two
+	// whitespace-separated tokens: <role> <uint64-version>. The staleness
+	// gate uses the engine-authoritative version.
 	roleProbeVersionModeEngine
 
-	// roleProbeVersionModeMalformed means the stdout carries at least one
-	// `kb-role-version=` line but the value is empty, not a uint64, or
-	// duplicated. The event must be rejected; falling back to EventTime would
-	// let a single typo silently bypass the new staleness gate.
+	// roleProbeVersionModeMalformed means the stdout carries two tokens whose
+	// second token is not a uint64, or three or more tokens. The event must
+	// be rejected; falling back to EventTime would let a single typo silently
+	// bypass the new staleness gate.
 	roleProbeVersionModeMalformed
 )
-
-// roleProbeVersionLinePrefix marks the trailer line that carries the
-// engine-authoritative role version. The prefix is intentionally narrow
-// (instead of a bare `version=`) so it does not collide with addon-specific
-// stdout that already uses `version=...` as part of business output.
-const roleProbeVersionLinePrefix = "kb-role-version="
 
 // engineVersionAnnotationPrefix distinguishes the engine-authoritative role
 // version recorded on the Pod annotation from the legacy bare EventTime
@@ -67,60 +61,56 @@ type roleProbeOutput struct {
 }
 
 // parseRoleProbeOutput parses the kbagent roleProbe stdout into a role name
-// plus an optional engine-authoritative version. The grammar is:
+// plus an optional engine-authoritative version. The grammar is a single
+// stdout that splits on any whitespace (spaces, tabs, newlines) into
+// either:
 //
-//	<role>\n[<other-trailer-lines>\n][<role-version-line>\n]...
+//	<role>                  // legacy single-token form
+//	<role> <uint64-version> // engine-authoritative form
 //
-// where <role-version-line> is exactly `kb-role-version=<uint64>`. The first
-// line is always treated as the role name to preserve compatibility with the
-// pre-existing single-line contract; legacy addons that emit only a role name
-// still parse with mode=None and fall back to the EventTime staleness path.
+// Examples that all advance to mode=Engine version=10:
 //
-// Strictness for the version trailer is deliberate: addons that try to use
-// the new contract but emit a broken value (empty, non-uint64, or repeated)
-// are flagged Malformed so the controller can reject the event rather than
-// silently fall back. A silent fall back would let a typo or accidental
-// double-line bypass the staleness gate the addon meant to install.
+//	primary 10
+//	primary\n10
+//	primary\t10\n
+//
+// Strictness on the engine form is deliberate: any addon that emits a second
+// token but cannot make it a uint64, or that emits three or more tokens, is
+// flagged Malformed and the event is rejected. A silent fallback would let a
+// typo (`primary  10extra`, `primary 10 ok`) bypass the staleness gate the
+// addon meant to install.
 func parseRoleProbeOutput(stdout []byte) roleProbeOutput {
 	if len(stdout) == 0 {
 		return roleProbeOutput{mode: roleProbeVersionModeNone}
 	}
-	lines := strings.Split(string(stdout), "\n")
-	out := roleProbeOutput{
-		role: strings.ToLower(strings.TrimSpace(lines[0])),
-		mode: roleProbeVersionModeNone,
-	}
-
-	versionLineFound := false
-	for _, line := range lines[1:] {
-		trimmed := strings.TrimSpace(line)
-		if !strings.HasPrefix(trimmed, roleProbeVersionLinePrefix) {
-			continue
+	tokens := strings.Fields(string(stdout))
+	switch len(tokens) {
+	case 0:
+		return roleProbeOutput{mode: roleProbeVersionModeNone}
+	case 1:
+		return roleProbeOutput{
+			role: strings.ToLower(tokens[0]),
+			mode: roleProbeVersionModeNone,
 		}
-		if versionLineFound {
-			// Multiple kb-role-version lines: addon attempted the new contract
-			// but emitted a duplicate. Reject explicitly.
-			out.mode = roleProbeVersionModeMalformed
-			out.version = 0
-			return out
-		}
-		versionLineFound = true
-		raw := strings.TrimPrefix(trimmed, roleProbeVersionLinePrefix)
-		if raw == "" {
-			out.mode = roleProbeVersionModeMalformed
-			out.version = 0
-			continue
-		}
-		v, err := strconv.ParseUint(raw, 10, 64)
+	case 2:
+		v, err := strconv.ParseUint(tokens[1], 10, 64)
 		if err != nil {
-			out.mode = roleProbeVersionModeMalformed
-			out.version = 0
-			continue
+			return roleProbeOutput{
+				role: strings.ToLower(tokens[0]),
+				mode: roleProbeVersionModeMalformed,
+			}
 		}
-		out.mode = roleProbeVersionModeEngine
-		out.version = v
+		return roleProbeOutput{
+			role:    strings.ToLower(tokens[0]),
+			version: v,
+			mode:    roleProbeVersionModeEngine,
+		}
+	default:
+		return roleProbeOutput{
+			role: strings.ToLower(tokens[0]),
+			mode: roleProbeVersionModeMalformed,
+		}
 	}
-	return out
 }
 
 // roleProbeGateDecision is the outcome of the staleness gate that determines

--- a/controllers/workloads/instance_event_controller_helper.go
+++ b/controllers/workloads/instance_event_controller_helper.go
@@ -1,0 +1,189 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package workloads
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// roleProbeVersionMode classifies how a roleProbe stdout payload encodes its
+// engine-authoritative role version.
+type roleProbeVersionMode int
+
+const (
+	// roleProbeVersionModeNone means the stdout carries only the role name on
+	// its first line, with no kb-role-version trailer. This is the legacy
+	// addon contract; the staleness gate falls back to EventTime.
+	roleProbeVersionModeNone roleProbeVersionMode = iota
+
+	// roleProbeVersionModeEngine means the stdout carries exactly one
+	// `kb-role-version=<uint64>` trailer line and the value parses cleanly.
+	// The staleness gate uses the engine-authoritative version.
+	roleProbeVersionModeEngine
+
+	// roleProbeVersionModeMalformed means the stdout carries at least one
+	// `kb-role-version=` line but the value is empty, not a uint64, or
+	// duplicated. The event must be rejected; falling back to EventTime would
+	// let a single typo silently bypass the new staleness gate.
+	roleProbeVersionModeMalformed
+)
+
+// roleProbeVersionLinePrefix marks the trailer line that carries the
+// engine-authoritative role version. The prefix is intentionally narrow
+// (instead of a bare `version=`) so it does not collide with addon-specific
+// stdout that already uses `version=...` as part of business output.
+const roleProbeVersionLinePrefix = "kb-role-version="
+
+// engineVersionAnnotationPrefix distinguishes the engine-authoritative role
+// version recorded on the Pod annotation from the legacy bare EventTime
+// micros that older controllers used to record. Mixed-format handling lives
+// in checkRoleProbeStale.
+const engineVersionAnnotationPrefix = "engine:"
+
+// roleProbeOutput is the parsed view of a kbagent roleProbe stdout payload.
+type roleProbeOutput struct {
+	role    string
+	version uint64
+	mode    roleProbeVersionMode
+}
+
+// parseRoleProbeOutput parses the kbagent roleProbe stdout into a role name
+// plus an optional engine-authoritative version. The grammar is:
+//
+//	<role>\n[<other-trailer-lines>\n][<role-version-line>\n]...
+//
+// where <role-version-line> is exactly `kb-role-version=<uint64>`. The first
+// line is always treated as the role name to preserve compatibility with the
+// pre-existing single-line contract; legacy addons that emit only a role name
+// still parse with mode=None and fall back to the EventTime staleness path.
+//
+// Strictness for the version trailer is deliberate: addons that try to use
+// the new contract but emit a broken value (empty, non-uint64, or repeated)
+// are flagged Malformed so the controller can reject the event rather than
+// silently fall back. A silent fall back would let a typo or accidental
+// double-line bypass the staleness gate the addon meant to install.
+func parseRoleProbeOutput(stdout []byte) roleProbeOutput {
+	if len(stdout) == 0 {
+		return roleProbeOutput{mode: roleProbeVersionModeNone}
+	}
+	lines := strings.Split(string(stdout), "\n")
+	out := roleProbeOutput{
+		role: strings.ToLower(strings.TrimSpace(lines[0])),
+		mode: roleProbeVersionModeNone,
+	}
+
+	versionLineFound := false
+	for _, line := range lines[1:] {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, roleProbeVersionLinePrefix) {
+			continue
+		}
+		if versionLineFound {
+			// Multiple kb-role-version lines: addon attempted the new contract
+			// but emitted a duplicate. Reject explicitly.
+			out.mode = roleProbeVersionModeMalformed
+			out.version = 0
+			return out
+		}
+		versionLineFound = true
+		raw := strings.TrimPrefix(trimmed, roleProbeVersionLinePrefix)
+		if raw == "" {
+			out.mode = roleProbeVersionModeMalformed
+			out.version = 0
+			continue
+		}
+		v, err := strconv.ParseUint(raw, 10, 64)
+		if err != nil {
+			out.mode = roleProbeVersionModeMalformed
+			out.version = 0
+			continue
+		}
+		out.mode = roleProbeVersionModeEngine
+		out.version = v
+	}
+	return out
+}
+
+// roleProbeGateDecision is the outcome of the staleness gate that determines
+// whether a parsed roleProbe event may write the Pod role label and advance
+// the LastRoleEventVersionAnnotationKey.
+type roleProbeGateDecision int
+
+const (
+	// roleProbeGateAccept lets the caller write the Pod role label and
+	// advance the annotation to newAnnotation.
+	roleProbeGateAccept roleProbeGateDecision = iota
+
+	// roleProbeGateRejectStale rejects the event because its version is not
+	// strictly newer than the recorded version. The caller must not write
+	// the Pod role label and must not change the annotation.
+	roleProbeGateRejectStale
+
+	// roleProbeGateRejectMalformed rejects the event because its stdout
+	// carried a kb-role-version line that did not parse. The caller must
+	// not write the Pod role label and must not change the annotation.
+	roleProbeGateRejectMalformed
+)
+
+// checkRoleProbeStale decides whether the parsed roleProbe event should
+// advance the Pod role label and what the new annotation value should be
+// when the event is accepted. The four legitimate annotation/mode
+// combinations are pinned by unit tests:
+//
+//   - engine event vs engine annotation: numeric compare; reject if not
+//     strictly newer.
+//   - engine event vs legacy bare EventTime annotation: accept and upgrade.
+//   - legacy event vs engine annotation: reject; the engine-version gate
+//     cannot be silently downgraded back to EventTime.
+//   - legacy event vs legacy bare EventTime annotation: bare-numeric
+//     compare on EventTime micros (preserves the pre-existing behaviour for
+//     addons that have not adopted the new contract).
+//
+// A Malformed event is always rejected with the annotation untouched.
+func checkRoleProbeStale(parsed roleProbeOutput, lastAnnotation string, eventTimeMicros int64) (roleProbeGateDecision, string) {
+	switch parsed.mode {
+	case roleProbeVersionModeMalformed:
+		return roleProbeGateRejectMalformed, lastAnnotation
+	case roleProbeVersionModeEngine:
+		newAnnotation := fmt.Sprintf("%s%d", engineVersionAnnotationPrefix, parsed.version)
+		if strings.HasPrefix(lastAnnotation, engineVersionAnnotationPrefix) {
+			lastRaw := strings.TrimPrefix(lastAnnotation, engineVersionAnnotationPrefix)
+			lastV, err := strconv.ParseUint(lastRaw, 10, 64)
+			if err == nil && parsed.version <= lastV {
+				return roleProbeGateRejectStale, lastAnnotation
+			}
+		}
+		return roleProbeGateAccept, newAnnotation
+	default: // roleProbeVersionModeNone (legacy event)
+		if strings.HasPrefix(lastAnnotation, engineVersionAnnotationPrefix) {
+			return roleProbeGateRejectStale, lastAnnotation
+		}
+		newAnnotation := fmt.Sprintf("%d", eventTimeMicros)
+		if lastAnnotation != "" {
+			lastV, err := strconv.ParseUint(lastAnnotation, 10, 64)
+			if err == nil && uint64(eventTimeMicros) <= lastV {
+				return roleProbeGateRejectStale, lastAnnotation
+			}
+		}
+		return roleProbeGateAccept, newAnnotation
+	}
+}

--- a/controllers/workloads/instance_event_controller_helper_test.go
+++ b/controllers/workloads/instance_event_controller_helper_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package workloads
+
+import "testing"
+
+func TestParseRoleProbeOutputLegacyOnly(t *testing.T) {
+	out := parseRoleProbeOutput([]byte("primary"))
+	if out.role != "primary" {
+		t.Fatalf("role = %q, want %q", out.role, "primary")
+	}
+	if out.mode != roleProbeVersionModeNone {
+		t.Fatalf("mode = %d, want None", out.mode)
+	}
+	if out.version != 0 {
+		t.Fatalf("version = %d, want 0", out.version)
+	}
+}
+
+func TestParseRoleProbeOutputEngineVersion(t *testing.T) {
+	out := parseRoleProbeOutput([]byte("primary\nkb-role-version=10"))
+	if out.role != "primary" {
+		t.Fatalf("role = %q, want %q", out.role, "primary")
+	}
+	if out.mode != roleProbeVersionModeEngine {
+		t.Fatalf("mode = %d, want Engine", out.mode)
+	}
+	if out.version != 10 {
+		t.Fatalf("version = %d, want 10", out.version)
+	}
+}
+
+func TestParseRoleProbeOutputEngineVersionWithExtraTrailerLine(t *testing.T) {
+	out := parseRoleProbeOutput([]byte("primary\nfoo=bar\nkb-role-version=42"))
+	if out.role != "primary" {
+		t.Fatalf("role = %q, want %q", out.role, "primary")
+	}
+	if out.mode != roleProbeVersionModeEngine {
+		t.Fatalf("mode = %d, want Engine", out.mode)
+	}
+	if out.version != 42 {
+		t.Fatalf("version = %d, want 42", out.version)
+	}
+}
+
+func TestParseRoleProbeOutputMalformedEmptyVersion(t *testing.T) {
+	out := parseRoleProbeOutput([]byte("primary\nkb-role-version="))
+	if out.mode != roleProbeVersionModeMalformed {
+		t.Fatalf("mode = %d, want Malformed", out.mode)
+	}
+}
+
+func TestParseRoleProbeOutputMalformedNonUint64(t *testing.T) {
+	out := parseRoleProbeOutput([]byte("primary\nkb-role-version=abc"))
+	if out.mode != roleProbeVersionModeMalformed {
+		t.Fatalf("mode = %d, want Malformed", out.mode)
+	}
+}
+
+func TestParseRoleProbeOutputMalformedDuplicateVersion(t *testing.T) {
+	out := parseRoleProbeOutput([]byte("primary\nkb-role-version=10\nkb-role-version=20"))
+	if out.mode != roleProbeVersionModeMalformed {
+		t.Fatalf("mode = %d, want Malformed", out.mode)
+	}
+}
+
+// RED-1: engine event with strictly older version vs already-recorded engine
+// annotation must be rejected as stale.
+func TestCheckRoleProbeStaleEngineRejectsOlderVersion(t *testing.T) {
+	parsed := roleProbeOutput{role: "primary", version: 9, mode: roleProbeVersionModeEngine}
+	decision, newAnnotation := checkRoleProbeStale(parsed, "engine:10", 0)
+	if decision != roleProbeGateRejectStale {
+		t.Fatalf("decision = %d, want RejectStale", decision)
+	}
+	if newAnnotation != "engine:10" {
+		t.Fatalf("newAnnotation = %q, want %q (unchanged)", newAnnotation, "engine:10")
+	}
+}
+
+// RED-2: engine event with strictly newer version vs recorded engine
+// annotation must be accepted and advance the annotation.
+func TestCheckRoleProbeStaleEngineAcceptsNewerVersion(t *testing.T) {
+	parsed := roleProbeOutput{role: "primary", version: 11, mode: roleProbeVersionModeEngine}
+	decision, newAnnotation := checkRoleProbeStale(parsed, "engine:10", 0)
+	if decision != roleProbeGateAccept {
+		t.Fatalf("decision = %d, want Accept", decision)
+	}
+	if newAnnotation != "engine:11" {
+		t.Fatalf("newAnnotation = %q, want %q", newAnnotation, "engine:11")
+	}
+}
+
+// RED-3: engine event arriving when the Pod still has a bare EventTime
+// annotation from an earlier legacy controller / addon must accept and
+// upgrade the annotation to engine:<n>.
+func TestCheckRoleProbeStaleEngineUpgradesFromLegacyAnnotation(t *testing.T) {
+	parsed := roleProbeOutput{role: "primary", version: 11, mode: roleProbeVersionModeEngine}
+	decision, newAnnotation := checkRoleProbeStale(parsed, "1779550000000000", 1779550600000000)
+	if decision != roleProbeGateAccept {
+		t.Fatalf("decision = %d, want Accept", decision)
+	}
+	if newAnnotation != "engine:11" {
+		t.Fatalf("newAnnotation = %q, want %q", newAnnotation, "engine:11")
+	}
+}
+
+// RED-4: a kb-role-version trailer that does not parse must reject the event
+// without falling back to the EventTime path. The annotation must not change.
+func TestCheckRoleProbeStaleMalformedRejects(t *testing.T) {
+	parsed := roleProbeOutput{role: "primary", version: 0, mode: roleProbeVersionModeMalformed}
+	decision, newAnnotation := checkRoleProbeStale(parsed, "engine:10", 1779550600000000)
+	if decision != roleProbeGateRejectMalformed {
+		t.Fatalf("decision = %d, want RejectMalformed", decision)
+	}
+	if newAnnotation != "engine:10" {
+		t.Fatalf("newAnnotation = %q, want %q (unchanged)", newAnnotation, "engine:10")
+	}
+}
+
+// Legacy event arriving at a Pod whose annotation is already engine-format
+// must be rejected: the engine-version gate cannot be silently downgraded
+// back to EventTime by an unaware emitter.
+func TestCheckRoleProbeStaleLegacyEventRejectedAgainstEngineAnnotation(t *testing.T) {
+	parsed := roleProbeOutput{role: "primary", mode: roleProbeVersionModeNone}
+	decision, newAnnotation := checkRoleProbeStale(parsed, "engine:10", 1779550600000000)
+	if decision != roleProbeGateRejectStale {
+		t.Fatalf("decision = %d, want RejectStale", decision)
+	}
+	if newAnnotation != "engine:10" {
+		t.Fatalf("newAnnotation = %q, want %q (unchanged)", newAnnotation, "engine:10")
+	}
+}
+
+// Legacy event vs legacy annotation must keep the existing lexical EventTime
+// behaviour: strictly newer micros advances, older or equal rejects.
+func TestCheckRoleProbeStaleLegacyEventAdvancesOnNewerEventTime(t *testing.T) {
+	parsed := roleProbeOutput{role: "primary", mode: roleProbeVersionModeNone}
+	decision, newAnnotation := checkRoleProbeStale(parsed, "1779550000000000", 1779550600000000)
+	if decision != roleProbeGateAccept {
+		t.Fatalf("decision = %d, want Accept", decision)
+	}
+	if newAnnotation != "1779550600000000" {
+		t.Fatalf("newAnnotation = %q, want %q", newAnnotation, "1779550600000000")
+	}
+}
+
+func TestCheckRoleProbeStaleLegacyEventRejectsOnOlderEventTime(t *testing.T) {
+	parsed := roleProbeOutput{role: "primary", mode: roleProbeVersionModeNone}
+	decision, newAnnotation := checkRoleProbeStale(parsed, "1779550600000000", 1779550000000000)
+	if decision != roleProbeGateRejectStale {
+		t.Fatalf("decision = %d, want RejectStale", decision)
+	}
+	if newAnnotation != "1779550600000000" {
+		t.Fatalf("newAnnotation = %q, want %q (unchanged)", newAnnotation, "1779550600000000")
+	}
+}

--- a/controllers/workloads/instance_event_controller_helper_test.go
+++ b/controllers/workloads/instance_event_controller_helper_test.go
@@ -171,3 +171,27 @@ func TestCheckRoleProbeStaleLegacyEventRejectsOnOlderEventTime(t *testing.T) {
 		t.Fatalf("newAnnotation = %q, want %q (unchanged)", newAnnotation, "1779550600000000")
 	}
 }
+
+// Peer pod cleanup must honour the same engine-version gate so a stale primary
+// event cannot strip the label from a peer that has already advanced past it.
+func TestCheckRoleProbeStaleRejectsPeerCleanupWhenPeerHasNewerEngineVersion(t *testing.T) {
+	parsed := roleProbeOutput{role: "primary", version: 10, mode: roleProbeVersionModeEngine}
+	decision, newAnnotation := checkRoleProbeStale(parsed, "engine:15", 0)
+	if decision != roleProbeGateRejectStale {
+		t.Fatalf("decision = %d, want RejectStale", decision)
+	}
+	if newAnnotation != "engine:15" {
+		t.Fatalf("newAnnotation = %q, want %q (unchanged)", newAnnotation, "engine:15")
+	}
+}
+
+func TestCheckRoleProbeStaleAcceptsPeerCleanupWhenPeerHasOlderEngineVersion(t *testing.T) {
+	parsed := roleProbeOutput{role: "primary", version: 20, mode: roleProbeVersionModeEngine}
+	decision, newAnnotation := checkRoleProbeStale(parsed, "engine:15", 0)
+	if decision != roleProbeGateAccept {
+		t.Fatalf("decision = %d, want Accept", decision)
+	}
+	if newAnnotation != "engine:20" {
+		t.Fatalf("newAnnotation = %q, want %q", newAnnotation, "engine:20")
+	}
+}

--- a/controllers/workloads/instance_event_controller_helper_test.go
+++ b/controllers/workloads/instance_event_controller_helper_test.go
@@ -34,8 +34,8 @@ func TestParseRoleProbeOutputLegacyOnly(t *testing.T) {
 	}
 }
 
-func TestParseRoleProbeOutputEngineVersion(t *testing.T) {
-	out := parseRoleProbeOutput([]byte("primary\nkb-role-version=10"))
+func TestParseRoleProbeOutputEngineVersionSpaceSeparated(t *testing.T) {
+	out := parseRoleProbeOutput([]byte("primary 10"))
 	if out.role != "primary" {
 		t.Fatalf("role = %q, want %q", out.role, "primary")
 	}
@@ -47,8 +47,21 @@ func TestParseRoleProbeOutputEngineVersion(t *testing.T) {
 	}
 }
 
-func TestParseRoleProbeOutputEngineVersionWithExtraTrailerLine(t *testing.T) {
-	out := parseRoleProbeOutput([]byte("primary\nfoo=bar\nkb-role-version=42"))
+func TestParseRoleProbeOutputEngineVersionNewlineSeparated(t *testing.T) {
+	out := parseRoleProbeOutput([]byte("primary\n10"))
+	if out.role != "primary" {
+		t.Fatalf("role = %q, want %q", out.role, "primary")
+	}
+	if out.mode != roleProbeVersionModeEngine {
+		t.Fatalf("mode = %d, want Engine", out.mode)
+	}
+	if out.version != 10 {
+		t.Fatalf("version = %d, want 10", out.version)
+	}
+}
+
+func TestParseRoleProbeOutputEngineVersionToleratesSurroundingWhitespace(t *testing.T) {
+	out := parseRoleProbeOutput([]byte("\tprimary\t42\n"))
 	if out.role != "primary" {
 		t.Fatalf("role = %q, want %q", out.role, "primary")
 	}
@@ -60,24 +73,27 @@ func TestParseRoleProbeOutputEngineVersionWithExtraTrailerLine(t *testing.T) {
 	}
 }
 
-func TestParseRoleProbeOutputMalformedEmptyVersion(t *testing.T) {
-	out := parseRoleProbeOutput([]byte("primary\nkb-role-version="))
+func TestParseRoleProbeOutputMalformedNonUint64SecondToken(t *testing.T) {
+	out := parseRoleProbeOutput([]byte("primary abc"))
 	if out.mode != roleProbeVersionModeMalformed {
 		t.Fatalf("mode = %d, want Malformed", out.mode)
 	}
 }
 
-func TestParseRoleProbeOutputMalformedNonUint64(t *testing.T) {
-	out := parseRoleProbeOutput([]byte("primary\nkb-role-version=abc"))
+func TestParseRoleProbeOutputMalformedThreeOrMoreTokens(t *testing.T) {
+	out := parseRoleProbeOutput([]byte("primary 10 extra"))
 	if out.mode != roleProbeVersionModeMalformed {
 		t.Fatalf("mode = %d, want Malformed", out.mode)
 	}
 }
 
-func TestParseRoleProbeOutputMalformedDuplicateVersion(t *testing.T) {
-	out := parseRoleProbeOutput([]byte("primary\nkb-role-version=10\nkb-role-version=20"))
-	if out.mode != roleProbeVersionModeMalformed {
-		t.Fatalf("mode = %d, want Malformed", out.mode)
+func TestParseRoleProbeOutputEmpty(t *testing.T) {
+	out := parseRoleProbeOutput([]byte(""))
+	if out.mode != roleProbeVersionModeNone {
+		t.Fatalf("mode = %d, want None", out.mode)
+	}
+	if out.role != "" {
+		t.Fatalf("role = %q, want empty", out.role)
 	}
 }
 

--- a/pkg/controller/instanceset/pod_role_event_handler.go
+++ b/pkg/controller/instanceset/pod_role_event_handler.go
@@ -20,173 +20,32 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package instanceset
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"strings"
-
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
-	"github.com/apecloud/kubeblocks/pkg/constant"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	"github.com/apecloud/kubeblocks/pkg/kbagent/proto"
 )
 
+// PodRoleEventHandler is registered against the k8score EventReconciler
+// dispatcher but is intentionally a no-op for the kbagent roleProbe Event path:
+// since the multi-cluster Instance API refactor in apecloud/kubeblocks#9697,
+// controllers/workloads InstanceEventReconciler is the sole writer of the Pod
+// role label for kbagent roleProbe events and owns the engine-authoritative
+// kb-role-version staleness gate. Letting this handler also write the label
+// would re-introduce the dual-writer race the gate is supposed to close.
 type PodRoleEventHandler struct{}
 
-const (
-	// roleChangedAnnotKey is used to mark the role change event has been handled.
-	roleChangedAnnotKey = "role.kubeblocks.io/event-handled"
-)
-
-func (h *PodRoleEventHandler) Handle(cli client.Client, reqCtx intctrlutil.RequestCtx, _ record.EventRecorder, event *corev1.Event) error {
-	// kbagent roleProbe events are owned by controllers/workloads
-	// InstanceEventReconciler since the multi-cluster Instance API refactor in
-	// #9697. PodRoleEventHandler must not race-write the Pod role label on
-	// those events; the engine-authoritative kb-role-version staleness gate
-	// lives only in InstanceEventReconciler. Other event paths (if any future
-	// non-kbagent roleProbe sources reuse this handler) are left untouched.
-	if isKBAgentRoleProbeEvent(event) {
-		return nil
-	}
+func (h *PodRoleEventHandler) Handle(_ client.Client, _ intctrlutil.RequestCtx, _ record.EventRecorder, _ *corev1.Event) error {
 	return nil
 }
 
+// isKBAgentRoleProbeEvent stays exported so other packages (notably the
+// k8score EventReconciler outer guard) can identify these events without
+// reintroducing duplicate constants.
 func isKBAgentRoleProbeEvent(event *corev1.Event) bool {
 	return event.ReportingController == proto.ProbeEventReportingController &&
 		event.Reason == "roleProbe" &&
 		event.InvolvedObject.FieldPath == proto.ProbeEventFieldPath
-}
-
-// handleRoleChangedEvent handles role changed event and return role.
-func handleRoleChangedEvent(cli client.Client, reqCtx intctrlutil.RequestCtx, event *corev1.Event) (string, error) {
-	probeEvent := &proto.ProbeEvent{}
-	if err := json.Unmarshal([]byte(event.Message), probeEvent); err != nil {
-		reqCtx.Log.Error(err, "unmarshal role probe event failed")
-		return "", nil
-	}
-
-	if probeEvent.Code != 0 {
-		reqCtx.Log.Info("role probe failed", "message", probeEvent.Message)
-		return "", nil
-	}
-	role := strings.ToLower(strings.TrimSpace(string(probeEvent.Output)))
-	version := roleEventVersion(event)
-
-	podName := types.NamespacedName{
-		Namespace: event.InvolvedObject.Namespace,
-		Name:      event.InvolvedObject.Name,
-	}
-	pod := &corev1.Pod{}
-	if err := cli.Get(reqCtx.Ctx, podName, pod); err != nil {
-		return role, err
-	}
-	// event belongs to old pod with the same name, ignore it
-	if pod.Name == event.InvolvedObject.Name && string(pod.UID) != string(event.InvolvedObject.UID) {
-		return role, nil
-	}
-
-	if checkStaleLastRoleEventVersion(version, pod) {
-		reqCtx.Log.Info("stale role event received, ignore it", "version", version, "pod", pod.Name)
-		return role, nil
-	}
-
-	var name string
-	if pod.Labels != nil {
-		if n, ok := pod.Labels[WorkloadsInstanceLabelKey]; ok {
-			name = n
-		}
-	}
-	its := &workloads.InstanceSet{}
-	if err := cli.Get(reqCtx.Ctx, types.NamespacedName{Namespace: pod.Namespace, Name: name}, its); err != nil {
-		return "", err
-	}
-	reqCtx.Log.Info("handle role change event", "pod", pod.Name, "role", role)
-
-	if err := updatePodRoleLabel(cli, reqCtx, *its, pod, role, version); err != nil {
-		return "", err
-	}
-	return role, nil
-}
-
-// compare the version of the current role event with the last version recorded in the pod annotation,
-// stale role event will be ignored.
-func checkStaleLastRoleEventVersion(version string, pod *corev1.Pod) bool {
-	lastRoleEventVersion, ok := pod.Annotations[constant.LastRoleEventVersionAnnotationKey]
-	if ok {
-		if version <= lastRoleEventVersion && !strings.Contains(lastRoleEventVersion, ":") {
-			return true
-		}
-	}
-	return false
-}
-
-func roleEventVersion(event *corev1.Event) string {
-	return fmt.Sprintf("%d", event.EventTime.UnixMicro())
-}
-
-func updatePodRoleLabel(cli client.Client, reqCtx intctrlutil.RequestCtx, its workloads.InstanceSet,
-	pod *corev1.Pod, roleName string, version string) error {
-	var (
-		ctx                = reqCtx.Ctx
-		roleMap            = composeRoleMap(its)
-		normalizedRoleName = strings.ToLower(roleName)
-		role, defined      = roleMap[normalizedRoleName]
-	)
-	// update pod role label
-	newPod := pod.DeepCopy()
-	if defined {
-		newPod.Labels[RoleLabelKey] = normalizedRoleName
-	} else {
-		delete(newPod.Labels, RoleLabelKey)
-	}
-	if newPod.Annotations == nil {
-		newPod.Annotations = map[string]string{}
-	}
-	newPod.Annotations[constant.LastRoleEventVersionAnnotationKey] = version
-	if err := cli.Update(ctx, newPod); err != nil {
-		return err
-	}
-
-	if role.IsExclusive {
-		return removeExclusiveRoleLabels(cli, reqCtx, its, pod.Name, normalizedRoleName, version)
-	}
-	return nil
-}
-
-func removeExclusiveRoleLabels(cli client.Client, reqCtx intctrlutil.RequestCtx, its workloads.InstanceSet, newPodName, roleName, version string) error {
-	labels := getMatchLabels(its.Name)
-	labels[RoleLabelKey] = roleName
-	var pods corev1.PodList
-	if err := cli.List(reqCtx.Ctx, &pods, client.InNamespace(its.Namespace), client.MatchingLabels(labels)); err != nil {
-		return err
-	}
-
-	var errs []error
-	for i, pod := range pods.Items {
-		if pod.Name == newPodName {
-			continue
-		}
-		if checkStaleLastRoleEventVersion(version, &pod) {
-			reqCtx.Log.Info("stale remove exclusive role label event, ignore it", "role event version", version, "pod", pod.Name)
-			continue
-		}
-
-		newPod := pods.Items[i].DeepCopy()
-		delete(newPod.Labels, RoleLabelKey)
-		if newPod.Annotations == nil {
-			newPod.Annotations = map[string]string{}
-		}
-		newPod.Annotations[constant.LastRoleEventVersionAnnotationKey] = version
-		if err := cli.Update(reqCtx.Ctx, newPod); err != nil {
-			errs = append(errs, err)
-		} else {
-			reqCtx.Log.Info("remove exclusive role label", "pod", newPod.Name, "role", roleName)
-		}
-	}
-	return errors.Join(errs...)
 }

--- a/pkg/controller/instanceset/pod_role_event_handler.go
+++ b/pkg/controller/instanceset/pod_role_event_handler.go
@@ -25,7 +25,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
-	"github.com/apecloud/kubeblocks/pkg/kbagent/proto"
 )
 
 // PodRoleEventHandler is registered against the k8score EventReconciler
@@ -33,19 +32,12 @@ import (
 // since the multi-cluster Instance API refactor in apecloud/kubeblocks#9697,
 // controllers/workloads InstanceEventReconciler is the sole writer of the Pod
 // role label for kbagent roleProbe events and owns the engine-authoritative
-// kb-role-version staleness gate. Letting this handler also write the label
-// would re-introduce the dual-writer race the gate is supposed to close.
+// role-version staleness gate. The kbagent roleProbe events are also short-
+// circuited at the k8score EventReconciler outer guard so this handler never
+// observes them in practice; the no-op body is kept as a belt-and-braces
+// guarantee against future dispatcher changes.
 type PodRoleEventHandler struct{}
 
 func (h *PodRoleEventHandler) Handle(_ client.Client, _ intctrlutil.RequestCtx, _ record.EventRecorder, _ *corev1.Event) error {
 	return nil
-}
-
-// isKBAgentRoleProbeEvent stays exported so other packages (notably the
-// k8score EventReconciler outer guard) can identify these events without
-// reintroducing duplicate constants.
-func isKBAgentRoleProbeEvent(event *corev1.Event) bool {
-	return event.ReportingController == proto.ProbeEventReportingController &&
-		event.Reason == "roleProbe" &&
-		event.InvolvedObject.FieldPath == proto.ProbeEventFieldPath
 }

--- a/pkg/controller/instanceset/pod_role_event_handler.go
+++ b/pkg/controller/instanceset/pod_role_event_handler.go
@@ -44,30 +44,16 @@ const (
 )
 
 func (h *PodRoleEventHandler) Handle(cli client.Client, reqCtx intctrlutil.RequestCtx, _ record.EventRecorder, event *corev1.Event) error {
-	if !isKBAgentRoleProbeEvent(event) {
+	// kbagent roleProbe events are owned by controllers/workloads
+	// InstanceEventReconciler since the multi-cluster Instance API refactor in
+	// #9697. PodRoleEventHandler must not race-write the Pod role label on
+	// those events; the engine-authoritative kb-role-version staleness gate
+	// lives only in InstanceEventReconciler. Other event paths (if any future
+	// non-kbagent roleProbe sources reuse this handler) are left untouched.
+	if isKBAgentRoleProbeEvent(event) {
 		return nil
 	}
-	var (
-		err         error
-		annotations = event.GetAnnotations()
-	)
-	// filter role changed event that has been handled
-	count := fmt.Sprintf("count-%d", event.Count)
-	if annotations != nil && annotations[roleChangedAnnotKey] == count {
-		return nil
-	}
-
-	if _, err = handleRoleChangedEvent(cli, reqCtx, event); err != nil {
-		return err
-	}
-
-	// event order is crucial in role probing, but it's not guaranteed when controller restarted, so we have to mark them to be filtered
-	patch := client.MergeFrom(event.DeepCopy())
-	if event.Annotations == nil {
-		event.Annotations = make(map[string]string, 0)
-	}
-	event.Annotations[roleChangedAnnotKey] = count
-	return cli.Patch(reqCtx.Ctx, event, patch)
+	return nil
 }
 
 func isKBAgentRoleProbeEvent(event *corev1.Event) bool {

--- a/pkg/controller/instanceset/pod_role_event_handler_test.go
+++ b/pkg/controller/instanceset/pod_role_event_handler_test.go
@@ -20,19 +20,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package instanceset
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/golang/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
-	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/builder"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	"github.com/apecloud/kubeblocks/pkg/kbagent/proto"
@@ -63,288 +58,52 @@ var _ = Describe("pod role label event handler test", func() {
 	}
 
 	Context("Handle function", func() {
-		It("should work well", func() {
+		// kbagent roleProbe events are owned by InstanceEventReconciler in
+		// controllers/workloads since the multi-cluster Instance API refactor
+		// (#9697). PodRoleEventHandler must not race-write the Pod role
+		// label on those events; the engine-authoritative kb-role-version
+		// staleness gate lives only in InstanceEventReconciler. Earlier
+		// versions of this handler wrote the role label here without the new
+		// gate, which let stale role observations override a freshly-demoted
+		// pod's label during failover.
+		It("must not touch the Pod when handed a kbagent roleProbe event", func() {
 			cli := k8sMock
 			reqCtx := intctrlutil.RequestCtx{
 				Ctx: ctx,
 				Log: logger,
 			}
 			pod := builder.NewPodBuilder(namespace, getPodName(name, 0)).SetUID(uid).GetObject()
-			pod.ResourceVersion = "1"
-			role := workloads.ReplicaRole{
-				Name:                 "leader",
-				ParticipatesInQuorum: true,
-				UpdatePriority:       5,
-			}
-
-			By("build an expected message")
-			event := newRoleProbeEvent(pod, "foo", role.Name, 0)
+			event := newRoleProbeEvent(pod, "kbagent-role-event", "primary", 0)
 
 			handler := &PodRoleEventHandler{}
-			k8sMock.EXPECT().
-				Get(gomock.Any(), gomock.Any(), &corev1.Pod{}, gomock.Any()).
-				DoAndReturn(func(_ context.Context, objKey client.ObjectKey, p *corev1.Pod, _ ...client.GetOption) error {
-					p.Namespace = objKey.Namespace
-					p.Name = objKey.Name
-					p.UID = pod.UID
-					p.Labels = map[string]string{
-						constant.AppInstanceLabelKey: name,
-						WorkloadsInstanceLabelKey:    name,
-					}
-					return nil
-				}).Times(1)
-			k8sMock.EXPECT().
-				Get(gomock.Any(), gomock.Any(), &workloads.InstanceSet{}, gomock.Any()).
-				DoAndReturn(func(_ context.Context, objKey client.ObjectKey, its *workloads.InstanceSet, _ ...client.GetOption) error {
-					its.Namespace = objKey.Namespace
-					its.Name = objKey.Name
-					its.Spec.Roles = []workloads.ReplicaRole{role}
-					return nil
-				}).Times(1)
-			k8sMock.EXPECT().
-				Update(gomock.Any(), gomock.Any(), gomock.Any()).
-				DoAndReturn(func(_ context.Context, pd *corev1.Pod, _ ...client.UpdateOption) error {
-					Expect(pd).ShouldNot(BeNil())
-					Expect(pd.Labels).ShouldNot(BeNil())
-					Expect(pd.Labels[RoleLabelKey]).Should(Equal(role.Name))
-					return nil
-				}).Times(1)
-			k8sMock.EXPECT().
-				Patch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-				DoAndReturn(func(_ context.Context, evt *corev1.Event, patch client.Patch, _ ...client.PatchOption) error {
-					Expect(evt).ShouldNot(BeNil())
-					Expect(evt.Annotations).ShouldNot(BeNil())
-					Expect(evt.Annotations[roleChangedAnnotKey]).Should(Equal(fmt.Sprintf("count-%d", evt.Count)))
-					return nil
-				}).Times(1)
+			// No client calls of any kind are expected: the handler must be a
+			// silent no-op so InstanceEventReconciler stays the sole writer.
+			k8sMock.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			k8sMock.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			k8sMock.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			k8sMock.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
 			Expect(handler.Handle(cli, reqCtx, nil, event)).Should(Succeed())
-
-			By("build an unexpected message")
-			event = newRoleProbeEvent(pod, "foo", role.Name, 0)
-			event.Message = "unexpected message"
-			k8sMock.EXPECT().
-				Patch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-				DoAndReturn(func(_ context.Context, evt *corev1.Event, patch client.Patch, _ ...client.PatchOption) error {
-					Expect(evt).ShouldNot(BeNil())
-					Expect(evt.Annotations).ShouldNot(BeNil())
-					Expect(evt.Annotations[roleChangedAnnotKey]).Should(Equal(fmt.Sprintf("count-%d", evt.Count)))
-					return nil
-				}).Times(1)
-			Expect(handler.Handle(cli, reqCtx, nil, event)).Should(Succeed())
-
-			By("read a stale pod")
-			event = newRoleProbeEvent(pod, "foo", role.Name, 0)
-
-			k8sMock.EXPECT().
-				Get(gomock.Any(), gomock.Any(), &corev1.Pod{}, gomock.Any()).
-				DoAndReturn(func(_ context.Context, objKey client.ObjectKey, p *corev1.Pod, _ ...client.GetOption) error {
-					p.Namespace = objKey.Namespace
-					p.ResourceVersion = "0"
-					p.Name = objKey.Name
-					p.UID = pod.UID
-					p.Labels = map[string]string{
-						constant.AppInstanceLabelKey: name,
-						WorkloadsInstanceLabelKey:    name,
-					}
-					return nil
-				}).Times(1)
-			k8sMock.EXPECT().
-				Get(gomock.Any(), gomock.Any(), &workloads.InstanceSet{}, gomock.Any()).
-				DoAndReturn(func(_ context.Context, objKey client.ObjectKey, its *workloads.InstanceSet, _ ...client.GetOption) error {
-					its.Namespace = objKey.Namespace
-					its.Name = objKey.Name
-					its.Spec.Roles = []workloads.ReplicaRole{role}
-					return nil
-				}).Times(1)
-			updateErr := fmt.Errorf("the object has been modified; please apply your changes to the latest version and try again")
-			k8sMock.EXPECT().
-				Update(gomock.Any(), gomock.Any(), gomock.Any()).
-				DoAndReturn(func(_ context.Context, pd *corev1.Pod, _ ...client.UpdateOption) error {
-					Expect(pd).ShouldNot(BeNil())
-					Expect(pd.Labels).ShouldNot(BeNil())
-					Expect(pd.Labels[RoleLabelKey]).Should(Equal(role.Name))
-					if pd.ResourceVersion <= pod.ResourceVersion {
-						return updateErr
-					}
-					return nil
-				}).Times(1)
-			Expect(handler.Handle(cli, reqCtx, nil, event)).Should(Equal(updateErr))
 		})
-	})
 
-	Context("exclusive role", func() {
-		var (
-			cli     client.Client
-			reqCtx  intctrlutil.RequestCtx
-			pod     *corev1.Pod
-			handler *PodRoleEventHandler
-		)
-
-		BeforeEach(func() {
-			cli = k8sMock
-			reqCtx = intctrlutil.RequestCtx{
+		It("must be a no-op for non-kbagent events as well", func() {
+			cli := k8sMock
+			reqCtx := intctrlutil.RequestCtx{
 				Ctx: ctx,
 				Log: logger,
 			}
-			pod = builder.NewPodBuilder(namespace, getPodName(name, 0)).SetUID(uid).GetObject()
-			pod.ResourceVersion = "1"
-			handler = &PodRoleEventHandler{}
-		})
-
-		It("should remove exclusive role labels from other pods when a new pod claims exclusive role", func() {
-			// Create an exclusive role
-			exclusiveRole := workloads.ReplicaRole{
-				Name:                 "leader",
-				ParticipatesInQuorum: true,
-				UpdatePriority:       5,
-				IsExclusive:          true, // Exclusive role
-			}
-
-			// Create an event for the new pod claiming the exclusive role
-			event := newRoleProbeEvent(pod, "foo", exclusiveRole.Name, 0)
-
-			// Mock other pods with the same exclusive role label
-			otherPod1 := builder.NewPodBuilder(namespace, getPodName(name, 1)).
-				SetUID("uid-other-1").
-				AddLabels(constant.AppManagedByLabelKey, constant.AppName).
-				AddLabels(WorkloadsManagedByLabelKey, workloads.InstanceSetKind).
-				AddLabels(WorkloadsInstanceLabelKey, name).
-				AddLabels(RoleLabelKey, exclusiveRole.Name).
-				GetObject()
-			otherPod2 := builder.NewPodBuilder(namespace, getPodName(name, 2)).
-				SetUID("uid-other-2").
-				AddLabels(constant.AppManagedByLabelKey, constant.AppName).
-				AddLabels(WorkloadsManagedByLabelKey, workloads.InstanceSetKind).
-				AddLabels(WorkloadsInstanceLabelKey, name).
-				AddLabels(RoleLabelKey, exclusiveRole.Name).
+			otherEvent := builder.NewEventBuilder(namespace, "unrelated-event").
+				SetReason("SomeOtherReason").
+				SetReportingController("some-other-controller").
 				GetObject()
 
-			k8sMock.EXPECT().
-				Get(gomock.Any(), gomock.Any(), &corev1.Pod{}, gomock.Any()).
-				DoAndReturn(func(_ context.Context, objKey client.ObjectKey, p *corev1.Pod, _ ...client.GetOption) error {
-					p.Namespace = objKey.Namespace
-					p.Name = objKey.Name
-					p.UID = pod.UID
-					p.Labels = map[string]string{
-						constant.AppManagedByLabelKey: constant.AppName,
-						WorkloadsManagedByLabelKey:    workloads.InstanceSetKind,
-						WorkloadsInstanceLabelKey:     name,
-					}
-					return nil
-				}).Times(1)
+			handler := &PodRoleEventHandler{}
+			k8sMock.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			k8sMock.EXPECT().Update(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			k8sMock.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+			k8sMock.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
-			k8sMock.EXPECT().
-				Get(gomock.Any(), gomock.Any(), &workloads.InstanceSet{}, gomock.Any()).
-				DoAndReturn(func(_ context.Context, objKey client.ObjectKey, its *workloads.InstanceSet, _ ...client.GetOption) error {
-					its.Namespace = objKey.Namespace
-					its.Name = objKey.Name
-					its.Spec.Roles = []workloads.ReplicaRole{exclusiveRole}
-					return nil
-				}).Times(1)
-
-			// Expect update for the main pod (adding role label)
-			k8sMock.EXPECT().
-				Update(gomock.Any(), gomock.Any(), gomock.Any()).
-				DoAndReturn(func(_ context.Context, pd *corev1.Pod, _ ...client.UpdateOption) error {
-					Expect(pd).ShouldNot(BeNil())
-					Expect(pd.Labels).ShouldNot(BeNil())
-					Expect(pd.Labels[RoleLabelKey]).Should(Equal(exclusiveRole.Name))
-					return nil
-				}).Times(1)
-
-			// Expect list call to find other pods with the same exclusive role
-			k8sMock.EXPECT().
-				List(gomock.Any(), gomock.Any(), gomock.Any()).
-				DoAndReturn(func(_ context.Context, podList *corev1.PodList, opts ...client.ListOption) error {
-					podList.Items = []corev1.Pod{*otherPod1, *otherPod2}
-					return nil
-				}).Times(1)
-
-			// Expect updates to remove role labels from other pods
-			k8sMock.EXPECT().
-				Update(gomock.Any(), gomock.Any(), gomock.Any()).
-				DoAndReturn(func(_ context.Context, pd *corev1.Pod, _ ...client.UpdateOption) error {
-					Expect(pd).ShouldNot(BeNil())
-					// Should be one of the other pods (not the main pod)
-					Expect(pd.Name).ShouldNot(Equal(pod.Name))
-					// Role label should be removed
-					Expect(pd.Labels).ShouldNot(HaveKey(RoleLabelKey))
-					return nil
-				}).Times(2) // Two other pods
-
-			// Expect event patch
-			k8sMock.EXPECT().
-				Patch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-				DoAndReturn(func(_ context.Context, evt *corev1.Event, patch client.Patch, _ ...client.PatchOption) error {
-					Expect(evt).ShouldNot(BeNil())
-					Expect(evt.Annotations).ShouldNot(BeNil())
-					Expect(evt.Annotations[roleChangedAnnotKey]).Should(Equal(fmt.Sprintf("count-%d", evt.Count)))
-					return nil
-				}).Times(1)
-
-			Expect(handler.Handle(cli, reqCtx, nil, event)).Should(Succeed())
-		})
-
-		It("should not remove role labels when role is not exclusive", func() {
-			// Create a non-exclusive role
-			nonExclusiveRole := workloads.ReplicaRole{
-				Name:                 "follower",
-				ParticipatesInQuorum: true,
-				UpdatePriority:       3,
-				IsExclusive:          false, // Not exclusive
-			}
-
-			// Create an event for the new pod claiming the non-exclusive role
-			event := newRoleProbeEvent(pod, "foo", nonExclusiveRole.Name, 0)
-
-			// Expectations
-			k8sMock.EXPECT().
-				Get(gomock.Any(), gomock.Any(), &corev1.Pod{}, gomock.Any()).
-				DoAndReturn(func(_ context.Context, objKey client.ObjectKey, p *corev1.Pod, _ ...client.GetOption) error {
-					p.Namespace = objKey.Namespace
-					p.Name = objKey.Name
-					p.UID = pod.UID
-					p.Labels = map[string]string{
-						constant.AppManagedByLabelKey: constant.AppName,
-						WorkloadsManagedByLabelKey:    workloads.InstanceSetKind,
-						WorkloadsInstanceLabelKey:     name,
-					}
-					return nil
-				}).Times(1)
-
-			k8sMock.EXPECT().
-				Get(gomock.Any(), gomock.Any(), &workloads.InstanceSet{}, gomock.Any()).
-				DoAndReturn(func(_ context.Context, objKey client.ObjectKey, its *workloads.InstanceSet, _ ...client.GetOption) error {
-					its.Namespace = objKey.Namespace
-					its.Name = objKey.Name
-					its.Spec.Roles = []workloads.ReplicaRole{nonExclusiveRole}
-					return nil
-				}).Times(1)
-
-			// Expect update for the main pod only (no list or updates for other pods)
-			k8sMock.EXPECT().
-				Update(gomock.Any(), gomock.Any(), gomock.Any()).
-				DoAndReturn(func(_ context.Context, pd *corev1.Pod, _ ...client.UpdateOption) error {
-					Expect(pd).ShouldNot(BeNil())
-					Expect(pd.Labels).ShouldNot(BeNil())
-					Expect(pd.Labels[RoleLabelKey]).Should(Equal(nonExclusiveRole.Name))
-					return nil
-				}).Times(1)
-
-			// Should NOT call List (since role is not exclusive)
-			// Should NOT call Update for other pods
-
-			// Expect event patch
-			k8sMock.EXPECT().
-				Patch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-				DoAndReturn(func(_ context.Context, evt *corev1.Event, patch client.Patch, _ ...client.PatchOption) error {
-					Expect(evt).ShouldNot(BeNil())
-					Expect(evt.Annotations).ShouldNot(BeNil())
-					Expect(evt.Annotations[roleChangedAnnotKey]).Should(Equal(fmt.Sprintf("count-%d", evt.Count)))
-					return nil
-				}).Times(1)
-
-			Expect(handler.Handle(cli, reqCtx, nil, event)).Should(Succeed())
+			Expect(handler.Handle(cli, reqCtx, nil, otherEvent)).Should(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
## Summary

Replaces the closed PR #10278. That attempt had two design defects:
1. It deleted `controllers/workloads/instance_event_controller.go` (the Instance API role event entry point introduced by #9697) thinking it was the legacy writer.
2. It stamped a wall-clock version inside kbagent. kbagent cannot see real engine-internal role state, so identical script output across a true short failover never registered as a fresh role fact.

This PR reverses both. `InstanceEventReconciler` stays as the single writer of the Pod role label for kbagent roleProbe events, and the staleness version comes from the addon's `roleProbe` action stdout — an engine-authoritative value the script extracts from raft term, sentinel config-epoch, PG timeline, or equivalent.

## Contract

`roleProbe` action stdout supports two formats:

- **Legacy (single line)**: just the role name. Controller falls back to the existing EventTime staleness path. Unchanged for any addon that has not adopted the new format.
- **Engine-authoritative version (multi-line)**: first line is the role name, optional second line is `kb-role-version=<uint64>`. The controller uses this version as the staleness gate.

Example:
```
primary
kb-role-version=10
```

Parser is strict: a `kb-role-version=` line whose value is empty, not a `uint64`, or duplicated is flagged Malformed and the event is rejected outright. Silently falling back to EventTime on malformed input would let a typo bypass the new gate.

The version must come from an engine/coordination role epoch that is monotonic and comparable across Pods within a Component. Wall-clock micros, kbagent counters, controller state, random tokens, runids, and per-Pod local counters are all rejected by contract.

## Annotation format

`LastRoleEventVersionAnnotationKey` becomes prefix-tagged:
- Engine-version events write `engine:<n>`.
- Legacy events keep bare `<EventTime micros>` for backward compat.

Four mixed-format combinations handled explicitly and pinned by unit tests:
- Engine event vs `engine:<n>` annotation → numeric compare, reject unless strictly newer.
- Engine event vs bare legacy annotation → accept and upgrade annotation to `engine:<n>`.
- Legacy event vs `engine:<n>` annotation → reject (no downgrade to EventTime gate).
- Legacy event vs bare legacy annotation → existing bare-numeric EventTime compare (preserved).

## Single-writer fix

`PodRoleEventHandler` is no-op for kbagent roleProbe events. Before this PR, both `PodRoleEventHandler` (via `EventReconciler` in `k8score`) and `InstanceEventReconciler` watched the same `corev1.Event` objects and wrote the Pod role label; whichever reconciler picked the event up first marked the shared `kubeblocks.io/event-handled` annotation and the other path skipped, so the engine-version gate could be bypassed depending on controller-runtime scheduling.

The file `pkg/controller/instanceset/pod_role_event_handler.go` is kept; its now-unused helpers (`handleRoleChangedEvent`, `checkStaleLastRoleEventVersion`, `removeExclusiveRoleLabels`, `updatePodRoleLabel`, `roleEventVersion`) are dead in this PR and queued for a separate cleanup once the no-op contract has soaked.

## Backward compatibility / rollout skew

| Controller | Addon stdout | Result |
|---|---|---|
| New | Legacy single line | Works, falls back to EventTime path |
| New | New multi-line + `kb-role-version=` | Works, engine-version gate active |
| Old (pre-upgrade) | Legacy single line | Works (no change) |
| Old (pre-upgrade) | New multi-line | **Broken** — old controller's `TrimSpace` does not remove internal `\n`, so the whole stdout becomes the role name, matches no `ReplicaRole`, and the label is not written |

Deployment rule: upgrade the controller first, then upgrade the addon. Addon PRs that change `roleProbe` to multi-line output must declare a minimum KubeBlocks version requirement.

## Validation

- `go test ./controllers/workloads -count=1 -run "TestParseRoleProbeOutput|TestCheckRoleProbeStale"` PASS (13 pure-helper tests covering the parser modes and the four mixed-format gate cases).
- `go test ./pkg/controller/instanceset -count=1` PASS (kbagent roleProbe event → 0 client calls; non-kbagent event → 0 client calls; remaining package specs unchanged).
- `go build ./...` PASS after the changes.
- `git diff --check` clean.
- Envtest-backed Reconcile-level tests in `controllers/workloads` use the existing Ginkgo suite (`BeforeSuite` needs envtest binaries) and are not exercised locally; CI will run them.

## Boundary

This is a controller / kbagent contract fix. It does not on its own constitute a release-ready closure for the live role-event ping-pong scenario. Release-ready requires:
- The addon failover archive end-to-end replay against a patched binary with an addon that emits the engine-authoritative version (whitespace-separated second token, e.g. `primary\n<config-epoch>`).
- Multi-round soak validation under stable + failover workloads.
- Long-duration runtime without re-introducing the periodic patch churn.

Addons that have not adopted the new stdout format keep their existing stale-role exposure on the legacy path; the addon-api doc explicitly says the engine-authoritative version is required to fully fix the gate.

### Addon roleProbe contract caveat

The role token and the engine version token must come from the **same engine authority**. If an addon's `roleProbe` reports `<role>` from one source (for example a local `INFO replication role:<role>` query that lags during failover) and `<version>` from another source (for example `sentinel config-epoch` that has already bumped), the controller can receive **two pods emitting `primary <same-version>`** in the same failover window. In that input the controller has no fact to pick the true primary; any same-epoch tiebreaker heuristic (last-writer, equal-version-but-different-role override, peer-cleanup chasing) would either re-open the silent stale-primary write-back this PR is trying to close, or risk stripping the label from the real new primary depending on event arrival order.

This PR therefore does **not** try to recover from a false `primary <same-version>` emitted by the addon. The addon's `roleProbe` script is responsible for cross-checking the role token against the same authoritative source that produced the version. For Sentinel-based engines that means the script must require local `INFO server run_id` to equal Sentinel's current master `runid` before emitting `primary <config-epoch>`; otherwise the script should emit `secondary <config-epoch>`. A Valkey V1 round (archive sha `718c06b2e07f...da53e79`) confirms the failure surface when only local `INFO replication` plus Sentinel `config-epoch` are used as the role-and-version pair: two pods reported `primary 3` simultaneously and the controller correctly had no basis to pick between them. The fix for that surface belongs in the addon's `roleProbe` script, not in the controller gate.

## Files changed

- `controllers/workloads/instance_event_controller.go` — wire the parser + gate into the existing Reconcile path; write `engine:<n>` to the annotation when accepted.
- `controllers/workloads/instance_event_controller_helper.go` — new file: `parseRoleProbeOutput` + `checkRoleProbeStale` plus the explicit `roleProbeVersionMode` / `roleProbeGateDecision` types.
- `controllers/workloads/instance_event_controller_helper_test.go` — new file: 13 pure-helper unit tests (parser + four mixed-format gate cases + edge cases).
- `pkg/controller/instanceset/pod_role_event_handler.go` — `Handle` is now a no-op for kbagent roleProbe events.
- `pkg/controller/instanceset/pod_role_event_handler_test.go` — replaces the older write-label assertions with two `Times(0)` no-op assertions.

Companion doc change in `kubeblocks-addon-docs` (`docs/addon-api/05a-lifecycle-roles-and-probe.md`) lands in a separate PR there.

