### PR TITLE
fix(operations): rebuild no-backup instances without helper PV handoff

### DIFF
--- a/pkg/operations/rebuild_instance_inplace.go
+++ b/pkg/operations/rebuild_instance_inplace.go
@@ -48,9 +48,11 @@ import (
 const (
 	rebuildFromAnnotation           = "operations.kubeblocks.io/rebuild-from"
 	rebuildTmpPVCNameLabel          = "operations.kubeblocks.io/rebuild-tmp-pvc"
+	rebuildSourcePVCUIDAnnotation   = "operations.kubeblocks.io/rebuild-source-pvc-uid"
 	sourcePVReclaimPolicyAnnotation = "operations.kubeblocks.io/source-reclaim-policy"
 
 	waitingForInstanceReadyMessage   = "Waiting for the rebuilding instance to be ready"
+	waitingForDynamicPVCMessage      = "Waiting for source PVCs to be dynamically reprovisioned"
 	waitingForPostReadyRestorePrefix = "Waiting for postReady Restore"
 
 	ignoreRoleCheckAnnotationKey = "operations.kubeblocks.io/ignore-role-check"
@@ -83,8 +85,10 @@ func (inPlaceHelper *inplaceRebuildHelper) rebuildInstanceWithNoBackup(reqCtx in
 		return false, err
 	}
 	if progressDetail.Message != waitingForInstanceReadyMessage {
-		// 2. rebuild source pvcs and recreate the instance by deleting it.
-		return false, inPlaceHelper.rebuildSourcePVCsAndRecreateInstance(reqCtx, cli, opsRes.OpsRequest, progressDetail)
+		// 2. no-backup rebuild only needs a fresh source PVC. Do not require a
+		// helper PV to be visible because vcluster fake-PV environments may not
+		// expose a transferable PV object to the KB controller.
+		return false, inPlaceHelper.rebuildSourcePVCsByDynamicProvision(reqCtx, cli, opsRes.OpsRequest, progressDetail)
 	}
 
 	// 3. waiting for new instance is available.
@@ -437,6 +441,74 @@ func (inPlaceHelper *inplaceRebuildHelper) rebuildSourcePVCsAndRecreateInstance(
 	return nil
 }
 
+func (inPlaceHelper *inplaceRebuildHelper) rebuildSourcePVCsByDynamicProvision(reqCtx intctrlutil.RequestCtx,
+	cli client.Client,
+	opsRequest *opsv1alpha1.OpsRequest,
+	progressDetail *opsv1alpha1.ProgressStatusDetail) error {
+	itsName := constant.GenerateWorkloadNamePattern(inPlaceHelper.synthesizedComp.ClusterName, inPlaceHelper.synthesizedComp.Name)
+
+	targetPodDeleted := false
+	waitingForSourcePVC := false
+	for sourcePVCName, builtTmpPVC := range inPlaceHelper.pvcMap {
+		tmpPVC, err := inPlaceHelper.getLiveTmpPVCOrBuilt(reqCtx, cli, builtTmpPVC)
+		if err != nil {
+			return err
+		}
+		sourcePVC, err := inPlaceHelper.getSourcePVC(reqCtx, cli, sourcePVCName, tmpPVC.Namespace)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				waitingForSourcePVC = true
+				continue
+			}
+			return err
+		}
+		if sourcePVC.DeletionTimestamp != nil {
+			waitingForSourcePVC = true
+			if err := inPlaceHelper.removePVCFinalizer(reqCtx, cli, sourcePVC); err != nil {
+				return err
+			}
+			continue
+		}
+		oldSourcePVCUID := tmpPVC.Annotations[rebuildSourcePVCUIDAnnotation]
+		if oldSourcePVCUID == "" {
+			if err := inPlaceHelper.recordSourcePVCUIDOnTmpPVC(reqCtx, cli, tmpPVC, sourcePVC); err != nil {
+				return err
+			}
+			oldSourcePVCUID = string(sourcePVC.UID)
+		}
+		if string(sourcePVC.UID) == oldSourcePVCUID {
+			waitingForSourcePVC = true
+			if !targetPodDeleted {
+				if err := inPlaceHelper.setInstanceNodeSelectorForRebuild(reqCtx, cli, itsName); err != nil {
+					return err
+				}
+				if err := inPlaceHelper.deleteTargetPodForRebuild(reqCtx, cli, opsRequest); err != nil {
+					return err
+				}
+				targetPodDeleted = true
+			}
+			if err := inPlaceHelper.deleteSourcePVCForRebuild(reqCtx, cli, sourcePVC); err != nil {
+				return err
+			}
+			continue
+		}
+		if sourcePVC.Status.Phase != corev1.ClaimBound {
+			waitingForSourcePVC = true
+			continue
+		}
+		if err := inPlaceHelper.cleanupTmpPVC(reqCtx, cli, tmpPVC); err != nil {
+			return err
+		}
+	}
+	if waitingForSourcePVC {
+		progressDetail.Message = waitingForDynamicPVCMessage
+		return nil
+	}
+
+	progressDetail.Message = waitingForInstanceReadyMessage
+	return nil
+}
+
 func (inPlaceHelper *inplaceRebuildHelper) deleteTargetPodForRebuild(reqCtx intctrlutil.RequestCtx,
 	cli client.Client,
 	opsRequest *opsv1alpha1.OpsRequest) error {
@@ -445,6 +517,21 @@ func (inPlaceHelper *inplaceRebuildHelper) deleteTargetPodForRebuild(reqCtx intc
 		options = append(options, client.GracePeriodSeconds(0))
 	}
 	return client.IgnoreNotFound(intctrlutil.BackgroundDeleteObject(cli, reqCtx.Ctx, inPlaceHelper.targetPod, options...))
+}
+
+func (inPlaceHelper *inplaceRebuildHelper) recordSourcePVCUIDOnTmpPVC(reqCtx intctrlutil.RequestCtx,
+	cli client.Client,
+	tmpPVC *corev1.PersistentVolumeClaim,
+	sourcePVC *corev1.PersistentVolumeClaim) error {
+	if tmpPVC.UID == "" {
+		return nil
+	}
+	patch := client.MergeFrom(tmpPVC.DeepCopy())
+	if tmpPVC.Annotations == nil {
+		tmpPVC.Annotations = map[string]string{}
+	}
+	tmpPVC.Annotations[rebuildSourcePVCUIDAnnotation] = string(sourcePVC.UID)
+	return cli.Patch(reqCtx.Ctx, tmpPVC, patch)
 }
 
 func (inPlaceHelper *inplaceRebuildHelper) setSourcePVCVolumeNameForRebuild(reqCtx intctrlutil.RequestCtx,

--- a/pkg/operations/rebuild_instance_test.go
+++ b/pkg/operations/rebuild_instance_test.go
@@ -361,6 +361,83 @@ var _ = Describe("OpsUtil functions", func() {
 			}
 		}
 
+		sourcePVCsShouldDynamicReprovision := func(reqCtx intctrlutil.RequestCtx, opsRes *OpsResource) {
+			sourcePVCTemplateList := &corev1.PersistentVolumeClaimList{}
+			Expect(k8sClient.List(ctx, sourcePVCTemplateList,
+				client.MatchingLabels{constant.KBAppComponentLabelKey: defaultCompName},
+				client.InNamespace(opsRes.OpsRequest.Namespace))).Should(Succeed())
+			sourcePVCTemplates := map[string]*corev1.PersistentVolumeClaim{}
+			sourcePVCUIDs := map[string]types.UID{}
+			targetSourcePVCs := map[string]bool{}
+			for _, ins := range opsRes.OpsRequest.Spec.RebuildFrom[0].Instances {
+				targetSourcePVCs[fmt.Sprintf("%s-%s", testapps.DataVolumeName, ins.Name)] = true
+			}
+			for i := range sourcePVCTemplateList.Items {
+				pvc := sourcePVCTemplateList.Items[i].DeepCopy()
+				if _, ok := pvc.Annotations[rebuildFromAnnotation]; ok {
+					continue
+				}
+				if !targetSourcePVCs[pvc.Name] {
+					continue
+				}
+				sourcePVCTemplates[pvc.Name] = pvc
+				sourcePVCUIDs[pvc.Name] = pvc.UID
+			}
+
+			_, err := GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
+			Expect(err).Should(Succeed())
+			for sourcePVCName := range sourcePVCTemplates {
+				Eventually(func(g Gomega) {
+					pvc := &corev1.PersistentVolumeClaim{}
+					err := k8sClient.Get(ctx, client.ObjectKey{Name: sourcePVCName, Namespace: opsRes.OpsRequest.Namespace}, pvc)
+					if apierrors.IsNotFound(err) {
+						return
+					}
+					g.Expect(err).Should(Succeed())
+					g.Expect(pvc.DeletionTimestamp).ShouldNot(BeNil())
+				}).Should(Succeed())
+				testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.PersistentVolumeClaimSignature, true,
+					client.InNamespace(opsRes.OpsRequest.Namespace), client.MatchingFields{"metadata.name": sourcePVCName})
+			}
+
+			initInstanceSetPods(ctx, k8sClient, opsRes)
+			By("expect rebuild to wait while InstanceSet has not recreated dynamically provisioned source PVCs")
+			_, err = GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
+			Expect(err).Should(Succeed())
+			for _, detail := range opsRes.OpsRequest.Status.Components[defaultCompName].ProgressDetails {
+				Expect(detail.Message).Should(Equal(waitingForDynamicPVCMessage))
+			}
+
+			for sourcePVCName := range sourcePVCTemplates {
+				sourcePVCTemplate := sourcePVCTemplates[sourcePVCName]
+				recreatedSourcePVC := sourcePVCTemplate.DeepCopy()
+				recreatedSourcePVC.ResourceVersion = ""
+				recreatedSourcePVC.UID = ""
+				recreatedSourcePVC.CreationTimestamp = metav1.Time{}
+				recreatedSourcePVC.DeletionTimestamp = nil
+				recreatedSourcePVC.ManagedFields = nil
+				recreatedSourcePVC.Finalizers = nil
+				recreatedSourcePVC.Spec.VolumeName = "dynamic-" + sourcePVCName
+				Expect(k8sClient.Create(ctx, recreatedSourcePVC)).Should(Succeed())
+				Expect(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKeyFromObject(recreatedSourcePVC), func(pvc *corev1.PersistentVolumeClaim) {
+					pvc.Status.Phase = corev1.ClaimBound
+				})()).Should(Succeed())
+			}
+
+			Eventually(func(g Gomega) {
+				_, err := GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
+				g.Expect(err).Should(Succeed())
+				for sourcePVCName, oldUID := range sourcePVCUIDs {
+					pvc := &corev1.PersistentVolumeClaim{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: sourcePVCName, Namespace: opsRes.OpsRequest.Namespace}, pvc)).Should(Succeed())
+					g.Expect(pvc.UID).ShouldNot(Equal(oldUID))
+				}
+				for _, detail := range opsRes.OpsRequest.Status.Components[defaultCompName].ProgressDetails {
+					g.Expect(detail.Message).Should(Equal(waitingForInstanceReadyMessage))
+				}
+			}).Should(Succeed())
+		}
+
 		waitForInstanceToAvailable := func(reqCtx intctrlutil.RequestCtx, opsRes *OpsResource, ignoreRoleCheck bool) {
 			By("waiting for the rebuild instance to ready")
 			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest), func(g Gomega, ops *opsv1alpha1.OpsRequest) {
@@ -409,7 +486,7 @@ var _ = Describe("OpsUtil functions", func() {
 			}
 			Expect(tmpPVCCount).Should(Equal(rebuildInstanceCount))
 
-			By("fake the rebuilding pod to be Completed and fake pvs are created.")
+			By("fake the rebuilding pod to be Completed.")
 			for i := range podList.Items {
 				pod := &podList.Items[i]
 				Expect(testapps.ChangeObjStatus(&testCtx, pod, func() {
@@ -417,8 +494,8 @@ var _ = Describe("OpsUtil functions", func() {
 				})).Should(Succeed())
 			}
 
-			By("expect to create the source pvcs and the pvs have rebind them.")
-			sourcePVCsShouldRebindPVs(reqCtx, opsRes, pvcList)
+			By("expect to dynamically reprovision the source pvcs without requiring helper pvs.")
+			sourcePVCsShouldDynamicReprovision(reqCtx, opsRes)
 
 			By("expect the opsRequest to succeed")
 			waitForInstanceToAvailable(reqCtx, opsRes, false)


### PR DESCRIPTION
## Problem

A MySQL semisync RebuildInstance test on the release-1.0 line reproduced a control-plane failure in the no-backup in-place path:

`can not found the pv by the pvc "rebuild-..."`

This path does not restore data from a Backup. It only needs the old source PVC to be replaced so the instance can come back with a fresh volume. Requiring a helper PV lookup makes the operation fail in environments where the virtual cluster does not expose a transferable PV object to the KubeBlocks controller.

## Changes

- Split the no-backup RebuildInstance handoff from the backup-based helper-PV handoff.
- For no-backup rebuild, record the old source PVC UID on the temp PVC, delete the target pod/source PVC, wait for a new Bound source PVC with a different UID, then clean up the temp PVC.
- Keep backup-based rebuild on the existing helper PV handoff path.
- Update the no-backup RebuildInstance test to cover dynamic source PVC reprovisioning without creating helper PVs.

## Validation

- `go generate ./pkg/testutil/k8s/mocks/...`
- `go test -c ./pkg/operations`
- `KUBEBUILDER_ASSETS="$(./bin/setup-envtest-release-0.21 use 1.26.1 -p path)" go test ./pkg/operations -run TestAPIs -ginkgo.focus "test rebuild instance with no backup" -count=1 -v`
- `KUBEBUILDER_ASSETS="$(./bin/setup-envtest-release-0.21 use 1.26.1 -p path)" go test ./pkg/operations -run TestAPIs -count=1`
- `git diff --check`

## Boundaries

This is scoped to no-backup RebuildInstance. Backup-based rebuild still requires the existing restore/helper-PV flow and is not claimed fixed by this PR.
