### PR TITLE
chore: gate role-probe by engine-authoritative version

### DIFF
--- a/apis/apps/v1/componentdefinition_types.go
+++ b/apis/apps/v1/componentdefinition_types.go
@@ -1558,9 +1558,30 @@ type ComponentLifecycleActions struct {
 	// Without this, services that rely on roleSelectors might improperly direct traffic to wrong replicas.
 	//
 	// Expected output of this action:
-	// - On Success: The determined role of the replica, which must align with one of the roles specified
-	//   in the component definition.
-	// - On Failure: An error message, if applicable, indicating why the action failed.
+	//   - On Success: The determined role of the replica, which must align with one of the roles
+	//     specified in the component definition. Stdout MUST be one of the two forms below:
+	//
+	//       <role>                  // single-token form
+	//       <role> <roleVersion>    // versioned form
+	//
+	//     The two tokens are separated by whitespace (spaces, tabs, or newlines).
+	//     <roleVersion> is an optional unsigned 64-bit decimal integer that
+	//     carries the component's authoritative role version for stale-role
+	//     handling, especially stale exclusive-role claims. A versioned
+	//     result is accepted only when its <roleVersion> is newer than the
+	//     versioned result the controller has already accepted for this Pod.
+	//     The version should represent the complete role fact. For an
+	//     exclusive primary role, identical versions reported by different
+	//     replicas must not describe contradictory primary ownership.
+	//     <role> remains a valid single-token form. Stdout that looks
+	//     versioned but whose second token is not an unsigned 64-bit decimal
+	//     integer, or stdout with three or more whitespace-separated tokens,
+	//     is rejected as malformed and the Pod's role label is not updated.
+	//     A component may migrate a Pod from the single-token form to the
+	//     versioned form. After a Pod has reported the versioned form,
+	//     later single-token results from that Pod are ignored to avoid
+	//     downgrading from authoritative role-version ordering.
+	//   - On Failure: An error message, if applicable, indicating why the action failed.
 	//
 	// Note: This field is immutable once it has been set.
 	//

--- a/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
@@ -8478,9 +8478,30 @@ spec:
                       Without this, services that rely on roleSelectors might improperly direct traffic to wrong replicas.
 
                       Expected output of this action:
-                      - On Success: The determined role of the replica, which must align with one of the roles specified
-                        in the component definition.
-                      - On Failure: An error message, if applicable, indicating why the action failed.
+                        - On Success: The determined role of the replica, which must align with one of the roles
+                          specified in the component definition. Stdout MUST be one of the two forms below:
+
+                            <role>                  // single-token form
+                            <role> <roleVersion>    // versioned form
+
+                          The two tokens are separated by whitespace (spaces, tabs, or newlines).
+                          <roleVersion> is an optional unsigned 64-bit decimal integer that
+                          carries the component's authoritative role version for stale-role
+                          handling, especially stale exclusive-role claims. A versioned
+                          result is accepted only when its <roleVersion> is newer than the
+                          versioned result the controller has already accepted for this Pod.
+                          The version should represent the complete role fact. For an
+                          exclusive primary role, identical versions reported by different
+                          replicas must not describe contradictory primary ownership.
+                          <role> remains a valid single-token form. Stdout that looks
+                          versioned but whose second token is not an unsigned 64-bit decimal
+                          integer, or stdout with three or more whitespace-separated tokens,
+                          is rejected as malformed and the Pod's role label is not updated.
+                          A component may migrate a Pod from the single-token form to the
+                          versioned form. After a Pod has reported the versioned form,
+                          later single-token results from that Pod are ignored to avoid
+                          downgrading from authoritative role-version ordering.
+                        - On Failure: An error message, if applicable, indicating why the action failed.
 
                       Note: This field is immutable once it has been set.
                     properties:

--- a/controllers/workloads/role_event_handler.go
+++ b/controllers/workloads/role_event_handler.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -53,6 +54,13 @@ const (
 	instanceKind = "Instance"
 )
 
+// roleProbeOutput is the parsed view of a kbagent roleProbe stdout payload.
+type roleProbeOutput struct {
+	role                    string
+	authoritativeVersion    uint64
+	hasAuthoritativeVersion bool
+}
+
 type roleEventResult struct {
 	Event          types.NamespacedName
 	EventUID       types.UID
@@ -69,6 +77,7 @@ type roleEventResult struct {
 	RoleDefined    bool
 	Handled        bool
 	ExclusiveClean bool
+	parsed         roleProbeOutput
 }
 
 type RoleEventHandler struct{}
@@ -86,10 +95,10 @@ func (h *RoleEventHandler) Handle(cli client.Client, reqCtx intctrlutil.RequestC
 			Namespace: event.InvolvedObject.Namespace,
 			Name:      event.InvolvedObject.Name,
 		},
-		Version: roleEventVersion(event),
 		Branch:  roleEventBranchUnknown,
 		Result:  "ignored",
 		Reason:  "notHandled",
+		Version: fmt.Sprintf("%d", event.EventTime.UnixMicro()),
 	}
 	handled, err := h.handleRoleProbeEvent(reqCtx.Ctx, cli, event, result)
 	result.Handled = handled
@@ -105,12 +114,20 @@ func (h *RoleEventHandler) handleRoleProbeEvent(ctx context.Context, cli client.
 		return true, nil
 	}
 
-	result.Role = strings.ToLower(strings.TrimSpace(string(probeEvent.Output)))
 	if probeEvent.Code != 0 {
 		result.Result = "skipped"
 		result.Reason = fmt.Sprintf("roleProbeFailed:%s", probeEvent.Message)
 		return true, nil
 	}
+
+	parsed, parseErr := parseRoleProbeOutput(probeEvent.Output)
+	if parseErr != nil {
+		result.Result = "skipped"
+		result.Reason = "malformedRoleProbeOutput"
+		return true, nil
+	}
+	result.Role = parsed.role
+	result.parsed = parsed
 
 	pod := &corev1.Pod{}
 	if err := cli.Get(ctx, result.Pod, pod); err != nil {
@@ -166,7 +183,7 @@ func (h *RoleEventHandler) handleRoleProbeEvent(ctx context.Context, cli client.
 }
 
 func (h *RoleEventHandler) handleInstanceSetRoleProbe(ctx context.Context, cli client.Client, pod *corev1.Pod, itsName string, result *roleEventResult) (bool, error) {
-	if checkStaleLastRoleEventVersion(result.Version, pod) {
+	if !acceptRoleProbeEvent(pod, result.Version, result.parsed) {
 		result.Result = "skipped"
 		result.Reason = "staleRoleEventVersion"
 		return true, nil
@@ -187,7 +204,36 @@ func (h *RoleEventHandler) handleInstanceSetRoleProbe(ctx context.Context, cli c
 	roleMap := composeRoleMap(its.Spec.Roles)
 	role, defined := roleMap[result.Role]
 	result.RoleDefined = defined
-	if err := updatePodRoleLabel(ctx, cli, pod, result.Role, result.Version, defined); err != nil {
+
+	if defined && role.IsExclusive {
+		if !result.parsed.hasAuthoritativeVersion {
+			held, err := versionedPeerHoldsExclusiveRole(ctx, cli, *its, pod.Name, result.Role)
+			if err != nil {
+				result.Result = "failed"
+				result.Reason = "checkVersionedExclusiveRoleError"
+				return false, err
+			}
+			if held {
+				result.Result = "skipped"
+				result.Reason = "versionedPeerHeldExclusiveRole"
+				return true, nil
+			}
+		} else {
+			stale, err := newerOrEqualVersionedExclusiveRoleHeldByPeer(ctx, cli, *its, pod.Name, result.Role, result.parsed.authoritativeVersion)
+			if err != nil {
+				result.Result = "failed"
+				result.Reason = "checkPeerRoleVersionError"
+				return false, err
+			}
+			if stale {
+				result.Result = "skipped"
+				result.Reason = "stalePeerRoleVersion"
+				return true, nil
+			}
+		}
+	}
+
+	if err := updatePodRoleLabel(ctx, cli, pod, result.Role, defined, result.Version, result.parsed); err != nil {
 		result.Result = "failed"
 		result.Reason = "updatePodRoleLabelError"
 		return false, err
@@ -195,7 +241,7 @@ func (h *RoleEventHandler) handleInstanceSetRoleProbe(ctx context.Context, cli c
 
 	if defined && role.IsExclusive {
 		result.ExclusiveClean = true
-		if err := removeExclusiveRoleLabels(ctx, cli, *its, pod.Name, result.Role, result.Version); err != nil {
+		if err := removeExclusiveRoleLabels(ctx, cli, *its, pod.Name, result.Role, result.Version, result.parsed); err != nil {
 			result.Result = "failed"
 			result.Reason = "removeExclusiveRoleLabelsError"
 			return false, err
@@ -207,7 +253,7 @@ func (h *RoleEventHandler) handleInstanceSetRoleProbe(ctx context.Context, cli c
 }
 
 func (h *RoleEventHandler) handleInstanceRoleProbe(ctx context.Context, cli client.Client, pod *corev1.Pod, instName string, result *roleEventResult) (bool, error) {
-	if checkStaleLastRoleEventVersion(result.Version, pod) {
+	if !acceptRoleProbeEvent(pod, result.Version, result.parsed) {
 		result.Result = "skipped"
 		result.Reason = "staleRoleEventVersion"
 		return true, nil
@@ -227,7 +273,7 @@ func (h *RoleEventHandler) handleInstanceRoleProbe(ctx context.Context, cli clie
 
 	_, defined := composeRoleMap(inst.Spec.Roles)[result.Role]
 	result.RoleDefined = defined
-	if err := updatePodRoleLabel(ctx, cli, pod, result.Role, result.Version, defined); err != nil {
+	if err := updatePodRoleLabel(ctx, cli, pod, result.Role, defined, result.Version, result.parsed); err != nil {
 		result.Result = "failed"
 		result.Reason = "updatePodRoleLabelError"
 		return false, err
@@ -243,18 +289,89 @@ func isRoleProbeEvent(event *corev1.Event) bool {
 		event.InvolvedObject.FieldPath == proto.ProbeEventFieldPath
 }
 
-func roleEventVersion(event *corev1.Event) string {
-	return fmt.Sprintf("%d", event.EventTime.UnixMicro())
+// parseRoleProbeOutput parses kbagent roleProbe stdout into a role name plus
+// an optional authoritative role version. The grammar splits stdout on any
+// whitespace (spaces, tabs, newlines) into:
+//
+//	<role>                  // single-token form
+//	<role> <uint64-version> // versioned form
+//
+// A probe script that emits a non-uint64 second token or three or more tokens
+// is a parse error. Falling back to EventTime would let a typo bypass the
+// authoritative-version ordering the probe script meant to use.
+func parseRoleProbeOutput(stdout []byte) (roleProbeOutput, error) {
+	if len(stdout) == 0 {
+		return roleProbeOutput{}, nil
+	}
+	tokens := strings.Fields(string(stdout))
+	switch len(tokens) {
+	case 0:
+		return roleProbeOutput{}, nil
+	case 1:
+		return roleProbeOutput{
+			role: strings.ToLower(tokens[0]),
+		}, nil
+	case 2:
+		v, err := strconv.ParseUint(tokens[1], 10, 64)
+		if err != nil {
+			return roleProbeOutput{
+				role: strings.ToLower(tokens[0]),
+			}, fmt.Errorf("invalid role version %q: %w", tokens[1], err)
+		}
+		return roleProbeOutput{
+			role:                    strings.ToLower(tokens[0]),
+			authoritativeVersion:    v,
+			hasAuthoritativeVersion: true,
+		}, nil
+	default:
+		return roleProbeOutput{
+			role: strings.ToLower(tokens[0]),
+		}, fmt.Errorf("invalid role probe output: expected one or two tokens, got %d", len(tokens))
+	}
 }
 
-func checkStaleLastRoleEventVersion(version string, pod *corev1.Pod) bool {
-	lastRoleEventVersion, ok := pod.Annotations[constant.LastRoleEventVersionAnnotationKey]
-	if ok {
-		if version <= lastRoleEventVersion && !strings.Contains(lastRoleEventVersion, ":") {
+// acceptRoleProbeEvent decides whether to accept a parsed roleProbe event for
+// a particular Pod. Each output form is gated by its own staleness anchor:
+//
+//   - Versioned result (`<role> <uint64>`) is accepted iff its version is
+//     strictly greater than the Pod's recorded authoritative role version.
+//   - Single-token result (`<role>`) is accepted iff its EventTime micros are
+//     strictly greater than the recorded single-token EventTime anchor.
+//     A single-token result is also rejected once the same Pod has accepted
+//     any versioned result, avoiding downgrade from authoritative ordering.
+//
+// Versioned results do not consult the single-token anchor. The two anchors
+// stay independent; the only cross-anchor rule is the same-Pod
+// versioned-to-single-token downgrade block described above.
+func acceptRoleProbeEvent(pod *corev1.Pod, eventVersion string, parsed roleProbeOutput) bool {
+	if parsed.hasAuthoritativeVersion {
+		last := podAnnotation(pod, constant.LastRoleAuthoritativeVersionAnnotationKey)
+		if last == "" {
 			return true
 		}
+		lastV, err := strconv.ParseUint(last, 10, 64)
+		if err != nil || parsed.authoritativeVersion > lastV {
+			return true
+		}
+		return false
 	}
-	return false
+
+	if podAnnotation(pod, constant.LastRoleAuthoritativeVersionAnnotationKey) != "" {
+		return false
+	}
+	last := podAnnotation(pod, constant.LastRoleEventVersionAnnotationKey)
+	if last == "" {
+		return true
+	}
+	lastV, err := strconv.ParseUint(last, 10, 64)
+	if err != nil {
+		return true
+	}
+	eventV, parseErr := strconv.ParseUint(eventVersion, 10, 64)
+	if parseErr != nil {
+		return true
+	}
+	return eventV > lastV
 }
 
 func composeRoleMap(roles []workloads.ReplicaRole) map[string]workloads.ReplicaRole {
@@ -284,7 +401,13 @@ func resolveRoleEventBranchByControllerRef(pod *corev1.Pod) (roleEventBranch, st
 	}
 }
 
-func updatePodRoleLabel(ctx context.Context, cli client.Client, pod *corev1.Pod, roleName, version string, roleDefined bool) error {
+// updatePodRoleLabel writes the new role label (or removes it when the role
+// is not in the workload's role list) and advances the path-specific
+// annotation for the accepted event. Versioned results stamp
+// LastRoleAuthoritativeVersionAnnotationKey only; single-token results stamp
+// LastRoleEventVersionAnnotationKey only. The other key is left untouched so
+// that a migration window does not silently downgrade either stream's anchor.
+func updatePodRoleLabel(ctx context.Context, cli client.Client, pod *corev1.Pod, roleName string, roleDefined bool, eventVersion string, parsed roleProbeOutput) error {
 	newPod := pod.DeepCopy()
 	if newPod.Labels == nil {
 		newPod.Labels = make(map[string]string)
@@ -297,14 +420,44 @@ func updatePodRoleLabel(ctx context.Context, cli client.Client, pod *corev1.Pod,
 	if newPod.Annotations == nil {
 		newPod.Annotations = map[string]string{}
 	}
-	newPod.Annotations[constant.LastRoleEventVersionAnnotationKey] = version
+	if parsed.hasAuthoritativeVersion {
+		newPod.Annotations[constant.LastRoleAuthoritativeVersionAnnotationKey] = strconv.FormatUint(parsed.authoritativeVersion, 10)
+	} else {
+		newPod.Annotations[constant.LastRoleEventVersionAnnotationKey] = eventVersion
+	}
 	if reflect.DeepEqual(newPod.Labels, pod.Labels) && reflect.DeepEqual(newPod.Annotations, pod.Annotations) {
 		return nil
 	}
 	return cli.Update(ctx, newPod)
 }
 
-func removeExclusiveRoleLabels(ctx context.Context, cli client.Client, its workloads.InstanceSet, newPodName, roleName, version string) error {
+// removeExclusiveRoleLabels strips the exclusive role label from peers when
+// a new owner of the exclusive role has been accepted. Peer-cleanup
+// behavior is path-specific:
+//
+//   - Single-token (EventTime) path: each accepted strip also stamps the peer's
+//     LastRoleEventVersionAnnotationKey with the cleanup event's EventTime
+//     micros. Without this stamp, a delayed single-token event from the demoted
+//     primary whose EventTime is older than the cleanup event but newer
+//     than the peer's own previous annotation would still pass the gate
+//     and write the exclusive role back. Stamping is the one-way ratchet
+//     the single-token stream relies on.
+//   - Versioned path: each accepted strip leaves the peer's
+//     LastRoleAuthoritativeVersionAnnotationKey untouched. The role version is
+//     a per-pod monotonically increasing number; stamping the peer with
+//     the new primary's role version (which originated from a different
+//     pod's kbagent) would let the strict-newer gate later reject a
+//     legitimate event from the peer at the same role epoch — for
+//     example after failover the demoted pod's next event is
+//     `secondary <same-epoch>`. The peer's own previous role-version annotation
+//     is already a sufficient staleness anchor for queued events from the
+//     demoted primary, because those events' versions are <= the peer's
+//     recorded version.
+//
+// Whether to strip is still decided per peer by the same gate: a peer that
+// has already advanced past the new event on the matching key is left
+// alone.
+func removeExclusiveRoleLabels(ctx context.Context, cli client.Client, its workloads.InstanceSet, newPodName, roleName string, eventVersion string, parsed roleProbeOutput) error {
 	labels := map[string]string{
 		constant.AppManagedByLabelKey:          constant.AppName,
 		instanceset.WorkloadsManagedByLabelKey: workloads.InstanceSetKind,
@@ -321,21 +474,102 @@ func removeExclusiveRoleLabels(ctx context.Context, cli client.Client, its workl
 		if pod.Name == newPodName {
 			continue
 		}
-		if checkStaleLastRoleEventVersion(version, &pod) {
+		if !acceptRoleProbeEvent(&pod, eventVersion, parsed) {
 			continue
 		}
 
 		newPod := pods.Items[i].DeepCopy()
-		delete(newPod.Labels, constant.RoleLabelKey)
-		if newPod.Annotations == nil {
-			newPod.Annotations = map[string]string{}
+		if _, has := newPod.Labels[constant.RoleLabelKey]; !has {
+			continue
 		}
-		newPod.Annotations[constant.LastRoleEventVersionAnnotationKey] = version
+		delete(newPod.Labels, constant.RoleLabelKey)
+		if !parsed.hasAuthoritativeVersion {
+			if newPod.Annotations == nil {
+				newPod.Annotations = map[string]string{}
+			}
+			newPod.Annotations[constant.LastRoleEventVersionAnnotationKey] = eventVersion
+		}
 		if err := cli.Update(ctx, newPod); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	return errors.Join(errs...)
+}
+
+func podAnnotation(pod *corev1.Pod, key string) string {
+	if pod.Annotations == nil {
+		return ""
+	}
+	return pod.Annotations[key]
+}
+
+// versionedPeerHoldsExclusiveRole reports whether any peer pod in the
+// InstanceSet currently holds the exclusive role label and carries a
+// LastRoleAuthoritativeVersionAnnotationKey value. It is used to keep a
+// single-token roleProbe event from displacing an exclusive role that
+// a versioned peer already owns: the single-token gate consults only
+// the EventTime anchor, so a versioned peer's anchor is
+// invisible to it; without this guard a single-token fallback event
+// from a probe script could strip the role label off the
+// authoritative primary and the versioned peer's next same-version event
+// would then be rejected by the strict-newer gate and the role label could
+// not be restored.
+func versionedPeerHoldsExclusiveRole(ctx context.Context, cli client.Client, its workloads.InstanceSet, selfName, roleName string) (bool, error) {
+	labels := map[string]string{
+		constant.AppManagedByLabelKey:          constant.AppName,
+		instanceset.WorkloadsManagedByLabelKey: workloads.InstanceSetKind,
+		instanceset.WorkloadsInstanceLabelKey:  its.Name,
+		constant.RoleLabelKey:                  roleName,
+	}
+	var pods corev1.PodList
+	if err := cli.List(ctx, &pods, client.InNamespace(its.Namespace), client.MatchingLabels(labels)); err != nil {
+		return false, err
+	}
+	for _, p := range pods.Items {
+		if p.Name == selfName {
+			continue
+		}
+		if podAnnotation(&p, constant.LastRoleAuthoritativeVersionAnnotationKey) != "" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// newerOrEqualVersionedExclusiveRoleHeldByPeer reports whether any peer pod
+// already holds the same exclusive role with an authoritative role version
+// that is at least as new as the incoming versioned event. The caller must run this
+// before writing the current pod's role label; otherwise a stale delayed
+// versioned event can label itself while peer cleanup correctly refuses to
+// strip the newer peer, leaving two pods with the exclusive role.
+func newerOrEqualVersionedExclusiveRoleHeldByPeer(ctx context.Context, cli client.Client, its workloads.InstanceSet, selfName, roleName string, incomingVersion uint64) (bool, error) {
+	labels := map[string]string{
+		constant.AppManagedByLabelKey:          constant.AppName,
+		instanceset.WorkloadsManagedByLabelKey: workloads.InstanceSetKind,
+		instanceset.WorkloadsInstanceLabelKey:  its.Name,
+		constant.RoleLabelKey:                  roleName,
+	}
+	var pods corev1.PodList
+	if err := cli.List(ctx, &pods, client.InNamespace(its.Namespace), client.MatchingLabels(labels)); err != nil {
+		return false, err
+	}
+	for _, p := range pods.Items {
+		if p.Name == selfName {
+			continue
+		}
+		last := podAnnotation(&p, constant.LastRoleAuthoritativeVersionAnnotationKey)
+		if last == "" {
+			continue
+		}
+		lastV, err := strconv.ParseUint(last, 10, 64)
+		if err != nil {
+			continue
+		}
+		if lastV >= incomingVersion {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func logRoleProbeEvent(logger logr.Logger, result *roleEventResult, err error) {

--- a/controllers/workloads/role_event_handler_test.go
+++ b/controllers/workloads/role_event_handler_test.go
@@ -42,7 +42,151 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/kbagent/proto"
 )
 
-func TestRoleEventHandlerHandlesInstanceSetRoleAndExclusive(t *testing.T) {
+// --- parser tests ---
+
+func TestParseRoleProbeOutputSingleToken(t *testing.T) {
+	out, err := parseRoleProbeOutput([]byte("primary"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.role != "primary" || out.hasAuthoritativeVersion || out.authoritativeVersion != 0 {
+		t.Fatalf("got %+v, want role=primary without authoritative version", out)
+	}
+}
+
+func TestParseRoleProbeOutputVersionedSpaceSeparated(t *testing.T) {
+	out, err := parseRoleProbeOutput([]byte("primary 10"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.role != "primary" || !out.hasAuthoritativeVersion || out.authoritativeVersion != 10 {
+		t.Fatalf("got %+v, want role=primary authoritativeVersion=10", out)
+	}
+}
+
+func TestParseRoleProbeOutputVersionedNewlineSeparated(t *testing.T) {
+	out, err := parseRoleProbeOutput([]byte("primary\n10"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.role != "primary" || !out.hasAuthoritativeVersion || out.authoritativeVersion != 10 {
+		t.Fatalf("got %+v, want role=primary authoritativeVersion=10", out)
+	}
+}
+
+func TestParseRoleProbeOutputVersionedTolerantOfSurroundingWhitespace(t *testing.T) {
+	out, err := parseRoleProbeOutput([]byte("\tprimary\t42\n"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.role != "primary" || !out.hasAuthoritativeVersion || out.authoritativeVersion != 42 {
+		t.Fatalf("got %+v, want role=primary authoritativeVersion=42", out)
+	}
+}
+
+func TestParseRoleProbeOutputMalformedSecondTokenNotUint64(t *testing.T) {
+	out, err := parseRoleProbeOutput([]byte("primary abc"))
+	if err == nil {
+		t.Fatalf("got nil error for %+v", out)
+	}
+}
+
+func TestParseRoleProbeOutputMalformedThreeOrMoreTokens(t *testing.T) {
+	out, err := parseRoleProbeOutput([]byte("primary 10 extra"))
+	if err == nil {
+		t.Fatalf("got nil error for %+v", out)
+	}
+}
+
+func TestParseRoleProbeOutputEmpty(t *testing.T) {
+	out, err := parseRoleProbeOutput([]byte(""))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out.hasAuthoritativeVersion || out.role != "" {
+		t.Fatalf("got %+v, want empty role without authoritative version", out)
+	}
+}
+
+// --- gate tests: each path consults only its own annotation key ---
+
+func TestAcceptRoleProbeEventVersionedRejectsOlderVersion(t *testing.T) {
+	pod := podWithAnnotations(map[string]string{constant.LastRoleAuthoritativeVersionAnnotationKey: "10"})
+	parsed := versionedRoleProbeOutput("primary", 9)
+	if acceptRoleProbeEvent(pod, "0", parsed) {
+		t.Fatalf("expected stale versioned result to be rejected")
+	}
+}
+
+func TestAcceptRoleProbeEventVersionedRejectsEqualVersion(t *testing.T) {
+	pod := podWithAnnotations(map[string]string{constant.LastRoleAuthoritativeVersionAnnotationKey: "10"})
+	parsed := versionedRoleProbeOutput("primary", 10)
+	if acceptRoleProbeEvent(pod, "0", parsed) {
+		t.Fatalf("expected equal versioned result to be rejected")
+	}
+}
+
+func TestAcceptRoleProbeEventVersionedAcceptsNewerVersion(t *testing.T) {
+	pod := podWithAnnotations(map[string]string{constant.LastRoleAuthoritativeVersionAnnotationKey: "10"})
+	parsed := versionedRoleProbeOutput("primary", 11)
+	if !acceptRoleProbeEvent(pod, "0", parsed) {
+		t.Fatalf("expected newer versioned result to be accepted")
+	}
+}
+
+// Versioned results do not consult the single-token annotation key.
+func TestAcceptRoleProbeEventVersionedIgnoresSingleTokenAnnotation(t *testing.T) {
+	pod := podWithAnnotations(map[string]string{constant.LastRoleEventVersionAnnotationKey: "1779550000000000"})
+	parsed := versionedRoleProbeOutput("primary", 1)
+	if !acceptRoleProbeEvent(pod, "1", parsed) {
+		t.Fatalf("expected versioned result to ignore single-token EventTime anchor")
+	}
+}
+
+func TestAcceptRoleProbeEventSingleTokenAcceptsNewerEventTime(t *testing.T) {
+	pod := podWithAnnotations(map[string]string{constant.LastRoleEventVersionAnnotationKey: "1779550000000000"})
+	parsed := roleProbeOutput{role: "primary"}
+	if !acceptRoleProbeEvent(pod, "1779550600000000", parsed) {
+		t.Fatalf("expected newer single-token result to be accepted")
+	}
+}
+
+func TestAcceptRoleProbeEventSingleTokenRejectsOlderEventTime(t *testing.T) {
+	pod := podWithAnnotations(map[string]string{constant.LastRoleEventVersionAnnotationKey: "1779550600000000"})
+	parsed := roleProbeOutput{role: "primary"}
+	if acceptRoleProbeEvent(pod, "1779550000000000", parsed) {
+		t.Fatalf("expected stale single-token result to be rejected")
+	}
+}
+
+// A Pod that has accepted any versioned result rejects subsequent
+// single-token results from the same Pod, avoiding downgrade from
+// authoritative role-version ordering.
+func TestAcceptRoleProbeEventSingleTokenRejectedOnPodAlreadyAcceptedVersionedEvent(t *testing.T) {
+	pod := podWithAnnotations(map[string]string{constant.LastRoleAuthoritativeVersionAnnotationKey: "10"})
+	parsed := roleProbeOutput{role: "primary"}
+	if acceptRoleProbeEvent(pod, "1779550600000000", parsed) {
+		t.Fatalf("expected same-Pod single-token result to be rejected after a versioned result")
+	}
+}
+
+// The same-Pod downgrade rule also blocks single-token results even if the
+// Pod has accumulated a single-token annotation alongside the roleVersion
+// annotation.
+func TestAcceptRoleProbeEventSingleTokenRejectedOnPodWithBothAnnotationsWhenRoleVersionPresent(t *testing.T) {
+	pod := podWithAnnotations(map[string]string{
+		constant.LastRoleAuthoritativeVersionAnnotationKey: "10",
+		constant.LastRoleEventVersionAnnotationKey:         "1000000",
+	})
+	parsed := roleProbeOutput{role: "primary"}
+	if acceptRoleProbeEvent(pod, "2000000", parsed) {
+		t.Fatalf("expected single-token result to be rejected when roleVersion anchor is present")
+	}
+}
+
+// --- end-to-end handler tests via fake client ---
+
+func TestRoleEventHandlerHandlesInstanceSetSingleTokenAndExclusiveCleanupStampsPeerAnnotation(t *testing.T) {
 	ctx := context.Background()
 	now := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
 	leader := workloads.ReplicaRole{Name: "leader", IsExclusive: true}
@@ -67,8 +211,270 @@ func TestRoleEventHandlerHandlesInstanceSetRoleAndExclusive(t *testing.T) {
 		t.Fatalf("expected event to be handled")
 	}
 
-	assertPodRole(t, ctx, cli, pod, "leader", fmt.Sprintf("%d", event.EventTime.UnixMicro()))
-	assertPodRole(t, ctx, cli, otherPod, "", fmt.Sprintf("%d", event.EventTime.UnixMicro()))
+	wantSingleToken := fmt.Sprintf("%d", event.EventTime.UnixMicro())
+	assertPodRole(t, ctx, cli, pod, "leader", wantSingleToken)
+	// Peer's exclusive role label is stripped. Single-token cleanup also stamps
+	// the peer's LastRoleEventVersionAnnotationKey with the cleanup event's
+	// EventTime: without this stamp a delayed single-token event from the demoted
+	// primary whose EventTime is older than the cleanup but newer than the
+	// peer's own previous annotation would slip back through the gate.
+	assertPodRole(t, ctx, cli, otherPod, "", wantSingleToken)
+	assertPodLastRoleAuthoritativeVersion(t, ctx, cli, otherPod, "")
+}
+
+// Versioned path peer cleanup must strip the label but leave the peer's
+// LastRoleAuthoritativeVersionAnnotationKey untouched. Stamping it would let the
+// strict-newer gate later reject a legitimate event from the peer at the
+// same versioned epoch (e.g. demoted pod emitting `secondary <same-epoch>`).
+func TestRoleEventHandlerHandlesInstanceSetVersionedAndExclusiveCleanupDoesNotStampPeerVersionedAnnotation(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	leader := workloads.ReplicaRole{Name: "leader", IsExclusive: true}
+	follower := workloads.ReplicaRole{Name: "follower"}
+	its := &workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "mysql"},
+		Spec:       workloads.InstanceSetSpec{Roles: []workloads.ReplicaRole{leader, follower}},
+	}
+	pod := roleEventPod("default", "mysql-0", "uid-0", map[string]string{
+		instanceset.WorkloadsInstanceLabelKey: "mysql",
+	})
+	otherPod := roleEventPod("default", "mysql-1", "uid-1", map[string]string{
+		constant.AppManagedByLabelKey:          constant.AppName,
+		instanceset.WorkloadsManagedByLabelKey: workloads.InstanceSetKind,
+		instanceset.WorkloadsInstanceLabelKey:  "mysql",
+		constant.RoleLabelKey:                  "leader",
+	})
+	otherPod.Annotations = map[string]string{
+		constant.LastRoleAuthoritativeVersionAnnotationKey: "0",
+	}
+	event := roleProbeEventWithOutput("default", "event-1", pod, "leader 1", now)
+	cli := roleEventFakeClient(t, its, pod, otherPod, event)
+
+	if handled := handleRoleEvent(t, ctx, cli, event); !handled {
+		t.Fatalf("expected event to be handled")
+	}
+
+	assertPodRole(t, ctx, cli, pod, "leader", "")
+	assertPodLastRoleAuthoritativeVersion(t, ctx, cli, pod, "1")
+	assertPodRole(t, ctx, cli, otherPod, "", "")
+	// Critical contract: peer versioned annotation is NOT advanced; otherwise
+	// the peer's own next event at authoritative role version 1 would be rejected as
+	// stale by the strict-newer gate.
+	assertPodLastRoleAuthoritativeVersion(t, ctx, cli, otherPod, "0")
+}
+
+// Regression for Valkey r4 mixed-mode bug on PR #10283 head 714f684b: a
+// single-token `primary` event from a non-quorum probe script fallback path must not
+// strip the exclusive role label off a versioned peer. Without
+// this guard the single-token event runs exclusive cleanup against the
+// versioned-held primary (the gate consults only the single-token annotation,
+// which on the versioned peer is empty, so cleanup is accepted); after the
+// label is stripped the versioned peer's next same-roleVersion event is
+// rejected by the strict-newer gate and the role label can never be
+// restored.
+func TestRoleEventHandlerSingleTokenExclusiveEventBlockedByVersionedHoldingPeer(t *testing.T) {
+	ctx := context.Background()
+	leader := workloads.ReplicaRole{Name: "leader", IsExclusive: true}
+	follower := workloads.ReplicaRole{Name: "follower"}
+	its := &workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "vlk"},
+		Spec:       workloads.InstanceSetSpec{Roles: []workloads.ReplicaRole{leader, follower}},
+	}
+	versionedPeer := roleEventPod("default", "vlk-3", "uid-3", map[string]string{
+		constant.AppManagedByLabelKey:          constant.AppName,
+		instanceset.WorkloadsManagedByLabelKey: workloads.InstanceSetKind,
+		instanceset.WorkloadsInstanceLabelKey:  "vlk",
+		constant.RoleLabelKey:                  "leader",
+	})
+	versionedPeer.Annotations = map[string]string{
+		constant.LastRoleAuthoritativeVersionAnnotationKey: "3",
+	}
+	singleTokenPod := roleEventPod("default", "vlk-2", "uid-2", map[string]string{
+		instanceset.WorkloadsInstanceLabelKey: "vlk",
+	})
+	event := roleProbeEvent("default", "event-1", singleTokenPod, "leader", time.Now())
+	cli := roleEventFakeClient(t, its, versionedPeer, singleTokenPod, event)
+
+	if handled := handleRoleEvent(t, ctx, cli, event); !handled {
+		t.Fatalf("expected event to be handled (skipped + reason=versionedHeldExclusiveRole)")
+	}
+
+	// single-token pod must not have received the leader label; versioned peer's
+	// label and annotations must be unchanged.
+	assertPodRole(t, ctx, cli, singleTokenPod, "", "")
+	assertPodLastRoleVersion(t, ctx, cli, singleTokenPod, "")
+	assertPodRole(t, ctx, cli, versionedPeer, "leader", "")
+	assertPodLastRoleAuthoritativeVersion(t, ctx, cli, versionedPeer, "3")
+	assertPodLastRoleVersion(t, ctx, cli, versionedPeer, "")
+}
+
+// When the role being claimed is non-exclusive, the versioned-held-peer
+// guard does not apply: a single-token event for a non-exclusive role still
+// goes through normally even when another peer carries a versioned
+// annotation.
+func TestRoleEventHandlerSingleTokenNonExclusiveEventNotBlockedByVersionedPeer(t *testing.T) {
+	ctx := context.Background()
+	leader := workloads.ReplicaRole{Name: "leader", IsExclusive: true}
+	follower := workloads.ReplicaRole{Name: "follower"}
+	its := &workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "vlk"},
+		Spec:       workloads.InstanceSetSpec{Roles: []workloads.ReplicaRole{leader, follower}},
+	}
+	versionedPeer := roleEventPod("default", "vlk-3", "uid-3", map[string]string{
+		constant.AppManagedByLabelKey:          constant.AppName,
+		instanceset.WorkloadsManagedByLabelKey: workloads.InstanceSetKind,
+		instanceset.WorkloadsInstanceLabelKey:  "vlk",
+		constant.RoleLabelKey:                  "leader",
+	})
+	versionedPeer.Annotations = map[string]string{
+		constant.LastRoleAuthoritativeVersionAnnotationKey: "3",
+	}
+	singleTokenPod := roleEventPod("default", "vlk-2", "uid-2", map[string]string{
+		instanceset.WorkloadsInstanceLabelKey: "vlk",
+	})
+	event := roleProbeEvent("default", "event-1", singleTokenPod, "follower", time.Now())
+	cli := roleEventFakeClient(t, its, versionedPeer, singleTokenPod, event)
+
+	if handled := handleRoleEvent(t, ctx, cli, event); !handled {
+		t.Fatalf("expected event to be handled")
+	}
+
+	wantSingleToken := fmt.Sprintf("%d", event.EventTime.UnixMicro())
+	assertPodRole(t, ctx, cli, singleTokenPod, "follower", wantSingleToken)
+	// Versioned peer untouched (cleanup only runs for exclusive roles).
+	assertPodRole(t, ctx, cli, versionedPeer, "leader", "")
+	assertPodLastRoleAuthoritativeVersion(t, ctx, cli, versionedPeer, "3")
+}
+
+// A single-token exclusive event still runs normally when no peer holds the
+// exclusive role with a versioned annotation. This pins that the guard
+// only fires in mixed-mode coexistence.
+func TestRoleEventHandlerSingleTokenExclusiveEventAcceptedWhenNoVersionedPeerHoldsRole(t *testing.T) {
+	ctx := context.Background()
+	leader := workloads.ReplicaRole{Name: "leader", IsExclusive: true}
+	follower := workloads.ReplicaRole{Name: "follower"}
+	its := &workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "vlk"},
+		Spec:       workloads.InstanceSetSpec{Roles: []workloads.ReplicaRole{leader, follower}},
+	}
+	// peer holds leader but only via single-token annotation, no versioned annotation
+	singleTokenPeer := roleEventPod("default", "vlk-1", "uid-1", map[string]string{
+		constant.AppManagedByLabelKey:          constant.AppName,
+		instanceset.WorkloadsManagedByLabelKey: workloads.InstanceSetKind,
+		instanceset.WorkloadsInstanceLabelKey:  "vlk",
+		constant.RoleLabelKey:                  "leader",
+	})
+	singleTokenPeer.Annotations = map[string]string{
+		constant.LastRoleEventVersionAnnotationKey: "1000000",
+	}
+	singleTokenPod := roleEventPod("default", "vlk-0", "uid-0", map[string]string{
+		instanceset.WorkloadsInstanceLabelKey: "vlk",
+	})
+	now := time.Unix(0, 2000000*int64(time.Microsecond))
+	event := roleProbeEvent("default", "event-1", singleTokenPod, "leader", now)
+	cli := roleEventFakeClient(t, its, singleTokenPeer, singleTokenPod, event)
+
+	if handled := handleRoleEvent(t, ctx, cli, event); !handled {
+		t.Fatalf("expected event to be handled")
+	}
+
+	wantSingleToken := fmt.Sprintf("%d", event.EventTime.UnixMicro())
+	assertPodRole(t, ctx, cli, singleTokenPod, "leader", wantSingleToken)
+	// single-token peer stripped + single-token annotation stamped per the
+	// single-token-path one-way ratchet contract.
+	assertPodRole(t, ctx, cli, singleTokenPeer, "", wantSingleToken)
+}
+
+func TestRoleEventHandlerVersionedExclusiveEventBlockedByPeerWithNewerVersionedVersion(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+	leader := workloads.ReplicaRole{Name: "leader", IsExclusive: true}
+	follower := workloads.ReplicaRole{Name: "follower"}
+	its := &workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "vlk"},
+		Spec:       workloads.InstanceSetSpec{Roles: []workloads.ReplicaRole{leader, follower}},
+	}
+	versionedPeer := roleEventPod("default", "vlk-1", "uid-1", map[string]string{
+		constant.AppManagedByLabelKey:          constant.AppName,
+		instanceset.WorkloadsManagedByLabelKey: workloads.InstanceSetKind,
+		instanceset.WorkloadsInstanceLabelKey:  "vlk",
+		constant.RoleLabelKey:                  "leader",
+	})
+	versionedPeer.Annotations = map[string]string{
+		constant.LastRoleAuthoritativeVersionAnnotationKey: "5",
+	}
+	versionedPod := roleEventPod("default", "vlk-0", "uid-0", map[string]string{
+		instanceset.WorkloadsInstanceLabelKey: "vlk",
+	})
+	versionedPod.Annotations = map[string]string{
+		constant.LastRoleAuthoritativeVersionAnnotationKey: "3",
+	}
+	event := roleProbeEventWithOutput("default", "event-1", versionedPod, "leader 4", now)
+	cli := roleEventFakeClient(t, its, versionedPeer, versionedPod, event)
+
+	if handled := handleRoleEvent(t, ctx, cli, event); !handled {
+		t.Fatalf("expected event to be handled (skipped + reason=stalePeerRoleEventVersion)")
+	}
+
+	assertPodRole(t, ctx, cli, versionedPod, "", "")
+	assertPodLastRoleAuthoritativeVersion(t, ctx, cli, versionedPod, "3")
+	assertPodRole(t, ctx, cli, versionedPeer, "leader", "")
+	assertPodLastRoleAuthoritativeVersion(t, ctx, cli, versionedPeer, "5")
+}
+
+// Versioned events for an exclusive role are not affected by the
+// single-token-only versioned-held-peer guard: a versioned event from one pod is
+// allowed to take the role from an older versioned peer (and cleanup will
+// strip the peer label as usual, gated by the versioned-version comparison).
+func TestRoleEventHandlerVersionedExclusiveEventNotBlockedByVersionedPeerGuard(t *testing.T) {
+	ctx := context.Background()
+	now := time.Now()
+	leader := workloads.ReplicaRole{Name: "leader", IsExclusive: true}
+	follower := workloads.ReplicaRole{Name: "follower"}
+	its := &workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "vlk"},
+		Spec:       workloads.InstanceSetSpec{Roles: []workloads.ReplicaRole{leader, follower}},
+	}
+	versionedPeer := roleEventPod("default", "vlk-2", "uid-2", map[string]string{
+		constant.AppManagedByLabelKey:          constant.AppName,
+		instanceset.WorkloadsManagedByLabelKey: workloads.InstanceSetKind,
+		instanceset.WorkloadsInstanceLabelKey:  "vlk",
+		constant.RoleLabelKey:                  "leader",
+	})
+	versionedPeer.Annotations = map[string]string{
+		constant.LastRoleAuthoritativeVersionAnnotationKey: "3",
+	}
+	versionedPod := roleEventPod("default", "vlk-3", "uid-3", map[string]string{
+		instanceset.WorkloadsInstanceLabelKey: "vlk",
+	})
+	event := roleProbeEventWithOutput("default", "event-1", versionedPod, "leader 5", now)
+	cli := roleEventFakeClient(t, its, versionedPeer, versionedPod, event)
+
+	if handled := handleRoleEvent(t, ctx, cli, event); !handled {
+		t.Fatalf("expected event to be handled")
+	}
+
+	assertPodRole(t, ctx, cli, versionedPod, "leader", "")
+	assertPodLastRoleAuthoritativeVersion(t, ctx, cli, versionedPod, "5")
+	// Peer label stripped by versioned-path cleanup (authoritative role version 5 > peer's 3).
+	assertPodRole(t, ctx, cli, versionedPeer, "", "")
+	// Peer versioned annotation untouched per the V1 fix.
+	assertPodLastRoleAuthoritativeVersion(t, ctx, cli, versionedPeer, "3")
+}
+
+// Regression for the prior V1 round: after versioned-path cleanup strips the
+// old primary's label, the old primary's own next roleProbe event at the
+// same versioned epoch must be accepted. With per-path keys this is enforced
+// directly by acceptRoleProbeEvent: the peer's annotation stays at the older
+// version so a same-epoch secondary event from the peer is strictly newer.
+func TestRoleEventVersionedCleanupLeavesPeerAbleToAcceptItsOwnSameEpochSecondaryEvent(t *testing.T) {
+	pod := podWithAnnotations(map[string]string{
+		constant.LastRoleAuthoritativeVersionAnnotationKey: "0",
+	})
+	parsed := versionedRoleProbeOutput("secondary", 1)
+	if !acceptRoleProbeEvent(pod, "0", parsed) {
+		t.Fatalf("expected peer to accept same-epoch secondary event")
+	}
 }
 
 func TestRoleEventHandlerHandlesInstanceRoleWithoutExclusiveCleanup(t *testing.T) {
@@ -185,6 +591,7 @@ func TestRoleEventHandlerConsumesInvalidProbeMessageWithoutPodUpdate(t *testing.
 
 	assertPodRole(t, ctx, cli, pod, "leader", "")
 	assertPodLastRoleVersion(t, ctx, cli, pod, "")
+	assertPodLastRoleAuthoritativeVersion(t, ctx, cli, pod, "")
 }
 
 func TestRoleEventHandlerConsumesProbeFailureWithoutPodUpdate(t *testing.T) {
@@ -202,6 +609,31 @@ func TestRoleEventHandlerConsumesProbeFailureWithoutPodUpdate(t *testing.T) {
 
 	assertPodRole(t, ctx, cli, pod, "leader", "")
 	assertPodLastRoleVersion(t, ctx, cli, pod, "")
+	assertPodLastRoleAuthoritativeVersion(t, ctx, cli, pod, "")
+}
+
+func TestRoleEventHandlerRejectsMalformedRoleProbeOutput(t *testing.T) {
+	ctx := context.Background()
+	pod := roleEventPod("default", "mysql-0", "uid-0", map[string]string{
+		constant.KBAppInstanceNameLabelKey: "mysql-0",
+		constant.RoleLabelKey:              "leader",
+	})
+	inst := &workloads.Instance{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "mysql-0"},
+		Spec:       workloads.InstanceSpec{Roles: []workloads.ReplicaRole{{Name: "leader"}, {Name: "follower"}}},
+	}
+	event := roleProbeEventWithOutput("default", "event-1", pod, "follower abc", time.Now())
+	cli := roleEventFakeClient(t, inst, pod, event)
+
+	if handled := handleRoleEvent(t, ctx, cli, event); !handled {
+		t.Fatalf("expected event to be handled")
+	}
+
+	// Role label must not change; both annotations must stay empty since
+	// malformed output is rejected before any write.
+	assertPodRole(t, ctx, cli, pod, "leader", "")
+	assertPodLastRoleVersion(t, ctx, cli, pod, "")
+	assertPodLastRoleAuthoritativeVersion(t, ctx, cli, pod, "")
 }
 
 func TestRoleEventHandlerConsumesStalePodUIDWithoutPodUpdate(t *testing.T) {
@@ -220,6 +652,7 @@ func TestRoleEventHandlerConsumesStalePodUIDWithoutPodUpdate(t *testing.T) {
 
 	assertPodRole(t, ctx, cli, pod, "leader", "")
 	assertPodLastRoleVersion(t, ctx, cli, pod, "")
+	assertPodLastRoleAuthoritativeVersion(t, ctx, cli, pod, "")
 }
 
 func TestRoleEventHandlerConsumesPodNotFound(t *testing.T) {
@@ -269,6 +702,7 @@ func TestRoleEventHandlerConsumesMissingWorkloadWithoutPodUpdate(t *testing.T) {
 
 			assertPodRole(t, ctx, cli, pod, "leader", "")
 			assertPodLastRoleVersion(t, ctx, cli, pod, "")
+			assertPodLastRoleAuthoritativeVersion(t, ctx, cli, pod, "")
 		})
 	}
 }
@@ -316,6 +750,12 @@ func roleEventPod(namespace, name, uid string, labels map[string]string) *corev1
 	return pod
 }
 
+func podWithAnnotations(annotations map[string]string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Annotations: annotations},
+	}
+}
+
 func setControllerRef(obj client.Object, apiVersion, kind, name string) {
 	controller := true
 	obj.SetOwnerReferences([]metav1.OwnerReference{{
@@ -329,6 +769,31 @@ func setControllerRef(obj client.Object, apiVersion, kind, name string) {
 
 func roleProbeEvent(namespace, name string, pod *corev1.Pod, role string, eventTime time.Time) *corev1.Event {
 	return roleProbeEventWithCode(namespace, name, pod, role, eventTime, 0, "")
+}
+
+func roleProbeEventWithOutput(namespace, name string, pod *corev1.Pod, output string, eventTime time.Time) *corev1.Event {
+	message, err := json.Marshal(proto.ProbeEvent{
+		Probe:  "roleProbe",
+		Code:   0,
+		Output: []byte(output),
+	})
+	if err != nil {
+		panic(err)
+	}
+	return builder.NewEventBuilder(namespace, name).
+		SetInvolvedObject(corev1.ObjectReference{
+			APIVersion: "v1",
+			Kind:       "Pod",
+			Namespace:  pod.Namespace,
+			Name:       pod.Name,
+			UID:        pod.UID,
+			FieldPath:  proto.ProbeEventFieldPath,
+		}).
+		SetReason("roleProbe").
+		SetMessage(string(message)).
+		SetReportingController(proto.ProbeEventReportingController).
+		SetEventTime(metav1.NewMicroTime(eventTime)).
+		GetObject()
 }
 
 func roleProbeEventWithCode(namespace, name string, pod *corev1.Pod, role string, eventTime time.Time, code int32, messageText string) *corev1.Event {
@@ -357,6 +822,14 @@ func roleProbeEventWithCode(namespace, name string, pod *corev1.Pod, role string
 		GetObject()
 }
 
+func versionedRoleProbeOutput(role string, version uint64) roleProbeOutput {
+	return roleProbeOutput{
+		role:                    role,
+		authoritativeVersion:    version,
+		hasAuthoritativeVersion: true,
+	}
+}
+
 func assertPodRole(t *testing.T, ctx context.Context, cli client.Client, pod *corev1.Pod, role, version string) {
 	t.Helper()
 	var stored corev1.Pod
@@ -371,7 +844,7 @@ func assertPodRole(t *testing.T, ctx context.Context, cli client.Client, pod *co
 		t.Fatalf("expected role %q, got %q", role, stored.Labels[constant.RoleLabelKey])
 	}
 	if version != "" && stored.Annotations[constant.LastRoleEventVersionAnnotationKey] != version {
-		t.Fatalf("expected version %q, got %q", version, stored.Annotations[constant.LastRoleEventVersionAnnotationKey])
+		t.Fatalf("expected single-token version %q, got %q", version, stored.Annotations[constant.LastRoleEventVersionAnnotationKey])
 	}
 }
 
@@ -382,6 +855,17 @@ func assertPodLastRoleVersion(t *testing.T, ctx context.Context, cli client.Clie
 		t.Fatalf("get pod failed: %v", err)
 	}
 	if stored.Annotations[constant.LastRoleEventVersionAnnotationKey] != version {
-		t.Fatalf("expected version %q, got %q", version, stored.Annotations[constant.LastRoleEventVersionAnnotationKey])
+		t.Fatalf("expected single-token version %q, got %q", version, stored.Annotations[constant.LastRoleEventVersionAnnotationKey])
+	}
+}
+
+func assertPodLastRoleAuthoritativeVersion(t *testing.T, ctx context.Context, cli client.Client, pod *corev1.Pod, version string) {
+	t.Helper()
+	var stored corev1.Pod
+	if err := cli.Get(ctx, client.ObjectKeyFromObject(pod), &stored); err != nil {
+		t.Fatalf("get pod failed: %v", err)
+	}
+	if stored.Annotations[constant.LastRoleAuthoritativeVersionAnnotationKey] != version {
+		t.Fatalf("expected authoritative role version %q, got %q", version, stored.Annotations[constant.LastRoleAuthoritativeVersionAnnotationKey])
 	}
 }

--- a/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
@@ -8478,9 +8478,30 @@ spec:
                       Without this, services that rely on roleSelectors might improperly direct traffic to wrong replicas.
 
                       Expected output of this action:
-                      - On Success: The determined role of the replica, which must align with one of the roles specified
-                        in the component definition.
-                      - On Failure: An error message, if applicable, indicating why the action failed.
+                        - On Success: The determined role of the replica, which must align with one of the roles
+                          specified in the component definition. Stdout MUST be one of the two forms below:
+
+                            <role>                  // single-token form
+                            <role> <roleVersion>    // versioned form
+
+                          The two tokens are separated by whitespace (spaces, tabs, or newlines).
+                          <roleVersion> is an optional unsigned 64-bit decimal integer that
+                          carries the component's authoritative role version for stale-role
+                          handling, especially stale exclusive-role claims. A versioned
+                          result is accepted only when its <roleVersion> is newer than the
+                          versioned result the controller has already accepted for this Pod.
+                          The version should represent the complete role fact. For an
+                          exclusive primary role, identical versions reported by different
+                          replicas must not describe contradictory primary ownership.
+                          <role> remains a valid single-token form. Stdout that looks
+                          versioned but whose second token is not an unsigned 64-bit decimal
+                          integer, or stdout with three or more whitespace-separated tokens,
+                          is rejected as malformed and the Pod's role label is not updated.
+                          A component may migrate a Pod from the single-token form to the
+                          versioned form. After a Pod has reported the versioned form,
+                          later single-token results from that Pod are ignored to avoid
+                          downgrading from authoritative role-version ordering.
+                        - On Failure: An error message, if applicable, indicating why the action failed.
 
                       Note: This field is immutable once it has been set.
                     properties:

--- a/docs/developer_docs/api-reference/cluster.md
+++ b/docs/developer_docs/api-reference/cluster.md
@@ -6020,9 +6020,31 @@ which initiates an update of the replica&rsquo;s role.</p>
 It ensures replicas are correctly labeled with their respective roles.
 Without this, services that rely on roleSelectors might improperly direct traffic to wrong replicas.</p>
 <p>Expected output of this action:
-- On Success: The determined role of the replica, which must align with one of the roles specified
-  in the component definition.
-- On Failure: An error message, if applicable, indicating why the action failed.</p>
+  - On Success: The determined role of the replica, which must align with one of the roles
+specified in the component definition. Stdout MUST be one of the two forms below:</p>
+<pre><code>  &lt;role&gt;                  // single-token form
+  &lt;role&gt; &lt;roleVersion&gt;    // versioned form
+The two tokens are separated by whitespace (spaces, tabs, or newlines).
+&lt;roleVersion&gt; is an optional unsigned 64-bit decimal integer that
+carries the component's authoritative role version for stale-role
+handling, especially stale exclusive-role claims. A versioned
+result is accepted only when its &lt;roleVersion&gt; is newer than the
+versioned result the controller has already accepted for this Pod.
+The version should represent the complete role fact. For an
+exclusive primary role, identical versions reported by different
+replicas must not describe contradictory primary ownership.
+&lt;role&gt; remains a valid single-token form. Stdout that looks
+versioned but whose second token is not an unsigned 64-bit decimal
+integer, or stdout with three or more whitespace-separated tokens,
+is rejected as malformed and the Pod's role label is not updated.
+A component may migrate a Pod from the single-token form to the
+versioned form. After a Pod has reported the versioned form,
+later single-token results from that Pod are ignored to avoid
+downgrading from authoritative role-version ordering.
+</code></pre>
+<ul>
+<li>On Failure: An error message, if applicable, indicating why the action failed.</li>
+</ul>
 <p>Note: This field is immutable once it has been set.</p>
 </td>
 </tr>

--- a/pkg/constant/annotations.go
+++ b/pkg/constant/annotations.go
@@ -37,8 +37,19 @@ const (
 
 	KBAppClusterUIDKey                = "apps.kubeblocks.io/cluster-uid"
 	BackupPolicyTemplateAnnotationKey = "apps.kubeblocks.io/backup-policy-template"
+	// LastRoleEventVersionAnnotationKey records the EventTime micros of the
+	// most recent single-token roleProbe result the controller accepted on a
+	// Pod. It is the staleness anchor for the `<role>` stdout form;
+	// versioned stdout (`<role> <roleVersion>`) is tracked separately via
+	// LastRoleAuthoritativeVersionAnnotationKey.
 	LastRoleEventVersionAnnotationKey = "apps.kubeblocks.io/last-role-snapshot-version"
-	ComponentScaleInAnnotationKey     = "apps.kubeblocks.io/component-scale-in" // ComponentScaleInAnnotationKey specifies whether the component is scaled in
+	// LastRoleAuthoritativeVersionAnnotationKey records the authoritative uint64
+	// roleVersion from the most recent versioned roleProbe result the
+	// controller accepted on a Pod. The two annotation keys never share
+	// semantics: single-token results read/write only the EventTime key and
+	// versioned results read/write only the roleVersion key.
+	LastRoleAuthoritativeVersionAnnotationKey = "apps.kubeblocks.io/last-role-authoritative-version"
+	ComponentScaleInAnnotationKey             = "apps.kubeblocks.io/component-scale-in" // ComponentScaleInAnnotationKey specifies whether the component is scaled in
 
 	// SkipPreTerminateAnnotationKey specifies to skip the pre-terminate action for a component.
 	SkipPreTerminateAnnotationKey = "apps.kubeblocks.io/skip-pre-terminate"


### PR DESCRIPTION
Backport of #10283 (merged commit `c1a814cb8`) to `release-1.1`.

Auto-cherry-pick to `release-1.1` did not produce a PR. Manual cherry-pick succeeded cleanly with no conflicts.

(Replaces #10302 which used a branch name that did not match the `bugfix/|feature/|release/|hotfix/` PR Pre-Check standard.)

## Summary

Re-applies the versioned roleProbe contract on the unified `controllers/workloads/role_event_handler.go`:

- `roleProbe` action stdout supports two forms: `<role>` (single-token) and `<role> <roleVersion>` (versioned with authoritative role version).
- Strict-newer ordering for versioned events; same-Pod commit-to-versioned-form rule blocks single-token downgrade after a versioned result.
- Versioned exclusive-role gate at the Pod level (`acceptRoleProbeEvent`) and at the peer level (`newerOrEqualVersionedExclusiveRoleHeldByPeer` / `versionedPeerHoldsExclusiveRole`) protects against same-version peer collisions.
- Per-path peer cleanup: single-token path stamps peer `LastRoleEventVersionAnnotationKey`; versioned path leaves peer `LastRoleAuthoritativeVersionAnnotationKey` untouched.
- `result.Version` carries the single-token event timestamp; helpers reuse it directly.

## Validation

- `go test ./controllers/workloads -count=1 -run '^TestParseRoleProbeOutput|^TestAcceptRoleProbeEvent|^TestRoleEventHandler'` PASS (35 specs) locally on this cherry-pick on top of `release-1.1`.
- `go vet ./controllers/workloads/...` clean.
- `git diff --check` clean.

## Boundary

This is a backport-only PR. The release-ready closure of the Valkey Bug B live scenario still requires the v3 addon (Sentinel quorum) plus multi-round stable+failover soak with this controller image, independent of merging this backport.