### PR TITLE
fix: keep populated PVC released while waiting postReady

### DIFF
--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -995,23 +995,42 @@ func (r *VolumePopulatorReconciler) completeBoundPVCIfNeeded(reqCtx intctrlutil.
 	pvc *corev1.PersistentVolumeClaim,
 	restoreCtx *pvcRestoreContext) error {
 	restoreMgr := restoreCtx.restoreMgr
+	populateReleased := pvcPopulateReleased(pvc)
 	for i := range pvc.Status.Conditions {
 		condition := pvc.Status.Conditions[i]
 		if string(condition.Type) != appsv1.ConditionTypeRestore {
 			continue
 		}
-		switch condition.Status {
-		case corev1.ConditionTrue:
-			return nil
-		case corev1.ConditionFalse:
+		if condition.Status == corev1.ConditionFalse {
 			return nil
 		}
 		break
 	}
-	// Release the target PVC after prepareData and PV rebind. PostReady actions
-	// may need the workload pod to start, which cannot happen while the populate
-	// PVC still owns the restored PV.
-	if err := r.Cleanup(reqCtx, pvc); err != nil {
+	if !populateReleased {
+		// Release the target PVC after prepareData and PV rebind. PostReady
+		// actions may need the workload pod to start, which cannot happen while
+		// the populate PVC still owns the restored PV or while the target PVC is
+		// still marked as being populated.
+		if err := r.Cleanup(reqCtx, pvc); err != nil {
+			return err
+		}
+		reason := ReasonPopulatingSucceed
+		message := "Populator finished"
+		if restoreCtx.mode == pvcRestoreModeProvisionOnly {
+			reason = ReasonPopulatingProvisioned
+			message = "PVC provisioned without data restore"
+		}
+		if err := r.updatePVCPopulatingCondition(reqCtx, pvc, reason, message); err != nil {
+			return err
+		}
+		if restoreCtx.mode == pvcRestoreModeRestoreData {
+			dprestore.SetRestoreStageCondition(restoreMgr.Restore, dpv1alpha1.PrepareData, dprestore.ReasonSucceed, "prepare data successfully")
+			if err := r.patchInternalRestoreStatus(reqCtx, restoreMgr); err != nil {
+				return err
+			}
+		}
+	}
+	if err := r.syncTargetPVCBoundStatusIfReady(reqCtx, pvc); err != nil {
 		return err
 	}
 	postReadyCompleted, err := r.ensurePostReadyRestoreCompleted(reqCtx, pvc, restoreCtx)
@@ -1027,14 +1046,7 @@ func (r *VolumePopulatorReconciler) completeBoundPVCIfNeeded(reqCtx intctrlutil.
 		reason = ReasonPopulatingProvisioned
 		message = "PVC provisioned without data restore"
 	}
-	if err := r.UpdatePVCConditions(reqCtx, pvc, reason, message); err != nil {
-		return err
-	}
-	if restoreCtx.mode == pvcRestoreModeProvisionOnly {
-		return nil
-	}
-	dprestore.SetRestoreStageCondition(restoreMgr.Restore, dpv1alpha1.PrepareData, dprestore.ReasonSucceed, "prepare data successfully")
-	return r.patchInternalRestoreStatus(reqCtx, restoreMgr)
+	return r.UpdatePVCConditions(reqCtx, pvc, reason, message)
 }
 
 func (r *VolumePopulatorReconciler) waitForSerialPredecessors(reqCtx intctrlutil.RequestCtx,
@@ -1127,7 +1139,7 @@ func (r *VolumePopulatorReconciler) ensurePostReadyRestoreCompleted(reqCtx intct
 	allBound, err := r.allRestorePVCsForComponentBound(reqCtx, pvc)
 	if err != nil || !allBound {
 		if err == nil {
-			err = r.UpdatePVCConditions(reqCtx, pvc, ReasonPopulatingProcessing, "Waiting for all restore PVCs to finish prepareData")
+			err = r.updatePVCConditionsIfPopulateNotReleased(reqCtx, pvc, "Waiting for all restore PVCs to finish prepareData")
 		}
 		return false, err
 	}
@@ -1144,7 +1156,7 @@ func (r *VolumePopulatorReconciler) ensurePostReadyRestoreCompleted(reqCtx intct
 		return false, err
 	}
 	if comp.Status.Phase != appsv1.RunningComponentPhase || componentPostProvisionRunning(comp) {
-		if err = r.UpdatePVCConditions(reqCtx, pvc, ReasonPopulatingProcessing, "Waiting for component to finish post-provision"); err != nil {
+		if err = r.updatePVCConditionsIfPopulateNotReleased(reqCtx, pvc, "Waiting for component to finish post-provision"); err != nil {
 			return false, err
 		}
 		return false, nil
@@ -1159,7 +1171,7 @@ func (r *VolumePopulatorReconciler) ensurePostReadyRestoreCompleted(reqCtx intct
 			return false, err
 		}
 		if cluster.Status.Phase != appsv1.RunningClusterPhase {
-			if err = r.UpdatePVCConditions(reqCtx, pvc, ReasonPopulatingProcessing, "Waiting for cluster to run before postReady restore"); err != nil {
+			if err = r.updatePVCConditionsIfPopulateNotReleased(reqCtx, pvc, "Waiting for cluster to run before postReady restore"); err != nil {
 				return false, err
 			}
 			return false, nil
@@ -1177,7 +1189,7 @@ func (r *VolumePopulatorReconciler) ensurePostReadyRestoreCompleted(reqCtx intct
 		if err = r.Client.Create(reqCtx.Ctx, postReadyRestore); err != nil && !apierrors.IsAlreadyExists(err) {
 			return false, err
 		}
-		if err = r.UpdatePVCConditions(reqCtx, pvc, ReasonPopulatingProcessing, "Waiting for postReady restore to complete"); err != nil {
+		if err = r.updatePVCConditionsIfPopulateNotReleased(reqCtx, pvc, "Waiting for postReady restore to complete"); err != nil {
 			return false, err
 		}
 		return false, nil
@@ -1191,11 +1203,20 @@ func (r *VolumePopulatorReconciler) ensurePostReadyRestoreCompleted(reqCtx intct
 	case dpv1alpha1.RestorePhaseFailed:
 		return false, intctrlutil.NewFatalError(fmt.Sprintf("postReady restore %s/%s failed", existing.Namespace, existing.Name))
 	default:
-		if err = r.UpdatePVCConditions(reqCtx, pvc, ReasonPopulatingProcessing, "Waiting for postReady restore to complete"); err != nil {
+		if err = r.updatePVCConditionsIfPopulateNotReleased(reqCtx, pvc, "Waiting for postReady restore to complete"); err != nil {
 			return false, err
 		}
 		return false, nil
 	}
+}
+
+func (r *VolumePopulatorReconciler) updatePVCConditionsIfPopulateNotReleased(reqCtx intctrlutil.RequestCtx,
+	pvc *corev1.PersistentVolumeClaim,
+	message string) error {
+	if pvcPopulateReleased(pvc) {
+		return nil
+	}
+	return r.UpdatePVCConditions(reqCtx, pvc, ReasonPopulatingProcessing, message)
 }
 
 func (r *VolumePopulatorReconciler) buildPostReadyRestore(reqCtx intctrlutil.RequestCtx,
@@ -1355,6 +1376,12 @@ func findPVCConditionByType(pvc *corev1.PersistentVolumeClaim, conditionType str
 		}
 	}
 	return nil
+}
+
+func pvcPopulateReleased(pvc *corev1.PersistentVolumeClaim) bool {
+	cond := findPVCConditionByType(pvc, string(PersistentVolumeClaimPopulating))
+	return cond != nil && cond.Status == corev1.ConditionTrue &&
+		(cond.Reason == ReasonPopulatingSucceed || cond.Reason == ReasonPopulatingProvisioned)
 }
 
 func (r *VolumePopulatorReconciler) listRestorePVCsForComponent(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim) ([]corev1.PersistentVolumeClaim, error) {
@@ -1742,6 +1769,48 @@ func (r *VolumePopulatorReconciler) bindTargetPVCToPV(reqCtx intctrlutil.Request
 	return r.Client.Patch(reqCtx.Ctx, pvc, patch)
 }
 
+func pvClaimRefMatchesPVC(claimRef *corev1.ObjectReference, pvc *corev1.PersistentVolumeClaim) bool {
+	return claimRef != nil &&
+		claimRef.Name == pvc.Name &&
+		claimRef.Namespace == pvc.Namespace &&
+		claimRef.UID == pvc.UID
+}
+
+func (r *VolumePopulatorReconciler) syncTargetPVCBoundStatusIfReady(reqCtx intctrlutil.RequestCtx,
+	pvc *corev1.PersistentVolumeClaim) error {
+	if pvc.Spec.VolumeName == "" {
+		return nil
+	}
+	pv := &corev1.PersistentVolume{}
+	if err := r.Client.Get(reqCtx.Ctx, types.NamespacedName{Name: pvc.Spec.VolumeName}, pv); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	if !pvClaimRefMatchesPVC(pv.Spec.ClaimRef, pvc) {
+		return nil
+	}
+	return r.syncTargetPVCBoundStatus(reqCtx, pvc, pv)
+}
+
+func (r *VolumePopulatorReconciler) syncTargetPVCBoundStatus(reqCtx intctrlutil.RequestCtx,
+	pvc *corev1.PersistentVolumeClaim,
+	pv *corev1.PersistentVolume) error {
+	capacity := pv.Spec.Capacity.DeepCopy()
+	accessModes := slices.Clone(pv.Spec.AccessModes)
+	if pvc.Status.Phase == corev1.ClaimBound &&
+		reflect.DeepEqual(pvc.Status.Capacity, capacity) &&
+		slices.Equal(pvc.Status.AccessModes, accessModes) {
+		return nil
+	}
+	patch := client.MergeFrom(pvc.DeepCopy())
+	pvc.Status.Phase = corev1.ClaimBound
+	pvc.Status.Capacity = capacity
+	pvc.Status.AccessModes = accessModes
+	return r.Client.Status().Patch(reqCtx.Ctx, pvc, patch)
+}
+
 func (r *VolumePopulatorReconciler) UpdatePVCConditions(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim, reason, message string) error {
 	progressCondition := corev1.PersistentVolumeClaimCondition{
 		Type:               PersistentVolumeClaimPopulating,
@@ -1795,6 +1864,26 @@ func (r *VolumePopulatorReconciler) UpdatePVCConditions(reqCtx intctrlutil.Reque
 	switch reason {
 	case ReasonPopulatingProcessing:
 		r.Recorder.Event(pvc, corev1.EventTypeNormal, ReasonStartToVolumePopulate, message)
+	case ReasonPopulatingSucceed, ReasonPopulatingProvisioned:
+		r.Recorder.Event(pvc, corev1.EventTypeNormal, ReasonVolumePopulateSucceed, message)
+	}
+	return r.Client.Status().Patch(reqCtx.Ctx, pvc, pvcPatch)
+}
+
+func (r *VolumePopulatorReconciler) updatePVCPopulatingCondition(reqCtx intctrlutil.RequestCtx,
+	pvc *corev1.PersistentVolumeClaim,
+	reason,
+	message string) error {
+	progressCondition := corev1.PersistentVolumeClaimCondition{
+		Type:               PersistentVolumeClaimPopulating,
+		Status:             corev1.ConditionTrue,
+		LastTransitionTime: metav1.Now(),
+		Reason:             reason,
+		Message:            message,
+	}
+	pvcPatch := client.MergeFrom(pvc.DeepCopy())
+	upsertPVCCondition(&pvc.Status.Conditions, progressCondition)
+	switch reason {
 	case ReasonPopulatingSucceed, ReasonPopulatingProvisioned:
 		r.Recorder.Event(pvc, corev1.EventTypeNormal, ReasonVolumePopulateSucceed, message)
 	}

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -1274,6 +1274,23 @@ func TestCompleteBoundPVCReleasesPopulatePVCBeforeWaitingForPostReady(t *testing
 			VolumeName: "data-pv",
 		},
 	}
+	pv := &corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "data-pv"},
+		Spec: corev1.PersistentVolumeSpec{
+			Capacity: corev1.ResourceList{
+				corev1.ResourceStorage: resource.MustParse("1Gi"),
+			},
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			ClaimRef: &corev1.ObjectReference{
+				Namespace: pvc.Namespace,
+				Name:      pvc.Name,
+				UID:       pvc.UID,
+			},
+		},
+		Status: corev1.PersistentVolumeStatus{
+			Phase: corev1.VolumeBound,
+		},
+	}
 	comp := &kbappsv1.Component{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
@@ -1289,10 +1306,84 @@ func TestCompleteBoundPVCReleasesPopulatePVCBeforeWaitingForPostReady(t *testing
 			}},
 		},
 	}
+	restore := &dpv1alpha1.Restore{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "prepare-data-restore",
+		},
+		Spec: dpv1alpha1.RestoreSpec{Backup: dpv1alpha1.BackupRef{Name: backup.Name, Namespace: backup.Namespace}},
+	}
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).
+			WithStatusSubresource(pvc, restore).
+			WithObjects(backup, pvc, populatePVC, pv, comp, restore).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+	restoreMgr := dprestore.NewRestoreManager(restore, nil, scheme, reconciler.Client)
+	restoreMgr.PostReadyBackupSets = []dprestore.BackupActionSet{{Backup: backup}}
+
+	err := reconciler.completeBoundPVCIfNeeded(
+		intctrlutil.RequestCtx{Ctx: context.Background()},
+		pvc,
+		&pvcRestoreContext{restoreMgr: restoreMgr, mode: pvcRestoreModeRestoreData},
+	)
+
+	require.Error(t, err)
+	require.True(t, intctrlutil.IsRequeueError(err), err)
+	currentPVC := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), currentPVC))
+	require.NotContains(t, currentPVC.Finalizers, dptypes.DataProtectionFinalizerName)
+	require.Equal(t, corev1.ClaimBound, currentPVC.Status.Phase)
+	require.Equal(t, resource.MustParse("1Gi"), currentPVC.Status.Capacity[corev1.ResourceStorage])
+	require.Equal(t, []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}, currentPVC.Status.AccessModes)
+	populatingCondition := findPVCConditionByType(currentPVC, string(PersistentVolumeClaimPopulating))
+	require.NotNil(t, populatingCondition)
+	require.Equal(t, ReasonPopulatingSucceed, populatingCondition.Reason)
+	restoreCondition := findPVCConditionByType(currentPVC, kbappsv1.ConditionTypeRestore)
+	require.Nil(t, restoreCondition)
+	currentPopulatePVC := &corev1.PersistentVolumeClaim{}
+	require.Error(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(populatePVC), currentPopulatePVC))
+}
+
+func TestCompleteBoundPVCContinuesPostReadyAfterPopulateReleased(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+	require.NoError(t, kbappsv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	apiGroup := dptypes.DataprotectionAPIGroup
+	backup := newBackupForRestoreDecision([]string{"data"}, nil)
+	pvc := newPVCForRestoreDecision("data", "mysql", "")
+	pvc.UID = types.UID("target-pvc")
+	pvc.Spec.VolumeName = "data-pv"
+	pvc.Spec.DataSourceRef = &corev1.TypedObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     dptypes.BackupKind,
+		Name:     backup.Name,
+	}
+	pvc.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
+	pvc.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+	pvc.Status.Conditions = []corev1.PersistentVolumeClaimCondition{
+		{
+			Type:   PersistentVolumeClaimPopulating,
+			Status: corev1.ConditionTrue,
+			Reason: ReasonPopulatingSucceed,
+		},
+	}
+	comp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "mysql"),
+			UID:       "component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
+	}
 	reconciler := &VolumePopulatorReconciler{
 		Client: fake.NewClientBuilder().WithScheme(scheme).
 			WithStatusSubresource(pvc).
-			WithObjects(backup, pvc, populatePVC, comp).
+			WithObjects(backup, pvc, comp).
 			Build(),
 		Scheme:   scheme,
 		Recorder: record.NewFakeRecorder(10),
@@ -1310,11 +1401,88 @@ func TestCompleteBoundPVCReleasesPopulatePVCBeforeWaitingForPostReady(t *testing
 
 	require.Error(t, err)
 	require.True(t, intctrlutil.IsRequeueError(err), err)
+	restoreList := &dpv1alpha1.RestoreList{}
+	require.NoError(t, reconciler.Client.List(context.Background(), restoreList, client.InNamespace("default")))
+	require.Len(t, restoreList.Items, 1)
+	require.Equal(t, postReadyRestoreName(comp.UID), restoreList.Items[0].Name)
 	currentPVC := &corev1.PersistentVolumeClaim{}
 	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), currentPVC))
