### PR TITLE
fix(apps): truncate over-sized status condition message/reason

### DIFF
--- a/controllers/apps/cluster/cluster_status_conditions.go
+++ b/controllers/apps/cluster/cluster_status_conditions.go
@@ -80,8 +80,8 @@ func newFailedProvisioningStartedCondition(err error) metav1.Condition {
 	return metav1.Condition{
 		Type:    appsv1.ConditionTypeProvisioningStarted,
 		Status:  metav1.ConditionFalse,
-		Message: err.Error(),
-		Reason:  getConditionReasonWithError(ReasonPreCheckFailed, err),
+		Message: intctrlutil.TruncateConditionMessage(err.Error()),
+		Reason:  intctrlutil.TruncateConditionReason(getConditionReasonWithError(ReasonPreCheckFailed, err)),
 	}
 }
 
@@ -108,8 +108,8 @@ func newFailedApplyResourcesCondition(err error) metav1.Condition {
 	return metav1.Condition{
 		Type:    appsv1.ConditionTypeApplyResources,
 		Status:  metav1.ConditionFalse,
-		Message: err.Error(),
-		Reason:  getConditionReasonWithError(ReasonApplyResourcesFailed, err),
+		Message: intctrlutil.TruncateConditionMessage(err.Error()),
+		Reason:  intctrlutil.TruncateConditionReason(getConditionReasonWithError(ReasonApplyResourcesFailed, err)),
 	}
 }
 

--- a/controllers/apps/component/utils.go
+++ b/controllers/apps/component/utils.go
@@ -75,8 +75,8 @@ func newFailedProvisioningStartedCondition(err error) metav1.Condition {
 	return metav1.Condition{
 		Type:    appsv1.ComponentConditionProvisioningStarted,
 		Status:  metav1.ConditionFalse,
-		Message: err.Error(),
-		Reason:  getConditionReasonWithError(reasonPreCheckFailed, err),
+		Message: intctrlutil.TruncateConditionMessage(err.Error()),
+		Reason:  intctrlutil.TruncateConditionReason(getConditionReasonWithError(reasonPreCheckFailed, err)),
 	}
 }
 

--- a/pkg/controllerutil/condition_truncate.go
+++ b/pkg/controllerutil/condition_truncate.go
@@ -1,0 +1,75 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package controllerutil
+
+import (
+	"unicode/utf8"
+)
+
+// metav1.Condition.message has a CRD maxLength of 32768 bytes. Leave a margin
+// so the truncation marker fits and writes still succeed when the unbounded
+// underlying error (for example, a kbagent action stderr dump that already
+// exceeds 32768 bytes by itself) would otherwise cause the API server to
+// reject the status patch with "Too long: may not be more than 32768 bytes".
+const maxConditionMessageBytes = 32000
+
+// metav1.Condition.reason has a CRD maxLength of 1024 bytes.
+const maxConditionReasonBytes = 1024
+
+// conditionMsgTruncationMarker is appended to a truncated message so readers
+// can tell the message was cut off rather than naturally short. The full
+// underlying error remains available in the controller log; this marker only
+// covers the on-cluster Condition surface.
+const conditionMsgTruncationMarker = "\n[...truncated; see controller log for full error]"
+
+// TruncateConditionMessage returns msg unchanged when it fits in the Condition
+// message budget, otherwise it returns a UTF-8 safe prefix followed by the
+// truncation marker. The result is guaranteed to be valid UTF-8 and no longer
+// than maxConditionMessageBytes bytes.
+func TruncateConditionMessage(msg string) string {
+	if len(msg) <= maxConditionMessageBytes {
+		return msg
+	}
+	limit := maxConditionMessageBytes - len(conditionMsgTruncationMarker)
+	truncated := msg[:limit]
+	// A naive byte-level cut can land in the middle of a multi-byte rune.
+	// Walk back one byte at a time until the remaining prefix parses as
+	// valid UTF-8 — this also handles the case where the final byte is a
+	// rune start but the rune itself is incomplete.
+	for !utf8.ValidString(truncated) && len(truncated) > 0 {
+		truncated = truncated[:len(truncated)-1]
+	}
+	return truncated + conditionMsgTruncationMarker
+}
+
+// TruncateConditionReason returns reason unchanged when it fits in the
+// Condition reason budget, otherwise a UTF-8 safe prefix cut to fit. No marker
+// is appended — reason is a short identifier consumed by automation, not a
+// human-readable message.
+func TruncateConditionReason(reason string) string {
+	if len(reason) <= maxConditionReasonBytes {
+		return reason
+	}
+	truncated := reason[:maxConditionReasonBytes]
+	for !utf8.ValidString(truncated) && len(truncated) > 0 {
+		truncated = truncated[:len(truncated)-1]
+	}
+	return truncated
+}

