### PR TITLE
chore: add release name shortening helper

### DIFF
--- a/pkg/constant/pattern.go
+++ b/pkg/constant/pattern.go
@@ -21,8 +21,11 @@ package constant
 
 import (
 	"fmt"
+	"hash/fnv"
 	"strings"
 )
+
+const KubeNameMaxLength = 63
 
 // GenerateClusterComponentName generates the cluster component name.
 func GenerateClusterComponentName(clusterName, compName string) string {
@@ -95,4 +98,26 @@ func GenerateDefaultRoleName(cmpdName string) string {
 // GenerateWorkloadNamePattern generates the workload name pattern
 func GenerateWorkloadNamePattern(clusterName, compName string) string {
 	return fmt.Sprintf("%s-%s", clusterName, compName)
+}
+
+func ShortenKubeName(raw string, maxLen int) string {
+	if maxLen <= 0 || len(raw) <= maxLen {
+		return raw
+	}
+	suffix := shortHash(raw)
+	if maxLen <= len(suffix)+1 {
+		return suffix[:maxLen]
+	}
+	prefixLen := maxLen - len(suffix) - 1
+	prefix := strings.TrimSuffix(raw[:prefixLen], "-")
+	if prefix == "" {
+		return suffix[:maxLen]
+	}
+	return fmt.Sprintf("%s-%s", prefix, suffix)
+}
+
+func shortHash(raw string) string {
+	hasher := fnv.New32a()
+	_, _ = hasher.Write([]byte(raw))
+	return fmt.Sprintf("%08x", hasher.Sum32())
 }

--- a/pkg/constant/pattern_test.go
+++ b/pkg/constant/pattern_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright (C) 2022-2025 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package constant
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestShortenKubeNameKeepsShortNames(t *testing.T) {
+	got := ShortenKubeName("demo-valkey-sentinel", KubeNameMaxLength)
+	if got != "demo-valkey-sentinel" {
+		t.Fatalf("shortened name = %s, want unchanged short name", got)
+	}
+}
+
+func TestShortenKubeNameShortensLongNames(t *testing.T) {
+	raw := "vlk-smoke-rerun-202206-restore-202950-valkey-sentinel-valkey-sentinel"
+
+	got := ShortenKubeName(raw, KubeNameMaxLength)
+	if len(got) > KubeNameMaxLength {
+		t.Fatalf("shortened name length = %d, want <= %d: %s", len(got), KubeNameMaxLength, got)
+	}
+	if !strings.HasPrefix(got, "vlk-smoke-rerun-202206-restore-202950-valkey") {
+		t.Fatalf("shortened name prefix = %s, want stable readable prefix", got)
+	}
+	if got == raw {
+		t.Fatalf("name was not shortened: %s", got)
+	}
+}
+
+func TestShortenKubeNameAvoidsCollisionsForSamePrefix(t *testing.T) {
+	rawA := "vlk-smoke-rerun-202206-restore-202950-valkey-sentinel-alpha"
+	rawB := "vlk-smoke-rerun-202206-restore-202950-valkey-sentinel-bravo"
+
+	nameA := ShortenKubeName(rawA, 40)
+	nameB := ShortenKubeName(rawB, 40)
+	if nameA == nameB {
+		t.Fatalf("different long inputs collided: %s", nameA)
+	}
+}
+
+func TestShortenKubeNameIsDeterministic(t *testing.T) {
+	raw := "vlk-smoke-rerun-202206-restore-202950-valkey-sentinel-valkey-sentinel"
+
+	name1 := ShortenKubeName(raw, KubeNameMaxLength)
+	name2 := ShortenKubeName(raw, KubeNameMaxLength)
+	if name1 != name2 {
+		t.Fatalf("shortened name generation is not deterministic: %s != %s", name1, name2)
+	}
+}


### PR DESCRIPTION
## Summary
- add the missing Kubernetes name shortening helper used by #10274 on release-1.1
- add focused unit coverage for deterministic shortening behavior