### PR TITLE
fix: release populated PVC before postReady restore

### DIFF
--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -1008,6 +1008,12 @@ func (r *VolumePopulatorReconciler) completeBoundPVCIfNeeded(reqCtx intctrlutil.
 		}
 		break
 	}
+	// Release the target PVC after prepareData and PV rebind. PostReady actions
+	// may need the workload pod to start, which cannot happen while the populate
+	// PVC still owns the restored PV.
+	if err := r.Cleanup(reqCtx, pvc); err != nil {
+		return err
+	}
 	postReadyCompleted, err := r.ensurePostReadyRestoreCompleted(reqCtx, pvc, restoreCtx)
 	if err != nil {
 		return err

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -1246,6 +1246,77 @@ func TestEnsurePostReadyRestoreCompletedUsesOneRestorePerComponent(t *testing.T)
 	require.Equal(t, backup.Name, restoreList.Items[0].Spec.Backup.Name)
 }
 
+func TestCompleteBoundPVCReleasesPopulatePVCBeforeWaitingForPostReady(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+	require.NoError(t, kbappsv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	apiGroup := dptypes.DataprotectionAPIGroup
+	backup := newBackupForRestoreDecision([]string{"data"}, nil)
+	pvc := newPVCForRestoreDecision("data", "mysql", "")
+	pvc.UID = types.UID("target-pvc")
+	pvc.Finalizers = []string{dptypes.DataProtectionFinalizerName}
+	pvc.Spec.VolumeName = "data-pv"
+	pvc.Spec.DataSourceRef = &corev1.TypedObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     dptypes.BackupKind,
+		Name:     backup.Name,
+	}
+	pvc.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
+	pvc.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+	populatePVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: pvc.Namespace,
+			Name:      getPopulatePVCName(pvc.UID),
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName: "data-pv",
+		},
+	}
+	comp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "mysql"),
+			UID:       "component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{
+			Phase: kbappsv1.CreatingComponentPhase,
+			Conditions: []metav1.Condition{{
+				Type:   kbappsv1.ComponentConditionProgressing,
+				Status: metav1.ConditionTrue,
+				Reason: "PostProvision",
+			}},
+		},
+	}
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).
+			WithStatusSubresource(pvc).
+			WithObjects(backup, pvc, populatePVC, comp).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{
+		Spec: dpv1alpha1.RestoreSpec{Backup: dpv1alpha1.BackupRef{Name: backup.Name, Namespace: backup.Namespace}},
+	}, nil, scheme, reconciler.Client)
+	restoreMgr.PostReadyBackupSets = []dprestore.BackupActionSet{{Backup: backup}}
+
+	err := reconciler.completeBoundPVCIfNeeded(
+		intctrlutil.RequestCtx{Ctx: context.Background()},
+		pvc,
+		&pvcRestoreContext{restoreMgr: restoreMgr, mode: pvcRestoreModeRestoreData},
+	)
+
+	require.Error(t, err)
+	require.True(t, intctrlutil.IsRequeueError(err), err)
+	currentPVC := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), currentPVC))
+	require.NotContains(t, currentPVC.Finalizers, dptypes.DataProtectionFinalizerName)
+	currentPopulatePVC := &corev1.PersistentVolumeClaim{}
+	require.Error(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(populatePVC), currentPopulatePVC))
+}
+
 func TestEnsurePostReadyRestoreCompletedRejectsMismatchedExistingRestore(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))


### PR DESCRIPTION
## Summary

- release the target PVC path after prepareData succeeds and the populated PV has been rebound
- avoid waiting for component post-provision before deleting the temporary populate PVC
- add a regression test for the postReady deadlock where the component is still Creating/PostProvision

Fixes #10333

## Testing

- `go test ./controllers/dataprotection -run 'TestCompleteBoundPVCReleasesPopulatePVCBeforeWaitingForPostReady|TestHandleSyncPVCErrorKeepsInternalRequeueWhenPVCIsPopulating|TestEnsurePostReadyRestoreCompletedUsesOneRestorePerComponent|TestEnsurePostReadyRestoreCompletedRejectsMismatchedExistingRestore|TestBuildPostReadyRestoreSelectsHighestPriorityRole|TestProvisionOnlyCreatesPopulatePVCWithoutJob' -count=1`
- `KUBEBUILDER_ASSETS="/Users/wei/Library/Application Support/io.kubebuilder.envtest/k8s/1.26.1-darwin-arm64" go test ./controllers/dataprotection -count=1`
- `git diff --check origin/main..HEAD`