--- a/pkg/controllerutil/condition_truncate_test.go
+++ b/pkg/controllerutil/condition_truncate_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package controllerutil
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestTruncateConditionMessage_EmptyAndSmall(t *testing.T) {
+	for name, in := range map[string]string{
+		"empty":      "",
+		"short":      "boom",
+		"at_limit":   strings.Repeat("a", maxConditionMessageBytes),
+		"just_below": strings.Repeat("a", maxConditionMessageBytes-1),
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := TruncateConditionMessage(in)
+			if got != in {
+				t.Fatalf("expected unchanged message, got len=%d (in len=%d)", len(got), len(in))
+			}
+		})
+	}
+}
+
+func TestTruncateConditionMessage_LargeASCII(t *testing.T) {
+	in := strings.Repeat("x", maxConditionMessageBytes*2)
+	got := TruncateConditionMessage(in)
+	if len(got) > maxConditionMessageBytes {
+		t.Fatalf("expected len <= %d, got %d", maxConditionMessageBytes, len(got))
+	}
+	if !strings.HasSuffix(got, conditionMsgTruncationMarker) {
+		t.Fatalf("expected trailing truncation marker, got %q", got[len(got)-100:])
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("expected valid UTF-8 result")
+	}
+}
+
+func TestTruncateConditionMessage_UTF8RuneBoundaryAfterFirstByte(t *testing.T) {
+	// "中" is 3 bytes: 0xE4 0xB8 0xAD. Build a payload whose naive
+	// byte-cut at maxConditionMessageBytes - len(marker) lands one byte
+	// past a "中" start, leaving 0xE4 alone at the tail (rune start but
+	// incomplete). The implementation must walk back to a valid UTF-8
+	// boundary.
+	limit := maxConditionMessageBytes - len(conditionMsgTruncationMarker)
+	// Build a prefix of (limit-1) ASCII bytes, then "中". The byte at
+	// index (limit-1) is the first byte 0xE4 of the multi-byte rune.
+	in := strings.Repeat("a", limit-1) + "中" + strings.Repeat("a", maxConditionMessageBytes)
+
+	got := TruncateConditionMessage(in)
+	if !utf8.ValidString(got) {
+		t.Fatalf("result is not valid UTF-8: %q", got[len(got)-10:])
+	}
+	if len(got) > maxConditionMessageBytes {
+		t.Fatalf("expected len <= %d, got %d", maxConditionMessageBytes, len(got))
+	}
+	if !strings.HasSuffix(got, conditionMsgTruncationMarker) {
+		t.Fatalf("expected marker suffix")
+	}
+}
+
+func TestTruncateConditionMessage_UTF8RuneBoundaryAfterSecondByte(t *testing.T) {
+	// Variant: naive cut lands after the second byte of "中" (0xB8 is
+	// not a rune start, but walking back to the prior byte 0xE4 still
+	// leaves an incomplete rune — the loop must continue until the
+	// result parses as valid UTF-8.
+	limit := maxConditionMessageBytes - len(conditionMsgTruncationMarker)
+	in := strings.Repeat("a", limit-2) + "中" + strings.Repeat("a", maxConditionMessageBytes)
+
+	got := TruncateConditionMessage(in)
+	if !utf8.ValidString(got) {
+		t.Fatalf("result is not valid UTF-8")
+	}
+	if len(got) > maxConditionMessageBytes {
+		t.Fatalf("expected len <= %d, got %d", maxConditionMessageBytes, len(got))
+	}
+	if !strings.HasSuffix(got, conditionMsgTruncationMarker) {
+		t.Fatalf("expected marker suffix")
+	}
+}
+
+func TestTruncateConditionMessage_RealWorldErrorShape(t *testing.T) {
+	// Approximates the C03 scenario: a single kbagent action error that
+	// already exceeds 32 KiB on its own. Verify it fits the post-fix
+	// budget and stays valid UTF-8.
+	payload := "action: udf-shardingShardRemove, executed on pod: rds-x, error: exit code: 1, stderr: "
+	payload += strings.Repeat("rds-cluster-shard-pod-fqdn-line ", 2000) // ~64 KiB
+	got := TruncateConditionMessage(payload)
+	if len(got) > maxConditionMessageBytes {
+		t.Fatalf("expected len <= %d, got %d", maxConditionMessageBytes, len(got))
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("expected valid UTF-8 result")
+	}
+	if !strings.HasSuffix(got, conditionMsgTruncationMarker) {
+		t.Fatalf("expected truncation marker")
+	}
+}
+
+func TestTruncateConditionReason_EmptyAndSmall(t *testing.T) {
+	for name, in := range map[string]string{
+		"empty":    "",
+		"short":    "ApplyResourcesFailed",
+		"at_limit": strings.Repeat("a", maxConditionReasonBytes),
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := TruncateConditionReason(in)
+			if got != in {
+				t.Fatalf("expected unchanged reason, got len=%d", len(got))
+			}
+		})
+	}
+}
+
+func TestTruncateConditionReason_LargeASCII(t *testing.T) {
+	in := strings.Repeat("R", maxConditionReasonBytes*3)
+	got := TruncateConditionReason(in)
+	if len(got) > maxConditionReasonBytes {
+		t.Fatalf("expected len <= %d, got %d", maxConditionReasonBytes, len(got))
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("expected valid UTF-8 result")
+	}
+}
+
+func TestTruncateConditionReason_UTF8RuneBoundary(t *testing.T) {
+	// Naive cut lands inside a 3-byte rune. The walk-back must stop on
+	// a valid UTF-8 prefix.
+	in := strings.Repeat("R", maxConditionReasonBytes-1) + "中" + strings.Repeat("R", maxConditionReasonBytes)
+	got := TruncateConditionReason(in)
+	if !utf8.ValidString(got) {
+		t.Fatalf("result not valid UTF-8")
+	}
+	if len(got) > maxConditionReasonBytes {
+		t.Fatalf("expected len <= %d, got %d", maxConditionReasonBytes, len(got))
+	}
+}


