### PR TITLE
fix: project role probe result to workload status

### DIFF
--- a/controllers/workloads/role_event_handler.go
+++ b/controllers/workloads/role_event_handler.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
@@ -238,6 +239,11 @@ func (h *RoleEventHandler) handleInstanceSetRoleProbe(ctx context.Context, cli c
 		result.Reason = "updatePodRoleLabelError"
 		return false, err
 	}
+	if err := updateInstanceSetRoleStatus(ctx, cli, pod, itsName, role.Name, defined); err != nil {
+		result.Result = "failed"
+		result.Reason = "updateInstanceSetRoleStatusError"
+		return false, err
+	}
 
 	if defined && role.IsExclusive {
 		result.ExclusiveClean = true
@@ -271,16 +277,69 @@ func (h *RoleEventHandler) handleInstanceRoleProbe(ctx context.Context, cli clie
 		return false, err
 	}
 
-	_, defined := composeRoleMap(inst.Spec.Roles)[result.Role]
+	role, defined := composeRoleMap(inst.Spec.Roles)[result.Role]
 	result.RoleDefined = defined
 	if err := updatePodRoleLabel(ctx, cli, pod, result.Role, defined, result.Version, result.parsed); err != nil {
 		result.Result = "failed"
 		result.Reason = "updatePodRoleLabelError"
 		return false, err
 	}
+	roleName := ""
+	if defined {
+		roleName = role.Name
+	}
+	if err := updateInstanceRoleStatus(ctx, cli, pod, instName, roleName); err != nil {
+		result.Result = "failed"
+		result.Reason = "updateInstanceRoleStatusError"
+		return false, err
+	}
 	result.Result = "handled"
 	result.Reason = "updated"
 	return true, nil
+}
+
+func updateInstanceSetRoleStatus(ctx context.Context, cli client.Client, pod *corev1.Pod, itsName, roleName string, roleDefined bool) error {
+	if !intctrlutil.IsPodReady(pod) {
+		return nil
+	}
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		its := &workloads.InstanceSet{}
+		if err := cli.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: itsName}, its); err != nil {
+			return err
+		}
+		nextRole := ""
+		if roleDefined {
+			nextRole = roleName
+		}
+		for i := range its.Status.InstanceStatus {
+			if its.Status.InstanceStatus[i].PodName != pod.Name {
+				continue
+			}
+			if its.Status.InstanceStatus[i].Role == nextRole {
+				return nil
+			}
+			its.Status.InstanceStatus[i].Role = nextRole
+			return cli.Status().Update(ctx, its)
+		}
+		return nil
+	})
+}
+
+func updateInstanceRoleStatus(ctx context.Context, cli client.Client, pod *corev1.Pod, instName, roleName string) error {
+	if !intctrlutil.IsPodReady(pod) {
+		return nil
+	}
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		inst := &workloads.Instance{}
+		if err := cli.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: instName}, inst); err != nil {
+			return err
+		}
+		if inst.Status.Role == roleName {
+			return nil
+		}
+		inst.Status.Role = roleName
+		return cli.Status().Update(ctx, inst)
+	})
 }
 
 func isRoleProbeEvent(event *corev1.Event) bool {

--- a/controllers/workloads/role_event_handler_test.go
+++ b/controllers/workloads/role_event_handler_test.go
@@ -222,6 +222,33 @@ func TestRoleEventHandlerHandlesInstanceSetSingleTokenAndExclusiveCleanupStampsP
 	assertPodLastRoleAuthoritativeVersion(t, ctx, cli, otherPod, "")
 }
 
