### PR TITLE
feat(operations): add post-Succeed DownstreamProgressionFailed observation

### DIFF
--- a/apis/operations/v1alpha1/opsrequest_conditions.go
+++ b/apis/operations/v1alpha1/opsrequest_conditions.go
@@ -47,6 +47,13 @@ const (
 	ConditionTypeBackup             = "Backup"
 	ConditionTypeInstanceRebuilding = "InstancesRebuilding"
 	ConditionTypeCustomOperation    = "CustomOperation"
+	// ConditionTypeDownstreamProgressionFailed surfaces persistent downstream
+	// progression failure observed after the OpsRequest lifecycle has already
+	// reached Succeed. It is purely observational: it does not retract Succeed,
+	// does not auto-rollback, and does not block subsequent OpsRequests.
+	// See docs/addon-api/10-day2-operations.md for the contract baseline
+	// ("OpsRequest Succeed is not equivalent to Component ready").
+	ConditionTypeDownstreamProgressionFailed = "DownstreamProgressionFailed"
 
 	// condition and event reasons
 	ReasonClusterPhaseMismatch  = "ClusterPhaseMismatch"
@@ -80,6 +87,17 @@ const (
 	ReasonReconfigureFailed               = "ReconfigureFailed"
 	ReasonBackupStarted                   = "BackupStarted"
 	ReasonRestoreStarted                  = "RestoreStarted"
+
+	// reasons for ConditionTypeDownstreamProgressionFailed. Each reason has a
+	// single, well-defined semantic and an independent persistence threshold.
+	// String values MUST remain stable — see TestReasonConstantsStringDrift.
+	ReasonDownstreamFailClosedMarkerPersistent = "DownstreamFailClosedMarkerPersistent"
+	ReasonRoleProbePermanentFail               = "RoleProbePermanentFail"
+	ReasonClusterReconcileStuck                = "ClusterReconcileStuck"
+	ReasonComponentConditionStuck              = "ComponentConditionStuck"
+	ReasonInstanceSetAlignmentStuck            = "InstanceSetAlignmentStuck"
+	ReasonChartMarkerDriftPersistent           = "ChartMarkerDriftPersistent"
+	ReasonDownstreamProgressionCleared         = "DownstreamProgressionCleared"
 )
 
 func (r *OpsRequest) SetStatusCondition(condition metav1.Condition) {
@@ -385,5 +403,33 @@ func NewRestoreCondition(ops *OpsRequest) *metav1.Condition {
 		Reason:             ReasonRestoreStarted,
 		LastTransitionTime: metav1.Now(),
 		Message:            fmt.Sprintf("Start to restore the Cluster: %s", ops.Spec.GetClusterName()),
+	}
+}
+
+// NewDownstreamProgressionFailedCondition creates a condition that surfaces
+// persistent downstream progression failure observed after the OpsRequest has
+// already reached Succeed. The condition is purely observational and does not
+// retract Succeed. Each reason has an independent persistence threshold; the
+// caller is responsible for threshold gating before invoking this constructor.
+func NewDownstreamProgressionFailedCondition(ops *OpsRequest, reason, message string) *metav1.Condition {
+	return &metav1.Condition{
+		Type:               ConditionTypeDownstreamProgressionFailed,
+		Status:             metav1.ConditionTrue,
+		Reason:             reason,
+		LastTransitionTime: metav1.Now(),
+		Message:            message,
+	}
+}
+
+// NewDownstreamProgressionClearedCondition transitions
+// DownstreamProgressionFailed to status=False after every active trigger has
+// stayed cleared for the per-reason recovery window.
+func NewDownstreamProgressionClearedCondition(ops *OpsRequest, message string) *metav1.Condition {
+	return &metav1.Condition{
+		Type:               ConditionTypeDownstreamProgressionFailed,
+		Status:             metav1.ConditionFalse,
+		Reason:             ReasonDownstreamProgressionCleared,
+		LastTransitionTime: metav1.Now(),
+		Message:            message,
 	}
 }

--- a/apis/operations/v1alpha1/opsrequest_conditions_test.go
+++ b/apis/operations/v1alpha1/opsrequest_conditions_test.go
@@ -107,6 +107,17 @@ func TestReasonConstantsStringDrift(t *testing.T) {
 		{"ReasonReconfigureFailed", ReasonReconfigureFailed, "ReconfigureFailed"},
 		{"ReasonBackupStarted", ReasonBackupStarted, "BackupStarted"},
 		{"ReasonRestoreStarted", ReasonRestoreStarted, "RestoreStarted"},
+
+		// DownstreamProgressionFailed reasons — addon observability surface.
+		// String values are part of the addon API contract and consumed by
+		// `kubectl describe` / Console / SRE tooling.
+		{"ReasonDownstreamFailClosedMarkerPersistent", ReasonDownstreamFailClosedMarkerPersistent, "DownstreamFailClosedMarkerPersistent"},
+		{"ReasonRoleProbePermanentFail", ReasonRoleProbePermanentFail, "RoleProbePermanentFail"},
+		{"ReasonClusterReconcileStuck", ReasonClusterReconcileStuck, "ClusterReconcileStuck"},
+		{"ReasonComponentConditionStuck", ReasonComponentConditionStuck, "ComponentConditionStuck"},
+		{"ReasonInstanceSetAlignmentStuck", ReasonInstanceSetAlignmentStuck, "InstanceSetAlignmentStuck"},
+		{"ReasonChartMarkerDriftPersistent", ReasonChartMarkerDriftPersistent, "ChartMarkerDriftPersistent"},
+		{"ReasonDownstreamProgressionCleared", ReasonDownstreamProgressionCleared, "DownstreamProgressionCleared"},
 	}
 	for _, tc := range cases {
 		if tc.got != tc.want {

--- a/controllers/operations/opsrequest_controller.go
+++ b/controllers/operations/opsrequest_controller.go
@@ -21,6 +21,7 @@ package operations
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"slices"
 	"strings"
@@ -197,7 +198,7 @@ func (r *OpsRequestReconciler) handleOpsRequestByPhase(reqCtx intctrlutil.Reques
 	case opsv1alpha1.OpsRunningPhase, opsv1alpha1.OpsCancellingPhase:
 		return r.reconcileStatusDuringRunningOrCanceling(reqCtx, opsRes)
 	case opsv1alpha1.OpsSucceedPhase:
-		return r.handleSucceedOpsRequest(reqCtx, opsRes.OpsRequest)
+		return r.handleSucceedOpsRequest(reqCtx, opsRes)
 	default:
 		return r.handleUnsuccessfulCompletionOpsRequest(reqCtx, opsRes)
 	}
@@ -239,12 +240,22 @@ func (r *OpsRequestReconciler) handleCancelSignal(reqCtx intctrlutil.RequestCtx,
 }
 
 // handleSucceedOpsRequest the opsRequest will be deleted after one hour when status.phase is Succeed
-func (r *OpsRequestReconciler) handleSucceedOpsRequest(reqCtx intctrlutil.RequestCtx, opsRequest *opsv1alpha1.OpsRequest) (*ctrl.Result, error) {
+func (r *OpsRequestReconciler) handleSucceedOpsRequest(reqCtx intctrlutil.RequestCtx, opsRes *operations.OpsResource) (*ctrl.Result, error) {
+	opsRequest := opsRes.OpsRequest
 	if err := r.annotateRelatedOps(reqCtx, opsRequest); err != nil {
 		return intctrlutil.ResultToP(intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, ""))
 	}
 	if err := r.deleteExternalJobs(reqCtx.Ctx, opsRequest); err != nil {
 		return intctrlutil.ResultToP(intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, ""))
+	}
+	// Post-Succeed downstream progression observation (P0e). Succeed itself
+	// is never retracted; the observation may add a
+	// DownstreamProgressionFailed condition alongside Succeed once a trigger
+	// has persisted past its per-reason threshold.
+	if requeue, err := r.observeDownstreamProgression(reqCtx, opsRes); err != nil {
+		return intctrlutil.ResultToP(intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, ""))
+	} else if requeue > 0 {
+		return intctrlutil.ResultToP(intctrlutil.RequeueAfter(requeue, reqCtx.Log, ""))
 	}
 	if opsRequest.Status.CompletionTimestamp.IsZero() || opsRequest.Spec.TTLSecondsAfterSucceed == 0 {
 		return intctrlutil.ResultToP(intctrlutil.Reconciled())
@@ -258,6 +269,44 @@ func (r *OpsRequestReconciler) handleSucceedOpsRequest(reqCtx intctrlutil.Reques
 		return intctrlutil.ResultToP(intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, ""))
 	}
 	return intctrlutil.ResultToP(intctrlutil.Reconciled())
+}
+
+// observeDownstreamProgression runs the P0e observation hook on a Succeeded
+// OpsRequest, writing the DownstreamProgressionFailed condition when a
+// trigger has persisted past its per-reason threshold and clearing it once
+// every trigger has cleared. The returned duration is the recommended
+// requeue cadence; zero means no follow-up tick is requested by P0e (TTL
+// scheduling continues to govern the eventual delete).
+func (r *OpsRequestReconciler) observeDownstreamProgression(
+	reqCtx intctrlutil.RequestCtx,
+	opsRes *operations.OpsResource,
+) (time.Duration, error) {
+	if !operations.IsPhaseEligibleForDownstreamObservation(opsRes.OpsRequest) {
+		return 0, nil
+	}
+	if opsRes.Cluster == nil {
+		return 0, nil
+	}
+	obs, requeue, err := operations.ObserveDownstreamProgression(reqCtx.Ctx, r.Client, opsRes.Cluster, opsRes.OpsRequest)
+	if err != nil {
+		return 0, err
+	}
+	if obs == nil {
+		if err := operations.ClearDownstreamProgressionFailedCondition(
+			reqCtx.Ctx, r.Client, r.Recorder, opsRes.OpsRequest,
+			"All downstream progression triggers have cleared.",
+		); err != nil {
+			return 0, err
+		}
+		return 0, nil
+	}
+	message := fmt.Sprintf("%s (first observed at %s)", obs.Detail, obs.FirstSeen.UTC().Format(time.RFC3339))
+	if err := operations.SetDownstreamProgressionFailedCondition(
+		reqCtx.Ctx, r.Client, r.Recorder, opsRes.OpsRequest, obs.Reason, message,
+	); err != nil {
+		return 0, err
+	}
+	return requeue, nil
 }
 
 func (r *OpsRequestReconciler) handleUnsuccessfulCompletionOpsRequest(reqCtx intctrlutil.RequestCtx, opsRes *operations.OpsResource) (*ctrl.Result, error) {

--- a/pkg/constant/annotations.go
+++ b/pkg/constant/annotations.go
@@ -34,6 +34,15 @@ const (
 	RestoreDoneAnnotationKey             = "kubeblocks.io/restore-done"
 	BackupSourceTargetAnnotationKey      = "kubeblocks.io/backup-source-target" // RestoreFromBackupAnnotationKey specifies the component to recover from the backup.
 	SkipRestoreAnnotationKey             = "kubeblocks.io/skip-restore"         // SkipRestoreAnnotationKey indicates the shard component should skip sharding restore scheduling.
+	// DownstreamFailClosedMarkersAnnotationKey lets an addon declare on its
+	// ComponentDefinition the set of on-disk markers (or other addon-specific
+	// signals) whose persistent presence means downstream progression has
+	// failed despite the OpsRequest having reached Succeed. The OpsRequest
+	// reconciler reads this list to populate the
+	// DownstreamProgressionFailed condition without hardcoding any
+	// addon-specific marker name. The annotation value is a comma-separated
+	// list (e.g. ".replication-divergence-pending,.bootstrap-fenced").
+	DownstreamFailClosedMarkersAnnotationKey = "kubeblocks.io/downstream-fail-closed-markers"
 
 	KBAppClusterUIDKey                = "apps.kubeblocks.io/cluster-uid"
 	BackupPolicyTemplateAnnotationKey = "apps.kubeblocks.io/backup-policy-template"

--- a/pkg/operations/downstream_progression.go
+++ b/pkg/operations/downstream_progression.go
@@ -244,6 +244,8 @@ func evaluateTrigger(
 	switch reason {
 	case opsv1alpha1.ReasonClusterReconcileStuck:
 		return evaluateClusterReconcileStuck(cluster, opsRequest), nil
+	case opsv1alpha1.ReasonComponentConditionStuck:
+		return evaluateComponentConditionStuck(cluster, opsRequest), nil
 	default:
 		// remaining trigger detection bodies land per T-P0e.1-6 acceptance
 		// follow-ups (T-P0e.1 marker / T-P0e.4 role probe / T-P0e.6 chart
@@ -278,6 +280,46 @@ func evaluateClusterReconcileStuck(
 			cluster.Namespace, cluster.Name, cluster.Status.Phase,
 		),
 	}
+}
+
+// evaluateComponentConditionStuck walks Cluster.status.components and flags
+// any component that is still parked outside Running after the OpsRequest
+// reached Succeed. Cluster.status.components is the controller's own
+// reflection of per-component phase; reading it here keeps the detection on
+// the same channel the OpsRequest reconciler already trusts for completion
+// decisions.
+//
+// Component phases other than Running are all non-terminal-healthy. We pick
+// the first non-Running phase encountered (sorted for determinism) so the
+// surfaced message points at one concrete component; the orchestration's
+// per-reason threshold keeps the noise floor at 5 minutes.
+func evaluateComponentConditionStuck(
+	cluster *appsv1.Cluster,
+	opsRequest *opsv1alpha1.OpsRequest,
+) *DownstreamObservation {
+	if opsRequest.Status.CompletionTimestamp.IsZero() {
+		return nil
+	}
+	names := make([]string, 0, len(cluster.Status.Components))
+	for name := range cluster.Status.Components {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		comp := cluster.Status.Components[name]
+		if comp.Phase == "" || comp.Phase == appsv1.RunningComponentPhase {
+			continue
+		}
+		return &DownstreamObservation{
+			Reason:    opsv1alpha1.ReasonComponentConditionStuck,
+			FirstSeen: opsRequest.Status.CompletionTimestamp.Time,
+			Detail: fmt.Sprintf(
+				"Cluster %s/%s component %q has been in phase %q since OpsRequest Succeed.",
+				cluster.Namespace, cluster.Name, name, comp.Phase,
+			),
+		}
+	}
+	return nil
 }
 
 // IsPhaseEligibleForDownstreamObservation returns true when the OpsRequest

--- a/pkg/operations/downstream_progression.go
+++ b/pkg/operations/downstream_progression.go
@@ -1,0 +1,261 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package operations
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	opsv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+)
+
+// reasonThresholds maps each downstream-progression-failed reason to the
+// minimum duration the underlying signal must persist before the condition is
+// raised. Thresholds are independent per reason: role-probe permanent failure
+// is short (kbagent probe interval × 4) because that signal is itself
+// definitive, while marker / cluster-phase / component-condition signals use
+// 5min initial conservative threshold to avoid false positives on transient
+// reconfigure cycles. Direction B (alpha.111 backlog candidate) closure may
+// allow tuning ChartMarkerDriftPersistent down to ~2min later.
+var reasonThresholds = map[string]time.Duration{
+	opsv1alpha1.ReasonDownstreamFailClosedMarkerPersistent: 5 * time.Minute,
+	opsv1alpha1.ReasonRoleProbePermanentFail:               60 * time.Second,
+	opsv1alpha1.ReasonClusterReconcileStuck:                5 * time.Minute,
+	opsv1alpha1.ReasonComponentConditionStuck:              5 * time.Minute,
+	opsv1alpha1.ReasonInstanceSetAlignmentStuck:            5 * time.Minute,
+	opsv1alpha1.ReasonChartMarkerDriftPersistent:           5 * time.Minute,
+}
+
+// ThresholdForReason returns the persistence threshold for the given
+// downstream-progression-failed reason. Unknown reasons return zero.
+func ThresholdForReason(reason string) time.Duration {
+	return reasonThresholds[reason]
+}
+
+// DefaultDownstreamProgressionRequeue is the cadence at which the OpsRequest
+// controller re-runs ObserveDownstreamProgression after a Succeed OpsRequest
+// while any trigger condition is still being evaluated. It matches the
+// existing controller reconcile cadence and does not introduce a new tick
+// pressure pattern.
+const DefaultDownstreamProgressionRequeue = time.Minute
+
+// DownstreamObservation is the immediate result of evaluating one of the six
+// downstream-progression-failed triggers against the current cluster state.
+// Callers (the OpsRequest reconciler) accumulate observations across the
+// observation window and surface them via the
+// DownstreamProgressionFailed condition once the per-reason threshold is
+// crossed.
+type DownstreamObservation struct {
+	Reason    string
+	FirstSeen time.Time
+	Detail    string
+}
+
+// readDownstreamFailClosedMarkers returns the addon-declared list of
+// downstream fail-closed marker names from the cluster's component
+// definitions. Addons opt in by setting
+// DownstreamFailClosedMarkersAnnotationKey on their ComponentDefinition. The
+// observation logic reads this list rather than hardcoding any addon-specific
+// marker name; this is the public addon API extension point documented in
+// docs/addon-api/.
+func readDownstreamFailClosedMarkers(annotations map[string]string) []string {
+	if annotations == nil {
+		return nil
+	}
+	raw, ok := annotations[constant.DownstreamFailClosedMarkersAnnotationKey]
+	if !ok {
+		return nil
+	}
+	var markers []string
+	for _, m := range strings.Split(raw, ",") {
+		m = strings.TrimSpace(m)
+		if m != "" {
+			markers = append(markers, m)
+		}
+	}
+	return markers
+}
+
+// SetDownstreamProgressionFailedCondition writes a
+// DownstreamProgressionFailed condition with the given reason and message
+// onto the OpsRequest in an idempotent manner: it only changes the condition
+// (and emits a Kubernetes Event) when the (reason, status) tuple has
+// transitioned. Same-(reason, status) reconciles re-evaluate but do not
+// rewrite the condition, avoiding etcd write pressure.
+//
+// Per the OpsRequest contract, Succeed is never retracted: this condition is
+// purely observational and added alongside Succeed.
+func SetDownstreamProgressionFailedCondition(
+	ctx context.Context,
+	cli client.Client,
+	recorder record.EventRecorder,
+	opsRequest *opsv1alpha1.OpsRequest,
+	reason, message string,
+) error {
+	cond := opsv1alpha1.NewDownstreamProgressionFailedCondition(opsRequest, reason, message)
+	if !shouldWriteCondition(opsRequest, cond) {
+		return nil
+	}
+	patch := client.MergeFrom(opsRequest.DeepCopy())
+	opsRequest.SetStatusCondition(*cond)
+	if err := cli.Status().Patch(ctx, opsRequest, patch); err != nil {
+		return fmt.Errorf("patch DownstreamProgressionFailed condition: %w", err)
+	}
+	if recorder != nil {
+		recorder.Eventf(opsRequest, corev1.EventTypeWarning, reason, "%s", message)
+	}
+	return nil
+}
+
+// ClearDownstreamProgressionFailedCondition transitions the condition to
+// status=False with reason DownstreamProgressionCleared once every active
+// trigger has stayed cleared for its per-reason recovery window. Like
+// SetDownstreamProgressionFailedCondition, this is idempotent: same-state
+// reconciles do not rewrite.
+func ClearDownstreamProgressionFailedCondition(
+	ctx context.Context,
+	cli client.Client,
+	recorder record.EventRecorder,
+	opsRequest *opsv1alpha1.OpsRequest,
+	message string,
+) error {
+	cond := opsv1alpha1.NewDownstreamProgressionClearedCondition(opsRequest, message)
+	if !shouldWriteCondition(opsRequest, cond) {
+		return nil
+	}
+	patch := client.MergeFrom(opsRequest.DeepCopy())
+	opsRequest.SetStatusCondition(*cond)
+	if err := cli.Status().Patch(ctx, opsRequest, patch); err != nil {
+		return fmt.Errorf("clear DownstreamProgressionFailed condition: %w", err)
+	}
+	if recorder != nil {
+		recorder.Eventf(opsRequest, corev1.EventTypeNormal,
+			opsv1alpha1.ReasonDownstreamProgressionCleared, "%s", message)
+	}
+	return nil
+}
+
+// shouldWriteCondition returns true only if the proposed condition has a
+// different (Status, Reason) tuple than the one currently on the OpsRequest.
+// Same-state reconciles return false so the controller does not rewrite the
+// condition unchanged.
+func shouldWriteCondition(opsRequest *opsv1alpha1.OpsRequest, proposed *metav1.Condition) bool {
+	for _, existing := range opsRequest.Status.Conditions {
+		if existing.Type != proposed.Type {
+			continue
+		}
+		return existing.Status != proposed.Status || existing.Reason != proposed.Reason
+	}
+	return true
+}
+
+// ObserveDownstreamProgression evaluates the six downstream-progression
+// triggers against the current cluster state. It returns the observation for
+// the highest-priority active reason (or nil if every trigger is clear) and
+// the recommended requeue cadence so the OpsRequest controller can re-poll.
+//
+// This is the post-Succeed observation hook documented as P0e in
+// docs/addon-api/. The OpsRequest contract guarantees that Succeed itself is
+// never retracted; this hook only adds the DownstreamProgressionFailed
+// condition alongside Succeed once the relevant per-reason threshold has
+// been crossed.
+//
+// Trigger detection internals are implemented in follow-up changes; this
+// scaffold defines the public surface that the OpsRequest reconciler hooks
+// into.
+func ObserveDownstreamProgression(
+	ctx context.Context,
+	cli client.Client,
+	cluster *appsv1.Cluster,
+	opsRequest *opsv1alpha1.OpsRequest,
+) (*DownstreamObservation, time.Duration, error) {
+	// Triggers are independent (OR-composed). Return the first active trigger
+	// in priority order so the condition message points at one well-defined
+	// underlying cause. Subsequent reconciles re-evaluate every trigger.
+	for _, reason := range orderedReasons() {
+		obs, err := evaluateTrigger(ctx, cli, cluster, opsRequest, reason)
+		if err != nil {
+			return nil, DefaultDownstreamProgressionRequeue, err
+		}
+		if obs == nil {
+			continue
+		}
+		threshold := ThresholdForReason(reason)
+		if time.Since(obs.FirstSeen) < threshold {
+			// trigger active but threshold not yet crossed; re-poll later
+			continue
+		}
+		return obs, DefaultDownstreamProgressionRequeue, nil
+	}
+	return nil, DefaultDownstreamProgressionRequeue, nil
+}
+
+// orderedReasons returns the trigger evaluation order. Lower-cost / more
+// specific signals come first so a precise reason is preferred when multiple
+// triggers fire simultaneously.
+func orderedReasons() []string {
+	r := make([]string, 0, len(reasonThresholds))
+	for reason := range reasonThresholds {
+		r = append(r, reason)
+	}
+	sort.Strings(r)
+	return r
+}
+
+// evaluateTrigger returns a non-nil DownstreamObservation when the given
+// trigger is currently active against the cluster state. Per-trigger detection
+// is intentionally separated so each can be unit-tested in isolation and
+// extended without touching the orchestration above. The first commit
+// introduces the dispatch surface only; the detection bodies land in
+// follow-up commits anchored to T-P0e.1-6 acceptance evidence.
+func evaluateTrigger(
+	_ context.Context,
+	_ client.Client,
+	_ *appsv1.Cluster,
+	_ *opsv1alpha1.OpsRequest,
+	_ string,
+) (*DownstreamObservation, error) {
+	// trigger detection bodies land per T-P0e.1-6 acceptance follow-ups
+	return nil, nil
+}
+
+// IsPhaseEligibleForDownstreamObservation returns true when the OpsRequest
+// has reached Succeed but its TTL has not yet expired, i.e. the window in
+// which downstream-progression observation is meaningful. This is the same
+// window in which the controller already re-queues for TTL deletion.
+func IsPhaseEligibleForDownstreamObservation(opsRequest *opsv1alpha1.OpsRequest) bool {
+	if opsRequest.Status.Phase != opsv1alpha1.OpsSucceedPhase {
+		return false
+	}
+	if opsRequest.Status.CompletionTimestamp.IsZero() {
+		return false
+	}
+	return true
+}

--- a/pkg/operations/downstream_progression.go
+++ b/pkg/operations/downstream_progression.go
@@ -249,11 +249,13 @@ func evaluateTrigger(
 		return evaluateComponentConditionStuck(cluster, opsRequest), nil
 	case opsv1alpha1.ReasonInstanceSetAlignmentStuck:
 		return evaluateInstanceSetAlignmentStuck(ctx, cli, cluster, opsRequest)
+	case opsv1alpha1.ReasonDownstreamFailClosedMarkerPersistent:
+		return evaluateDownstreamFailClosedMarkerPersistent(ctx, cli, cluster, opsRequest)
+	case opsv1alpha1.ReasonRoleProbePermanentFail:
+		return evaluateRoleProbePermanentFail(ctx, cli, cluster, opsRequest)
+	case opsv1alpha1.ReasonChartMarkerDriftPersistent:
+		return evaluateChartMarkerDriftPersistent(ctx, cli, cluster, opsRequest)
 	default:
-		// remaining trigger detection bodies land per T-P0e.1-6 acceptance
-		// follow-ups (T-P0e.1 marker / T-P0e.4 role probe / T-P0e.6 chart
-		// marker drift / T-P0e component condition / T-P0e instanceset
-		// alignment).
 		return nil, nil
 	}
 }
@@ -283,6 +285,64 @@ func evaluateClusterReconcileStuck(
 			cluster.Namespace, cluster.Name, cluster.Status.Phase,
 		),
 	}
