### PR TITLE
fix(operations): rebuild no-backup instances via fresh PVCs

### DIFF
--- a/pkg/operations/rebuild_instance.go
+++ b/pkg/operations/rebuild_instance.go
@@ -293,6 +293,13 @@ func (r rebuildInstanceOpsHandler) rebuildInstanceInPlace(reqCtx intctrlutil.Req
 	}
 	inPlaceHelper, err := r.prepareInplaceRebuildHelper(reqCtx, cli, opsRes, rebuildFrom, instance, index)
 	if err != nil {
+		if rebuildFrom.BackupName == "" && progressDetail.Message == waitingForDynamicPVCMessage && apierrors.IsNotFound(err) {
+			inPlaceHelper, err = r.prepareNoBackupRebuildHelperWithoutTargetPod(reqCtx, cli, opsRes, rebuildFrom, instance, index)
+			if err != nil {
+				return false, err
+			}
+			return inPlaceHelper.rebuildInstanceWithNoBackup(reqCtx, cli, opsRes, progressDetail)
+		}
 		return false, err
 	}
 
@@ -622,6 +629,36 @@ func (r rebuildInstanceOpsHandler) prepareInplaceRebuildHelper(reqCtx intctrluti
 		volumeMounts:           volumeMounts,
 		rebuildPrefix:          rebuildPrefix,
 		envForRestore:          rebuildInstance.RestoreEnv,
+	}, nil
+}
+
+func (r rebuildInstanceOpsHandler) prepareNoBackupRebuildHelperWithoutTargetPod(reqCtx intctrlutil.RequestCtx,
+	cli client.Client,
+	opsRes *OpsResource,
+	rebuildInstance opsv1alpha1.RebuildInstance,
+	instance opsv1alpha1.Instance,
+	index int) (*inplaceRebuildHelper, error) {
+	synthesizedComp, err := r.buildSynthesizedComponent(reqCtx.Ctx, cli, opsRes.Cluster, rebuildInstance.ComponentName)
+	if err != nil {
+		return nil, err
+	}
+	rebuildPrefix := fmt.Sprintf("rebuild-%s", opsRes.OpsRequest.UID[:8])
+	pvcMap, err := buildDynamicSourcePVCMap(opsRes, synthesizedComp, instance.Name, rebuildPrefix, index)
+	if err != nil {
+		return nil, err
+	}
+	return &inplaceRebuildHelper{
+		index:           index,
+		instance:        instance,
+		synthesizedComp: synthesizedComp,
+		pvcMap:          pvcMap,
+		targetPod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      instance.Name,
+				Namespace: opsRes.Cluster.Namespace,
+			},
+		},
+		rebuildPrefix: rebuildPrefix,
 	}, nil
 }
 

--- a/pkg/operations/rebuild_instance.go
+++ b/pkg/operations/rebuild_instance.go
@@ -293,13 +293,6 @@ func (r rebuildInstanceOpsHandler) rebuildInstanceInPlace(reqCtx intctrlutil.Req
 	}
 	inPlaceHelper, err := r.prepareInplaceRebuildHelper(reqCtx, cli, opsRes, rebuildFrom, instance, index)
 	if err != nil {
-		if rebuildFrom.BackupName == "" && progressDetail.Message != waitingForInstanceReadyMessage && apierrors.IsNotFound(err) {
-			inPlaceHelper, err = r.prepareNoBackupRebuildHelperWithoutTargetPod(reqCtx, cli, opsRes, rebuildFrom, instance, index)
-			if err != nil {
-				return false, err
-			}
-			return inPlaceHelper.rebuildInstanceWithNoBackup(reqCtx, cli, opsRes, progressDetail)
-		}
 		return false, err
 	}
 
@@ -612,7 +605,7 @@ func (r rebuildInstanceOpsHandler) prepareInplaceRebuildHelper(reqCtx intctrluti
 		return nil, err
 	}
 	rebuildPrefix := fmt.Sprintf("rebuild-%s", opsRes.OpsRequest.UID[:8])
-	pvcMap, volumes, volumeMounts, err := getPVCMapAndVolumes(opsRes, synthesizedComp, targetPod, rebuildPrefix, index)
+	pvcMap, volumes, volumeMounts, err := getPVCMapAndVolumes(opsRes, synthesizedComp, targetPod, rebuildPrefix, index, rebuildInstance.BackupName == "")
 	if err != nil {
 		return nil, err
 	}
@@ -629,36 +622,6 @@ func (r rebuildInstanceOpsHandler) prepareInplaceRebuildHelper(reqCtx intctrluti
 		volumeMounts:           volumeMounts,
 		rebuildPrefix:          rebuildPrefix,
 		envForRestore:          rebuildInstance.RestoreEnv,
-	}, nil
-}
-
-func (r rebuildInstanceOpsHandler) prepareNoBackupRebuildHelperWithoutTargetPod(reqCtx intctrlutil.RequestCtx,
-	cli client.Client,
-	opsRes *OpsResource,
-	rebuildInstance opsv1alpha1.RebuildInstance,
-	instance opsv1alpha1.Instance,
-	index int) (*inplaceRebuildHelper, error) {
-	synthesizedComp, err := r.buildSynthesizedComponent(reqCtx.Ctx, cli, opsRes.Cluster, rebuildInstance.ComponentName)
-	if err != nil {
-		return nil, err
-	}
-	rebuildPrefix := fmt.Sprintf("rebuild-%s", opsRes.OpsRequest.UID[:8])
-	pvcMap, err := buildDynamicSourcePVCMap(opsRes, synthesizedComp, instance.Name, rebuildPrefix, index)
-	if err != nil {
-		return nil, err
-	}
-	return &inplaceRebuildHelper{
-		index:           index,
-		instance:        instance,
-		synthesizedComp: synthesizedComp,
-		pvcMap:          pvcMap,
-		targetPod: &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      instance.Name,
-				Namespace: opsRes.Cluster.Namespace,
-			},
-		},
-		rebuildPrefix: rebuildPrefix,
 	}, nil
 }
 

