### PR TITLE
chore: require KB labels for external-managed ConfigMaps

### DIFF
--- a/apis/apps/v1/componentdefinition_types.go
+++ b/apis/apps/v1/componentdefinition_types.go
@@ -1106,8 +1106,11 @@ type ComponentFileTemplate struct {
 	// +optional
 	DefaultMode *int32 `json:"defaultMode,omitempty"`
 
-	// ExternalManaged indicates whether the configuration is managed by an external system.
-	// When set to true, the controller will ignore the management of this configuration.
+	// ExternalManaged specifies whether the file management is delegated to an external system.
+	//
+	// When set to true, the apps controller will ignore the rendering and lifecycle management of
+	// this file. A ConfigMap source for this template is accepted only when the referenced ConfigMap
+	// carries the common KubeBlocks component labels.
 	//
 	// +optional
 	ExternalManaged *bool `json:"externalManaged,omitempty"`

--- a/apis/apps/v1/types.go
+++ b/apis/apps/v1/types.go
@@ -542,9 +542,12 @@ type ClusterComponentConfig struct {
 	// +optional
 	Reconfigure *Action `json:"reconfigure,omitempty"`
 
-	// ExternalManaged indicates whether the configuration is managed by an external system.
-	// When set to true, the controller will use the user-provided template and reconfigure action,
-	// ignoring the default template and update behavior.
+	// ExternalManaged specifies whether the configuration management is delegated to an external system.
+	//
+	// When set to true, the apps controller does not render or manage the configuration from the
+	// default templates and update behaviors specified in the ComponentDefinition. A ConfigMap source
+	// for an external-managed configuration is accepted only when the referenced ConfigMap carries
+	// the common KubeBlocks component labels.
 	//
 	// +optional
 	ExternalManaged *bool `json:"externalManaged,omitempty"`

--- a/config/crd/bases/apps.kubeblocks.io_clusters.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusters.yaml
@@ -266,9 +266,12 @@ spec:
                             x-kubernetes-map-type: atomic
                           externalManaged:
                             description: |-
-                              ExternalManaged indicates whether the configuration is managed by an external system.
-                              When set to true, the controller will use the user-provided template and reconfigure action,
-                              ignoring the default template and update behavior.
+                              ExternalManaged specifies whether the configuration management is delegated to an external system.
+
+                              When set to true, the apps controller does not render or manage the configuration from the
+                              default templates and update behaviors specified in the ComponentDefinition. A ConfigMap source
+                              for an external-managed configuration is accepted only when the referenced ConfigMap carries
+                              the common KubeBlocks component labels.
                             type: boolean
                           name:
                             description: The name of the config.
@@ -11410,9 +11413,12 @@ spec:
                                 x-kubernetes-map-type: atomic
                               externalManaged:
                                 description: |-
-                                  ExternalManaged indicates whether the configuration is managed by an external system.
-                                  When set to true, the controller will use the user-provided template and reconfigure action,
-                                  ignoring the default template and update behavior.
+                                  ExternalManaged specifies whether the configuration management is delegated to an external system.
+
+                                  When set to true, the apps controller does not render or manage the configuration from the
+                                  default templates and update behaviors specified in the ComponentDefinition. A ConfigMap source
+                                  for an external-managed configuration is accepted only when the referenced ConfigMap carries
+                                  the common KubeBlocks component labels.
                                 type: boolean
                               name:
                                 description: The name of the config.

--- a/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
@@ -3709,8 +3709,11 @@ spec:
                       type: integer
                     externalManaged:
                       description: |-
-                        ExternalManaged indicates whether the configuration is managed by an external system.
-                        When set to true, the controller will ignore the management of this configuration.
+                        ExternalManaged specifies whether the file management is delegated to an external system.
+
+                        When set to true, the apps controller will ignore the rendering and lifecycle management of
+                        this file. A ConfigMap source for this template is accepted only when the referenced ConfigMap
+                        carries the common KubeBlocks component labels.
                       type: boolean
                     name:
                       description: Specifies the name of the template.
@@ -17042,8 +17045,11 @@ spec:
                       type: integer
                     externalManaged:
                       description: |-
-                        ExternalManaged indicates whether the configuration is managed by an external system.
-                        When set to true, the controller will ignore the management of this configuration.
+                        ExternalManaged specifies whether the file management is delegated to an external system.
+
+                        When set to true, the apps controller will ignore the rendering and lifecycle management of
+                        this file. A ConfigMap source for this template is accepted only when the referenced ConfigMap
+                        carries the common KubeBlocks component labels.
                       type: boolean
                     name:
                       description: Specifies the name of the template.

--- a/config/crd/bases/apps.kubeblocks.io_components.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_components.yaml
@@ -152,9 +152,12 @@ spec:
                       x-kubernetes-map-type: atomic
                     externalManaged:
                       description: |-
-                        ExternalManaged indicates whether the configuration is managed by an external system.
-                        When set to true, the controller will use the user-provided template and reconfigure action,
-                        ignoring the default template and update behavior.
+                        ExternalManaged specifies whether the configuration management is delegated to an external system.
+
+                        When set to true, the apps controller does not render or manage the configuration from the
+                        default templates and update behaviors specified in the ComponentDefinition. A ConfigMap source
+                        for an external-managed configuration is accepted only when the referenced ConfigMap carries
+                        the common KubeBlocks component labels.
                       type: boolean
                     name:
                       description: The name of the config.

--- a/config/crd/bases/apps.kubeblocks.io_sidecardefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_sidecardefinitions.yaml
@@ -85,8 +85,11 @@ spec:
                       type: integer
                     externalManaged:
                       description: |-
-                        ExternalManaged indicates whether the configuration is managed by an external system.
-                        When set to true, the controller will ignore the management of this configuration.
+                        ExternalManaged specifies whether the file management is delegated to an external system.
+
+                        When set to true, the apps controller will ignore the rendering and lifecycle management of
+                        this file. A ConfigMap source for this template is accepted only when the referenced ConfigMap
+                        carries the common KubeBlocks component labels.
                       type: boolean
                     name:
                       description: Specifies the name of the template.
@@ -1519,8 +1522,11 @@ spec:
                       type: integer
                     externalManaged:
                       description: |-
-                        ExternalManaged indicates whether the configuration is managed by an external system.
-                        When set to true, the controller will ignore the management of this configuration.
+                        ExternalManaged specifies whether the file management is delegated to an external system.
+
+                        When set to true, the apps controller will ignore the rendering and lifecycle management of
+                        this file. A ConfigMap source for this template is accepted only when the referenced ConfigMap
+                        carries the common KubeBlocks component labels.
                       type: boolean
                     name:
                       description: Specifies the name of the template.

--- a/config/crd/bases/parameters.kubeblocks.io_componentparameters.yaml
+++ b/config/crd/bases/parameters.kubeblocks.io_componentparameters.yaml
@@ -141,8 +141,11 @@ spec:
                           type: integer
                         externalManaged:
                           description: |-
-                            ExternalManaged indicates whether the configuration is managed by an external system.
-                            When set to true, the controller will ignore the management of this configuration.
+                            ExternalManaged specifies whether the file management is delegated to an external system.
+
+                            When set to true, the apps controller will ignore the rendering and lifecycle management of
+                            this file. A ConfigMap source for this template is accepted only when the referenced ConfigMap
+                            carries the common KubeBlocks component labels.
                           type: boolean
                         name:
                           description: Specifies the name of the template.

--- a/controllers/apps/component/transformer_component_validation.go
+++ b/controllers/apps/component/transformer_component_validation.go
@@ -22,8 +22,15 @@ package component
 import (
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	appsutil "github.com/apecloud/kubeblocks/controllers/apps/util"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 )
@@ -52,6 +59,9 @@ func (t *componentValidationTransformer) Transform(ctx graph.TransformContext, d
 	if err = validateCompReplicas(comp, transCtx.CompDef); err != nil {
 		return intctrlutil.NewRequeueError(appsutil.RequeueDuration, err.Error())
 	}
+	if err = validateExternalManagedConfigSources(transCtx); err != nil {
+		return intctrlutil.NewRequeueError(appsutil.RequeueDuration, err.Error())
+	}
 	// if err = validateSidecarContainers(comp, transCtx.CompDef); err != nil {
 	// 	return newRequeueError(requeueDuration, err.Error())
 	// }
@@ -74,4 +84,100 @@ func validateCompReplicas(comp *appsv1.Component, compDef *appsv1.ComponentDefin
 
 func replicasOutOfLimitError(replicas int32, replicasLimit appsv1.ReplicasLimit) error {
 	return fmt.Errorf("replicas %d out-of-limit [%d, %d]", replicas, replicasLimit.MinReplicas, replicasLimit.MaxReplicas)
+}
+
+func validateExternalManagedConfigSources(transCtx *componentTransformContext) error {
+	comp := transCtx.Component
+	if len(comp.Spec.Configs) == 0 {
+		return nil
+	}
+
+	externalManagedTemplates := map[string]component.SynthesizedFileTemplate{}
+	for _, tpl := range transCtx.SynthesizeComponent.FileTemplates {
+		if tpl.Config && ptr.Deref(tpl.ExternalManaged, false) {
+			externalManagedTemplates[tpl.Name] = tpl
+		}
+	}
+
+	var externalManagedConfigs []appsv1.ClusterComponentConfig
+	externalManagedConfigTemplates := map[string]component.SynthesizedFileTemplate{}
+	for _, config := range comp.Spec.Configs {
+		if config.Name == nil || config.ConfigMap == nil || config.ConfigMap.Name == "" {
+			continue
+		}
+		tpl, externalManagedTemplate := externalManagedTemplates[*config.Name]
+		if !externalManagedTemplate && !ptr.Deref(config.ExternalManaged, false) {
+			continue
+		}
+		externalManagedConfigs = append(externalManagedConfigs, config)
+		if externalManagedTemplate {
+			externalManagedConfigTemplates[*config.Name] = tpl
+		}
+	}
+	if len(externalManagedConfigs) == 0 {
+		return nil
+	}
+
+	clusterName, err := component.GetClusterName(comp)
+	if err != nil {
+		return err
+	}
+	compName, err := component.ShortName(clusterName, comp.Name)
+	if err != nil {
+		return err
+	}
+
+	for _, config := range externalManagedConfigs {
+		tpl := externalManagedConfigTemplates[*config.Name]
+		if isExistingExternalManagedConfigSource(transCtx, config, tpl) {
+			continue
+		}
+		if err := validateManagedConfigMapLabels(transCtx, config.ConfigMap.Name, clusterName, compName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func isExistingExternalManagedConfigSource(transCtx *componentTransformContext, config appsv1.ClusterComponentConfig, tpl component.SynthesizedFileTemplate) bool {
+	if transCtx.RunningWorkload == nil || config.ConfigMap == nil || tpl.VolumeName == "" {
+		return false
+	}
+	for _, volume := range transCtx.RunningWorkload.Spec.Template.Spec.Volumes {
+		if volume.Name == tpl.VolumeName && volume.ConfigMap != nil && volume.ConfigMap.Name == config.ConfigMap.Name {
+			return true
+		}
+	}
+	return false
+}
+
+func validateManagedConfigMapLabels(transCtx *componentTransformContext, cmName, clusterName, compName string) error {
+	cm := &corev1.ConfigMap{}
+	cmKey := types.NamespacedName{
+		Namespace: transCtx.Component.Namespace,
+		Name:      cmName,
+	}
+	if err := transCtx.Client.Get(transCtx.Context, cmKey, cm); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("configMap %q for external-managed config is not found", cmName)
+		}
+		return err
+	}
+
+	// Treat these common component labels as the apps-level handoff contract for
+	// externally managed config sources. The component controller intentionally
+	// does not inspect parameters-specific names, annotations, finalizers, or
+	// owner references.
+	expectedLabels := map[string]string{
+		constant.AppManagedByLabelKey:   constant.AppName,
+		constant.AppInstanceLabelKey:    clusterName,
+		constant.KBAppComponentLabelKey: compName,
+	}
+	for key, expected := range expectedLabels {
+		if actual := cm.Labels[key]; actual != expected {
+			return fmt.Errorf("configMap %q for external-managed config must have label %q=%q, got %q",
+				cmName, key, expected, actual)
+		}
+	}
+	return nil
 }

--- a/controllers/apps/component/transformer_component_validation_test.go
+++ b/controllers/apps/component/transformer_component_validation_test.go
@@ -1,0 +1,251 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package component
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/component"
+)
+
+func TestValidateExternalManagedConfigSources(t *testing.T) {
+	const (
+		namespace   = "default"
+		clusterName = "test-cluster"
+		compName    = "mysql"
+		configName  = "mysql-config"
+		sidecarName = "sidecar-config"
+		cmName      = "mysql-cm"
+	)
+
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name                   string
+		generation             int64
+		config                 appsv1.ClusterComponentConfig
+		compDefExternalManaged bool
+		sidecarExternalManaged bool
+		runningWorkload        *workloads.InstanceSet
+		cm                     *corev1.ConfigMap
+		wantErr                bool
+	}{
+		{
+			name:                   "rejects external-managed configmap when referenced configmap is missing",
+			generation:             1,
+			config:                 externalManagedConfig(configName, cmName),
+			compDefExternalManaged: true,
+			wantErr:                true,
+		},
+		{
+			name:                   "rejects external-managed configmap without kb component labels",
+			generation:             1,
+			config:                 externalManagedConfig(configName, cmName),
+			compDefExternalManaged: true,
+			cm:                     configMap(namespace, cmName, nil),
+			wantErr:                true,
+		},
+		{
+			name:                   "accepts existing external-managed configmap source already mounted by workload",
+			generation:             2,
+			config:                 externalManagedConfig(configName, cmName),
+			compDefExternalManaged: true,
+			runningWorkload:        workloadWithConfigVolume(configName+"-volume", cmName),
+			cm:                     configMap(namespace, cmName, nil),
+		},
+		{
+			name:                   "rejects changed external-managed configmap source without kb component labels",
+			generation:             2,
+			config:                 externalManagedConfig(configName, cmName),
+			compDefExternalManaged: true,
+			runningWorkload:        workloadWithConfigVolume(configName+"-volume", "old-"+cmName),
+			cm:                     configMap(namespace, cmName, nil),
+			wantErr:                true,
+		},
+		{
+			name:                   "accepts external-managed configmap with only kb component labels",
+			generation:             1,
+			config:                 externalManagedConfig(configName, cmName),
+			compDefExternalManaged: true,
+			cm: configMap(namespace, cmName, map[string]string{
+				constant.AppManagedByLabelKey:   constant.AppName,
+				constant.AppInstanceLabelKey:    clusterName,
+				constant.KBAppComponentLabelKey: compName,
+			}),
+		},
+		{
+			name:       "ignores user-specified configmap when config is not external-managed",
+			generation: 1,
+			config: appsv1.ClusterComponentConfig{
+				Name: ptr.To(configName),
+				ClusterComponentConfigSource: appsv1.ClusterComponentConfigSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: cmName},
+					},
+				},
+			},
+			compDefExternalManaged: false,
+		},
+		{
+			name:                   "rejects sidecar external-managed configmap without kb component labels",
+			generation:             1,
+			config:                 externalManagedConfig(sidecarName, cmName),
+			sidecarExternalManaged: true,
+			cm:                     configMap(namespace, cmName, nil),
+			wantErr:                true,
+		},
+		{
+			name:                   "accepts sidecar external-managed configmap with only kb component labels",
+			generation:             1,
+			config:                 externalManagedConfig(sidecarName, cmName),
+			sidecarExternalManaged: true,
+			cm: configMap(namespace, cmName, map[string]string{
+				constant.AppManagedByLabelKey:   constant.AppName,
+				constant.AppInstanceLabelKey:    clusterName,
+				constant.KBAppComponentLabelKey: compName,
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var objs []client.Object
+			if tt.cm != nil {
+				objs = append(objs, tt.cm)
+			}
+
+			err := validateExternalManagedConfigSources(&componentTransformContext{
+				Context: context.Background(),
+				Client:  fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build(),
+				Component: &appsv1.Component{
+					ObjectMeta: metav1ObjectMeta(namespace,
+						constant.GenerateClusterComponentName(clusterName, compName),
+						tt.generation,
+						constant.GetCompLabels(clusterName, compName)),
+					Spec: appsv1.ComponentSpec{
+						Configs: []appsv1.ClusterComponentConfig{tt.config},
+					},
+				},
+				CompDef: &appsv1.ComponentDefinition{
+					Spec: appsv1.ComponentDefinitionSpec{
+						Configs: []appsv1.ComponentFileTemplate{{
+							Name:            configName,
+							ExternalManaged: ptr.To(tt.compDefExternalManaged),
+						}},
+					},
+				},
+				SynthesizeComponent: synthesizedComponentWithFileTemplates(
+					configName, tt.compDefExternalManaged,
+					sidecarName, tt.sidecarExternalManaged),
+				RunningWorkload: tt.runningWorkload,
+			})
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+func externalManagedConfig(name, cmName string) appsv1.ClusterComponentConfig {
+	return appsv1.ClusterComponentConfig{
+		Name: ptr.To(name),
+		ClusterComponentConfigSource: appsv1.ClusterComponentConfigSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: cmName},
+			},
+		},
+	}
+}
+
+func configMap(namespace, name string, labels map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1ObjectMeta(namespace, name, 0, labels),
+		Data:       map[string]string{"config": "value"},
+	}
+}
+
+func synthesizedComponentWithFileTemplates(configName string, compDefExternalManaged bool, sidecarName string, sidecarExternalManaged bool) *component.SynthesizedComponent {
+	return &component.SynthesizedComponent{
+		FileTemplates: []component.SynthesizedFileTemplate{
+			{
+				ComponentFileTemplate: appsv1.ComponentFileTemplate{
+					Name:            configName,
+					VolumeName:      configName + "-volume",
+					ExternalManaged: ptr.To(compDefExternalManaged),
+				},
+				Config: true,
+			},
+			{
+				ComponentFileTemplate: appsv1.ComponentFileTemplate{
+					Name:            sidecarName,
+					VolumeName:      sidecarName + "-volume",
+					ExternalManaged: ptr.To(sidecarExternalManaged),
+				},
+				Config: true,
+			},
+		},
+	}
+}
+
+func workloadWithConfigVolume(volumeName, cmName string) *workloads.InstanceSet {
+	return &workloads.InstanceSet{
+		Spec: workloads.InstanceSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{{
+						Name: volumeName,
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{Name: cmName},
+							},
+						},
+					}},
+				},
+			},
+		},
+	}
+}
+
+func metav1ObjectMeta(namespace, name string, generation int64, labels map[string]string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Namespace:  namespace,
+		Name:       name,
+		Generation: generation,
+		Labels:     labels,
+	}
+}

