### PR TITLE
chore: preserve existing external-managed ConfigMap sources

### DIFF
--- a/controllers/apps/component/transformer_component_validation.go
+++ b/controllers/apps/component/transformer_component_validation.go
@@ -92,22 +92,27 @@ func validateExternalManagedConfigSources(transCtx *componentTransformContext) e
 		return nil
 	}
 
-	externalManagedTemplates := map[string]bool{}
+	externalManagedTemplates := map[string]component.SynthesizedFileTemplate{}
 	for _, tpl := range transCtx.SynthesizeComponent.FileTemplates {
 		if tpl.Config && ptr.Deref(tpl.ExternalManaged, false) {
-			externalManagedTemplates[tpl.Name] = true
+			externalManagedTemplates[tpl.Name] = tpl
 		}
 	}
 
 	var externalManagedConfigs []appsv1.ClusterComponentConfig
+	externalManagedConfigTemplates := map[string]component.SynthesizedFileTemplate{}
 	for _, config := range comp.Spec.Configs {
 		if config.Name == nil || config.ConfigMap == nil || config.ConfigMap.Name == "" {
 			continue
 		}
-		if !externalManagedTemplates[*config.Name] && !ptr.Deref(config.ExternalManaged, false) {
+		tpl, externalManagedTemplate := externalManagedTemplates[*config.Name]
+		if !externalManagedTemplate && !ptr.Deref(config.ExternalManaged, false) {
 			continue
 		}
 		externalManagedConfigs = append(externalManagedConfigs, config)
+		if externalManagedTemplate {
+			externalManagedConfigTemplates[*config.Name] = tpl
+		}
 	}
 	if len(externalManagedConfigs) == 0 {
 		return nil
@@ -123,11 +128,27 @@ func validateExternalManagedConfigSources(transCtx *componentTransformContext) e
 	}
 
 	for _, config := range externalManagedConfigs {
+		tpl := externalManagedConfigTemplates[*config.Name]
+		if isExistingExternalManagedConfigSource(transCtx, config, tpl) {
+			continue
+		}
 		if err := validateManagedConfigMapLabels(transCtx, config.ConfigMap.Name, clusterName, compName); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func isExistingExternalManagedConfigSource(transCtx *componentTransformContext, config appsv1.ClusterComponentConfig, tpl component.SynthesizedFileTemplate) bool {
+	if transCtx.RunningWorkload == nil || config.ConfigMap == nil || tpl.VolumeName == "" {
+		return false
+	}
+	for _, volume := range transCtx.RunningWorkload.Spec.Template.Spec.Volumes {
+		if volume.Name == tpl.VolumeName && volume.ConfigMap != nil && volume.ConfigMap.Name == config.ConfigMap.Name {
+			return true
+		}
+	}
+	return false
 }
 
 func validateManagedConfigMapLabels(transCtx *componentTransformContext, cmName, clusterName, compName string) error {

--- a/controllers/apps/component/transformer_component_validation_test.go
+++ b/controllers/apps/component/transformer_component_validation_test.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 )
@@ -57,6 +58,7 @@ func TestValidateExternalManagedConfigSources(t *testing.T) {
 		config                 appsv1.ClusterComponentConfig
 		compDefExternalManaged bool
 		sidecarExternalManaged bool
+		runningWorkload        *workloads.InstanceSet
 		cm                     *corev1.ConfigMap
 		wantErr                bool
 	}{
@@ -72,6 +74,23 @@ func TestValidateExternalManagedConfigSources(t *testing.T) {
 			generation:             1,
 			config:                 externalManagedConfig(configName, cmName),
 			compDefExternalManaged: true,
+			cm:                     configMap(namespace, cmName, nil),
+			wantErr:                true,
+		},
+		{
+			name:                   "accepts existing external-managed configmap source already mounted by workload",
+			generation:             2,
+			config:                 externalManagedConfig(configName, cmName),
+			compDefExternalManaged: true,
+			runningWorkload:        workloadWithConfigVolume(configName+"-volume", cmName),
+			cm:                     configMap(namespace, cmName, nil),
+		},
+		{
+			name:                   "rejects changed external-managed configmap source without kb component labels",
+			generation:             2,
+			config:                 externalManagedConfig(configName, cmName),
+			compDefExternalManaged: true,
+			runningWorkload:        workloadWithConfigVolume(configName+"-volume", "old-"+cmName),
 			cm:                     configMap(namespace, cmName, nil),
 			wantErr:                true,
 		},
@@ -150,6 +169,7 @@ func TestValidateExternalManagedConfigSources(t *testing.T) {
 				SynthesizeComponent: synthesizedComponentWithFileTemplates(
 					configName, tt.compDefExternalManaged,
 					sidecarName, tt.sidecarExternalManaged),
+				RunningWorkload: tt.runningWorkload,
 			})
 			if tt.wantErr && err == nil {
 				t.Fatal("expected error, got nil")
@@ -185,6 +205,7 @@ func synthesizedComponentWithFileTemplates(configName string, compDefExternalMan
 			{
 				ComponentFileTemplate: appsv1.ComponentFileTemplate{
 					Name:            configName,
+					VolumeName:      configName + "-volume",
 					ExternalManaged: ptr.To(compDefExternalManaged),
 				},
 				Config: true,
@@ -192,9 +213,29 @@ func synthesizedComponentWithFileTemplates(configName string, compDefExternalMan
 			{
 				ComponentFileTemplate: appsv1.ComponentFileTemplate{
 					Name:            sidecarName,
+					VolumeName:      sidecarName + "-volume",
 					ExternalManaged: ptr.To(sidecarExternalManaged),
 				},
 				Config: true,
+			},
+		},
+	}
+}
+
+func workloadWithConfigVolume(volumeName, cmName string) *workloads.InstanceSet {
+	return &workloads.InstanceSet{
+		Spec: workloads.InstanceSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{{
+						Name: volumeName,
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{Name: cmName},
+							},
+						},
+					}},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- Preserve existing external-managed ConfigMap sources that are already mounted by the running workload.
- Keep requiring KB common component labels for newly introduced external-managed ConfigMap sources or ConfigMap source changes.
- Add regression coverage for the existing-source compatibility path and the changed-source rejection path.

## Validation
- make manifests
- go test -mod=mod ./controllers/apps/component -run TestValidateExternalManagedConfigSources
- go test -mod=mod ./controllers/apps/component