### PR TITLE
fix: avoid terminal pod failure for transient waiting states

### DIFF
--- a/pkg/controllerutil/pod_utils.go
+++ b/pkg/controllerutil/pod_utils.go
@@ -470,7 +470,7 @@ func IsPodFailedAndTimedOut(pod *corev1.Pod) (bool, bool, string) {
 func isAnyContainerFailed(containersStatus []corev1.ContainerStatus) (bool, string) {
 	for _, v := range containersStatus {
 		waitingState := v.State.Waiting
-		if waitingState != nil && waitingState.Message != "" {
+		if isFailedWaitingState(waitingState) {
 			return true, waitingState.Message
 		}
 		terminatedState := v.State.Terminated
@@ -479,6 +479,36 @@ func isAnyContainerFailed(containersStatus []corev1.ContainerStatus) (bool, stri
 		}
 	}
 	return false, ""
+}
+
+func isFailedWaitingState(waitingState *corev1.ContainerStateWaiting) bool {
+	if waitingState == nil || waitingState.Message == "" {
+		return false
+	}
+	if isTransientWaitingState(waitingState) {
+		return false
+	}
+	switch waitingState.Reason {
+	case "CrashLoopBackOff",
+		"ErrImagePull",
+		"ImagePullBackOff",
+		"InvalidImageName",
+		"CreateContainerConfigError",
+		"CreateContainerError",
+		"RunContainerError":
+		return true
+	}
+	return false
+}
+
+func isTransientWaitingState(waitingState *corev1.ContainerStateWaiting) bool {
+	switch waitingState.Reason {
+	case "ContainerCreating", "PodInitializing":
+		return true
+	}
+	msg := waitingState.Message
+	return strings.Contains(msg, "failed to sync configmap cache: timed out waiting for the condition") ||
+		strings.Contains(msg, "failed to sync secret cache: timed out waiting for the condition")
 }
 
 // IsContainerFailedAndTimedOut checks whether the failed container has timed out.

--- a/pkg/controllerutil/pod_utils_test.go
+++ b/pkg/controllerutil/pod_utils_test.go
@@ -86,6 +86,79 @@ func TestPodIsReady(t *testing.T) {
 	}
 }
 
+func TestIsPodFailedAndTimedOut(t *testing.T) {
+	newInitWaitingPod := func(reason, message string) *corev1.Pod {
+		return &corev1.Pod{
+			Status: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{
+					{
+						Type:               corev1.PodInitialized,
+						Status:             corev1.ConditionFalse,
+						LastTransitionTime: metav1.NewTime(time.Now().Add(-PodContainerFailedTimeout - time.Second)),
+					},
+				},
+				InitContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name: "init",
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{
+								Reason:  reason,
+								Message: message,
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name         string
+		reason       string
+		message      string
+		expectFailed bool
+		expectMsg    string
+	}{
+		{
+			name:    "transient configmap cache sync timeout",
+			reason:  "ContainerCreating",
+			message: "failed to sync configmap cache: timed out waiting for the condition",
+		},
+		{
+			name:    "transient secret cache sync timeout",
+			reason:  "CreateContainerConfigError",
+			message: "failed to sync secret cache: timed out waiting for the condition",
+		},
+		{
+			name:    "generic container creating",
+			reason:  "ContainerCreating",
+			message: "creating container",
+		},
+		{
+			name:         "terminal create container config error",
+			reason:       "CreateContainerConfigError",
+			message:      `configmap "missing" not found`,
+			expectFailed: true,
+			expectMsg:    `configmap "missing" not found`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			failed, timedOut, message := IsPodFailedAndTimedOut(newInitWaitingPod(tt.reason, tt.message))
+			if failed != tt.expectFailed {
+				t.Fatalf("failed = %v, want %v", failed, tt.expectFailed)
+			}
+			if timedOut != tt.expectFailed {
+				t.Fatalf("timedOut = %v, want %v", timedOut, tt.expectFailed)
+			}
+			if message != tt.expectMsg {
+				t.Fatalf("message = %q, want %q", message, tt.expectMsg)
+			}
+		})
+	}
+}
+
 func TestGetPodRevision(t *testing.T) {
 	pod := testk8s.NewFakePod("foo", 1)
 	if GetPodRevision(pod) != "" {


### PR DESCRIPTION
## Problem

During Elasticsearch restart pre-validation, a data pod briefly hit a kubelet waiting error while the pod was being recreated:

```
failed to sync configmap cache: timed out waiting for the condition
```

The pod later completed init containers, became Ready, and the Elasticsearch cluster was healthy, but the Restart OpsRequest had already been marked `Failed`.

The current pod failure helper treats any container `Waiting` state with a non-empty message as a failure. After `PodContainerFailedTimeout` this can mark transient kubelet waiting as `InstanceFailure`, which then freezes rolling Ops progress as `Failed`.

## Change

- Only treat known terminal waiting reasons as failed after the timeout.
- Keep transient waiting states such as `ContainerCreating`, `PodInitializing`, and kubelet configmap/secret cache sync timeouts out of terminal pod failure classification.
- Keep non-zero terminated containers as failures.

## Tests

- `go generate ./pkg/testutil/k8s/mocks/...`
- `go test ./pkg/controllerutil -run TestIsPodFailedAndTimedOut -count=1`
- `go test ./pkg/controllerutil -run TestPodIsReady -count=1`
- `git diff --check origin/main...HEAD`

Full `go test ./pkg/controllerutil -run TestAPIs -count=1` is blocked on this machine because `/usr/local/kubebuilder/bin/etcd` is missing; no specs ran in that attempt.
