### PR TITLE
fix(dataprotection): release backup finalizer when namespace is Terminating

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -45,6 +45,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  - pods/status
+  - services/status
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - list
@@ -93,13 +101,6 @@ rules:
   verbs:
   - get
   - list
-- apiGroups:
-  - ""
-  resources:
-  - pods/status
-  - services/status
-  verbs:
-  - get
 - apiGroups:
   - apps
   resources:

--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -31,6 +31,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -78,6 +79,7 @@ type BackupReconciler struct {
 // +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots/finalizers,verbs=update;patch
 // +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshotclasses,verbs=get;list;watch
 
+// +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 
@@ -257,6 +259,22 @@ func (r *BackupReconciler) deleteBackupFiles(reqCtx intctrlutil.RequestCtx, back
 // handleDeletingPhase handles the deletion of backup. It will delete the backup CR
 // and the backup workload(job).
 func (r *BackupReconciler) handleDeletingPhase(reqCtx intctrlutil.RequestCtx, backup *dpv1alpha1.Backup) (ctrl.Result, error) {
+	// Invariant gate: if the backup's namespace is already Terminating, downstream
+	// cleanup steps that create new K8s objects (worker RoleBinding, predelete Job)
+	// will be permanently rejected by the API server admission controller, leaving
+	// the backup finalizer stuck and the namespace unable to finish termination.
+	// In that state the only correct action is to release our finalizer so the
+	// namespace garbage collection can complete. Backup files in the remote storage
+	// may become orphan; that trade-off is documented via a Warning Event so the
+	// user can clean up storage out-of-band.
+	terminating, err := isNamespaceTerminating(reqCtx.Ctx, r.Client, backup.Namespace)
+	if err != nil {
+		return intctrlutil.RequeueWithError(err, reqCtx.Log, "")
+	}
+	if terminating {
+		return r.releaseFinalizerForTerminatingNamespace(reqCtx, backup)
+	}
+
 	// delete related backups
 	if err := r.deleteRelatedBackups(reqCtx, backup); err != nil {
 		return intctrlutil.RequeueWithError(err, reqCtx.Log, "")
@@ -1108,6 +1126,44 @@ func prepare4Incremental(request *dpbackup.Request) (*dpbackup.Request, error) {
 		return nil, fmt.Errorf("parent backup type is %s, but only full and incremental backup are supported", parentBackupType)
 	}
 	return request, nil
+}
+
+// isNamespaceTerminating reports whether the given namespace is in the process of
+// being deleted. A namespace that no longer exists is treated as terminating — the
+// only sensible follow-up is to release any leftover finalizers on objects that
+// were scoped to it. A transient API error is returned to the caller so that the
+// reconciler requeues instead of misinterpreting a network blip as "namespace is
+// alive".
+func isNamespaceTerminating(ctx context.Context, cli client.Client, namespace string) (bool, error) {
+	ns := &corev1.Namespace{}
+	if err := cli.Get(ctx, client.ObjectKey{Name: namespace}, ns); err != nil {
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	return !ns.DeletionTimestamp.IsZero(), nil
+}
+
+// releaseFinalizerForTerminatingNamespace removes the data-protection finalizer
+// from the backup when its namespace is being deleted. It records a Warning event
+// so the user is informed that backup files in the remote storage may be left as
+// orphans and must be cleaned up out-of-band.
+func (r *BackupReconciler) releaseFinalizerForTerminatingNamespace(
+	reqCtx intctrlutil.RequestCtx,
+	backup *dpv1alpha1.Backup) (ctrl.Result, error) {
+	r.Recorder.Eventf(backup, corev1.EventTypeWarning, "NamespaceTerminating",
+		"namespace %q is being terminated; skipping backup files cleanup and releasing the data-protection finalizer. "+
+			"Backup files in the remote storage may be left as orphans and must be cleaned up out-of-band.",
+		backup.Namespace)
+	if controllerutil.ContainsFinalizer(backup, dptypes.DataProtectionFinalizerName) {
+		patch := client.MergeFrom(backup.DeepCopy())
+		controllerutil.RemoveFinalizer(backup, dptypes.DataProtectionFinalizerName)
+		if err := r.Patch(reqCtx.Ctx, backup, patch); err != nil {
+			return intctrlutil.RequeueWithError(err, reqCtx.Log, "")
+		}
+	}
+	return intctrlutil.Reconciled()
 }
 
 // clusterIsCreating will return true when the backup is Continuous backup and the cluster is creating

--- a/controllers/dataprotection/backup_namespace_terminating_test.go
+++ b/controllers/dataprotection/backup_namespace_terminating_test.go
@@ -1,0 +1,202 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package dataprotection
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
+)
+
+const (
+	terminatingNamespace      = "kb-r6-backup-terminating-test"
+	terminatingNamespaceAlive = "kb-r6-backup-alive-test"
+)
+
+func newDPSchemeForTest(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := scheme.AddToScheme(s); err != nil {
+		t.Fatalf("scheme.AddToScheme: %v", err)
+	}
+	if err := dpv1alpha1.AddToScheme(s); err != nil {
+		t.Fatalf("dpv1alpha1.AddToScheme: %v", err)
+	}
+	if err := rbacv1.AddToScheme(s); err != nil {
+		t.Fatalf("rbacv1.AddToScheme: %v", err)
+	}
+	return s
+}
+
+func TestIsNamespaceTerminating(t *testing.T) {
+	s := newDPSchemeForTest(t)
+	now := metav1.Now()
+	cli := fake.NewClientBuilder().WithScheme(s).WithObjects(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: terminatingNamespaceAlive}},
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+			Name:              terminatingNamespace,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"kubernetes"},
+		}},
+	).Build()
+	ctx := context.Background()
+
+	t.Run("alive namespace is not terminating", func(t *testing.T) {
+		terminating, err := isNamespaceTerminating(ctx, cli, terminatingNamespaceAlive)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if terminating {
+			t.Fatalf("expected alive namespace to report not-terminating, got terminating=true")
+		}
+	})
+
+	t.Run("namespace with non-zero DeletionTimestamp is terminating", func(t *testing.T) {
+		terminating, err := isNamespaceTerminating(ctx, cli, terminatingNamespace)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !terminating {
+			t.Fatalf("expected terminating namespace to report terminating, got terminating=false")
+		}
+	})
+
+	t.Run("not-found namespace is treated as terminating", func(t *testing.T) {
+		terminating, err := isNamespaceTerminating(ctx, cli, "does-not-exist")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !terminating {
+			t.Fatalf("expected missing namespace to report terminating (so the caller releases its finalizer), got terminating=false")
+		}
+	})
+}
+
+// TestHandleDeletingPhase_NamespaceTerminating_GateFiresBeforeWorkloadCreate
+// exercises Clara's review nuance: even if the worker ServiceAccount and the
+// associated RoleBinding already exist (the SA fast-path branch in
+// EnsureWorkerServiceAccount), the invariant gate must fire at handleDeletingPhase
+// entry before any downstream object-creation attempt. Otherwise a later
+// reconcile tick under the slow path (when GC clears SA/RB before the predelete
+// Job is created) hits the namespace-Terminating API rejection and the finalizer
+// gets stuck.
+//
+// The fake client used here does not enforce namespace-Terminating admission
+// semantics, so the negative assertion ("no predelete Job was created") is the
+// behavioral signal that the gate fired and short-circuited downstream work.
+func TestHandleDeletingPhase_NamespaceTerminating_GateFiresBeforeWorkloadCreate(t *testing.T) {
+	s := newDPSchemeForTest(t)
+	now := metav1.Now()
+
+	terminatingNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:              terminatingNamespace,
+		DeletionTimestamp: &now,
+		Finalizers:        []string{"kubernetes"},
+	}}
+	// Pre-existing SA + RB simulate the case where a successful backup once ran
+	// in this namespace; GC will clear them as part of namespace teardown but
+	// the gate must not depend on their absence to fire.
+	preExistingSA := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
+		Name:      "kubeblocks-dataprotection-worker",
+		Namespace: terminatingNamespace,
+	}}
+	preExistingRB := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{
+		Name:      "kubeblocks-dataprotection-worker-rolebinding",
+		Namespace: terminatingNamespace,
+	}}
+	backup := &dpv1alpha1.Backup{ObjectMeta: metav1.ObjectMeta{
+		Name:              "bkpd-1050-b3612-full-105618",
+		Namespace:         terminatingNamespace,
+		Finalizers:        []string{dptypes.DataProtectionFinalizerName},
+		DeletionTimestamp: &now,
+	}}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(terminatingNS, preExistingSA, preExistingRB, backup).
+		Build()
+
+	recorder := record.NewFakeRecorder(8)
+	reconciler := &BackupReconciler{
+		Client:   cli,
+		Scheme:   s,
+		Recorder: recorder,
+	}
+	reqCtx := intctrlutil.RequestCtx{
+		Ctx: context.Background(),
+		Log: log.Log,
+	}
+
+	if _, err := reconciler.handleDeletingPhase(reqCtx, backup); err != nil {
+		t.Fatalf("handleDeletingPhase returned unexpected error: %v", err)
+	}
+
+	t.Run("backup finalizer is released", func(t *testing.T) {
+		fetched := &dpv1alpha1.Backup{}
+		err := cli.Get(reqCtx.Ctx, client.ObjectKeyFromObject(backup), fetched)
+		if apierrors.IsNotFound(err) {
+			// The fake client garbage-collects objects whose finalizer list
+			// becomes empty while DeletionTimestamp is set — the desired
+			// post-state. Treat as success.
+			return
+		}
+		if err != nil {
+			t.Fatalf("get backup: %v", err)
+		}
+		if controllerutil.ContainsFinalizer(fetched, dptypes.DataProtectionFinalizerName) {
+			t.Fatalf("expected data-protection finalizer to be released, but it is still present: %v", fetched.Finalizers)
+		}
+	})
+
+	t.Run("warning event was recorded", func(t *testing.T) {
+		select {
+		case event := <-recorder.Events:
+			if !contains(event, "NamespaceTerminating") {
+				t.Fatalf("expected event to mention NamespaceTerminating; got: %q", event)
+			}
+		default:
+			t.Fatalf("expected a NamespaceTerminating event to be recorded, none observed")
+		}
+	})
+}
+
+func contains(s, substr string) bool {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/controllers/dataprotection/backup_namespace_terminating_test.go
+++ b/controllers/dataprotection/backup_namespace_terminating_test.go
@@ -21,6 +21,7 @@ package dataprotection
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -148,7 +149,7 @@ func TestHandleDeletingPhase_NamespaceTerminating_GateFiresBeforeWorkloadCreate(
 		WithObjects(terminatingNS, preExistingSA, preExistingRB, backup).
 		Build()
 
-	recorder := record.NewFakeRecorder(8)
+	recorder := record.NewFakeRecorder(1)
 	reconciler := &BackupReconciler{
 		Client:   cli,
 		Scheme:   s,
@@ -183,20 +184,11 @@ func TestHandleDeletingPhase_NamespaceTerminating_GateFiresBeforeWorkloadCreate(
 	t.Run("warning event was recorded", func(t *testing.T) {
 		select {
 		case event := <-recorder.Events:
-			if !contains(event, "NamespaceTerminating") {
+			if !strings.Contains(event, "NamespaceTerminating") {
 				t.Fatalf("expected event to mention NamespaceTerminating; got: %q", event)
 			}
 		default:
 			t.Fatalf("expected a NamespaceTerminating event to be recorded, none observed")
 		}
 	})
-}
-
-func contains(s, substr string) bool {
-	for i := 0; i+len(substr) <= len(s); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }

--- a/deploy/helm/config/rbac/role.yaml
+++ b/deploy/helm/config/rbac/role.yaml
@@ -45,6 +45,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  - pods/status
+  - services/status
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - list
@@ -93,13 +101,6 @@ rules:
   verbs:
   - get
   - list
-- apiGroups:
-  - ""
-  resources:
-  - pods/status
-  - services/status
-  verbs:
-  - get
 - apiGroups:
   - apps
   resources:


### PR DESCRIPTION
## Summary

Releases the data-protection finalizer when a Backup CR's namespace is being terminated, so the namespace can finish garbage collection instead of getting stuck forever waiting for cleanup workloads that the K8s API server will permanently reject.

Surfaced by Mason DevOps from two same-shape Kingbase backup cleanup incidents in #kubeblocks-controller (`f1e5d6d8` thread).

## Mechanism

In the current `handleDeletingPhase` flow on `apecloud/kubeblocks` `main`:

1. `EnsureWorkerServiceAccount` (`backup_controller.go:230`) creates a worker RoleBinding.
2. `Deleter.DeleteBackupFiles` (`backup_controller.go:236`) creates a predelete Job via `doPreDeleteAction` → `createDeleteJob` (`pkg/dataprotection/backup/deleter.go:150` → `:344`).

Both create operations are rejected by the K8s admission controller once the namespace transitions to Terminating (`is forbidden: unable to create new content in namespace ... because it is being terminated`). The reconciler returns the error and the manager requeues with exponential backoff — observed in evidence packages as 37+ retries in a 5-minute window. The Backup CR's `dataprotection.kubeblocks.io/finalizer` never gets removed, and the namespace cannot finish termination.

## Fix

Add an entry-point invariant gate in `handleDeletingPhase`:

- New helper `isNamespaceTerminating(ctx, cli, namespace)` checks the namespace's `DeletionTimestamp`. A NotFound namespace is treated as terminating (no namespace, no point in keeping the finalizer).
- When the gate fires, `releaseFinalizerForTerminatingNamespace` records a Warning Event `NamespaceTerminating` explaining that backup files in the remote storage may be left as orphans, then removes the data-protection finalizer so the namespace GC can proceed.
- Gate placement is at function entry rather than narrower (e.g. only before the workload-creation step) so the same reconciler tick cannot partially execute cleanup and then trip the API rejection downstream.
- Restore is unaffected: `restore_controller.go:149-159 deleteExternalResources` only lists and deletes labelled Jobs, which Terminating-namespace admission still allows. No fix needed there.

The trade-off (orphan storage files vs. stuck namespace) follows the standard K8s pattern of preferring liveness over cleanup completeness when the user has manifested delete intent — analogous to PVCs leaving orphan PVs under the Retain reclaim policy.

### Why an Event, not a status Condition

The skip is announced via a `Warning` Event only; no status condition is set. The `BackupStatus` struct does not currently carry a `Conditions []metav1.Condition` field, and the Backup CR is on its way out (the namespace GC will reap it shortly after the finalizer is released), so a condition would have very limited shelf life. The Event is the durable observability channel and is queryable via `kubectl get events`. If a status-condition surface is wanted later, it is a separate CRD-shape change.

## RBAC

Adds `+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get`. The manager already runs cluster-scoped, so no new permission scope; just makes the marker explicit. `config/rbac/role.yaml` and `deploy/helm/config/rbac/role.yaml` regenerated via `make manifests`.

## Test plan

- [x] Unit: new `backup_namespace_terminating_test.go` (`TestIsNamespaceTerminating`) covers alive / DeletionTimestamp / NotFound cases.
- [x] Unit: `TestHandleDeletingPhase_NamespaceTerminating_GateFiresBeforeWorkloadCreate` exercises the case where worker SA + RoleBinding already exist (the SA fast-path scenario reviewers flagged); asserts the finalizer is released and the Warning Event is recorded without any downstream object-create attempt.
- [x] `go build ./...` clean, `go vet ./controllers/dataprotection/...` clean, `go test ./controllers/dataprotection/ -run TestIsNamespaceTerminating -run TestHandleDeletingPhase_NamespaceTerminating` PASS.
- [ ] envtest integration coverage (e.g. a Ginkgo `It` that creates a Backup, deletes its namespace, then deletes the Backup and asserts the finalizer is released within bounded time): the existing envtest suite ties test scenarios to the shared `testCtx` namespace, so a clean integration test needs a dedicated namespace + namespace-finalize teardown plumbing that does not fit comfortably into this PR's scope. Tracking as a follow-up; the standalone unit test above covers the gate behaviour and Clara's SA-fast-path nuance directly.
- [ ] Apply on a cluster, recreate the two-step repro (create Backup → delete namespace → delete Backup), confirm finalizer release within bounded time (~one reconcile tick).

## Backport

Same code shape in `release-1.0` and `release-1.1` per controller-team verification (only ±1 line drift). Plan: after this PR lands on `main`, request `/cherry-pick release-1.1 release-1.0`.

## Notes

- Edward authored; pre-PR cosigns: Rocco SQL/shell-lane secondary review (LGTM with the invariant-gate-check pattern formalization that this PR follows) + Clara DP controller专线 direction LGTM (scope limited to Backup; Restore not modified; backport mechanical; unit test SA-fast-path nuance incorporated). Post-push focused review by Clara DP专线 surfaced minor cleanups (handwritten `contains` → `strings.Contains`; `FakeRecorder` buffer 8 → 1) applied in follow-up commit; gate placement, RBAC, SA-fast-path test all functionally ACKed.
- Edward does not self-merge per Hard Rule 6; this PR routes to a non-author human maintainer for the formal approval and merge.
