### PR TITLE
fix: support ordinal target pod selector

### DIFF
--- a/apis/apps/v1/componentdefinition_types.go
+++ b/apis/apps/v1/componentdefinition_types.go
@@ -1870,6 +1870,9 @@ type Action struct {
 	// - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
 	// - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
 	//   will be selected for the Action.
+	// - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+	//   and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+	//   The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 	//
 	// This field cannot be updated.
 	//
@@ -1979,6 +1982,9 @@ type ExecAction struct {
 	// - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
 	// - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
 	//   will be selected for the Action.
+	// - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+	//   and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+	//   The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 	//
 	// This field cannot be updated.
 	//

--- a/config/crd/bases/apps.kubeblocks.io_clusters.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusters.yaml
@@ -465,6 +465,9 @@ spec:
                                       - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                       - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                         will be selected for the Action.
+                                      - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                        and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                        The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                       This field cannot be updated.
                                     type: string
@@ -620,6 +623,9 @@ spec:
                                   - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                   - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                     will be selected for the Action.
+                                  - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                    and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                    The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                   This field cannot be updated.
                                 type: string
@@ -11616,6 +11622,9 @@ spec:
                                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                             will be selected for the Action.
+                                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                           This field cannot be updated.
                                         type: string
@@ -11771,6 +11780,9 @@ spec:
                                       - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                       - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                         will be selected for the Action.
+                                      - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                        and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                        The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                       This field cannot be updated.
                                     type: string

--- a/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
@@ -4077,6 +4077,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -4231,6 +4234,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -4482,6 +4488,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -4648,6 +4657,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -4927,6 +4939,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -5081,6 +5096,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -5343,6 +5361,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -5497,6 +5518,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -5762,6 +5786,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -5916,6 +5943,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -6183,6 +6213,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -6337,6 +6370,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -6594,6 +6630,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -6748,6 +6787,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -7005,6 +7047,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -7159,6 +7204,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -7416,6 +7464,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -7570,6 +7621,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -7829,6 +7883,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -7983,6 +8040,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -8236,6 +8296,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -8390,6 +8453,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -8678,6 +8744,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -8844,6 +8913,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -9123,6 +9195,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -9277,6 +9352,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string

--- a/config/crd/bases/apps.kubeblocks.io_components.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_components.yaml
@@ -348,6 +348,9 @@ spec:
                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                   will be selected for the Action.
+                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                 This field cannot be updated.
                               type: string
@@ -502,6 +505,9 @@ spec:
                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                               will be selected for the Action.
+                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                             This field cannot be updated.
                           type: string
@@ -765,6 +771,9 @@ spec:
                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                   will be selected for the Action.
+                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                 This field cannot be updated.
                               type: string
@@ -919,6 +928,9 @@ spec:
                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                               will be selected for the Action.
+                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                             This field cannot be updated.
                           type: string

--- a/config/crd/bases/apps.kubeblocks.io_rollouts.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_rollouts.yaml
@@ -331,6 +331,9 @@ spec:
                                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                                   will be selected for the Action.
+                                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                                 This field cannot be updated.
                                               type: string
@@ -488,6 +491,9 @@ spec:
                                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                               will be selected for the Action.
+                                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                             This field cannot be updated.
                                           type: string
@@ -755,6 +761,9 @@ spec:
                                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                                   will be selected for the Action.
+                                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                                 This field cannot be updated.
                                               type: string
@@ -912,6 +921,9 @@ spec:
                                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                               will be selected for the Action.
+                                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                             This field cannot be updated.
                                           type: string
@@ -3656,6 +3668,9 @@ spec:
                                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                                   will be selected for the Action.
+                                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                                 This field cannot be updated.
                                               type: string
@@ -3813,6 +3828,9 @@ spec:
                                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                               will be selected for the Action.
+                                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                             This field cannot be updated.
                                           type: string
@@ -4080,6 +4098,9 @@ spec:
                                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                                   will be selected for the Action.
+                                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                                 This field cannot be updated.
                                               type: string
@@ -4237,6 +4258,9 @@ spec:
                                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                               will be selected for the Action.
+                                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                             This field cannot be updated.
                                           type: string

--- a/config/crd/bases/apps.kubeblocks.io_shardingdefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_shardingdefinitions.yaml
@@ -247,6 +247,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -401,6 +404,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -677,6 +683,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -831,6 +840,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -1102,6 +1114,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -1256,6 +1271,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -1527,6 +1545,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -1681,6 +1702,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string

--- a/config/crd/bases/workloads.kubeblocks.io_instances.yaml
+++ b/config/crd/bases/workloads.kubeblocks.io_instances.yaml
@@ -255,6 +255,9 @@ spec:
                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                   will be selected for the Action.
+                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                 This field cannot be updated.
                               type: string
@@ -409,6 +412,9 @@ spec:
                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                               will be selected for the Action.
+                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                             This field cannot be updated.
                           type: string
@@ -1661,6 +1667,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -1815,6 +1824,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -2064,6 +2076,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -2218,6 +2233,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string

--- a/config/crd/bases/workloads.kubeblocks.io_instancesets.yaml
+++ b/config/crd/bases/workloads.kubeblocks.io_instancesets.yaml
@@ -256,6 +256,9 @@ spec:
                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                   will be selected for the Action.
+                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                 This field cannot be updated.
                               type: string
@@ -410,6 +413,9 @@ spec:
                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                               will be selected for the Action.
+                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                             This field cannot be updated.
                           type: string
@@ -2642,6 +2648,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -2796,6 +2805,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -3045,6 +3057,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -3199,6 +3214,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string

--- a/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
@@ -465,6 +465,9 @@ spec:
                                       - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                       - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                         will be selected for the Action.
+                                      - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                        and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                        The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                       This field cannot be updated.
                                     type: string
@@ -620,6 +623,9 @@ spec:
                                   - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                   - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                     will be selected for the Action.
+                                  - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                    and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                    The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                   This field cannot be updated.
                                 type: string
@@ -11616,6 +11622,9 @@ spec:
                                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                             will be selected for the Action.
+                                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                           This field cannot be updated.
                                         type: string
@@ -11771,6 +11780,9 @@ spec:
                                       - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                       - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                         will be selected for the Action.
+                                      - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                        and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                        The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                       This field cannot be updated.
                                     type: string

--- a/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
@@ -4077,6 +4077,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -4231,6 +4234,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -4482,6 +4488,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -4648,6 +4657,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -4927,6 +4939,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -5081,6 +5096,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -5343,6 +5361,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -5497,6 +5518,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -5762,6 +5786,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -5916,6 +5943,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -6183,6 +6213,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -6337,6 +6370,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -6594,6 +6630,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -6748,6 +6787,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -7005,6 +7047,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -7159,6 +7204,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -7416,6 +7464,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -7570,6 +7621,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -7829,6 +7883,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -7983,6 +8040,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -8236,6 +8296,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -8390,6 +8453,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -8678,6 +8744,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -8844,6 +8913,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -9123,6 +9195,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -9277,6 +9352,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string

--- a/deploy/helm/crds/apps.kubeblocks.io_components.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_components.yaml
@@ -348,6 +348,9 @@ spec:
                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                   will be selected for the Action.
+                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                 This field cannot be updated.
                               type: string
@@ -502,6 +505,9 @@ spec:
                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                               will be selected for the Action.
+                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                             This field cannot be updated.
                           type: string
@@ -765,6 +771,9 @@ spec:
                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                   will be selected for the Action.
+                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                 This field cannot be updated.
                               type: string
@@ -919,6 +928,9 @@ spec:
                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                               will be selected for the Action.
+                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                             This field cannot be updated.
                           type: string

--- a/deploy/helm/crds/apps.kubeblocks.io_rollouts.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_rollouts.yaml
@@ -331,6 +331,9 @@ spec:
                                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                                   will be selected for the Action.
+                                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                                 This field cannot be updated.
                                               type: string
@@ -488,6 +491,9 @@ spec:
                                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                               will be selected for the Action.
+                                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                             This field cannot be updated.
                                           type: string
@@ -755,6 +761,9 @@ spec:
                                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                                   will be selected for the Action.
+                                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                                 This field cannot be updated.
                                               type: string
@@ -912,6 +921,9 @@ spec:
                                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                               will be selected for the Action.
+                                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                             This field cannot be updated.
                                           type: string
@@ -3656,6 +3668,9 @@ spec:
                                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                                   will be selected for the Action.
+                                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                                 This field cannot be updated.
                                               type: string
@@ -3813,6 +3828,9 @@ spec:
                                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                               will be selected for the Action.
+                                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                             This field cannot be updated.
                                           type: string
@@ -4080,6 +4098,9 @@ spec:
                                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                                   will be selected for the Action.
+                                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                                 This field cannot be updated.
                                               type: string
@@ -4237,6 +4258,9 @@ spec:
                                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                               will be selected for the Action.
+                                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                             This field cannot be updated.
                                           type: string

--- a/deploy/helm/crds/apps.kubeblocks.io_shardingdefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_shardingdefinitions.yaml
@@ -247,6 +247,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -401,6 +404,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -677,6 +683,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -831,6 +840,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -1102,6 +1114,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -1256,6 +1271,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -1527,6 +1545,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -1681,6 +1702,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string

--- a/deploy/helm/crds/workloads.kubeblocks.io_instances.yaml
+++ b/deploy/helm/crds/workloads.kubeblocks.io_instances.yaml
@@ -255,6 +255,9 @@ spec:
                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                   will be selected for the Action.
+                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                 This field cannot be updated.
                               type: string
@@ -409,6 +412,9 @@ spec:
                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                               will be selected for the Action.
+                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                             This field cannot be updated.
                           type: string
@@ -1661,6 +1667,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -1815,6 +1824,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -2064,6 +2076,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -2218,6 +2233,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string

--- a/deploy/helm/crds/workloads.kubeblocks.io_instancesets.yaml
+++ b/deploy/helm/crds/workloads.kubeblocks.io_instancesets.yaml
@@ -256,6 +256,9 @@ spec:
                                 - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                                 - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                   will be selected for the Action.
+                                - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                  and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                  The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                                 This field cannot be updated.
                               type: string
@@ -410,6 +413,9 @@ spec:
                             - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                             - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                               will be selected for the Action.
+                            - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                              and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                              The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                             This field cannot be updated.
                           type: string
@@ -2642,6 +2648,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -2796,6 +2805,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string
@@ -3045,6 +3057,9 @@ spec:
                               - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                               - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                                 will be selected for the Action.
+                              - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                                and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                                The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                               This field cannot be updated.
                             type: string
@@ -3199,6 +3214,9 @@ spec:
                           - When `targetPodSelector` is set to `Any` or `All`, this field will be ignored.
                           - When `targetPodSelector` is set to `Role`, only those replicas whose role matches the `matchingKey`
                             will be selected for the Action.
+                          - When `targetPodSelector` is set to `Ordinal`, `matchingKey` must be a non-negative integer
+                            and only the replica whose Pod name ends with `-<matchingKey>` will be selected for the Action.
+                            The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.
 
                           This field cannot be updated.
                         type: string

--- a/docs/developer_docs/api-reference/cluster.md
+++ b/docs/developer_docs/api-reference/cluster.md
@@ -2465,6 +2465,9 @@ The impact of this field depends on the <code>targetPodSelector</code> value:</p
 <li>When <code>targetPodSelector</code> is set to <code>Any</code> or <code>All</code>, this field will be ignored.</li>
 <li>When <code>targetPodSelector</code> is set to <code>Role</code>, only those replicas whose role matches the <code>matchingKey</code>
 will be selected for the Action.</li>
+<li>When <code>targetPodSelector</code> is set to <code>Ordinal</code>, <code>matchingKey</code> must be a non-negative integer
+and only the replica whose Pod name ends with <code>-&lt;matchingKey&gt;</code> will be selected for the Action.
+The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.</li>
 </ul>
 <p>This field cannot be updated.</p>
 </td>
@@ -8185,6 +8188,9 @@ The impact of this field depends on the <code>targetPodSelector</code> value:</p
 <li>When <code>targetPodSelector</code> is set to <code>Any</code> or <code>All</code>, this field will be ignored.</li>
 <li>When <code>targetPodSelector</code> is set to <code>Role</code>, only those replicas whose role matches the <code>matchingKey</code>
 will be selected for the Action.</li>
+<li>When <code>targetPodSelector</code> is set to <code>Ordinal</code>, <code>matchingKey</code> must be a non-negative integer
+and only the replica whose Pod name ends with <code>-&lt;matchingKey&gt;</code> will be selected for the Action.
+The selector is considered ambiguous and the action fails if multiple Pods share the same ordinal.</li>
 </ul>
 <p>This field cannot be updated.</p>
 </td>

--- a/pkg/controller/lifecycle/kbagent.go
+++ b/pkg/controller/lifecycle/kbagent.go
@@ -23,6 +23,8 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"strconv"
+	"strings"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -450,6 +452,37 @@ func SelectTargetPods(pods []*corev1.Pod, pod *corev1.Pod, spec *appsv1.Action) 
 		return rolePods
 	}
 
+	podsWithOrdinal := func() ([]*corev1.Pod, error) {
+		ordinal, err := strconv.Atoi(matchingKey)
+		if err != nil || ordinal < 0 {
+			return nil, fmt.Errorf("invalid ordinal matchingKey: %s", matchingKey)
+		}
+
+		var ordinalPods []*corev1.Pod
+		for i, pod := range pods {
+			idx := strings.LastIndex(pod.Name, "-")
+			if idx < 0 || idx == len(pod.Name)-1 {
+				continue
+			}
+			podOrdinal, err := strconv.Atoi(pod.Name[idx+1:])
+			if err != nil {
+				continue
+			}
+			if podOrdinal == ordinal {
+				ordinalPods = append(ordinalPods, pods[i])
+			}
+		}
+		if len(ordinalPods) > 1 {
+			var podNames []string
+			for _, pod := range ordinalPods {
+				podNames = append(podNames, pod.Name)
+			}
+			return nil, fmt.Errorf("ambiguous ordinal selector matchingKey %s matches multiple pods: %s",
+				matchingKey, strings.Join(podNames, ","))
+		}
+		return ordinalPods, nil
+	}
+
 	switch selector {
 	case appsv1.AnyReplica:
 		return anyPod(), nil
@@ -458,7 +491,7 @@ func SelectTargetPods(pods []*corev1.Pod, pod *corev1.Pod, spec *appsv1.Action) 
 	case appsv1.RoleSelector:
 		return podsWithRole(), nil
 	case appsv1.OrdinalSelector:
-		return nil, fmt.Errorf("ordinal selector is not supported")
+		return podsWithOrdinal()
 	default:
 		return nil, fmt.Errorf("unknown pod selector: %s", selector)
 	}

--- a/pkg/controller/lifecycle/lifecycle_test.go
+++ b/pkg/controller/lifecycle/lifecycle_test.go
@@ -717,6 +717,97 @@ var _ = Describe("lifecycle", func() {
 			Expect(err.Error()).Should(ContainSubstring("pod pod-1 has no ip"))
 		})
 
+		It("pod selector - ordinal", func() {
+			lifecycleActions.PostProvision.Exec.TargetPodSelector = appsv1.OrdinalSelector
+			lifecycleActions.PostProvision.Exec.MatchingKey = "1"
+			pods = []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      "pod-0",
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "kbagent",
+								Ports: []corev1.ContainerPort{
+									{
+										Name: "http",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      "pod-1",
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "kbagent",
+								Ports: []corev1.ContainerPort{
+									{
+										Name: "http",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			lifecycle, err := New(namespace, clusterName, compName, lifecycleActions, nil, nil, pods)
+			Expect(err).Should(BeNil())
+			Expect(lifecycle).ShouldNot(BeNil())
+
+			err = lifecycle.PostProvision(ctx, k8sClient, nil)
+			Expect(err).ShouldNot(BeNil())
+			Expect(err.Error()).Should(ContainSubstring("pod pod-1 has no ip"))
+		})
+
+		It("pod selector - ordinal invalid matching key", func() {
+			lifecycleActions.PostProvision.Exec.TargetPodSelector = appsv1.OrdinalSelector
+			lifecycleActions.PostProvision.Exec.MatchingKey = "invalid"
+
+			lifecycle, err := New(namespace, clusterName, compName, lifecycleActions, nil, nil, pods)
+			Expect(err).Should(BeNil())
+			Expect(lifecycle).ShouldNot(BeNil())
+
+			err = lifecycle.PostProvision(ctx, k8sClient, nil)
+			Expect(err).ShouldNot(BeNil())
+			Expect(err.Error()).Should(ContainSubstring("invalid ordinal matchingKey: invalid"))
+		})
+
+		It("pod selector - ordinal ambiguous", func() {
+			lifecycleActions.PostProvision.Exec.TargetPodSelector = appsv1.OrdinalSelector
+			lifecycleActions.PostProvision.Exec.MatchingKey = "0"
+			pods = []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      "pod-0",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: namespace,
+						Name:      "pod-template-0",
+					},
+				},
+			}
+
+			lifecycle, err := New(namespace, clusterName, compName, lifecycleActions, nil, nil, pods)
+			Expect(err).Should(BeNil())
+			Expect(lifecycle).ShouldNot(BeNil())
+
+			err = lifecycle.PostProvision(ctx, k8sClient, nil)
+			Expect(err).ShouldNot(BeNil())
+			Expect(err.Error()).Should(ContainSubstring("ambiguous ordinal selector matchingKey 0 matches multiple pods: pod-0,pod-template-0"))
+		})
+
 		It("pod selector - has no matched", func() {
 			lifecycleActions.PostProvision.Exec.TargetPodSelector = appsv1.RoleSelector
 			lifecycleActions.PostProvision.Exec.MatchingKey = "leader"


### PR DESCRIPTION
## Summary
- Backport ordinal target pod selector support to release-1.1.
- Select pods by non-negative ordinal suffix in pod names.
- Reject ambiguous ordinal matches when multiple pods share the same ordinal.
- Update v1 API docs, generated CRDs, Helm CRDs, and API reference docs.

## Validation
- env GOFLAGS=-mod=mod make manifests
- env GOFLAGS=-mod=mod make doc
- git diff --cached --check
- go test ./pkg/controller/lifecycle