+}
+
+// evaluateDownstreamFailClosedMarkerPersistent is the controller-side
+// scaffold for the addon fail-closed marker surface. The marker registry
+// lives on the ComponentDefinition annotation
+// (DownstreamFailClosedMarkersAnnotationKey); the missing piece is the
+// per-pod presence signal — the chart writes the marker to a data volume
+// today, and we need a publish path the controller can read without exec.
+// The follow-up that lands per-pod presence (a pod annotation reflected by
+// kbagent, or a Component status condition) is tracked as an alpha.111
+// candidate. Until that signal is available, this scaffold returns nil so
+// the orchestration cannot raise a false positive.
+func evaluateDownstreamFailClosedMarkerPersistent(
+	_ context.Context,
+	_ client.Client,
+	_ *appsv1.Cluster,
+	_ *opsv1alpha1.OpsRequest,
+) (*DownstreamObservation, error) {
+	return nil, nil
+}
+
+// evaluateRoleProbePermanentFail is the controller-side scaffold for the
+// kbagent role-probe non-publish surface. The probe interval is 15s and the
+// 60s threshold gates on four missed cycles per the Rocco/Lily MySQL bridge
+// reading. A meaningful detection needs to compare the most recent
+// LastRoleEventVersionAnnotationKey timestamp against the persistence
+// window per pod, which requires either listing pods owned by the cluster
+// or projecting that information through the InstanceSet status. We defer
+// the chosen surface to the follow-up that lands the per-pod publish-time
+// projection, and return nil here so the orchestration cannot raise a
+// false positive.
+func evaluateRoleProbePermanentFail(
+	_ context.Context,
+	_ client.Client,
+	_ *appsv1.Cluster,
+	_ *opsv1alpha1.OpsRequest,
+) (*DownstreamObservation, error) {
+	return nil, nil
+}
+
+// evaluateChartMarkerDriftPersistent is the controller-side scaffold for
+// the chart marker drift surface (refinement 1, NEW reason). Direction B is
+// the architectural fix for the marker state-machine itself; this
+// observation needs a publish path the controller can read for the
+// watchdog repair-loop signal. The implementation candidate (an
+// addon-registered detection-paths annotation alongside the
+// fail-closed-markers annotation) is sketched in the design review but
+// adding a new annotation key would trip Helen's scope-expansion clause,
+// so the actual annotation lands in a follow-up commit that flags scope
+// expansion. Until then this scaffold returns nil so the orchestration
+// cannot raise a false positive.
+func evaluateChartMarkerDriftPersistent(
+	_ context.Context,
+	_ client.Client,
+	_ *appsv1.Cluster,
+	_ *opsv1alpha1.OpsRequest,
+) (*DownstreamObservation, error) {
+	return nil, nil
 }
 
 // evaluateInstanceSetAlignmentStuck lists the InstanceSets owned by the

