### PR TITLE
fix: keep recoverable ops failures in progress

### DIFF
--- a/pkg/operations/ops_comp_helper.go
+++ b/pkg/operations/ops_comp_helper.go
@@ -244,7 +244,6 @@ func (c componentOpsHelper) reconcileActionWithComponentOps(reqCtx intctrlutil.R
 		completedProgressCount int32
 		err                    error
 		clusterDef             *appsv1.ClusterDefinition
-		requeueAfter           time.Duration
 	)
 	if opsRes.Cluster.Spec.ClusterDef != "" {
 		if clusterDef, err = getClusterDefByName(reqCtx.Ctx, cli, opsRes.Cluster.Spec.ClusterDef); err != nil {
@@ -277,9 +276,6 @@ func (c componentOpsHelper) reconcileActionWithComponentOps(reqCtx intctrlutil.R
 		if err != nil {
 			return opsRequestPhase, 0, err
 		}
-		if pgResource.requeueAfter > 0 && (requeueAfter == 0 || pgResource.requeueAfter < requeueAfter) {
-			requeueAfter = pgResource.requeueAfter
-		}
 		componentFailureCount := componentStatusFailureCount(opsCompStatus)
 		componentHasFailure := componentFailureCount > 0
 		if componentHasFailure {
@@ -309,7 +305,7 @@ func (c componentOpsHelper) reconcileActionWithComponentOps(reqCtx intctrlutil.R
 		}
 	}
 	if !opsIsCompleted {
-		return opsRequestPhase, requeueAfter, nil
+		return opsRequestPhase, 0, nil
 	}
 	if existFailure {
 		return opsv1alpha1.OpsFailedPhase, 0, nil

--- a/pkg/operations/ops_comp_helper.go
+++ b/pkg/operations/ops_comp_helper.go
@@ -135,13 +135,14 @@ func (c componentOpsHelper) cancelComponentOps(ctx context.Context,
 	return cli.Update(ctx, opsRes.Cluster)
 }
 
-func (c componentOpsHelper) existFailure(ops *opsv1alpha1.OpsRequest, componentName string) bool {
-	for _, v := range ops.Status.Components[componentName].ProgressDetails {
+func componentStatusFailureCount(compStatus opsv1alpha1.OpsRequestComponentStatus) int32 {
+	var count int32
+	for _, v := range compStatus.ProgressDetails {
 		if v.Status == opsv1alpha1.FailedProgressStatus {
-			return true
+			count++
 		}
 	}
-	return false
+	return count
 }
 
 func (c componentOpsHelper) getComponentOps(componentName string) (ComponentOpsInterface, bool) {
@@ -243,6 +244,7 @@ func (c componentOpsHelper) reconcileActionWithComponentOps(reqCtx intctrlutil.R
 		completedProgressCount int32
 		err                    error
 		clusterDef             *appsv1.ClusterDefinition
+		requeueAfter           time.Duration
 	)
 	if opsRes.Cluster.Spec.ClusterDef != "" {
 		if clusterDef, err = getClusterDefByName(reqCtx.Ctx, cli, opsRes.Cluster.Spec.ClusterDef); err != nil {
@@ -268,10 +270,8 @@ func (c componentOpsHelper) reconcileActionWithComponentOps(reqCtx intctrlutil.R
 		if err != nil {
 			return opsRequestPhase, 0, err
 		}
-		expectProgressCount += expectCount
-		completedProgressCount += completedCount
-		if c.existFailure(opsRes.OpsRequest, pgResource.compOps.GetComponentName()) {
-			existFailure = true
+		if pgResource.requeueAfter > 0 && (requeueAfter == 0 || pgResource.requeueAfter < requeueAfter) {
+			requeueAfter = pgResource.requeueAfter
 		}
 		var componentPhase appsv1.ComponentPhase
 		if pgResource.shards == nil {
@@ -279,14 +279,22 @@ func (c componentOpsHelper) reconcileActionWithComponentOps(reqCtx intctrlutil.R
 		} else {
 			componentPhase = opsRes.Cluster.Status.Shardings[pgResource.compOps.GetComponentName()].Phase
 		}
+		componentFailureCount := componentStatusFailureCount(opsCompStatus)
+		componentHasFailure := componentFailureCount > 0
+		if componentHasFailure {
+			existFailure = true
+		}
+		expectProgressCount += expectCount
+		completedProgressCount += completedCount
 		// conditions whether ops is running:
 		//  1. completedProgressCount is not equal to expectProgressCount.
 		//  2. the component phase is not a terminal phase or no completed progress if the ops
 		//  needs to wait for the component phase to reach a terminal state.
-		if expectCount != completedCount {
+		switch {
+		case expectCount != completedCount:
 			opsIsCompleted = false
-		} else if !pgResource.noWaitComponentCompleted &&
-			(!slices.Contains(componentTerminalPhases(), componentPhase) || noAnyProgressCompleted(pgResource.clusterComponent.Replicas, completedCount)) {
+		case !pgResource.noWaitComponentCompleted &&
+			(!slices.Contains(componentTerminalPhases(), componentPhase) || noAnyProgressCompleted(pgResource.clusterComponent.Replicas, completedCount)):
 			opsIsCompleted = false
 		}
 		opsCompStatus.Phase = componentPhase
@@ -300,7 +308,7 @@ func (c componentOpsHelper) reconcileActionWithComponentOps(reqCtx intctrlutil.R
 		}
 	}
 	if !opsIsCompleted {
-		return opsRequestPhase, 0, nil
+		return opsRequestPhase, requeueAfter, nil
 	}
 	if existFailure {
 		return opsv1alpha1.OpsFailedPhase, 0, nil

--- a/pkg/operations/ops_comp_helper.go
+++ b/pkg/operations/ops_comp_helper.go
@@ -265,6 +265,13 @@ func (c componentOpsHelper) reconcileActionWithComponentOps(reqCtx intctrlutil.R
 	existFailure := false
 	for i := range progressResources {
 		pgResource := progressResources[i]
+		var componentPhase appsv1.ComponentPhase
+		if pgResource.shards == nil {
+			componentPhase = opsRes.Cluster.Status.Components[pgResource.compOps.GetComponentName()].Phase
+		} else {
+			componentPhase = opsRes.Cluster.Status.Shardings[pgResource.compOps.GetComponentName()].Phase
+		}
+		pgResource.componentPhase = componentPhase
 		opsCompStatus := opsRequest.Status.Components[pgResource.compOps.GetComponentName()]
 		expectCount, completedCount, err := handleStatusProgress(reqCtx, cli, opsRes, &pgResource, &opsCompStatus)
 		if err != nil {
@@ -272,12 +279,6 @@ func (c componentOpsHelper) reconcileActionWithComponentOps(reqCtx intctrlutil.R
 		}
 		if pgResource.requeueAfter > 0 && (requeueAfter == 0 || pgResource.requeueAfter < requeueAfter) {
 			requeueAfter = pgResource.requeueAfter
-		}
-		var componentPhase appsv1.ComponentPhase
-		if pgResource.shards == nil {
-			componentPhase = opsRes.Cluster.Status.Components[pgResource.compOps.GetComponentName()].Phase
-		} else {
-			componentPhase = opsRes.Cluster.Status.Shardings[pgResource.compOps.GetComponentName()].Phase
 		}
 		componentFailureCount := componentStatusFailureCount(opsCompStatus)
 		componentHasFailure := componentFailureCount > 0

--- a/pkg/operations/ops_manager.go
+++ b/pkg/operations/ops_manager.go
@@ -274,10 +274,14 @@ func (opsMgr *OpsManager) checkAndHandleOpsTimeout(reqCtx intctrlutil.RequestCtx
 		return 0, PatchOpsStatus(reqCtx.Ctx, cli, opsRes, opsv1alpha1.OpsAbortedPhase,
 			opsv1alpha1.NewAbortedCondition("Aborted due to exceeding the specified timeout period (timeoutSeconds)"))
 	}
+	timeoutRequeueAfter := time.Until(timeoutPoint)
 	if requeueAfter != 0 {
+		if timeoutRequeueAfter < requeueAfter {
+			return timeoutRequeueAfter, nil
+		}
 		return requeueAfter, nil
 	}
-	return time.Until(timeoutPoint), nil
+	return timeoutRequeueAfter, nil
 }
 
 func GetOpsManager() *OpsManager {

--- a/pkg/operations/ops_progress_util.go
+++ b/pkg/operations/ops_progress_util.go
@@ -321,6 +321,10 @@ func handleFailedOrProcessingProgressDetail(opsRes *OpsResource,
 	instance Instance) (completedCount int32) {
 	componentName := pgRes.clusterComponent.Name
 	if instance.IsFailedAndTimedOut() {
+		if pgRes.recoverableFailureGracePeriod > 0 &&
+			observeRecoverableInstanceFailure(opsRes, pgRes, compStatus, progressDetail, componentName) {
+			return 0
+		}
 		podMessage := getFailedPodMessage(opsRes.Cluster, componentName, instance.GetName())
 		message := getProgressFailedMessage(pgRes.opsMessageKey, progressDetail.ObjectKey, componentName, podMessage)
 		progressDetail.SetStatusAndMessage(opsv1alpha1.FailedProgressStatus, message)
@@ -332,6 +336,40 @@ func handleFailedOrProcessingProgressDetail(opsRes *OpsResource,
 	setComponentStatusProgressDetail(opsRes.Recorder, opsRes.OpsRequest,
 		&compStatus.ProgressDetails, progressDetail)
 	return completedCount
+}
+
+func observeRecoverableInstanceFailure(opsRes *OpsResource,
+	pgRes *progressResource,
+	compStatus *opsv1alpha1.OpsRequestComponentStatus,
+	progressDetail opsv1alpha1.ProgressStatusDetail,
+	componentName string) bool {
+	now := time.Now()
+	existingProgressDetail := findStatusProgressDetail(compStatus.ProgressDetails, progressDetail.ObjectKey)
+	if existingProgressDetail != nil &&
+		existingProgressDetail.Status == opsv1alpha1.ProcessingProgressStatus &&
+		!existingProgressDetail.StartTime.IsZero() {
+		deadline := existingProgressDetail.StartTime.Add(pgRes.recoverableFailureGracePeriod)
+		if now.Before(deadline) {
+			setProgressResourceRequeueAfter(pgRes, time.Until(deadline))
+			return true
+		}
+		return false
+	}
+	progressDetail.SetStatusAndMessage(opsv1alpha1.ProcessingProgressStatus,
+		getProgressProcessingMessage(pgRes.opsMessageKey, progressDetail.ObjectKey, componentName))
+	setComponentStatusProgressDetail(opsRes.Recorder, opsRes.OpsRequest,
+		&compStatus.ProgressDetails, progressDetail)
+	setProgressResourceRequeueAfter(pgRes, pgRes.recoverableFailureGracePeriod)
+	return true
+}
+
+func setProgressResourceRequeueAfter(pgRes *progressResource, requeueAfter time.Duration) {
+	if requeueAfter <= 0 {
+		return
+	}
+	if pgRes.requeueAfter == 0 || requeueAfter < pgRes.requeueAfter {
+		pgRes.requeueAfter = requeueAfter
+	}
 }
 
 // notRecreatedDuringOperation checks if instance is re-created during the component's operation.

--- a/pkg/operations/ops_progress_util.go
+++ b/pkg/operations/ops_progress_util.go
@@ -320,11 +320,8 @@ func handleFailedOrProcessingProgressDetail(opsRes *OpsResource,
 	progressDetail opsv1alpha1.ProgressStatusDetail,
 	instance Instance) (completedCount int32) {
 	componentName := pgRes.clusterComponent.Name
-	if instance.IsFailedAndTimedOut() {
-		if pgRes.recoverableFailureGracePeriod > 0 &&
-			observeRecoverableInstanceFailure(opsRes, pgRes, compStatus, progressDetail, componentName) {
-			return 0
-		}
+	if pgRes.componentPhase == appsv1.FailedComponentPhase ||
+		(instance.IsFailedAndTimedOut() && !pgRes.deferInstanceFailureToWorkloadPhase) {
 		podMessage := getFailedPodMessage(opsRes.Cluster, componentName, instance.GetName())
 		message := getProgressFailedMessage(pgRes.opsMessageKey, progressDetail.ObjectKey, componentName, podMessage)
 		progressDetail.SetStatusAndMessage(opsv1alpha1.FailedProgressStatus, message)
@@ -336,40 +333,6 @@ func handleFailedOrProcessingProgressDetail(opsRes *OpsResource,
 	setComponentStatusProgressDetail(opsRes.Recorder, opsRes.OpsRequest,
 		&compStatus.ProgressDetails, progressDetail)
 	return completedCount
-}
-
-func observeRecoverableInstanceFailure(opsRes *OpsResource,
-	pgRes *progressResource,
-	compStatus *opsv1alpha1.OpsRequestComponentStatus,
-	progressDetail opsv1alpha1.ProgressStatusDetail,
-	componentName string) bool {
-	now := time.Now()
-	existingProgressDetail := findStatusProgressDetail(compStatus.ProgressDetails, progressDetail.ObjectKey)
-	if existingProgressDetail != nil &&
-		existingProgressDetail.Status == opsv1alpha1.ProcessingProgressStatus &&
-		!existingProgressDetail.StartTime.IsZero() {
-		deadline := existingProgressDetail.StartTime.Add(pgRes.recoverableFailureGracePeriod)
-		if now.Before(deadline) {
-			setProgressResourceRequeueAfter(pgRes, time.Until(deadline))
-			return true
-		}
-		return false
-	}
-	progressDetail.SetStatusAndMessage(opsv1alpha1.ProcessingProgressStatus,
-		getProgressProcessingMessage(pgRes.opsMessageKey, progressDetail.ObjectKey, componentName))
-	setComponentStatusProgressDetail(opsRes.Recorder, opsRes.OpsRequest,
-		&compStatus.ProgressDetails, progressDetail)
-	setProgressResourceRequeueAfter(pgRes, pgRes.recoverableFailureGracePeriod)
-	return true
-}
-
-func setProgressResourceRequeueAfter(pgRes *progressResource, requeueAfter time.Duration) {
-	if requeueAfter <= 0 {
-		return
-	}
-	if pgRes.requeueAfter == 0 || requeueAfter < pgRes.requeueAfter {
-		pgRes.requeueAfter = requeueAfter
-	}
 }
 
 // notRecreatedDuringOperation checks if instance is re-created during the component's operation.

--- a/pkg/operations/ops_util_test.go
+++ b/pkg/operations/ops_util_test.go
@@ -299,6 +299,26 @@ var _ = Describe("OpsUtil functions", func() {
 			Expect(progressDetail.Status).Should(Equal(opsv1alpha1.FailedProgressStatus))
 		})
 
+		It("caps recoverable failure requeue by ops timeout", func() {
+			timeoutSeconds := int32(60)
+			opsRes := &OpsResource{
+				OpsRequest: &opsv1alpha1.OpsRequest{
+					Spec: opsv1alpha1.OpsRequestSpec{
+						TimeoutSeconds: &timeoutSeconds,
+					},
+					Status: opsv1alpha1.OpsRequestStatus{
+						StartTimestamp: metav1.NewTime(time.Now().Add(-30 * time.Second)),
+					},
+				},
+			}
+
+			requeueAfter, err := GetOpsManager().checkAndHandleOpsTimeout(intctrlutil.RequestCtx{Ctx: ctx},
+				k8sClient, opsRes, restartRecoverableFailureObservationWindow)
+			Expect(err).Should(BeNil())
+			Expect(requeueAfter).Should(BeNumerically(">", 0))
+			Expect(requeueAfter).Should(BeNumerically("<", time.Minute))
+		})
+
 		It("Test opsRequest with disable ha", func() {
 			By("init operations resources ")
 			opsRes, _, _ := initOperationsResources(compDefName, clusterName)

--- a/pkg/operations/ops_util_test.go
+++ b/pkg/operations/ops_util_test.go
@@ -151,6 +151,154 @@ var _ = Describe("OpsUtil functions", func() {
 			Expect(opsPhase).Should(Equal(opsv1alpha1.OpsFailedPhase))
 		})
 
+		It("keeps restart ops running when a failed progress is not backed by a failed component", func() {
+			By("init operations resources ")
+			opsRes, _, _ := initOperationsResources(compDefName, clusterName)
+			testapps.MockInstanceSetComponent(&testCtx, clusterName, defaultCompName)
+			pods := testapps.MockInstanceSetPods(&testCtx, nil, opsRes.Cluster, defaultCompName)
+			time.Sleep(time.Second)
+
+			ops := testops.NewOpsRequestObj("restart-ops-"+randomStr, testCtx.DefaultNamespace,
+				clusterName, opsv1alpha1.RestartType)
+			ops.Spec.RestartList = []opsv1alpha1.ComponentOps{{ComponentName: defaultCompName}}
+			opsRes.OpsRequest = testops.CreateOpsRequest(ctx, testCtx, ops)
+			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsRunningPhase
+			opsRes.OpsRequest.Status.StartTimestamp = metav1.NewTime(time.Now().Add(-time.Second))
+			runtimes, err := buildOpsRuntimes(ctx, k8sClient, opsRes)
+			Expect(err).Should(BeNil())
+			opsRes.Runtimes = runtimes
+
+			handleRestartProgress := func(reqCtx intctrlutil.RequestCtx,
+				cli client.Client,
+				opsRes *OpsResource,
+				pgRes *progressResource,
+				compStatus *opsv1alpha1.OpsRequestComponentStatus) (expectProgressCount int32, completedCount int32, err error) {
+				pgRes.recoverableFailureGracePeriod = restartRecoverableFailureObservationWindow
+				return handleComponentStatusProgress(reqCtx, cli, opsRes, pgRes, compStatus,
+					func(ops *opsv1alpha1.OpsRequest, instance Instance, pgRes *progressResource) bool {
+						creationTimestamp := instance.GetCreationTimestamp()
+						return !creationTimestamp.Before(&ops.Status.StartTimestamp)
+					})
+			}
+
+			recreatePod := func(pod *corev1.Pod) *corev1.Pod {
+				testk8s.MockPodIsTerminating(ctx, testCtx, pod)
+				testk8s.RemovePodFinalizer(ctx, testCtx, pod)
+				return testapps.MockInstanceSetPod(&testCtx, nil, clusterName, defaultCompName, pod.Name, "follower")
+			}
+			for i := range pods {
+				pods[i] = recreatePod(pods[i])
+			}
+			testk8s.MockPodIsFailed(ctx, testCtx, pods[2])
+
+			reqCtx := intctrlutil.RequestCtx{Ctx: ctx}
+			compOpsHelper := newComponentOpsHelper(opsRes.OpsRequest.Spec.RestartList)
+			opsPhase, requeueAfter, err := compOpsHelper.reconcileActionWithComponentOps(reqCtx, k8sClient, opsRes,
+				"test", handleRestartProgress)
+			Expect(err).Should(BeNil())
+			Expect(opsPhase).Should(Equal(opsv1alpha1.OpsRunningPhase))
+			Expect(requeueAfter).Should(BeNumerically(">", 0))
+			Expect(opsRes.OpsRequest.Status.Progress).Should(Equal("2/3"))
+			progressDetail := findStatusProgressDetail(opsRes.OpsRequest.Status.Components[defaultCompName].ProgressDetails,
+				getProgressObjectKey(constant.PodKind, pods[2].Name))
+			Expect(progressDetail).ShouldNot(BeNil())
+			Expect(progressDetail.Status).Should(Equal(opsv1alpha1.ProcessingProgressStatus))
+
+			By("mock the failed instance recovers while the component remains Running")
+			recoveredPod := pods[2]
+			patch := client.MergeFrom(recoveredPod.DeepCopy())
+			recoveredPod.Status.Conditions = []corev1.PodCondition{
+				{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				},
+				{
+					Type:   corev1.ContainersReady,
+					Status: corev1.ConditionTrue,
+				},
+			}
+			recoveredPod.Status.ContainerStatuses = []corev1.ContainerStatus{
+				{
+					Name: recoveredPod.Spec.Containers[0].Name,
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{},
+					},
+				},
+			}
+			Expect(k8sClient.Status().Patch(ctx, recoveredPod, patch)).Should(Succeed())
+
+			opsPhase, _, err = compOpsHelper.reconcileActionWithComponentOps(reqCtx, k8sClient, opsRes,
+				"test", handleRestartProgress)
+			Expect(err).Should(BeNil())
+			Expect(opsPhase).Should(Equal(opsv1alpha1.OpsSucceedPhase))
+			Expect(opsRes.OpsRequest.Status.Progress).Should(Equal("3/3"))
+		})
+
+		It("fails restart ops after a recoverable failure observation window expires", func() {
+			By("init operations resources ")
+			opsRes, _, _ := initOperationsResources(compDefName, clusterName)
+			testapps.MockInstanceSetComponent(&testCtx, clusterName, defaultCompName)
+			pods := testapps.MockInstanceSetPods(&testCtx, nil, opsRes.Cluster, defaultCompName)
+			time.Sleep(time.Second)
+
+			ops := testops.NewOpsRequestObj("restart-ops-"+randomStr, testCtx.DefaultNamespace,
+				clusterName, opsv1alpha1.RestartType)
+			ops.Spec.RestartList = []opsv1alpha1.ComponentOps{{ComponentName: defaultCompName}}
+			opsRes.OpsRequest = testops.CreateOpsRequest(ctx, testCtx, ops)
+			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsRunningPhase
+			opsRes.OpsRequest.Status.StartTimestamp = metav1.NewTime(time.Now().Add(-time.Second))
+			runtimes, err := buildOpsRuntimes(ctx, k8sClient, opsRes)
+			Expect(err).Should(BeNil())
+			opsRes.Runtimes = runtimes
+
+			handleRestartProgress := func(reqCtx intctrlutil.RequestCtx,
+				cli client.Client,
+				opsRes *OpsResource,
+				pgRes *progressResource,
+				compStatus *opsv1alpha1.OpsRequestComponentStatus) (expectProgressCount int32, completedCount int32, err error) {
+				pgRes.recoverableFailureGracePeriod = restartRecoverableFailureObservationWindow
+				return handleComponentStatusProgress(reqCtx, cli, opsRes, pgRes, compStatus,
+					func(ops *opsv1alpha1.OpsRequest, instance Instance, pgRes *progressResource) bool {
+						creationTimestamp := instance.GetCreationTimestamp()
+						return !creationTimestamp.Before(&ops.Status.StartTimestamp)
+					})
+			}
+
+			recreatePod := func(pod *corev1.Pod) *corev1.Pod {
+				testk8s.MockPodIsTerminating(ctx, testCtx, pod)
+				testk8s.RemovePodFinalizer(ctx, testCtx, pod)
+				return testapps.MockInstanceSetPod(&testCtx, nil, clusterName, defaultCompName, pod.Name, "follower")
+			}
+			for i := range pods {
+				pods[i] = recreatePod(pods[i])
+			}
+			testk8s.MockPodIsFailed(ctx, testCtx, pods[2])
+
+			reqCtx := intctrlutil.RequestCtx{Ctx: ctx}
+			compOpsHelper := newComponentOpsHelper(opsRes.OpsRequest.Spec.RestartList)
+			opsPhase, requeueAfter, err := compOpsHelper.reconcileActionWithComponentOps(reqCtx, k8sClient, opsRes,
+				"test", handleRestartProgress)
+			Expect(err).Should(BeNil())
+			Expect(opsPhase).Should(Equal(opsv1alpha1.OpsRunningPhase))
+			Expect(requeueAfter).Should(BeNumerically(">", 0))
+
+			progressDetail := findStatusProgressDetail(opsRes.OpsRequest.Status.Components[defaultCompName].ProgressDetails,
+				getProgressObjectKey(constant.PodKind, pods[2].Name))
+			Expect(progressDetail).ShouldNot(BeNil())
+			progressDetail.StartTime = metav1.NewTime(time.Now().Add(-restartRecoverableFailureObservationWindow - time.Second))
+
+			opsPhase, requeueAfter, err = compOpsHelper.reconcileActionWithComponentOps(reqCtx, k8sClient, opsRes,
+				"test", handleRestartProgress)
+			Expect(err).Should(BeNil())
+			Expect(requeueAfter).Should(BeZero())
+			Expect(opsPhase).Should(Equal(opsv1alpha1.OpsFailedPhase))
+			Expect(opsRes.OpsRequest.Status.Progress).Should(Equal("3/3"))
+			progressDetail = findStatusProgressDetail(opsRes.OpsRequest.Status.Components[defaultCompName].ProgressDetails,
+				getProgressObjectKey(constant.PodKind, pods[2].Name))
+			Expect(progressDetail).ShouldNot(BeNil())
+			Expect(progressDetail.Status).Should(Equal(opsv1alpha1.FailedProgressStatus))
+		})
+
 		It("Test opsRequest with disable ha", func() {
 			By("init operations resources ")
 			opsRes, _, _ := initOperationsResources(compDefName, clusterName)

--- a/pkg/operations/ops_util_test.go
+++ b/pkg/operations/ops_util_test.go
@@ -173,7 +173,7 @@ var _ = Describe("OpsUtil functions", func() {
 				opsRes *OpsResource,
 				pgRes *progressResource,
 				compStatus *opsv1alpha1.OpsRequestComponentStatus) (expectProgressCount int32, completedCount int32, err error) {
-				pgRes.recoverableFailureGracePeriod = restartRecoverableFailureObservationWindow
+				pgRes.deferInstanceFailureToWorkloadPhase = true
 				return handleComponentStatusProgress(reqCtx, cli, opsRes, pgRes, compStatus,
 					func(ops *opsv1alpha1.OpsRequest, instance Instance, pgRes *progressResource) bool {
 						creationTimestamp := instance.GetCreationTimestamp()
@@ -197,7 +197,7 @@ var _ = Describe("OpsUtil functions", func() {
 				"test", handleRestartProgress)
 			Expect(err).Should(BeNil())
 			Expect(opsPhase).Should(Equal(opsv1alpha1.OpsRunningPhase))
-			Expect(requeueAfter).Should(BeNumerically(">", 0))
+			Expect(requeueAfter).Should(BeZero())
 			Expect(opsRes.OpsRequest.Status.Progress).Should(Equal("2/3"))
 			progressDetail := findStatusProgressDetail(opsRes.OpsRequest.Status.Components[defaultCompName].ProgressDetails,
 				getProgressObjectKey(constant.PodKind, pods[2].Name))
@@ -234,7 +234,7 @@ var _ = Describe("OpsUtil functions", func() {
 			Expect(opsRes.OpsRequest.Status.Progress).Should(Equal("3/3"))
 		})
 
-		It("fails restart ops after a recoverable failure observation window expires", func() {
+		It("fails restart ops when component reaches terminal failed phase", func() {
 			By("init operations resources ")
 			opsRes, _, _ := initOperationsResources(compDefName, clusterName)
 			testapps.MockInstanceSetComponent(&testCtx, clusterName, defaultCompName)
@@ -256,7 +256,7 @@ var _ = Describe("OpsUtil functions", func() {
 				opsRes *OpsResource,
 				pgRes *progressResource,
 				compStatus *opsv1alpha1.OpsRequestComponentStatus) (expectProgressCount int32, completedCount int32, err error) {
-				pgRes.recoverableFailureGracePeriod = restartRecoverableFailureObservationWindow
+				pgRes.deferInstanceFailureToWorkloadPhase = true
 				return handleComponentStatusProgress(reqCtx, cli, opsRes, pgRes, compStatus,
 					func(ops *opsv1alpha1.OpsRequest, instance Instance, pgRes *progressResource) bool {
 						creationTimestamp := instance.GetCreationTimestamp()
@@ -280,12 +280,12 @@ var _ = Describe("OpsUtil functions", func() {
 				"test", handleRestartProgress)
 			Expect(err).Should(BeNil())
 			Expect(opsPhase).Should(Equal(opsv1alpha1.OpsRunningPhase))
-			Expect(requeueAfter).Should(BeNumerically(">", 0))
+			Expect(requeueAfter).Should(BeZero())
 
-			progressDetail := findStatusProgressDetail(opsRes.OpsRequest.Status.Components[defaultCompName].ProgressDetails,
-				getProgressObjectKey(constant.PodKind, pods[2].Name))
-			Expect(progressDetail).ShouldNot(BeNil())
-			progressDetail.StartTime = metav1.NewTime(time.Now().Add(-restartRecoverableFailureObservationWindow - time.Second))
+			By("mock component reaches terminal Failed phase")
+			clusterComp := opsRes.Cluster.Status.Components[defaultCompName]
+			clusterComp.Phase = appsv1.FailedComponentPhase
+			opsRes.Cluster.Status.SetComponentStatus(defaultCompName, clusterComp)
 
 			opsPhase, requeueAfter, err = compOpsHelper.reconcileActionWithComponentOps(reqCtx, k8sClient, opsRes,
 				"test", handleRestartProgress)
@@ -293,30 +293,10 @@ var _ = Describe("OpsUtil functions", func() {
 			Expect(requeueAfter).Should(BeZero())
 			Expect(opsPhase).Should(Equal(opsv1alpha1.OpsFailedPhase))
 			Expect(opsRes.OpsRequest.Status.Progress).Should(Equal("3/3"))
-			progressDetail = findStatusProgressDetail(opsRes.OpsRequest.Status.Components[defaultCompName].ProgressDetails,
+			progressDetail := findStatusProgressDetail(opsRes.OpsRequest.Status.Components[defaultCompName].ProgressDetails,
 				getProgressObjectKey(constant.PodKind, pods[2].Name))
 			Expect(progressDetail).ShouldNot(BeNil())
 			Expect(progressDetail.Status).Should(Equal(opsv1alpha1.FailedProgressStatus))
-		})
-
-		It("caps recoverable failure requeue by ops timeout", func() {
-			timeoutSeconds := int32(60)
-			opsRes := &OpsResource{
-				OpsRequest: &opsv1alpha1.OpsRequest{
-					Spec: opsv1alpha1.OpsRequestSpec{
-						TimeoutSeconds: &timeoutSeconds,
-					},
-					Status: opsv1alpha1.OpsRequestStatus{
-						StartTimestamp: metav1.NewTime(time.Now().Add(-30 * time.Second)),
-					},
-				},
-			}
-
-			requeueAfter, err := GetOpsManager().checkAndHandleOpsTimeout(intctrlutil.RequestCtx{Ctx: ctx},
-				k8sClient, opsRes, restartRecoverableFailureObservationWindow)
-			Expect(err).Should(BeNil())
-			Expect(requeueAfter).Should(BeNumerically(">", 0))
-			Expect(requeueAfter).Should(BeNumerically("<", time.Minute))
 		})
 
 		It("Test opsRequest with disable ha", func() {

--- a/pkg/operations/restart.go
+++ b/pkg/operations/restart.go
@@ -38,8 +38,6 @@ type restartOpsHandler struct {
 
 var _ OpsHandler = restartOpsHandler{}
 
-const restartRecoverableFailureObservationWindow = 5 * time.Minute
-
 func init() {
 	restartBehaviour := OpsBehaviour{
 		// if cluster is Abnormal or Failed, new opsRequest may repair it.
@@ -91,7 +89,7 @@ func (r restartOpsHandler) ReconcileAction(reqCtx intctrlutil.RequestCtx, cli cl
 		opsRes *OpsResource,
 		pgRes *progressResource,
 		compStatus *opsv1alpha1.OpsRequestComponentStatus) (expectProgressCount int32, completedCount int32, err error) {
-		pgRes.recoverableFailureGracePeriod = restartRecoverableFailureObservationWindow
+		pgRes.deferInstanceFailureToWorkloadPhase = true
 		return handleComponentStatusProgress(reqCtx, cli, opsRes, pgRes, compStatus, r.podApplyCompOps)
 	}
 	return r.compOpsHelper.reconcileActionWithComponentOps(reqCtx, cli, opsRes,

--- a/pkg/operations/restart.go
+++ b/pkg/operations/restart.go
@@ -38,6 +38,8 @@ type restartOpsHandler struct {
 
 var _ OpsHandler = restartOpsHandler{}
 
+const restartRecoverableFailureObservationWindow = 5 * time.Minute
+
 func init() {
 	restartBehaviour := OpsBehaviour{
 		// if cluster is Abnormal or Failed, new opsRequest may repair it.
@@ -89,6 +91,7 @@ func (r restartOpsHandler) ReconcileAction(reqCtx intctrlutil.RequestCtx, cli cl
 		opsRes *OpsResource,
 		pgRes *progressResource,
 		compStatus *opsv1alpha1.OpsRequestComponentStatus) (expectProgressCount int32, completedCount int32, err error) {
+		pgRes.recoverableFailureGracePeriod = restartRecoverableFailureObservationWindow
 		return handleComponentStatusProgress(reqCtx, cli, opsRes, pgRes, compStatus, r.podApplyCompOps)
 	}
 	return r.compOpsHelper.reconcileActionWithComponentOps(reqCtx, cli, opsRes,

--- a/pkg/operations/type.go
+++ b/pkg/operations/type.go
@@ -111,6 +111,10 @@ type progressResource struct {
 	// checks if it needs to wait the component to complete.
 	// if only updates a part of pods, set it to false.
 	noWaitComponentCompleted bool
+	// keeps a failed instance under observation for ops types that can recover
+	// from transient workload failure signals.
+	recoverableFailureGracePeriod time.Duration
+	requeueAfter                  time.Duration
 }
 
 // OpsRuntime abstracts the standard ops paths that only need workload/member views

--- a/pkg/operations/type.go
+++ b/pkg/operations/type.go
@@ -111,10 +111,11 @@ type progressResource struct {
 	// checks if it needs to wait the component to complete.
 	// if only updates a part of pods, set it to false.
 	noWaitComponentCompleted bool
-	// keeps a failed instance under observation for ops types that can recover
-	// from transient workload failure signals.
-	recoverableFailureGracePeriod time.Duration
-	requeueAfter                  time.Duration
+	// lets ops types such as restart defer pod-level failure signals until the
+	// workload/component reaches a terminal failure state.
+	deferInstanceFailureToWorkloadPhase bool
+	componentPhase                      appsv1.ComponentPhase
+	requeueAfter                        time.Duration
 }
 
 // OpsRuntime abstracts the standard ops paths that only need workload/member views

--- a/pkg/operations/type.go
+++ b/pkg/operations/type.go
@@ -115,7 +115,6 @@ type progressResource struct {
 	// workload/component reaches a terminal failure state.
 	deferInstanceFailureToWorkloadPhase bool
 	componentPhase                      appsv1.ComponentPhase
-	requeueAfter                        time.Duration
 }
 
 // OpsRuntime abstracts the standard ops paths that only need workload/member views


### PR DESCRIPTION
## What happened

An Elasticsearch restart OpsRequest was marked `Failed` while the target Pod later became Ready and the Elasticsearch cluster stayed green.

The preserved evidence shows the Pod did have a real failed/waiting history during recreate:

```text
Error: failed to sync configmap cache: timed out waiting for the condition
```

That history should remain visible on the Pod / InstanceSet side. The bug is in how restart Ops consumes that signal: restart progress should not use Pod progress details as the primary terminal-state anchor.

Fixes #10300

## Root cause

Rolling Ops progress counted a failed progress detail as completed and then finalized the whole OpsRequest as `Failed` as soon as all expected instances had either succeeded or failed.

Earlier patch attempts either broadened Component-phase suppression to every component Ops path, or scoped restart to a fixed Pod failure observation window. Both directions still made restart semantics depend too much on Pod progress details.

## Fix

Keep the shared Pod / InstanceSet failure signal unchanged.

For restart Ops only, defer pod-level failed/timed-out signals until the workload/component reports a terminal failed phase:

- restart still records per-instance progress and waits for workload readiness to drive success;
- a transient failed Pod signal remains diagnostic evidence, but restart progress keeps that instance `Processing` while the Component is not terminal failed;
- if the Component reaches `Failed`, restart marks the affected progress as `Failed` and the OpsRequest fails;
- other Ops paths keep the existing terminal failed-progress behavior.

This makes Cluster / Component / InstanceSet state the terminal source for restart failure, while Pod state remains diagnostic evidence.

## Validation

Local validation:

```text
git diff --check
KUBEBUILDER_ASSETS='/Users/wei/Library/Application Support/io.kubebuilder.envtest/k8s/1.26.1-darwin-arm64' go test ./pkg/operations -run TestAPIs -count=1
```

Added envtest coverage for both restart branches:

- a failed Pod signal is kept as `Processing` while the Component is not terminal failed, reports `2/3`, and can later recover to `Succeed`;
- if the Component reaches terminal `Failed`, restart Ops returns `Failed` instead of treating Pod diagnostics as an independent terminal anchor;
- the existing non-restart/shared failed-progress path still returns Ops `Failed`.

Evidence boundary: the ES field occurrence is N=1. This PR fixes the deterministic restart Ops progress contract. It is not a release-ready claim; ES needs fresh exact-head runtime validation after this new head is sideloaded.
