### PR TITLE
chore: require KB labels for external-managed ConfigMaps

### DIFF
--- a/apis/apps/v1/componentdefinition_types.go
+++ b/apis/apps/v1/componentdefinition_types.go
@@ -1127,9 +1127,11 @@ type ComponentFileTemplate struct {
 	// +optional
 	Reconfigure *Action `json:"reconfigure,omitempty"`
 
-	// ExternalManaged specifies whether the file management is delegated to an external system or manual user control.
+	// ExternalManaged specifies whether the file management is delegated to an external system.
 	//
-	// When set to true, the controller will ignore the management of this file.
+	// When set to true, the apps controller will ignore the rendering and lifecycle management of
+	// this file. A ConfigMap source for this template is accepted only when the referenced ConfigMap
+	// carries the common KubeBlocks component labels.
 	//
 	// +optional
 	ExternalManaged *bool `json:"externalManaged,omitempty"`

--- a/apis/apps/v1/types.go
+++ b/apis/apps/v1/types.go
@@ -530,12 +530,12 @@ type ClusterComponentConfig struct {
 	// The external source for the configuration.
 	ClusterComponentConfigSource `json:",inline"`
 
-	// ExternalManaged specifies whether the configuration management is delegated to an external system
-	// or manual user control.
+	// ExternalManaged specifies whether the configuration management is delegated to an external system.
 	//
-	// When set to true, the controller will exclusively utilize the user-provided configuration source
-	// and the 'reconfigure' action defined in this config, bypassing the default templates and
-	// update behaviors specified in the ComponentDefinition.
+	// When set to true, the apps controller does not render or manage the configuration from the
+	// default templates and update behaviors specified in the ComponentDefinition. A ConfigMap source
+	// for an external-managed configuration is accepted only when the referenced ConfigMap carries
+	// the common KubeBlocks component labels.
 	//
 	// +optional
 	ExternalManaged *bool `json:"externalManaged,omitempty"`

--- a/config/crd/bases/apps.kubeblocks.io_clusters.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusters.yaml
@@ -273,12 +273,12 @@ spec:
                             x-kubernetes-map-type: atomic
                           externalManaged:
                             description: |-
-                              ExternalManaged specifies whether the configuration management is delegated to an external system
-                              or manual user control.
+                              ExternalManaged specifies whether the configuration management is delegated to an external system.
 
-                              When set to true, the controller will exclusively utilize the user-provided configuration source
-                              and the 'reconfigure' action defined in this config, bypassing the default templates and
-                              update behaviors specified in the ComponentDefinition.
+                              When set to true, the apps controller does not render or manage the configuration from the
+                              default templates and update behaviors specified in the ComponentDefinition. A ConfigMap source
+                              for an external-managed configuration is accepted only when the referenced ConfigMap carries
+                              the common KubeBlocks component labels.
                             type: boolean
                           name:
                             description: The name of the config.
@@ -11477,12 +11477,12 @@ spec:
                                 x-kubernetes-map-type: atomic
                               externalManaged:
                                 description: |-
-                                  ExternalManaged specifies whether the configuration management is delegated to an external system
-                                  or manual user control.
+                                  ExternalManaged specifies whether the configuration management is delegated to an external system.
 
-                                  When set to true, the controller will exclusively utilize the user-provided configuration source
-                                  and the 'reconfigure' action defined in this config, bypassing the default templates and
-                                  update behaviors specified in the ComponentDefinition.
+                                  When set to true, the apps controller does not render or manage the configuration from the
+                                  default templates and update behaviors specified in the ComponentDefinition. A ConfigMap source
+                                  for an external-managed configuration is accepted only when the referenced ConfigMap carries
+                                  the common KubeBlocks component labels.
                                 type: boolean
                               name:
                                 description: The name of the config.

--- a/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
@@ -3709,9 +3709,11 @@ spec:
                       type: integer
                     externalManaged:
                       description: |-
-                        ExternalManaged specifies whether the file management is delegated to an external system or manual user control.
+                        ExternalManaged specifies whether the file management is delegated to an external system.
 
-                        When set to true, the controller will ignore the management of this file.
+                        When set to true, the apps controller will ignore the rendering and lifecycle management of
+                        this file. A ConfigMap source for this template is accepted only when the referenced ConfigMap
+                        carries the common KubeBlocks component labels.
                       type: boolean
                     name:
                       description: Specifies the name of the template.
@@ -17457,9 +17459,11 @@ spec:
                       type: integer
                     externalManaged:
                       description: |-
-                        ExternalManaged specifies whether the file management is delegated to an external system or manual user control.
+                        ExternalManaged specifies whether the file management is delegated to an external system.
 
-                        When set to true, the controller will ignore the management of this file.
+                        When set to true, the apps controller will ignore the rendering and lifecycle management of
+                        this file. A ConfigMap source for this template is accepted only when the referenced ConfigMap
+                        carries the common KubeBlocks component labels.
                       type: boolean
                     name:
                       description: Specifies the name of the template.

--- a/config/crd/bases/apps.kubeblocks.io_components.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_components.yaml
@@ -159,12 +159,12 @@ spec:
                       x-kubernetes-map-type: atomic
                     externalManaged:
                       description: |-
-                        ExternalManaged specifies whether the configuration management is delegated to an external system
-                        or manual user control.
+                        ExternalManaged specifies whether the configuration management is delegated to an external system.
 
-                        When set to true, the controller will exclusively utilize the user-provided configuration source
-                        and the 'reconfigure' action defined in this config, bypassing the default templates and
-                        update behaviors specified in the ComponentDefinition.
+                        When set to true, the apps controller does not render or manage the configuration from the
+                        default templates and update behaviors specified in the ComponentDefinition. A ConfigMap source
+                        for an external-managed configuration is accepted only when the referenced ConfigMap carries
+                        the common KubeBlocks component labels.
                       type: boolean
                     name:
                       description: The name of the config.

--- a/config/crd/bases/apps.kubeblocks.io_sidecardefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_sidecardefinitions.yaml
@@ -85,9 +85,11 @@ spec:
                       type: integer
                     externalManaged:
                       description: |-
-                        ExternalManaged specifies whether the file management is delegated to an external system or manual user control.
+                        ExternalManaged specifies whether the file management is delegated to an external system.
 
-                        When set to true, the controller will ignore the management of this file.
+                        When set to true, the apps controller will ignore the rendering and lifecycle management of
+                        this file. A ConfigMap source for this template is accepted only when the referenced ConfigMap
+                        carries the common KubeBlocks component labels.
                       type: boolean
                     name:
                       description: Specifies the name of the template.
@@ -1936,9 +1938,11 @@ spec:
                       type: integer
                     externalManaged:
                       description: |-
-                        ExternalManaged specifies whether the file management is delegated to an external system or manual user control.
+                        ExternalManaged specifies whether the file management is delegated to an external system.
 
-                        When set to true, the controller will ignore the management of this file.
+                        When set to true, the apps controller will ignore the rendering and lifecycle management of
+                        this file. A ConfigMap source for this template is accepted only when the referenced ConfigMap
+                        carries the common KubeBlocks component labels.
                       type: boolean
                     name:
                       description: Specifies the name of the template.

--- a/config/crd/bases/parameters.kubeblocks.io_componentparameters.yaml
+++ b/config/crd/bases/parameters.kubeblocks.io_componentparameters.yaml
@@ -175,9 +175,11 @@ spec:
                           type: integer
                         externalManaged:
                           description: |-
-                            ExternalManaged specifies whether the file management is delegated to an external system or manual user control.
+                            ExternalManaged specifies whether the file management is delegated to an external system.
 
-                            When set to true, the controller will ignore the management of this file.
+                            When set to true, the apps controller will ignore the rendering and lifecycle management of
+                            this file. A ConfigMap source for this template is accepted only when the referenced ConfigMap
+                            carries the common KubeBlocks component labels.
                           type: boolean
                         name:
                           description: Specifies the name of the template.

--- a/controllers/apps/component/component_controller_test.go
+++ b/controllers/apps/component/component_controller_test.go
@@ -1502,7 +1502,7 @@ var _ = Describe("Component Controller", func() {
 		Eventually(testapps.CheckObjExists(&testCtx, client.ObjectKeyFromObject(cm), &corev1.ConfigMap{}, false)).Should(Succeed())
 	}
 
-	testFileTemplateProvision := func(compName, compDefName, fileTemplate string) {
+	testExternalManagedConfigMapWithoutLabelsRejected := func(compName, compDefName string) {
 		var (
 			serverConfigName   = "server-conf"
 			serverConfigHash   = "abcdefg"
@@ -1527,7 +1527,7 @@ var _ = Describe("Component Controller", func() {
 			compDefObj = cmpd.DeepCopy()
 		})()).ShouldNot(HaveOccurred())
 
-		createCompObj(compName, compDefName, func(f *testapps.MockComponentFactory) {
+		createCompObjWithPhase(compName, compDefName, func(f *testapps.MockComponentFactory) {
 			f.SetConfigs([]kbappsv1.ClusterComponentConfig{
 				{
 					Name: ptr.To(serverConfigName),
@@ -1544,52 +1544,20 @@ var _ = Describe("Component Controller", func() {
 					ReconfigureAction: serverConfigAction,
 				},
 			})
-		})
+		}, "")
 
-		By("check the file template objects")
-		var defaultInitConfigHash string
-		for _, tplName := range []string{fileTemplate, serverConfigName} {
-			cmKey := types.NamespacedName{
-				Namespace: testCtx.DefaultNamespace,
-				Name:      fileTemplateObjectName(&component.SynthesizedComponent{FullCompName: compKey.Name}, tplName),
-			}
-			if tplName == fileTemplate {
-				Eventually(testapps.CheckObj(&testCtx, cmKey, func(g Gomega, cm *corev1.ConfigMap) {
-					g.Expect(cm.Data).Should(HaveKeyWithValue("level", "info"))
-					defaultInitConfigHash = cm.Annotations[constant.CMInsConfigurationHashLabelKey]
-					g.Expect(defaultInitConfigHash).NotTo(BeEmpty())
-				})).Should(Succeed())
-			} else {
-				// doesn't provision it
-				Consistently(testapps.CheckObjExists(&testCtx, cmKey, &corev1.ConfigMap{}, false)).Should(Succeed())
-			}
-		}
-
-		By("check the workload")
-		itsKey := compKey
-		Eventually(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
-			g.Expect(its.Spec.Configs).Should(HaveLen(2))
-			g.Expect(its.Spec.Configs[0].Name).Should(Equal(fileTemplate))
-			g.Expect(its.Spec.Configs[0].ConfigHash).ShouldNot(BeNil())
-			g.Expect(*its.Spec.Configs[0].ConfigHash).Should(Equal(defaultInitConfigHash))
-			g.Expect(its.Spec.Configs[0].Restart).Should(BeNil())
-			g.Expect(its.Spec.Configs[0].Reconfigure).ShouldNot(BeNil())
-			g.Expect(*its.Spec.Configs[0].Reconfigure).Should(Equal(*compDefObj.Spec.LifecycleActions.Reconfigure))
-			g.Expect(its.Spec.Configs[0].ReconfigureActionName).Should(BeEmpty()) // default reconfigure action
-			g.Expect(its.Spec.Configs[1].Name).Should(Equal(serverConfigName))
-			g.Expect(its.Spec.Configs[1].ConfigHash).ShouldNot(BeNil())
-			g.Expect(*its.Spec.Configs[1].ConfigHash).Should(Equal(serverConfigHash))
-			g.Expect(its.Spec.Configs[1].Restart).ShouldNot(BeNil())
-			g.Expect(*its.Spec.Configs[1].Restart).Should(BeTrue())
-			g.Expect(its.Spec.Configs[1].Reconfigure).ShouldNot(BeNil())
-			g.Expect(*its.Spec.Configs[1].Reconfigure).Should(Equal(*serverConfigAction))
-			g.Expect(its.Spec.Configs[1].ReconfigureActionName).Should(Equal(
-				component.UserReconfigureActionName(component.SynthesizedFileTemplate{
-					ComponentFileTemplate: kbappsv1.ComponentFileTemplate{
-						Name: serverConfigName,
-					},
-				})))
+		By("check the component validation error")
+		Eventually(testapps.CheckObj(&testCtx, compKey, func(g Gomega, comp *kbappsv1.Component) {
+			g.Expect(comp.Status.Conditions).Should(HaveLen(1))
+			g.Expect(comp.Status.Conditions[0].Type).Should(BeEquivalentTo(kbappsv1.ComponentConditionProvisioningStarted))
+			g.Expect(comp.Status.Conditions[0].Status).Should(BeEquivalentTo(metav1.ConditionFalse))
+			g.Expect(comp.Status.Conditions[0].Message).Should(ContainSubstring(
+				fmt.Sprintf("configMap %q for external-managed config must have label", compDefObj.Spec.Configs[0].Template)))
 		})).Should(Succeed())
+
+		By("check the workload is not created")
+		itsKey := compKey
+		Consistently(testapps.CheckObjExists(&testCtx, itsKey, &workloads.InstanceSet{}, false)).Should(Succeed())
 	}
 
 	testReconfigureAction := func(compName, compDefName, fileTemplate string) {
@@ -2386,8 +2354,8 @@ var _ = Describe("Component Controller", func() {
 			testFileTemplateVolumes(defaultCompName, compDefObj.Name, fileTemplate)
 		})
 
-		It("config template provision", func() {
-			testFileTemplateProvision(defaultCompName, compDefObj.Name, fileTemplate)
+		It("rejects external-managed configmap without labels", func() {
+			testExternalManagedConfigMapWithoutLabelsRejected(defaultCompName, compDefObj.Name)
 		})
 
 		It("reconfigure - action", func() {

--- a/controllers/apps/component/transformer_component_validation.go
+++ b/controllers/apps/component/transformer_component_validation.go
@@ -22,8 +22,15 @@ package component
 import (
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	appsutil "github.com/apecloud/kubeblocks/controllers/apps/util"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 )
@@ -52,6 +59,9 @@ func (t *componentValidationTransformer) Transform(ctx graph.TransformContext, d
 	if err = validateCompReplicas(comp, transCtx.CompDef); err != nil {
 		return intctrlutil.NewRequeueError(appsutil.RequeueDuration, err.Error())
 	}
+	if err = validateExternalManagedConfigSources(transCtx); err != nil {
+		return intctrlutil.NewRequeueError(appsutil.RequeueDuration, err.Error())
+	}
 	// if err = validateSidecarContainers(comp, transCtx.CompDef); err != nil {
 	// 	return newRequeueError(requeueDuration, err.Error())
 	// }
@@ -74,4 +84,79 @@ func validateCompReplicas(comp *appsv1.Component, compDef *appsv1.ComponentDefin
 
 func replicasOutOfLimitError(replicas int32, replicasLimit appsv1.ReplicasLimit) error {
 	return fmt.Errorf("replicas %d out-of-limit [%d, %d]", replicas, replicasLimit.MinReplicas, replicasLimit.MaxReplicas)
+}
+
+func validateExternalManagedConfigSources(transCtx *componentTransformContext) error {
+	comp := transCtx.Component
+	if len(comp.Spec.Configs) == 0 {
+		return nil
+	}
+
+	externalManagedTemplates := map[string]bool{}
+	for _, tpl := range transCtx.SynthesizeComponent.FileTemplates {
+		if tpl.Config && ptr.Deref(tpl.ExternalManaged, false) {
+			externalManagedTemplates[tpl.Name] = true
+		}
+	}
+
+	var externalManagedConfigs []appsv1.ClusterComponentConfig
+	for _, config := range comp.Spec.Configs {
+		if config.Name == nil || config.ConfigMap == nil || config.ConfigMap.Name == "" {
+			continue
+		}
+		if !externalManagedTemplates[*config.Name] && !ptr.Deref(config.ExternalManaged, false) {
+			continue
+		}
+		externalManagedConfigs = append(externalManagedConfigs, config)
+	}
+	if len(externalManagedConfigs) == 0 {
+		return nil
+	}
+
+	clusterName, err := component.GetClusterName(comp)
+	if err != nil {
+		return err
+	}
+	compName, err := component.ShortName(clusterName, comp.Name)
+	if err != nil {
+		return err
+	}
+
+	for _, config := range externalManagedConfigs {
+		if err := validateManagedConfigMapLabels(transCtx, config.ConfigMap.Name, clusterName, compName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateManagedConfigMapLabels(transCtx *componentTransformContext, cmName, clusterName, compName string) error {
+	cm := &corev1.ConfigMap{}
+	cmKey := types.NamespacedName{
+		Namespace: transCtx.Component.Namespace,
+		Name:      cmName,
+	}
+	if err := transCtx.Client.Get(transCtx.Context, cmKey, cm); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("configMap %q for external-managed config is not found", cmName)
+		}
+		return err
+	}
+
+	// Treat these common component labels as the apps-level handoff contract for
+	// externally managed config sources. The component controller intentionally
+	// does not inspect parameters-specific names, annotations, finalizers, or
+	// owner references.
+	expectedLabels := map[string]string{
+		constant.AppManagedByLabelKey:   constant.AppName,
+		constant.AppInstanceLabelKey:    clusterName,
+		constant.KBAppComponentLabelKey: compName,
+	}
+	for key, expected := range expectedLabels {
+		if actual := cm.Labels[key]; actual != expected {
+			return fmt.Errorf("configMap %q for external-managed config must have label %q=%q, got %q",
+				cmName, key, expected, actual)
+		}
+	}
+	return nil
 }

--- a/controllers/apps/component/transformer_component_validation_test.go
+++ b/controllers/apps/component/transformer_component_validation_test.go
@@ -1,0 +1,210 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package component
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/component"
+)
+
+func TestValidateExternalManagedConfigSources(t *testing.T) {
+	const (
+		namespace   = "default"
+		clusterName = "test-cluster"
+		compName    = "mysql"
+		configName  = "mysql-config"
+		sidecarName = "sidecar-config"
+		cmName      = "mysql-cm"
+	)
+
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name                   string
+		generation             int64
+		config                 appsv1.ClusterComponentConfig
+		compDefExternalManaged bool
+		sidecarExternalManaged bool
+		cm                     *corev1.ConfigMap
+		wantErr                bool
+	}{
+		{
+			name:                   "rejects external-managed configmap when referenced configmap is missing",
+			generation:             1,
+			config:                 externalManagedConfig(configName, cmName),
+			compDefExternalManaged: true,
+			wantErr:                true,
+		},
+		{
+			name:                   "rejects external-managed configmap without kb component labels",
+			generation:             1,
+			config:                 externalManagedConfig(configName, cmName),
+			compDefExternalManaged: true,
+			cm:                     configMap(namespace, cmName, nil),
+			wantErr:                true,
+		},
+		{
+			name:                   "accepts external-managed configmap with only kb component labels",
+			generation:             1,
+			config:                 externalManagedConfig(configName, cmName),
+			compDefExternalManaged: true,
+			cm: configMap(namespace, cmName, map[string]string{
+				constant.AppManagedByLabelKey:   constant.AppName,
+				constant.AppInstanceLabelKey:    clusterName,
+				constant.KBAppComponentLabelKey: compName,
+			}),
+		},
+		{
+			name:       "ignores user-specified configmap when config is not external-managed",
+			generation: 1,
+			config: appsv1.ClusterComponentConfig{
+				Name: ptr.To(configName),
+				ClusterComponentConfigSource: appsv1.ClusterComponentConfigSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: cmName},
+					},
+				},
+			},
+			compDefExternalManaged: false,
+		},
+		{
+			name:                   "rejects sidecar external-managed configmap without kb component labels",
+			generation:             1,
+			config:                 externalManagedConfig(sidecarName, cmName),
+			sidecarExternalManaged: true,
+			cm:                     configMap(namespace, cmName, nil),
+			wantErr:                true,
+		},
+		{
+			name:                   "accepts sidecar external-managed configmap with only kb component labels",
+			generation:             1,
+			config:                 externalManagedConfig(sidecarName, cmName),
+			sidecarExternalManaged: true,
+			cm: configMap(namespace, cmName, map[string]string{
+				constant.AppManagedByLabelKey:   constant.AppName,
+				constant.AppInstanceLabelKey:    clusterName,
+				constant.KBAppComponentLabelKey: compName,
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var objs []client.Object
+			if tt.cm != nil {
+				objs = append(objs, tt.cm)
+			}
+
+			err := validateExternalManagedConfigSources(&componentTransformContext{
+				Context: context.Background(),
+				Client:  fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build(),
+				Component: &appsv1.Component{
+					ObjectMeta: metav1ObjectMeta(namespace,
+						constant.GenerateClusterComponentName(clusterName, compName),
+						tt.generation,
+						constant.GetCompLabels(clusterName, compName)),
+					Spec: appsv1.ComponentSpec{
+						Configs: []appsv1.ClusterComponentConfig{tt.config},
+					},
+				},
+				CompDef: &appsv1.ComponentDefinition{
+					Spec: appsv1.ComponentDefinitionSpec{
+						Configs: []appsv1.ComponentFileTemplate{{
+							Name:            configName,
+							ExternalManaged: ptr.To(tt.compDefExternalManaged),
+						}},
+					},
+				},
+				SynthesizeComponent: synthesizedComponentWithFileTemplates(
+					configName, tt.compDefExternalManaged,
+					sidecarName, tt.sidecarExternalManaged),
+			})
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+func externalManagedConfig(name, cmName string) appsv1.ClusterComponentConfig {
+	return appsv1.ClusterComponentConfig{
+		Name: ptr.To(name),
+		ClusterComponentConfigSource: appsv1.ClusterComponentConfigSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: cmName},
+			},
+		},
+	}
+}
+
+func configMap(namespace, name string, labels map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1ObjectMeta(namespace, name, 0, labels),
+		Data:       map[string]string{"config": "value"},
+	}
+}
+
+func synthesizedComponentWithFileTemplates(configName string, compDefExternalManaged bool, sidecarName string, sidecarExternalManaged bool) *component.SynthesizedComponent {
+	return &component.SynthesizedComponent{
+		FileTemplates: []component.SynthesizedFileTemplate{
+			{
+				ComponentFileTemplate: appsv1.ComponentFileTemplate{
+					Name:            configName,
+					ExternalManaged: ptr.To(compDefExternalManaged),
+				},
+				Config: true,
+			},
+			{
+				ComponentFileTemplate: appsv1.ComponentFileTemplate{
+					Name:            sidecarName,
+					ExternalManaged: ptr.To(sidecarExternalManaged),
+				},
+				Config: true,
+			},
+		},
+	}
+}
+
+func metav1ObjectMeta(namespace, name string, generation int64, labels map[string]string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Namespace:  namespace,
+		Name:       name,
+		Generation: generation,
+		Labels:     labels,
+	}
+}

--- a/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
@@ -273,12 +273,12 @@ spec:
                             x-kubernetes-map-type: atomic
                           externalManaged:
                             description: |-
-                              ExternalManaged specifies whether the configuration management is delegated to an external system
-                              or manual user control.
+                              ExternalManaged specifies whether the configuration management is delegated to an external system.
 
-                              When set to true, the controller will exclusively utilize the user-provided configuration source
-                              and the 'reconfigure' action defined in this config, bypassing the default templates and
-                              update behaviors specified in the ComponentDefinition.
+                              When set to true, the apps controller does not render or manage the configuration from the
+                              default templates and update behaviors specified in the ComponentDefinition. A ConfigMap source
+                              for an external-managed configuration is accepted only when the referenced ConfigMap carries
+                              the common KubeBlocks component labels.
                             type: boolean
                           name:
                             description: The name of the config.
@@ -11477,12 +11477,12 @@ spec:
                                 x-kubernetes-map-type: atomic
                               externalManaged:
                                 description: |-
-                                  ExternalManaged specifies whether the configuration management is delegated to an external system
-                                  or manual user control.
+                                  ExternalManaged specifies whether the configuration management is delegated to an external system.
 
-                                  When set to true, the controller will exclusively utilize the user-provided configuration source
-                                  and the 'reconfigure' action defined in this config, bypassing the default templates and
-                                  update behaviors specified in the ComponentDefinition.
+                                  When set to true, the apps controller does not render or manage the configuration from the
+                                  default templates and update behaviors specified in the ComponentDefinition. A ConfigMap source
+                                  for an external-managed configuration is accepted only when the referenced ConfigMap carries
+                                  the common KubeBlocks component labels.
                                 type: boolean
                               name:
                                 description: The name of the config.

--- a/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
@@ -3709,9 +3709,11 @@ spec:
                       type: integer
                     externalManaged:
                       description: |-
-                        ExternalManaged specifies whether the file management is delegated to an external system or manual user control.
+                        ExternalManaged specifies whether the file management is delegated to an external system.
 
-                        When set to true, the controller will ignore the management of this file.
+                        When set to true, the apps controller will ignore the rendering and lifecycle management of
+                        this file. A ConfigMap source for this template is accepted only when the referenced ConfigMap
+                        carries the common KubeBlocks component labels.
                       type: boolean
                     name:
                       description: Specifies the name of the template.
@@ -17457,9 +17459,11 @@ spec:
                       type: integer
                     externalManaged:
                       description: |-
-                        ExternalManaged specifies whether the file management is delegated to an external system or manual user control.
+                        ExternalManaged specifies whether the file management is delegated to an external system.
 
-                        When set to true, the controller will ignore the management of this file.
+                        When set to true, the apps controller will ignore the rendering and lifecycle management of
+                        this file. A ConfigMap source for this template is accepted only when the referenced ConfigMap
+                        carries the common KubeBlocks component labels.
                       type: boolean
                     name:
                       description: Specifies the name of the template.

--- a/deploy/helm/crds/apps.kubeblocks.io_components.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_components.yaml
@@ -159,12 +159,12 @@ spec:
                       x-kubernetes-map-type: atomic
                     externalManaged:
                       description: |-
-                        ExternalManaged specifies whether the configuration management is delegated to an external system
-                        or manual user control.
+                        ExternalManaged specifies whether the configuration management is delegated to an external system.
 
-                        When set to true, the controller will exclusively utilize the user-provided configuration source
-                        and the 'reconfigure' action defined in this config, bypassing the default templates and
-                        update behaviors specified in the ComponentDefinition.
+                        When set to true, the apps controller does not render or manage the configuration from the
+                        default templates and update behaviors specified in the ComponentDefinition. A ConfigMap source
+                        for an external-managed configuration is accepted only when the referenced ConfigMap carries
+                        the common KubeBlocks component labels.
                       type: boolean
                     name:
                       description: The name of the config.

--- a/deploy/helm/crds/apps.kubeblocks.io_sidecardefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_sidecardefinitions.yaml
@@ -85,9 +85,11 @@ spec:
                       type: integer
                     externalManaged:
                       description: |-
-                        ExternalManaged specifies whether the file management is delegated to an external system or manual user control.
+                        ExternalManaged specifies whether the file management is delegated to an external system.
 
-                        When set to true, the controller will ignore the management of this file.
+                        When set to true, the apps controller will ignore the rendering and lifecycle management of
+                        this file. A ConfigMap source for this template is accepted only when the referenced ConfigMap
+                        carries the common KubeBlocks component labels.
                       type: boolean
                     name:
                       description: Specifies the name of the template.
@@ -1936,9 +1938,11 @@ spec:
                       type: integer
                     externalManaged:
                       description: |-
-                        ExternalManaged specifies whether the file management is delegated to an external system or manual user control.
+                        ExternalManaged specifies whether the file management is delegated to an external system.
 
-                        When set to true, the controller will ignore the management of this file.
+                        When set to true, the apps controller will ignore the rendering and lifecycle management of
+                        this file. A ConfigMap source for this template is accepted only when the referenced ConfigMap
+                        carries the common KubeBlocks component labels.
                       type: boolean
                     name:
                       description: Specifies the name of the template.

--- a/deploy/helm/crds/parameters.kubeblocks.io_componentparameters.yaml
+++ b/deploy/helm/crds/parameters.kubeblocks.io_componentparameters.yaml
@@ -175,9 +175,11 @@ spec:
                           type: integer
                         externalManaged:
                           description: |-
-                            ExternalManaged specifies whether the file management is delegated to an external system or manual user control.
+                            ExternalManaged specifies whether the file management is delegated to an external system.
 
-                            When set to true, the controller will ignore the management of this file.
+                            When set to true, the apps controller will ignore the rendering and lifecycle management of
+                            this file. A ConfigMap source for this template is accepted only when the referenced ConfigMap
+                            carries the common KubeBlocks component labels.
                           type: boolean
                         name:
                           description: Specifies the name of the template.

--- a/docs/developer_docs/api-reference/cluster.md
+++ b/docs/developer_docs/api-reference/cluster.md
@@ -2867,11 +2867,11 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>ExternalManaged specifies whether the configuration management is delegated to an external system
-or manual user control.</p>
-<p>When set to true, the controller will exclusively utilize the user-provided configuration source
-and the &lsquo;reconfigure&rsquo; action defined in this config, bypassing the default templates and
-update behaviors specified in the ComponentDefinition.</p>
+<p>ExternalManaged specifies whether the configuration management is delegated to an external system.</p>
+<p>When set to true, the apps controller does not render or manage the configuration from the
+default templates and update behaviors specified in the ComponentDefinition. A ConfigMap source
+for an external-managed configuration is accepted only when the referenced ConfigMap carries
+the common KubeBlocks component labels.</p>
 </td>
 </tr>
 <tr>
@@ -6134,8 +6134,10 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>ExternalManaged specifies whether the file management is delegated to an external system or manual user control.</p>
-<p>When set to true, the controller will ignore the management of this file.</p>
+<p>ExternalManaged specifies whether the file management is delegated to an external system.</p>
+<p>When set to true, the apps controller will ignore the rendering and lifecycle management of
+this file. A ConfigMap source for this template is accepted only when the referenced ConfigMap
+carries the common KubeBlocks component labels.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
## Summary
- validate external-managed Component config sources in the component controller
- require referenced ConfigMaps to carry the apps-level KB component label handoff contract
- derive external-managed config templates from synthesized file templates, so ComponentDefinition and SidecarDefinition configs are covered consistently
- update v1 API comments, generated CRDs, Helm CRDs, and API reference docs to remove the old manual user-control contract and document the label requirement
- update controller tests for the label-based rejection behavior and add focused validation tests, including sidecar config coverage

## Design note
This intentionally uses the common apps labels as the temporary handoff contract: `app.kubernetes.io/managed-by`, `app.kubernetes.io/instance`, and `apps.kubeblocks.io/component-name`. The component controller does not inspect parameters-specific generated names, annotations, finalizers, or ownerReferences, because those are parameters subsystem implementation details and would invert the dependency direction.

This is not intended as a namespace security boundary against a user who deliberately forges labels. It is an apps-level ownership signal for external-managed ConfigMap sources.

## API contract
The v1 API descriptions now define `externalManaged` as delegation to an external system, not manual user control. They document that ConfigMap sources for external-managed configurations/templates are accepted only when the referenced ConfigMap carries the common KubeBlocks component labels.

## Motivation
externalManaged config templates can be managed by another controller, such as the parameters subsystem, which writes a ConfigMap reference back to the Component API. A user-specified ConfigMap without the common KB component labels takes a different ownership path and can accidentally bypass that management. This change blocks that unsupported path while preserving handoffs identified by the common KB component labels.

## Validation
- `go test -mod=mod ./controllers/apps/component -run TestValidateExternalManagedConfigSources`
- `KUBEBUILDER_ASSETS=/Users/leon/Library/Application\ Support/io.kubebuilder.envtest/k8s/1.26.1-darwin-arm64 go test -mod=mod ./controllers/apps/component`
- `env GOFLAGS=-mod=mod make manifests`
- `env GOFLAGS=-mod=mod make doc`