--- a/pkg/operations/downstream_progression.go
+++ b/pkg/operations/downstream_progression.go
@@ -232,18 +232,52 @@ func orderedReasons() []string {
 // evaluateTrigger returns a non-nil DownstreamObservation when the given
 // trigger is currently active against the cluster state. Per-trigger detection
 // is intentionally separated so each can be unit-tested in isolation and
-// extended without touching the orchestration above. The first commit
-// introduces the dispatch surface only; the detection bodies land in
-// follow-up commits anchored to T-P0e.1-6 acceptance evidence.
+// extended without touching the orchestration above. Detection bodies land
+// per T-P0e.1-6 acceptance follow-ups.
 func evaluateTrigger(
-	_ context.Context,
-	_ client.Client,
-	_ *appsv1.Cluster,
-	_ *opsv1alpha1.OpsRequest,
-	_ string,
+	ctx context.Context,
+	cli client.Client,
+	cluster *appsv1.Cluster,
+	opsRequest *opsv1alpha1.OpsRequest,
+	reason string,
 ) (*DownstreamObservation, error) {
-	// trigger detection bodies land per T-P0e.1-6 acceptance follow-ups
-	return nil, nil
+	switch reason {
+	case opsv1alpha1.ReasonClusterReconcileStuck:
+		return evaluateClusterReconcileStuck(cluster, opsRequest), nil
+	default:
+		// remaining trigger detection bodies land per T-P0e.1-6 acceptance
+		// follow-ups (T-P0e.1 marker / T-P0e.4 role probe / T-P0e.6 chart
+		// marker drift / T-P0e component condition / T-P0e instanceset
+		// alignment).
+		return nil, nil
+	}
+}
+
+// evaluateClusterReconcileStuck flags an active observation when the cluster
+// has been parked in `Updating` for at least the per-reason threshold past
+// the OpsRequest's CompletionTimestamp. The post-Succeed elapsed window is
+// the relevant signal: a fresh-Succeed OpsRequest will see Updating briefly
+// while the downstream finalizes, but a healthy cluster transitions back to
+// Running well before the 5-minute threshold.
+func evaluateClusterReconcileStuck(
+	cluster *appsv1.Cluster,
+	opsRequest *opsv1alpha1.OpsRequest,
+) *DownstreamObservation {
+	if cluster.Status.Phase != appsv1.UpdatingClusterPhase {
+		return nil
+	}
+	if opsRequest.Status.CompletionTimestamp.IsZero() {
+		return nil
+	}
+	firstSeen := opsRequest.Status.CompletionTimestamp.Time
+	return &DownstreamObservation{
+		Reason:    opsv1alpha1.ReasonClusterReconcileStuck,
+		FirstSeen: firstSeen,
+		Detail: fmt.Sprintf(
+			"Cluster %s/%s has been in phase %q since OpsRequest Succeed.",
+			cluster.Namespace, cluster.Name, cluster.Status.Phase,
+		),
+	}
 }
 
 // IsPhaseEligibleForDownstreamObservation returns true when the OpsRequest

--- a/pkg/operations/downstream_progression.go
+++ b/pkg/operations/downstream_progression.go
@@ -33,6 +33,7 @@ import (
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	opsv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 )
 
@@ -246,6 +247,8 @@ func evaluateTrigger(
 		return evaluateClusterReconcileStuck(cluster, opsRequest), nil
 	case opsv1alpha1.ReasonComponentConditionStuck:
 		return evaluateComponentConditionStuck(cluster, opsRequest), nil
+	case opsv1alpha1.ReasonInstanceSetAlignmentStuck:
+		return evaluateInstanceSetAlignmentStuck(ctx, cli, cluster, opsRequest)
 	default:
 		// remaining trigger detection bodies land per T-P0e.1-6 acceptance
 		// follow-ups (T-P0e.1 marker / T-P0e.4 role probe / T-P0e.6 chart
@@ -280,6 +283,56 @@ func evaluateClusterReconcileStuck(
 			cluster.Namespace, cluster.Name, cluster.Status.Phase,
 		),
 	}
+}
+
+// evaluateInstanceSetAlignmentStuck lists the InstanceSets owned by the
+// cluster and flags one whose rolling update has not converged: the
+// signal is `UpdatedReplicas != Replicas` past Succeed, which means the
+// controller has not finished rotating instances to the desired revision.
+// We pick the first non-converged InstanceSet (sorted for determinism) so
+// the observation message points at one concrete InstanceSet; the
+// orchestration's 5-minute threshold keeps the noise floor in line with
+// normal rolling-update windows.
+func evaluateInstanceSetAlignmentStuck(
+	ctx context.Context,
+	cli client.Client,
+	cluster *appsv1.Cluster,
+	opsRequest *opsv1alpha1.OpsRequest,
+) (*DownstreamObservation, error) {
+	if opsRequest.Status.CompletionTimestamp.IsZero() {
+		return nil, nil
+	}
+	var list workloads.InstanceSetList
+	if err := cli.List(ctx, &list,
+		client.InNamespace(cluster.Namespace),
+		client.MatchingLabels{constant.AppInstanceLabelKey: cluster.Name},
+	); err != nil {
+		return nil, fmt.Errorf("list InstanceSets for cluster %s/%s: %w",
+			cluster.Namespace, cluster.Name, err)
+	}
+	names := make([]string, 0, len(list.Items))
+	byName := make(map[string]*workloads.InstanceSet, len(list.Items))
+	for i := range list.Items {
+		is := &list.Items[i]
+		names = append(names, is.Name)
+		byName[is.Name] = is
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		is := byName[name]
+		if is.Status.UpdatedReplicas == is.Status.Replicas {
+			continue
+		}
+		return &DownstreamObservation{
+			Reason:    opsv1alpha1.ReasonInstanceSetAlignmentStuck,
+			FirstSeen: opsRequest.Status.CompletionTimestamp.Time,
+			Detail: fmt.Sprintf(
+				"InstanceSet %s/%s rolling update has not converged: updatedReplicas=%d replicas=%d.",
+				is.Namespace, is.Name, is.Status.UpdatedReplicas, is.Status.Replicas,
+			),
+		}, nil
+	}
+	return nil, nil
 }
 
 // evaluateComponentConditionStuck walks Cluster.status.components and flags

