### PR TITLE
fix(component): wait for parameter config backfill

### DIFF
--- a/controllers/apps/component/transformer_component_template.go
+++ b/controllers/apps/component/transformer_component_template.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/Masterminds/sprig/v3"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -38,7 +39,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	appsutil "github.com/apecloud/kubeblocks/controllers/apps/util"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/builder"
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
@@ -46,6 +49,8 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/lifecycle"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	parameters "github.com/apecloud/kubeblocks/pkg/parameters"
+	configcore "github.com/apecloud/kubeblocks/pkg/parameters/core"
 )
 
 const (
@@ -113,10 +118,98 @@ func (t *componentFileTemplateTransformer) instanceAssistantObject(transCtx *com
 func (t *componentFileTemplateTransformer) precheck(transCtx *componentTransformContext) error {
 	for _, tpl := range transCtx.SynthesizeComponent.FileTemplates {
 		if len(tpl.Template) == 0 {
+			waiting, err := t.waitingForParameterBackfill(transCtx, tpl)
+			if err != nil {
+				return err
+			}
+			if waiting {
+				return intctrlutil.NewRequeueError(appsutil.RequeueDuration,
+					fmt.Sprintf("waiting for parameters controller to backfill config template: %s", tpl.Name))
+			}
 			return fmt.Errorf("config/script template has no template specified: %s", tpl.Name)
 		}
 	}
 	return nil
+}
+
+func (t *componentFileTemplateTransformer) waitingForParameterBackfill(
+	transCtx *componentTransformContext,
+	tpl component.SynthesizedFileTemplate) (bool, error) {
+	if !isExternalManaged(tpl) {
+		return false, nil
+	}
+
+	clusterName, err := component.GetClusterName(transCtx.Component)
+	if err != nil {
+		return false, err
+	}
+	componentName, err := component.ShortName(clusterName, transCtx.Component.Name)
+	if err != nil {
+		return false, err
+	}
+
+	parameter := &parametersv1alpha1.ComponentParameter{}
+	parameterKey := types.NamespacedName{
+		Namespace: transCtx.Component.Namespace,
+		Name:      configcore.GenerateComponentConfigurationName(clusterName, componentName),
+	}
+	if err := transCtx.Client.Get(transCtx.Context, parameterKey, parameter); err != nil {
+		if apierrors.IsNotFound(err) {
+			return t.parameterBackfillExpected(transCtx, tpl)
+		}
+		return false, err
+	}
+
+	for _, item := range parameter.Spec.ConfigItemDetails {
+		if item.ConfigSpec == nil || item.ConfigSpec.Name != tpl.Name {
+			continue
+		}
+		if !ptr.Deref(item.ConfigSpec.ExternalManaged, false) {
+			return false, nil
+		}
+		if status := parameters.GetItemStatus(&parameter.Status, tpl.Name); status != nil {
+			if parameters.IsFailedPhase(status.Phase) {
+				return false, fmt.Errorf("parameters controller failed to backfill config template %s: %s",
+					tpl.Name, ptr.Deref(status.Message, ""))
+			}
+		}
+		if parameters.IsFailedPhase(parameter.Status.Phase) {
+			return false, fmt.Errorf("componentParameter %s failed to backfill config template %s: %s",
+				parameter.Name, tpl.Name, parameter.Status.Message)
+		}
+		return true, nil
+	}
+
+	if parameters.IsFailedPhase(parameter.Status.Phase) {
+		expected, err := t.parameterBackfillExpected(transCtx, tpl)
+		if err != nil {
+			return false, err
+		}
+		if expected {
+			return false, fmt.Errorf("componentParameter %s failed to backfill config template %s: %s",
+				parameter.Name, tpl.Name, parameter.Status.Message)
+		}
+		return false, nil
+	}
+	return t.parameterBackfillExpected(transCtx, tpl)
+}
+
+func (t *componentFileTemplateTransformer) parameterBackfillExpected(
+	transCtx *componentTransformContext,
+	tpl component.SynthesizedFileTemplate) (bool, error) {
+	if transCtx.CompDef == nil {
+		return false, nil
+	}
+	configs, _, err := parameters.ResolveCmpdParametersDefs(transCtx.Context, transCtx.Client, transCtx.CompDef)
+	if err != nil {
+		return false, err
+	}
+	for _, config := range parameters.ResolveParameterTemplate(transCtx.CompDef.Spec, configs) {
+		if config.Name == tpl.Name {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (t *componentFileTemplateTransformer) handleTemplateObjectChanges(transCtx *componentTransformContext,

--- a/controllers/apps/component/transformer_component_template_test.go
+++ b/controllers/apps/component/transformer_component_template_test.go
@@ -240,10 +240,9 @@ var _ = Describe("file templates transformer test", func() {
 		reader.Objects = append(reader.Objects, &parametersv1alpha1.ParametersDefinition{
 			ObjectMeta: metav1.ObjectMeta{Name: "server-conf-params"},
 			Spec: parametersv1alpha1.ParametersDefinitionSpec{
-				ComponentDef:   compDefName,
-				TemplateName:   "serverConf",
-				FileName:       "server.conf",
-				ServiceVersion: "*",
+				ComponentDef: compDefName,
+				TemplateName: "serverConf",
+				FileName:     "server.conf",
 				FileFormatConfig: &parametersv1alpha1.FileFormatConfig{
 					Format: parametersv1alpha1.Properties,
 				},

--- a/controllers/apps/component/transformer_component_template_test.go
+++ b/controllers/apps/component/transformer_component_template_test.go
@@ -400,6 +400,30 @@ var _ = Describe("file templates transformer test", func() {
 			Expect(err.Error()).ShouldNot(ContainSubstring("config/script template has no template specified"))
 		})
 
+		It("external managed - w/o template waits when component parameter exists before config details are filled", func() {
+			transCtx.SynthesizeComponent.FileTemplates[1].Template = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].Namespace = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].ExternalManaged = ptr.To(true)
+			claimServerConfByParametersDefinition()
+			reader.Objects = append(reader.Objects, &parametersv1alpha1.ComponentParameter{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testCtx.DefaultNamespace,
+					Name:      configcore.GenerateComponentConfigurationName(clusterName, compName),
+				},
+				Spec: parametersv1alpha1.ComponentParameterSpec{
+					ClusterName:   clusterName,
+					ComponentName: compName,
+				},
+			})
+
+			transformer := &componentFileTemplateTransformer{}
+			err := transformer.Transform(transCtx, dag)
+			Expect(err).ShouldNot(BeNil())
+			Expect(intctrlutil.IsRequeueError(err)).Should(BeTrue())
+			Expect(err.Error()).Should(ContainSubstring("waiting for parameters controller to backfill config template: serverConf"))
+			Expect(err.Error()).ShouldNot(ContainSubstring("config/script template has no template specified"))
+		})
+
 		It("external managed - w/o template still fails when parameters controller did not claim the config", func() {
 			transCtx.SynthesizeComponent.FileTemplates[1].Template = ""
 			transCtx.SynthesizeComponent.FileTemplates[1].Namespace = ""

--- a/controllers/apps/component/transformer_component_template_test.go
+++ b/controllers/apps/component/transformer_component_template_test.go
@@ -31,12 +31,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	appsutil "github.com/apecloud/kubeblocks/controllers/apps/util"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	configcore "github.com/apecloud/kubeblocks/pkg/parameters/core"
 )
 
 var _ = Describe("file templates transformer test", func() {
@@ -226,6 +229,29 @@ var _ = Describe("file templates transformer test", func() {
 		}))
 	}
 
+	claimServerConfByParametersDefinition := func() {
+		transCtx.CompDef.Spec.Configs = []appsv1.ComponentFileTemplate{
+			{
+				Name:            "serverConf",
+				Template:        "server-template-cm",
+				ExternalManaged: ptr.To(true),
+			},
+		}
+		reader.Objects = append(reader.Objects, &parametersv1alpha1.ParametersDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: "server-conf-params"},
+			Spec: parametersv1alpha1.ParametersDefinitionSpec{
+				ComponentDef:   compDefName,
+				TemplateName:   "serverConf",
+				FileName:       "server.conf",
+				ServiceVersion: "*",
+				FileFormatConfig: &parametersv1alpha1.FileFormatConfig{
+					Format: parametersv1alpha1.Properties,
+				},
+			},
+			Status: parametersv1alpha1.ParametersDefinitionStatus{Phase: parametersv1alpha1.PDAvailablePhase},
+		})
+	}
+
 	// checkEnvWithAction := func(action string) {
 	//	podSpec := transCtx.SynthesizeComponent.PodSpec
 	//	for _, c := range podSpec.Containers {
@@ -326,6 +352,124 @@ var _ = Describe("file templates transformer test", func() {
 			err := transformer.Transform(transCtx, dag)
 			Expect(err).ShouldNot(BeNil())
 			Expect(err.Error()).Should(ContainSubstring("config/script template has no template specified"))
+		})
+
+		It("external managed - w/o template waits when parameters definition claims the config before component parameter exists", func() {
+			transCtx.SynthesizeComponent.FileTemplates[1].Template = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].Namespace = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].ExternalManaged = ptr.To(true)
+			claimServerConfByParametersDefinition()
+
+			transformer := &componentFileTemplateTransformer{}
+			err := transformer.Transform(transCtx, dag)
+			Expect(err).ShouldNot(BeNil())
+			Expect(intctrlutil.IsRequeueError(err)).Should(BeTrue())
+			Expect(err.Error()).Should(ContainSubstring("waiting for parameters controller to backfill config template: serverConf"))
+			Expect(err.Error()).ShouldNot(ContainSubstring("config/script template has no template specified"))
+		})
+
+		It("external managed - w/o template waits when component parameter claims the config", func() {
+			transCtx.SynthesizeComponent.FileTemplates[1].Template = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].Namespace = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].ExternalManaged = ptr.To(true)
+			reader.Objects = append(reader.Objects, &parametersv1alpha1.ComponentParameter{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testCtx.DefaultNamespace,
+					Name:      configcore.GenerateComponentConfigurationName(clusterName, compName),
+				},
+				Spec: parametersv1alpha1.ComponentParameterSpec{
+					ClusterName:   clusterName,
+					ComponentName: compName,
+					ConfigItemDetails: []parametersv1alpha1.ConfigTemplateItemDetail{
+						{
+							Name: "serverConf",
+							ConfigSpec: &appsv1.ComponentFileTemplate{
+								Name:            "serverConf",
+								ExternalManaged: ptr.To(true),
+							},
+						},
+					},
+				},
+			})
+
+			transformer := &componentFileTemplateTransformer{}
+			err := transformer.Transform(transCtx, dag)
+			Expect(err).ShouldNot(BeNil())
+			Expect(intctrlutil.IsRequeueError(err)).Should(BeTrue())
+			Expect(err.Error()).Should(ContainSubstring("waiting for parameters controller to backfill config template: serverConf"))
+			Expect(err.Error()).ShouldNot(ContainSubstring("config/script template has no template specified"))
+		})
+
+		It("external managed - w/o template still fails when parameters controller did not claim the config", func() {
+			transCtx.SynthesizeComponent.FileTemplates[1].Template = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].Namespace = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].ExternalManaged = ptr.To(true)
+			reader.Objects = append(reader.Objects, &parametersv1alpha1.ComponentParameter{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testCtx.DefaultNamespace,
+					Name:      configcore.GenerateComponentConfigurationName(clusterName, compName),
+				},
+				Spec: parametersv1alpha1.ComponentParameterSpec{
+					ClusterName:   clusterName,
+					ComponentName: compName,
+					ConfigItemDetails: []parametersv1alpha1.ConfigTemplateItemDetail{
+						{
+							Name: "otherConf",
+							ConfigSpec: &appsv1.ComponentFileTemplate{
+								Name:            "otherConf",
+								ExternalManaged: ptr.To(true),
+							},
+						},
+					},
+				},
+			})
+
+			transformer := &componentFileTemplateTransformer{}
+			err := transformer.Transform(transCtx, dag)
+			Expect(err).ShouldNot(BeNil())
+			Expect(intctrlutil.IsRequeueError(err)).Should(BeFalse())
+			Expect(err.Error()).Should(ContainSubstring("config/script template has no template specified"))
+		})
+
+		It("external managed - w/o template fails loudly when claimed parameter config failed", func() {
+			transCtx.SynthesizeComponent.FileTemplates[1].Template = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].Namespace = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].ExternalManaged = ptr.To(true)
+			message := "render failed"
+			reader.Objects = append(reader.Objects, &parametersv1alpha1.ComponentParameter{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testCtx.DefaultNamespace,
+					Name:      configcore.GenerateComponentConfigurationName(clusterName, compName),
+				},
+				Spec: parametersv1alpha1.ComponentParameterSpec{
+					ClusterName:   clusterName,
+					ComponentName: compName,
+					ConfigItemDetails: []parametersv1alpha1.ConfigTemplateItemDetail{
+						{
+							Name: "serverConf",
+							ConfigSpec: &appsv1.ComponentFileTemplate{
+								Name:            "serverConf",
+								ExternalManaged: ptr.To(true),
+							},
+						},
+					},
+				},
+				Status: parametersv1alpha1.ComponentParameterStatus{
+					ConfigurationItemStatus: []parametersv1alpha1.ConfigTemplateItemDetailStatus{
+						{
+							Name:    "serverConf",
+							Phase:   parametersv1alpha1.CMergeFailedPhase,
+							Message: &message,
+						},
+					},
+				},
+			})
+
+			transformer := &componentFileTemplateTransformer{}
+			err := transformer.Transform(transCtx, dag)
+			Expect(err).ShouldNot(BeNil())
+			Expect(intctrlutil.IsRequeueError(err)).Should(BeFalse())
+			Expect(err.Error()).Should(ContainSubstring("parameters controller failed to backfill config template serverConf: render failed"))
 		})
 	})
 })