-	require.NotContains(t, currentPVC.Finalizers, dptypes.DataProtectionFinalizerName)
-	currentPopulatePVC := &corev1.PersistentVolumeClaim{}
-	require.Error(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(populatePVC), currentPopulatePVC))
+	populatingCondition := findPVCConditionByType(currentPVC, string(PersistentVolumeClaimPopulating))
+	require.NotNil(t, populatingCondition)
+	require.Equal(t, ReasonPopulatingSucceed, populatingCondition.Reason)
+	restoreCondition := findPVCConditionByType(currentPVC, kbappsv1.ConditionTypeRestore)
+	require.Nil(t, restoreCondition)
+}
+
+func TestCompleteBoundPVCMarksRestoreSucceededAfterPostReadyCompleted(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+	require.NoError(t, kbappsv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	apiGroup := dptypes.DataprotectionAPIGroup
+	backup := newBackupForRestoreDecision([]string{"data"}, nil)
+	pvc := newPVCForRestoreDecision("data", "mysql", "")
+	pvc.UID = types.UID("target-pvc")
+	pvc.Spec.VolumeName = "data-pv"
+	pvc.Spec.DataSourceRef = &corev1.TypedObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     dptypes.BackupKind,
+		Name:     backup.Name,
+	}
+	pvc.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
+	pvc.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+	pvc.Status.Conditions = []corev1.PersistentVolumeClaimCondition{{
+		Type:   PersistentVolumeClaimPopulating,
+		Status: corev1.ConditionTrue,
+		Reason: ReasonPopulatingSucceed,
+	}}
+	comp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "mysql"),
+			UID:       "component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
+	}
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).
+			WithStatusSubresource(pvc).
+			WithObjects(backup, pvc, comp).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{
+		Spec: dpv1alpha1.RestoreSpec{Backup: dpv1alpha1.BackupRef{Name: backup.Name, Namespace: backup.Namespace}},
+	}, nil, scheme, reconciler.Client)
+	restoreMgr.PostReadyBackupSets = []dprestore.BackupActionSet{{Backup: backup}}
+	postReadyRestore, err := reconciler.buildPostReadyRestore(
+		intctrlutil.RequestCtx{Ctx: context.Background()},
+		pvc,
+		restoreMgr,
+		comp,
+	)
+	require.NoError(t, err)
+	postReadyRestore.Status.Phase = dpv1alpha1.RestorePhaseCompleted
+	require.NoError(t, reconciler.Client.Create(context.Background(), postReadyRestore))
+
+	err = reconciler.completeBoundPVCIfNeeded(
+		intctrlutil.RequestCtx{Ctx: context.Background()},
+		pvc,
+		&pvcRestoreContext{restoreMgr: restoreMgr, mode: pvcRestoreModeRestoreData},
+	)
+
+	require.NoError(t, err)
+	currentPVC := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), currentPVC))
+	populatingCondition := findPVCConditionByType(currentPVC, string(PersistentVolumeClaimPopulating))
+	require.NotNil(t, populatingCondition)
+	require.Equal(t, ReasonPopulatingSucceed, populatingCondition.Reason)
+	restoreCondition := findPVCConditionByType(currentPVC, kbappsv1.ConditionTypeRestore)
+	require.NotNil(t, restoreCondition)
+	require.Equal(t, corev1.ConditionTrue, restoreCondition.Status)
+	require.Equal(t, ReasonPopulatingSucceed, restoreCondition.Reason)
 }
 
 func TestEnsurePostReadyRestoreCompletedRejectsMismatchedExistingRestore(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #10336.

This is a follow-up to #10334. The target PVC is now released in two safe steps after prepareData and PV rebind:

1. remove the populate-side ownership and mark `Populating=Succeed` so postReady can continue without downgrading the PVC back to Processing;
2. after the PV claimRef exactly matches the target PVC, mirror the bound PV capacity/accessModes into the target PVC status so the scheduler can bind the restore pod.

## Why

Redis PR #182 B05 proved the controller fix had to close two separate contracts:

- #10334 removed the DataProtection finalizer and populate PVC before postReady, but the target PVC could still be written back to Processing.
- The first #10337 candidate fixed that downgrade and produced `Populating=Succeed`, but the latest B05 run still showed the business PVC as `Pending` with capacity `0` even though the PV was already `Bound` and its claimRef pointed at the target PVC. The restore pod then stayed Pending on VolumeBinding PreBind timeout.

## Changes

- Keep the released PVC from being downgraded while postReady is still waiting.
- Sync the target PVC status to `Bound` only after the PV claimRef matches the target PVC name/namespace/UID.
- Copy PV capacity and accessModes into the target PVC status at that safe release point.
- Keep API-level `Restore=True` for the final postReady-completed state; `Populating=Succeed` remains the earlier volume-populator release signal.
- Extend the regression test to assert finalizer removal, `Populating=Succeed`, PVC `Bound`, capacity, and accessModes before postReady completes.

## Tests

- `go test ./controllers/dataprotection -run 'TestCompleteBoundPVCReleasesPopulatePVCBeforeWaitingForPostReady|TestCompleteBoundPVCContinuesPostReadyAfterPopulateReleased|TestCompleteBoundPVCMarksRestoreSucceededAfterPostReadyCompleted|TestRebindPVCAndPVWaitsUntilPopulatePVCIsBound' -count=1`
- `KUBEBUILDER_ASSETS=<envtest assets> go test ./controllers/dataprotection -count=1`
- `git diff --check`

## Runtime boundary

This PR has not been validated as Redis B05 PASS. After a new candidate image or merge image, Redis B05 still needs to rerun through Backup Completed -> PVC Bound -> Pod Running -> Redis readback -> cleanup clean.