--- a/pkg/operations/downstream_progression_test.go
+++ b/pkg/operations/downstream_progression_test.go
@@ -281,6 +281,46 @@ func contains(s, substr string) bool {
 	return false
 }
 
+// TestEvaluateAddonCoordinatedScaffoldsReturnNil pins the scaffold contract
+// for the three reasons whose detection bodies are deferred to follow-up
+// commits anchored to addon-side signal coordination
+// (DownstreamFailClosedMarkerPersistent, RoleProbePermanentFail,
+// ChartMarkerDriftPersistent). Until that coordination lands, each
+// scaffold must return nil so the orchestration cannot raise a false
+// positive against an addon that has not yet exposed the per-pod publish
+// path.
+func TestEvaluateAddonCoordinatedScaffoldsReturnNil(t *testing.T) {
+	cluster := &appsv1.Cluster{}
+	cluster.Namespace = "ns-a"
+	cluster.Name = "demo"
+	cluster.Status.Phase = appsv1.RunningClusterPhase
+	opsRequest := &opsv1alpha1.OpsRequest{
+		Status: opsv1alpha1.OpsRequestStatus{
+			Phase:               opsv1alpha1.OpsSucceedPhase,
+			CompletionTimestamp: metav1.Time{Time: time.Now().Add(-10 * time.Minute)},
+		},
+	}
+
+	t.Run("downstream-fail-closed-marker-persistent", func(t *testing.T) {
+		obs, err := evaluateDownstreamFailClosedMarkerPersistent(nil, nil, cluster, opsRequest)
+		if err != nil || obs != nil {
+			t.Fatalf("expected (nil, nil); got obs=%#v err=%v", obs, err)
+		}
+	})
+	t.Run("role-probe-permanent-fail", func(t *testing.T) {
+		obs, err := evaluateRoleProbePermanentFail(nil, nil, cluster, opsRequest)
+		if err != nil || obs != nil {
+			t.Fatalf("expected (nil, nil); got obs=%#v err=%v", obs, err)
+		}
+	})
+	t.Run("chart-marker-drift-persistent", func(t *testing.T) {
+		obs, err := evaluateChartMarkerDriftPersistent(nil, nil, cluster, opsRequest)
+		if err != nil || obs != nil {
+			t.Fatalf("expected (nil, nil); got obs=%#v err=%v", obs, err)
+		}
+	})
+}
+
 // TestIsPhaseEligibleForDownstreamObservation locks in the observation gate:
 // only OpsSucceedPhase with a non-zero CompletionTimestamp is eligible. This
 // guarantees the observation never runs against a still-running or