+func TestRoleEventHandlerProjectsInstanceSetRoleStatusAfterPodRoleUpdate(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	leader := workloads.ReplicaRole{Name: "leader"}
+	follower := workloads.ReplicaRole{Name: "follower"}
+	its := &workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "mysql"},
+		Spec:       workloads.InstanceSetSpec{Roles: []workloads.ReplicaRole{leader, follower}},
+		Status: workloads.InstanceSetStatus{
+			InstanceStatus: []workloads.InstanceStatus{{PodName: "mysql-0"}},
+		},
+	}
+	pod := roleEventPod("default", "mysql-0", "uid-0", map[string]string{
+		instanceset.WorkloadsInstanceLabelKey: "mysql",
+	})
+	markPodReady(pod)
+	event := roleProbeEvent("default", "event-1", pod, "leader", now)
+	cli := roleEventFakeClient(t, its, pod, event)
+
+	if handled := handleRoleEvent(t, ctx, cli, event); !handled {
+		t.Fatalf("expected event to be handled")
+	}
+
+	assertPodRole(t, ctx, cli, pod, "leader", fmt.Sprintf("%d", event.EventTime.UnixMicro()))
+	assertInstanceSetRoleStatus(t, ctx, cli, "default", "mysql", "mysql-0", "leader")
+}
+
 // Versioned path peer cleanup must strip the label but leave the peer's
 // LastRoleAuthoritativeVersionAnnotationKey untouched. Stamping it would let the
 // strict-newer gate later reject a legitimate event from the peer at the
@@ -511,6 +538,30 @@ func TestRoleEventHandlerHandlesInstanceRoleWithoutExclusiveCleanup(t *testing.T
 	assertPodRole(t, ctx, cli, pod, "leader", fmt.Sprintf("%d", event.EventTime.UnixMicro()))
 }
 
+func TestRoleEventHandlerProjectsInstanceRoleStatusAfterPodRoleUpdate(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	leader := workloads.ReplicaRole{Name: "leader"}
+	follower := workloads.ReplicaRole{Name: "follower"}
+	inst := &workloads.Instance{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "mysql-0"},
+		Spec:       workloads.InstanceSpec{Roles: []workloads.ReplicaRole{leader, follower}},
+	}
+	pod := roleEventPod("default", "mysql-0", "uid-0", map[string]string{
+		constant.KBAppInstanceNameLabelKey: "mysql-0",
+	})
+	markPodReady(pod)
+	event := roleProbeEvent("default", "event-1", pod, "leader", now)
+	cli := roleEventFakeClient(t, inst, pod, event)
+
+	if handled := handleRoleEvent(t, ctx, cli, event); !handled {
+		t.Fatalf("expected event to be handled")
+	}
+
+	assertPodRole(t, ctx, cli, pod, "leader", fmt.Sprintf("%d", event.EventTime.UnixMicro()))
+	assertInstanceRoleStatus(t, ctx, cli, "default", "mysql-0", "leader")
+}
+
 func TestRoleEventHandlerDeletesUndefinedInstanceSetRole(t *testing.T) {
 	ctx := context.Background()
 	now := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
@@ -739,7 +790,11 @@ func roleEventFakeClient(t *testing.T, objects ...client.Object) client.Client {
 	if err := workloads.AddToScheme(scheme); err != nil {
 		t.Fatalf("add workloads scheme: %v", err)
 	}
-	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&workloads.InstanceSet{}, &workloads.Instance{}).
+		WithObjects(objects...).
+		Build()
 }
 
 func roleEventPod(namespace, name, uid string, labels map[string]string) *corev1.Pod {
@@ -748,6 +803,13 @@ func roleEventPod(namespace, name, uid string, labels map[string]string) *corev1
 		pod.Labels = labels
 	}
 	return pod