--- a/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
@@ -266,9 +266,12 @@ spec:
                             x-kubernetes-map-type: atomic
                           externalManaged:
                             description: |-
-                              ExternalManaged indicates whether the configuration is managed by an external system.
-                              When set to true, the controller will use the user-provided template and reconfigure action,
-                              ignoring the default template and update behavior.
+                              ExternalManaged specifies whether the configuration management is delegated to an external system.
+
+                              When set to true, the apps controller does not render or manage the configuration from the
+                              default templates and update behaviors specified in the ComponentDefinition. A ConfigMap source
+                              for an external-managed configuration is accepted only when the referenced ConfigMap carries
+                              the common KubeBlocks component labels.
                             type: boolean
                           name:
                             description: The name of the config.
@@ -11410,9 +11413,12 @@ spec:
                                 x-kubernetes-map-type: atomic
                               externalManaged:
                                 description: |-
-                                  ExternalManaged indicates whether the configuration is managed by an external system.
-                                  When set to true, the controller will use the user-provided template and reconfigure action,
-                                  ignoring the default template and update behavior.
+                                  ExternalManaged specifies whether the configuration management is delegated to an external system.
+
+                                  When set to true, the apps controller does not render or manage the configuration from the
+                                  default templates and update behaviors specified in the ComponentDefinition. A ConfigMap source
+                                  for an external-managed configuration is accepted only when the referenced ConfigMap carries
+                                  the common KubeBlocks component labels.
                                 type: boolean
                               name:
                                 description: The name of the config.

