### PR TITLE
fix: keep same-namespace restore PVC dataSourceRef valid

### DIFF
--- a/controllers/apps/cluster/restore_intent.go
+++ b/controllers/apps/cluster/restore_intent.go
@@ -98,7 +98,7 @@ func injectRestoreIntentToVCT(cluster *appsv1.Cluster, componentName string, vct
 	}
 	apiGroup := restore.Source.APIGroup
 	var namespace *string
-	if restore.Source.Namespace != "" {
+	if restore.Source.Namespace != "" && restore.Source.Namespace != cluster.Namespace {
 		namespace = &restore.Source.Namespace
 	}
 	vct.Spec.DataSourceRef = &corev1.TypedObjectReference{

--- a/controllers/apps/cluster/restore_intent_test.go
+++ b/controllers/apps/cluster/restore_intent_test.go
@@ -74,6 +74,47 @@ func TestInjectRestoreIntentRemovesStaleOptionalAnnotations(t *testing.T) {
 	require.Equal(t, "backup-ns", *vct.Spec.DataSourceRef.Namespace)
 }
 
+func TestInjectRestoreIntentOmitsDataSourceRefNamespaceForSameNamespaceSource(t *testing.T) {
+	cluster := &appsv1.Cluster{}
+	cluster.Name = "test-cluster"
+	cluster.Namespace = "test-ns"
+	cluster.Spec.Restore = &appsv1.ClusterRestore{
+		Source: appsv1.ClusterRestoreSource{
+			APIGroup:  testRestoreSourceAPIGroup,
+			Kind:      testRestoreSourceKind,
+			Name:      "backup",
+			Namespace: "test-ns",
+		},
+	}
+	vct := &appsv1.PersistentVolumeClaimTemplate{Name: "data"}
+
+	injectRestoreIntentToVCT(cluster, "redis", vct)
+
+	require.Equal(t, "test-ns", vct.Annotations[constant.RestoreSourceNamespaceAnnotationKey])
+	require.NotNil(t, vct.Spec.DataSourceRef)
+	require.Nil(t, vct.Spec.DataSourceRef.Namespace)
+}
+
+func TestInjectRestoreIntentOmitsDataSourceRefNamespaceForDefaultNamespaceSource(t *testing.T) {
+	cluster := &appsv1.Cluster{}
+	cluster.Name = "test-cluster"
+	cluster.Namespace = "test-ns"
+	cluster.Spec.Restore = &appsv1.ClusterRestore{
+		Source: appsv1.ClusterRestoreSource{
+			APIGroup: testRestoreSourceAPIGroup,
+			Kind:     testRestoreSourceKind,
+			Name:     "backup",
+		},
+	}
+	vct := &appsv1.PersistentVolumeClaimTemplate{Name: "data"}
+
+	injectRestoreIntentToVCT(cluster, "redis", vct)
+
+	require.Equal(t, "test-ns", vct.Annotations[constant.RestoreSourceNamespaceAnnotationKey])
+	require.NotNil(t, vct.Spec.DataSourceRef)
+	require.Nil(t, vct.Spec.DataSourceRef.Namespace)
+}
+
 func TestClusterRestoreSourceAPIGroupIsRequiredByCRD(t *testing.T) {
 	data, err := os.ReadFile("../../../config/crd/bases/apps.kubeblocks.io_clusters.yaml")
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- omit `spec.dataSourceRef.namespace` when a Cluster restore source is in the same namespace as the target Cluster
- keep the explicit restore source namespace annotation so the DataProtection controller can still resolve the Backup source namespace
- add regression coverage for explicit same-namespace source and default source namespace

## Why

A Redis restore run on the current main restore API path created the Cluster, Component, and InstanceSet with restore intent metadata, but the final PVC was created without `spec.dataSourceRef`. With no PVC data source, the DataProtection volume populator had no restore entry point, so no restore orchestration was created and the Redis pod booted with an empty data volume.

The live object chain showed the restore source was in the same namespace as the restore target. The KubeBlocks restore annotations already carry that source namespace. The PVC `dataSourceRef.namespace` field is only needed for true cross-namespace sources; setting it for same-namespace restore makes the PVC data source fragile in clusters where namespaced PVC data sources are not enabled.

## Validation

```bash
go test ./controllers/apps/cluster -run 'TestInjectRestoreIntent|TestApplyClusterRestoreIntent|TestSetRestoreCondition' -count=1
git diff --check origin/main..HEAD
```

## Boundary

This PR fixes the controller projection of restore intent into PVC templates. It does not claim Redis runtime recovery until the Redis B05 scenario is rerun with a controller image containing this commit.


Fixes #10326