--- a/pkg/operations/rebuild_instance.go
+++ b/pkg/operations/rebuild_instance.go
@@ -293,7 +293,7 @@ func (r rebuildInstanceOpsHandler) rebuildInstanceInPlace(reqCtx intctrlutil.Req
 	}
 	inPlaceHelper, err := r.prepareInplaceRebuildHelper(reqCtx, cli, opsRes, rebuildFrom, instance, index)
 	if err != nil {
-		if rebuildFrom.BackupName == "" && progressDetail.Message == waitingForDynamicPVCMessage && apierrors.IsNotFound(err) {
+		if rebuildFrom.BackupName == "" && progressDetail.Message != waitingForInstanceReadyMessage && apierrors.IsNotFound(err) {
 			inPlaceHelper, err = r.prepareNoBackupRebuildHelperWithoutTargetPod(reqCtx, cli, opsRes, rebuildFrom, instance, index)
 			if err != nil {
 				return false, err

--- a/pkg/operations/rebuild_instance.go
+++ b/pkg/operations/rebuild_instance.go
@@ -285,12 +285,6 @@ func (r rebuildInstanceOpsHandler) rebuildInstanceInPlace(reqCtx intctrlutil.Req
 	rebuildFrom opsv1alpha1.RebuildInstance,
 	instance opsv1alpha1.Instance,
 	index int) (bool, error) {
-	if progressDetail.Message == waitingForInstanceReadyMessage {
-		targetPod := &corev1.Pod{}
-		if err := cli.Get(reqCtx.Ctx, client.ObjectKey{Name: instance.Name, Namespace: opsRes.Cluster.Namespace}, targetPod); err != nil {
-			return false, client.IgnoreNotFound(err)
-		}
-	}
 	inPlaceHelper, err := r.prepareInplaceRebuildHelper(reqCtx, cli, opsRes, rebuildFrom, instance, index)
 	if err != nil {
 		return false, err

--- a/pkg/operations/rebuild_instance.go
+++ b/pkg/operations/rebuild_instance.go
@@ -285,6 +285,12 @@ func (r rebuildInstanceOpsHandler) rebuildInstanceInPlace(reqCtx intctrlutil.Req
 	rebuildFrom opsv1alpha1.RebuildInstance,
 	instance opsv1alpha1.Instance,
 	index int) (bool, error) {
+	if progressDetail.Message == waitingForInstanceReadyMessage {
+		targetPod := &corev1.Pod{}
+		if err := cli.Get(reqCtx.Ctx, client.ObjectKey{Name: instance.Name, Namespace: opsRes.Cluster.Namespace}, targetPod); err != nil {
+			return false, client.IgnoreNotFound(err)
+		}
+	}
 	inPlaceHelper, err := r.prepareInplaceRebuildHelper(reqCtx, cli, opsRes, rebuildFrom, instance, index)
 	if err != nil {
 		return false, err

--- a/pkg/operations/rebuild_instance_inplace.go
+++ b/pkg/operations/rebuild_instance_inplace.go
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package operations
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -46,11 +47,13 @@ import (
 )
 
 const (
-	rebuildFromAnnotation           = "operations.kubeblocks.io/rebuild-from"
-	rebuildTmpPVCNameLabel          = "operations.kubeblocks.io/rebuild-tmp-pvc"
-	sourcePVReclaimPolicyAnnotation = "operations.kubeblocks.io/source-reclaim-policy"
+	rebuildFromAnnotation                = "operations.kubeblocks.io/rebuild-from"
+	rebuildTmpPVCNameLabel               = "operations.kubeblocks.io/rebuild-tmp-pvc"
+	rebuildSourcePVCIdentitiesAnnotation = "operations.kubeblocks.io/rebuild-source-pvc-identities"
+	sourcePVReclaimPolicyAnnotation      = "operations.kubeblocks.io/source-reclaim-policy"
 
 	waitingForInstanceReadyMessage   = "Waiting for the rebuilding instance to be ready"
+	waitingForDynamicPVCMessage      = "Waiting for source PVCs to be dynamically reprovisioned"
 	waitingForPostReadyRestorePrefix = "Waiting for postReady Restore"
 
 	ignoreRoleCheckAnnotationKey = "operations.kubeblocks.io/ignore-role-check"
@@ -77,17 +80,14 @@ func (inPlaceHelper *inplaceRebuildHelper) rebuildInstanceWithNoBackup(reqCtx in
 	cli client.Client,
 	opsRes *OpsResource,
 	progressDetail *opsv1alpha1.ProgressStatusDetail) (bool, error) {
-	// 1. restore the new pvs.
-	completed, err := inPlaceHelper.rebuildInstancePVByPod(reqCtx, cli, opsRes, progressDetail)
-	if err != nil || !completed {
-		return false, err
-	}
 	if progressDetail.Message != waitingForInstanceReadyMessage {
-		// 2. rebuild source pvcs and recreate the instance by deleting it.
-		return false, inPlaceHelper.rebuildSourcePVCsAndRecreateInstance(reqCtx, cli, opsRes.OpsRequest, progressDetail)
+		// no-backup rebuild has no data source to restore. Recreate the source
+		// PVC from the current workload template instead of building helper
+		// tmp PVCs/PVs that cannot carry backup data.
+		return false, inPlaceHelper.rebuildSourcePVCsByDynamicProvision(reqCtx, cli, opsRes.OpsRequest, progressDetail)
 	}
 
-	// 3. waiting for new instance is available.
+	// waiting for new instance is available.
 	return instanceIsAvailable(inPlaceHelper.synthesizedComp, inPlaceHelper.targetPod, opsRes.OpsRequest.Annotations[ignoreRoleCheckAnnotationKey])
 }
 
@@ -434,6 +434,138 @@ func (inPlaceHelper *inplaceRebuildHelper) rebuildSourcePVCsAndRecreateInstance(
 	}
 
 	progressDetail.Message = waitingForInstanceReadyMessage
+	return nil
+}
+
+type rebuildSourcePVCIdentity struct {
+	UID        string `json:"uid,omitempty"`
+	VolumeName string `json:"volumeName,omitempty"`
+}
+
+func (inPlaceHelper *inplaceRebuildHelper) rebuildSourcePVCsByDynamicProvision(reqCtx intctrlutil.RequestCtx,
+	cli client.Client,
+	opsRequest *opsv1alpha1.OpsRequest,
+	progressDetail *opsv1alpha1.ProgressStatusDetail) error {
+	itsName := constant.GenerateWorkloadNamePattern(inPlaceHelper.synthesizedComp.ClusterName, inPlaceHelper.synthesizedComp.Name)
+
+	sourcePVCIdentities, err := getRecordedSourcePVCIdentities(opsRequest)
+	if err != nil {
+		return err
+	}
+	waitingForSourcePVC := false
+	for sourcePVCName, builtTmpPVC := range inPlaceHelper.pvcMap {
+		sourcePVC, err := inPlaceHelper.getSourcePVC(reqCtx, cli, sourcePVCName, builtTmpPVC.Namespace)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				waitingForSourcePVC = true
+				continue
+			}
+			return err
+		}
+		if sourcePVC.DeletionTimestamp != nil {
+			waitingForSourcePVC = true
+			if err := inPlaceHelper.removePVCFinalizer(reqCtx, cli, sourcePVC); err != nil {
+				return err
+			}
+			continue
+		}
+		oldIdentity := sourcePVCIdentities[sourcePVCName]
+		if oldIdentity.UID == "" {
+			if err := inPlaceHelper.recordSourcePVCIdentityOnOpsRequest(reqCtx, cli, opsRequest, sourcePVC); err != nil {
+				return err
+			}
+			oldIdentity = rebuildSourcePVCIdentity{UID: string(sourcePVC.UID), VolumeName: sourcePVC.Spec.VolumeName}
+			sourcePVCIdentities[sourcePVCName] = oldIdentity
+		}
+		if string(sourcePVC.UID) == oldIdentity.UID {
+			waitingForSourcePVC = true
+			if err := inPlaceHelper.deleteSourcePVCForRebuild(reqCtx, cli, sourcePVC); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := inPlaceHelper.validateDynamicSourcePVC(sourcePVC, builtTmpPVC, oldIdentity); err != nil {
+			return err
+		}
+		if sourcePVC.Status.Phase != corev1.ClaimBound {
+			waitingForSourcePVC = true
+			continue
+		}
+	}
+	if waitingForSourcePVC {
+		progressDetail.Message = waitingForDynamicPVCMessage
+		return nil
+	}
+	if err := inPlaceHelper.setInstanceNodeSelectorForRebuild(reqCtx, cli, itsName); err != nil {
+		return err
+	}
+	if err := inPlaceHelper.deleteTargetPodForRebuild(reqCtx, cli, opsRequest); err != nil {
+		return err
+	}
+
+	progressDetail.Message = waitingForInstanceReadyMessage
+	return nil
+}
+
+func getRecordedSourcePVCIdentities(opsRequest *opsv1alpha1.OpsRequest) (map[string]rebuildSourcePVCIdentity, error) {
+	sourcePVCIdentities := map[string]rebuildSourcePVCIdentity{}
+	if opsRequest.Annotations == nil || opsRequest.Annotations[rebuildSourcePVCIdentitiesAnnotation] == "" {
+		return sourcePVCIdentities, nil
+	}
+	if err := json.Unmarshal([]byte(opsRequest.Annotations[rebuildSourcePVCIdentitiesAnnotation]), &sourcePVCIdentities); err != nil {
+		return nil, err
+	}
+	return sourcePVCIdentities, nil
+}
+
+func (inPlaceHelper *inplaceRebuildHelper) recordSourcePVCIdentityOnOpsRequest(reqCtx intctrlutil.RequestCtx,
+	cli client.Client,
+	opsRequest *opsv1alpha1.OpsRequest,
+	sourcePVC *corev1.PersistentVolumeClaim) error {
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		latest := &opsv1alpha1.OpsRequest{}
+		if err := cli.Get(reqCtx.Ctx, types.NamespacedName{Name: opsRequest.Name, Namespace: opsRequest.Namespace}, latest); err != nil {
+			return err
+		}
+		sourcePVCIdentities, err := getRecordedSourcePVCIdentities(latest)
+		if err != nil {
+			return err
+		}
+		if sourcePVCIdentities[sourcePVC.Name].UID != "" {
+			opsRequest.Annotations = latest.Annotations
+			return nil
+		}
+		sourcePVCIdentities[sourcePVC.Name] = rebuildSourcePVCIdentity{UID: string(sourcePVC.UID), VolumeName: sourcePVC.Spec.VolumeName}
+		data, err := json.Marshal(sourcePVCIdentities)
+		if err != nil {
+			return err
+		}
+		patch := client.MergeFrom(latest.DeepCopy())
+		if latest.Annotations == nil {
+			latest.Annotations = map[string]string{}
+		}
+		latest.Annotations[rebuildSourcePVCIdentitiesAnnotation] = string(data)
+		if err := cli.Patch(reqCtx.Ctx, latest, patch); err != nil {
+			return err
+		}
+		opsRequest.Annotations = latest.Annotations
+		return nil
+	})
+}
+
+func (inPlaceHelper *inplaceRebuildHelper) validateDynamicSourcePVC(sourcePVC, builtTmpPVC *corev1.PersistentVolumeClaim, oldIdentity rebuildSourcePVCIdentity) error {
+	for key, expected := range builtTmpPVC.Labels {
+		if expected == "" {
+			continue
+		}
+		if sourcePVC.Labels[key] != expected {
+			return intctrlutil.NewFatalError(fmt.Sprintf(`the source pvc "%s" is not rebuilt from the expected workload template: label "%s" expected "%s", got "%s"`,
+				sourcePVC.Name, key, expected, sourcePVC.Labels[key]))
+		}
+	}
+	if oldIdentity.VolumeName != "" && sourcePVC.Spec.VolumeName != "" && oldIdentity.VolumeName == sourcePVC.Spec.VolumeName {
+		return intctrlutil.NewFatalError(fmt.Sprintf(`the source pvc "%s" is still bound to the old pv "%s"`, sourcePVC.Name, sourcePVC.Spec.VolumeName))
+	}
 	return nil
 }
 

--- a/pkg/operations/rebuild_instance_inplace.go
+++ b/pkg/operations/rebuild_instance_inplace.go
@@ -20,7 +20,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package operations
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -47,13 +46,11 @@ import (
 )
 
 const (
-	rebuildFromAnnotation                = "operations.kubeblocks.io/rebuild-from"
-	rebuildTmpPVCNameLabel               = "operations.kubeblocks.io/rebuild-tmp-pvc"
-	rebuildSourcePVCIdentitiesAnnotation = "operations.kubeblocks.io/rebuild-source-pvc-identities"
-	sourcePVReclaimPolicyAnnotation      = "operations.kubeblocks.io/source-reclaim-policy"
+	rebuildFromAnnotation           = "operations.kubeblocks.io/rebuild-from"
+	rebuildTmpPVCNameLabel          = "operations.kubeblocks.io/rebuild-tmp-pvc"
+	sourcePVReclaimPolicyAnnotation = "operations.kubeblocks.io/source-reclaim-policy"
 
 	waitingForInstanceReadyMessage   = "Waiting for the rebuilding instance to be ready"
-	waitingForDynamicPVCMessage      = "Waiting for source PVCs to be dynamically reprovisioned"
 	waitingForPostReadyRestorePrefix = "Waiting for postReady Restore"
 
 	ignoreRoleCheckAnnotationKey = "operations.kubeblocks.io/ignore-role-check"
@@ -437,198 +434,30 @@ func (inPlaceHelper *inplaceRebuildHelper) rebuildSourcePVCsAndRecreateInstance(
 	return nil
 }
 
-type rebuildSourcePVCIdentity struct {
-	UID        string `json:"uid,omitempty"`
-	VolumeName string `json:"volumeName,omitempty"`
-	Absent     bool   `json:"absent,omitempty"`
-}
-
 func (inPlaceHelper *inplaceRebuildHelper) rebuildSourcePVCsByDynamicProvision(reqCtx intctrlutil.RequestCtx,
 	cli client.Client,
 	opsRequest *opsv1alpha1.OpsRequest,
 	progressDetail *opsv1alpha1.ProgressStatusDetail) error {
 	itsName := constant.GenerateWorkloadNamePattern(inPlaceHelper.synthesizedComp.ClusterName, inPlaceHelper.synthesizedComp.Name)
-
-	sourcePVCIdentities, err := getRecordedSourcePVCIdentities(opsRequest)
-	if err != nil {
+	if err := inPlaceHelper.setInstanceNodeSelectorForRebuild(reqCtx, cli, itsName); err != nil {
 		return err
 	}
-	waitingForSourcePVC := false
-	needDeleteTargetPod := false
-	targetPodDeleted, err := inPlaceHelper.targetPodDeletedForRebuild(reqCtx, cli)
-	if err != nil {
-		return err
-	}
-	if !targetPodDeleted {
-		if err := inPlaceHelper.setInstanceNodeSelectorForRebuild(reqCtx, cli, itsName); err != nil {
-			return err
-		}
-	}
-	for sourcePVCName, builtTmpPVC := range inPlaceHelper.pvcMap {
-		sourcePVC, err := inPlaceHelper.getSourcePVC(reqCtx, cli, sourcePVCName, builtTmpPVC.Namespace)
+	for sourcePVCName, sourcePVCTemplate := range inPlaceHelper.pvcMap {
+		sourcePVC, err := inPlaceHelper.getSourcePVC(reqCtx, cli, sourcePVCName, sourcePVCTemplate.Namespace)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				waitingForSourcePVC = true
-				if sourcePVCIdentities[sourcePVCName].UID == "" && !sourcePVCIdentities[sourcePVCName].Absent {
-					if err := inPlaceHelper.recordSourcePVCAbsentOnOpsRequest(reqCtx, cli, opsRequest, sourcePVCName); err != nil {
-						return err
-					}
-					sourcePVCIdentities[sourcePVCName] = rebuildSourcePVCIdentity{Absent: true}
-				}
-				if !targetPodDeleted {
-					needDeleteTargetPod = true
-				}
 				continue
 			}
 			return err
 		}
-		oldIdentity := sourcePVCIdentities[sourcePVCName]
-		if oldIdentity.UID == "" {
-			if oldIdentity.Absent {
-				if !targetPodDeleted {
-					waitingForSourcePVC = true
-					needDeleteTargetPod = true
-					continue
-				}
-				if sourcePVC.DeletionTimestamp != nil {
-					waitingForSourcePVC = true
-					continue
-				}
-				if err := inPlaceHelper.validateDynamicSourcePVC(sourcePVC, builtTmpPVC, oldIdentity); err != nil {
-					return err
-				}
-				if sourcePVC.Status.Phase != corev1.ClaimBound {
-					waitingForSourcePVC = true
-				}
-				continue
-			}
-			if err := inPlaceHelper.recordSourcePVCIdentityOnOpsRequest(reqCtx, cli, opsRequest, sourcePVC); err != nil {
-				return err
-			}
-			oldIdentity = rebuildSourcePVCIdentity{UID: string(sourcePVC.UID), VolumeName: sourcePVC.Spec.VolumeName}
-			sourcePVCIdentities[sourcePVCName] = oldIdentity
-		}
-		if sourcePVC.DeletionTimestamp != nil {
-			waitingForSourcePVC = true
-			if !targetPodDeleted {
-				needDeleteTargetPod = true
-			}
-			continue
-		}
-		if string(sourcePVC.UID) == oldIdentity.UID {
-			waitingForSourcePVC = true
-			if !targetPodDeleted {
-				needDeleteTargetPod = true
-			}
-			if err := inPlaceHelper.deleteSourcePVCForDynamicProvision(reqCtx, cli, sourcePVC); err != nil {
-				return err
-			}
-			continue
-		}
-		if err := inPlaceHelper.validateDynamicSourcePVC(sourcePVC, builtTmpPVC, oldIdentity); err != nil {
+		if err := inPlaceHelper.deleteSourcePVCForDynamicProvision(reqCtx, cli, sourcePVC); err != nil {
 			return err
 		}
-		if !targetPodDeleted {
-			waitingForSourcePVC = true
-			needDeleteTargetPod = true
-			continue
-		}
-		if sourcePVC.Status.Phase != corev1.ClaimBound {
-			waitingForSourcePVC = true
-			continue
-		}
 	}
-	if needDeleteTargetPod {
-		if err := inPlaceHelper.deleteTargetPodForRebuild(reqCtx, cli, opsRequest); err != nil {
-			return err
-		}
-		progressDetail.Message = waitingForDynamicPVCMessage
-		return nil
+	if err := inPlaceHelper.deleteTargetPodForRebuild(reqCtx, cli, opsRequest); err != nil {
+		return err
 	}
-	if waitingForSourcePVC {
-		progressDetail.Message = waitingForDynamicPVCMessage
-		return nil
-	}
-
 	progressDetail.Message = waitingForInstanceReadyMessage
-	return nil
-}
-
-func getRecordedSourcePVCIdentities(opsRequest *opsv1alpha1.OpsRequest) (map[string]rebuildSourcePVCIdentity, error) {
-	sourcePVCIdentities := map[string]rebuildSourcePVCIdentity{}
-	if opsRequest.Annotations == nil || opsRequest.Annotations[rebuildSourcePVCIdentitiesAnnotation] == "" {
-		return sourcePVCIdentities, nil
-	}
-	if err := json.Unmarshal([]byte(opsRequest.Annotations[rebuildSourcePVCIdentitiesAnnotation]), &sourcePVCIdentities); err != nil {
-		return nil, err
-	}
-	return sourcePVCIdentities, nil
-}
-
-func (inPlaceHelper *inplaceRebuildHelper) recordSourcePVCIdentityOnOpsRequest(reqCtx intctrlutil.RequestCtx,
-	cli client.Client,
-	opsRequest *opsv1alpha1.OpsRequest,
-	sourcePVC *corev1.PersistentVolumeClaim) error {
-	return inPlaceHelper.recordSourcePVCStateOnOpsRequest(reqCtx, cli, opsRequest, sourcePVC.Name,
-		rebuildSourcePVCIdentity{UID: string(sourcePVC.UID), VolumeName: sourcePVC.Spec.VolumeName})
-}
-
-func (inPlaceHelper *inplaceRebuildHelper) recordSourcePVCAbsentOnOpsRequest(reqCtx intctrlutil.RequestCtx,
-	cli client.Client,
-	opsRequest *opsv1alpha1.OpsRequest,
-	sourcePVCName string) error {
-	return inPlaceHelper.recordSourcePVCStateOnOpsRequest(reqCtx, cli, opsRequest, sourcePVCName, rebuildSourcePVCIdentity{Absent: true})
-}
-
-func (inPlaceHelper *inplaceRebuildHelper) recordSourcePVCStateOnOpsRequest(reqCtx intctrlutil.RequestCtx,
-	cli client.Client,
-	opsRequest *opsv1alpha1.OpsRequest,
-	sourcePVCName string,
-	identity rebuildSourcePVCIdentity) error {
-	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		latest := &opsv1alpha1.OpsRequest{}
-		if err := cli.Get(reqCtx.Ctx, types.NamespacedName{Name: opsRequest.Name, Namespace: opsRequest.Namespace}, latest); err != nil {
-			return err
-		}
-		sourcePVCIdentities, err := getRecordedSourcePVCIdentities(latest)
-		if err != nil {
-			return err
-		}
-		if sourcePVCIdentities[sourcePVCName].UID != "" || sourcePVCIdentities[sourcePVCName].Absent {
-			opsRequest.Annotations = latest.Annotations
-			return nil
-		}
-		sourcePVCIdentities[sourcePVCName] = identity
-		data, err := json.Marshal(sourcePVCIdentities)
-		if err != nil {
-			return err
-		}
-		patch := client.MergeFrom(latest.DeepCopy())
-		if latest.Annotations == nil {
-			latest.Annotations = map[string]string{}
-		}
-		latest.Annotations[rebuildSourcePVCIdentitiesAnnotation] = string(data)
-		if err := cli.Patch(reqCtx.Ctx, latest, patch); err != nil {
-			return err
-		}
-		opsRequest.Annotations = latest.Annotations
-		return nil
-	})
-}
-
-func (inPlaceHelper *inplaceRebuildHelper) validateDynamicSourcePVC(sourcePVC, builtTmpPVC *corev1.PersistentVolumeClaim, oldIdentity rebuildSourcePVCIdentity) error {
-	for key, expected := range builtTmpPVC.Labels {
-		if expected == "" {
-			continue
-		}
-		if sourcePVC.Labels[key] != expected {
-			return intctrlutil.NewFatalError(fmt.Sprintf(`the source pvc "%s" is not rebuilt from the expected workload template: label "%s" expected "%s", got "%s"`,
-				sourcePVC.Name, key, expected, sourcePVC.Labels[key]))
-		}
-	}
-	if oldIdentity.VolumeName != "" && sourcePVC.Spec.VolumeName != "" && oldIdentity.VolumeName == sourcePVC.Spec.VolumeName {
-		return intctrlutil.NewFatalError(fmt.Sprintf(`the source pvc "%s" is still bound to the old pv "%s"`, sourcePVC.Name, sourcePVC.Spec.VolumeName))
-	}
 	return nil
 }
 
@@ -640,18 +469,6 @@ func (inPlaceHelper *inplaceRebuildHelper) deleteTargetPodForRebuild(reqCtx intc
 		options = append(options, client.GracePeriodSeconds(0))
 	}
 	return client.IgnoreNotFound(intctrlutil.BackgroundDeleteObject(cli, reqCtx.Ctx, inPlaceHelper.targetPod, options...))
-}
-
-func (inPlaceHelper *inplaceRebuildHelper) targetPodDeletedForRebuild(reqCtx intctrlutil.RequestCtx,
-	cli client.Client) (bool, error) {
-	targetPod := &corev1.Pod{}
-	if err := cli.Get(reqCtx.Ctx, client.ObjectKey{Name: inPlaceHelper.targetPod.Name, Namespace: inPlaceHelper.targetPod.Namespace}, targetPod); err != nil {
-		if apierrors.IsNotFound(err) {
-			return true, nil
-		}
-		return false, err
-	}
-	return false, nil
 }
 
 func (inPlaceHelper *inplaceRebuildHelper) setSourcePVCVolumeNameForRebuild(reqCtx intctrlutil.RequestCtx,
@@ -915,7 +732,8 @@ func getPVCMapAndVolumes(opsRes *OpsResource,
 	synthesizedComp *component.SynthesizedComponent,
 	targetPod *corev1.Pod,
 	rebuildPrefix string,
-	index int) (map[string]*corev1.PersistentVolumeClaim, []corev1.Volume, []corev1.VolumeMount, error) {
+	index int,
+	noBackup bool) (map[string]*corev1.PersistentVolumeClaim, []corev1.Volume, []corev1.VolumeMount, error) {
 	var (
 		volumes      []corev1.Volume
 		volumeMounts []corev1.VolumeMount
@@ -942,6 +760,16 @@ func getPVCMapAndVolumes(opsRes *OpsResource,
 			// which has not been backported to release-1.0. PVCNamePrefixAnnotationKey is also unset on this
 			// release line, so the helper's fallback is equivalent to the simple "<template>-<pod>" naming.
 			sourcePVCName = fmt.Sprintf("%s-%s", vct.Name, targetPod.Name)
+		}
+		if noBackup {
+			pvcMap[sourcePVCName] = &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      sourcePVCName,
+					Namespace: targetPod.Namespace,
+				},
+				Spec: vct.Spec,
+			}
+			continue
 		}
 		pvcLabels := getWellKnownLabels(synthesizedComp)
 		tmpPVC := &corev1.PersistentVolumeClaim{
@@ -972,39 +800,6 @@ func getPVCMapAndVolumes(opsRes *OpsResource,
 		})
 	}
 	return pvcMap, volumes, volumeMounts, nil
-}
-
-func buildDynamicSourcePVCMap(opsRes *OpsResource,
-	synthesizedComp *component.SynthesizedComponent,
-	targetPodName string,
-	rebuildPrefix string,
-	index int) (map[string]*corev1.PersistentVolumeClaim, error) {
-	workloadName := constant.GenerateWorkloadNamePattern(opsRes.Cluster.Name, synthesizedComp.Name)
-	templateName, _, err := getTemplateNameAndOrdinal(workloadName, targetPodName)
-	if err != nil {
-		return nil, err
-	}
-	pvcMap := map[string]*corev1.PersistentVolumeClaim{}
-	for _, vct := range synthesizedComp.VolumeClaimTemplates {
-		sourcePVCName := intctrlutil.ComposePVCName(corev1.PersistentVolumeClaim{
-			ObjectMeta: vct.ObjectMeta,
-			Spec:       vct.Spec,
-		}, workloadName, targetPodName)
-		tmpPVC := &corev1.PersistentVolumeClaim{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-%s-%d", rebuildPrefix, common.CutString(synthesizedComp.Name+"-"+vct.Name, 30), index),
-				Namespace: opsRes.Cluster.Namespace,
-				Labels:    getWellKnownLabels(synthesizedComp),
-				Annotations: map[string]string{
-					rebuildFromAnnotation: opsRes.OpsRequest.Name,
-				},
-			},
-			Spec: vct.Spec,
-		}
-		plan.BuildPersistentVolumeClaimLabels(synthesizedComp, tmpPVC, vct.Name, templateName)
-		pvcMap[sourcePVCName] = tmpPVC
-	}
-	return pvcMap, nil
 }
 
 func getWellKnownLabels(synthesizedComp *component.SynthesizedComponent) map[string]string {

--- a/pkg/operations/rebuild_instance_inplace.go
+++ b/pkg/operations/rebuild_instance_inplace.go
@@ -450,7 +450,7 @@ func (inPlaceHelper *inplaceRebuildHelper) rebuildSourcePVCsByDynamicProvision(r
 			}
 			return err
 		}
-		if err := inPlaceHelper.deleteSourcePVCForDynamicProvision(reqCtx, cli, sourcePVC); err != nil {
+		if err := inPlaceHelper.deleteSourcePVCForRebuild(reqCtx, cli, sourcePVC); err != nil {
 			return err
 		}
 	}
@@ -687,17 +687,6 @@ func (inPlaceHelper *inplaceRebuildHelper) deleteSourcePVCForRebuild(reqCtx intc
 		return err
 	}
 	return inPlaceHelper.removePVCFinalizer(reqCtx, cli, sourcePVC)
-}
-
-func (inPlaceHelper *inplaceRebuildHelper) deleteSourcePVCForDynamicProvision(reqCtx intctrlutil.RequestCtx,
-	cli client.Client,
-	sourcePVC *corev1.PersistentVolumeClaim) error {
-	if sourcePVC.DeletionTimestamp != nil {
-		return nil
-	}
-	// In the no-backup path, PVC protection is the signal that the old pod
-	// has not fully released the volume yet. Do not clear it here.
-	return intctrlutil.BackgroundDeleteObject(cli, reqCtx.Ctx, sourcePVC)
 }
 
 func (inPlaceHelper *inplaceRebuildHelper) revertReclaimPolicy(reqCtx intctrlutil.RequestCtx,

--- a/pkg/operations/rebuild_instance_inplace.go
+++ b/pkg/operations/rebuild_instance_inplace.go
@@ -459,6 +459,11 @@ func (inPlaceHelper *inplaceRebuildHelper) rebuildSourcePVCsByDynamicProvision(r
 	if err != nil {
 		return err
 	}
+	if !targetPodDeleted {
+		if err := inPlaceHelper.setInstanceNodeSelectorForRebuild(reqCtx, cli, itsName); err != nil {
+			return err
+		}
+	}
 	for sourcePVCName, builtTmpPVC := range inPlaceHelper.pvcMap {
 		sourcePVC, err := inPlaceHelper.getSourcePVC(reqCtx, cli, sourcePVCName, builtTmpPVC.Namespace)
 		if err != nil {
@@ -514,7 +519,6 @@ func (inPlaceHelper *inplaceRebuildHelper) rebuildSourcePVCsByDynamicProvision(r
 			waitingForSourcePVC = true
 			if !targetPodDeleted {
 				needDeleteTargetPod = true
-				continue
 			}
 			if err := inPlaceHelper.deleteSourcePVCForDynamicProvision(reqCtx, cli, sourcePVC); err != nil {
 				return err
@@ -524,15 +528,17 @@ func (inPlaceHelper *inplaceRebuildHelper) rebuildSourcePVCsByDynamicProvision(r
 		if err := inPlaceHelper.validateDynamicSourcePVC(sourcePVC, builtTmpPVC, oldIdentity); err != nil {
 			return err
 		}
+		if !targetPodDeleted {
+			waitingForSourcePVC = true
+			needDeleteTargetPod = true
+			continue
+		}
 		if sourcePVC.Status.Phase != corev1.ClaimBound {
 			waitingForSourcePVC = true
 			continue
 		}
 	}
 	if needDeleteTargetPod {
-		if err := inPlaceHelper.setInstanceNodeSelectorForRebuild(reqCtx, cli, itsName); err != nil {
-			return err
-		}
 		if err := inPlaceHelper.deleteTargetPodForRebuild(reqCtx, cli, opsRequest); err != nil {
 			return err
 		}

--- a/pkg/operations/rebuild_instance_inplace.go
+++ b/pkg/operations/rebuild_instance_inplace.go
@@ -467,17 +467,29 @@ func (inPlaceHelper *inplaceRebuildHelper) rebuildSourcePVCsByDynamicProvision(r
 			}
 			return err
 		}
-		if sourcePVC.DeletionTimestamp != nil {
-			waitingForSourcePVC = true
-			continue
-		}
 		oldIdentity := sourcePVCIdentities[sourcePVCName]
 		if oldIdentity.UID == "" {
+			if targetPodDeleted && sourcePVC.DeletionTimestamp == nil {
+				if err := inPlaceHelper.validateDynamicSourcePVC(sourcePVC, builtTmpPVC, oldIdentity); err != nil {
+					return err
+				}
+				if sourcePVC.Status.Phase != corev1.ClaimBound {
+					waitingForSourcePVC = true
+				}
+				continue
+			}
 			if err := inPlaceHelper.recordSourcePVCIdentityOnOpsRequest(reqCtx, cli, opsRequest, sourcePVC); err != nil {
 				return err
 			}
 			oldIdentity = rebuildSourcePVCIdentity{UID: string(sourcePVC.UID), VolumeName: sourcePVC.Spec.VolumeName}
 			sourcePVCIdentities[sourcePVCName] = oldIdentity
+		}
+		if sourcePVC.DeletionTimestamp != nil {
+			waitingForSourcePVC = true
+			if !targetPodDeleted {
+				needDeleteTargetPod = true
+			}
+			continue
 		}
 		if string(sourcePVC.UID) == oldIdentity.UID {
 			waitingForSourcePVC = true

--- a/pkg/operations/rebuild_instance_inplace.go
+++ b/pkg/operations/rebuild_instance_inplace.go
@@ -440,6 +440,7 @@ func (inPlaceHelper *inplaceRebuildHelper) rebuildSourcePVCsAndRecreateInstance(
 type rebuildSourcePVCIdentity struct {
 	UID        string `json:"uid,omitempty"`
 	VolumeName string `json:"volumeName,omitempty"`
+	Absent     bool   `json:"absent,omitempty"`
 }
 
 func (inPlaceHelper *inplaceRebuildHelper) rebuildSourcePVCsByDynamicProvision(reqCtx intctrlutil.RequestCtx,
@@ -463,13 +464,31 @@ func (inPlaceHelper *inplaceRebuildHelper) rebuildSourcePVCsByDynamicProvision(r
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				waitingForSourcePVC = true
+				if sourcePVCIdentities[sourcePVCName].UID == "" && !sourcePVCIdentities[sourcePVCName].Absent {
+					if err := inPlaceHelper.recordSourcePVCAbsentOnOpsRequest(reqCtx, cli, opsRequest, sourcePVCName); err != nil {
+						return err
+					}
+					sourcePVCIdentities[sourcePVCName] = rebuildSourcePVCIdentity{Absent: true}
+				}
+				if !targetPodDeleted {
+					needDeleteTargetPod = true
+				}
 				continue
 			}
 			return err
 		}
 		oldIdentity := sourcePVCIdentities[sourcePVCName]
 		if oldIdentity.UID == "" {
-			if targetPodDeleted && sourcePVC.DeletionTimestamp == nil {
+			if oldIdentity.Absent {
+				if !targetPodDeleted {
+					waitingForSourcePVC = true
+					needDeleteTargetPod = true
+					continue
+				}
+				if sourcePVC.DeletionTimestamp != nil {
+					waitingForSourcePVC = true
+					continue
+				}
 				if err := inPlaceHelper.validateDynamicSourcePVC(sourcePVC, builtTmpPVC, oldIdentity); err != nil {
 					return err
 				}
@@ -544,6 +563,22 @@ func (inPlaceHelper *inplaceRebuildHelper) recordSourcePVCIdentityOnOpsRequest(r
 	cli client.Client,
 	opsRequest *opsv1alpha1.OpsRequest,
 	sourcePVC *corev1.PersistentVolumeClaim) error {
+	return inPlaceHelper.recordSourcePVCStateOnOpsRequest(reqCtx, cli, opsRequest, sourcePVC.Name,
+		rebuildSourcePVCIdentity{UID: string(sourcePVC.UID), VolumeName: sourcePVC.Spec.VolumeName})
+}
+
+func (inPlaceHelper *inplaceRebuildHelper) recordSourcePVCAbsentOnOpsRequest(reqCtx intctrlutil.RequestCtx,
+	cli client.Client,
+	opsRequest *opsv1alpha1.OpsRequest,
+	sourcePVCName string) error {
+	return inPlaceHelper.recordSourcePVCStateOnOpsRequest(reqCtx, cli, opsRequest, sourcePVCName, rebuildSourcePVCIdentity{Absent: true})
+}
+
+func (inPlaceHelper *inplaceRebuildHelper) recordSourcePVCStateOnOpsRequest(reqCtx intctrlutil.RequestCtx,
+	cli client.Client,
+	opsRequest *opsv1alpha1.OpsRequest,
+	sourcePVCName string,
+	identity rebuildSourcePVCIdentity) error {
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		latest := &opsv1alpha1.OpsRequest{}
 		if err := cli.Get(reqCtx.Ctx, types.NamespacedName{Name: opsRequest.Name, Namespace: opsRequest.Namespace}, latest); err != nil {
@@ -553,11 +588,11 @@ func (inPlaceHelper *inplaceRebuildHelper) recordSourcePVCIdentityOnOpsRequest(r
 		if err != nil {
 			return err
 		}
-		if sourcePVCIdentities[sourcePVC.Name].UID != "" {
+		if sourcePVCIdentities[sourcePVCName].UID != "" || sourcePVCIdentities[sourcePVCName].Absent {
 			opsRequest.Annotations = latest.Annotations
 			return nil
 		}
-		sourcePVCIdentities[sourcePVC.Name] = rebuildSourcePVCIdentity{UID: string(sourcePVC.UID), VolumeName: sourcePVC.Spec.VolumeName}
+		sourcePVCIdentities[sourcePVCName] = identity
 		data, err := json.Marshal(sourcePVCIdentities)
 		if err != nil {
 			return err

--- a/pkg/operations/rebuild_instance_inplace.go
+++ b/pkg/operations/rebuild_instance_inplace.go
@@ -450,8 +450,10 @@ func (inPlaceHelper *inplaceRebuildHelper) rebuildSourcePVCsByDynamicProvision(r
 			}
 			return err
 		}
-		if err := inPlaceHelper.deleteSourcePVCForRebuild(reqCtx, cli, sourcePVC); err != nil {
-			return err
+		if sourcePVC.DeletionTimestamp == nil {
+			if err := intctrlutil.BackgroundDeleteObject(cli, reqCtx.Ctx, sourcePVC); err != nil {
+				return err
+			}
 		}
 	}
 	if err := inPlaceHelper.deleteTargetPodForRebuild(reqCtx, cli, opsRequest); err != nil {

--- a/pkg/operations/rebuild_instance_inplace.go
+++ b/pkg/operations/rebuild_instance_inplace.go
@@ -453,6 +453,11 @@ func (inPlaceHelper *inplaceRebuildHelper) rebuildSourcePVCsByDynamicProvision(r
 		return err
 	}
 	waitingForSourcePVC := false
+	needDeleteTargetPod := false
+	targetPodDeleted, err := inPlaceHelper.targetPodDeletedForRebuild(reqCtx, cli)
+	if err != nil {
+		return err
+	}
 	for sourcePVCName, builtTmpPVC := range inPlaceHelper.pvcMap {
 		sourcePVC, err := inPlaceHelper.getSourcePVC(reqCtx, cli, sourcePVCName, builtTmpPVC.Namespace)
 		if err != nil {
@@ -464,9 +469,6 @@ func (inPlaceHelper *inplaceRebuildHelper) rebuildSourcePVCsByDynamicProvision(r
 		}
 		if sourcePVC.DeletionTimestamp != nil {
 			waitingForSourcePVC = true
-			if err := inPlaceHelper.removePVCFinalizer(reqCtx, cli, sourcePVC); err != nil {
-				return err
-			}
 			continue
 		}
 		oldIdentity := sourcePVCIdentities[sourcePVCName]
@@ -479,7 +481,11 @@ func (inPlaceHelper *inplaceRebuildHelper) rebuildSourcePVCsByDynamicProvision(r
 		}
 		if string(sourcePVC.UID) == oldIdentity.UID {
 			waitingForSourcePVC = true
-			if err := inPlaceHelper.deleteSourcePVCForRebuild(reqCtx, cli, sourcePVC); err != nil {
+			if !targetPodDeleted {
+				needDeleteTargetPod = true
+				continue
+			}
+			if err := inPlaceHelper.deleteSourcePVCForDynamicProvision(reqCtx, cli, sourcePVC); err != nil {
 				return err
 			}
 			continue
@@ -492,15 +498,19 @@ func (inPlaceHelper *inplaceRebuildHelper) rebuildSourcePVCsByDynamicProvision(r
 			continue
 		}
 	}
-	if waitingForSourcePVC {
+	if needDeleteTargetPod {
+		if err := inPlaceHelper.setInstanceNodeSelectorForRebuild(reqCtx, cli, itsName); err != nil {
+			return err
+		}
+		if err := inPlaceHelper.deleteTargetPodForRebuild(reqCtx, cli, opsRequest); err != nil {
+			return err
+		}
 		progressDetail.Message = waitingForDynamicPVCMessage
 		return nil
 	}
-	if err := inPlaceHelper.setInstanceNodeSelectorForRebuild(reqCtx, cli, itsName); err != nil {
-		return err
-	}
-	if err := inPlaceHelper.deleteTargetPodForRebuild(reqCtx, cli, opsRequest); err != nil {
-		return err
+	if waitingForSourcePVC {
+		progressDetail.Message = waitingForDynamicPVCMessage
+		return nil
 	}
 
 	progressDetail.Message = waitingForInstanceReadyMessage
@@ -577,6 +587,18 @@ func (inPlaceHelper *inplaceRebuildHelper) deleteTargetPodForRebuild(reqCtx intc
 		options = append(options, client.GracePeriodSeconds(0))
 	}
 	return client.IgnoreNotFound(intctrlutil.BackgroundDeleteObject(cli, reqCtx.Ctx, inPlaceHelper.targetPod, options...))
+}
+
+func (inPlaceHelper *inplaceRebuildHelper) targetPodDeletedForRebuild(reqCtx intctrlutil.RequestCtx,
+	cli client.Client) (bool, error) {
+	targetPod := &corev1.Pod{}
+	if err := cli.Get(reqCtx.Ctx, client.ObjectKey{Name: inPlaceHelper.targetPod.Name, Namespace: inPlaceHelper.targetPod.Namespace}, targetPod); err != nil {
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	return false, nil
 }
 
 func (inPlaceHelper *inplaceRebuildHelper) setSourcePVCVolumeNameForRebuild(reqCtx intctrlutil.RequestCtx,
@@ -797,6 +819,17 @@ func (inPlaceHelper *inplaceRebuildHelper) deleteSourcePVCForRebuild(reqCtx intc
 	return inPlaceHelper.removePVCFinalizer(reqCtx, cli, sourcePVC)
 }
 
+func (inPlaceHelper *inplaceRebuildHelper) deleteSourcePVCForDynamicProvision(reqCtx intctrlutil.RequestCtx,
+	cli client.Client,
+	sourcePVC *corev1.PersistentVolumeClaim) error {
+	if sourcePVC.DeletionTimestamp != nil {
+		return nil
+	}
+	// In the no-backup path, PVC protection is the signal that the old pod
+	// has not fully released the volume yet. Do not clear it here.
+	return intctrlutil.BackgroundDeleteObject(cli, reqCtx.Ctx, sourcePVC)
+}
+
 func (inPlaceHelper *inplaceRebuildHelper) revertReclaimPolicy(reqCtx intctrlutil.RequestCtx,
 	cli client.Client, pv *corev1.PersistentVolume) error {
 	reclaimPolicy := pv.Annotations[sourcePVReclaimPolicyAnnotation]
@@ -886,6 +919,39 @@ func getPVCMapAndVolumes(opsRes *OpsResource,
 		})
 	}
 	return pvcMap, volumes, volumeMounts, nil
+}
+
+func buildDynamicSourcePVCMap(opsRes *OpsResource,
+	synthesizedComp *component.SynthesizedComponent,
+	targetPodName string,
+	rebuildPrefix string,
+	index int) (map[string]*corev1.PersistentVolumeClaim, error) {
+	workloadName := constant.GenerateWorkloadNamePattern(opsRes.Cluster.Name, synthesizedComp.Name)
+	templateName, _, err := getTemplateNameAndOrdinal(workloadName, targetPodName)
+	if err != nil {
+		return nil, err
+	}
+	pvcMap := map[string]*corev1.PersistentVolumeClaim{}
+	for _, vct := range synthesizedComp.VolumeClaimTemplates {
+		sourcePVCName := intctrlutil.ComposePVCName(corev1.PersistentVolumeClaim{
+			ObjectMeta: vct.ObjectMeta,
+			Spec:       vct.Spec,
+		}, workloadName, targetPodName)
+		tmpPVC := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-%s-%d", rebuildPrefix, common.CutString(synthesizedComp.Name+"-"+vct.Name, 30), index),
+				Namespace: opsRes.Cluster.Namespace,
+				Labels:    getWellKnownLabels(synthesizedComp),
+				Annotations: map[string]string{
+					rebuildFromAnnotation: opsRes.OpsRequest.Name,
+				},
+			},
+			Spec: vct.Spec,
+		}
+		plan.BuildPersistentVolumeClaimLabels(synthesizedComp, tmpPVC, vct.Name, templateName)
+		pvcMap[sourcePVCName] = tmpPVC
+	}
+	return pvcMap, nil
 }
 
 func getWellKnownLabels(synthesizedComp *component.SynthesizedComponent) map[string]string {

--- a/pkg/operations/rebuild_instance_test.go
+++ b/pkg/operations/rebuild_instance_test.go
@@ -602,6 +602,63 @@ var _ = Describe("OpsUtil functions", func() {
 			})).Should(Succeed())
 		})
 
+		It("does not accept an existing source PVC as dynamically rebuilt when the target pod is already absent", func() {
+			opsRes := prepareOpsRes("", true)
+			reqCtx := intctrlutil.RequestCtx{Ctx: testCtx.Ctx}
+			sourcePVCs := map[string]rebuildSourcePVCIdentity{}
+			targetSourcePVCs := map[string]bool{}
+			for _, ins := range opsRes.OpsRequest.Spec.RebuildFrom[0].Instances {
+				targetSourcePVCs[fmt.Sprintf("%s-%s", testapps.DataVolumeName, ins.Name)] = true
+				pod := &corev1.Pod{}
+				Expect(k8sClient.Get(ctx, client.ObjectKey{Name: ins.Name, Namespace: opsRes.OpsRequest.Namespace}, pod)).Should(Succeed())
+				Expect(k8sClient.Delete(ctx, pod)).Should(Succeed())
+			}
+			for _, ins := range opsRes.OpsRequest.Spec.RebuildFrom[0].Instances {
+				Eventually(func(g Gomega) {
+					pod := &corev1.Pod{}
+					err := k8sClient.Get(ctx, client.ObjectKey{Name: ins.Name, Namespace: opsRes.OpsRequest.Namespace}, pod)
+					g.Expect(apierrors.IsNotFound(err)).Should(BeTrue())
+				}).Should(Succeed())
+			}
+			pvcList := &corev1.PersistentVolumeClaimList{}
+			Expect(k8sClient.List(ctx, pvcList,
+				client.MatchingLabels{constant.KBAppComponentLabelKey: defaultCompName},
+				client.InNamespace(opsRes.OpsRequest.Namespace))).Should(Succeed())
+			for i := range pvcList.Items {
+				pvc := pvcList.Items[i].DeepCopy()
+				if !targetSourcePVCs[pvc.Name] {
+					continue
+				}
+				Expect(testapps.ChangeObj(&testCtx, pvc, func(p *corev1.PersistentVolumeClaim) {
+					p.Finalizers = append(p.Finalizers, "kubernetes.io/pvc-protection")
+				})).Should(Succeed())
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pvc), pvc)).Should(Succeed())
+				sourcePVCs[pvc.Name] = rebuildSourcePVCIdentity{UID: string(pvc.UID), VolumeName: pvc.Spec.VolumeName}
+			}
+
+			_, err := GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
+			Expect(err).Should(Succeed())
+
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest), func(g Gomega, ops *opsv1alpha1.OpsRequest) {
+				recordedIdentities, err := getRecordedSourcePVCIdentities(ops)
+				g.Expect(err).Should(Succeed())
+				for sourcePVCName, oldIdentity := range sourcePVCs {
+					g.Expect(recordedIdentities).Should(HaveKeyWithValue(sourcePVCName, oldIdentity))
+				}
+				for _, detail := range ops.Status.Components[defaultCompName].ProgressDetails {
+					g.Expect(detail.Message).Should(Equal(waitingForDynamicPVCMessage))
+				}
+			})).Should(Succeed())
+			for sourcePVCName := range sourcePVCs {
+				Eventually(func(g Gomega) {
+					pvc := &corev1.PersistentVolumeClaim{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: sourcePVCName, Namespace: opsRes.OpsRequest.Namespace}, pvc)).Should(Succeed())
+					g.Expect(pvc.DeletionTimestamp).ShouldNot(BeNil())
+					g.Expect(pvc.Finalizers).Should(ContainElement("kubernetes.io/pvc-protection"))
+				}).Should(Succeed())
+			}
+		})
+
 		It("pre-binds restored PV claimRef to the source PVC", func() {
 			reqCtx := intctrlutil.RequestCtx{Ctx: testCtx.Ctx}
 			sourcePVCName := "data-rebuild-source-" + testCtx.GetRandomStr()

--- a/pkg/operations/rebuild_instance_test.go
+++ b/pkg/operations/rebuild_instance_test.go
@@ -405,11 +405,7 @@ var _ = Describe("OpsUtil functions", func() {
 					}
 					g.Expect(err).Should(Succeed())
 					g.Expect(pvc.DeletionTimestamp).ShouldNot(BeNil())
-					if sourcePVCName == preDeletingSourcePVCName {
-						g.Expect(pvc.Finalizers).Should(ContainElement("kubernetes.io/pvc-protection"))
-					} else {
-						g.Expect(pvc.Finalizers).Should(BeEmpty())
-					}
+					g.Expect(pvc.Finalizers).Should(ContainElement("kubernetes.io/pvc-protection"))
 				}).Should(Succeed())
 			}
 			for _, ins := range opsRes.OpsRequest.Spec.RebuildFrom[0].Instances {
@@ -418,6 +414,18 @@ var _ = Describe("OpsUtil functions", func() {
 					err := k8sClient.Get(ctx, client.ObjectKey{Name: ins.Name, Namespace: opsRes.OpsRequest.Namespace}, pod)
 					g.Expect(apierrors.IsNotFound(err)).Should(BeTrue())
 				}).Should(Succeed())
+			}
+
+			By("expect old source PVCs to keep PVC protection until the workload releases them")
+			for sourcePVCName := range sourcePVCTemplates {
+				Eventually(func(g Gomega) {
+					pvc := &corev1.PersistentVolumeClaim{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: sourcePVCName, Namespace: opsRes.OpsRequest.Namespace}, pvc)).Should(Succeed())
+					g.Expect(pvc.DeletionTimestamp).ShouldNot(BeNil())
+					g.Expect(pvc.Finalizers).Should(ContainElement("kubernetes.io/pvc-protection"))
+				}).Should(Succeed())
+				testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.PersistentVolumeClaimSignature, true,
+					client.InNamespace(opsRes.OpsRequest.Namespace), client.MatchingFields{"metadata.name": sourcePVCName})
 			}
 
 			By("expect rebuild to wait for the rebuilt instance")

--- a/pkg/operations/rebuild_instance_test.go
+++ b/pkg/operations/rebuild_instance_test.go
@@ -404,16 +404,12 @@ var _ = Describe("OpsUtil functions", func() {
 					g.Expect(recordedIdentities).Should(HaveKeyWithValue(sourcePVCName, oldIdentity))
 				}
 			})).Should(Succeed())
-			By("expect source PVCs to stay active until the old target pod is gone")
+			By("expect source PVC deletion to be requested before deleting the old target pod")
 			for sourcePVCName := range sourcePVCTemplates {
 				Eventually(func(g Gomega) {
 					pvc := &corev1.PersistentVolumeClaim{}
 					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: sourcePVCName, Namespace: opsRes.OpsRequest.Namespace}, pvc)).Should(Succeed())
-					if sourcePVCName == preDeletingSourcePVCName {
-						g.Expect(pvc.DeletionTimestamp).ShouldNot(BeNil())
-					} else {
-						g.Expect(pvc.DeletionTimestamp).Should(BeNil())
-					}
+					g.Expect(pvc.DeletionTimestamp).ShouldNot(BeNil())
 					g.Expect(pvc.Finalizers).Should(ContainElement("kubernetes.io/pvc-protection"))
 				}).Should(Succeed())
 			}
@@ -425,7 +421,7 @@ var _ = Describe("OpsUtil functions", func() {
 				}).Should(Succeed())
 			}
 
-			By("expect old source PVCs to be deleted only after the old target pod is absent, without clearing PVC protection")
+			By("expect old source PVCs to keep PVC protection until the workload releases them")
 			_, err = GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
 			Expect(err).Should(Succeed())
 			for sourcePVCName := range sourcePVCTemplates {

--- a/pkg/operations/rebuild_instance_test.go
+++ b/pkg/operations/rebuild_instance_test.go
@@ -367,7 +367,6 @@ var _ = Describe("OpsUtil functions", func() {
 				client.MatchingLabels{constant.KBAppComponentLabelKey: defaultCompName},
 				client.InNamespace(opsRes.OpsRequest.Namespace))).Should(Succeed())
 			sourcePVCTemplates := map[string]*corev1.PersistentVolumeClaim{}
-			sourcePVCIdentities := map[string]rebuildSourcePVCIdentity{}
 			targetSourcePVCs := map[string]bool{}
 			for _, ins := range opsRes.OpsRequest.Spec.RebuildFrom[0].Instances {
 				targetSourcePVCs[fmt.Sprintf("%s-%s", testapps.DataVolumeName, ins.Name)] = true
@@ -385,7 +384,6 @@ var _ = Describe("OpsUtil functions", func() {
 				})).Should(Succeed())
 				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pvc), pvc)).Should(Succeed())
 				sourcePVCTemplates[pvc.Name] = pvc
