### PR TITLE
fix: resolve continuous backup base for annotation restore

### DIFF
--- a/pkg/controller/plan/restore.go
+++ b/pkg/controller/plan/restore.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -40,6 +41,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/factory"
 	"github.com/apecloud/kubeblocks/pkg/controller/instanceset"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	dprestore "github.com/apecloud/kubeblocks/pkg/dataprotection/restore"
 	dputils "github.com/apecloud/kubeblocks/pkg/dataprotection/utils"
 )
 
@@ -99,7 +101,11 @@ func (r *RestoreManager) DoRestore(comp *component.SynthesizedComponent, compObj
 	if backupObj.Status.BackupMethod == nil {
 		return intctrlutil.NewErrorf(intctrlutil.ErrorTypeRestoreFailed, `status.backupMethod of backup "%s" can not be empty`, backupObj.Name)
 	}
-	if err = r.DoPrepareData(comp, compObj, backupObj); err != nil {
+	prepareDataBackupObj, err := r.resolvePrepareDataBackup(backupObj)
+	if err != nil {
+		return err
+	}
+	if err = r.DoPrepareData(comp, compObj, prepareDataBackupObj); err != nil {
 		return err
 	}
 	if compObj.Status.Phase != appsv1.RunningComponentPhase {
@@ -122,6 +128,44 @@ func (r *RestoreManager) DoRestore(comp *component.SynthesizedComponent, compObj
 	}
 	// do clean up
 	return r.cleanupRestoreAnnotations(comp.Name)
+}
+
+func (r *RestoreManager) resolvePrepareDataBackup(backupObj *dpv1alpha1.Backup) (*dpv1alpha1.Backup, error) {
+	if backupObj.Status.BackupMethod.TargetVolumes != nil {
+		return backupObj, nil
+	}
+	restore := &dpv1alpha1.Restore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      r.Cluster.Name + "-annotation-restore-preview",
+			Namespace: r.Cluster.Namespace,
+		},
+		Spec: dpv1alpha1.RestoreSpec{
+			Backup: dpv1alpha1.BackupRef{
+				Name:      backupObj.Name,
+				Namespace: r.namespace,
+			},
+			RestoreTime: r.RestoreTime,
+		},
+	}
+	reqCtx := intctrlutil.RequestCtx{
+		Ctx:      r.Ctx,
+		Recorder: record.NewFakeRecorder(16),
+	}
+	restoreMGR := dprestore.NewRestoreManager(restore, reqCtx.Recorder, r.Scheme, r.Client)
+	backupSet, err := restoreMGR.GetBackupActionSetByNamespaced(reqCtx, r.Client, backupObj.Name, r.namespace)
+	if err != nil {
+		return nil, err
+	}
+	if backupSet.ActionSet == nil || backupSet.ActionSet.Spec.BackupType != dpv1alpha1.BackupTypeContinuous {
+		return backupObj, nil
+	}
+	if err := restoreMGR.BuildContinuousRestoreManager(reqCtx, r.Client, *backupSet); err != nil {
+		return nil, err
+	}
+	if len(restoreMGR.PrepareDataBackupSets) == 0 {
+		return backupObj, nil
+	}
+	return restoreMGR.PrepareDataBackupSets[0].Backup, nil
 }
 
 func (r *RestoreManager) DoPrepareData(comp *component.SynthesizedComponent,

--- a/pkg/controller/plan/restore_test.go
+++ b/pkg/controller/plan/restore_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 	"github.com/apecloud/kubeblocks/pkg/generics"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
 	testdp "github.com/apecloud/kubeblocks/pkg/testutil/dataprotection"
@@ -255,6 +256,97 @@ var _ = Describe("Restore", func() {
 			_ = restoreMGR.DoRestore(synthesizedComponent, compObj, true)
 			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(cluster), func(g Gomega, tmpCluster *appsv1.Cluster) {
 				g.Expect(tmpCluster.Annotations[constant.RestoreFromBackupAnnotationKey]).Should(BeEmpty())
+			})).Should(Succeed())
+		})
+
+		It("creates prepareData from the base backup when annotation restore references a continuous backup", func() {
+			continuousActionSetName := "continuous-actionset-" + randomStr
+			continuousActionSet := testapps.CreateCustomizedObj(&testCtx, "backup/actionset.yaml",
+				&dpv1alpha1.ActionSet{}, testapps.WithName(continuousActionSetName), func(actionSet *dpv1alpha1.ActionSet) {
+					actionSet.Spec.BackupType = dpv1alpha1.BackupTypeContinuous
+				})
+			Expect(continuousActionSet.Name).Should(Equal(continuousActionSetName))
+
+			baseStatus := backup.Status
+			baseStatus.BackupMethod.ActionSetName = fullBackupActionSetName
+			baseStatus.TimeRange = &dpv1alpha1.BackupTimeRange{
+				Start: baseStatus.StartTimestamp,
+				End:   baseStatus.CompletionTimestamp,
+			}
+			patchBackupStatus(baseStatus, client.ObjectKeyFromObject(backup))
+			Expect(testapps.ChangeObj(&testCtx, backup, func(baseBackup *dpv1alpha1.Backup) {
+				baseBackup.Labels[dptypes.BackupTypeLabelKey] = string(dpv1alpha1.BackupTypeFull)
+				baseBackup.Labels[dptypes.BackupPolicyLabelKey] = testdp.BackupPolicyName
+			})).Should(Succeed())
+
+			restoreTime := now.Add(time.Minute * 30)
+			continuousBackupName := "continuous-backup-" + randomStr
+			continuousBackup := testdp.NewBackupFactory(testCtx.DefaultNamespace, continuousBackupName).
+				SetLabels(map[string]string{
+					constant.AppInstanceLabelKey:    sourceCluster,
+					constant.KBAppComponentLabelKey: defaultCompName,
+					dptypes.BackupTypeLabelKey:      string(dpv1alpha1.BackupTypeContinuous),
+					dptypes.BackupPolicyLabelKey:    testdp.BackupPolicyName,
+				}).
+				SetBackupPolicyName(testdp.BackupPolicyName).
+				SetBackupMethod(testdp.ContinuousMethodName).
+				Create(&testCtx).GetObject()
+			continuousStart := &metav1.Time{Time: now.Time}
+			continuousStop := &metav1.Time{Time: now.Add(time.Hour)}
+			continuousStatus := dpv1alpha1.BackupStatus{
+				Phase:               dpv1alpha1.BackupPhaseCompleted,
+				StartTimestamp:      continuousStart,
+				CompletionTimestamp: continuousStop,
+				TimeRange: &dpv1alpha1.BackupTimeRange{
+					Start: continuousStart,
+					End:   continuousStop,
+				},
+				BackupMethod: &dpv1alpha1.BackupMethod{
+					Name:          testdp.ContinuousMethodName,
+					ActionSetName: continuousActionSetName,
+				},
+			}
+			patchBackupStatus(continuousStatus, client.ObjectKeyFromObject(continuousBackup))
+
+			By("restore from a continuous backup annotation")
+			restoreFromBackup := fmt.Sprintf(`{"%s": {"name":"%s", "restoreTime":"%s"}}`,
+				defaultCompName, continuousBackup.Name, restoreTime.UTC().Format(time.RFC3339))
+			Expect(testapps.ChangeObj(&testCtx, cluster, func(tmpCluster *appsv1.Cluster) {
+				tmpCluster.Annotations = map[string]string{
+					constant.RestoreFromBackupAnnotationKey: restoreFromBackup,
+				}
+			})).Should(Succeed())
+
+			restoreMGR := NewRestoreManager(ctx, k8sClient, cluster, scheme.Scheme, nil, 3, 0)
+			err := restoreMGR.DoRestore(synthesizedComponent, compObj, true)
+			Expect(intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeNeedWaiting)).Should(BeTrue())
+
+			By("checking prepareData is created from the resolved base backup")
+			restoreMeta := restoreMGR.GetRestoreObjectMeta(synthesizedComponent, dpv1alpha1.PrepareData, "")
+			Eventually(testapps.CheckObj(&testCtx, types.NamespacedName{Name: restoreMeta.Name, Namespace: restoreMeta.Namespace}, func(g Gomega, restore *dpv1alpha1.Restore) {
+				g.Expect(restore.Spec.Backup.Name).Should(Equal(backup.Name))
+			})).Should(Succeed())
+
+			By("checking postReady still replays from the continuous backup")
+			Expect(testapps.GetAndChangeObjStatus(&testCtx, types.NamespacedName{Name: restoreMeta.Name, Namespace: restoreMeta.Namespace}, func(restore *dpv1alpha1.Restore) {
+				restore.Status.Phase = dpv1alpha1.RestorePhaseCompleted
+			})()).Should(Succeed())
+			Expect(testapps.ChangeObjStatus(&testCtx, cluster, func() {
+				cluster.Status.Phase = appsv1.RunningClusterPhase
+				cluster.Status.Components = map[string]appsv1.ClusterComponentStatus{
+					defaultCompName: {
+						Phase: appsv1.RunningComponentPhase,
+					},
+				}
+			})).Should(Succeed())
+			Expect(testapps.ChangeObjStatus(&testCtx, compObj, func() {
+				compObj.Status.Phase = appsv1.RunningComponentPhase
+			})).Should(Succeed())
+
+			_ = restoreMGR.DoRestore(synthesizedComponent, compObj, true)
+			restoreMeta = restoreMGR.GetRestoreObjectMeta(synthesizedComponent, dpv1alpha1.PostReady, "")
+			Eventually(testapps.CheckObj(&testCtx, types.NamespacedName{Name: restoreMeta.Name, Namespace: restoreMeta.Namespace}, func(g Gomega, restore *dpv1alpha1.Restore) {
+				g.Expect(restore.Spec.Backup.Name).Should(Equal(continuousBackup.Name))
 			})).Should(Succeed())
 		})
 	})


