### PR TITLE
fix(kbagent): honor declared action timeout

### DIFF
--- a/apis/apps/v1/componentdefinition_types.go
+++ b/apis/apps/v1/componentdefinition_types.go
@@ -1870,7 +1870,7 @@ type Action struct {
 	// Specifies the maximum duration in seconds that the Action is allowed to run.
 	//
 	// Behavior based on the value:
-	// - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+	// - Positive (> 0): The action will be terminated after this many seconds.
 	// - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
 	// - Negative (< 0): No timeout is applied; the action runs until the command completes.
 	//

--- a/config/crd/bases/apps.kubeblocks.io_clusters.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusters.yaml
@@ -699,7 +699,7 @@ spec:
                                   Specifies the maximum duration in seconds that the Action is allowed to run.
 
                                   Behavior based on the value:
-                                  - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                                  - Positive (> 0): The action will be terminated after this many seconds.
                                   - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                                   - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -11904,7 +11904,7 @@ spec:
                                       Specifies the maximum duration in seconds that the Action is allowed to run.
 
                                       Behavior based on the value:
-                                      - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                                      - Positive (> 0): The action will be terminated after this many seconds.
                                       - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                                       - Negative (< 0): No timeout is applied; the action runs until the command completes.
 

--- a/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
@@ -4133,7 +4133,7 @@ spec:
                             Specifies the maximum duration in seconds that the Action is allowed to run.
 
                             Behavior based on the value:
-                            - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                            - Positive (> 0): The action will be terminated after this many seconds.
                             - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                             - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -4712,7 +4712,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -5141,7 +5141,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -5562,7 +5562,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -5978,7 +5978,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -6397,7 +6397,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -6818,7 +6818,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -7229,7 +7229,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -7640,7 +7640,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -8051,7 +8051,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -8464,7 +8464,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -8869,7 +8869,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -9314,7 +9314,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -9735,7 +9735,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -17860,7 +17860,7 @@ spec:
                             Specifies the maximum duration in seconds that the Action is allowed to run.
 
                             Behavior based on the value:
-                            - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                            - Positive (> 0): The action will be terminated after this many seconds.
                             - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                             - Negative (< 0): No timeout is applied; the action runs until the command completes.
 

--- a/config/crd/bases/apps.kubeblocks.io_components.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_components.yaml
@@ -581,7 +581,7 @@ spec:
                             Specifies the maximum duration in seconds that the Action is allowed to run.
 
                             Behavior based on the value:
-                            - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                            - Positive (> 0): The action will be terminated after this many seconds.
                             - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                             - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -1002,7 +1002,7 @@ spec:
                             Specifies the maximum duration in seconds that the Action is allowed to run.
 
                             Behavior based on the value:
-                            - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                            - Positive (> 0): The action will be terminated after this many seconds.
                             - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                             - Negative (< 0): No timeout is applied; the action runs until the command completes.
 

--- a/config/crd/bases/apps.kubeblocks.io_rollouts.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_rollouts.yaml
@@ -555,7 +555,7 @@ spec:
                                             Specifies the maximum duration in seconds that the Action is allowed to run.
 
                                             Behavior based on the value:
-                                            - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                                            - Positive (> 0): The action will be terminated after this many seconds.
                                             - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                                             - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -979,7 +979,7 @@ spec:
                                             Specifies the maximum duration in seconds that the Action is allowed to run.
 
                                             Behavior based on the value:
-                                            - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                                            - Positive (> 0): The action will be terminated after this many seconds.
                                             - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                                             - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -3880,7 +3880,7 @@ spec:
                                             Specifies the maximum duration in seconds that the Action is allowed to run.
 
                                             Behavior based on the value:
-                                            - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                                            - Positive (> 0): The action will be terminated after this many seconds.
                                             - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                                             - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -4304,7 +4304,7 @@ spec:
                                             Specifies the maximum duration in seconds that the Action is allowed to run.
 
                                             Behavior based on the value:
-                                            - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                                            - Positive (> 0): The action will be terminated after this many seconds.
                                             - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                                             - Negative (< 0): No timeout is applied; the action runs until the command completes.
 

--- a/config/crd/bases/apps.kubeblocks.io_shardingdefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_shardingdefinitions.yaml
@@ -484,7 +484,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -914,7 +914,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -1339,7 +1339,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -1764,7 +1764,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 

--- a/config/crd/bases/apps.kubeblocks.io_sidecardefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_sidecardefinitions.yaml
@@ -509,7 +509,7 @@ spec:
                             Specifies the maximum duration in seconds that the Action is allowed to run.
 
                             Behavior based on the value:
-                            - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                            - Positive (> 0): The action will be terminated after this many seconds.
                             - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                             - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -2360,7 +2360,7 @@ spec:
                             Specifies the maximum duration in seconds that the Action is allowed to run.
 
                             Behavior based on the value:
-                            - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                            - Positive (> 0): The action will be terminated after this many seconds.
                             - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                             - Negative (< 0): No timeout is applied; the action runs until the command completes.
 

--- a/config/crd/bases/parameters.kubeblocks.io_componentparameters.yaml
+++ b/config/crd/bases/parameters.kubeblocks.io_componentparameters.yaml
@@ -601,7 +601,7 @@ spec:
                                 Specifies the maximum duration in seconds that the Action is allowed to run.
 
                                 Behavior based on the value:
-                                - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                                - Positive (> 0): The action will be terminated after this many seconds.
                                 - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                                 - Negative (< 0): No timeout is applied; the action runs until the command completes.
 

--- a/config/crd/bases/workloads.kubeblocks.io_instances.yaml
+++ b/config/crd/bases/workloads.kubeblocks.io_instances.yaml
@@ -476,7 +476,7 @@ spec:
                             Specifies the maximum duration in seconds that the Action is allowed to run.
 
                             Behavior based on the value:
-                            - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                            - Positive (> 0): The action will be terminated after this many seconds.
                             - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                             - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -1884,7 +1884,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -2287,7 +2287,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 

--- a/config/crd/bases/workloads.kubeblocks.io_instancesets.yaml
+++ b/config/crd/bases/workloads.kubeblocks.io_instancesets.yaml
@@ -476,7 +476,7 @@ spec:
                             Specifies the maximum duration in seconds that the Action is allowed to run.
 
                             Behavior based on the value:
-                            - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                            - Positive (> 0): The action will be terminated after this many seconds.
                             - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                             - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -2864,7 +2864,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -3267,7 +3267,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 

--- a/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
@@ -699,7 +699,7 @@ spec:
                                   Specifies the maximum duration in seconds that the Action is allowed to run.
 
                                   Behavior based on the value:
-                                  - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                                  - Positive (> 0): The action will be terminated after this many seconds.
                                   - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                                   - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -11904,7 +11904,7 @@ spec:
                                       Specifies the maximum duration in seconds that the Action is allowed to run.
 
                                       Behavior based on the value:
-                                      - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                                      - Positive (> 0): The action will be terminated after this many seconds.
                                       - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                                       - Negative (< 0): No timeout is applied; the action runs until the command completes.
 

--- a/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
@@ -4133,7 +4133,7 @@ spec:
                             Specifies the maximum duration in seconds that the Action is allowed to run.
 
                             Behavior based on the value:
-                            - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                            - Positive (> 0): The action will be terminated after this many seconds.
                             - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                             - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -4712,7 +4712,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -5141,7 +5141,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -5562,7 +5562,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -5978,7 +5978,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -6397,7 +6397,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -6818,7 +6818,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -7229,7 +7229,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -7640,7 +7640,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -8051,7 +8051,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -8464,7 +8464,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -8869,7 +8869,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -9314,7 +9314,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -9735,7 +9735,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -17860,7 +17860,7 @@ spec:
                             Specifies the maximum duration in seconds that the Action is allowed to run.
 
                             Behavior based on the value:
-                            - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                            - Positive (> 0): The action will be terminated after this many seconds.
                             - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                             - Negative (< 0): No timeout is applied; the action runs until the command completes.
 

--- a/deploy/helm/crds/apps.kubeblocks.io_components.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_components.yaml
@@ -581,7 +581,7 @@ spec:
                             Specifies the maximum duration in seconds that the Action is allowed to run.
 
                             Behavior based on the value:
-                            - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                            - Positive (> 0): The action will be terminated after this many seconds.
                             - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                             - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -1002,7 +1002,7 @@ spec:
                             Specifies the maximum duration in seconds that the Action is allowed to run.
 
                             Behavior based on the value:
-                            - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                            - Positive (> 0): The action will be terminated after this many seconds.
                             - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                             - Negative (< 0): No timeout is applied; the action runs until the command completes.
 

--- a/deploy/helm/crds/apps.kubeblocks.io_rollouts.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_rollouts.yaml
@@ -555,7 +555,7 @@ spec:
                                             Specifies the maximum duration in seconds that the Action is allowed to run.
 
                                             Behavior based on the value:
-                                            - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                                            - Positive (> 0): The action will be terminated after this many seconds.
                                             - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                                             - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -979,7 +979,7 @@ spec:
                                             Specifies the maximum duration in seconds that the Action is allowed to run.
 
                                             Behavior based on the value:
-                                            - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                                            - Positive (> 0): The action will be terminated after this many seconds.
                                             - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                                             - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -3880,7 +3880,7 @@ spec:
                                             Specifies the maximum duration in seconds that the Action is allowed to run.
 
                                             Behavior based on the value:
-                                            - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                                            - Positive (> 0): The action will be terminated after this many seconds.
                                             - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                                             - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -4304,7 +4304,7 @@ spec:
                                             Specifies the maximum duration in seconds that the Action is allowed to run.
 
                                             Behavior based on the value:
-                                            - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                                            - Positive (> 0): The action will be terminated after this many seconds.
                                             - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                                             - Negative (< 0): No timeout is applied; the action runs until the command completes.
 

--- a/deploy/helm/crds/apps.kubeblocks.io_shardingdefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_shardingdefinitions.yaml
@@ -484,7 +484,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -914,7 +914,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -1339,7 +1339,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -1764,7 +1764,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 

--- a/deploy/helm/crds/apps.kubeblocks.io_sidecardefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_sidecardefinitions.yaml
@@ -509,7 +509,7 @@ spec:
                             Specifies the maximum duration in seconds that the Action is allowed to run.
 
                             Behavior based on the value:
-                            - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                            - Positive (> 0): The action will be terminated after this many seconds.
                             - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                             - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -2360,7 +2360,7 @@ spec:
                             Specifies the maximum duration in seconds that the Action is allowed to run.
 
                             Behavior based on the value:
-                            - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                            - Positive (> 0): The action will be terminated after this many seconds.
                             - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                             - Negative (< 0): No timeout is applied; the action runs until the command completes.
 

--- a/deploy/helm/crds/parameters.kubeblocks.io_componentparameters.yaml
+++ b/deploy/helm/crds/parameters.kubeblocks.io_componentparameters.yaml
@@ -601,7 +601,7 @@ spec:
                                 Specifies the maximum duration in seconds that the Action is allowed to run.
 
                                 Behavior based on the value:
-                                - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                                - Positive (> 0): The action will be terminated after this many seconds.
                                 - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                                 - Negative (< 0): No timeout is applied; the action runs until the command completes.
 

--- a/deploy/helm/crds/workloads.kubeblocks.io_instances.yaml
+++ b/deploy/helm/crds/workloads.kubeblocks.io_instances.yaml
@@ -476,7 +476,7 @@ spec:
                             Specifies the maximum duration in seconds that the Action is allowed to run.
 
                             Behavior based on the value:
-                            - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                            - Positive (> 0): The action will be terminated after this many seconds.
                             - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                             - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -1884,7 +1884,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -2287,7 +2287,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 

--- a/deploy/helm/crds/workloads.kubeblocks.io_instancesets.yaml
+++ b/deploy/helm/crds/workloads.kubeblocks.io_instancesets.yaml
@@ -476,7 +476,7 @@ spec:
                             Specifies the maximum duration in seconds that the Action is allowed to run.
 
                             Behavior based on the value:
-                            - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                            - Positive (> 0): The action will be terminated after this many seconds.
                             - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                             - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -2864,7 +2864,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 
@@ -3267,7 +3267,7 @@ spec:
                           Specifies the maximum duration in seconds that the Action is allowed to run.
 
                           Behavior based on the value:
-                          - Positive (> 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+                          - Positive (> 0): The action will be terminated after this many seconds.
                           - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
                           - Negative (< 0): No timeout is applied; the action runs until the command completes.
 

--- a/docs/developer_docs/api-reference/cluster.md
+++ b/docs/developer_docs/api-reference/cluster.md
@@ -2494,7 +2494,7 @@ int32
 <em>(Optional)</em>
 <p>Specifies the maximum duration in seconds that the Action is allowed to run.</p>
 <p>Behavior based on the value:
-- Positive (&gt; 0): The action will be terminated after this many seconds. The maximum allowed value is 60.
+- Positive (&gt; 0): The action will be terminated after this many seconds.
 - Zero (= 0): The timeout is managed by the system, defaulting to 30 seconds typically.
 - Negative (&lt; 0): No timeout is applied; the action runs until the command completes.</p>
 <p>This field cannot be updated.</p>

--- a/pkg/kbagent/service/action_utils.go
+++ b/pkg/kbagent/service/action_utils.go
@@ -61,7 +61,6 @@ const (
 	defaultMaxIdleConnectionsPerHost = 20
 
 	defaultActionCallTimeout = 30 * time.Second
-	maxActionCallTimeout     = 60 * time.Second
 
 	defaultHTTPHost   = "127.0.0.1"
 	defaultHTTPScheme = "HTTP"
@@ -178,7 +177,7 @@ func actionCallTimeoutContext(ctx context.Context, timeout *int32) (context.Cont
 	case ptr.Deref(timeout, 0) == 0:
 		return context.WithTimeout(ctx, defaultActionCallTimeout)
 	case *timeout > 0:
-		return context.WithTimeout(ctx, min(time.Duration(*timeout)*time.Second, maxActionCallTimeout))
+		return context.WithTimeout(ctx, time.Duration(*timeout)*time.Second)
 	default:
 		return ctx, func() {}
 	}

--- a/pkg/kbagent/service/action_utils_test.go
+++ b/pkg/kbagent/service/action_utils_test.go
@@ -32,6 +32,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -63,6 +64,39 @@ var _ = Describe("action utils", func() {
 		Expect(ok).Should(BeTrue())
 		return err
 	}
+
+	Context("timeout context", func() {
+		deadlineRemaining := func(timeout *int32) (time.Duration, bool) {
+			ctxWithTimeout, cancel := actionCallTimeoutContext(ctx, timeout)
+			defer cancel()
+			deadline, ok := ctxWithTimeout.Deadline()
+			if !ok {
+				return 0, false
+			}
+			return time.Until(deadline), true
+		}
+
+		It("uses the default action timeout when timeout is not specified", func() {
+			remaining, ok := deadlineRemaining(nil)
+			Expect(ok).Should(BeTrue())
+			Expect(remaining).Should(BeNumerically(">", 25*time.Second))
+			Expect(remaining).Should(BeNumerically("<=", defaultActionCallTimeout))
+		})
+
+		It("honors action timeoutSeconds above 60 seconds", func() {
+			timeout := int32(300)
+			remaining, ok := deadlineRemaining(&timeout)
+			Expect(ok).Should(BeTrue())
+			Expect(remaining).Should(BeNumerically(">", 295*time.Second))
+			Expect(remaining).Should(BeNumerically("<=", 300*time.Second))
+		})
+
+		It("does not set a deadline for negative timeout", func() {
+			timeout := int32(-1)
+			_, ok := deadlineRemaining(&timeout)
+			Expect(ok).Should(BeFalse())
+		})
+	})
 
 	Context("exec", func() {
 		It("x - ok", func() {


### PR DESCRIPTION
## What this PR does

Fixes #10297.

Removes the fixed 60s cap from kbagent action calls when an action declares a positive timeout. kbagent now uses the declared `timeoutSeconds` value directly.

Existing behavior is preserved for the other cases:
- `timeoutSeconds` unset or 0: keep the 30s default
- `timeoutSeconds` negative: keep no per-action deadline

This also updates the Action `timeoutSeconds` API comment, generated CRDs, Helm CRDs, and API reference docs so the public contract matches runtime behavior.

## Why this is needed

Lifecycle actions may declare a timeout larger than 60s, but kbagent currently clips every positive timeout to 60s. That makes the action contract misleading: addon authors can declare a longer action timeout, but the runtime may still fail the action after about 60s.

Oracle R5 evidence reproduced the contract gap on `memberJoin`:
- live ComponentDefinition declared `lifecycleActions.memberJoin.timeoutSeconds: 300`
- the same HScale 2->3 OpsRequest window produced six `memberJoin timedOut` results
- kbagent recorded costs of 60090 / 60864 / 60338 / 60383 / 60340 / 60122 ms for those attempts
- the KubeBlocks controller logged the same six `action: memberJoin, error: timedOut` events in that Ops window
- a later attempt completed with rc=0 once the new standby was OPEN, DMON was ready, and Data Guard broker reported SUCCESS

This PR fixes the controller-side timeout enforcement contract. It does not change Oracle scripts or assert that any particular addon timeout value is sufficient for every run; patched-image validation still has to prove the declared timeout chosen by the addon is long enough for that addon scenario.

## Tests

- `make manifests`
- `make api-doc`
- `go test ./pkg/kbagent/service -run TestAPIs/action\ utils/timeout\ context -count=1`
- `go test ./pkg/kbagent/service -count=1`
- `git diff --check`

/pick release-1.0 release-1.1