-				sourcePVCIdentities[pvc.Name] = rebuildSourcePVCIdentity{UID: string(pvc.UID), VolumeName: pvc.Spec.VolumeName}
 			}
 			initialSourcePVCNames := make([]string, 0, len(sourcePVCTemplates))
 			for sourcePVCName := range sourcePVCTemplates {
@@ -397,13 +395,6 @@ var _ = Describe("OpsUtil functions", func() {
 
 			_, err := GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
 			Expect(err).Should(Succeed())
-			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest), func(g Gomega, ops *opsv1alpha1.OpsRequest) {
-				recordedIdentities, err := getRecordedSourcePVCIdentities(ops)
-				g.Expect(err).Should(Succeed())
-				for sourcePVCName, oldIdentity := range sourcePVCIdentities {
-					g.Expect(recordedIdentities).Should(HaveKeyWithValue(sourcePVCName, oldIdentity))
-				}
-			})).Should(Succeed())
 			By("expect source PVC deletion to be requested before deleting the old target pod")
 			for sourcePVCName := range sourcePVCTemplates {
 				Eventually(func(g Gomega) {
@@ -435,95 +426,12 @@ var _ = Describe("OpsUtil functions", func() {
 					client.InNamespace(opsRes.OpsRequest.Namespace), client.MatchingFields{"metadata.name": sourcePVCName})
 			}
 
-			By("expect rebuild to wait while InstanceSet has not recreated dynamically provisioned source PVCs")
+			By("expect rebuild to wait for the rebuilt instance")
 			_, err = GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
 			Expect(err).Should(Succeed())
 			for _, detail := range opsRes.OpsRequest.Status.Components[defaultCompName].ProgressDetails {
-				Expect(detail.Message).Should(Equal(waitingForDynamicPVCMessage))
+				Expect(detail.Message).Should(Equal(waitingForInstanceReadyMessage))
 			}
-
-			sourcePVCNames := make([]string, 0, len(sourcePVCTemplates))
-			for sourcePVCName := range sourcePVCTemplates {
-				sourcePVCNames = append(sourcePVCNames, sourcePVCName)
-			}
-			slices.Sort(sourcePVCNames)
-			recreateSourcePVC := func(sourcePVCName string) {
-				sourcePVCTemplate := sourcePVCTemplates[sourcePVCName]
-				recreatedSourcePVC := sourcePVCTemplate.DeepCopy()
-				recreatedSourcePVC.ResourceVersion = ""
-				recreatedSourcePVC.UID = ""
-				recreatedSourcePVC.CreationTimestamp = metav1.Time{}
-				recreatedSourcePVC.DeletionTimestamp = nil
-				recreatedSourcePVC.ManagedFields = nil
-				recreatedSourcePVC.Finalizers = nil
-				recreatedSourcePVC.Spec.VolumeName = "dynamic-" + sourcePVCName
-				Expect(k8sClient.Create(ctx, recreatedSourcePVC)).Should(Succeed())
-				Expect(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKeyFromObject(recreatedSourcePVC), func(pvc *corev1.PersistentVolumeClaim) {
-					pvc.Status.Phase = corev1.ClaimBound
-				})()).Should(Succeed())
-			}
-			if len(sourcePVCNames) > 1 {
-				firstSourcePVCName := sourcePVCNames[0]
-				recreateSourcePVC(firstSourcePVCName)
-				_, err = GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
-				Expect(err).Should(Succeed())
-				firstPVC := &corev1.PersistentVolumeClaim{}
-				Expect(k8sClient.Get(ctx, client.ObjectKey{Name: firstSourcePVCName, Namespace: opsRes.OpsRequest.Namespace}, firstPVC)).Should(Succeed())
-				Expect(string(firstPVC.UID)).ShouldNot(Equal(sourcePVCIdentities[firstSourcePVCName].UID))
-				Expect(firstPVC.DeletionTimestamp).Should(BeNil())
-				progressMessages := make([]string, 0, len(opsRes.OpsRequest.Status.Components[defaultCompName].ProgressDetails))
-				for _, detail := range opsRes.OpsRequest.Status.Components[defaultCompName].ProgressDetails {
-					progressMessages = append(progressMessages, detail.Message)
-				}
-				Expect(progressMessages).Should(ContainElement(waitingForDynamicPVCMessage))
-				Expect(progressMessages).Should(ContainElement(waitingForInstanceReadyMessage))
-			}
-
-			for _, sourcePVCName := range sourcePVCNames {
-				existing := &corev1.PersistentVolumeClaim{}
-				err := k8sClient.Get(ctx, client.ObjectKey{Name: sourcePVCName, Namespace: opsRes.OpsRequest.Namespace}, existing)
-				if err == nil {
-					if existing.DeletionTimestamp == nil && string(existing.UID) != sourcePVCIdentities[sourcePVCName].UID {
-						if existing.Spec.VolumeName == "" {
-							Expect(testapps.ChangeObj(&testCtx, existing, func(pvc *corev1.PersistentVolumeClaim) {
-								pvc.Spec.VolumeName = "dynamic-" + sourcePVCName
-							})).Should(Succeed())
-						}
-						Expect(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKey{Name: sourcePVCName, Namespace: opsRes.OpsRequest.Namespace}, func(pvc *corev1.PersistentVolumeClaim) {
-							pvc.Status.Phase = corev1.ClaimBound
-						})()).Should(Succeed())
-						continue
-					}
-					testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.PersistentVolumeClaimSignature, true,
-						client.InNamespace(opsRes.OpsRequest.Namespace), client.MatchingFields{"metadata.name": sourcePVCName})
-				} else {
-					Expect(apierrors.IsNotFound(err)).Should(BeTrue())
-				}
-				Eventually(func(g Gomega) {
-					pvc := &corev1.PersistentVolumeClaim{}
-					err := k8sClient.Get(ctx, client.ObjectKey{Name: sourcePVCName, Namespace: opsRes.OpsRequest.Namespace}, pvc)
-					g.Expect(apierrors.IsNotFound(err)).Should(BeTrue())
-				}).Should(Succeed())
-				recreateSourcePVC(sourcePVCName)
-			}
-
-			Eventually(func(g Gomega) {
-				_, err := GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
-				g.Expect(err).Should(Succeed())
-				for sourcePVCName, oldIdentity := range sourcePVCIdentities {
-					pvc := &corev1.PersistentVolumeClaim{}
-					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: sourcePVCName, Namespace: opsRes.OpsRequest.Namespace}, pvc)).Should(Succeed())
-					g.Expect(string(pvc.UID)).ShouldNot(Equal(oldIdentity.UID))
-					if oldIdentity.VolumeName != "" && pvc.Spec.VolumeName != "" {
-						g.Expect(pvc.Spec.VolumeName).ShouldNot(Equal(oldIdentity.VolumeName))
-					}
-				}
-				ops := &opsv1alpha1.OpsRequest{}
-				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(opsRes.OpsRequest), ops)).Should(Succeed())
-				for _, detail := range ops.Status.Components[defaultCompName].ProgressDetails {
-					g.Expect(detail.Message).Should(Or(Equal(waitingForInstanceReadyMessage), MatchRegexp(`^Rebuild pod .+ successfully$`)))
-				}
-			}).Should(Succeed())
 		}
 
 		waitForInstanceToAvailable := func(reqCtx intctrlutil.RequestCtx, opsRes *OpsResource, ignoreRoleCheck bool) {
@@ -598,63 +506,6 @@ var _ = Describe("OpsUtil functions", func() {
 			})).Should(Succeed())
 		})
 