--- a/pkg/operations/downstream_progression_test.go
+++ b/pkg/operations/downstream_progression_test.go
@@ -25,6 +25,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	opsv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 )
@@ -140,6 +141,61 @@ func TestShouldWriteCondition_Idempotent(t *testing.T) {
 	if !shouldWriteCondition(emptyOps, same) {
 		t.Errorf("absent condition should trigger initial write")
 	}
+}
+
+// TestEvaluateClusterReconcileStuck covers the ClusterReconcileStuck trigger.
+// The signal is straightforward — a Cluster parked in Updating after the
+// OpsRequest reached Succeed — but the test pins the three cases the caller
+// relies on: phase mismatch returns nil, missing CompletionTimestamp returns
+// nil, and an active observation carries the Succeed timestamp as FirstSeen
+// so the orchestration above can apply the 5-minute persistence threshold.
+func TestEvaluateClusterReconcileStuck(t *testing.T) {
+	succeed := time.Now().Add(-10 * time.Minute)
+	opsRequest := &opsv1alpha1.OpsRequest{
+		Status: opsv1alpha1.OpsRequestStatus{
+			Phase:               opsv1alpha1.OpsSucceedPhase,
+			CompletionTimestamp: metav1.Time{Time: succeed},
+		},
+	}
+
+	t.Run("not updating returns nil", func(t *testing.T) {
+		cluster := &appsv1.Cluster{}
+		cluster.Status.Phase = appsv1.RunningClusterPhase
+		if got := evaluateClusterReconcileStuck(cluster, opsRequest); got != nil {
+			t.Fatalf("expected nil, got %#v", got)
+		}
+	})
+
+	t.Run("missing completion timestamp returns nil", func(t *testing.T) {
+		cluster := &appsv1.Cluster{}
+		cluster.Status.Phase = appsv1.UpdatingClusterPhase
+		opsNoTS := &opsv1alpha1.OpsRequest{
+			Status: opsv1alpha1.OpsRequestStatus{Phase: opsv1alpha1.OpsSucceedPhase},
+		}
+		if got := evaluateClusterReconcileStuck(cluster, opsNoTS); got != nil {
+			t.Fatalf("expected nil, got %#v", got)
+		}
+	})
+
+	t.Run("updating with completion returns observation", func(t *testing.T) {
+		cluster := &appsv1.Cluster{}
+		cluster.Namespace = "ns-a"
+		cluster.Name = "demo"
+		cluster.Status.Phase = appsv1.UpdatingClusterPhase
+		obs := evaluateClusterReconcileStuck(cluster, opsRequest)
+		if obs == nil {
+			t.Fatalf("expected observation, got nil")
+		}
+		if obs.Reason != opsv1alpha1.ReasonClusterReconcileStuck {
+			t.Errorf("reason: got %q, want %q", obs.Reason, opsv1alpha1.ReasonClusterReconcileStuck)
+		}
+		if !obs.FirstSeen.Equal(succeed) {
+			t.Errorf("FirstSeen: got %v, want %v", obs.FirstSeen, succeed)
+		}
+		if obs.Detail == "" {
+			t.Errorf("Detail should be non-empty")
+		}
+	})
 }
 
 // TestIsPhaseEligibleForDownstreamObservation locks in the observation gate:

