### PR TITLE
fix: support ordinal target pod selector

### DIFF
--- a/apis/apps/v1/componentdefinition_types.go
+++ b/apis/apps/v1/componentdefinition_types.go
@@ -1884,6 +1884,9 @@ type Action struct {
 	// - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
 	// - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
 	//   will be selected for the Action.
+	// - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+	//   and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+	//   The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 	//
 	// This field cannot be updated.
 	//
@@ -1993,6 +1996,9 @@ type ExecAction struct {
 	// - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
 	// - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
 	//   will be selected for the Action.
+	// - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+	//   and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+	//   The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 	//
 	// This field cannot be updated.
 	//

--- a/config/crd/bases/apps.kubeblocks.io_clusters.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusters.yaml
@@ -477,6 +477,9 @@ spec:
                                       - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                       - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                         will be selected for the Action.
+                                      - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                        and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                        The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                       This field cannot be updated.
                                     type: string
@@ -632,6 +635,9 @@ spec:
                                   - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                   - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                     will be selected for the Action.
+                                  - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                    and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                    The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                   This field cannot be updated.
                                 type: string
@@ -11685,6 +11691,9 @@ spec:
                                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                             will be selected for the Action.
+                                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                           This field cannot be updated.
                                         type: string
@@ -11840,6 +11849,9 @@ spec:
                                       - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                       - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                         will be selected for the Action.
+                                      - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                        and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                        The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                       This field cannot be updated.
                                     type: string

--- a/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
@@ -3914,6 +3914,9 @@ spec:
                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                   will be selected for the Action.
+                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                 This field cannot be updated.
                               type: string
@@ -4068,6 +4071,9 @@ spec:
                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                               will be selected for the Action.
+                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                             This field cannot be updated.
                           type: string
@@ -4493,6 +4499,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -4647,6 +4656,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -4898,6 +4910,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -5064,6 +5079,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -5343,6 +5361,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -5497,6 +5518,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -5759,6 +5783,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -5913,6 +5940,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -6178,6 +6208,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -6332,6 +6365,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -6599,6 +6635,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -6753,6 +6792,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -7010,6 +7052,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -7164,6 +7209,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -7421,6 +7469,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -7575,6 +7626,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -7832,6 +7886,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -7986,6 +8043,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -8245,6 +8305,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -8399,6 +8462,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -8650,6 +8716,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -8804,6 +8873,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -9092,6 +9164,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -9258,6 +9333,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -9537,6 +9615,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -9691,6 +9772,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -17664,6 +17748,9 @@ spec:
                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                   will be selected for the Action.
+                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                 This field cannot be updated.
                               type: string
@@ -17818,6 +17905,9 @@ spec:
                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                               will be selected for the Action.
+                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                             This field cannot be updated.
                           type: string

--- a/config/crd/bases/apps.kubeblocks.io_components.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_components.yaml
@@ -360,6 +360,9 @@ spec:
                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                   will be selected for the Action.
+                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                 This field cannot be updated.
                               type: string
@@ -514,6 +517,9 @@ spec:
                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                               will be selected for the Action.
+                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                             This field cannot be updated.
                           type: string
@@ -781,6 +787,9 @@ spec:
                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                   will be selected for the Action.
+                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                 This field cannot be updated.
                               type: string
@@ -935,6 +944,9 @@ spec:
                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                               will be selected for the Action.
+                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                             This field cannot be updated.
                           type: string

--- a/config/crd/bases/apps.kubeblocks.io_rollouts.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_rollouts.yaml
@@ -331,6 +331,9 @@ spec:
                                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                                   will be selected for the Action.
+                                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                                 This field cannot be updated.
                                               type: string
@@ -488,6 +491,9 @@ spec:
                                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                               will be selected for the Action.
+                                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                             This field cannot be updated.
                                           type: string
@@ -755,6 +761,9 @@ spec:
                                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                                   will be selected for the Action.
+                                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                                 This field cannot be updated.
                                               type: string
@@ -912,6 +921,9 @@ spec:
                                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                               will be selected for the Action.
+                                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                             This field cannot be updated.
                                           type: string
@@ -3656,6 +3668,9 @@ spec:
                                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                                   will be selected for the Action.
+                                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                                 This field cannot be updated.
                                               type: string
@@ -3813,6 +3828,9 @@ spec:
                                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                               will be selected for the Action.
+                                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                             This field cannot be updated.
                                           type: string
@@ -4080,6 +4098,9 @@ spec:
                                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                                   will be selected for the Action.
+                                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                                 This field cannot be updated.
                                               type: string
@@ -4237,6 +4258,9 @@ spec:
                                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                               will be selected for the Action.
+                                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                             This field cannot be updated.
                                           type: string

--- a/config/crd/bases/apps.kubeblocks.io_shardingdefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_shardingdefinitions.yaml
@@ -247,6 +247,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -401,6 +404,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -677,6 +683,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -831,6 +840,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -1102,6 +1114,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -1256,6 +1271,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -1527,6 +1545,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -1681,6 +1702,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string

--- a/config/crd/bases/apps.kubeblocks.io_sidecardefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_sidecardefinitions.yaml
@@ -290,6 +290,9 @@ spec:
                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                   will be selected for the Action.
+                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                 This field cannot be updated.
                               type: string
@@ -444,6 +447,9 @@ spec:
                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                               will be selected for the Action.
+                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                             This field cannot be updated.
                           type: string
@@ -2143,6 +2149,9 @@ spec:
                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                   will be selected for the Action.
+                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                 This field cannot be updated.
                               type: string
@@ -2297,6 +2306,9 @@ spec:
                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                               will be selected for the Action.
+                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                             This field cannot be updated.
                           type: string

--- a/config/crd/bases/parameters.kubeblocks.io_componentparameters.yaml
+++ b/config/crd/bases/parameters.kubeblocks.io_componentparameters.yaml
@@ -381,6 +381,9 @@ spec:
                                     - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                     - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                       will be selected for the Action.
+                                    - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                      and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                      The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                     This field cannot be updated.
                                   type: string
@@ -536,6 +539,9 @@ spec:
                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                   will be selected for the Action.
+                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                 This field cannot be updated.
                               type: string

--- a/config/crd/bases/workloads.kubeblocks.io_instances.yaml
+++ b/config/crd/bases/workloads.kubeblocks.io_instances.yaml
@@ -255,6 +255,9 @@ spec:
                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                   will be selected for the Action.
+                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                 This field cannot be updated.
                               type: string
@@ -409,6 +412,9 @@ spec:
                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                               will be selected for the Action.
+                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                             This field cannot be updated.
                           type: string
@@ -1663,6 +1669,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -1817,6 +1826,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -2066,6 +2078,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -2220,6 +2235,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string

--- a/config/crd/bases/workloads.kubeblocks.io_instancesets.yaml
+++ b/config/crd/bases/workloads.kubeblocks.io_instancesets.yaml
@@ -255,6 +255,9 @@ spec:
                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                   will be selected for the Action.
+                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                 This field cannot be updated.
                               type: string
@@ -409,6 +412,9 @@ spec:
                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                               will be selected for the Action.
+                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                             This field cannot be updated.
                           type: string
@@ -2643,6 +2649,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -2797,6 +2806,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -3046,6 +3058,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -3200,6 +3215,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string

--- a/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
@@ -477,6 +477,9 @@ spec:
                                       - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                       - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                         will be selected for the Action.
+                                      - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                        and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                        The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                       This field cannot be updated.
                                     type: string
@@ -632,6 +635,9 @@ spec:
                                   - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                   - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                     will be selected for the Action.
+                                  - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                    and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                    The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                   This field cannot be updated.
                                 type: string
@@ -11685,6 +11691,9 @@ spec:
                                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                             will be selected for the Action.
+                                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                           This field cannot be updated.
                                         type: string
@@ -11840,6 +11849,9 @@ spec:
                                       - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                       - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                         will be selected for the Action.
+                                      - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                        and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                        The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                       This field cannot be updated.
                                     type: string

--- a/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
@@ -3914,6 +3914,9 @@ spec:
                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                   will be selected for the Action.
+                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                 This field cannot be updated.
                               type: string
@@ -4068,6 +4071,9 @@ spec:
                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                               will be selected for the Action.
+                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                             This field cannot be updated.
                           type: string
@@ -4493,6 +4499,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -4647,6 +4656,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -4898,6 +4910,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -5064,6 +5079,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -5343,6 +5361,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -5497,6 +5518,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -5759,6 +5783,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -5913,6 +5940,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -6178,6 +6208,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -6332,6 +6365,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -6599,6 +6635,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -6753,6 +6792,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -7010,6 +7052,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -7164,6 +7209,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -7421,6 +7469,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -7575,6 +7626,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -7832,6 +7886,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -7986,6 +8043,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -8245,6 +8305,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -8399,6 +8462,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -8650,6 +8716,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -8804,6 +8873,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -9092,6 +9164,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -9258,6 +9333,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -9537,6 +9615,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -9691,6 +9772,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -17664,6 +17748,9 @@ spec:
                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                   will be selected for the Action.
+                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                 This field cannot be updated.
                               type: string
@@ -17818,6 +17905,9 @@ spec:
                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                               will be selected for the Action.
+                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                             This field cannot be updated.
                           type: string

--- a/deploy/helm/crds/apps.kubeblocks.io_components.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_components.yaml
@@ -360,6 +360,9 @@ spec:
                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                   will be selected for the Action.
+                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                 This field cannot be updated.
                               type: string
@@ -514,6 +517,9 @@ spec:
                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                               will be selected for the Action.
+                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                             This field cannot be updated.
                           type: string
@@ -781,6 +787,9 @@ spec:
                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                   will be selected for the Action.
+                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                 This field cannot be updated.
                               type: string
@@ -935,6 +944,9 @@ spec:
                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                               will be selected for the Action.
+                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                             This field cannot be updated.
                           type: string

--- a/deploy/helm/crds/apps.kubeblocks.io_rollouts.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_rollouts.yaml
@@ -331,6 +331,9 @@ spec:
                                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                                   will be selected for the Action.
+                                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                                 This field cannot be updated.
                                               type: string
@@ -488,6 +491,9 @@ spec:
                                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                               will be selected for the Action.
+                                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                             This field cannot be updated.
                                           type: string
@@ -755,6 +761,9 @@ spec:
                                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                                   will be selected for the Action.
+                                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                                 This field cannot be updated.
                                               type: string
@@ -912,6 +921,9 @@ spec:
                                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                               will be selected for the Action.
+                                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                             This field cannot be updated.
                                           type: string
@@ -3656,6 +3668,9 @@ spec:
                                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                                   will be selected for the Action.
+                                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                                 This field cannot be updated.
                                               type: string
@@ -3813,6 +3828,9 @@ spec:
                                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                               will be selected for the Action.
+                                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                             This field cannot be updated.
                                           type: string
@@ -4080,6 +4098,9 @@ spec:
                                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                                   will be selected for the Action.
+                                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                                 This field cannot be updated.
                                               type: string
@@ -4237,6 +4258,9 @@ spec:
                                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                               will be selected for the Action.
+                                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                             This field cannot be updated.
                                           type: string

--- a/deploy/helm/crds/apps.kubeblocks.io_shardingdefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_shardingdefinitions.yaml
@@ -247,6 +247,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -401,6 +404,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -677,6 +683,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -831,6 +840,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -1102,6 +1114,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -1256,6 +1271,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -1527,6 +1545,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -1681,6 +1702,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string

--- a/deploy/helm/crds/apps.kubeblocks.io_sidecardefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_sidecardefinitions.yaml
@@ -290,6 +290,9 @@ spec:
                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                   will be selected for the Action.
+                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                 This field cannot be updated.
                               type: string
@@ -444,6 +447,9 @@ spec:
                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                               will be selected for the Action.
+                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                             This field cannot be updated.
                           type: string
@@ -2143,6 +2149,9 @@ spec:
                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                   will be selected for the Action.
+                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                 This field cannot be updated.
                               type: string
@@ -2297,6 +2306,9 @@ spec:
                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                               will be selected for the Action.
+                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                             This field cannot be updated.
                           type: string

--- a/deploy/helm/crds/parameters.kubeblocks.io_componentparameters.yaml
+++ b/deploy/helm/crds/parameters.kubeblocks.io_componentparameters.yaml
@@ -381,6 +381,9 @@ spec:
                                     - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                     - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                       will be selected for the Action.
+                                    - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                      and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                      The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                     This field cannot be updated.
                                   type: string
@@ -536,6 +539,9 @@ spec:
                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                   will be selected for the Action.
+                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                 This field cannot be updated.
                               type: string

--- a/deploy/helm/crds/workloads.kubeblocks.io_instances.yaml
+++ b/deploy/helm/crds/workloads.kubeblocks.io_instances.yaml
@@ -255,6 +255,9 @@ spec:
                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                   will be selected for the Action.
+                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                 This field cannot be updated.
                               type: string
@@ -409,6 +412,9 @@ spec:
                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                               will be selected for the Action.
+                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                             This field cannot be updated.
                           type: string
@@ -1663,6 +1669,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -1817,6 +1826,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -2066,6 +2078,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -2220,6 +2235,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string

--- a/deploy/helm/crds/workloads.kubeblocks.io_instancesets.yaml
+++ b/deploy/helm/crds/workloads.kubeblocks.io_instancesets.yaml
@@ -255,6 +255,9 @@ spec:
                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                   will be selected for the Action.
+                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                 This field cannot be updated.
                               type: string
@@ -409,6 +412,9 @@ spec:
                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                               will be selected for the Action.
+                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                             This field cannot be updated.
                           type: string
@@ -2643,6 +2649,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -2797,6 +2806,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -3046,6 +3058,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -3200,6 +3215,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string

--- a/docs/developer_docs/api-reference/cluster.md
+++ b/docs/developer_docs/api-reference/cluster.md
@@ -2479,6 +2479,9 @@ The impact of this field depends on the <code>targetPodSelector</code> value:</p
 <li>When <code>targetPodSelector</code> is set to <code>Any</code> or <code>All</code>, this field will be ignored.</li>
 <li>When <code>targetPodSelector</code> is set to <code>Role</code>, only those replicas whose role matches the <code>matchingKey</code>
 will be selected for the Action.</li>
+<li>When <code>targetPodSelector</code> is set to <code>Ordinal</code>, <code>matchingKey</code> must be a non-negative integer
+and only the replica whose Pod name ends with <code>-&lt;matchingKey&gt;</code> will be selected for the Action.
+The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.</li>
 </ul>
 <p>This field cannot be updated.</p>
 </td>
@@ -8395,6 +8398,9 @@ The impact of this field depends on the <code>targetPodSelector</code> value:</p
 <li>When <code>targetPodSelector</code> is set to <code>Any</code> or <code>All</code>, this field will be ignored.</li>
 <li>When <code>targetPodSelector</code> is set to <code>Role</code>, only those replicas whose role matches the <code>matchingKey</code>
 will be selected for the Action.</li>
+<li>When <code>targetPodSelector</code> is set to <code>Ordinal</code>, <code>matchingKey</code> must be a non-negative integer
+and only the replica whose Pod name ends with <code>-&lt;matchingKey&gt;</code> will be selected for the Action.
+The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.</li>
 </ul>
 <p>This field cannot be updated.</p>
 </td>

--- a/pkg/controller/lifecycle/kbagent.go
+++ b/pkg/controller/lifecycle/kbagent.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -488,6 +489,37 @@ func SelectTargetPods(pods []*corev1.Pod, pod *corev1.Pod, spec *appsv1.Action) 
 		return rolePods
 	}
 
+	podsWithOrdinal := func() ([]*corev1.Pod, error) {
+		ordinal, err := strconv.Atoi(matchingKey)
+		if err != nil || ordinal < 0 {
+			return nil, fmt.Errorf("invalid ordinal matchingKey: %s", matchingKey)
+		}
+
+		var ordinalPods []*corev1.Pod
+		for i, pod := range pods {
+			idx := strings.LastIndex(pod.Name, "-")
+			if idx < 0 || idx == len(pod.Name)-1 {
+				continue
+			}
+			podOrdinal, err := strconv.Atoi(pod.Name[idx+1:])
+			if err != nil {
+				continue
+			}
+			if podOrdinal == ordinal {
+				ordinalPods = append(ordinalPods, pods[i])
+			}
+		}
+		if len(ordinalPods) > 1 {
+			var podNames []string
+			for _, pod := range ordinalPods {
+				podNames = append(podNames, pod.Name)
+			}
+			return nil, fmt.Errorf("ambiguous ordinal selector matchingKey %s matches multiple pods: %s",
+				matchingKey, strings.Join(podNames, ","))
+		}
+		return ordinalPods, nil
+	}
+
 	switch selector {
 	case appsv1.AnyReplica:
 		return anyPod(), nil
@@ -496,7 +528,7 @@ func SelectTargetPods(pods []*corev1.Pod, pod *corev1.Pod, spec *appsv1.Action) 
 	case appsv1.RoleSelector:
 		return podsWithRole(), nil
 	case appsv1.OrdinalSelector:
-		return nil, fmt.Errorf("ordinal selector is not supported")
+		return podsWithOrdinal()
 	default:
 		return nil, fmt.Errorf("unknown pod selector: %s", selector)
 	}

--- a/pkg/controller/lifecycle/lifecycle_test.go
+++ b/pkg/controller/lifecycle/lifecycle_test.go
@@ -717,6 +717,97 @@ var _ = Describe("lifecycle", func() {
 			Expect(err.Error()).Should(ContainSubstring("pod pod-1 has no ip"))
 		})
 
+		It("pod selector - ordinal", func() {
+			lifecycleActions.PostProvision.Exec.TargetPodSelector = appsv1.OrdinalSelector
+			lifecycleActions.PostProvision.Exec.MatchingKey = "1"
+			pods = []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      "pod-0",
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "kbagent",
+								Ports: []corev1.ContainerPort{
+									{
+										Name: "http",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      "pod-1",
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "kbagent",
+								Ports: []corev1.ContainerPort{
+									{
+										Name: "http",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			lifecycle, err := New(namespace, clusterName, compName, lifecycleActions, nil, nil, pods)
+			Expect(err).Should(BeNil())
+			Expect(lifecycle).ShouldNot(BeNil())
+
+			err = lifecycle.PostProvision(ctx, k8sClient, nil)
+			Expect(err).ShouldNot(BeNil())
+			Expect(err.Error()).Should(ContainSubstring("pod pod-1 has no ip"))
+		})
+
+		It("pod selector - ordinal invalid matching key", func() {
+			lifecycleActions.PostProvision.Exec.TargetPodSelector = appsv1.OrdinalSelector
+			lifecycleActions.PostProvision.Exec.MatchingKey = "invalid"
+
+			lifecycle, err := New(namespace, clusterName, compName, lifecycleActions, nil, nil, pods)
+			Expect(err).Should(BeNil())
+			Expect(lifecycle).ShouldNot(BeNil())
+
+			err = lifecycle.PostProvision(ctx, k8sClient, nil)
+			Expect(err).ShouldNot(BeNil())
+			Expect(err.Error()).Should(ContainSubstring("invalid ordinal matchingKey: invalid"))
+		})
+
+		It("pod selector - ordinal ambiguous", func() {
+			lifecycleActions.PostProvision.Exec.TargetPodSelector = appsv1.OrdinalSelector
+			lifecycleActions.PostProvision.Exec.MatchingKey = "0"
+			pods = []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      "pod-0",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      "pod-template-0",
+					},
+				},
+			}
+
+			lifecycle, err := New(namespace, clusterName, compName, lifecycleActions, nil, nil, pods)
+			Expect(err).Should(BeNil())
+			Expect(lifecycle).ShouldNot(BeNil())
+
+			err = lifecycle.PostProvision(ctx, k8sClient, nil)
+			Expect(err).ShouldNot(BeNil())
+			Expect(err.Error()).Should(ContainSubstring("ambiguous ordinal selector matchingKey 0 matches multiple pods: pod-0,pod-template-0"))
+		})
+
 		It("pod selector - has no matched", func() {
 			lifecycleActions.PostProvision.Exec.TargetPodSelector = appsv1.RoleSelector
 			lifecycleActions.PostProvision.Exec.MatchingKey = "leader"


### PR DESCRIPTION
## Summary
- support lifecycle action targetPodSelector: Ordinal by matching the numeric suffix in pod names
- reject invalid ordinal matchingKey values with a clear error
- add regression tests for ordinal selection and invalid matchingKey handling

## Root Cause
TargetPodSelector declared Ordinal as a valid enum, but SelectTargetPods returned ordinal selector is not supported at runtime.

## Validation
- go test ./pkg/controller/lifecycle

Fixes #10330