-		It("does not accept an existing source PVC as dynamically rebuilt when the target pod is already absent", func() {
-			opsRes := prepareOpsRes("", true)
-			reqCtx := intctrlutil.RequestCtx{Ctx: testCtx.Ctx}
-			sourcePVCs := map[string]rebuildSourcePVCIdentity{}
-			targetSourcePVCs := map[string]bool{}
-			for _, ins := range opsRes.OpsRequest.Spec.RebuildFrom[0].Instances {
-				targetSourcePVCs[fmt.Sprintf("%s-%s", testapps.DataVolumeName, ins.Name)] = true
-				pod := &corev1.Pod{}
-				Expect(k8sClient.Get(ctx, client.ObjectKey{Name: ins.Name, Namespace: opsRes.OpsRequest.Namespace}, pod)).Should(Succeed())
-				Expect(k8sClient.Delete(ctx, pod)).Should(Succeed())
-			}
-			for _, ins := range opsRes.OpsRequest.Spec.RebuildFrom[0].Instances {
-				Eventually(func(g Gomega) {
-					pod := &corev1.Pod{}
-					err := k8sClient.Get(ctx, client.ObjectKey{Name: ins.Name, Namespace: opsRes.OpsRequest.Namespace}, pod)
-					g.Expect(apierrors.IsNotFound(err)).Should(BeTrue())
-				}).Should(Succeed())
-			}
-			pvcList := &corev1.PersistentVolumeClaimList{}
-			Expect(k8sClient.List(ctx, pvcList,
-				client.MatchingLabels{constant.KBAppComponentLabelKey: defaultCompName},
-				client.InNamespace(opsRes.OpsRequest.Namespace))).Should(Succeed())
-			for i := range pvcList.Items {
-				pvc := pvcList.Items[i].DeepCopy()
-				if !targetSourcePVCs[pvc.Name] {
-					continue
-				}
-				Expect(testapps.ChangeObj(&testCtx, pvc, func(p *corev1.PersistentVolumeClaim) {
-					p.Finalizers = append(p.Finalizers, "kubernetes.io/pvc-protection")
-				})).Should(Succeed())
-				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pvc), pvc)).Should(Succeed())
-				sourcePVCs[pvc.Name] = rebuildSourcePVCIdentity{UID: string(pvc.UID), VolumeName: pvc.Spec.VolumeName}
-			}
-
-			_, err := GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
-			Expect(err).Should(Succeed())
-
-			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest), func(g Gomega, ops *opsv1alpha1.OpsRequest) {
-				recordedIdentities, err := getRecordedSourcePVCIdentities(ops)
-				g.Expect(err).Should(Succeed())
-				for sourcePVCName, oldIdentity := range sourcePVCs {
-					g.Expect(recordedIdentities).Should(HaveKeyWithValue(sourcePVCName, oldIdentity))
-				}
-				for _, detail := range ops.Status.Components[defaultCompName].ProgressDetails {
-					g.Expect(detail.Message).Should(Equal(waitingForDynamicPVCMessage))
-				}
-			})).Should(Succeed())
-			for sourcePVCName := range sourcePVCs {
-				Eventually(func(g Gomega) {
-					pvc := &corev1.PersistentVolumeClaim{}
-					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: sourcePVCName, Namespace: opsRes.OpsRequest.Namespace}, pvc)).Should(Succeed())
-					g.Expect(pvc.DeletionTimestamp).ShouldNot(BeNil())
-					g.Expect(pvc.Finalizers).Should(ContainElement("kubernetes.io/pvc-protection"))
-				}).Should(Succeed())
-			}
-		})
-
 		It("pre-binds restored PV claimRef to the source PVC", func() {
 			reqCtx := intctrlutil.RequestCtx{Ctx: testCtx.Ctx}
 			sourcePVCName := "data-rebuild-source-" + testCtx.GetRandomStr()
@@ -706,28 +557,6 @@ var _ = Describe("OpsUtil functions", func() {
 
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sourcePVC), sourcePVC)).Should(Succeed())
 			Expect(sourcePVC.Spec.VolumeName).Should(ContainSubstring("restored-pv-"))
-		})
-
-		It("rejects a dynamically provisioned source PVC with mismatched identity", func() {
-			helper := &inplaceRebuildHelper{}
-			expectedPVC := &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "data-rebuild-expected",
-					Labels: map[string]string{constant.KBAppComponentLabelKey: defaultCompName},
-				},
-			}
-			foreignPVC := &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:   "data-rebuild-expected",
-					Labels: map[string]string{constant.KBAppComponentLabelKey: "foreign"},
-				},
-				Spec: corev1.PersistentVolumeClaimSpec{VolumeName: "new-pv"},
-			}
-			Expect(helper.validateDynamicSourcePVC(foreignPVC, expectedPVC, rebuildSourcePVCIdentity{UID: "old-uid", VolumeName: "old-pv"})).Should(MatchError(ContainSubstring("not rebuilt from the expected workload template")))
-
-			reusedOldPV := expectedPVC.DeepCopy()
-			reusedOldPV.Spec.VolumeName = "old-pv"
-			Expect(helper.validateDynamicSourcePVC(reusedOldPV, expectedPVC, rebuildSourcePVCIdentity{UID: "old-uid", VolumeName: "old-pv"})).Should(MatchError(ContainSubstring("still bound to the old pv")))
 		})
 
 		It("preserves rebuild identity metadata when reverting the reclaim policy", func() {

--- a/pkg/operations/rebuild_instance_test.go
+++ b/pkg/operations/rebuild_instance_test.go
@@ -380,6 +380,10 @@ var _ = Describe("OpsUtil functions", func() {
 				if !targetSourcePVCs[pvc.Name] {
 					continue
 				}
+				Expect(testapps.ChangeObj(&testCtx, pvc, func(p *corev1.PersistentVolumeClaim) {
+					p.Finalizers = append(p.Finalizers, "kubernetes.io/pvc-protection")
+				})).Should(Succeed())
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pvc), pvc)).Should(Succeed())
 				sourcePVCTemplates[pvc.Name] = pvc
 				sourcePVCIdentities[pvc.Name] = rebuildSourcePVCIdentity{UID: string(pvc.UID), VolumeName: pvc.Spec.VolumeName}
 			}