### PR DESCRIPTION
## Summary

When a Cluster or Component status condition `Message` is set directly from `err.Error()`, the underlying error can already exceed K8s' 32 768-byte `metav1.Condition.message` limit by itself — a single kbagent lifecycle action failure can produce a 47 KiB stderr payload when the action script dumps cluster topology on every retry.

Once that happens the API server rejects every subsequent status patch:

```
Cluster ... is invalid: status.conditions[2].message:
Too long: may not be more than 32768 bytes
```

The controller can no longer update Cluster status, the Cluster gets stuck in `Updating`, and downstream observers (oncall, runners, `ClusterReady`) cannot move forward until the underlying error serendipitously shrinks below the limit.

This PR adds two helpers in `pkg/controllerutil` that callers can pipe condition writes through, and applies them at every condition-write site that takes an arbitrary `err.Error()`.

## What this PR changes

- `pkg/controllerutil/condition_truncate.go` (new): adds
  - `TruncateConditionMessage` — caps message at 32 000 bytes (≈750 bytes of margin under the 32 768 CRD limit for the appended marker), walks back to a valid UTF-8 boundary using `utf8.ValidString` so a multi-byte rune is never cut mid-way, and appends `"\n[...truncated; see controller log for full error]"` so readers can tell the message was clipped. The full underlying error remains in the controller log via the existing `transCtx.Logger.Error` path.
  - `TruncateConditionReason` — caps reason at the CRD's 1024-byte limit. Reason has no marker because it is a short identifier consumed by automation, not a human message.
- `controllers/apps/cluster/cluster_status_conditions.go`: pipe `Message` / `Reason` through the new helpers in `newFailedProvisioningStartedCondition` and `newFailedApplyResourcesCondition`.
- `controllers/apps/component/utils.go`: same for `newFailedProvisioningStartedCondition`.

## What this PR does NOT change

- `setApplyResourceCondition` still ignores `IsRequeueError` — same behavior as before.
- `LifecycleActionStatus.Message` writes in `transformer_cluster_component.go` are NOT touched in this PR — that field is on Sharding status, not a `metav1.Condition`, so it does not hit the same 32 768 CRD validation. Tracked separately for a follow-up if it surfaces.
- OpsRequest / DP / parameters condition writers are NOT touched — only sites that pipe arbitrary `err.Error()` from kbagent lifecycle action failures into a `metav1.Condition.Message` are in scope here.

## Tests

`pkg/controllerutil/condition_truncate_test.go` (new) covers:

- empty / under-limit / at-limit / over-limit paths for both helpers
- a real-world-shaped ~64 KiB kbagent stderr payload (matches the C03 scenario)
- three explicit UTF-8 boundary cases where a naive byte-level cut lands in the middle of a 3-byte rune (`中`, `U+4E2D` = `E4 B8 AD`) — the helper must return a valid UTF-8 prefix in every case, including the subtle case where the final byte is `RuneStart` but the rune itself is incomplete

Local validation on the worktree:

```
ok  github.com/apecloud/kubeblocks/pkg/controllerutil         0.866s   # unit tests
ok  github.com/apecloud/kubeblocks/controllers/apps/cluster   23.084s  # envtest
ok  github.com/apecloud/kubeblocks/controllers/apps/component 61.139s  # envtest
```

`go build ./...` clean; `make test-go-generate` clean.

## Scenario this fixes (from C03 evidence)

Redis cluster `scale-in` 4→3 shards triggered a `udf-shardingShardRemove` action that returned `exit 1` with verbose stderr (full pod list + cluster topology + `redis-cli --cluster fix` output). The single err.Error() was already 47 012 bytes — over the 32 768 limit on its own. The Cluster was stuck in `Updating` for ~17 minutes until something downstream serendipitously bypassed the over-sized condition.

After this fix, the controller is allowed to keep writing the condition even when the error payload is unbounded; the on-cluster surface stays under the CRD limit while the full error remains available in the controller log.
