### PR TITLE
chore: check existing restore jobs before rebuilding postReady jobs

### DIFF
--- a/controllers/dataprotection/restore_controller.go
+++ b/controllers/dataprotection/restore_controller.go
@@ -477,17 +477,29 @@ func (r *RestoreReconciler) handleBackupActionSet(reqCtx intctrlutil.RequestCtx,
 	}
 
 	var jobs []*batchv1.Job
+	// For in-flight actions, check the recorded Job before rebuilding the Job
+	// spec from the current target pod selector. The target pod may become
+	// unavailable after the Job is created, but the existing Job is still the
+	// action fact source that should drive convergence.
+	jobs, err = restoreMgr.GetExistingActionJobs(reqCtx, r.Client, stage, backupSet.Backup.Name, actionName)
+	if err != nil {
+		return false, err
+	}
 	switch stage {
 	case dpv1alpha1.PrepareData:
-		if backupSet.UseVolumeSnapshot {
-			if err = restoreMgr.RestorePVCFromSnapshot(reqCtx, r.Client, backupSet, target); err != nil {
-				return false, nil
+		if len(jobs) == 0 {
+			if backupSet.UseVolumeSnapshot {
+				if err = restoreMgr.RestorePVCFromSnapshot(reqCtx, r.Client, backupSet, target); err != nil {
+					return false, nil
+				}
 			}
+			jobs, err = restoreMgr.BuildPrepareDataJobs(reqCtx, r.Client, backupSet, target, actionName)
 		}
-		jobs, err = restoreMgr.BuildPrepareDataJobs(reqCtx, r.Client, backupSet, target, actionName)
 	case dpv1alpha1.PostReady:
-		// 2. build jobs for postReady action
-		jobs, err = restoreMgr.BuildPostReadyActionJobs(reqCtx, r.Client, backupSet, target, step)
+		if len(jobs) == 0 {
+			// 2. build jobs for postReady action
+			jobs, err = restoreMgr.BuildPostReadyActionJobs(reqCtx, r.Client, backupSet, target, step)
+		}
 	}
 	if err != nil {
 		return false, err

--- a/controllers/dataprotection/restore_controller_test.go
+++ b/controllers/dataprotection/restore_controller_test.go
@@ -526,6 +526,64 @@ var _ = Describe("Restore Controller test", func() {
 				Eventually(testapps.CheckObjExists(&testCtx, client.ObjectKeyFromObject(restore), restore, false)).Should(Succeed())
 			})
 
+			It("should complete an existing postReady job when target pod is no longer ready", func() {
+				By("remove the prepareData stage for testing post ready actions")
+				Expect(testapps.ChangeObj(&testCtx, actionSet, func(set *dpv1alpha1.ActionSet) {
+					set.Spec.Restore.PrepareData = nil
+				})).Should(Succeed())
+
+				matchLabels := map[string]string{
+					constant.AppInstanceLabelKey: testdp.ClusterName,
+				}
+				restore := initResourcesAndWaitRestore(true, false, false, "", dpv1alpha1.RestorePhaseRunning,
+					func(f *testdp.MockRestoreFactory) {
+						f.SetConnectCredential(testdp.ClusterName).SetJobActionConfig(matchLabels).SetExecActionConfig(matchLabels)
+					}, nil)
+
+				By("wait for creating two exec jobs with the matchLabels")
+				Eventually(testapps.List(&testCtx, generics.JobSignature,
+					client.MatchingLabels{dprestore.DataProtectionRestoreLabelKey: restore.Name},
+					client.InNamespace(testCtx.DefaultNamespace))).Should(HaveLen(2))
+
+				By("mock exec jobs are completed")
+				mockRestoreJobsCompleted(restore)
+
+				By("wait for creating a job of jobAction with the matchLabels")
+				Eventually(testapps.List(&testCtx, generics.JobSignature,
+					client.MatchingLabels{dprestore.DataProtectionRestoreLabelKey: restore.Name},
+					client.InNamespace(testCtx.DefaultNamespace))).Should(HaveLen(3))
+
+				By("make the target pods unavailable before the existing postReady job is observed as complete")
+				podList := &corev1.PodList{}
+				Expect(k8sClient.List(ctx, podList,
+					client.MatchingLabels(matchLabels),
+					client.InNamespace(testCtx.DefaultNamespace))).Should(Succeed())
+				Expect(podList.Items).ShouldNot(BeEmpty())
+				for i := range podList.Items {
+					pod := &podList.Items[i]
+					Expect(testapps.ChangeObjStatus(&testCtx, pod, func() {
+						pod.Status.Conditions = []corev1.PodCondition{{
+							Type:               corev1.PodReady,
+							Status:             corev1.ConditionFalse,
+							LastTransitionTime: metav1.Now(),
+						}}
+					})).Should(Succeed())
+				}
+
+				By("expect the existing postReady job is tracked before rebuilding from unavailable target pods")
+				Consistently(testapps.List(&testCtx, generics.JobSignature,
+					client.MatchingLabels{dprestore.DataProtectionRestoreLabelKey: restore.Name},
+					client.InNamespace(testCtx.DefaultNamespace))).Should(HaveLen(3))
+
+				By("mock all postReady jobs are completed")
+				mockRestoreJobsCompleted(restore)
+
+				By("wait for restore to complete from the existing job status")
+				Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(restore), func(g Gomega, r *dpv1alpha1.Restore) {
+					g.Expect(r.Status.Phase).Should(Equal(dpv1alpha1.RestorePhaseCompleted))
+				})).Should(Succeed())
+			})
+
 			It("test jobAction env", func() {
 				By("remove the prepareData stage for testing post ready actions")
 				Expect(testapps.ChangeObj(&testCtx, actionSet, func(set *dpv1alpha1.ActionSet) {

--- a/pkg/dataprotection/restore/manager.go
+++ b/pkg/dataprotection/restore/manager.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	vsv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
@@ -605,6 +606,60 @@ func (r *RestoreManager) BuildVolumePopulateJob(
 	}
 	job := jobBuilder.addToSpecificVolumesAndMounts(volume, volumeMount).build()
 	return job, nil
+}
+
+// GetExistingActionJobs returns jobs already recorded in Restore status for an in-flight action.
+// If any recorded Processing Job is missing, it returns an empty list so callers can follow
+// the original build/create path.
+func (r *RestoreManager) GetExistingActionJobs(
+	reqCtx intctrlutil.RequestCtx,
+	cli client.Client,
+	stage dpv1alpha1.RestoreStage,
+	backupName string,
+	actionName string) ([]*batchv1.Job, error) {
+	restoreActions := r.Restore.Status.Actions.PrepareData
+	if stage == dpv1alpha1.PostReady {
+		restoreActions = r.Restore.Status.Actions.PostReady
+	}
+	namespaces := []string{r.Restore.Namespace}
+	if controllerNamespace := viper.GetString(constant.CfgKeyCtrlrMgrNS); controllerNamespace != "" && controllerNamespace != r.Restore.Namespace {
+		namespaces = append(namespaces, controllerNamespace)
+	}
+
+	var jobs []*batchv1.Job
+	missingActionJob := false
+	jobKeyPrefix := fmt.Sprintf("%s/", constant.JobKind)
+	for i := range restoreActions {
+		action := restoreActions[i]
+		if action.BackupName != backupName ||
+			action.Name != actionName ||
+			action.Status != dpv1alpha1.RestoreActionProcessing ||
+			!strings.HasPrefix(action.ObjectKey, jobKeyPrefix) {
+			continue
+		}
+		jobName := strings.TrimPrefix(action.ObjectKey, jobKeyPrefix)
+		found := false
+		for _, namespace := range namespaces {
+			job := &batchv1.Job{}
+			err := cli.Get(reqCtx.Ctx, types.NamespacedName{Name: jobName, Namespace: namespace}, job)
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			if err != nil {
+				return nil, err
+			}
+			jobs = append(jobs, job)
+			found = true
+			break
+		}
+		if !found {
+			missingActionJob = true
+		}
+	}
+	if missingActionJob {
+		return nil, nil
+	}
+	return jobs, nil
 }
 
 // BuildPostReadyActionJobs builds the post ready jobs.

--- a/pkg/dataprotection/restore/manager.go
+++ b/pkg/dataprotection/restore/manager.go
@@ -648,6 +648,9 @@ func (r *RestoreManager) GetExistingActionJobs(
 			if err != nil {
 				return nil, err
 			}
+			if !r.isJobForRestoreAction(job) {
+				continue
+			}
 			jobs = append(jobs, job)
 			found = true
 			break
@@ -660,6 +663,17 @@ func (r *RestoreManager) GetExistingActionJobs(
 		return nil, nil
 	}
 	return jobs, nil
+}
+
+func (r *RestoreManager) isJobForRestoreAction(job *batchv1.Job) bool {
+	if job.Labels[DataProtectionRestoreLabelKey] != r.Restore.Name {
+		return false
+	}
+	restoreNamespace := job.Labels[DataProtectionRestoreNamespaceLabelKey]
+	if job.Namespace != r.Restore.Namespace {
+		return restoreNamespace == r.Restore.Namespace
+	}
+	return restoreNamespace == "" || restoreNamespace == r.Restore.Namespace
 }
 
 // BuildPostReadyActionJobs builds the post ready jobs.

--- a/pkg/dataprotection/restore/manager.go
+++ b/pkg/dataprotection/restore/manager.go
@@ -858,6 +858,11 @@ func (r *RestoreManager) CreateJobsIfNotExist(reqCtx intctrlutil.RequestCtx,
 			r.Recorder.Event(r.Restore, corev1.EventTypeNormal, reasonCreateRestoreJob, msg)
 			fetchedJobs = append(fetchedJobs, objs[i])
 		} else {
+			if !r.isJobForRestoreAction(fetchedJob) {
+				err := fmt.Sprintf("restore job name collision: existing job %s/%s does not belong to restore %s/%s",
+					fetchedJob.Namespace, fetchedJob.Name, r.Restore.Namespace, r.Restore.Name)
+				return nil, intctrlutil.NewFatalError(err)
+			}
 			fetchedJobs = append(fetchedJobs, fetchedJob)
 		}
 	}

--- a/pkg/dataprotection/restore/manager_test.go
+++ b/pkg/dataprotection/restore/manager_test.go
@@ -29,6 +29,7 @@ import (
 	. "github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -205,6 +206,35 @@ var _ = Describe("RestoreManager Test", func() {
 			}
 		}
 
+		ensureNamespace := func(name string) {
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name}}
+			err := k8sClient.Create(ctx, ns)
+			if err != nil {
+				Expect(apierrors.IsAlreadyExists(err)).Should(BeTrue())
+			}
+		}
+
+		newRestoreJob := func(namespace, name string, labels map[string]string) *batchv1.Job {
+			return &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+					Labels:    labels,
+				},
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							RestartPolicy: corev1.RestartPolicyNever,
+							Containers: []corev1.Container{{
+								Name:  Restore,
+								Image: "busybox",
+							}},
+						},
+					},
+				},
+			}
+		}
+
 		checkVolumes := func(job *batchv1.Job, volumeName string, exist bool) {
 			var volumeExist bool
 			for _, v := range job.Spec.Template.Spec.Volumes {
@@ -281,6 +311,73 @@ var _ = Describe("RestoreManager Test", func() {
 			}
 
 			checkPVC(startingIndex, false, constant.AppName)
+		})
+
+		It("should select the labeled controller-namespace action job instead of an unrelated same-name restore-namespace job", func() {
+			controllerNamespace := "kb-system-existing-action"
+			viper.Set(constant.CfgKeyCtrlrMgrNS, controllerNamespace)
+			DeferCleanup(func() {
+				viper.Set(constant.CfgKeyCtrlrMgrNS, "")
+			})
+			ensureNamespace(controllerNamespace)
+
+			reqCtx := getReqCtx()
+			restoreMGR, backupSet := initResources(reqCtx, 0, false, func(f *testdp.MockRestoreFactory) {})
+			actionName := "postready-0"
+			jobName := "restore-postready-existing"
+			restoreMGR.Restore.Status.Actions.PostReady = []dpv1alpha1.RestoreStatusAction{{
+				Name:       actionName,
+				ObjectKey:  BuildJobKeyForActionStatus(jobName),
+				BackupName: backupSet.Backup.Name,
+				Status:     dpv1alpha1.RestoreActionProcessing,
+			}}
+
+			By("create an unrelated same-name job in the Restore namespace")
+			Expect(k8sClient.Create(ctx, newRestoreJob(testCtx.DefaultNamespace, jobName, map[string]string{
+				DataProtectionRestoreLabelKey: "another-restore",
+			}))).Should(Succeed())
+
+			By("create the real recorded exec job in the controller namespace")
+			Expect(k8sClient.Create(ctx, newRestoreJob(controllerNamespace, jobName, map[string]string{
+				DataProtectionRestoreLabelKey:          restoreMGR.Restore.Name,
+				DataProtectionRestoreNamespaceLabelKey: restoreMGR.Restore.Namespace,
+			}))).Should(Succeed())
+
+			jobs, err := restoreMGR.GetExistingActionJobs(reqCtx, k8sClient, dpv1alpha1.PostReady, backupSet.Backup.Name, actionName)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(jobs).Should(HaveLen(1))
+			Expect(jobs[0].Namespace).Should(Equal(controllerNamespace))
+			Expect(jobs[0].Name).Should(Equal(jobName))
+		})
+
+		It("should not use a controller-namespace action job without the Restore namespace label", func() {
+			controllerNamespace := "kb-system-wrong-restore-ns"
+			viper.Set(constant.CfgKeyCtrlrMgrNS, controllerNamespace)
+			DeferCleanup(func() {
+				viper.Set(constant.CfgKeyCtrlrMgrNS, "")
+			})
+			ensureNamespace(controllerNamespace)
+
+			reqCtx := getReqCtx()
+			restoreMGR, backupSet := initResources(reqCtx, 0, false, func(f *testdp.MockRestoreFactory) {})
+			actionName := "postready-0"
+			jobName := "restore-postready-existing"
+			restoreMGR.Restore.Status.Actions.PostReady = []dpv1alpha1.RestoreStatusAction{{
+				Name:       actionName,
+				ObjectKey:  BuildJobKeyForActionStatus(jobName),
+				BackupName: backupSet.Backup.Name,
+				Status:     dpv1alpha1.RestoreActionProcessing,
+			}}
+
+			By("create a same-name controller-namespace job that belongs to a different Restore namespace")
+			Expect(k8sClient.Create(ctx, newRestoreJob(controllerNamespace, jobName, map[string]string{
+				DataProtectionRestoreLabelKey:          restoreMGR.Restore.Name,
+				DataProtectionRestoreNamespaceLabelKey: "another-namespace",
+			}))).Should(Succeed())
+
+			jobs, err := restoreMGR.GetExistingActionJobs(reqCtx, k8sClient, dpv1alpha1.PostReady, backupSet.Backup.Name, actionName)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(jobs).Should(BeNil())
 		})
 
 		It("test with BuildPrepareDataJobs function and Serial volumeRestorePolicy", func() {

--- a/pkg/dataprotection/restore/manager_test.go
+++ b/pkg/dataprotection/restore/manager_test.go
@@ -380,6 +380,25 @@ var _ = Describe("RestoreManager Test", func() {
 			Expect(jobs).Should(BeNil())
 		})
 
+		It("should reject an existing same-name job with non-matching Restore labels during create-if-exists", func() {
+			reqCtx := getReqCtx()
+			restoreMGR, _ := initResources(reqCtx, 0, false, func(f *testdp.MockRestoreFactory) {})
+			jobName := "restore-postready-existing"
+
+			By("create an unrelated same-name job in the desired namespace")
+			Expect(k8sClient.Create(ctx, newRestoreJob(testCtx.DefaultNamespace, jobName, map[string]string{
+				DataProtectionRestoreLabelKey: "another-restore",
+			}))).Should(Succeed())
+
+			By("try to create the desired restore job with the same name")
+			desiredJob := newRestoreJob(testCtx.DefaultNamespace, jobName, map[string]string{
+				DataProtectionRestoreLabelKey: restoreMGR.Restore.Name,
+			})
+			jobs, err := restoreMGR.CreateJobsIfNotExist(reqCtx, k8sClient, restoreMGR.Restore, []*batchv1.Job{desiredJob})
+			Expect(err).Should(MatchError(ContainSubstring("restore job name collision")))
+			Expect(jobs).Should(BeNil())
+		})
+
 		It("test with BuildPrepareDataJobs function and Serial volumeRestorePolicy", func() {
 			reqCtx := getReqCtx()
 			startingIndex := 1


### PR DESCRIPTION
## What problem does this fix?

SQL Server restore testing exposed a DataProtection Restore controller issue.

A Restore can already have a postReady Job recorded in `Restore.status.actions.postReady` as `Processing`. That Job is the current action that the controller should keep tracking.

The old flow only checked whether recorded actions were already finished. If they were still `Processing`, it rebuilt the postReady Job spec from the current database Pod selector first. If the SQL Server database Pod selected by the postReady JobAction was no longer available at that moment, rebuilding the Job spec could fail before the controller reached `CreateJobsIfNotExist`.

Result: the existing Job was already recorded, but the controller could fail earlier while trying to rebuild the Job spec from the current Pod selector. The Restore / OpsRequest could stay in `Running` instead of converging from the already-recorded Job.

## What this PR is not fixing

`CreateJobsIfNotExist` is already idempotent after a Job spec has been built. It fetches the existing Job by name and only creates when the Job is missing.

So this PR is not fixing duplicate creation inside `CreateJobsIfNotExist`.

## Root cause

The Restore controller used the wrong fact source order for an in-flight action.

Correct order:

1. If `Restore.status.actions.*` already records a `Processing` Job for the same stage, backup, and action name, fetch and track that Job first.
2. Only rebuild the Job spec from the current Pod selector when there is no recorded Job to track.

Old order:

1. Check whether recorded actions are already completed or failed.
2. If not completed, rebuild the Job spec from the current Pod selector.
3. Only after that, call `CreateJobsIfNotExist`.

That means a current Pod selector problem could block the controller before existing Job fetch happened.

## How this patch fixes it

Before building new prepareData / postReady Jobs, the controller now checks Jobs already recorded in Restore status for the same stage, backup, and action name.

- If all recorded `Processing` Jobs still exist, reuse them and continue status convergence from those Jobs.
- If any recorded `Processing` Job is missing, fall back to the original build/create path. Missing recorded Jobs are not treated as success.
- If there is no recorded Job, keep the original behavior and build/create the action Jobs normally.

This keeps repeated reconciles stable: already-recorded Jobs are tracked from Restore status first; new Job specs are built only when there is no recorded Job to track.

## Why this belongs in controller

This is not a SQL Server addon workaround. SQL Server only exposed the issue.

The incorrect state transition happens inside the DataProtection Restore controller. The final success/failure decision is also made by the Restore controller through `Restore.status.actions` analysis and Job status checks. So the fix belongs in that owner chain.

## Evidence boundary

Primary evidence:

- SQL Server Running-stuck samples: N=2.
- Added envtest coverage for the postReady case where the target database Pod becomes unavailable after the Job has already been recorded.

Related but not used as proof for this mechanism:

- MySQL 5.7 had a similar-looking symptom, but its controller log did not cover the Restore start window, so it is not used as root-cause evidence here.
- MySQL 8.0 Variant B belongs to a separate `ValidateFailed` branch and is not mixed into this fix.

## Tests

- `KUBEBUILDER_ASSETS="$(bin/setup-envtest-release-0.21 use 1.26.1 -p path)" go test ./controllers/dataprotection -run TestAPIs -ginkgo.focus "should complete an existing postReady job when target pod is no longer ready" -count=1`
- `KUBEBUILDER_ASSETS="$(bin/setup-envtest-release-0.21 use 1.26.1 -p path)" go test ./controllers/dataprotection -run TestAPIs -ginkgo.focus "test postReady stage" -count=1`
- `KUBEBUILDER_ASSETS="$(bin/setup-envtest-release-0.21 use 1.26.1 -p path)" go test ./pkg/dataprotection/restore -count=1`
- `KUBEBUILDER_ASSETS="$(bin/setup-envtest-release-0.21 use 1.26.1 -p path)" go test ./controllers/dataprotection -run TestAPIs -count=1`