--- a/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
@@ -3709,8 +3709,11 @@ spec:
                       type: integer
                     externalManaged:
                       description: |-
-                        ExternalManaged indicates whether the configuration is managed by an external system.
-                        When set to true, the controller will ignore the management of this configuration.
+                        ExternalManaged specifies whether the file management is delegated to an external system.
+
+                        When set to true, the apps controller will ignore the rendering and lifecycle management of
+                        this file. A ConfigMap source for this template is accepted only when the referenced ConfigMap
+                        carries the common KubeBlocks component labels.
                       type: boolean
                     name:
                       description: Specifies the name of the template.
@@ -17042,8 +17045,11 @@ spec:
                       type: integer
                     externalManaged:
                       description: |-
-                        ExternalManaged indicates whether the configuration is managed by an external system.
-                        When set to true, the controller will ignore the management of this configuration.
+                        ExternalManaged specifies whether the file management is delegated to an external system.
+
+                        When set to true, the apps controller will ignore the rendering and lifecycle management of
+                        this file. A ConfigMap source for this template is accepted only when the referenced ConfigMap
+                        carries the common KubeBlocks component labels.
                       type: boolean
                     name:
                       description: Specifies the name of the template.

--- a/deploy/helm/crds/apps.kubeblocks.io_components.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_components.yaml
@@ -152,9 +152,12 @@ spec:
                       x-kubernetes-map-type: atomic
                     externalManaged:
                       description: |-
