### PR TITLE
fix: migrate ApeCloud MySQL binlog path on upgrade

### DIFF
--- a/controllers/apps/component/transformer_component_workload.go
+++ b/controllers/apps/component/transformer_component_workload.go
@@ -99,6 +99,7 @@ func (t *componentWorkloadTransformer) reconcileWorkload(ctx context.Context, cl
 	for i, container := range protoITS.Spec.Template.Spec.InitContainers {
 		protoITS.Spec.Template.Spec.InitContainers[i].Image = intctrlutil.ReplaceImageRegistry(container.Image)
 	}
+	injectMySQLBinlogPathCompatInitContainer(synthesizedComp, runningITS, protoITS)
 
 	t.buildInstanceSetPlacementAnnotation(comp, protoITS)
 
@@ -107,6 +108,162 @@ func (t *componentWorkloadTransformer) reconcileWorkload(ctx context.Context, cl
 	}
 
 	return nil
+}
+
+const (
+	mysqlBinlogPathCompatInitContainerName = "kb-compat-mysql-binlog-path"
+	mysqlBinlogPathCompatDataRoot          = "/data/mysql"
+	mysqlBinlogPathCompatScript            = `set -eu
+
+data_root=${KB_COMPAT_MYSQL_DATA_ROOT:-/data/mysql}
+old_index="$data_root/data/mysql-bin.index"
+new_dir="$data_root/binlog"
+new_index="$new_dir/mysql-bin.index"
+marker="$new_dir/.kb-binlog-path-migrated"
+
+[ -s "$old_index" ] || exit 0
+mkdir -p "$new_dir"
+[ ! -f "$marker" ] || exit 0
+
+tmp_index="$new_index.kb-migrate.$$"
+trap 'rm -f "$tmp_index"' EXIT
+awk -v dir="$new_dir" '{
+  base=$0
+  sub(/^.*\//, "", base)
+  if (base != "") print dir "/" base
+}' "$old_index" > "$tmp_index"
+
+[ -s "$tmp_index" ] || exit 0
+all_new_binlogs_exist=true
+while IFS= read -r path || [ -n "$path" ]; do
+  [ -n "$path" ] || continue
+  if [ ! -s "$path" ]; then
+    all_new_binlogs_exist=false
+    break
+  fi
+done < "$tmp_index"
+
+if [ -s "$new_index" ] && cmp -s "$new_index" "$tmp_index" && [ "$all_new_binlogs_exist" = true ]; then
+  date > "$marker" 2>/dev/null || true
+  exit 0
+fi
+
+if [ -s "$new_index" ]; then
+  non_bootstrap=$(awk 'NF && $0 !~ /(^|\/)mysql-bin\.000001$/ { print; exit }' "$new_index")
+  if [ -n "$non_bootstrap" ]; then
+    echo "existing mysql binlog index is already beyond bootstrap; skip migration: $non_bootstrap"
+    date > "$marker" 2>/dev/null || true
+    exit 0
+  fi
+fi
+
+ts=$(date +%Y%m%d%H%M%S 2>/dev/null || echo now)
+backup="$data_root/repair-binlog-path-$ts"
+mkdir -p "$backup"
+cp -a "$old_index" "$backup/mysql-bin.index.from-data"
+cp -a "$new_index" "$backup/mysql-bin.index.from-binlog" 2>/dev/null || true
+
+while IFS= read -r entry || [ -n "$entry" ]; do
+  [ -n "$entry" ] || continue
+  base=${entry##*/}
+  src="$data_root/data/$base"
+  dst="$new_dir/$base"
+  if [ ! -s "$src" ]; then
+    echo "missing source binlog: $src" >&2
+    exit 1
+  fi
+  if [ -e "$dst" ] && ! cmp -s "$src" "$dst"; then
+    mv "$dst" "$backup/$base.existing"
+  fi
+  [ -e "$dst" ] || cp -a "$src" "$dst"
+done < "$old_index"
+
+mv "$tmp_index" "$new_index"
+chown -R mysql:mysql "$new_dir" 2>/dev/null || true
+date > "$marker" 2>/dev/null || true
+sync
+echo "migrated mysql binlog index to $new_index"`
+)
+
+func injectMySQLBinlogPathCompatInitContainer(synthesizedComp *component.SynthesizedComponent, runningITS, protoITS *workloads.InstanceSet) {
+	if runningITS == nil || protoITS == nil {
+		return
+	}
+	spec := &protoITS.Spec.Template.Spec
+	if _, container := intctrlutil.GetContainerByName(spec.InitContainers, mysqlBinlogPathCompatInitContainerName); container != nil {
+		return
+	}
+	mysqlContainer := findMySQLBinlogPathCompatContainer(synthesizedComp, spec.Containers)
+	if mysqlContainer == nil {
+		return
+	}
+	dataMount, ok := findMySQLBinlogPathCompatDataMount(mysqlContainer.VolumeMounts)
+	if !ok {
+		return
+	}
+	initContainer := buildMySQLBinlogPathCompatInitContainer(mysqlContainer, dataMount)
+	if _, runningContainer := intctrlutil.GetContainerByName(runningITS.Spec.Template.Spec.Containers, mysqlContainer.Name); runningContainer != nil && runningContainer.Image != "" {
+		initContainer.Image = runningContainer.Image
+		initContainer.ImagePullPolicy = runningContainer.ImagePullPolicy
+	}
+	spec.InitContainers = append(spec.InitContainers, initContainer)
+}
+
+func findMySQLBinlogPathCompatContainer(synthesizedComp *component.SynthesizedComponent, containers []corev1.Container) *corev1.Container {
+	for i := range containers {
+		if isApeCloudMySQLImage(containers[i].Image) {
+			return &containers[i]
+		}
+	}
+	if !isApeCloudMySQLComponent(synthesizedComp) {
+		return nil
+	}
+	for i := range containers {
+		if containers[i].Name == "mysql" {
+			return &containers[i]
+		}
+	}
+	return nil
+}
+
+func isApeCloudMySQLImage(image string) bool {
+	image = strings.ToLower(image)
+	return strings.Contains(image, "apecloud-mysql-server")
+}
+
+func isApeCloudMySQLComponent(synthesizedComp *component.SynthesizedComponent) bool {
+	if synthesizedComp == nil {
+		return false
+	}
+	serviceKind := strings.ToLower(synthesizedComp.ServiceKind)
+	compDefName := strings.ToLower(synthesizedComp.CompDefName)
+	return serviceKind == "wesql" || strings.Contains(compDefName, "apecloud-mysql") || strings.Contains(compDefName, "wesql")
+}
+
+func findMySQLBinlogPathCompatDataMount(mounts []corev1.VolumeMount) (corev1.VolumeMount, bool) {
+	for _, mount := range mounts {
+		if strings.TrimRight(mount.MountPath, "/") == mysqlBinlogPathCompatDataRoot {
+			return mount, true
+		}
+	}
+	return corev1.VolumeMount{}, false
+}
+
+func buildMySQLBinlogPathCompatInitContainer(mysqlContainer *corev1.Container, dataMount corev1.VolumeMount) corev1.Container {
+	dataMount.MountPath = strings.TrimRight(dataMount.MountPath, "/")
+	return corev1.Container{
+		Name:            mysqlBinlogPathCompatInitContainerName,
+		Image:           mysqlContainer.Image,
+		ImagePullPolicy: mysqlContainer.ImagePullPolicy,
+		Command:         []string{"/bin/sh", "-ec", mysqlBinlogPathCompatScript},
+		Env: []corev1.EnvVar{{
+			Name:  "KB_COMPAT_MYSQL_DATA_ROOT",
+			Value: dataMount.MountPath,
+		}},
+		Resources:       mysqlContainer.Resources,
+		SecurityContext: mysqlContainer.SecurityContext,
+		VolumeMounts:    []corev1.VolumeMount{dataMount},
+	}
 }
 
 func (t *componentWorkloadTransformer) buildInstanceSetPlacementAnnotation(comp *appsv1.Component, its *workloads.InstanceSet) {

--- a/controllers/apps/component/transformer_component_workload_test.go
+++ b/controllers/apps/component/transformer_component_workload_test.go
@@ -198,6 +198,74 @@ var _ = Describe("Component Workload Operations Test", func() {
 			Expect(ops.leaveMemberForPod(pod1, pods)).Should(Succeed())
 		})
 
+		It("should inject ApeCloud MySQL binlog path compatibility init container", func() {
+			runningITS := testapps.NewInstanceSetFactory(testCtx.DefaultNamespace,
+				"running-mysql-its", clusterName, compName).
+				AddContainer(corev1.Container{
+					Name:            "mysql",
+					Image:           "mirror.local/apecloud/apecloud-mysql-server:8.0.30",
+					ImagePullPolicy: corev1.PullIfNotPresent,
+				}).
+				GetObject()
+			protoITS := runningITS.DeepCopy()
+			protoITS.Spec.Template.Spec.Containers = []corev1.Container{{
+				Name:            "mysql",
+				Image:           testapps.ApeCloudMySQLImage,
+				ImagePullPolicy: corev1.PullAlways,
+				VolumeMounts: []corev1.VolumeMount{{
+					Name:      "data",
+					MountPath: "/data/mysql/",
+				}},
+			}}
+
+			injectMySQLBinlogPathCompatInitContainer(&component.SynthesizedComponent{
+				ServiceKind:    "mysql",
+				ServiceVersion: "8.0.30",
+			}, runningITS, protoITS)
+
+			Expect(protoITS.Spec.Template.Spec.InitContainers).Should(HaveLen(1))
+			initContainer := protoITS.Spec.Template.Spec.InitContainers[0]
+			Expect(initContainer.Name).Should(Equal(mysqlBinlogPathCompatInitContainerName))
+			Expect(initContainer.Image).Should(Equal("mirror.local/apecloud/apecloud-mysql-server:8.0.30"))
+			Expect(initContainer.ImagePullPolicy).Should(Equal(corev1.PullIfNotPresent))
+			Expect(initContainer.Command).Should(Equal([]string{"/bin/sh", "-ec", mysqlBinlogPathCompatScript}))
+			Expect(initContainer.Env).Should(ContainElement(corev1.EnvVar{
+				Name:  "KB_COMPAT_MYSQL_DATA_ROOT",
+				Value: "/data/mysql",
+			}))
+			Expect(initContainer.VolumeMounts).Should(Equal([]corev1.VolumeMount{{
+				Name:      "data",
+				MountPath: "/data/mysql",
+			}}))
+			Expect(initContainer.Command[2]).Should(ContainSubstring("old_index=\"$data_root/data/mysql-bin.index\""))
+			Expect(initContainer.Command[2]).Should(ContainSubstring("new_index=\"$new_dir/mysql-bin.index\""))
+
+			injectMySQLBinlogPathCompatInitContainer(synthesizeComp, runningITS, protoITS)
+			Expect(protoITS.Spec.Template.Spec.InitContainers).Should(HaveLen(1))
+		})
+
+		It("should skip binlog path compatibility for non ApeCloud MySQL workloads", func() {
+			runningITS := testapps.NewInstanceSetFactory(testCtx.DefaultNamespace,
+				"running-vanilla-mysql-its", clusterName, compName).
+				AddContainer(corev1.Container{
+					Name:  "mysql",
+					Image: "mysql:8.0",
+				}).
+				GetObject()
+			protoITS := runningITS.DeepCopy()
+			protoITS.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{{
+				Name:      "data",
+				MountPath: "/data/mysql",
+			}}
+
+			injectMySQLBinlogPathCompatInitContainer(&component.SynthesizedComponent{
+				ServiceKind:    "mysql",
+				ServiceVersion: "8.0.30",
+			}, runningITS, protoITS)
+
+			Expect(protoITS.Spec.Template.Spec.InitContainers).Should(BeEmpty())
+		})
+
 		It("should eliminate upgrade-only diff by preserving legacy config-manager", func() {
 			oldITS := testapps.NewInstanceSetFactory(testCtx.DefaultNamespace,
 				"old-its", clusterName, compName).


### PR DESCRIPTION
## Summary
- inject a compatibility init container for existing ApeCloud MySQL workloads during component workload reconciliation
- migrate legacy `/data/mysql/data/mysql-bin.*` entries into `/data/mysql/binlog/` before mysqld starts
- rewrite `/data/mysql/binlog/mysql-bin.index` to absolute paths and mark successful migration to avoid repeat rewrites

## Why
KB 0.9-era ApeCloud MySQL config uses `/data/mysql/binlog/mysql-bin`, while old clusters can still have real binlogs under `/data/mysql/data/mysql-bin.*`. After upgrade/reconfigure, mysqld may read the new bootstrap index (`mysql-bin.000001`) and fail WeSQL consensus recovery with `consensus_init_last_index_of_term for recovery failed`.

## Safety
- only runs for existing workloads, not brand-new workloads
- targets ApeCloud MySQL by image/component signals and requires the `/data/mysql` data mount
- no-ops when the legacy index is absent, when the migration marker exists, or when the new index is already beyond bootstrap
- backs up old/new index files and only moves conflicting target binlogs

## Verification
- `go test -c ./controllers/apps/component`
- `git diff --check`

Full `go test ./controllers/apps/component` cannot run in this local environment because envtest requires `/usr/local/kubebuilder/bin/etcd`, which is not installed.