--- a/controllers/apps/util/mock_reader.go
+++ b/controllers/apps/util/mock_reader.go
@@ -38,6 +38,9 @@ func (r *MockReader) Get(ctx context.Context, key client.ObjectKey, obj client.O
 	for _, o := range r.Objects {
 		// ignore the GVK check
 		if client.ObjectKeyFromObject(o) == key {
+			if !reflect.TypeOf(o).Elem().AssignableTo(reflect.TypeOf(obj).Elem()) {
+				continue
+			}
 			reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(o).Elem())
 			return nil
 		}


### PR DESCRIPTION
## What happened

An addon test hit a component reconcile blocker before any database pods were created. The component controller repeatedly returned:

```
config/script template has no template specified: oceanbase-sysvars
```

The affected ComponentDefinition config uses the KB 1.2 parameters contract correctly: `ComponentDefinition.spec.configs[*].name` is the binding key, the template ConfigMap is referenced by `ComponentFileTemplate.template`, and `ParametersDefinition.spec.templateName` points to the config name.

## What changed

When an `externalManaged` file template has no runtime template yet, the component template precheck now distinguishes two cases:

- If the config is claimed by the parameters path, return a requeue error and wait for parameters backfill instead of failing with an empty-template error.
- If the config is not claimed by parameters, or the parameters path has already failed, keep the fail-loud behavior.

The test reader also now skips same-name objects of the wrong type, which is needed for Component and ComponentParameter objects that can share names in tests.

## Tests

- `git diff --check`
- `go generate ./pkg/testutil/k8s/mocks`
- `go test ./controllers/apps/component -count=1 -ginkgo.focus='external managed - w/o template'` compiled the package but could not execute specs locally because the machine is missing `/usr/local/kubebuilder/bin/etcd` for envtest.

## Boundary

This is a component-controller fix for the pre-backfill window. It does not claim addon runtime or DataProtection acceptance; the addon test still needs to rerun on a controller build that contains this commit.

Replacement for #10340, which used a branch name rejected by repository checks.