### PR DESCRIPTION
## What

Fix the release-1.1 Cluster annotation restore path when the annotation references a Continuous backup.

The old annotation path used the same Continuous backup for both prepareData and postReady. Continuous backups do not have `status.backupMethod.targetVolumes`, so prepareData no-ops and the PITR replay can run without a restored base data volume.

This PR resolves the prepareData backup through the existing DP continuous restore manager:

- Full/selective backups keep the existing behavior.
- Continuous backups resolve the base backup for prepareData.
- postReady still uses the original Continuous backup so PITR replay semantics are preserved.

Current `main` no longer has this old annotation path after #10246; this is scoped to `release-1.1`.

## Issue

- Closes / tracks #10314 for release-1.1 old annotation path behavior.

## Tests

```text
KUBEBUILDER_ASSETS="/Users/wei/Library/Application Support/io.kubebuilder.envtest/k8s/1.26.1-darwin-arm64" \
  go test ./pkg/controller/plan -count=1 --ginkgo.focus='creates prepareData from the base backup when annotation restore references a continuous backup'

KUBEBUILDER_ASSETS="/Users/wei/Library/Application Support/io.kubebuilder.envtest/k8s/1.26.1-darwin-arm64" \
  go test ./pkg/controller/plan ./pkg/dataprotection/restore -count=1

git diff --check
```

## Boundaries

- This is local controller/envtest validation only.
- No runtime PITR restore validation is claimed here.
- `release-1.0` still has the old annotation path and should be handled separately if that branch needs the same behavior.