@@ -393,21 +397,37 @@ var _ = Describe("OpsUtil functions", func() {
 					g.Expect(recordedIdentities).Should(HaveKeyWithValue(sourcePVCName, oldIdentity))
 				}
 			})).Should(Succeed())
+			By("expect source PVCs to stay active until the old target pod is gone")
 			for sourcePVCName := range sourcePVCTemplates {
 				Eventually(func(g Gomega) {
 					pvc := &corev1.PersistentVolumeClaim{}
-					err := k8sClient.Get(ctx, client.ObjectKey{Name: sourcePVCName, Namespace: opsRes.OpsRequest.Namespace}, pvc)
-					if apierrors.IsNotFound(err) {
-						return
-					}
-					g.Expect(err).Should(Succeed())
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: sourcePVCName, Namespace: opsRes.OpsRequest.Namespace}, pvc)).Should(Succeed())
+					g.Expect(pvc.DeletionTimestamp).Should(BeNil())
+					g.Expect(pvc.Finalizers).Should(ContainElement("kubernetes.io/pvc-protection"))
+				}).Should(Succeed())
+			}
+			for _, ins := range opsRes.OpsRequest.Spec.RebuildFrom[0].Instances {
+				Eventually(func(g Gomega) {
+					pod := &corev1.Pod{}
+					err := k8sClient.Get(ctx, client.ObjectKey{Name: ins.Name, Namespace: opsRes.OpsRequest.Namespace}, pod)
+					g.Expect(apierrors.IsNotFound(err)).Should(BeTrue())
+				}).Should(Succeed())
+			}
+
+			By("expect old source PVCs to be deleted only after the old target pod is absent, without clearing PVC protection")
+			_, err = GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
+			Expect(err).Should(Succeed())
+			for sourcePVCName := range sourcePVCTemplates {
+				Eventually(func(g Gomega) {
+					pvc := &corev1.PersistentVolumeClaim{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: sourcePVCName, Namespace: opsRes.OpsRequest.Namespace}, pvc)).Should(Succeed())
 					g.Expect(pvc.DeletionTimestamp).ShouldNot(BeNil())
+					g.Expect(pvc.Finalizers).Should(ContainElement("kubernetes.io/pvc-protection"))
 				}).Should(Succeed())
 				testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.PersistentVolumeClaimSignature, true,
 					client.InNamespace(opsRes.OpsRequest.Namespace), client.MatchingFields{"metadata.name": sourcePVCName})
 			}
 
