### PR TITLE
fix: bind target pvc after volume population

### DIFF
--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -1703,7 +1703,7 @@ func (r *VolumePopulatorReconciler) rebindPVCAndPV(reqCtx intctrlutil.RequestCtx
 	// Examine the claimref for the PV and see if it's bound to the correct PVC
 	claimRef := pv.Spec.ClaimRef
 	if claimRef != nil && claimRef.Name == pvc.Name && claimRef.Namespace == pvc.Namespace && claimRef.UID == pvc.UID {
-		return true, nil
+		return true, r.bindTargetPVCToPV(reqCtx, pvc, pv.Name)
 	}
 	// Make new PV with strategic patch values to perform the PV rebind
 	patchPV := client.MergeFrom(pv.DeepCopy())
@@ -1717,7 +1717,23 @@ func (r *VolumePopulatorReconciler) rebindPVCAndPV(reqCtx intctrlutil.RequestCtx
 		pv.Annotations = map[string]string{}
 	}
 	pv.Annotations[AnnPopulateFrom] = pvc.Spec.DataSourceRef.Name
-	return true, r.Client.Patch(reqCtx.Ctx, pv, patchPV)
+	if err := r.Client.Patch(reqCtx.Ctx, pv, patchPV); err != nil {
+		return false, err
+	}
+	return true, r.bindTargetPVCToPV(reqCtx, pvc, pv.Name)
+}
+
+func (r *VolumePopulatorReconciler) bindTargetPVCToPV(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim, pvName string) error {
+	if pvc.Spec.VolumeName == pvName {
+		return nil
+	}
+	if pvc.Spec.VolumeName != "" {
+		return intctrlutil.NewFatalError(fmt.Sprintf("target PVC %s/%s is already bound to PV %s, expected %s",
+			pvc.Namespace, pvc.Name, pvc.Spec.VolumeName, pvName))
+	}
+	patch := client.MergeFrom(pvc.DeepCopy())
+	pvc.Spec.VolumeName = pvName
+	return r.Client.Patch(reqCtx.Ctx, pvc, patch)
 }
 
 func (r *VolumePopulatorReconciler) UpdatePVCConditions(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim, reason, message string) error {

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -276,10 +276,8 @@ var _ = Describe("Volume Populator Controller test", func() {
 				g.Expect(tmpPV.Spec.ClaimRef.Name).Should(Equal(pvc.Name))
 				g.Expect(tmpPV.Spec.ClaimRef.UID).Should(Equal(pvc.UID))
 			})).Should(Succeed())
-
-			// mock pvc.spec.volumeName
-			Expect(testapps.ChangeObj(&testCtx, pvc, func(claim *corev1.PersistentVolumeClaim) {
-				claim.Spec.VolumeName = pv.Name
+			Eventually(testapps.CheckObj(&testCtx, pvcKey, func(g Gomega, tmpPVC *corev1.PersistentVolumeClaim) {
+				g.Expect(tmpPVC.Spec.VolumeName).Should(Equal(pv.Name))
 			})).Should(Succeed())
 
 			By("expect for resources are cleaned up")
@@ -1571,7 +1569,7 @@ func TestRebindPVCAndPVWaitsUntilPopulatePVCIsBound(t *testing.T) {
 	require.False(t, rebound)
 
 	pv := &corev1.PersistentVolume{ObjectMeta: metav1.ObjectMeta{Name: "pv"}}
-	reconciler.Client = fake.NewClientBuilder().WithScheme(scheme).WithObjects(pv).Build()
+	reconciler.Client = fake.NewClientBuilder().WithScheme(scheme).WithObjects(pv, pvc).Build()
 	populatePVC.Spec.VolumeName = pv.Name
 
 	rebound, err = reconciler.rebindPVCAndPV(reqCtx, populatePVC, pvc)
@@ -1583,6 +1581,10 @@ func TestRebindPVCAndPVWaitsUntilPopulatePVCIsBound(t *testing.T) {
 	require.NotNil(t, patchedPV.Spec.ClaimRef)
 	require.Equal(t, pvc.Name, patchedPV.Spec.ClaimRef.Name)
 	require.Equal(t, pvc.UID, patchedPV.Spec.ClaimRef.UID)
+
+	patchedPVC := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, reconciler.Client.Get(reqCtx.Ctx, client.ObjectKeyFromObject(pvc), patchedPVC))
+	require.Equal(t, pv.Name, patchedPVC.Spec.VolumeName)
 }
 
 func TestRestoreSystemAccountSecretsUsesShardingSecretName(t *testing.T) {


### PR DESCRIPTION
## Summary

- set the target PVC `spec.volumeName` after the volume populator moves the populated PV `claimRef` to the target PVC
- keep the existing PV claimRef rebind behavior and fail fast if the target PVC is already bound to a different PV
- update the volume-populator regression tests so the controller, not the test, commits the target PVC binding

Fixes #10327

## Testing

- `go test ./controllers/dataprotection -run TestRebindPVCAndPVWaitsUntilPopulatePVCIsBound -count=1`
- `KUBEBUILDER_ASSETS="/Users/wei/Library/Application Support/io.kubebuilder.envtest/k8s/1.26.1-darwin-arm64" go test ./controllers/dataprotection -count=1`
- `git diff --check origin/main..HEAD`