-                        ExternalManaged indicates whether the configuration is managed by an external system.
-                        When set to true, the controller will use the user-provided template and reconfigure action,
-                        ignoring the default template and update behavior.
+                        ExternalManaged specifies whether the configuration management is delegated to an external system.
+
+                        When set to true, the apps controller does not render or manage the configuration from the
+                        default templates and update behaviors specified in the ComponentDefinition. A ConfigMap source
+                        for an external-managed configuration is accepted only when the referenced ConfigMap carries
+                        the common KubeBlocks component labels.
                       type: boolean
                     name:
                       description: The name of the config.

--- a/deploy/helm/crds/apps.kubeblocks.io_sidecardefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_sidecardefinitions.yaml
@@ -85,8 +85,11 @@ spec:
                       type: integer
                     externalManaged:
                       description: |-
-                        ExternalManaged indicates whether the configuration is managed by an external system.
-                        When set to true, the controller will ignore the management of this configuration.
+                        ExternalManaged specifies whether the file management is delegated to an external system.
+
+                        When set to true, the apps controller will ignore the rendering and lifecycle management of
+                        this file. A ConfigMap source for this template is accepted only when the referenced ConfigMap
+                        carries the common KubeBlocks component labels.
                       type: boolean
                     name:
                       description: Specifies the name of the template.