-			initInstanceSetPods(ctx, k8sClient, opsRes)
 			By("expect rebuild to wait while InstanceSet has not recreated dynamically provisioned source PVCs")
 			_, err = GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
 			Expect(err).Should(Succeed())

--- a/pkg/operations/rebuild_instance_test.go
+++ b/pkg/operations/rebuild_instance_test.go
@@ -387,6 +387,13 @@ var _ = Describe("OpsUtil functions", func() {
 				sourcePVCTemplates[pvc.Name] = pvc
 				sourcePVCIdentities[pvc.Name] = rebuildSourcePVCIdentity{UID: string(pvc.UID), VolumeName: pvc.Spec.VolumeName}
 			}
+			initialSourcePVCNames := make([]string, 0, len(sourcePVCTemplates))
+			for sourcePVCName := range sourcePVCTemplates {
+				initialSourcePVCNames = append(initialSourcePVCNames, sourcePVCName)
+			}
+			slices.Sort(initialSourcePVCNames)
+			preDeletingSourcePVCName := initialSourcePVCNames[0]
+			Expect(k8sClient.Delete(ctx, sourcePVCTemplates[preDeletingSourcePVCName])).Should(Succeed())
 
 			_, err := GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
 			Expect(err).Should(Succeed())
@@ -402,7 +409,11 @@ var _ = Describe("OpsUtil functions", func() {
 				Eventually(func(g Gomega) {
 					pvc := &corev1.PersistentVolumeClaim{}
 					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: sourcePVCName, Namespace: opsRes.OpsRequest.Namespace}, pvc)).Should(Succeed())
-					g.Expect(pvc.DeletionTimestamp).Should(BeNil())
+					if sourcePVCName == preDeletingSourcePVCName {
+						g.Expect(pvc.DeletionTimestamp).ShouldNot(BeNil())
+					} else {
+						g.Expect(pvc.DeletionTimestamp).Should(BeNil())
+					}
 					g.Expect(pvc.Finalizers).Should(ContainElement("kubernetes.io/pvc-protection"))
 				}).Should(Succeed())
 			}