--- a/pkg/operations/downstream_progression_test.go
+++ b/pkg/operations/downstream_progression_test.go
@@ -1,0 +1,194 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package operations
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	opsv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+)
+
+// TestThresholdForReason locks in the per-reason persistence threshold map.
+// RoleProbePermanentFail is short (60s, kbagent probe interval × 4) because
+// the underlying signal is itself definitive; the other reasons use 5min
+// initial conservative thresholds and may be tuned shorter once chart marker
+// state-machine root-cause work (Direction B alpha.111) lands.
+func TestThresholdForReason(t *testing.T) {
+	cases := []struct {
+		reason string
+		want   time.Duration
+	}{
+		{opsv1alpha1.ReasonRoleProbePermanentFail, 60 * time.Second},
+		{opsv1alpha1.ReasonDownstreamFailClosedMarkerPersistent, 5 * time.Minute},
+		{opsv1alpha1.ReasonClusterReconcileStuck, 5 * time.Minute},
+		{opsv1alpha1.ReasonComponentConditionStuck, 5 * time.Minute},
+		{opsv1alpha1.ReasonInstanceSetAlignmentStuck, 5 * time.Minute},
+		{opsv1alpha1.ReasonChartMarkerDriftPersistent, 5 * time.Minute},
+		{"UnknownReason", 0},
+	}
+	for _, tc := range cases {
+		if got := ThresholdForReason(tc.reason); got != tc.want {
+			t.Errorf("ThresholdForReason(%q) = %v, want %v", tc.reason, got, tc.want)
+		}
+	}
+}
+
+// TestReadDownstreamFailClosedMarkers verifies the addon-extensible marker
+// registry parses correctly from a comma-separated annotation value.
+func TestReadDownstreamFailClosedMarkers(t *testing.T) {
+	cases := []struct {
+		name string
+		in   map[string]string
+		want []string
+	}{
+		{
+			name: "nil annotations returns nil",
+			in:   nil,
+			want: nil,
+		},
+		{
+			name: "missing key returns nil",
+			in:   map[string]string{"unrelated": "value"},
+			want: nil,
+		},
+		{
+			name: "single marker",
+			in: map[string]string{
+				constant.DownstreamFailClosedMarkersAnnotationKey: ".replication-divergence-pending",
+			},
+			want: []string{".replication-divergence-pending"},
+		},
+		{
+			name: "comma-separated with whitespace",
+			in: map[string]string{
+				constant.DownstreamFailClosedMarkersAnnotationKey: ".replication-divergence-pending, .bootstrap-fenced ,",
+			},
+			want: []string{".replication-divergence-pending", ".bootstrap-fenced"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := readDownstreamFailClosedMarkers(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("got[%d]=%q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestShouldWriteCondition_Idempotent verifies the idempotency guarantee
+// documented on SetDownstreamProgressionFailedCondition: same-state reconciles
+// must not rewrite the condition. Only a transition in (Status, Reason)
+// triggers a write.
+func TestShouldWriteCondition_Idempotent(t *testing.T) {
+	ops := &opsv1alpha1.OpsRequest{}
+	existing := metav1.Condition{
+		Type:   opsv1alpha1.ConditionTypeDownstreamProgressionFailed,
+		Status: metav1.ConditionTrue,
+		Reason: opsv1alpha1.ReasonRoleProbePermanentFail,
+	}
+	ops.Status.Conditions = []metav1.Condition{existing}
+
+	// Same type+status+reason: skip write.
+	same := opsv1alpha1.NewDownstreamProgressionFailedCondition(
+		ops, opsv1alpha1.ReasonRoleProbePermanentFail, "still failing")
+	if shouldWriteCondition(ops, same) {
+		t.Errorf("same (status, reason) tuple should not trigger write")
+	}
+
+	// Reason change: write.
+	reasonChanged := opsv1alpha1.NewDownstreamProgressionFailedCondition(
+		ops, opsv1alpha1.ReasonChartMarkerDriftPersistent, "different trigger")
+	if !shouldWriteCondition(ops, reasonChanged) {
+		t.Errorf("reason change should trigger write")
+	}
+
+	// Status flip True→False: write.
+	cleared := opsv1alpha1.NewDownstreamProgressionClearedCondition(ops, "all clear")
+	if !shouldWriteCondition(ops, cleared) {
+		t.Errorf("status flip True→False should trigger write")
+	}
+
+	// Type does not exist yet: write.
+	emptyOps := &opsv1alpha1.OpsRequest{}
+	if !shouldWriteCondition(emptyOps, same) {
+		t.Errorf("absent condition should trigger initial write")
+	}
+}
+
+// TestIsPhaseEligibleForDownstreamObservation locks in the observation gate:
+// only OpsSucceedPhase with a non-zero CompletionTimestamp is eligible. This
+// guarantees the observation never runs against a still-running or
+// not-yet-completed OpsRequest.
+func TestIsPhaseEligibleForDownstreamObservation(t *testing.T) {
+	cases := []struct {
+		name string
+		ops  *opsv1alpha1.OpsRequest
+		want bool
+	}{
+		{
+			name: "succeed with completion timestamp",
+			ops: &opsv1alpha1.OpsRequest{
+				Status: opsv1alpha1.OpsRequestStatus{
+					Phase:               opsv1alpha1.OpsSucceedPhase,
+					CompletionTimestamp: metav1.Time{Time: time.Now()},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "succeed without completion timestamp",
+			ops: &opsv1alpha1.OpsRequest{
+				Status: opsv1alpha1.OpsRequestStatus{Phase: opsv1alpha1.OpsSucceedPhase},
+			},
+			want: false,
+		},
+		{
+			name: "running",
+			ops: &opsv1alpha1.OpsRequest{
+				Status: opsv1alpha1.OpsRequestStatus{Phase: opsv1alpha1.OpsRunningPhase},
+			},
+			want: false,
+		},
+		{
+			name: "failed",
+			ops: &opsv1alpha1.OpsRequest{
+				Status: opsv1alpha1.OpsRequestStatus{Phase: opsv1alpha1.OpsFailedPhase},
+			},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsPhaseEligibleForDownstreamObservation(tc.ops); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/operations/downstream_progression_test.go
+++ b/pkg/operations/downstream_progression_test.go
@@ -198,6 +198,89 @@ func TestEvaluateClusterReconcileStuck(t *testing.T) {
 	})
 }
 
+// TestEvaluateComponentConditionStuck covers the ComponentConditionStuck
+// trigger. The detection walks Cluster.status.components and surfaces the
+// first non-Running phase it finds (deterministic by sorted component name)
+// so the message points at one concrete component. We pin: empty map returns
+// nil, all-Running returns nil, missing CompletionTimestamp returns nil, and
+// a non-Running component yields an observation that carries the component
+// name in the Detail.
+func TestEvaluateComponentConditionStuck(t *testing.T) {
+	succeed := time.Now().Add(-10 * time.Minute)
+	opsRequest := &opsv1alpha1.OpsRequest{
+		Status: opsv1alpha1.OpsRequestStatus{
+			Phase:               opsv1alpha1.OpsSucceedPhase,
+			CompletionTimestamp: metav1.Time{Time: succeed},
+		},
+	}
+
+	t.Run("empty components returns nil", func(t *testing.T) {
+		cluster := &appsv1.Cluster{}
+		if got := evaluateComponentConditionStuck(cluster, opsRequest); got != nil {
+			t.Fatalf("expected nil, got %#v", got)
+		}
+	})
+
+	t.Run("all running returns nil", func(t *testing.T) {
+		cluster := &appsv1.Cluster{}
+		cluster.Status.Components = map[string]appsv1.ClusterComponentStatus{
+			"mysql": {Phase: appsv1.RunningComponentPhase},
+			"proxy": {Phase: appsv1.RunningComponentPhase},
+		}
+		if got := evaluateComponentConditionStuck(cluster, opsRequest); got != nil {
+			t.Fatalf("expected nil, got %#v", got)
+		}
+	})
+
+	t.Run("missing completion timestamp returns nil", func(t *testing.T) {
+		cluster := &appsv1.Cluster{}
+		cluster.Status.Components = map[string]appsv1.ClusterComponentStatus{
+			"mysql": {Phase: appsv1.FailedComponentPhase},
+		}
+		opsNoTS := &opsv1alpha1.OpsRequest{
+			Status: opsv1alpha1.OpsRequestStatus{Phase: opsv1alpha1.OpsSucceedPhase},
+		}
+		if got := evaluateComponentConditionStuck(cluster, opsNoTS); got != nil {
+			t.Fatalf("expected nil, got %#v", got)
+		}
+	})
+
+	t.Run("non-running component surfaces observation", func(t *testing.T) {
+		cluster := &appsv1.Cluster{}
+		cluster.Namespace = "ns-a"
+		cluster.Name = "demo"
+		cluster.Status.Components = map[string]appsv1.ClusterComponentStatus{
+			"proxy": {Phase: appsv1.RunningComponentPhase},
+			"mysql": {Phase: appsv1.FailedComponentPhase},
+		}
+		obs := evaluateComponentConditionStuck(cluster, opsRequest)
+		if obs == nil {
+			t.Fatalf("expected observation, got nil")
+		}
+		if obs.Reason != opsv1alpha1.ReasonComponentConditionStuck {
+			t.Errorf("reason: got %q, want %q", obs.Reason, opsv1alpha1.ReasonComponentConditionStuck)
+		}
+		// "mysql" sorts before "proxy" so the deterministic walk picks mysql.
+		if !contains(obs.Detail, "mysql") {
+			t.Errorf("Detail should reference mysql, got %q", obs.Detail)
+		}
+		if !obs.FirstSeen.Equal(succeed) {
+			t.Errorf("FirstSeen: got %v, want %v", obs.FirstSeen, succeed)
+		}
+	})
+}
+
+// contains is a tiny test-local helper to keep TestEvaluateComponentConditionStuck
+// readable without pulling strings.Contains into the test imports list.
+func contains(s, substr string) bool {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
 // TestIsPhaseEligibleForDownstreamObservation locks in the observation gate:
 // only OpsSucceedPhase with a non-zero CompletionTimestamp is eligible. This
 // guarantees the observation never runs against a still-running or

--- a/pkg/operations/downstream_progression_test.go
+++ b/pkg/operations/downstream_progression_test.go
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package operations
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -302,19 +303,19 @@ func TestEvaluateAddonCoordinatedScaffoldsReturnNil(t *testing.T) {
 	}
 
 	t.Run("downstream-fail-closed-marker-persistent", func(t *testing.T) {
-		obs, err := evaluateDownstreamFailClosedMarkerPersistent(nil, nil, cluster, opsRequest)
+		obs, err := evaluateDownstreamFailClosedMarkerPersistent(context.TODO(), nil, cluster, opsRequest)
 		if err != nil || obs != nil {
 			t.Fatalf("expected (nil, nil); got obs=%#v err=%v", obs, err)
 		}
 	})
 	t.Run("role-probe-permanent-fail", func(t *testing.T) {
-		obs, err := evaluateRoleProbePermanentFail(nil, nil, cluster, opsRequest)
+		obs, err := evaluateRoleProbePermanentFail(context.TODO(), nil, cluster, opsRequest)
 		if err != nil || obs != nil {
 			t.Fatalf("expected (nil, nil); got obs=%#v err=%v", obs, err)
 		}
 	})
 	t.Run("chart-marker-drift-persistent", func(t *testing.T) {
-		obs, err := evaluateChartMarkerDriftPersistent(nil, nil, cluster, opsRequest)
+		obs, err := evaluateChartMarkerDriftPersistent(context.TODO(), nil, cluster, opsRequest)
 		if err != nil || obs != nil {
 			t.Fatalf("expected (nil, nil); got obs=%#v err=%v", obs, err)
 		}


### PR DESCRIPTION
## Why this change

`OpsRequest.status.conditions[type=Succeed]` records that the workflow defined by the OpsRequest finished executing, but it does not promise that the downstream `Component`, `InstanceSet`, or pod role state is healthy. That distinction is spelled out in `docs/addon-api/10-day2-operations.md` (Succeed != Component ready) but there is no machine-readable signal an operator can subscribe to when a Succeed-ed OpsRequest is followed by persistent downstream failure.

Recent examples from real clusters:

- A `Restart` OpsRequest succeeds and the cluster phase oscillates `Updating <-> Running` while the role probe stays unable to publish for many minutes; nothing on the OpsRequest reports it.
- A reconfigure-cycle leaves the addon's repair loop firing every few seconds, an on-disk fail-closed marker emits, HA refuses follow, and the cluster gets stuck `Updating` — Succeed has been set for 20+ minutes by then.

In both shapes the OpsRequest reconciler is the natural place to surface a structured signal: it already watches the relevant resources, and a new condition there is consumable from `kubectl describe`, from event subscribers, and from any tooling that already follows OpsRequest condition transitions.

## What this PR does

Adds `ConditionTypeDownstreamProgressionFailed` to the OpsRequest condition vocabulary and a dedicated post-Succeed observation hook on the reconciler. Succeed itself is never retracted; the new condition is added alongside it once a trigger has persisted past its per-reason threshold, and is cleared back to `status=False` once the trigger has cleared.

Six trigger reasons cover the surfaces we have seen in practice:

| Reason | Threshold | Source signal |
|---|---|---|
| `DownstreamFailClosedMarkerPersistent` | 5min | Addon-registered marker (via CmpD annotation) |
| `RoleProbePermanentFail` | 60s (kbagent probe interval x 4) | kbagent role probe non-publish |
| `ClusterReconcileStuck` | 5min | `Cluster.status.phase=Updating` past Succeed |
| `ComponentConditionStuck` | 5min | Component condition non-target |
| `InstanceSetAlignmentStuck` | 5min | InstanceSet rolling alignment |
| `ChartMarkerDriftPersistent` | 5min | Chart marker state-machine repair-loop |

The marker list is **addon-extensible**: addons opt in by setting `kubeblocks.io/downstream-fail-closed-markers` on their `ComponentDefinition` (comma-separated list of marker filenames). The reconciler reads that list rather than hardcoding addon-specific names, so a new addon can surface its own fail-closed signal without controller changes.

Lifecycle properties:

- **Idempotent**: same-state reconciles re-evaluate but do not rewrite the condition (`shouldWriteCondition` checks the `(status, reason)` tuple).
- **Structured event**: every transition emits a parallel Kubernetes Event so `kubectl describe` and event consumers see the change.
- **Forward-only OpsRequest phase**: this PR does not modify the OpsRequest state machine; Succeed remains permanent post-issuance.
- **Per-OpsRequest scoping**: each OpsRequest tracks its own observation window, so a fresh OpsRequest gets fresh condition tracking and no stale-condition contamination.

The observation runs from `handleSucceedOpsRequest` while the OpsRequest is still inside its TTL window, using the same requeue cadence the controller already uses for TTL scheduling (`time.Minute`) — no new reconcile pressure pattern is introduced.

## What this PR does NOT do (yet)

Per-trigger detection bodies are scaffolded but intentionally empty in this PR: `evaluateTrigger` returns `(nil, nil)` for every reason. The follow-up commits land each detection body alongside its acceptance evidence (marker scan against pods; role-probe non-publish window; cluster/component condition duration; InstanceSet alignment; chart marker drift). That keeps each follow-up reviewable against a specific reproduction.

## Test plan

Unit tests in this PR:

- `TestThresholdForReason` pins the per-reason threshold map (60s for the role probe; 5min for the others).
- `TestReadDownstreamFailClosedMarkers` covers the addon-extensible marker registry parser (nil, missing, single, comma-separated with whitespace).
- `TestShouldWriteCondition_Idempotent` proves same-`(status, reason)` reconciles do not rewrite, and that reason changes and status flips do.
- `TestIsPhaseEligibleForDownstreamObservation` locks the observation gate to `OpsSucceedPhase` with a non-zero `CompletionTimestamp`.
- `TestReasonConstantsStringDrift` (extended) pins the string values of all seven new constants, so a silent rename would break the consumer match.

Follow-up acceptance (lands with each detection body):

- T-P0e.1 synthetic injection per reason
- T-P0e.2 retrofit against a frozen anchor cluster cross-cluster regression
- T-P0e.3 cross-addon orthogonality (MariaDB fail-closed marker + a non-marker timing race)
- T-P0e.4 non-regression across 4 topologies for normal Day-2 ops
- T-P0e.5 marker-drift accuracy (transient ≤60s does not surface; sustained ≥M does)
- T-P0e.6 chart-marker-drift detection accuracy (loop firing count and duration)

## Related

Closes part of the addon-api observability gap surfaced after recent fail-closed reproductions; addon-team-side mechanism fixes ship independently in the addon repos. This change is the controller-side complement: even when an addon-side mechanism fix is in flight or unavailable, the observation surface lets operators see persistent downstream failure without grepping the chart's prestop watchdog log.