@@ -1519,8 +1522,11 @@ spec:
                       type: integer
                     externalManaged:
                       description: |-
-                        ExternalManaged indicates whether the configuration is managed by an external system.
-                        When set to true, the controller will ignore the management of this configuration.
+                        ExternalManaged specifies whether the file management is delegated to an external system.
+
+                        When set to true, the apps controller will ignore the rendering and lifecycle management of
+                        this file. A ConfigMap source for this template is accepted only when the referenced ConfigMap
+                        carries the common KubeBlocks component labels.
                       type: boolean
                     name:
                       description: Specifies the name of the template.

--- a/deploy/helm/crds/parameters.kubeblocks.io_componentparameters.yaml
+++ b/deploy/helm/crds/parameters.kubeblocks.io_componentparameters.yaml
@@ -141,8 +141,11 @@ spec:
                           type: integer
                         externalManaged:
                           description: |-
-                            ExternalManaged indicates whether the configuration is managed by an external system.
-                            When set to true, the controller will ignore the management of this configuration.
+                            ExternalManaged specifies whether the file management is delegated to an external system.
+
+                            When set to true, the apps controller will ignore the rendering and lifecycle management of
+                            this file. A ConfigMap source for this template is accepted only when the referenced ConfigMap
+                            carries the common KubeBlocks component labels.
                           type: boolean
                         name:
                           description: Specifies the name of the template.