--- a/pkg/operations/rebuild_instance_test.go
+++ b/pkg/operations/rebuild_instance_test.go
@@ -361,6 +361,144 @@ var _ = Describe("OpsUtil functions", func() {
 			}
 		}
 
+		sourcePVCsShouldDynamicReprovision := func(reqCtx intctrlutil.RequestCtx, opsRes *OpsResource) {
+			sourcePVCTemplateList := &corev1.PersistentVolumeClaimList{}
+			Expect(k8sClient.List(ctx, sourcePVCTemplateList,
+				client.MatchingLabels{constant.KBAppComponentLabelKey: defaultCompName},
+				client.InNamespace(opsRes.OpsRequest.Namespace))).Should(Succeed())
+			sourcePVCTemplates := map[string]*corev1.PersistentVolumeClaim{}
+			sourcePVCIdentities := map[string]rebuildSourcePVCIdentity{}
+			targetSourcePVCs := map[string]bool{}
+			for _, ins := range opsRes.OpsRequest.Spec.RebuildFrom[0].Instances {
+				targetSourcePVCs[fmt.Sprintf("%s-%s", testapps.DataVolumeName, ins.Name)] = true
+			}
+			for i := range sourcePVCTemplateList.Items {
+				pvc := sourcePVCTemplateList.Items[i].DeepCopy()
+				if _, ok := pvc.Annotations[rebuildFromAnnotation]; ok {
+					continue
+				}
+				if !targetSourcePVCs[pvc.Name] {
+					continue
+				}
+				sourcePVCTemplates[pvc.Name] = pvc
+				sourcePVCIdentities[pvc.Name] = rebuildSourcePVCIdentity{UID: string(pvc.UID), VolumeName: pvc.Spec.VolumeName}
+			}
+
+			_, err := GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
+			Expect(err).Should(Succeed())
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest), func(g Gomega, ops *opsv1alpha1.OpsRequest) {
+				recordedIdentities, err := getRecordedSourcePVCIdentities(ops)
+				g.Expect(err).Should(Succeed())
+				for sourcePVCName, oldIdentity := range sourcePVCIdentities {
+					g.Expect(recordedIdentities).Should(HaveKeyWithValue(sourcePVCName, oldIdentity))
+				}
+			})).Should(Succeed())
+			for sourcePVCName := range sourcePVCTemplates {
+				Eventually(func(g Gomega) {
+					pvc := &corev1.PersistentVolumeClaim{}
+					err := k8sClient.Get(ctx, client.ObjectKey{Name: sourcePVCName, Namespace: opsRes.OpsRequest.Namespace}, pvc)
+					if apierrors.IsNotFound(err) {
+						return
+					}
+					g.Expect(err).Should(Succeed())
+					g.Expect(pvc.DeletionTimestamp).ShouldNot(BeNil())
+				}).Should(Succeed())
+				testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.PersistentVolumeClaimSignature, true,
+					client.InNamespace(opsRes.OpsRequest.Namespace), client.MatchingFields{"metadata.name": sourcePVCName})
+			}
+
+			initInstanceSetPods(ctx, k8sClient, opsRes)
+			By("expect rebuild to wait while InstanceSet has not recreated dynamically provisioned source PVCs")
+			_, err = GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
+			Expect(err).Should(Succeed())
+			for _, detail := range opsRes.OpsRequest.Status.Components[defaultCompName].ProgressDetails {
+				Expect(detail.Message).Should(Equal(waitingForDynamicPVCMessage))
+			}
+
+			sourcePVCNames := make([]string, 0, len(sourcePVCTemplates))
+			for sourcePVCName := range sourcePVCTemplates {
+				sourcePVCNames = append(sourcePVCNames, sourcePVCName)
+			}
+			slices.Sort(sourcePVCNames)
+			recreateSourcePVC := func(sourcePVCName string) {
+				sourcePVCTemplate := sourcePVCTemplates[sourcePVCName]
+				recreatedSourcePVC := sourcePVCTemplate.DeepCopy()
+				recreatedSourcePVC.ResourceVersion = ""
+				recreatedSourcePVC.UID = ""
+				recreatedSourcePVC.CreationTimestamp = metav1.Time{}
+				recreatedSourcePVC.DeletionTimestamp = nil
+				recreatedSourcePVC.ManagedFields = nil
+				recreatedSourcePVC.Finalizers = nil
+				recreatedSourcePVC.Spec.VolumeName = "dynamic-" + sourcePVCName
+				Expect(k8sClient.Create(ctx, recreatedSourcePVC)).Should(Succeed())
+				Expect(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKeyFromObject(recreatedSourcePVC), func(pvc *corev1.PersistentVolumeClaim) {
+					pvc.Status.Phase = corev1.ClaimBound
+				})()).Should(Succeed())
+			}
+			if len(sourcePVCNames) > 1 {
+				firstSourcePVCName := sourcePVCNames[0]
+				recreateSourcePVC(firstSourcePVCName)
+				_, err = GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
+				Expect(err).Should(Succeed())
+				firstPVC := &corev1.PersistentVolumeClaim{}
+				Expect(k8sClient.Get(ctx, client.ObjectKey{Name: firstSourcePVCName, Namespace: opsRes.OpsRequest.Namespace}, firstPVC)).Should(Succeed())
+				Expect(string(firstPVC.UID)).ShouldNot(Equal(sourcePVCIdentities[firstSourcePVCName].UID))
+				Expect(firstPVC.DeletionTimestamp).Should(BeNil())
+				progressMessages := make([]string, 0, len(opsRes.OpsRequest.Status.Components[defaultCompName].ProgressDetails))
+				for _, detail := range opsRes.OpsRequest.Status.Components[defaultCompName].ProgressDetails {
+					progressMessages = append(progressMessages, detail.Message)
+				}
+				Expect(progressMessages).Should(ContainElement(waitingForDynamicPVCMessage))
+				Expect(progressMessages).Should(ContainElement(waitingForInstanceReadyMessage))
+			}
+
+			for _, sourcePVCName := range sourcePVCNames {
+				existing := &corev1.PersistentVolumeClaim{}
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: sourcePVCName, Namespace: opsRes.OpsRequest.Namespace}, existing)
+				if err == nil {
+					if existing.DeletionTimestamp == nil && string(existing.UID) != sourcePVCIdentities[sourcePVCName].UID {
+						if existing.Spec.VolumeName == "" {
+							Expect(testapps.ChangeObj(&testCtx, existing, func(pvc *corev1.PersistentVolumeClaim) {
+								pvc.Spec.VolumeName = "dynamic-" + sourcePVCName
+							})).Should(Succeed())
+						}
+						Expect(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKey{Name: sourcePVCName, Namespace: opsRes.OpsRequest.Namespace}, func(pvc *corev1.PersistentVolumeClaim) {
+							pvc.Status.Phase = corev1.ClaimBound
+						})()).Should(Succeed())
+						continue
+					}
+					testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.PersistentVolumeClaimSignature, true,
+						client.InNamespace(opsRes.OpsRequest.Namespace), client.MatchingFields{"metadata.name": sourcePVCName})
+				} else {
+					Expect(apierrors.IsNotFound(err)).Should(BeTrue())
+				}
+				Eventually(func(g Gomega) {
+					pvc := &corev1.PersistentVolumeClaim{}
+					err := k8sClient.Get(ctx, client.ObjectKey{Name: sourcePVCName, Namespace: opsRes.OpsRequest.Namespace}, pvc)
+					g.Expect(apierrors.IsNotFound(err)).Should(BeTrue())
+				}).Should(Succeed())
+				recreateSourcePVC(sourcePVCName)
+			}
+
+			Eventually(func(g Gomega) {
+				_, err := GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
+				g.Expect(err).Should(Succeed())
+				for sourcePVCName, oldIdentity := range sourcePVCIdentities {
+					pvc := &corev1.PersistentVolumeClaim{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: sourcePVCName, Namespace: opsRes.OpsRequest.Namespace}, pvc)).Should(Succeed())
+					g.Expect(string(pvc.UID)).ShouldNot(Equal(oldIdentity.UID))
+					if oldIdentity.VolumeName != "" && pvc.Spec.VolumeName != "" {
+						g.Expect(pvc.Spec.VolumeName).ShouldNot(Equal(oldIdentity.VolumeName))
+					}
+				}
+				ops := &opsv1alpha1.OpsRequest{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(opsRes.OpsRequest), ops)).Should(Succeed())
+				for _, detail := range ops.Status.Components[defaultCompName].ProgressDetails {
+					g.Expect(detail.Message).Should(Or(Equal(waitingForInstanceReadyMessage), MatchRegexp(`^Rebuild pod .+ successfully$`)))
+				}
+			}).Should(Succeed())
+		}
+
 		waitForInstanceToAvailable := func(reqCtx intctrlutil.RequestCtx, opsRes *OpsResource, ignoreRoleCheck bool) {
 			By("waiting for the rebuild instance to ready")
 			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest), func(g Gomega, ops *opsv1alpha1.OpsRequest) {
@@ -389,16 +527,18 @@ var _ = Describe("OpsUtil functions", func() {
 			its := testapps.MockInstanceSetComponent(&testCtx, clusterName, defaultCompName)
 			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsRunningPhase
 			reqCtx := intctrlutil.RequestCtx{Ctx: testCtx.Ctx}
-
-			By("expect for the tmp pods and pvcs are created")
-			_, _ = GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
 			matchingLabels := client.MatchingLabels{
 				constant.OpsRequestNameLabelKey:      opsRes.OpsRequest.Name,
 				constant.OpsRequestNamespaceLabelKey: opsRes.OpsRequest.Namespace,
 			}
+
+			By("expect to dynamically reprovision the source pvcs without helper tmp resources.")
+			sourcePVCsShouldDynamicReprovision(reqCtx, opsRes)
+
+			By("expect no-backup rebuild to skip tmp pod/pvc creation")
 			podList := &corev1.PodList{}
 			Expect(k8sClient.List(ctx, podList, matchingLabels, client.InNamespace(opsRes.OpsRequest.Namespace))).Should(Succeed())
-			Expect(podList.Items).Should(HaveLen(rebuildInstanceCount))
+			Expect(podList.Items).Should(BeEmpty())
 			pvcList := &corev1.PersistentVolumeClaimList{}
 			Expect(k8sClient.List(ctx, pvcList, client.MatchingLabels{constant.KBAppComponentLabelKey: defaultCompName}, client.InNamespace(opsRes.OpsRequest.Namespace))).Should(Succeed())
 			tmpPVCCount := 0
@@ -407,18 +547,7 @@ var _ = Describe("OpsUtil functions", func() {
 					tmpPVCCount += 1
 				}
 			}
-			Expect(tmpPVCCount).Should(Equal(rebuildInstanceCount))
-
-			By("fake the rebuilding pod to be Completed and fake pvs are created.")
-			for i := range podList.Items {
-				pod := &podList.Items[i]
-				Expect(testapps.ChangeObjStatus(&testCtx, pod, func() {
-					pod.Status.Phase = corev1.PodSucceeded
-				})).Should(Succeed())
-			}
-
-			By("expect to create the source pvcs and the pvs have rebind them.")
-			sourcePVCsShouldRebindPVs(reqCtx, opsRes, pvcList)
+			Expect(tmpPVCCount).Should(BeZero())
 
 			By("expect the opsRequest to succeed")
 			waitForInstanceToAvailable(reqCtx, opsRes, false)
@@ -427,7 +556,7 @@ var _ = Describe("OpsUtil functions", func() {
 				g.Expect(ops.Status.Phase).Should(Equal(opsv1alpha1.OpsSucceedPhase))
 			}))
 
-			By("expect to clean up the tmp pods")
+			By("expect no tmp pods were left behind")
 			_, err := GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(testapps.List(&testCtx, generics.PodSignature, matchingLabels, client.InNamespace(opsRes.OpsRequest.Namespace))).Should(HaveLen(0))
@@ -493,6 +622,28 @@ var _ = Describe("OpsUtil functions", func() {
 
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(sourcePVC), sourcePVC)).Should(Succeed())
 			Expect(sourcePVC.Spec.VolumeName).Should(ContainSubstring("restored-pv-"))
+		})
+
+		It("rejects a dynamically provisioned source PVC with mismatched identity", func() {
+			helper := &inplaceRebuildHelper{}
+			expectedPVC := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "data-rebuild-expected",
+					Labels: map[string]string{constant.KBAppComponentLabelKey: defaultCompName},
+				},
+			}
+			foreignPVC := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "data-rebuild-expected",
+					Labels: map[string]string{constant.KBAppComponentLabelKey: "foreign"},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{VolumeName: "new-pv"},
+			}
+			Expect(helper.validateDynamicSourcePVC(foreignPVC, expectedPVC, rebuildSourcePVCIdentity{UID: "old-uid", VolumeName: "old-pv"})).Should(MatchError(ContainSubstring("not rebuilt from the expected workload template")))
+
+			reusedOldPV := expectedPVC.DeepCopy()
+			reusedOldPV.Spec.VolumeName = "old-pv"
+			Expect(helper.validateDynamicSourcePVC(reusedOldPV, expectedPVC, rebuildSourcePVCIdentity{UID: "old-uid", VolumeName: "old-pv"})).Should(MatchError(ContainSubstring("still bound to the old pv")))
 		})
 
 		It("preserves rebuild identity metadata when reverting the reclaim policy", func() {

--- a/pkg/operations/rebuild_instance_test.go
+++ b/pkg/operations/rebuild_instance_test.go
@@ -399,9 +399,17 @@ var _ = Describe("OpsUtil functions", func() {
 			for sourcePVCName := range sourcePVCTemplates {
 				Eventually(func(g Gomega) {
 					pvc := &corev1.PersistentVolumeClaim{}
-					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: sourcePVCName, Namespace: opsRes.OpsRequest.Namespace}, pvc)).Should(Succeed())
+					err := k8sClient.Get(ctx, client.ObjectKey{Name: sourcePVCName, Namespace: opsRes.OpsRequest.Namespace}, pvc)
+					if apierrors.IsNotFound(err) {
+						return
+					}
+					g.Expect(err).Should(Succeed())
 					g.Expect(pvc.DeletionTimestamp).ShouldNot(BeNil())
-					g.Expect(pvc.Finalizers).Should(ContainElement("kubernetes.io/pvc-protection"))
+					if sourcePVCName == preDeletingSourcePVCName {
+						g.Expect(pvc.Finalizers).Should(ContainElement("kubernetes.io/pvc-protection"))
+					} else {
+						g.Expect(pvc.Finalizers).Should(BeEmpty())
+					}
 				}).Should(Succeed())
 			}
 			for _, ins := range opsRes.OpsRequest.Spec.RebuildFrom[0].Instances {
@@ -412,23 +420,7 @@ var _ = Describe("OpsUtil functions", func() {
 				}).Should(Succeed())
 			}
 
-			By("expect old source PVCs to keep PVC protection until the workload releases them")
-			_, err = GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
-			Expect(err).Should(Succeed())
-			for sourcePVCName := range sourcePVCTemplates {
-				Eventually(func(g Gomega) {
-					pvc := &corev1.PersistentVolumeClaim{}
-					g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: sourcePVCName, Namespace: opsRes.OpsRequest.Namespace}, pvc)).Should(Succeed())
-					g.Expect(pvc.DeletionTimestamp).ShouldNot(BeNil())
-					g.Expect(pvc.Finalizers).Should(ContainElement("kubernetes.io/pvc-protection"))
-				}).Should(Succeed())
-				testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.PersistentVolumeClaimSignature, true,
-					client.InNamespace(opsRes.OpsRequest.Namespace), client.MatchingFields{"metadata.name": sourcePVCName})
-			}
-
 			By("expect rebuild to wait for the rebuilt instance")