+}
+
+func markPodReady(pod *corev1.Pod) {
+	pod.Status.Conditions = []corev1.PodCondition{{
+		Type:   corev1.PodReady,
+		Status: corev1.ConditionTrue,
+	}}
 }
 
 func podWithAnnotations(annotations map[string]string) *corev1.Pod {
@@ -867,5 +929,34 @@ func assertPodLastRoleAuthoritativeVersion(t *testing.T, ctx context.Context, cl
 	}
 	if stored.Annotations[constant.LastRoleAuthoritativeVersionAnnotationKey] != version {
 		t.Fatalf("expected authoritative role version %q, got %q", version, stored.Annotations[constant.LastRoleAuthoritativeVersionAnnotationKey])
+	}
+}
+
+func assertInstanceSetRoleStatus(t *testing.T, ctx context.Context, cli client.Client, namespace, name, podName, role string) {
+	t.Helper()
+	var stored workloads.InstanceSet
+	if err := cli.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &stored); err != nil {
+		t.Fatalf("get instanceset failed: %v", err)
+	}
+	for _, status := range stored.Status.InstanceStatus {
+		if status.PodName != podName {
+			continue
+		}
+		if status.Role != role {
+			t.Fatalf("expected instanceset status role %q for pod %q, got %q", role, podName, status.Role)
+		}
+		return
+	}
+	t.Fatalf("expected instanceset status entry for pod %q", podName)
+}
+
+func assertInstanceRoleStatus(t *testing.T, ctx context.Context, cli client.Client, namespace, name, role string) {
+	t.Helper()
+	var stored workloads.Instance
+	if err := cli.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &stored); err != nil {
+		t.Fatalf("get instance failed: %v", err)
+	}
+	if stored.Status.Role != role {
+		t.Fatalf("expected instance status role %q, got %q", role, stored.Status.Role)
 	}
 }


### PR DESCRIPTION
## Problem

A KB 1.2/main Vastbase smoke run reached a control-plane blocker after roleProbe succeeded. The database Pods were Ready and already carried role labels, but the legacy InstanceSet status never projected those roles into `status.instanceStatus[*].role`. Because the role stayed absent from workload status, the owning Cluster/Component remained in `Creating` instead of converging.

This is not an addon roleProbe output contract issue. The KB main addon API contract allows a roleProbe to emit a single role token, and the live Pods had the expected `kubeblocks.io/role` labels.

## Observed phenomenon

In the preserved Vastbase scene:

- `spec.enableInstanceAPI` was empty, so this was the legacy InstanceSet status path.
- All 3 Pods were Ready and owned by `InstanceSet/vb-smoke-vastbase`.
- Pod labels were `primary`, `standby`, and `standby`.
- `status.instanceStatus` contained the 3 pod names but each role field was empty.
- The controller logged the final role event for `vb-smoke-vastbase-0` as `primary`, but no later matching InstanceSet status reconcile was observed in the checked window.

## Why this supports the controller fix

The current legacy InstanceSet status reconciler already derives `status.instanceStatus[*].role` from Ready Pods that have `kubeblocks.io/role`. The missing piece is that the accepted roleProbe event updates the Pod label but can leave workload status stale until another workload reconcile happens.

That creates an async gap where downstream Cluster/Component status depends on a role that is already observed on the Pod but has not been published through workload status.

## What changed

- After an accepted InstanceSet roleProbe event updates the Pod role label, the handler now also updates the matching legacy `InstanceSet.status.instanceStatus[*].role` entry for Ready Pods.
- After an accepted Instance roleProbe event updates the Pod role label, the handler now also updates `Instance.status.role` for Ready Pods.
- Status updates use conflict retry and are no-ops when the status already matches or the status entry is absent.

## Tests

Added role-event handler regression coverage for both workload paths:

- accepted InstanceSet roleProbe updates Pod role label and projects the role into `InstanceSet.status.instanceStatus[*].role`;
- accepted Instance roleProbe updates Pod role label and projects the role into `Instance.status.role`.

Validation run:

```text
go test ./controllers/workloads -run 'Test(ParseRoleProbe|AcceptRoleProbe|RoleEventHandler)' -count=1
```

Result: PASS.

A broader package run was attempted, but this local machine does not have `/usr/local/kubebuilder/bin/etcd`, so envtest cannot start here. That is an environment prerequisite failure, not a package test failure.

## Boundaries

This PR is a controller unit/focused fix for role status publication. It is not a Vastbase runtime PASS and not release-ready evidence by itself. The preserved Vastbase smoke scene should be rerun or focused-validated with a controller image containing this commit before closing the addon test blocker.