--- a/docs/developer_docs/api-reference/cluster.md
+++ b/docs/developer_docs/api-reference/cluster.md
@@ -2872,9 +2872,11 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>ExternalManaged indicates whether the configuration is managed by an external system.
-When set to true, the controller will use the user-provided template and reconfigure action,
-ignoring the default template and update behavior.</p>
+<p>ExternalManaged specifies whether the configuration management is delegated to an external system.</p>
+<p>When set to true, the apps controller does not render or manage the configuration from the
+default templates and update behaviors specified in the ComponentDefinition. A ConfigMap source
+for an external-managed configuration is accepted only when the referenced ConfigMap carries
+the common KubeBlocks component labels.</p>
 </td>
 </tr>
 </tbody>
@@ -5909,8 +5911,10 @@ bool
 </td>
 <td>
 <em>(Optional)</em>
-<p>ExternalManaged indicates whether the configuration is managed by an external system.
-When set to true, the controller will ignore the management of this configuration.</p>
+<p>ExternalManaged specifies whether the file management is delegated to an external system.</p>
+<p>When set to true, the apps controller will ignore the rendering and lifecycle management of
+this file. A ConfigMap source for this template is accepted only when the referenced ConfigMap
+carries the common KubeBlocks component labels.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
## Summary
- Backport external-managed ConfigMap label validation for Component configs.
- Validate both component and sidecar synthesized file templates before allowing an external-managed ConfigMap source.
- Update API descriptions and generated CRDs/docs with the KB label handoff contract.

## Validation
- make manifests
- make doc
- go test -mod=mod ./controllers/apps/component -run TestValidateExternalManagedConfigSources
- go test -mod=mod ./controllers/apps/component