-			_, err = GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
-			Expect(err).Should(Succeed())
 			for _, detail := range opsRes.OpsRequest.Status.Components[defaultCompName].ProgressDetails {
 				Expect(detail.Message).Should(Equal(waitingForInstanceReadyMessage))
 			}


### PR DESCRIPTION
## Summary

Backport the no-backup RebuildInstance fresh-PVC flow from #10295 to `release-1.0`.

This keeps the backup/helper-PV rebuild path unchanged. For no-backup rebuild, the dynamic source PVC path now avoids the helper tmp-PVC/PV handoff and waits for the workload-owned fresh PVC/pod path instead.

## Validation

Controller package validation on this release-1.0 branch:

- `go test -c ./pkg/operations`: PASS
- `go test ./pkg/operations -run TestAPIs -count=1`: PASS

Patch-image runtime validation before opening this PR:

- MySQL PR #48 no-backup RebuildInstance single case: PASS=11 FAIL=0 SKIP=0
- OpsRequest reached `Succeed`
- rebuilt secondary caught up the baseline data
- topology stayed at one primary and one secondary
- controller restart count stayed 0 during the run
- cleanup finished with residual=0 and terminating=0
- evidence sha256: `6f082dfcc87372483a30fd0b07dfdc8bfe52e7dd6ec2f94d465bccfe7db4e249`

## Boundary

The runtime validation above is patch-version single-case validation for this release-1.0 branch. After this PR is merged and a new release-1.0 image is produced, the MySQL RebuildInstance final validation should re-pin the merged SHA/image and run again.
