### PR TITLE
docs: add formal addon practice guides

### DIFF
--- a/docs/developer_docs/kubeblocks-addon-development-practice-guide-v1.0.zh-CN.md
+++ b/docs/developer_docs/kubeblocks-addon-development-practice-guide-v1.0.zh-CN.md
@@ -1,0 +1,783 @@
+# KubeBlocks Addon 开发实践指南 release-1.0
+
+适用版本：KubeBlocks release-1.0 和 `kubeblocks-addons` release-1.0。
+
+适用对象：addon 开发者和负责开发 addon 的 agent。重点样本包括 MySQL、PostgreSQL、Redis、ClickHouse、Kafka、Etcd、MongoDB、Elasticsearch、Milvus、MinIO、Pulsar、RabbitMQ 等，其中 MySQL、PostgreSQL、Redis、ClickHouse、Kafka、Etcd 提供主要实践依据。
+
+## 1. 各环节都要先写清楚合同
+
+addon 开发不是把 YAML 字段填满，而是为每个能力建立可验证合同。release-1.0 的 API 分层要先说清楚：核心 apps 资源使用 `apps.kubeblocks.io/v1`，包括 `Cluster`、`ComponentDefinition`、`ClusterDefinition`、`ComponentVersion`、`ShardingDefinition`、`ServiceDescriptor`；但参数、数据保护和运维仍主要使用 `parameters.kubeblocks.io/v1alpha1`、`dataprotection.kubeblocks.io/v1alpha1`、`operations.kubeblocks.io/v1alpha1`。不要把 release-1.0 写成“全部 API 都已 v1 化”，也不要把仍在使用的 v1alpha1 能力误判为不可用。
+
+每个环节都要回答四个问题：addon 作者声明了什么，release-1.0 controller 实际消费什么，运行时应该看到什么，失败时先查 addon 还是查 KB。
+
+| 环节 | addon 必须声明的合同 | release-1.0 controller 主要消费点 | 常见误判 | 先查什么 |
+| --- | --- | --- | --- | --- |
+| Chart 组织 | helper 统一生成名称、label、模板引用和版本前缀 | Helm 渲染后的 core CR | 一个 values 能渲染就认为所有 topology 闭合 | `helm template` 后所有引用是否互相指到 |
+| 组件蓝图 | runtime、volumes、configs、scripts、services、roles、vars、accounts、TLS、lifecycle | `controllers/apps/component` 和 synthesized component | 把动态副本、资源、存储容量写死到蓝图里 | `ComponentDefinition.status.phase`、volume/config/script 名称 |
+| 拓扑 | topology、components、shardings、orders、default | `controllers/apps/cluster` normalization 和 topology 解析 | 未设置 default 却假设选第一个 | Cluster resolved topology、生成的 Component 列表 |
+| 版本管理 | ComponentDefinition 名称、serviceVersion、ComponentVersion releases、镜像 key | ComponentDefinition matching 和 ComponentVersion compatibility | 宽正则能命中就等于版本治理完成 | `ComponentVersion.status.serviceVersions`、resolved image |
+| 配置参数 | CMPD config name、template ConfigMap、PD fileName、PCR configs、schema、reload/restart 分类 | `controllers/parameters` 和 `pkg/controller/configuration` | PCR `configs[*].templateName`、模板 ConfigMap 名、运行时 ConfigMap 名混用 | PD、ParamConfigRenderer、ComponentParameter、runtime ConfigMap |
+| 变量和服务 | vars 来源、Service、ServiceRef、外部依赖、地址格式 | var resolver 和 service builder | 脚本私下约定变量格式 | 最终 Pod/action env、Service、EndpointSlice、连接自检 |
+| 账号和 TLS | systemAccounts、accountProvision、credential vars、证书挂载 | component validation、action executor、脚本 | 账号 Secret 存在就等于数据库内权限可用 | Secret、accountProvision 输出、实际连接和权限 |
+| lifecycle | roleProbe、availableProbe、memberJoin/Leave、switchover、preTerminate、dataDump/dataLoad | lifecycle executor、kbagent、component deletion/scale | 脚本退出 0 等于业务状态收敛 | action 输入、目标 Pod、role/status、业务自检 |
+| 内置 Ops | 每种 Ops 的底层前提 | `controllers/operations` 和 `pkg/operations` | OpsRequest 失败只看 operations 层 | 对应的组件、参数、备份、lifecycle 合同 |
+| 数据保护 | BackupPolicyTemplate、ActionSet、BackupRepo、method、target、脚本 | `controllers/dataprotection` 和 `pkg/dataprotection` | 只有 ActionSet 就声称支持备份 | BackupPolicy 是否生成、target/actionSet/artifact |
+| Restore/Rebuild | source backup、target mapping、prepareData、postReady、账号/TLS 兼容 | restore manager、operations rebuild flow | Backup 成功等于 Restore 成功 | Restore Job/PVC、目标 Component、数据健康检查 |
+| Upgrade/Rollout | serviceVersion、ComponentVersion、镜像、rollout、数据兼容 | ComponentVersion、workload rollout、operations upgrade | runtime image 能启动就等于升级支持 | old/new serviceVersion、Pod image、action image、数据兼容 |
+| Sharding | ShardingDefinition、shard template、shardsLimit、shard lifecycle | sharding/component transformers | 多副本等于 sharding | ShardingDefinition、shard Component、Service/vars、数据迁移边界 |
+| 操作排障 | 创建、删除、参数、scale、backup/restore、upgrade 的对象链 | cluster/component/operations/dataprotection/parameters 控制器 | 只看最后一个报错 | 从入口 CR 到生成对象再到脚本和业务状态 |
+
+每增加一个能力，都要能说明对象关系、controller 消费方式、运行验证和限制边界。
+
+## 2. 先定义 addon 的工作边界
+
+release-1.0 的 addon 首先是 Helm chart。真实仓库里有三类入口：`addons/<name>` 放 KubeBlocks 定义对象和脚本，`addons-cluster/<name>` 放可安装的 Cluster chart，`examples/<name>` 放用户 CR 示例。开发定义对象时以 `addons/<name>` 为主；验收用户路径时必须同时看 `addons-cluster/<name>` 和 `examples/<name>`，因为用户实际创建 Cluster、执行 Ops、Backup/Restore 往往从后两类入口开始。
+
+真实 addon 通常包含 `Chart.yaml`、`values.yaml`、`templates/`、配置模板目录、脚本目录、脚本单测目录和 examples。历史 addon 的目录名并不完全统一；新 addon 建议固定一套命名，避免后续维护者在 `config/configs`、单数/复数模板文件、脚本 ConfigMap 和脚本源码之间反复猜测。
+
+开始写 addon 前先确定四件事：
+
+- 引擎拆成几个组件。MySQL 拆 server/proxysql，Kafka 拆 broker/controller/combine，ClickHouse 拆 clickhouse/keeper，Redis 拆 redis/sentinel/twemproxy/syncer，Etcd 通常是单组件。
+- 是否需要多个 topology。MySQL 有 `semisync`、`mgr`、`orc`、`*-proxysql`；Redis 有 `standalone`、`replication`、`replication-syncer`、`replication-twemproxy`、`cluster`；ClickHouse 有 sharding；Kafka 有 broker/controller 或 combine。
+- 哪些能力 release-1.0 内置 Ops 可以覆盖。restart、stop/start、scale、vertical scaling、volume expansion、reconfigure、expose、switchover、upgrade、backup、restore、rebuild 都有入口，但 addon 必须提供底层脚本、参数或备份合同。
+- 哪些能力只能写限制。不能自然表达的数据迁移、复杂 rebalance、跨 topology 自动迁移、需要人工确认的破坏性步骤，不应包装成“已支持”。
+
+推荐目录形态如下。目录名、模板文件名和 ConfigMap 名称保持单数优先；同一类对象有多个实例时，用 `-<component>` 或 `-<purpose>` 后缀区分，不用单复数表达语义差异。
+
+```text
+addons/<engine>/
+  Chart.yaml
+  values.yaml
+  templates/
+    clusterdefinition.yaml
+    componentdefinition-<component>.yaml
+    componentversion-<component>.yaml
+    parametersdefinition-<component>.yaml
+    parameterconstraint-<component>.yaml
+    config-template-<component>.yaml
+    script-<component>.yaml
+    actionset.yaml
+    backuppolicytemplate.yaml
+  config/
+    *.tpl
+    *.cue
+    effects.yaml
+  scripts/
+    start.sh
+    role-probe.sh
+    member-join.sh
+    member-leave.sh
+    switchover.sh
+    reconfigure.sh
+    backup.sh
+    restore.sh
+addons-cluster/<engine>/
+  templates/cluster.yaml
+examples/<engine>/
+  cluster*.yaml
+  configure*.yaml
+  backup*.yaml
+  restore*.yaml
+  restart.yaml / scale*.yaml / switchover.yaml / upgrade.yaml
+```
+
+代表性 release-1.0 addon 样本：
+
+- MySQL：`addons/mysql/templates/clusterdefinition.yaml`、`cmpd-mysql80.yaml`、`cmpd-mysql80-mgr.yaml`、`cmpd-proxysql.yaml`、`cpmv.yaml`、`backuppolicytemplate.yaml`、`actionset-xtrabackup.yaml`、`paramsdef-80.yaml`。
+- PostgreSQL：`addons/postgresql/templates/cmpd.yaml`、`clusterdefinition.yaml`、`cmpv.yaml`、`paramsdef.yaml`、`backuppolicytemplate.yaml`、`actionset-wal-g.yaml`、`actionset-postgresql-pitr.yaml`。
+- Redis：`addons/redis/templates/clusterdefinition.yaml`、`cmpd-redis.yaml`、`cmpd-redis-cluster.yaml`、`shardingdefinition.yaml`、`cmpv-redis.yaml`、`backuppolicytemplate.yaml`、`backupactionset.yaml`、`paramsdef-redis.yaml`。
+- ClickHouse：`addons/clickhouse/templates/clusterdefinition.yaml`、`shardingdefinition.yaml`、`cmpd-ch.yaml`、`cmpd-keeper.yaml`、`cmpv.yaml`、`paramsdef-config.yaml`、`backuppolicytemplate.yaml`、`actionset.yaml`。
+- Kafka：`addons/kafka/templates/clusterdefinition.yaml`、`cmpd-broker.yaml`、`cmpd-controller.yaml`、`cmpd-combine.yaml`、`cmpv-broker.yaml`、`paramsdef.yaml`、`backuppolicytemplate.yaml`、`actionset.yaml`。
+- Etcd：`addons/etcd/templates/cmpd.yaml`、`cmpv.yaml`、`backuppolicytemplate.yaml`、`actionset.yaml`。
+
+并不是每个 release-1.0 addon 都有完整 ClusterDefinition。Etcd addon 本体主要提供 ComponentDefinition、ComponentVersion、BackupPolicyTemplate、ActionSet，示例可以直接用 `componentDef` 创建 Cluster。如果 addon 面向用户提供多个标准 topology，就提供 ClusterDefinition；如果只暴露一个轻量组件或作为外部依赖，也可以用 direct componentDef 示例，但这种写法不享受 topology orders。
+
+chart 层先做闭合检查，再谈业务语义。至少用代表性 values 渲染 standalone、HA、proxy、sharding、TLS on/off、不同 serviceVersion、备份恢复开关等组合，确认 helper、ConfigMap key、script key、`templateName`、`compDef`、BPT `compDefs`、PD `fileName`、ActionSet 名称、examples 中的名字全部闭合。topology 是验收维度，不是 README 分类；某个 topology 的 Cluster 能 Running，不代表它的 BackupPolicy、参数、proxy 路由、roleSelector Service、Restore 都可用。
+
+发布和 GitOps 验收要保存三类结果：旧版渲染、新版渲染、server-side dry-run 或 live object diff。release-1.0 API 中多处 list 字段使用 merge/retainKeys，例如 Cluster component 的 `volumeClaimTemplates` 和 OpsRequest 的 `volumeClaimTemplates`；因此不能只用文本 diff 判断最终对象。遇到升级或同步异常，先查 live 对象是否保留了旧字段、旧 ConfigMap/ActionSet/BPT 是否被 Helm keep 或 cluster-scoped 资源残留遮蔽，再查 controller 是否消费了预期 definition。只有在渲染对象、apiserver 默认化结果和下游生成对象都指向同一结论后，才讨论 KB 实现问题。
+
+## 3. 用 ComponentDefinition 表达组件蓝图
+
+release-1.0 的 `ComponentDefinition` 是组件静态蓝图。它描述 runtime PodSpec、volumes、configs、scripts、services、vars、systemAccounts、TLS、roles、lifecycleActions、ServiceRefDeclarations、update 策略和 RBAC。用户主要写 Cluster 和 definition；`Component` 是 controller 合成出的内部对象。Cluster 的 `componentSpecs` 提供实例化时的动态输入，例如副本数、资源、存储容量、调度、TLS 开关、serviceRefs、serviceVersion、外部服务绑定和用户覆盖配置。
+
+最小组件要能闭合以下关系：
+
+- `spec.runtime.containers[*].volumeMounts[*].name` 必须能在 `spec.volumes`、`spec.configs[*].volumeName`、`spec.scripts[*].volumeName` 或 runtime volumes 中找到。
+- `spec.configs[*].name` 是参数链路绑定键；`spec.configs[*].template` 是模板 ConfigMap 名；`spec.configs[*].volumeName` 决定挂载到哪个 volume。
+- `spec.scripts[*].template` 提供脚本 ConfigMap，`defaultMode` 要让容器内脚本可执行。
+- `spec.services[*].roleSelector` 依赖 `spec.roles` 和 `lifecycleActions.roleProbe`。
+- `systemAccounts`、TLS、vars 要能在启动脚本、lifecycle action、backup/restore 或外部连接里找到使用点。
+- `status.phase=Available` 是被 Cluster、BPT、PD、ComponentVersion 等引用前的最低门槛。
+
+release-1.0 API 注释明确：`runtime` 用于静态 PodSpec，CPU/memory、调度等动态设置应放到 `cluster.spec.componentSpecs`；`ComponentDefinition.status.phase=Available` 表示可以被相关对象使用。不要只看 CR 创建成功。
+
+字段语义矩阵：
+
+| 字段或对象关系 | release-1.0 实践语义 | 必须同时对齐 | 常见误用 |
+| --- | --- | --- | --- |
+| `spec.serviceKind` | 组件提供的服务类型，BPT、ServiceRefDeclaration 等也会使用同类概念 | BPT `serviceKind`、ServiceDescriptor、README | 大小写或命名不统一导致外部依赖和策略不匹配 |
+| `spec.serviceVersion` | 组件内核版本；可被 ComponentVersion release 覆盖 | ComponentVersion、PD serviceVersion、BPT versionMapping、examples | 未显式写 serviceVersion，误以为选择固定版本 |
+| `spec.runtime` | 静态 PodSpec | volumes、configs、scripts、ports、command | 把资源和调度这类实例参数写死 |
+| `spec.volumes[*].name` | 数据卷稳定身份 | Cluster VCT、runtime mount、BPT targetVolumes、volume expansion | PVC 创建了但没有挂到数据库目录 |
+| `spec.configs[*].name` | 配置模板身份和参数绑定键 | PCR `configs[*].templateName`、Cluster configs、ComponentParameter | 写成模板 ConfigMap 名 |
+| `spec.configs[*].template` | 模板 ConfigMap 名 | chart 渲染出的 ConfigMap | 模板 ConfigMap data 没有 PD `fileName` |
+| `spec.scripts[*].template` | 脚本 ConfigMap 名 | command/action 脚本路径、defaultMode | 脚本存在但不可执行 |
+| `spec.services[*].roleSelector` | 按 role 暴露服务 | roles、roleProbe、Service endpoints | 没有 roleProbe 却声明 roleSelector |
+| `spec.vars` | 注入 Pod/action 或渲染模板的运行时变量 | 脚本消费格式、Optional/Required 分支 | 脚本依赖未声明的变量格式 |
+| `spec.systemAccounts` | KB 管理的系统账号 | accountProvision、credentialVarRef、backup/probe/replication 脚本 | Secret 存在但数据库内账号未创建 |
+| `spec.tls` | TLS 文件形状和挂载路径 | Cluster TLS、启动配置、client、backup/restore job | 只验证 runtime，不验证其它执行面 |
+| `spec.roles` | roleProbe 输出集合和 update/service/backup 的角色基础 | roleProbe、updateStrategy、BPT target | role label 等同于业务一致性 |
+| `spec.lifecycleActions` | 组件生命周期脚本和 probe | action target、kbagent、Ops、delete/scale | action 成功等同于业务收敛 |
+| `spec.serviceRefDeclarations` | 外部依赖声明 | Cluster serviceRefs、serviceRefVarRef | 只声明依赖，没有 Cluster 绑定示例 |
+| `spec.replicasLimit` | 声明 scale 支持边界 | README、HorizontalScaling、examples | 声称支持边界但没有业务验证 |
+
+release-1.0 还有几组容易被低估的 ComponentDefinition 合同：
+
+| 能力 | release-1.0 字段和实现证据 | addon 写法要求 | 排查要点 |
+| --- | --- | --- | --- |
+| 数据卷和容量保护 | `spec.volumes[*].needSnapshot/highWatermark`、lifecycle `readonly/readwrite`、kbagent 任务配置 | 数据目录和 VCT 名称必须一一对应；如果声明 highWatermark，必须实现 readonly/readwrite 并证明业务进入/退出只读 | PVC、mountPath、volume 名、kbagent task、数据库读写状态 |
+| 可用性口径 | `available.withPhases/withRole/withProbe`，controller 会校验 `withProbe` 对应 availableProbe | 只有 probe 输出、role 和业务连接都闭合时才把 Component Available 当业务可用 | Component status、role label、probe stdout/stderr、连接测试 |
+| 单 Pod Service | `services[*].podService` 会按 Pod 生成 Service，`disableAutoProvision` 会跳过自动创建 | 需要 pod 级地址时显式声明 podService；不自动创建时要说明由谁创建 Service | Service 名称、selector、EndpointSlice、serviceVarRef 输出格式 |
+| hostNetwork | API 会把 DNSPolicy 调整到 `ClusterFirstWithHostNet`，port 来自 containerPorts | 只在引擎必须使用宿主网络时启用，并验证端口冲突和调度 | Pod spec、Node 端口占用、hostNetworkVarRef |
+| role 更新优先级 | `roles[*].updatePriority/participatesInQuorum/isExclusive` 影响角色语义和更新判断 | roleProbe 输出必须稳定；quorum 角色不能只靠名称猜测 | role label、InstanceSet update 顺序、业务 quorum |
+| 外部管理配置 | `configs[*].externalManaged/restartOnFileChange` 影响配置所有权和重启行为 | externalManaged 表示交给 parameters 链路管理，不表示模板 ConfigMap 名可随意替换 | PD/PCR/ComponentParameter、runtime ConfigMap、Pod restart |
+
+MySQL `cmpd-mysql80.yaml` 展示了典型蓝图：声明 `serviceVersion: 8.0.33`、配置模板 `mysql-replication-config`、`externalManaged: true`、runtime container、scripts、data volume 和工具 init container。PostgreSQL `cmpd.yaml` 更复杂：它声明 ServiceRef、roleSelector Service、roles、configs、scripts、vars、systemAccounts、TLS 变量和 accountProvision。Redis、Etcd 展示了 roleProbe/member lifecycle 轻量形态。
+
+release-1.0 controller 会做一部分定义校验，例如 service 端口、roleSelector、account/lifecycle、file template、hostNetwork 等，但 addon 不能把校验层当成完整业务证明。`roles` 与 `roleProbe` 的绑定、账号权限、TLS 工具链、脚本幂等和业务 member 状态仍要由 addon 的示例和测试自证。
+
+写完 ComponentDefinition 后必须立刻用最小 Cluster 样例验收：Cluster 能解析 topology 或 direct componentDef，生成 Component，Component 继续生成 InstanceSet/Pod/PVC/Service，Pod 内脚本和配置文件存在并权限正确。不要等到参数、备份和升级都写完后才发现基础蓝图未闭合。
+
+数据目录初始化、默认资源和文件权限也属于 ComponentDefinition 合同。release-1.0 会把 Component 合成为 InstanceSet，并在 factory 层处理默认资源、volumeClaimTemplates 和工作负载字段；addon 启动脚本不能只用“目录是否为空”决定是否初始化或清空数据。至少要区分空目录、只有 `lost+found` 的新 PVC、已有业务数据、restore/rebuild 写入的数据和半初始化目录。`defaultMode` 要按最终 Pod spec 和容器内 `stat` 验收：真实 addon 中同时存在 `0555`、`0755`、`0777`、`0444` 和十进制 `365` 这类写法，复核时不能只看源码字面量像不像八进制。
+
+`replicasLimit`、`podUpdatePolicy`、`podUpgradePolicy`、`instanceUpdateStrategy` 和 `policyRules` 都不是装饰字段。声明 scale 边界后，要验最小值、最大值、越界拒绝、HorizontalScaling、0 副本语义和业务成员关系；声明 ReCreate 或其它更新策略后，要在 upgrade/restart/reconfigure 中看 InstanceSet revision、current/updated replicas、partition 或 rollout 状态；声明 `policyRules` 后，要分别验证 runtime Pod、lifecycle action、backup/restore Job 是否使用到正确 ServiceAccount 和权限。权限不足常表现为 action 或 Job 失败，不应误判成脚本逻辑错误。
+
+## 4. 用 ClusterDefinition 表达拓扑，不表达组件细节
+
+release-1.0 的 `ClusterDefinition` 主要表达 topology：每个 topology 包含 components、shardings、orders 和 default。组件 runtime、脚本、账号、TLS 不应该放在 ClusterDefinition 里。
+
+实践规则：
+
+- 每个用户可选部署形态都应有明确 topology。MySQL 的 `semisync`、`mgr`、`orc`、`orc-proxysql`、`mgr-proxysql`、`semisync-proxysql`，Redis 的 `standalone`、`replication`、`cluster`，Kafka 的多组件拓扑，都是 release-1.0 的真实模式。
+- `default: true` 要显式设置。Cluster 未指定 topology 时应依赖默认 topology，不应让用户猜测。
+- `components[*].name` 是 topology 内组件名，Cluster `componentSpecs[*].name` 要和它对齐。
+- `components[*].compDef` 支持精确名、前缀或正则，release-1.0 API 注释写明系统会选择匹配的最新 ComponentDefinition。多匹配时的版本优先级和同名排序不应作为 addon 合同，addon 作者应使用 helper 固定规则并用渲染结果验证，避免宽正则误命中未来或残留版本。
+- `orders.provision/terminate/update` 表示跨组件顺序。proxy、sentinel、keeper、controller/broker 这类辅助组件要显式排序。release-1.0 controller 会校验 orders 覆盖 topology 中的 component 和 sharding，漏写 orders 会直接影响 Cluster 可用性。
+- sharding 不等于 replicas。`replicas` 是一个复制组内实例数，`ShardingDefinition` 表示多个 shard component。
+
+拓扑能力矩阵：
+
+| 拓扑能力 | release-1.0 表达方式 | controller 消费点 | 验收证据 | 不支持或未证明边界 |
+| --- | --- | --- | --- | --- |
+| 单组件 standalone | `ClusterDefinition.spec.topologies[*].components` | Cluster normalization | Component、InstanceSet、Pod、Service 全部生成 | 不证明 HA、backup、reconfigure |
+| 多组件 HA/proxy | topology components + orders | cluster/component reconcile 顺序 | server 先于 proxy 创建，proxy 先删除；服务可连接 | proxy 路由表和后端角色要另验 |
+| MGR/orc/sentinel/keeper | 不同 topology 指向不同 compDef | compDef matching | 每个 topology 的 CMPD/CMPV/PD/BPT 都闭合 | 一个 topology 成功不代表另一个成功 |
+| sharding | `ShardingDefinition` + topology `shardings` | sharding/component transformer | shard Component、Service、vars、scale 行为 | 不自动证明 rebalance 或数据迁移 |
+| direct componentDef | Cluster component 直接指定 ComponentDefinition，如果使用 | Cluster normalization | 不依赖 ClusterDefinition orders | 不应和 topology 语义混用 |
+
+ClickHouse `shardingdefinition.yaml` 和 Redis `shardingdefinition.yaml` 是 release-1.0 sharding 的关键样本。它们说明 shard 数、shard template 和 lifecycle 可以由单独对象表达，但 shard 增删后的业务数据迁移、slot/partition rebalance、跨 shard 元数据修复仍要由 addon 自己证明，不能只凭 ShardingDefinition 存在就写成已支持。
+
+sharding 是 release-1.0 的真实能力，但不要写得过满。Redis 是重点样本：它同时有 `ClusterDefinition.topologies[*].shardings`、`ShardingDefinition`、Cluster 示例和参数配置；需要独立验证 `Cluster.spec.shardings`、cluster-level service `componentSelector`、shard scale 和 shard lifecycle 是否真正闭合。
+
+`ShardingDefinition` 的语义要按对象链理解：`spec.template.compDef` 指向每个 shard 使用的 ComponentDefinition，`shardsLimit` 约束 shard 数量，`provisionStrategy/updateStrategy` 和 lifecycle `postProvision/preTerminate/shardAdd/shardRemove` 只表达 shard 组件的创建、更新和增删动作。它不自动表达 Redis slot 迁移、ClickHouse 分布式表修复、Kafka partition rebalance 或跨 shard restore。排查 sharding 时先看 Cluster topology 的 sharding 名，是否匹配到 ShardingDefinition，再看生成的 shard Component、每个 shard 的 ComponentDefinition/ComponentVersion、Service/vars 和业务层分片状态。
+
+排查 topology 时按这个顺序：Cluster `spec.clusterDef/topology/componentSpecs/shardings`，ClusterDefinition status 和 topology，匹配到的 ComponentDefinition/ComponentVersion，生成的 Component，InstanceSet/Pod/Service。不要把 topology component name、generated Component object name、Pod name、PVC name 和引擎成员 ID 混为一谈。
+
+实例身份要从 Component 往下看，而不是靠名字猜。release-1.0 使用 InstanceSet 承载工作负载，Pod/PVC/Service 的名字、label、ownerRef、ordinal 和引擎内部成员 ID 不是同一种身份。scale、rebuild、restore、同名 Cluster 重建和 sharding 场景下，脚本可以读取 Pod 名或 FQDN 作为运行时输入，但不要把它们写入不可重算的持久成员 ID。确实需要持久化成员映射时，应能从业务元数据重建，并在 restore/rebuild/scale-in 后验证映射仍然成立。
+
+## 5. 用 ComponentVersion 管理版本矩阵
+
+release-1.0 有 `apps.kubeblocks.io/v1` 的 `ComponentVersion`。它用 `compatibilityRules[*].compDefs` 把一组 ComponentDefinition 和若干 release 关联起来；每个 release 有 `name`、`serviceVersion` 和 `images`。API 注释明确：release 的 `serviceVersion` 会作为被选择 release 的 serviceVersion，覆盖 ComponentDefinition 自身定义的 serviceVersion。
+
+版本管理至少分五层：
+
+| 版本维度 | release-1.0 来源 | 被谁消费 | 必须验证什么 |
+| --- | --- | --- | --- |
+| chart version | `Chart.yaml` | Helm/package/release 管理 | 与模板、values、README 一致 |
+| ComponentDefinition name | CMPD metadata/helper | ClusterDefinition、BPT、PD、CMPV | 正则只命中预期版本 |
+| `spec.serviceVersion` | CMPD 或 CMPV release | Cluster normalize、PD、BPT versionMapping、upgrade | resolved serviceVersion 是预期版本 |
+| runtime image | CMPD runtime 或 CMPV `images` | Pod/InstanceSet | 实际 Pod image 被替换 |
+| action/tool image | lifecycle action、ActionSet、BPT env | action worker、backup/restore Job | 工具版本与 serviceVersion 兼容 |
+
+实践规则：
+
+- ComponentDefinition 名称应带引擎大版本或 addon 版本前缀，例如 MySQL 的 `mysql-8.0`、`mysql-8.4` 系列，Redis 的 `redis`、`redis-cluster`、`redis-sentinel` 系列。
+- ComponentVersion `compatibilityRules[*].compDefs` 可以写精确名、前缀或正则；release 名必须能在 `spec.releases[*].name` 中找到。
+- `images` key 要对应 runtime container、init container、lifecycle action 字段名或外部工具名。未知 key 不应被当成已验证替换。
+- 每个 serviceVersion 都要同时验证 runtime image、参数 schema、BPT method env、backup/restore 工具镜像和升级路径。
+- Cluster 未显式指定 serviceVersion 时，不要猜测最终选择；开发样例应显式写 serviceVersion，排查时看 resolved Component 和 Pod image。
+
+版本矩阵要覆盖“声明面”和“执行面”两类镜像。runtime container 和 init container 是声明面；lifecycle action image、backup/restore ActionSet image、参数 reload 脚本依赖的工具镜像是执行面。release-1.0 的 ComponentVersion 能改写 ComponentDefinition 中的 container、init container 和 lifecycle action image，但不会自动改写任意 ConfigMap 脚本里硬编码的工具镜像，也不会自动覆盖 ActionSet image。ActionSet/BPT 的工具镜像如果随数据库版本变化，需要在 BPT method env、ActionSet 模板或 chart values 中单独版本化。
+
+真实样本：
+
+- MySQL `cpmv.yaml`、`cpmv-orc.yaml`、`cpmv-mgr.yaml`、`cpmv-proxysql.yaml` 拆开管理不同组件和拓扑。
+- PostgreSQL `cmpv.yaml` 按版本循环生成 release。
+- Redis 拆出 `cmpv-redis.yaml`、`cmpv-redis-cluster.yaml`、`cmpv-redis-sentinel.yaml`、`cmpv-redis-twemproxy.yaml`。
+- Kafka 拆出 broker、controller、combine 等 ComponentVersion。
+
+升级验收不能只看新镜像启动。至少要保存 old/new 的 ComponentVersion status、Cluster/Component resolved serviceVersion、Pod image、action image、参数定义和 BPT method env。跨大版本的数据兼容、回滚限制和备份恢复兼容要写进 README 或实现说明；没有证据的组合写成未证明。
+
+release-1.0 未指定 serviceVersion 时存在自动选择路径。代码会在兼容的 ComponentDefinition 与 serviceVersion 中选择可用版本，并改写 runtime、init container 和 lifecycle exec image。这个行为适合 controller 默认化，不适合 addon 作者逃避版本矩阵；examples 和测试应显式写 serviceVersion，避免“最新匹配”随残留对象或新 release 漂移。
+
+BPT 的 `versionMapping` 是数据保护侧的版本矩阵。release-1.0 实现会按 Cluster 组件的 serviceVersion 匹配 method 侧版本，支持 exact、prefix 或 regexp 一类规则。它只能说明某个 backup method 用哪个版本化配置，不证明该 method 可 restore、可 rebuild 或可跨版本。每增加一个 ComponentVersion release，都要回查 PD/PCR、BPT `versionMapping`、ActionSet image/env 和 examples。
+
+## 6. 生命周期动作要按数据库语义建模
+
+release-1.0 `ComponentLifecycleActions` 支持 `postProvision`、`preTerminate`、`roleProbe`、`availableProbe`、`switchover`、`memberJoin`、`memberLeave`、`readonly`、`readwrite`、`dataDump`、`dataLoad`、`reconfigure`、`accountProvision`。其中 `reconfigure` 在 API 注释里标为 reserved for future versions；release-1.0 新 addon 不应把它作为通用参数热更新入口，参数体系仍主要依赖 ParametersDefinition 的 reloadAction 或重启路径。`readonly/readwrite` 可以作为 highWatermark 等容量保护链路的一部分，但只有在 addon 同时声明 volume highWatermark、实现 action、验证 kbagent 触发和数据库读写状态后，才能写成支持。
+
+动作矩阵：
+
+| 动作 | release-1.0 触发时机 | 输入和目标 | addon 要证明什么 | 常见误区 |
+| --- | --- | --- | --- | --- |
+| `postProvision` | 组件创建后，按 `preCondition` | `Immediately`、`RuntimeReady`、`ComponentReady`、`ClusterReady` | 一次性初始化幂等，依赖对象已存在 | Start/Restart 后期待重新执行 |
+| `preTerminate` | 删除或缩容释放资源前 | 默认目标或指定 target | Pod/执行面存在时能完成下线；失败可诊断 | Pod 已消失还假设能执行 |
+| `roleProbe` | 周期性探测 | 输出必须是预定义 role | Service、backup target、switchover、rollout 的角色基础 | role label 等同于数据库内部安全 |
+| `availableProbe` | 周期性探测可用性 | action 输出和退出码 | Component Available 口径和业务可服务一致 | 探针通过但业务不可写 |
+| `switchover` | 切换角色 | `KB_SWITCHOVER_*` 变量 | candidate 和无 candidate 路径都能解释 | action 成功后不查 role 收敛 |
+| `memberJoin` | 新副本 Pod Ready 后 | `KB_JOIN_MEMBER_POD_NAME/FQDN` | 业务成员加入、重复执行安全 | scale-out 只看 Pod Ready |
+| `memberLeave` | 移除副本前 | `KB_LEAVE_MEMBER_POD_NAME/FQDN` | 成员摘除、数据迁移边界、失败可恢复 | 把复杂 rebalance 塞进不可审计脚本 |
+| `readonly/readwrite` | highWatermark 或显式 action 触发只读/读写切换 | 目标 Pod/action、数据库状态 | action 幂等，业务读写状态可观测 | 只声明字段，不验证 kbagent 和业务状态 |
+| `dataDump/dataLoad` | 实例初始化类数据复制 | dump stdout、load stdin | 数据流干净且可重试 | 当成完整 Backup/Restore |
+| `accountProvision` | 创建非 init system account | `KB_ACCOUNT_*` | SQL/CLI 脱敏、转义、权限正确 | Secret 存在就认为账号已建 |
+
+action 执行成功只说明 release-1.0 action 机制认为该执行返回成功，不证明数据库业务状态已经收敛。每个动作都要配后置验证：roleProbe 看角色，Service/EndpointSlice 看流量目标，业务 CLI/SQL 看成员关系、读写状态、账号权限或数据结果。
+
+roleProbe 的 release-1.0 API 注释明确：如果 Component 定义了 roles，应该定义 roleProbe；roleProbe 输出必须匹配预定义 role。任何 roleSelector service、BackupPolicy target role、switchover、updatePriority 都依赖这个基础。MySQL、PostgreSQL、Redis、Etcd 都有 role/lifecycle 相关脚本，是开发和复核时必须重点验证的部分。
+
+`preTerminate` 是高风险动作。它适合“目标 Pod 或可管理执行面仍存在时”的业务下线。删除卡住时先查 Cluster/Component deletionTimestamp、InstanceSet/Pod 是否还存在、action 目标和 action 输出，再判断是否是 addon 设计问题。绕过执行只能作为有风险的运维恢复，不能作为 addon 删除流程验收通过。
+
+Action target 也要按 release-1.0 实现验证。`Any`、`All`、`Role` 是主要可用路径；`Ordinal` selector 在代码中有声明但返回不支持。需要按实例身份操作时，应通过 Ops 输入、Pod/Instance 名、业务成员 ID 和脚本自检建立明确映射，不要依赖 ordinal 直接选择 action 目标。
+
+action 的执行格式要写清楚。`exec.command` 是命令数组，不是 shell 字符串；如果脚本需要管道、重定向、变量展开或多命令，应调用脚本文件或显式 `sh -c`。`preCondition` 主要用于 `postProvision`，不要把它泛化为所有 lifecycle action 的等待条件。HTTP/GRPC action 如果使用，只能作为一次请求式动作，仍要配 timeout、retry 和业务后置验证；不要把 HTTP 200 或 gRPC OK 当成集群状态收敛。
+
+## 7. 变量注入和服务依赖是契约
+
+release-1.0 `ComponentDefinition.spec.vars` 支持多种来源：cluster、component、credential、service、serviceRef、TLS、hostNetwork、ConfigMap、Secret 等。变量可用于 Pod/action env，也可用于渲染 config/script 模板。变量不是脚本私货；每个变量的格式、缺失语义和刷新语义都要写进 addon 实现说明。
+
+常见变量和服务来源：
+
+| 来源 | release-1.0 输出或行为 | 脚本消费方式 | 验收证据 | 边界 |
+| --- | --- | --- | --- | --- |
+| `clusterVarRef` | cluster name、namespace、uid 等 | 普通 env/template 值 | 最终 Pod/action env | 不应作为不可重算业务成员 ID |
+| `componentVarRef` | component 名、replicas、Pod 名/FQDN 列表、按 role 过滤列表 | 逗号列表等字符串约定 | 脚本解析、scale 后验证 | Pod env 是创建时视图，拓扑变化要另验 |
+| `credentialVarRef` | system account 用户名/密码 | env 传入脚本 | Secret 和数据库内账号都存在 | 不应渲染进普通 ConfigMap |
+| `serviceVarRef` | 同 Cluster 内 KB 管理 Service host/port 等 | 连接地址或 advertised address | Service、EndpointSlice、连接测试 | Service 有值不等于业务可服务 |
+| `serviceRefVarRef` | Cluster 绑定的外部服务或其它 Cluster 服务 | 外部依赖 endpoint/credential | ServiceRef declaration、Cluster binding、真实连接 | declaration 不等于绑定 |
+| `tlsVarRef` | TLS 是否启用等 | 启动/连接分支 | TLS on/off 两套用例 | enabled 不证明工具链兼容 TLS |
+| `hostNetworkVarRef` | hostNetwork 场景端口 | advertised address | Pod spec 和实际端口 | hostPort/hostNetwork 有调度冲突边界 |
+
+PostgreSQL `cmpd.yaml` 是 ServiceRef 和 vars 的典型样本：它声明 `etcd`、`remote-instances` 两类 ServiceRefDeclaration，又用 `serviceRefVarRef` 注入 endpoint、host、port、username、password；同时注入 `POSTGRES_POD_NAME_LIST`、`POSTGRES_POD_FQDN_LIST`、credential、TLS enabled 等变量。Redis 和 Kafka 使用 serviceVarRef 构造对内或对外地址。
+
+实践规则：
+
+- 每个变量都要有脚本使用点；不用的变量不要提前注入。
+- Optional 缺失时脚本要处理 unset 和 empty；Required 缺失应尽早失败。
+- 列表格式要固定，例如逗号分隔 Pod/FQDN 列表；脚本不要用未说明的 `awk/cut/tr` 约定。
+- 同名 env 覆盖以最终 Pod/action env 为准，不以 YAML 书写顺序推断。
+- 外部依赖要写 declaration、Cluster 绑定示例、变量读取方式和变更生命周期。
+- 拓扑变化后的 action 不要依赖创建时写入 Pod env 的成员列表。scale、switchover、rebuild 后优先使用 action-time 注入、当前 Service/EndpointSlice 或业务 membership 查询。
+
+release-1.0 的变量解析还有几个具体格式要在实现说明中写明：
+
+| 变量类型 | 1.0 输出细节 | 实践要求 |
+| --- | --- | --- |
+| component Pod/FQDN 列表 | 通常是逗号分隔字符串，可按 role 过滤 | 脚本要固定分隔符解析，并处理空列表 |
+| service host | 普通 Service 输出单个 host；podService 输出按 Service 名排序后的逗号列表 | 需要 pod 级地址时不要按单值解析 |
+| service port/loadBalancer | podService 输出 `serviceName:value` 形式；NodePort/LoadBalancer 可能输出对外端口 | advertised address 要按 Service type 分支验证 |
+| credential | 用于 Pod/action env；不应假设可直接渲染进普通 ConfigMap | 敏感值只在需要的执行面注入 |
+| MultipleClusterObjectOption | 可 individual 或 combined，并设置 delimiter/keyValueDelimiter | 多组件、多 shard 场景要写清楚变量名和拼接格式 |
+
+服务排查顺序是：ComponentDefinition services，Cluster/Ops expose 或 Service override，最终 Service type/ports/selector，EndpointSlice，Pod label/Ready，注入 env，真实连接。不要修改 KB 系统 selector label 来“修”服务。
+
+## 8. 账号和 TLS 要作为一等能力设计
+
+release-1.0 `systemAccounts` 用于声明 KB 管理的系统账号。API 注释把系统账号和用户账号区分开：系统账号用于初始化、备份、探测、复制和管理动作。非 init account 通常需要 `lifecycleActions.accountProvision` 执行 SQL 或 CLI 创建语句。
+
+账号/TLS 使用面：
+
+| 使用面 | release-1.0 凭据来源 | 需要验证什么 | 失败排查入口 |
+| --- | --- | --- | --- |
+| runtime | init account、Secret、credentialVarRef | 启动和业务连接可用 | Pod env/Secret、数据库内账号 |
+| lifecycle/action | `accountProvision`、roleProbe/switchover/member 脚本 env | 目标 Pod 能执行，权限最小且脱敏 | action 输出、stderr、数据库权限 |
+| backup/restore | BPT target account、ActionSet env、BackupRepo Secret | Job/action 能连库和访问仓库 | Backup/Restore Job spec、Secret mount/env |
+| external dependency | ServiceDescriptor/ServiceRef credential | consumer 能读到 provider 凭据 | serviceRefVarRef env、真实连接 |
+| public connection | 用户 Secret 或 README 声明 | README 连接串与实际 Secret/Service/TLS 一致 | Secret、Service、client 连接 |
+
+PostgreSQL `cmpd.yaml` 声明了 `postgres`、`kbadmin`、`kbdataprotection`、`kbprobe`、`kbreplicator` 等账号，并通过 accountProvision 创建非 init 账号。MySQL、Redis 也有备份、探测或复制相关账号。账号名不是通用规则；通用合同是“每个执行面最小权限、可创建、可禁用、可诊断”。
+
+TLS 不能只看开关。ComponentDefinition `tls` 定义挂载路径和文件名，Cluster 侧启用或提供证书后，还要验证 runtime 启动、client 连接、roleProbe、accountProvision、backup/restore、postReady 是否都能看到正确证书路径和 trust store。TLS 关闭时脚本不能仍强依赖证书文件。
+
+Secret rotation 和 TLS rotation 不能从首次启动成功外推。Secret volume 可能更新，但数据库进程、连接池、action worker、backup/restore 工具是否热加载，需要 addon 自己证明；不能证明时写成需要 restart、reconfigure、rebuild 或人工处理。
+
+账号设计要覆盖禁用和自带 Secret 两类路径。release-1.0 system account 可以由 KB 生成，也可能由用户提供 Secret 或禁用某些账号；如果 addon 的 roleProbe、backup、replication 或 switchover 必须依赖某个系统账号，values 和 README 要明确禁止禁用，或给出替代凭据路径。密码策略只约束生成密码的形状，不证明数据库内权限、过期策略和轮换行为。
+
+## 9. 配置和参数管理要串成闭环
+
+release-1.0 的参数链路由 ComponentDefinition configs、模板 ConfigMap、`ParametersDefinition`、`ParamConfigRenderer`、`ComponentParameter`、runtime ConfigMap、reload/restart 路径共同构成。老的 `ConfigConstraint` 类型仍存在于 API 包中，但 release-1.0 真实主流 addon 已大量使用 `ParametersDefinition` 和 `ParamConfigRenderer`；新建或重写 addon 不应回到旧 ConfigConstraint 叙述。
+
+对象链：
+
+```text
+ComponentDefinition.spec.configs[*].name        # 配置模板身份，也是 PCR configs[*].templateName 应绑定的对象
+ComponentDefinition.spec.configs[*].template    # 模板 ConfigMap 名
+模板 ConfigMap data key                         # PD.fileName 要能找到的文件
+ParametersDefinition.spec.fileName              # schema 和参数分类作用的文件名
+ParamConfigRenderer.spec.componentDef           # 绑定目标 ComponentDefinition
+ParamConfigRenderer.spec.parametersDefs         # 引用一个或多个 ParametersDefinition
+ParamConfigRenderer.spec.configs[*].name        # 配置文件名
+ParamConfigRenderer.spec.configs[*].templateName # 引用 CMPD config item name
+ComponentParameter                              # controller 落地的参数状态
+runtime ConfigMap                               # 最终挂进 Pod 的配置文件
+reloadAction 或 restart                         # 参数真正生效的路径
+进程内配置查询                                  # 最终业务证据
+```
+
+release-1.0 `ParametersDefinitionSpec` 包含 `fileName`、`parametersSchema`、`reloadAction`、`downwardAPIChangeTriggeredActions`、`deletedPolicy`、`mergeReloadAndRestart`、`reloadStaticParamsBeforeRestart`、`staticParameters`、`dynamicParameters`、`immutableParameters`。`ParamConfigRendererSpec` 包含 `componentDef`、`serviceVersion`、`parametersDefs` 和 `configs`；其中 `configs[*].templateName` 才是连接 CMPD `spec.configs[*].name` 的关键字段。API 注释明确：动态 reload 只有在修改参数属于 dynamicParameters，且 reloadAction 已设置时才会触发；`reloadStaticParamsBeforeRestart` 是少数引擎需要先用 SQL/CLI 设置静态参数再重启的场景。
+
+实践规则：
+
+- `ParametersDefinition.spec.fileName` 必须是模板 ConfigMap data 中真实存在的文件名。
+- `ParamConfigRenderer.spec.componentDef` 要指向目标 ComponentDefinition；`parametersDefs` 要列出参与渲染的 PD；`configs[*].templateName` 要等于 CMPD `spec.configs[*].name`，不是模板 ConfigMap 名，也不是 runtime ConfigMap 名。
+- `staticParameters` 表示需要 restart，`dynamicParameters` 表示可 reload，`immutableParameters` 表示不应修改。没有分类证据时不要声明热更新。
+- `reloadAction.targetPodSelector` 可限制 reload 作用 Pod；如果不设置，API 注释说明会考虑 workload 管理的所有 Pod。动态参数实际作用域仍要由引擎证明。
+- `deletedPolicy` 要覆盖删参语义：RestoreToDefault 需要引擎支持，Reset 表示按模板重渲染。
+- 外部 ConfigMap、formatter、default value、Secret 进入配置文件等能力要单独证明；敏感值不要渲染进普通 ConfigMap。
+
+release-1.0 的参数对象链必须按下面的实现路径排查：
+
+| 阶段 | 1.0 对象和实现 | 判断标准 | 常见误判 |
+| --- | --- | --- | --- |
+| 定义可引用 | `ParametersDefinition.status.phase`、`ParamConfigRenderer.status.phase` | phase 为 Available，observedGeneration 跟上 | CR 存在就认为可被 Component 使用 |
+| ComponentParameter 生成 | `controllers/parameters/componentdrivenparameter_controller.go` 根据 Component、CMPD、PCR、PD 和模板 ConfigMap 生成 | `ComponentParameter.spec.configItemDetails[*].name/configSpec/configFileParams` 出现目标 config item | 没有 PCR 或 PD 不匹配时仍期待参数链路生效 |
+| 初始参数归类 | `ClassifyParamsFromConfigTemplate` 读取模板和参数定义 | 用户初始参数进入对应文件，不污染其它文件 | 一个参数名在多文件中含义相同 |
+| runtime diff | `controllers/parameters/config_util.go:createConfigPatch` 比较 last config 和 runtime ConfigMap | 能生成 file-level patch，并判断是否需要 restart | runtime ConfigMap 内容变了就一定 reload |
+| reload/restart 决策 | `controllers/parameters/policy_util.go:resolveReloadActionPolicy` | dynamic + reloadAction 才走 reload；static 或无 reloadAction 走 restart | `dynamicParameters` 写了但没有 reloadAction |
+| 状态落点 | `ComponentParameter.status.configurationStatus[*]` | phase、lastDoneRevision、updateRevision、reconcileDetail 能解释执行结果 | 只看 OpsRequest phase |
+
+`Parameter` CR 是用户 desired 参数入口之一，OpsRequest `Reconfiguring` 也会生成或驱动参数状态。`ComponentParameter` 不是一次性命令，而是 controller 持续消费的 desired/执行模型；错误的 `configItemDetails`、`configFileParams` 或 `userConfigTemplates` 会在后续 restart、scale、upgrade 中继续影响 runtime ConfigMap。修复参数绑定错误时，不要只改 chart；要同时检查 `Parameter`、`ComponentParameter.spec`、`ComponentParameter.status`、runtime ConfigMap 和进程内配置。
+
+release-1.0 参数字段的使用边界：
+
+| 字段 | 1.0 语义 | addon 要怎么写 | 不能外推 |
+| --- | --- | --- | --- |
+| `PD.reloadAction` | Unix signal、shell、TPL script、auto 等 reload 触发方式 | 只给真正支持热更新的参数配置 | 不能让 static 参数自动热更新 |
+| `PD.mergeReloadAndRestart` | 同一次 patch 同时需要 reload 和 restart 时是否合并为 restart | 需要在 mixed patch 用例中验证 | 不是 reload 和 restart 的全局顺序保证 |
+| `PD.reloadStaticParamsBeforeRestart` | 某些引擎要求 static 参数先经 SQL/CLI 设置再重启 | 只在引擎有这个机制时使用 | 不能解决任意 static 参数生效问题 |
+| `PD.deletedPolicy` | 删除参数时 Reset 或 RestoreToDefault | Reset 验模板重渲染；RestoreToDefault 验引擎命令 | 删除 key 后进程自动忘记旧值 |
+| `PCR.configs[*].fileFormatConfig` | 解析 ini/xml/yaml/json/hcl/dotenv/toml/properties/redis/props 等格式 | 每个文件格式单独验证 patch/delete/default 行为 | 格式名相同就说明注释、顺序、转义都保留 |
+| `PCR.configs[*].reRenderResourceTypes` | vscale、hscale、tls、shardingHScale 后触发重渲染 | 只用于配置确实依赖资源、TLS 或拓扑的文件 | scale 后进程一定已 reload |
+| `ConfigTemplateExtension.policy` | 用户模板和默认模板的 patch/replace/add/none 合并策略 | 写清楚用户模板覆盖范围和恢复路径 | 任意外部 ConfigMap 都能安全 merge |
+| `ParametersInFile.parameters[*]=nil` | 参数值为 nil 表示删除该参数 | 删参用例必须覆盖 runtime 文件和进程状态 | 删除 desired 等于删除进程内状态 |
+
+`ComponentParameter.spec.configItemDetails` 是排查参数链路的关键落点。它应该能解释每个 config item 的模板、runtime ConfigMap、hash 和状态；如果 PD/PCR 看起来正确但 reconfigure 未生效，先看 ComponentParameter 是否已经把 desired 写到目标 config item，再看 runtime ConfigMap 和 Pod 是否拿到新的配置。错误的 desired 一旦落入 ComponentParameter，后续 restart/upgrade 可能继续携带错误状态，修复时要先纠正模板绑定和 desired，再考虑是否清理污染对象。
+
+模板渲染能力要按 release-1.0 参数链路验证。formatter/default value 可以帮助把用户参数转成文件格式，但它不替 addon 自动判断静态/动态参数，也不保证删除参数后进程回到默认值。`restartOnFileChange`、`mergeReloadAndRestart`、`reloadStaticParamsBeforeRestart` 这类字段只能说明 controller 和 PD/PCR 的执行路径，最终仍要用进程内查询证明 effective 状态。
+
+真实样本：
+
+- MySQL `paramsdef-57.yaml`、`paramsdef-80.yaml`、`paramsdef-84-mgr.yaml` 和 `pcr-*.yaml` 展示了多版本、多拓扑参数定义。
+- PostgreSQL `paramsdef.yaml` 和 `pcr.yaml` 绑定 postgresql/pgbouncer 配置。
+- Redis `paramsdef-redis.yaml`、`paramsdef-redis-cluster.yaml` 以及 `pcr-redis*.yaml` 展示普通 redis 和 cluster 的差异。
+- ClickHouse `paramsdef-config.yaml`、`paramsdef-keeper.yaml`、`paramsdef-user.yaml` 展示多文件、多组件配置。
+- Kafka `paramsdef.yaml`、`pcr.yaml` 展示 broker/controller/combine 配置拆分。
+
+排查 reconfigure 时按三层看：第一层 PD/PCR/ComponentParameter 是否匹配到目标组件和文件；第二层 runtime ConfigMap 内容是否符合 desired；第三层进程内配置是否真的改变。OpsRequest 成功不等于进程已生效，runtime ConfigMap 更新也不等于进程已 reload。
+
+`ParamConfigRenderer.spec.serviceVersion` 存在，但 release-1.0 的校验和关联路径主要围绕 `componentDef`、`parametersDefs` 和 config template。不要因为写了 serviceVersion 就默认形成完整版本矩阵；每个 serviceVersion 的 PD/PCR、runtime ConfigMap 和进程配置都要用样例单独证明。
+
+参数验收至少要覆盖四类用例：创建时初始参数、动态参数变更、静态参数变更、删参。每类都要记录 desired、rendered、effective 三态：desired 看 `Parameter`/OpsRequest 和 ComponentParameter，rendered 看 runtime ConfigMap 和 revision/status，effective 看 SQL/CLI/config dump。若涉及 hscale/vscale/tls/shardingHScale 重渲染，还要在对应 Ops 后重复检查 runtime ConfigMap 和进程状态。
+
+## 10. 数据保护要同时提供策略和执行脚本
+
+release-1.0 数据保护使用 `BackupPolicyTemplate`、`ActionSet`、`BackupPolicy`、`BackupSchedule`、`Backup`、`Restore`、`BackupRepo` 等 API。完整能力至少需要 BPT 绑定组件、ActionSet 定义执行阶段、脚本实现数据流、BackupRepo 提供仓库、用户示例证明 Backup 和 Restore。
+
+数据保护对象矩阵：
+
+| 对象或阶段 | release-1.0 语义 | addon 要提供什么 | 验收证据 |
+| --- | --- | --- | --- |
+| BackupPolicyTemplate | 根据 `compDefs` 和 method 为组件生成 BackupPolicy | serviceKind、compDefs、target、schedules、backupMethods | 目标 Cluster 生成 BackupPolicy |
+| BPT target | 按 role、strategy、account 选备份目标 | roleProbe、system account、单副本 fallback 验证 | target Pod 和连接账号正确 |
+| backup method | 用户可选备份方法 | method name、actionSetName 或 snapshotVolumes、targetVolumes、env | method 语义单一 |
+| ActionSet backup | 执行 preBackup/backupData/postBackup/preDelete | 工具镜像、命令、状态同步、错误退出 | Backup Job/action 成功且有 artifact |
+| ActionSet restore | 执行 prepareData/postReady | restore 工具、PVC、账号/TLS、postReady | Restore 后目标可连接并数据正确 |
+| BackupRepo | 仓库和凭据 | repo provider、Secret、网络可达 | Backup/Restore Job 看到正确 env/mount |
+| BackupSchedule | 自动创建 Backup | schedule、repoName、enabled 状态 | CronJob/Backup 真实产生 |
+| Restore | 从 Backup 或时间点恢复 | source target、restoreTime、env、PVC、postReady | Restore phase、PVC、目标 Cluster 状态 |
+
+release-1.0 BPT API 明确：`compDefs` 支持精确名、前缀或正则；`backupMethods[*].snapshotVolumes=true` 时可以使用 CSI snapshot，不一定需要 ActionSet；非 snapshot method 要有 `actionSetName`。`TargetInstance.role` 有一个重要边界：如果指定 role 不存在会失败，但单副本 Cluster 会使用唯一实例，即使它不是指定 role。多副本 target 语义不能直接外推到单副本。
+
+BackupPolicyTemplate 生成 BackupPolicy 后，真正执行的是 BackupPolicy/Backup/ActionSet/BackupRepo 组合，而不是 BPT 本身。release-1.0 中 method 可以覆盖全局 target，`snapshotVolumes=true` 可以不需要 ActionSet，`compatibleMethod` 用于增量/差异备份寻找父备份，`versionMapping` 用 serviceVersion 选择 method env。开发时要为每个 method 建最小合同：
+
+| method 维度 | 1.0 字段 | 必须证明 | 不能外推 |
+| --- | --- | --- | --- |
+| 目标选择 | BPT `target` 或 method `target` | role/fallbackRole/strategy/account 选中正确 Pod；单副本 fallback 单独验 | role 名存在等于 target 安全 |
+| 执行方式 | `snapshotVolumes` 或 `actionSetName` | snapshot 产物或 ActionSet Job/exec 产物存在 | snapshot method 可 restore 到任意 StorageClass |
+| 数据卷 | `targetVolumes`、ActionSet `runOnTargetPodNode` | 目标 volume、mountPath、PVC/PV 可访问 | volume 名和数据库数据目录天然一致 |
+| 工具镜像/env | method `env/runtimeSettings/versionMapping`、ActionSet image/env | 每个 serviceVersion 的最终 Job env/image 正确 | runtime image 升级自动升级备份工具 |
+| 参数 | ActionSet `parametersSchema`、Backup/Restore `parameters` | Selective 或工具参数合法并传入脚本 | 参数 schema 证明业务对象选择正确 |
+| 删除和保留 | Backup `deletionPolicy`、retention、preDelete | CR 删除、repo artifact、snapshot/PVC 的保留策略可解释 | 删除 Backup CR 一定删除所有远端数据 |
+
+真实样本：
+
+- MySQL 提供 xtrabackup、incremental、pitr、volume snapshot、mydumper 等 ActionSet/BPT。
+- PostgreSQL 提供 pg_basebackup、pgdump、wal-g、wal-g incremental、PITR。
+- Redis 有 RDB/AOF 或 cluster 相关备份 ActionSet 和 BPT。
+- ClickHouse 有 full/incremental ActionSet 和 BPT。
+- Kafka 的 backup 更偏 topic/metadata 语义，不等价于块设备或数据库全量文件备份。
+- Etcd target leader，ActionSet 提供 data dump/load。
+
+每个 method 都要有 Restore 兼容矩阵：
+
+| method | 新集群 restore | rebuild | PITR/增量链 | TLS | 账号 | 跨版本 | 跨拓扑 | sharding |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| physical/full | 待 release-1.0 样本证明 | 待证明 | 不适用或待证明 | 待证明 | 待证明 | 待证明 | 待证明 | 待证明 |
+| logical | 待证明 | 待证明 | 不适用 | 待证明 | 待证明 | 待证明 | 待证明 | 待证明 |
+| incremental/PITR | 待证明 | 待证明 | 必须证明 base/parent/timeRange | 待证明 | 待证明 | 待证明 | 待证明 | 待证明 |
+| snapshot | 待证明 | 待证明 | 不适用 | 待证明 | 待证明 | 受 StorageClass/CSI 限制 | 待证明 | 待证明 |
+
+Backup 成功不等于 Restore 成功。每个 method 要证明 artifact 位置、工具镜像、formatVersion 或等价格式、账号/TLS、postReady 和目标 topology。空数据、无增量、仓库不可用、旧 Secret 轮换、target Pod 误选，都要有可诊断输出。
+
+release-1.0 的 Backup status 已经有 `formatVersion`、`path`、`kopiaRepoPath`、`persistentVolumeClaimName`、`timeRange`、`target/targets`、`backupMethod`、`encryptionConfig`、`actions`、`volumeSnapshots`、`parentBackupName`、`baseBackupName`、`extras` 等字段。addon 不需要每个字段都使用，但只要声明相应能力，就要把这些 status 作为验收入口。例如 PITR/Continuous 要看 `timeRange`，增量要看 parent/base，snapshot 要看 `volumeSnapshots`，加密要看 `encryptionConfig` 和对应 Secret。
+
+增量、差异和 Continuous 的父链不能靠命名约定。release-1.0 会校验父备份 phase、policy、method/compatibleMethod、结束时间、repo、加密配置和 target 数量；shard 数变化时可能找不到合法父备份。addon 如果支持增量或 PITR，必须写清楚 full/base/parent/continuous method 的组合、schedule 与 on-demand 的差异、`parentBackupName` 是否允许用户指定，以及 shard/topology 变化后的限制。
+
+release-1.0 Restore 和 Rebuild 有几个需要单独写明的边界。Restore 流程会从 Backup 的 cluster snapshot annotation 重建目标 Cluster 的部分 spec，TLS 等 component 级开关可能被恢复流程重写或清空，不能假设源 Cluster 的 TLS 行为原样继承到目标。RebuildInstance 支持 in-place 或 scale-out 替换，并可通过 Backup/Restore CR 准备数据；但多副本从备份重建的注释和实现路径更偏 full physical backup，logical backup 不能直接写成支持 rebuild。Restore readinessProbe 相关实现仍有 TODO，恢复完成必须用 postReady、ReadyConfig、业务连接和数据校验证明。
+
+数据保护的执行面要按消费者拆开验收。Backup method 被 Backup 直接消费，Restore 消费 ActionSet 的 prepareData/postReady 和源 Backup 元数据，RebuildInstance 又通过 operations 路径消费 restore 能力和目标实例成员关系。一个 method 在“新建 Cluster restore”可用，不自动证明“原 Cluster 单实例 rebuild”可用；一个 snapshot method 能产生 VolumeSnapshot，也不证明跨 StorageClass、跨 namespace、跨 topology 或 sharding restore 成立。每增加一个 ComponentDefinition、serviceVersion 或 topology，都要回看 BPT `compDefs`、`versionMapping`、method target、ActionSet image/env 和生成的 BackupPolicy。
+
+Restore API 本身还能表达 `resources`、`prepareDataConfig`、`ReadyConfig`、`env`、`parameters` 等，但这些字段不是 addon 自动完成 restore 的证据。`resources` 只说明要恢复哪些 Kubernetes 资源；`prepareDataConfig.volumeClaims` 和 `volumeClaimsTemplate` 说明恢复 Pod/PVC 如何准备数据；`ReadyConfig` 说明 postReady 阶段如何执行或探测。addon 作者要把“恢复 Kubernetes 对象”“恢复 PVC 数据”“数据库启动并可读写”“账号/TLS/服务恢复”拆成不同验收点。
+
+从已有 `Backup` 恢复新 `Cluster` 时，release-1.0 的用户入口应写成 Restore `OpsRequest`。不要要求 addon 用户手写 `kubeblocks.io/restore-from-backup` annotation；该 annotation 是 operations restore handler 根据源 Backup 和 OpsRequest 输入生成的内部恢复 intent。独立 `dataprotection Restore` CR 只负责 PVC 数据准备和 postReady，不会替用户创建新的 Cluster。
+
+最小示例要包含目标 Cluster 名、源 Backup 名和必要的恢复选项：
+
+```yaml
+apiVersion: operations.kubeblocks.io/v1alpha1
+kind: OpsRequest
+metadata:
+  name: restore-acmedb
+  namespace: demo
+spec:
+  clusterName: acmedb-restore
+  type: Restore
+  restore:
+    backupName: acmedb-backup-20260605
+    backupNamespace: demo
+    restorePointInTime: "2026-06-05T08:00:00Z"
+    volumeRestorePolicy: Serial
+    deferPostReadyUntilClusterRunning: true
+    parameters:
+      - name: restore-mode
+        value: full
+```
+
+这个入口依赖源 Backup 中保存的 cluster snapshot annotation。controller 会先读取 `backupName/backupNamespace`，要求 Backup 已 Completed，continuous backup 则会校验 `restorePointInTime`；随后从 Backup 的 cluster snapshot 反序列化源 Cluster，改成 `spec.clusterName` 指定的新名字和 OpsRequest namespace，并写入恢复 annotation。后续 Cluster/Component reconcile 会基于 annotation 创建 `Restore` 对象、PVC 和 restore Job。addon README 的 restore 示例必须让用户先确认源 Backup 存在、phase 合法、component/sharding label 可识别、method 和 ActionSet 带 restore 阶段、artifact 可访问、Backup 中存在 cluster snapshot；否则新 Cluster 不会被可靠创建或无法完成数据恢复。
+
+Restore OpsRequest 派生出的目标 Cluster 不是源 Cluster 的逐字段复刻。LoadBalancer Service、NodePort、selector、offline instances、TLS issuer、sharding account SecretRef、调度 selector 等字段可能被重置、清理或重写；addon 的连接文档和验收脚本必须以恢复后 live Cluster、Service、Secret 和 Pod spec 为准，不从源 Cluster YAML 推断最终值。
+
+PVC 恢复只覆盖 Backup method `targetVolumes` 声明、且目标 Cluster volumeClaimTemplates 中存在的卷。target volume 名称对不上时，目标 PVC 可能只走普通 provision，不会恢复数据。sharding restore 要说明 source targets 数量和目标 shards 数量的关系；targets 多于 shards 应失败，目标 shards 多于 source targets 时额外 shard 的 skip 行为不能写成数据完整恢复。
+
+restore 示例还要写恢复后的检查链：先看 OpsRequest phase/message，再看新 Cluster 是否创建、Cluster annotation 是否被逐步清理、Component/PVC 是否带 restore intent，最后看 `Restore` phase、restore Job、postReady、业务数据、账号、TLS 和 Service。跨 namespace 时必须显式写 `backupNamespace` 并验证 BackupRepo/Secret/Job 执行面有权限；PITR 只能用于对应 continuous method 和可恢复 timeRange，不能把任意 `restorePointInTime` 当成通用字段。
+
+ActionSet `onError` 字段有 `Continue` 和 `Fail` 两个枚举，但 release-1.0 API 注释明确当前只有 `Fail` 支持，`Continue` 是未来能力。addon 不应把 Continue 当成可用容错策略。需要忽略某个步骤失败时，应在脚本内部显式处理并输出可审计信息，而不是依赖 controller 忽略错误。
+
+BackupRepo 是独立依赖。Backup 会按 Backup label、BackupPolicy `backupRepoName` 或默认 BackupRepo 选择仓库；仓库必须是 Ready。BackupRepo 支持 Mount/Tool 两种 access method，status 里会暴露生成的 StorageClass、PVC、tool config Secret 等。repo 不可用、default repo 冲突、Secret 轮换、PVC/PV retain/delete、BackupRepo 删除被已有 Backup/PVC 阻塞，都应作为数据保护排查入口，而不是归因到 ActionSet。
+
+BackupSchedule 不是 BPT schedules 的简单展示。BPT 可以生成 BackupSchedule；用户也可以看到独立的 BackupSchedule 对象。排查自动备份时要看 BackupSchedule `status.phase`、`status.schedules[*].lastScheduleTime/lastSuccessfulTime/failureReason`、生成的 CronJob/Backup、Backup labels 和实际 Backup status。`cronExpression` 使用 UTC；schedule `name` 为空时会使用 backupMethod 作为名称，多个 schedule 名称必须避免冲突。
+
+## 11. Day-2 运维以内置操作为主
+
+release-1.0 `OpsRequest.spec.type` 支持 `Start`、`Stop`、`Restart`、`Switchover`、`VerticalScaling`、`HorizontalScaling`、`VolumeExpansion`、`Reconfiguring`、`Upgrade`、`Backup`、`Restore`、`Expose`、`RebuildInstance` 等类型。addon 作者不要从 OpsRequest 入口推断能力已经成立；每种 Ops 都依赖底层合同。
+
+Ops 矩阵：
+
+| Ops | release-1.0 入口字段 | 依赖的 addon 合同 | 运行验收 | 常见误用 |
+| --- | --- | --- | --- | --- |
+| Start/Stop/Restart | `start/stop/restart`，空列表表示全部组件 | 启动脚本幂等、readiness、一次性初始化保护 | Pod 重建或恢复后数据不丢 | restart 后重复初始化 |
+| HorizontalScaling | `horizontalScaling` | replicasLimit、memberJoin/memberLeave、sharding 边界 | 新成员加入或旧成员摘除 | 只看 Pod 数量 |
+| VerticalScaling | `verticalScaling` | 资源变更后引擎是否感知 | Pod/cgroup/进程资源状态 | 资源改了但数据库内部未更新 |
+| VolumeExpansion | `volumeExpansion` | VCT 名、PVC、mountPath、文件系统和引擎容量 | PVC、容器内 FS、引擎状态 | VCT 名和 volume 名不一致 |
+| Reconfiguring | `reconfigures` | PD/PCR/ComponentParameter、reload/restart | 文件和进程配置一致 | 只看 Ops Succeed |
+| Expose | `expose.services` | ComponentService、roleProbe、地址脚本 | Service/EndpointSlice/连接 | Service type 和 advertised address 混用 |
+| Switchover | `switchover` | roleProbe、switchover action、roleSelector Service | candidate 成为目标 role，服务切换 | action 成功后不查角色 |
+| Upgrade | `upgrade` | ComponentVersion、镜像、rollout、数据兼容 | old/new 版本和数据正确 | 只升级 runtime image |
+| Backup/Restore | `backup`、`restore` | BPT、ActionSet、BackupRepo、Restore 脚本 | Backup artifact 和 Restore 成功 | 只有 Backup 无 Restore |
+| RebuildInstance | rebuild 字段和 backup/restore 路径 | Restore 兼容矩阵、目标 PVC、postReady、member lifecycle | 单实例恢复并重新加入 | 新集群 restore 成功就声称 rebuild 支持 |
+
+容易误用的 release-1.0 Ops 字段：
+
+| 场景 | 字段 | 1.0 行为要点 | addon 验收 |
+| --- | --- | --- | --- |
+| scale-out 从备份扩容 | `horizontalScaling.scaleOut.fromBackup` | operations 会为新增实例准备 restore 数据 | method 必须支持该目标实例、RestoreEnv、postReady、memberJoin |
+| rebuild 指定来源 | `rebuildFrom.backupName/sourceBackupTargetName/restoreEnv` | rebuild 路径把 restore 能力接入实例替换或 in-place | source target、env merge、PVC、成员重加都要验证 |
+| 单实例原地 rebuild | `rebuildFrom.inPlace` | 不等价于新建 Cluster restore | 先证明数据准备和进程重启不会破坏成员关系 |
+| shard 级操作 | `ops.shards` 或 sharding 相关字段 | 对象选择进入 shard Component 链路 | 不自动证明 rebalance 或跨 shard 数据一致 |
+| Expose | `expose.services[*].roleSelector/podSelector/serviceType` | 只创建或更新 Service | advertised address、EndpointSlice 和客户端连接要另验 |
+| force/cancel/ttl | OpsRequest 状态机字段 | 控制排队、取消和清理 | 不代表业务动作可安全中断或跳过 |
+
+OpsRequest 还有 `force`、`enqueueOnForce`、`cancel`、TTL、precondition deadline、timeout 等状态机字段。它们只说明 operations controller 的队列和执行边界，不是业务事实。事实已经改变但 Ops 失败时，不要直接重试；先看 Cluster/Component/InstanceSet/Pod/PVC/Job、events、action 输出和业务自检，确认幂等安全。
+
+无法由内置 Ops 自然表达的需求写入 gap，不要用隐藏脚本包装成已支持。比如复杂 rebalance、跨 topology 在线迁移、需要人工确认的数据迁移，都应明确限制。
+
+组合操作要按“当前事实”重新判断，不要沿用上一个 Ops 的结论。典型组合包括 Reconfigure 后 Restart、Upgrade 后 Switchover、Scale-in 后 Backup、Restore 后 Rebuild、Stop 后 Delete。每次操作前先确认 Cluster/Component generation 已被观测、InstanceSet rollout 已完成、参数 desired/rendered/effective 三态一致、BackupPolicy/ComponentParameter 仍匹配当前 serviceVersion。否则后一个 Ops 的失败可能只是前一个 Ops 留下的未收敛状态，不应直接归因到 operations controller。
+
+## 12. 常见操作排障要从入口 CR 逐层向下查
+
+release-1.0 的运行问题通常跨多个控制器。排障顺序固定为：入口 CR 的 generation/observedGeneration/phase/message/conditions，被引用 definition/policy/action 的 Available 状态，controller 生成对象，最终 workload，脚本输出，业务自检。
+
+问题域表：
+
+| 问题域 | 第一批对象和字段 | 下一跳证据 | 边界 |
+| --- | --- | --- | --- |
+| 资源引用和 status | Cluster、Component、CMPD、CD、CMPV、PD、BPT、ActionSet 的 status | 生成的 Component、BackupPolicy、ComponentParameter、Job、events | 对象存在不等于可引用 |
+| 发布迁移和 GitOps | 新旧渲染结果、server-side dry-run、live spec | 下游对象 diff | list merge、retainKeys、默认值以 server 结果为准 |
+| 名字和身份 | topology name、component spec name、Component object name、Pod/PVC/Service | 引擎成员 ID、备份 target、shard identity | 不把 Pod 名或 ordinal 当业务成员 ID |
+| 终止和数据保留 | terminationPolicy、deletionTimestamp、finalizers | InstanceSet、Pod、PVC、preTerminate action | 删除卡住先查执行面是否还存在 |
+| 调度、PVC 和存储 | scheduling、runtimeClass、VCT、PVC retention | Pod/PVC events、StorageClass、mountPath | storage 问题常表现为创建失败 |
+| Service 和网络 | Component services、Expose、ServiceRef、serviceVarRef | Service、EndpointSlice、Pod label、连接测试 | Service 有 endpoint 不等于业务 ready |
+| ServiceAccount 和 RBAC | serviceAccountName、policyRules、Job/action SA | Role/RoleBinding、Pod/Job events | runtime Pod 和 Job/action 可能权限不同 |
+| Pod 更新和实例身份 | podUpdatePolicy、podUpgradePolicy、InstanceSet revision | current/updatedReplicas、partition、Pod/PVC | rollout 状态不等于业务兼容 |
+| Action、lifecycle 和 probe | action preCondition、target、container/image、timeout/retry | action worker、stdout/stderr、role/status | action 成功不等于业务收敛 |
+| variables、env 和外部依赖 | vars、ServiceDescriptor/ServiceRef、credential/tls var | 最终 env、config/script、真实连接 | Optional、列表格式、变量刷新要验证 |
+| 参数和 reconfigure | PD、PCR、ComponentParameter、OpsRequest | runtime ConfigMap、reload/restart、进程配置 | PD 匹配错先修 addon，不改 controller |
+| 备份、自动备份和 artifact | BPT、BackupPolicy、BackupSchedule、Backup | target Pod、ActionSet、Repo、Job/artifact | Backup Succeed 不证明 Restore |
+| Restore、scaleOut 和 rebuild | Restore、Cluster restore、RebuildInstance | prepareData/postReady、PVC、memberJoin | 不同消费者要分别验证 |
+| Ops 状态和失败现场 | OpsRequest phase/message/conditions、force/cancel/TTL | Component/InstanceSet/Pod/PVC/action 输出 | Ops 字段只是证据，不是最终事实 |
+
+操作表：
+
+| 操作 | 先查入口对象 | 再查底层对象 | 常见 addon 问题 | 推荐处理 |
+| --- | --- | --- | --- | --- |
+| 创建 Cluster | Cluster topology、componentSpecs、serviceVersion、VCT | CD、CMPD、CMPV、Component、InstanceSet、Pod、Service | topology/name/volume/script 不闭合 | 修 chart 合同和 helper |
+| 删除 Cluster/Component | deletionTimestamp、finalizers、terminationPolicy | InstanceSet、Pod、PVC、preTerminate | action 依赖已消失 Pod | 保留现场，先解释执行面为何消失 |
+| 参数变更 | OpsRequest、PD、PCR、ComponentParameter | template ConfigMap、runtime ConfigMap、reload/restart | PCR `templateName`、PD `fileName` 或参数分类错 | 按参数对象链逐层定位 |
+| restart/stop/start | OpsRequest、Component phase | InstanceSet、Pod、启动脚本 | 启动脚本不幂等 | 修脚本和 readiness |
+| horizontal scale | OpsRequest、Component replicas | InstanceSet、Pod、memberJoin/memberLeave | 成员关系未收敛 | 实现 member lifecycle 或声明限制 |
+| volume expansion | OpsRequest、VCT | PVC、Pod mount、文件系统、引擎容量 | 名称不一致或引擎不感知 | 先验 PVC，再验进程 |
+| switchover | OpsRequest、role status | roleProbe、action、Service endpoint | roleProbe 不稳定或 candidate 处理错 | 先修 roleProbe 和脚本 |
+| backup | BackupPolicy、Backup、BPT | target Pod、ActionSet、Repo、artifact | BPT 未匹配、target role 错、账号错 | 先看 BackupPolicy 生成和 target |
+| restore/rebuild | Restore 或 rebuild Ops | Restore Job/PVC、postReady、目标 Component | 只验证 Backup 未验证 Restore | 每 method 单独 restore 验证 |
+| upgrade | Cluster/Component serviceVersion、CMPV | resolved release、image、rollout、数据 | action/tool image 或参数 schema 未随版本更新 | 先证明版本解析和 rollout，再验数据 |
+
+## 13. 最低验收标准
+
+release-1.0 addon 功能不能只靠 README 声明。每个能力至少要有四类证据：实现文件、渲染对象、运行场景、观测结果。
+
+验收层：
+
+| 验收层 | release-1.0 需要做什么 | 能证明什么 | 不能证明什么 |
+| --- | --- | --- | --- |
+| chart lint/template | 用代表 values 渲染所有关键 topology、版本、TLS、备份和参数组合 | YAML 和 helper 闭合 | controller 消费后仍正确 |
+| server-side dry-run | 对 examples 和关键 CR 做 server-side dry-run | API/schema/defaulting 可接受 | 业务脚本能运行 |
+| 生成对象检查 | apply 后看 Component、InstanceSet、BackupPolicy、ComponentParameter、Job | controller 消费链路成立 | 业务状态已收敛 |
+| live smoke | 创建 Cluster、连接服务、执行最小 Ops、Backup+Restore | runtime 和脚本可用 | 所有边界组合 |
+| 故障用例 | 非法参数、缺 roleProbe、TLS on/off、target 错误、Restore 失败 | 排查路径可执行 | 自动恢复一定安全 |
+
+最低清单：
+
+- 关键 examples 能渲染，并且 helper、模板引用、script key、config key、compDef、BPT、PD、ActionSet 名称闭合。
+- `ComponentDefinition`、`ClusterDefinition`、`ComponentVersion`、`ParametersDefinition`、`BackupPolicyTemplate`、`ActionSet` 进入可引用状态。
+- 最小 Cluster 创建成功，Pod Ready，Service 可连接，脚本和配置文件存在且权限正确。
+- 每个声明支持的 topology 都独立验证，而不是只验 default topology。
+- 参数变更至少验证 PD/PCR/ComponentParameter、runtime ConfigMap、reload/restart 和进程内状态。
+- backup method 必须至少有一次 restore 验证；没有 restore 证据时只能写“支持 backup，restore 未证明”。
+- lifecycle action 必须验证目标选择、重复执行、失败输出和业务后置状态。
+- upgrade 必须验证 resolved serviceVersion、runtime image、action/tool image、参数 schema、备份方法和数据兼容。
+- 删除、scale-in、Stop 后删除必须验证 preTerminate/memberLeave 和 PVC/数据保留边界。
+
+声明才验收的能力：
+
+| 能力 | 最低证据 | 未证明时正文应如何写 |
+| --- | --- | --- |
+| HA/role/switchover | roleProbe、roleSelector Service、switchover action、业务角色查询 | “未证明切主”或“不支持在线切主” |
+| TLS | runtime、action、backup/restore、client 全执行面 | “仅 runtime TLS 已验证” |
+| 参数变更 | PD/PCR/ComponentParameter、runtime ConfigMap、进程配置 | “不支持 Ops reconfigure” |
+| backup/restore | BPT、ActionSet、BackupRepo、Backup artifact、Restore 数据 | “仅 backup 已验证” |
+| PITR/增量 | base/parent/timeRange、archive artifact、restoreTime 演练 | “PITR 未证明” |
+| rebuild | restore 到单实例、PVC、postReady、memberJoin | “新集群 restore 不代表 rebuild” |
+| upgrade | CMPV、镜像、rollout、数据兼容、回滚限制 | “升级路径未证明” |
+| sharding | ShardingDefinition、shard Component、Service/vars、数据迁移限制 | “sharding 部署可用，rebalance 未证明” |
+| 外部依赖 | ServiceRef declaration、Cluster binding、变量、真实连接 | “需要用户提供并重启/重建” |
+
+最终原则：没有 release-1.0 最终对象、执行面、脚本输出和业务自检证据的能力，只能标为“不支持”“未证明”或“当前 API 缺口”，不能写成已支持。
+
+
+## 14. 横向实践规则
+
+遇到故障时，先按对应能力选择排查路径，再回到具体对象和脚本验证。
+
+### 14.1 版本和镜像矩阵要同时覆盖 runtime 与执行面
+
+ComponentVersion 不能只替换主容器镜像。每个 release 至少要列清楚 runtime containers、init containers、lifecycle action、backup/restore ActionSet、参数 reloader、外部工具镜像是否随 serviceVersion 变化。API 注释允许 release image key 指向 lifecycle action 字段名；addon 作者必须用渲染结果和运行时 Pod/action env 证明 key 生效，不能靠字段名猜测。
+
+版本矩阵的验收顺序是：Cluster 或 Component 选择的 serviceVersion，匹配到的 ComponentDefinition，匹配到的 ComponentVersion release，resolved Pod image，resolved action/tool image，PD/PCR/BPT 对该 serviceVersion 的覆盖，最后是数据兼容和回滚限制。任何一步缺证据，都不能把 upgrade 写成已支持。
+
+### 14.2 Chart 名称闭合先于业务调试
+
+release-1.0 addon 中既有 `config/` 也有 `configs/`，既有 `config-template.yaml` 也有 `config-templates.yaml` 或 `redis-config-template.yaml`。这些文件名不是 API 语义；真正的合同是 Helm 渲染后 CMPD `spec.configs[*].name/template/volumeName`、模板 ConfigMap data key、PD `fileName`、PCR `configs[*].templateName`、scripts ConfigMap key 和容器内路径全部闭合。
+
+如果安装、升级或 GitOps sync 失败，先比较渲染对象和 live object，不要直接改 controller。特别关注 ConfigMap 大小、helm resource policy keep、server-side schema 差异、examples namespace/name、addons-cluster values 与 addon 本体 helper 是否同步。
+
+### 14.3 参数问题按 desired、rendered、effective 三态排查
+
+参数链路失败时不要只看 OpsRequest phase。先确认 desired：PD/PCR 是否匹配到目标 ComponentDefinition 和文件，static/dynamic/immutable 是否互斥，用户 patch 是否进入 ComponentParameter。再确认 rendered：runtime ConfigMap 是否按模板和 desired 生成。最后确认 effective：reloadAction 或 restart 是否执行，进程内配置是否变化。
+
+错误 desired 会持久影响后续 restart、scale 和 upgrade。修复时应先纠正 PD/PCR/templateName/fileName，再清理或重建受污染的 ComponentParameter/runtime ConfigMap；不要通过放宽 controller 匹配策略掩盖错误绑定。
+
+### 14.4 lifecycle 和删除问题先保留执行现场
+
+memberJoin、memberLeave、switchover、preTerminate、postStart 等 action 都是业务合同的一部分。排查时必须同时看 action target、目标 Pod 是否仍存在、kbagent/action worker 输出、脚本 stdout/stderr、role/status 和业务成员列表。action 成功只能说明脚本进程结束，不能说明成员关系或角色已经收敛。
+
+删除卡住时，先解释为什么 finalizer 需要的执行面不存在或 action 无法完成。如果 Pod 已全部消失，应追查谁先删除了 Pod、InstanceSet/PVC 是否仍在、terminationPolicy 和 preTerminate 依赖是否合理。`skip preTerminate` 或跳过 finalizer 只能作为明确风险的运维恢复手段，不能覆盖 addon 设计错误。
+
+### 14.5 Service、ServiceRef、账号和 TLS 要覆盖所有执行面
+
+Service 可达不等于客户端地址正确。NodePort、LoadBalancer、hostNetwork、pod direct access、roleSelector Service、advertised address 和脚本写入的 endpoint 要一起验证。ServiceRef 要按 declaration、Cluster binding、最终 env/config、真实连接四步验收；需要提前知道其它组件实例名、跨组件共享配置或依赖刷新时，如果 API 没有自然表达，应写入 gap。
+
+账号和 TLS 不只影响主容器启动。roleProbe、switchover、member lifecycle、backup/restore、rebuild、postReady、client examples 都要能拿到同一套凭据或证书。只证明 Secret/证书存在时，只能写“凭据/证书已生成”，不能写“数据库账号、TLS 连接和所有 action 已可用”。
+
+### 14.6 数据保护按 method 建兼容矩阵
+
+每个 backup method 都要独立证明 target、ActionSet 或 snapshot、BackupRepo env、artifact、format、delete 行为、restore prepareData、postReady 和业务数据校验。Backup Succeed 不能外推 Restore、PITR、RebuildInstance、跨版本、跨 topology、sharding 或 TLS 场景。
+
+BPT `compDefs` 是 topology 覆盖矩阵的一部分。每增加一个 ComponentDefinition 或 topology，都要重新确认对应 BackupPolicy 是否生成、target role 是否存在、单副本 fallback 是否符合预期。PITR/增量链还要证明 base/full backup、parent、archive path、timeRange 和 restoreTime。
+
+### 14.7 常见排查入口
+
+创建失败：Cluster -> ClusterDefinition/ComponentDefinition/ComponentVersion -> Component -> InstanceSet/Pod/PVC/Service -> scripts/configs -> 业务连接。重点看 topology/component 名、volumeName/mountPath、script key/defaultMode、serviceVersion resolved image。
+
+参数未生效：OpsRequest -> PD/PCR -> ComponentParameter -> runtime ConfigMap -> reload/restart action -> 进程内查询。重点看 `templateName`、`fileName`、参数分类和 desired 污染。
+
+scale/switchover 失败：OpsRequest -> Component/InstanceSet -> roleProbe/member action -> Service endpoints -> 业务成员状态。重点看 target selector、candidate env、member list 和脚本幂等。
+
+backup/restore 失败：BPT/BackupPolicy -> Backup/Restore -> ActionSet/Repo -> Job/action output -> artifact/PVC -> postReady -> 数据校验。重点看 method 兼容矩阵和 target role。
+
+删除卡住：Cluster/Component deletionTimestamp -> finalizers -> InstanceSet/Pod/PVC -> preTerminate/memberLeave 输出 -> 外部资源。重点看执行面是否还存在，跳过 finalizer 只能作为风险恢复。
+
+升级失败：Cluster/Component serviceVersion -> CMPV release -> Pod/action/tool image -> PD/PCR/BPT version coverage -> rollout -> 数据兼容。重点看 action/tool image 是否也版本化。
+
+
+### 14.8 release-1.0 实现边界
+
+定义对象的 status 是第一道门。ClusterDefinition、ComponentDefinition、ComponentVersion、ParametersDefinition、BackupPolicyTemplate、ActionSet 创建成功后，仍要看 observedGeneration、phase/message 和 controller event；定义对象未 Available 时，不要继续追业务脚本。
+
+lifecycle action 不是通用 shell hook。release-1.0 中 action `preCondition` 主要用于 postProvision；不要假设所有 action 都有同等前置条件。`exec.command` 是命令数组，不是 shell 字符串；需要管道、重定向或多命令时，脚本应显式使用 `sh -c` 或独立脚本文件。
+
+变量注入有顺序和作用域。表达式只能依赖已经解析出的变量；credential 变量用于 Pod/action env，不应假设可以直接参与普通 ConfigMap 模板渲染。ServiceRef 跨 namespace credential、legacy 字段和 serviceDescriptor/clusterServiceSelector 的优先级要用最终 env 和连接测试确认。
+
+数据保护模板同步也有边界。BPT 生成 BackupPolicy 后，method-level target 可能覆盖全局 target；snapshot method 可以不需要 ActionSet；已有 BackupPolicy 是否跟随模板更新，要看同步注解和 controller 行为。修改 BPT 后必须重新验证目标 Cluster 上的 BackupPolicy，而不是只看模板 YAML。
+
+## 15. 通用证据门禁和发布验收
+
+### 15.1 四级证据门禁
+
+每个能力都按四级证据验收：Chart 能渲染、引用对象能被 controller 消费、生成对象符合预期、数据库或工具执行面真的完成。任何一级缺失，都不要把能力写成 release-1.0 已支持；如果字段存在但生成对象或业务自检缺失，应先修 addon 合同或记录 gap/ambiguity，而不是修改 controller 让单个样例跑通。
+
+### 15.2 名称闭合要覆盖 data key 和脚本 key
+
+Chart 命名闭合不只检查 CR 名称，还要检查 ConfigMap 名、ConfigMap `data` key、`ParametersDefinition.spec.fileName`、`ParamConfigRenderer.spec.configs[*].templateName`、ComponentDefinition `configs[*].name`、script ConfigMap key、lifecycle command 中的脚本路径。参数链或生命周期链断开时，先找这条链的断点，不要改 controller 的匹配策略。
+
+### 15.3 ComponentDefinition 要落到 workload、PVC 和业务 identity
+
+ComponentDefinition 的 `services`、`podService`、`volumeClaimTemplates`、`roles`、`lifecycleActions`、`configs` 和 `vars` 都只是蓝图。创建失败时按 `ComponentDefinition -> Component -> workload/PVC/Service/ConfigMap/Job -> Pod/action output -> database self-check` 追踪。`replicasLimit`、`roleSelector`、`highWatermark` 或 `updateStrategy` 只表达 controller 可消费的意图，不自动证明 scale、切主、只读或升级的业务语义。
+
+### 15.4 Topology、orders 和 sharding 是独立验收维度
+
+多 topology addon 必须逐个验 `componentDef` 匹配、`serviceVersion` 解析、`orders.provision/update/terminate` 和生成 Component。Sharding 对象链能生成不等于数据自动迁移或 rebalance；如果 addon 需要自动迁移 shard 数据，但 release-1.0 没有实现证据，只能标为未证明或 gap，不能靠组合字段推导支持。
+
+### 15.5 版本矩阵要覆盖 runtime、action 和数据保护工具
+
+`ComponentVersion` 的验收范围至少包括 runtime 镜像、lifecycle/action 工具镜像、backup/restore 工具镜像、BPT `versionMapping`、examples 中的 `serviceVersion`。不要把 Chart `appVersion`、Chart `version` 或默认 latest 选择当成 API 合同。升级能力必须证明 runtime 与执行面镜像同步，否则只能写成单项镜像替换已验证。
+
+### 15.6 生命周期动作要保存现场并验证业务结果
+
+memberJoin、memberLeave、switchover、preTerminate、readonly/readwrite 这类动作都要同时验 target 选择、action image/container、脚本参数、timeout/retry、退出码、可审计输出和数据库业务结果。删除卡住时，如果 Pod 已经不存在，先查 finalizer、事件、Job/action 输出和业务成员状态；跳过 preTerminate 只能作为明确风险的恢复手段，不能掩盖 addon 脚本不可重入或成员清理合同错误。
+
+### 15.7 ServiceRef、账号和 TLS 要按执行面建矩阵
+
+ServiceRef、credential Secret、TLS Secret、podService 和 role service 的验证要覆盖 runtime、readiness、roleProbe、lifecycle action、backup、restore、client 连接。`optional` 只能说明依赖缺失时 controller 是否允许继续生成对象，不能证明脚本能接受空值。Secret 存在也不等于数据库用户已创建、证书路径正确或工具镜像已挂载。
+
+### 15.8 参数问题按 desired、rendered、effective 三态收敛
+
+release-1.0 参数排查要固定看三态：`ComponentParameter` 中的 desired、runtime ConfigMap 中的 rendered、数据库进程中的 effective。`reloadAction` 成功只能证明执行过动作；静态参数、`restartOnFileChange`、`mergeReloadAndRestart`、`deletedPolicy`、formatter 和用户模板合并都要分别验。外部任意 ConfigMap 合并不是 release-1.0 的自然能力，不能用参数链字段强行解释。
+
+### 15.9 数据保护按 method 建兼容矩阵
+
+每个 backup method 都要记录 target role、backup type、ActionSet、BackupRepo 需求、artifact 路径、是否可 restore、是否可 rebuild、是否可作为 incremental/differential/continuous parent。`Backup.status.phase=Completed` 只说明备份控制面完成，不能外推 artifact 完整、restore 可用或 PITR 成功。BackupRepo、BackupSchedule 和 parent backup chain 必须作为独立排查入口。
+
+### 15.10 Day-2 操作要定义完成条件
+
+Restart、ScaleOut、ScaleIn、VerticalScaling、VolumeExpansion、Switchover、Rebuild、Upgrade 的完成条件不能只看 OpsRequest phase。每个操作都要继续查 Component/workload/PVC/Job/action output 和数据库状态：成员列表、读写角色、参数生效、磁盘识别、数据目录、工具镜像版本等。无法通过 release-1.0 API 自然表达的操作前置条件或回滚语义应进入 gap。
+
+### 15.11 排障要有停止条件
+
+排障路径从入口 CR 开始，但不能停在入口 CR。常用停止条件是：引用对象不存在或未 Available，生成对象缺失，action/Job 明确失败，业务自检无法证明，或需求本身超出 release-1.0 API。到达这些停止条件后，应修 addon chart/script、补验收或记录 gap/ambiguity，不要为了单个失败样例修改 controller 合同。
+
+### 15.12 发布验收按能力声明组织
+
+发布验收不是按文件数量组织，而是按能力声明组织。每项声明能力至少覆盖：Helm render、CRD/schema、controller 生成对象、live smoke、失败路径和限制边界。声明支持 TLS、backup、restore、reconfigure、scale、upgrade、ServiceRef 时，都要给出对应的最小正反例；声明不支持时也要写清楚，避免后续 agent 拼 workaround。
+
+## 16. 高风险能力验收矩阵
+
+字段存在但消费者不完整、语义不清或缺少真实 addon 证据的，只能写成“未证明”“需要验证”或进入 gap/ambiguity。
+
+### 16.1 排障和验收要到达“下一跳”和“停止条件”
+
+release-1.0 的排障不能只列入口对象。每类问题都要写清楚下一跳对象、停止条件和推荐处理，避免在最后一个报错处直接修改 controller。
+
+| 问题域 | 入口 | 下一跳 | 停止条件 | 推荐处理 |
+| --- | --- | --- | --- | --- |
+| 资源引用和 status | Cluster、Component、CMPD、CD、CMPV、PD、BPT、ActionSet | 引用方对象、`observedGeneration`、phase/message、event | 引用对象不存在、未 Available、generation 未追上 | 修 chart 引用或等待/重建定义对象，不继续调业务脚本 |
+| 发布迁移和 GitOps | 新旧 Helm 渲染、server-side dry-run、live spec | Component、InstanceSet/PVC、BackupPolicy、BackupSchedule、ComponentParameter | server 最终对象与本地渲染不一致 | 以 apiserver/defaulting 和 live object 为准，写明保留/迁移/删除策略 |
+| 名字和身份 | topology name、component name、Component object name、Pod/PVC/Service name | 引擎成员 ID、备份 target、shard identity、持久数据里的 identity | 名称能渲染但业务 identity 不一致 | 修脚本 identity 映射，不把 ordinal 或 Pod 名当稳定业务身份 |
+| 终止和数据保留 | deletionTimestamp、finalizers、terminationPolicy | InstanceSet、Pod、PVC、preTerminate/memberLeave action、Backup/BackupRepo | action 所需 Pod 或 PVC 已不存在 | 先解释执行面为何消失；跳过动作只能作为风险恢复，不算删除流程验收 |
+| 调度、PVC 和存储 | scheduling、runtimeClass、VCT、PVC retention | Pod/PVC event、StorageClass、mountPath、文件系统、数据库容量查询 | PVC 已扩容但进程未识别 | 先验 K8s 存储，再验引擎内部容量刷新 |
+| Service 和网络 | CMPD services、Expose、ServiceRef、serviceVarRef、podService、hostNetwork | Service、EndpointSlice、Pod label、注入 env/config、连接测试 | Service 有 endpoint 但业务连接失败 | 修 Service selector、地址格式、advertised address 或脚本消费逻辑 |
+| ServiceAccount 和 RBAC | `serviceAccountName`、`policyRules`、Restore/Backup serviceAccountName | Pod/Job 使用的 SA、Role/RoleBinding、event | runtime Pod 有权限但 action/backup/restore Job 无权限 | 分执行面补 RBAC；不要假设主 Pod 权限自动继承到 worker |
+| Action、lifecycle 和 probe | action preCondition、target、handler、container/image、timeout/retry | action worker、volumeMount、stdout/stderr、exit code、role/status、业务状态 | action exit 0 但业务状态未变 | 修脚本幂等和后置校验，不把 timeout/retry 当语义证明 |
+| variables、env 和外部依赖 | CMPD vars、Cluster serviceRefs、ServiceDescriptor、credential/tls var | 最终 env、rendered config/script、真实连接 | Optional 缺失、列表格式或 credential 解析不符合脚本预期 | 写明变量格式和缺失行为；API 无法表达的刷新/共享需求进 gap |
+| 参数和 reconfigure | OpsRequest、PD、PCR、ComponentParameter | template ConfigMap、runtime ConfigMap、reload/restart、进程配置 dump | desired/rendered/effective 任一层断开 | 按三态定位；PD/PCR 绑定错先修 addon，不改匹配策略 |
+| 备份和 artifact | BPT、BackupPolicy、BackupSchedule、Backup | method、target Pod、ActionSet、BackupRepo、Job、artifact、formatVersion | Backup Completed 但 artifact/restore 未验 | 只能写 backup 已完成；restore/rebuild/PITR 仍需独立矩阵 |
+| Restore、scaleOut 和 rebuild | Restore、HorizontalScaling `scaleOut.fromBackup`、RebuildInstance | prepareData、postReady、PVC、sourceBackupTargetName、memberJoin、Service endpoint | 恢复数据写入但目标实例未加入业务拓扑 | 区分新集群 restore、scaleOut 和 rebuild，分别验收 |
+| Ops 状态和失败现场 | OpsRequest phase/message/conditions、force/cancel/TTL | Component、InstanceSet/Pod/PVC、Job/action output、业务自检 | Ops phase 与业务状态不一致 | 以底层对象和业务自检为准，保留失败现场后再决定重试或修 addon |
+
+### 16.2 Restore、Rebuild 和 scaleOut 要按消费者建矩阵
+
+release-1.0 同时存在 `Restore`、`RebuildInstance` 和 `HorizontalScaling.scaleOut.fromBackup` 这些消费者。它们可以共享 Backup、ActionSet 和 artifact，但不是同一个能力。一个 method 能 restore 到新集群，不等于能 rebuild 原实例，也不等于能用于 scaleOut 新副本。
+
+| 消费者 | release-1.0 入口 | 必须证明的对象链 | addon 必须自证的业务结果 | 不能外推的结论 |
+| --- | --- | --- | --- | --- |
+| 新集群 Restore | `dataprotection.kubeblocks.io/v1alpha1 Restore` | Backup、ActionSet restore、prepareData、ReadyConfig/postReady、Restore Job/PVC | 目标 Cluster/Component ready，数据可读写，账号/TLS 可用 | 不证明 RebuildInstance、scaleOut 或跨 topology restore |
+| PITR Restore | Restore `restoreTime` + continuous/PITR backup | base backup、parent chain、timeRange、archive artifact、restoreTime 格式 | 恢复到目标时间点，业务数据符合预期 | 不证明任意时间点都有可用归档 |
+| K8s 资源恢复 | Restore `resources.included` | 被 include 的 GroupResource、labelSelector、恢复后的 K8s 对象 | 资源对象恢复成功 | 不等于数据库数据恢复成功；exclude 仍是 TODO 边界 |
+| RebuildInstance | OpsRequest `rebuildFrom` | backupName、sourceBackupTargetName、restoreEnv、目标 instance、inPlace/replace、postReady/memberJoin | 被 rebuild 实例数据正确并重新加入复制组 | 不证明逻辑备份可用于多副本 rebuild；API 注释已限制多副本更适合 full physical backup |
+| scaleOut.fromBackup | OpsRequest `horizontalScaling.scaleOut.fromBackup` | backup、newInstances/replica change、restore prepareData、memberJoin | 新实例从备份拉起并加入成员列表 | 字段注释说明只对非 sharding component 有效；不证明 shard scale 或 rebalance |
+| rebuild 后补偿动作 | 真实 addon 的 post-rebuild 脚本或 OpsDefinition | post-rebuild action、目标 instance、业务元数据 | 引擎内部元数据完成修复 | 自定义或 addon 私有补偿不是通用 KB API 合同 |
+
+数据保护 method 的兼容矩阵至少包含这些列：method name、backup type、target role、ActionSet、BackupRepo 需求、artifact 类型、是否支持新集群 restore、是否支持 PITR、是否支持 RebuildInstance、是否支持 scaleOut.fromBackup、是否支持 sharding/topology 变化、需要的账号/TLS/env、已验证 addon 示例。没有验证的格子写“未证明”，不要留空让后续 agent 猜。
+
+### 16.3 网络、Service、RBAC 和 worker 执行面要分开验
+
+release-1.0 的主 Pod、lifecycle action、backup Job、restore Job、postReady Job 不是同一个执行面。主 Pod 能启动、Service 能连通、Secret 能读取，都不能自动外推到其它 worker。
+
+| 执行面 | 需要检查 | release-1.0 证据入口 | 常见错误 |
+| --- | --- | --- | --- |
+| runtime Pod | PodSpec、volumeMount、env、SA、ports、hostNetwork、hostNetworkVarRef | CMPD runtime、生成 Pod、真实 addon 中 Redis/MongoDB hostNetwork 样例 | 脚本读取 host IP/port，但 Service 或 env 格式不同 |
+| Service/Endpoint | Service type、selector、roleSelector、podService、EndpointSlice、publish/not-ready 行为 | CMPD services、生成 Service/EndpointSlice、Kafka/Redis/Etcd podService 样例 | Service 有 endpoint 但 role 不对或 advertised address 不对 |
+| ServiceRef | declaration、Cluster binding、ServiceDescriptor、credential、namespace | `pkg/controller/component/service_reference.go`、ServiceDescriptor controller | 跨 namespace credential 被禁止或 Secret key 未校验到业务可用 |
+| lifecycle action | target、container/image、volumeMount、SA/RBAC、timeout/retry | lifecycle executor、kbagent、action output | 默认容器或工具镜像与 runtime 版本不一致 |
+| backup worker | BackupPolicy serviceAccountName、ActionSet env、BackupRepo mount/tool secret | Backup/ActionSet/BackupRepo controller 和 Job | runtime TLS/账号未传递到 backup 工具 |
+| restore worker | Restore serviceAccountName、prepareData scheduling、ReadyConfig、postReady | Restore API 和 restore manager | prepareData 成功但 postReady 或业务连接失败 |
+| RBAC | Component `policyRules`、runtime SA、Job/action SA | final Pod/Job SA、Role/RoleBinding、event | 组件 Pod 有权限，restore/action Job 没权限 |
+
+ServiceDescriptor 在 release-1.0 中会校验基础字段和 SecretRef 是否存在，但实现里没有验证 Secret data key 的完整性。因此不能把 “ServiceDescriptor Available” 当成外部服务凭据可用证明；必须继续验证最终 env/config 和真实连接。ServiceRef 的 credential 跨 namespace 也不是任意可用能力，代码会禁止跨 namespace credential 变量引用；需要跨 namespace 外部依赖时，应使用明确的 ServiceDescriptor 和权限/凭据交付方式，并声明限制。
+
+### 16.4 高风险能力最低验收清单
+
+release-1.0 addon 声明相关能力时，至少提供下面这些证据：
+
+- 排障验收：至少能对创建、删除、reconfigure、scale、switchover、backup、restore/rebuild、upgrade 各给出入口 CR、下一跳对象、停止条件和推荐处理。
+- Restore/Rebuild/scaleOut 验收：每个 backup method 至少填一张消费者矩阵；未证明的消费者显式写“未证明”。
+- 网络和 worker 验收：runtime Pod、lifecycle action、backup Job、restore Job、postReady Job 分别检查 env、SA/RBAC、volumeMount、TLS/credential、工具镜像和业务连接。
+- Controller 修改边界：如果一个问题只能通过修改 KB controller 才能让单个 addon 跑通，但 API 合同、生成对象或业务自检证据不足，应先判定为 addon 合同问题、ambiguity 或 gap。

--- a/docs/developer_docs/kubeblocks-addon-development-practice-guide-v1.1.zh-CN.md
+++ b/docs/developer_docs/kubeblocks-addon-development-practice-guide-v1.1.zh-CN.md
@@ -1,0 +1,572 @@
+# KubeBlocks Addon 开发实践指南 release-1.1
+
+适用版本：KubeBlocks release-1.1 和 `kubeblocks-addons` release-1.1。
+
+适用对象：addon 开发者和负责开发 addon 的 agent。核心样本包括 MySQL、PostgreSQL、Redis、ClickHouse、Kafka、Etcd；扩展样本包括 MongoDB、Elasticsearch、Milvus、MinIO、Pulsar、RabbitMQ。
+
+## 1. 各环节都要先写清楚合同
+
+addon 开发不是把 YAML 字段填满，而是为每个能力建立可验证合同。release-1.1 的核心 apps API 使用 `apps.kubeblocks.io/v1`，主要包括 `Cluster`、`ComponentDefinition`、`ClusterDefinition`、`ComponentVersion`、`ShardingDefinition`、`ServiceDescriptor`。参数、数据保护和运维主要使用 `parameters.kubeblocks.io/v1alpha1`、`dataprotection.kubeblocks.io/v1alpha1`、`operations.kubeblocks.io/v1alpha1`。
+
+实践判断以四类证据闭环：addon 声明、controller 消费点、运行时对象、业务自检结果。四类证据缺一类时，只能把结论写成待验证、限制或 gap。
+
+| 环节 | addon 必须声明的合同 | release-1.1 controller 主要消费点 | 常见误判 | 先查什么 |
+| --- | --- | --- | --- | --- |
+| Chart 组织 | helper 统一生成名称、label、模板引用、版本前缀、脚本和配置 key | Helm 渲染后的 CR、server-side dry-run 后的对象 | 一个 values 能渲染就认为所有 topology 闭合 | `helm template`、server dry-run、最终引用关系 |
+| 组件蓝图 | runtime、volumes、configs、scripts、services、roles、vars、accounts、TLS、lifecycle、RBAC | `controllers/apps/component` 和 synthesized component | 把动态副本、资源、存储容量写死到蓝图里 | CMPD status、Component、InstanceSet/Pod/PVC/Service |
+| 拓扑 | topology、components、shardings、orders、default | `controllers/apps/cluster` normalization 和 topology 解析 | 未设置 default 却假设选第一个 | Cluster resolved topology、生成的 Component 列表 |
+| 版本管理 | CMPD 名称、serviceVersion、CMPV releases、镜像 key、工具镜像矩阵 | ComponentDefinition matching、ComponentVersion compatibility、workload image override | 宽正则能命中就等于版本治理完成 | CMPV status、resolved serviceVersion、Pod/action/tool image |
+| 配置参数 | CMPD config name、模板 ConfigMap、PD fileName、PCR configs、schema、reload/restart 分类 | `controllers/parameters`、ComponentParameter、runtime ConfigMap | `templateName`、模板 ConfigMap 名、runtime ConfigMap 名混用 | PD、PCR、ComponentParameter、runtime ConfigMap、进程内值 |
+| 变量和服务 | vars 来源、Service、ServiceRef、ServiceDescriptor、外部依赖、地址格式 | var resolver、service builder、ServiceDescriptor controller | 脚本私下约定变量格式 | 最终 Pod/action/backup/restore env、Service、EndpointSlice、连接自检 |
+| 账号和 TLS | systemAccounts、accountProvision、credential vars、证书挂载、worker 权限 | component validation、action executor、backup/restore job、脚本 | 账号 Secret 存在就等于数据库内权限可用 | Secret、accountProvision 输出、Job/Pod SA、实际连接和权限 |
+| lifecycle | roleProbe、availableProbe、memberJoin/Leave、switchover、preTerminate、dataDump/dataLoad | lifecycle executor、kbagent、component deletion/scale、Ops switchover | 脚本退出 0 等于业务状态收敛 | action 输入、target Pod、role/status、业务成员状态 |
+| 内置 Ops | 每种 Ops 的底层前提、目标对象和完成条件 | `controllers/operations` 和 `pkg/operations` | OpsRequest Succeed 等于业务完成 | OpsRequest、Component、InstanceSet/PVC/Service、脚本和业务状态 |
+| 数据保护 | BackupPolicyTemplate、ActionSet、BackupRepo、method、target、脚本、artifact | `controllers/dataprotection` 和 `pkg/dataprotection` | 只有 ActionSet 就声称支持备份 | BackupPolicy 是否生成、target/actionSet/repo/artifact/restore |
+| Restore/Rebuild | source backup、target mapping、prepareData、postReady、账号/TLS 兼容 | restore manager、operations rebuild flow、restore jobs | Backup 成功等于 Restore 成功 | Restore Job/PVC、目标 Component、memberJoin、数据健康检查 |
+| Upgrade/Rollout | serviceVersion、ComponentVersion、镜像、rollout、数据兼容 | ComponentVersion、workload rollout、operations upgrade | runtime image 能启动就等于升级支持 | old/new serviceVersion、Pod image、action image、BPT/PD 版本 |
+| Sharding | ShardingDefinition、shard template、shardsLimit、shard lifecycle | sharding/component transformers | 多副本等于 sharding | ShardingDefinition、shard Component、Service/vars、数据迁移边界 |
+| 操作排障 | 创建、删除、参数、scale、backup/restore、upgrade 的对象链 | cluster/component/operations/dataprotection/parameters 控制器 | 只看最后一个报错 | 从入口 CR 到生成对象再到脚本和业务状态 |
+
+每增加一个能力，都要能说明对象关系、controller 消费方式、运行验证和限制边界。控制器能接受字段，只说明 control plane 有入口；addon 能否作为产品能力交付，取决于最终对象、执行面和业务自检是否闭合。
+
+## 2. 先定义 addon 的工作边界
+
+release-1.1 的 addon 首先是 Helm chart。真实仓库里有三类入口：`addons/<name>` 放 KubeBlocks 定义对象和脚本，`addons-cluster/<name>` 放可安装的 Cluster chart，`examples/<name>` 放用户 CR 示例。定义对象以 `addons/<name>` 为主；验收用户路径时必须同时看 `addons-cluster/<name>` 和 `examples/<name>`。
+
+真实 addon 通常包含 `Chart.yaml`、`values.yaml`、`templates/`、配置模板目录、脚本目录、脚本单测目录和 examples。历史目录名不完全统一；新 addon 应固定单复数和文件命名，避免 `config/configs`、`config-template.yaml/config-templates.yaml`、脚本 ConfigMap 和脚本源码之间反复猜测。
+
+命名应按职责稳定下来：定义对象放在 `templates/`，配置源文件放在 `config/`，执行脚本放在 `scripts/`，用户安装入口放在 `addons-cluster/<engine>`，可直接验收的示例放在 `examples/<engine>`。模板文件名建议使用单数资源语义，例如 `clusterdefinition.yaml`、`componentdefinition-<component>.yaml`、`componentversion-<component>.yaml`、`parametersdefinition-<component>.yaml`、`parameterconstraint-<component>.yaml`、`config-template-<component>.yaml`、`script-<component>.yaml`、`actionset.yaml`、`backuppolicytemplate.yaml`。脚本源码名应表达动作语义，例如 `start.sh`、`role-probe.sh`、`member-join.sh`、`member-leave.sh`、`switchover.sh`、`reconfigure.sh`、`backup.sh`、`restore.sh`。
+
+代表性 release-1.1 addon 样本：
+
+- MySQL：`addons/mysql/templates/clusterdefinition.yaml`、`cmpd-mysql80.yaml`、`cmpd-mysql84.yaml`、`cmpd-proxysql.yaml`、`cpmv.yaml`、`backuppolicytemplate.yaml`、`actionset-xtrabackup.yaml`、`paramsdef-80.yaml`、`pcr-80.yaml`。
+- PostgreSQL：`addons/postgresql/templates/cmpd.yaml`、`clusterdefinition.yaml`、`cmpv.yaml`、`paramsdef.yaml`、`pcr.yaml`、`backuppolicytemplate.yaml`、`actionset-wal-g.yaml`、`actionset-pgbasebackup.yaml`。
+- Redis：`addons/redis/templates/clusterdefinition.yaml`、`cmpd-redis.yaml`、`cmpd-redis-cluster.yaml`、`shardingdefinition.yaml`、`cmpv-redis.yaml`、`backuppolicytemplate.yaml`、`backupactionset.yaml`、`paramsdef-redis.yaml`、`pcr-redis.yaml`。
+- ClickHouse：`addons/clickhouse/templates/clusterdefinition.yaml`、`shardingdefinition.yaml`、`cmpd-ch.yaml`、`cmpd-keeper.yaml`、`cmpv.yaml`、`paramsdef-config.yaml`、`pcr-ch.yaml`、`backuppolicytemplate.yaml`、`actionset.yaml`。
+- Kafka：`addons/kafka/templates/clusterdefinition.yaml`、`cmpd-broker.yaml`、`cmpd-controller.yaml`、`cmpd-combine.yaml`、`cmpv-broker.yaml`、`cmpv-controller.yaml`、`paramsdef.yaml`、`pcr.yaml`、`backuppolicytemplate.yaml`、`actionset.yaml`。
+- Etcd：`addons/etcd/templates/cmpd.yaml`、`cmpv.yaml`、`backuppolicytemplate.yaml`、`actionset.yaml`。
+- 扩展样本：MongoDB 使用 `cmpd-config-server.yaml`、`cmpd-mongodb-shard.yaml`、`cmpd-mongos.yaml`、`shardingdefinition.yaml` 和多 ActionSet；Elasticsearch 拆 6/7/8 版本 ComponentDefinition 和 `cmpv-es.yaml`、`cmpv-kibana.yaml`；Milvus 拆 standalone/data/index/query/proxy/minio/mixcoord；Pulsar 拆 bookkeeper/broker/proxy/zookeeper/bkrecovery；MinIO 和 RabbitMQ 是轻量单组件样本。
+
+chart 层先做闭合检查，再谈业务语义。至少用代表性 values 渲染 standalone、HA、proxy、sharding、TLS on/off、不同 serviceVersion、备份恢复开关等组合，确认 helper、ConfigMap key、script key、`templateName`、`compDef`、BPT `compDefs`、PD `fileName`、ActionSet 名称、examples 中的名字全部闭合。
+
+发布和 GitOps 验收要保存三类结果：旧版渲染、新版渲染、server-side dry-run 或 live object diff。release-1.1 API 中多处 list 字段使用 merge/retainKeys，例如 Cluster component 的 `volumeClaimTemplates` 和 OpsRequest 的 `volumeClaimTemplates`；不能只用文本 diff 判断最终对象。
+
+Chart 默认 values 也属于合同。默认 CPU、memory、storage、image registry、pull secret、TLS 开关、backup repo 名称、serviceVersion、topology、terminationPolicy 都要能生成可运行对象；默认值只适合 demo 时必须在 README 和 examples 中写清楚生产限制。镜像 registry、工具镜像、init container、backup/restore image 和 reloader/action image 要同时可配置，不能只让 runtime image 可替换。
+
+`values.schema.json` 只能作为用户输入约束的一部分。它能提前拦截类型、枚举、必填和范围错误，但不能证明 helper 生成的对象能被 apiserver 接受，也不能证明 controller 会按预期消费。schema、values、templates、examples 四者要一起维护：schema 允许的 topology、serviceVersion、storage class、TLS、backup method、expose service type 都必须有对应模板分支和示例；模板分支存在但 schema 不允许，用户入口仍然不可用。
+
+发布验收按三层 diff 做。第一层是 chart render diff，看 helper、labels、ownerRef、ConfigMap data key、script key、templateName、compDefs、serviceVersion 是否变化；第二层是 server-side dry-run/diff，看 CRD schema、默认值、merge/retainKeys 和不可变字段；第三层是 live object diff，看 Component、InstanceSet、PVC、Service、BackupPolicy、ComponentParameter、Job 是否被 controller 重新生成或保留。只有三层都能解释，才说明发布变化可审计。
+
+Helm uninstall、feature disable 和 chart 升级要区分定义对象和运行对象。删除一个模板文件不等于集群中对应 CR、Role、ServiceAccount、BackupPolicy、BackupSchedule、PVC 或 repo artifact 已被安全处理；保留策略、手工迁移步骤和不可回滚字段要在发布说明中写清楚。定义对象被删除后，已有 Cluster 是否继续引用旧对象、是否需要先升级 Cluster spec、是否需要保留模板 ConfigMap，都要在 live diff 中验证。
+
+## 3. 用 ComponentDefinition 表达组件蓝图
+
+release-1.1 的 `ComponentDefinition` 是组件静态蓝图。它描述 runtime PodSpec、volumes、configs、scripts、services、vars、systemAccounts、TLS、roles、lifecycleActions、ServiceRefDeclarations、update 策略、hostNetwork 和 RBAC。Cluster 的 `componentSpecs` 提供实例化时的动态输入，例如副本数、资源、存储容量、调度、TLS 开关、serviceRefs、serviceVersion、外部服务绑定、用户覆盖配置和 instances。
+
+最小组件要能闭合以下关系：
+
+- `spec.runtime.containers[*].volumeMounts[*].name` 必须能在 `spec.volumes`、`spec.configs[*].volumeName`、`spec.scripts[*].volumeName` 或 runtime volumes 中找到。
+- `spec.configs[*].name` 是配置 item 名称和参数链路绑定键；`spec.configs[*].template` 是模板 ConfigMap 名；`spec.configs[*].volumeName` 决定挂载到哪个 volume。
+- `spec.scripts[*].template` 提供脚本 ConfigMap；`defaultMode` 要让容器内脚本可执行，并以最终 Pod spec 和容器内文件权限为准。
+- `spec.services[*].roleSelector` 依赖 `spec.roles` 和 `lifecycleActions.roleProbe`；`podService`、`disableAutoProvision`、Expose Ops 和 ServiceRef 变量要分别验收。
+- `systemAccounts`、TLS、vars、policyRules 要能在启动脚本、lifecycle action、backup/restore、ServiceRef 或外部连接里找到使用点。
+- `status.phase=Available` 是被 Cluster、BPT、PD、ComponentVersion 等引用前的最低门槛。CR 创建成功不是可引用证明。
+
+字段语义矩阵：
+
+| 字段或对象关系 | release-1.1 实践语义 | 必须同时对齐 | 常见误用 |
+| --- | --- | --- | --- |
+| `spec.serviceKind` | 组件提供的服务类型 | BPT `serviceKind`、ServiceDescriptor、README | 大小写或命名不统一导致依赖和策略不匹配 |
+| `spec.serviceVersion` | 组件内核版本；可被 ComponentVersion release 覆盖 | ComponentVersion、PD serviceVersion、BPT versionMapping、examples | 未显式写 serviceVersion，误以为选择固定版本 |
+| `spec.runtime` | 静态 PodSpec | volumes、configs、scripts、ports、command | 把资源和调度这类实例参数写死 |
+| `spec.volumes[*].name` | 数据卷稳定身份 | Cluster VCT、runtime mount、BPT targetVolumes、volume expansion | PVC 创建了但没有挂到数据库目录 |
+| `spec.volumes[*].needSnapshot` | volume snapshot backup 候选数据卷 | BPT method `snapshotVolumes`、StorageClass snapshot 能力 | 声称支持 snapshot，但 method 和 volume 没绑定 |
+| `spec.volumes[*].highWatermark` | 容量阈值和 readonly/readwrite action 的触发依据 | lifecycle `readonly/readwrite`、引擎真实只读状态 | 字段存在但脚本无法让业务进入或退出只读 |
+| `spec.configs[*].name` | 配置模板身份和参数绑定键 | PCR `configs[*].templateName`、Cluster configs、ComponentParameter | 写成模板 ConfigMap 名 |
+| `spec.configs[*].template` | 模板 ConfigMap 名 | chart 渲染出的 ConfigMap | 模板 ConfigMap data 没有 PD `fileName` |
+| `spec.configs[*].externalManaged` | 配置交给 parameters 链路管理 | PD/PCR/ComponentParameter/runtime ConfigMap | 误以为可以任意指向底层 runtime ConfigMap |
+| `spec.scripts[*].template` | 脚本 ConfigMap 名 | command/action 脚本路径、defaultMode | 脚本存在但不可执行或 action 看不到 |
+| `spec.services[*].roleSelector` | 按 role 暴露服务 | roles、roleProbe、Service endpoints | 没有 roleProbe 却声明 roleSelector |
+| `spec.services[*].podService` | 每个 Pod 一个 Service | serviceVarRef 输出格式、外部访问脚本 | 误以为普通 roleSelector 仍然生效 |
+| `spec.vars` | 注入 Pod/action 或渲染模板的运行时变量 | 脚本消费格式、Optional/Required 分支 | 脚本依赖未声明或 stale 的变量格式 |
+| `spec.systemAccounts` | KB 管理的系统账号 | accountProvision、credentialVarRef、backup/probe/replication 脚本 | Secret 存在但数据库内账号未创建 |
+| `spec.tls` | TLS 文件形状和挂载路径 | Cluster TLS、启动配置、client、backup/restore job | 只验证 runtime，不验证其它执行面 |
+| `spec.roles` | roleProbe 输出集合和 update/service/backup 的角色基础 | roleProbe、updateStrategy、BPT target | role label 等同于业务一致性 |
+| `spec.lifecycleActions` | 组件生命周期脚本和 probe | action target、kbagent、Ops、delete/scale | action 成功等同于业务收敛 |
+| `spec.serviceRefDeclarations` | 外部依赖声明 | Cluster serviceRefs、serviceRefVarRef | 只声明依赖，没有 Cluster 绑定示例 |
+| `spec.replicasLimit` | 声明 scale 支持边界 | README、HorizontalScaling、examples | 声称支持边界但没有业务验证 |
+| `spec.available` | Component Available 判定策略 | readiness、roleProbe、availableProbe | Pod Ready 与业务可用混为一谈 |
+| `spec.hostNetwork` | hostNetwork 端口和 DNS 行为 | container ports、hostNetworkVarRef、advertised address | 启用 hostNetwork 后脚本仍用固定端口 |
+| `podUpdatePolicy`、`podUpgradePolicy`、`instanceUpdateStrategy` | 变更和升级 rollout 方式 | role priority、quorum、InstanceSet revision | 升级顺序破坏可用性 |
+| `policyRules` | runtime/action 可能需要的 RBAC 权限 | Pod/Job ServiceAccount、Role/RoleBinding | runtime 有权限，restore/action worker 没权限 |
+
+release-1.1 controller 会做一部分定义校验，例如 service 端口、roleSelector、account/lifecycle、file template、hostNetwork 和 availableProbe，但校验层不是完整业务证明。`roles` 与 `roleProbe` 的绑定、账号权限、TLS 工具链、脚本幂等和业务 member 状态仍要由 addon 的示例和测试自证。
+
+写完 ComponentDefinition 后，必须立刻写最小 Cluster 样例证明闭环：Cluster 解析 topology 或 direct componentDef，生成 Component，Component 继续生成 InstanceSet/Pod/PVC/Service，Pod 内脚本和配置文件存在且权限正确。不要等到参数、备份和升级都写完后才发现基础蓝图未闭合。
+
+最小验证链路固定看这些对象：Cluster spec/status，Component spec/status，引用到的 ComponentDefinition/ComponentVersion/ClusterDefinition，InstanceSet/Pod/PVC/Service，Pod events，容器内脚本和配置文件。Component `Running` 不等于 InstanceSet 全部 Available；Pod Ready 后还可能受 `minReadySeconds`、availableProbe、roleProbe 或 rollout 策略影响。
+
+数据目录初始化、默认资源和文件权限属于 ComponentDefinition 合同。启动脚本至少要区分空目录、只有 `lost+found` 的新 PVC、已有业务数据、restore/rebuild 写入的数据和半初始化目录；不要用简单的“目录为空/非空”决定是否初始化或清空数据。`defaultMode` 要按最终 Pod spec 和容器内 `stat` 验收，不能只看源码里写了一个看起来像八进制的数字。
+
+`replicasLimit` 是 scale 支持范围声明，不是业务已经支持所有边界的证明。声明后至少要验最小值、最大值、越界拒绝、HorizontalScaling Ops、README 示例和 0 副本语义。若引擎在 `replicas=0` 时没有可用入口、不能保留复制成员语义或不支持从 0 恢复，文档必须写成不支持或需要人工步骤。
+
+实例身份要从 Component 往下看，而不是靠名字猜。release-1.1 使用 InstanceSet 承载工作负载，Pod/PVC/Service 的名字、label、ownerRef、ordinal 和引擎内部成员 ID 不是同一种身份。scale、rebuild、restore、同名 Cluster 重建和 sharding 场景下，脚本可以读取 Pod 名或 FQDN 作为运行时输入，但不要把它们写入不可重算的持久成员 ID。
+
+## 4. 用 ClusterDefinition 表达拓扑，不表达组件细节
+
+release-1.1 的 `ClusterDefinition` 主要表达 topology：每个 topology 包含 components、shardings、orders 和 default。组件 runtime、脚本、账号、TLS 不应该放在 ClusterDefinition 里。
+
+实践规则：
+
+- 每个用户可选部署形态都应有明确 topology。MySQL 有 `semisync`、`mgr`、`orc`、`*-proxysql`；Redis 有 `standalone`、`replication`、`cluster`；Kafka 有 broker/controller/combine；MongoDB 有 replicaSet 和 sharding；ClickHouse 有 sharding 和 keeper。
+- `default: true` 要显式设置。Cluster 未指定 topology 时应依赖默认 topology，不应让用户猜测。
+- `components[*].name` 是 topology 内组件名，Cluster `componentSpecs[*].name` 要和它对齐。
+- `components[*].compDef` 支持精确名、前缀或正则。addon 应使用 helper 固定规则并用渲染结果验证，避免宽正则误命中未来或残留版本。
+- `orders.provision/terminate/update` 表示跨组件顺序。proxy、sentinel、keeper、controller/broker 这类辅助组件要显式排序。
+- sharding 不等于 replicas。`replicas` 是一个复制组内实例数，`ShardingDefinition` 表示多个 shard component。
+
+拓扑能力矩阵：
+
+| 拓扑能力 | release-1.1 表达方式 | controller 消费点 | 验收证据 | 不支持或未证明边界 |
+| --- | --- | --- | --- | --- |
+| 单组件 standalone | `ClusterDefinition.spec.topologies[*].components` | Cluster normalization | Component、InstanceSet、Pod、Service 全部生成 | 不证明 HA、backup、reconfigure |
+| 多组件 HA/proxy | topology components + orders | cluster/component reconcile 顺序 | server 先于 proxy 创建，proxy 先删除；服务可连接 | proxy 路由表和后端角色要另验 |
+| MGR/orc/sentinel/keeper | 不同 topology 指向不同 compDef | compDef matching | 每个 topology 的 CMPD/CMPV/PD/BPT 都闭合 | 一个 topology 成功不代表另一个成功 |
+| sharding | `ShardingDefinition` + topology `shardings` | sharding/component transformer | shard Component、Service、vars、scale 行为 | 不自动证明 rebalance 或数据迁移 |
+| direct componentDef | Cluster component 直接指定 ComponentDefinition，如果使用 | Cluster normalization | 不依赖 ClusterDefinition orders | 不应和 topology 语义混用 |
+
+`ShardingDefinition` 的语义要按对象链理解：`spec.template.compDef` 指向每个 shard 使用的 ComponentDefinition，`shardsLimit` 约束 shard 数量，`provisionStrategy/updateStrategy` 和 lifecycle `postProvision/preTerminate/shardAdd/shardRemove` 只表达 shard 组件的创建、更新和增删动作。它不自动表达 Redis slot 迁移、ClickHouse 分布式表修复、Kafka partition rebalance 或跨 shard restore。
+
+排查 topology 时按这个顺序：Cluster `spec.clusterDef/topology/componentSpecs/shardings`，ClusterDefinition status 和 topology，匹配到的 ComponentDefinition/ComponentVersion，生成的 Component，InstanceSet/Pod/Service。不要把 topology component name、generated Component object name、Pod name、PVC name 和引擎成员 ID 混为一谈。
+
+每个 topology 都要作为验收切片。新增一个 topology 后，至少要确认 CMPD/CMPV/PD/PCR/BPT/ActionSet/Service/roleProbe/examples 都覆盖该 topology；不能只验证 Cluster Running。proxy/router 类 topology 还要验证路由表、账号权限、roleSelector Service 和业务读写路径。
+
+## 5. 用 ComponentVersion 管理版本矩阵
+
+release-1.1 有 `apps.kubeblocks.io/v1` 的 `ComponentVersion`。它用 `compatibilityRules[*].compDefs` 把一组 ComponentDefinition 和若干 release 关联起来；每个 release 有 `name`、`serviceVersion` 和 `images`。release 的 `serviceVersion` 会作为被选择 release 的 serviceVersion，覆盖 ComponentDefinition 自身定义的 serviceVersion。
+
+版本管理至少分五层：
+
+| 版本维度 | release-1.1 来源 | 被谁消费 | 必须验证什么 |
+| --- | --- | --- | --- |
+| chart version | `Chart.yaml` | Helm/package/release 管理 | 与模板、values、README 一致 |
+| ComponentDefinition name | CMPD metadata/helper | ClusterDefinition、BPT、PD、CMPV | 正则只命中预期版本 |
+| `spec.serviceVersion` | CMPD 或 CMPV release | Cluster normalize、PD、BPT versionMapping、upgrade | resolved serviceVersion 是预期版本 |
+| runtime image | CMPD runtime 或 CMPV `images` | Pod/InstanceSet | 实际 Pod image 被替换 |
+| action/tool image | lifecycle action、ActionSet、BPT env | action worker、backup/restore Job | 工具版本与 serviceVersion 兼容 |
+
+实践规则：
+
+- ComponentDefinition 名称应带引擎大版本或 addon 版本前缀，并保持 helper 可预测。BPT、PD、PCR、ClusterDefinition、examples 不应各自手写不同匹配规则。
+- ComponentVersion `compatibilityRules[*].compDefs` 可以写精确名、前缀或正则；多匹配时不要把隐式优先级当作 addon 合同。
+- `images` key 要对应 runtime container、init container、lifecycle action 字段名或明确的工具镜像名。未知 key 不应被当成已验证替换。
+- 每个 serviceVersion 都要同时验证 runtime image、init image、lifecycle action image、参数 schema、BPT method env、backup/restore 工具镜像和升级路径。
+- Cluster 未显式指定 serviceVersion 时，不要猜测最终选择；开发样例应显式写 serviceVersion，排查时看 resolved Component、ComponentVersion status 和 Pod image。
+
+ComponentVersion 不能只替换主容器镜像。每个 release 至少要列清楚 runtime containers、init containers、lifecycle action、backup/restore ActionSet、参数 reloader、外部工具镜像是否随 serviceVersion 变化。ComponentVersion 能覆盖 ComponentDefinition 中的 runtime、init container 和 lifecycle action image；不会自动改写 ActionSet image，也不会改写脚本 ConfigMap 里硬编码的工具镜像。
+
+BPT 的 `versionMapping` 是数据保护侧的版本矩阵。它按 Cluster component 的 serviceVersion 匹配 method 侧版本化配置，只能说明某个 backup method 用哪个版本化配置，不证明该 method 可 restore、可 rebuild、可 scaleOut.fromBackup 或可跨版本。每增加一个 ComponentVersion release，都要回查 PD/PCR、BPT `versionMapping`、ActionSet image/env 和 examples。
+
+升级验收不能只看新镜像启动。至少要保存 old/new 的 ComponentVersion status、Cluster/Component resolved serviceVersion、Pod image、action image、参数定义、BPT method env 和业务数据兼容结果。跨大版本的数据兼容、回滚限制和备份恢复兼容要写进 README 或实现说明；没有证据的组合写成未证明。
+
+版本选择排查先看用户入口，再看 resolved 对象。用户入口包括 Cluster `componentSpecs[*].serviceVersion`、ClusterDefinition topology 中的 compDef 规则、ComponentVersion compatibilityRules、chart values 中的 image tag 和 examples 中的默认值。resolved 对象包括 Component spec、Component status、InstanceSet template、最终 Pod image、action worker image 和 BackupPolicy method env。任何一层缺失，都不能只靠 `Chart.yaml` 或镜像 tag 下结论。
+
+多个 ComponentVersion 同时覆盖同一 ComponentDefinition 时，addon 不应依赖隐式排序。推荐做法是让 ComponentDefinition 名称、serviceVersion、ComponentVersion release name 和 examples 保持可预测映射；如果需要兼容旧名，使用短期兼容规则并在发布验收中证明不会误命中新旧两个 release。
+
+升级路径要覆盖回滚和失败中断。runtime image 更新后，如果参数 schema、配置文件格式、数据目录格式或备份工具版本也变化，回滚可能不是简单换回旧 image。addon 文档应写清楚支持原地回滚、需要 restore、需要人工处理，还是未证明。没有回滚证据时，不要把 upgrade example 写成完整升级能力。
+
+## 6. 生命周期动作要按数据库语义建模
+
+release-1.1 `ComponentLifecycleActions` 支持 `postProvision`、`preTerminate`、`roleProbe`、`availableProbe`、`switchover`、`memberJoin`、`memberLeave`、`readonly`、`readwrite`、`dataDump`、`dataLoad`、`reconfigure`、`accountProvision` 等动作。action 是业务合同，不是通用 shell hook。
+
+实践规则：
+
+- roleProbe 输出必须匹配 `spec.roles` 中定义的 role。role label 会影响 roleSelector Service、Backup target、switchover 和 rollout。
+- `roles[*].isExclusive` 只约束 KB 记录的 role label 视角，不能证明数据库内部没有 split-brain，也不能替代引擎级 fencing、租约或 quorum 校验。
+- memberJoin/memberLeave 要幂等，能区分目标实例不存在、已加入、已移除和半加入状态。
+- switchover 要验证候选 Pod、旧主、复制状态、role label、Service endpoints 和业务读写状态。
+- preTerminate 适合目标 Pod 或可管理执行面仍存在时的业务下线。删除卡住时先保留现场，查 action target、Pod/PVC 是否存在、kbagent/action 输出和业务成员列表。
+- action `exec.command` 是命令数组，不是 shell 字符串；需要管道、重定向或多命令时，应调用脚本文件或显式 `sh -c`。
+- `preCondition` 主要用于 `postProvision` 类等待场景，不要泛化为所有 lifecycle action 的收敛证明。
+- release-1.1 的 `Ordinal` target selector 已在 lifecycle target 选择中实现；`matchingKey` 必须是非负整数，选择依据是 Pod 名最后一个 `-<ordinal>`，多 Pod 匹配同一 ordinal 会报 ambiguous。它适合明确的实例级动作，不适合表达持久业务成员身份。
+
+quorum 和更新顺序要作为 HA addon 的显式验收项：
+
+| 验收点 | 需要证明 |
+| --- | --- |
+| `roles[*].participatesInQuorum` | 哪些角色参与多数派；滚动、scale-in、Stop、故障恢复时不会把多数派同时拿下 |
+| `roles[*].updatePriority` | leader/primary、follower/secondary、learner 等角色的升级顺序符合引擎安全要求；相同 priority 不代表 leader 一定最后更新 |
+| `roleProbe` 周期和 threshold | role label 收敛延迟在 switchover、backup target、roleSelector service 和 rollout 中可接受 |
+| `podUpdatePolicy/podUpgradePolicy/instanceUpdateStrategy` | 与 quorum、role priority 和 switchover 策略组合后，升级期间仍满足业务可用性或明确需要停机 |
+| 引擎自检 | KB role label 与引擎 membership、term/epoch、primary lease 或一致性读写结果一致 |
+
+常见 lifecycle/action 字段语义如下：
+
+| 字段 | 脚本输入或选择语义 | addon 要证明什么 |
+| --- | --- | --- |
+| `postProvision.preCondition` | `Immediately`、`RuntimeReady`、`ComponentReady`、`ClusterReady` 决定动作触发时机 | 脚本依赖的 Pod、Service、账号、角色在该时机已经存在 |
+| `preTerminate` | 删除或缩容前执行，controller 等待它成功后继续释放资源 | 脚本不依赖已不存在的 Pod；不需要执行时有明确跳过策略 |
+| `availableProbe` 和 `available.withProbe` | 用 action 结果判定可用性；设置后会覆盖 withPhases/withRole 的判定方式 | probe 输出和失败语义稳定，不会把初始化中状态误判为可服务 |
+| `switchover` | 候选实例可由 Ops 指定；未指定候选时 action 成功不等于业务切换已可被客户端感知 | candidate 为空和非空两条路径都能处理；roleProbe 和 Service endpoint 最终收敛 |
+| `memberJoin` | 新成员加入复制组 | 新 Pod Ready 后能加入复制组，重复执行不会破坏已有成员 |
+| `memberLeave` | 删除前摘除成员 | 删除前能摘除成员；如果需要数据迁移，要作为单独限制说明 |
+| `readonly/readwrite` | 由 volume highWatermark 等容量保护路径触发 | 引擎有真实只读/读写切换命令，且状态可回查 |
+| `dataDump/dataLoad` | 实例初始化类数据复制 | 不等价于 Backup/Restore method |
+| `reconfigure` | 文件变更后的重载动作 | 脚本按文件名和参数名校验输入，支持幂等重试 |
+| `accountProvision` | 创建或变更数据库内账号 | SQL/CLI 执行有转义、脱敏和最小权限控制 |
+| `targetPodSelector` 和 `matchingKey` | `Role` 按 role 选择，`Ordinal` 按 Pod 名 ordinal 选择，`Any/All` 不使用 matchingKey | 依赖 role 的动作必须先证明 roleProbe；依赖 ordinal 的动作要证明 Pod 名到业务身份映射 |
+| `timeoutSeconds` 和 `retryPolicy` | 非 0 退出、HTTP 非 2xx、超时都会按策略失败或重试 | 脚本要能安全重试；长耗时动作不要用默认超时碰运气 |
+
+`preCondition` 要按脚本依赖选择，不要按“越晚越安全”猜：`Immediately` 适合只依赖 Secret 或本地初始化；`RuntimeReady` 适合需要容器文件、挂载卷或基础进程；`ComponentReady` 适合需要当前 Component 副本和 role 已收敛；`ClusterReady` 适合依赖其它 component 的后置初始化。若动作本身会推动 ComponentReady 或 ClusterReady，就不要选择会形成等待环的条件。
+
+HTTP/GRPC action 要把接口当成版本化合同。HTTP action 至少固定 method、path、headers、body、成功状态码范围和 body assertion；`204` 无 body 时不要写依赖 body 的断言。GRPC action 至少固定 service/method、payload schema、是否 unary、是否依赖 reflection，以及工具镜像里客户端版本。接口、payload 或工具镜像随 serviceVersion 改变时，要和 runtime image、PD、BPT 一起进入版本矩阵。
+
+超时和 retry 只说明 controller 视角的执行结果，不证明远端副作用已回滚。长耗时 action 要有幂等键或业务状态检查；超时后先查远端是否已部分执行，再决定重试、补偿或标为需要人工处理。retry 期间 targetPodSelector 可能重新选到不同 Pod，依赖单一目标的动作要固定目标输入或在脚本里拒绝目标漂移。
+
+`highWatermark` 场景要同时验收只读进入和读写恢复。触发 readonly 后，检查引擎真实只读状态、写请求失败方式和用户可见限制；容量恢复或扩容后，`readwrite` action 必须能把引擎带回可写，并用业务写入或引擎状态查询证明，而不是只看 action 退出 0。
+
+`memberJoin` 和 `memberLeave` 要同时证明三件事：controller 视角的 action 已完成，业务成员关系已经收敛，重复执行或中途失败后不会把状态写坏。scale-in 不能只等待固定时间：如果引擎因为 quorum、shard awareness、数据迁移、replica placement 或磁盘状态拒绝摘除成员，脚本要能给出可诊断错误、可恢复退出或明确人工处理步骤。
+
+拓扑变化后的 action 不要依赖创建时写入 Pod env 的成员列表。`componentVarRef.podNames/podFQDNs`、旧 `KB_*` 列表或脚本启动时缓存的 endpoint 只能证明 Pod 创建时的视图；scale-out、scale-in、switchover、rebuild 之后，脚本应优先使用 action-time 注入的目标 Pod/FQDN、当前 Service/EndpointSlice、业务 membership 查询或显式传入的 candidate。
+
+## 7. 变量注入和服务依赖是契约
+
+release-1.1 `ComponentDefinition.spec.vars` 支持多种来源：cluster、component、credential、service、serviceRef、TLS、hostNetwork、ConfigMap、Secret 等。变量可用于 Pod/action env，也可用于渲染 config/script 模板。变量不是脚本私货；每个变量的格式、缺失语义和刷新语义都要写进实现说明。
+
+常见变量和服务来源：
+
+| 来源 | release-1.1 输出或行为 | 脚本消费方式 | 验收证据 | 边界 |
+| --- | --- | --- | --- | --- |
+| `clusterVarRef` | cluster name、namespace、uid 等 | 普通 env/template 值 | 最终 Pod/action env | 不应作为不可重算业务成员 ID |
+| `componentVarRef` | component 名、replicas、Pod 名/FQDN 列表、按 role 过滤列表 | 逗号列表等字符串约定 | 脚本解析、scale 后验证 | Pod env 是创建时视图，拓扑变化要另验 |
+| `credentialVarRef` | system account 用户名/密码 | env 传入脚本 | Secret 和数据库内账号都存在 | 不应渲染进普通 ConfigMap |
+| `serviceVarRef` | Service host/port 或 podService 地址 | advertised address、client 连接 | Service、EndpointSlice、连接测试 | Service 可达不等于客户端地址正确 |
+| `serviceRefVarRef` | 外部依赖 ServiceDescriptor 或 KB Cluster 信息 | 跨组件/外部连接 | declaration、Cluster binding、最终 env、真实连接 | credential 跨 namespace 有限制 |
+| `tlsVarRef` | CA/cert/key 路径或 Secret 引用 | runtime/action/backup/restore TLS | 每个执行面连接测试 | Secret 存在不等于工具链可用 |
+| `hostNetworkVarRef` | hostNetwork 动态端口 | advertised address、配置文件 | Pod spec、端口占用、最终 env | hostNetwork 不是固定端口合同 |
+
+变量和服务合同检查：
+
+- 每个变量都要在脚本、config、action 或 Job 中有明确使用点。不要为了“可能以后有用”注入大量变量。
+- 避免 `runtime.containers[*].env`、CMPD `vars` 和 Cluster `componentSpecs[*].env` 定义同名变量。确实需要覆盖时，验收口径以最终 Pod env、action env 和渲染后的 config/script 为准。
+- `KB_` 前缀变量视为 KB 注入保留空间，addon 自定义变量不要复用。
+- 多组件和多 shard 变量要明确值格式，例如逗号分隔 Pod 列表、FQDN 列表、`name:port` 列表或 JSON 片段。
+- `Optional` 变量缺失时脚本要有显式分支；`Required` 变量缺失应让问题尽早暴露。不要假设 Optional 一定渲染为空字符串。
+- ServiceRef 要同时给出 declaration、Cluster 侧绑定示例和脚本读取方式。
+- 外部访问能力必须逐类型验证。ClusterIP、NodePort、LoadBalancer、hostNetwork 的地址来源和 DNS/端口语义不同，不能用一个 advertised address 模板覆盖所有模式。
+
+ServiceDescriptor 在 release-1.1 中会校验 `serviceKind`、`serviceVersion` 和 SecretRef 是否存在，但实现仍不校验 Secret data key 的完整性；credential 变量解析时 Secret key 缺失也可能不直接报错。不能把 `ServiceDescriptor.status.phase=Available` 当成外部服务凭据可用证明，必须验证最终 env/config 和真实连接。
+
+ServiceRef 的 credential 不能任意跨 namespace 引用。需要跨 namespace 外部依赖时，应使用明确的 ServiceDescriptor 和权限/凭据交付方式，并声明限制。`clusterServiceSelector` 和 `serviceDescriptor` 是不同绑定路径；前者引用 KB Cluster 服务，后者引用外部服务描述。两者产生的 endpoint、credential 和 serviceVersion 校验边界不同，不能在脚本里混成一个隐式合同。
+
+外部依赖要设计变更生命周期，而不只是首次注入。provider 的 endpoint、host、port、credential、ServiceDescriptor status 或拓扑发生变化后，consumer 是否自动 re-render、是否需要 Reconfigure、Restart、重建或明确不支持，都要写成支持矩阵并用最终 Pod/action env、runtime ConfigMap 和真实连接证明。
+
+服务和依赖注入的验收顺序是最终 Service、EndpointSlice、Pod label/Ready、注入 env、真实连接。`publishNotReadyAddresses` 只能说明 endpoint 可以早发布，不说明业务已经 ready；客户端是否会过早连接、是否有启动握手或重试，要由 addon 自己证明。
+
+## 8. 账号和 TLS 要作为一等能力设计
+
+账号至少分三类：初始化账号、运行时管理账号、执行面账号。执行面账号包括 roleProbe、backup、restore、replication、switchover、member lifecycle、client examples 等。每类账号都要说明生成方式、Secret key、数据库内权限、禁用行为和轮换边界。
+
+账号矩阵：
+
+| 账号类型 | 典型用途 | release-1.1 声明面 | 必须验收 |
+| --- | --- | --- | --- |
+| 初始化账号 | 首次初始化、root/admin 创建 | systemAccounts、accountProvision、init script | Secret key、数据库内账号、权限范围、重复执行 |
+| 运行时管理账号 | roleProbe、switchover、member lifecycle | credentialVarRef、lifecycle action env | action 执行面可读取，权限最小化，输出脱敏 |
+| 数据保护账号 | backup、restore、PITR、postReady | BPT target account、ActionSet env | Backup/Restore Job 可读，数据库权限和 TLS 均可用 |
+| 外部连接账号 | client example、proxy/router、ServiceRef consumer | ServiceDescriptor Secret、system account、用户 Secret | Secret key 完整、连接成功、权限和轮换策略 |
+| 复制或集群内部账号 | replication、sentinel、keeper、router | script/config、systemAccounts、Secret | scale、switchover、restore 后仍一致 |
+
+TLS 不是只让主 Pod 能启动。必须分别验证 runtime、roleProbe、lifecycle action、backup Job、restore Job、postReady Job、client example 是否拿到正确 CA/cert/key、路径、权限和连接参数。只证明 Secret 存在时，只能说证书对象已生成，不能说数据库 TLS 能力已支持。
+
+RBAC 要按执行面拆开。Component `policyRules`、runtime Pod 使用的 ServiceAccount、lifecycle action 所在 Pod、Backup/Restore Job、Repo pre-check Job 可能不是同一权限面。排查权限问题时先看最终 Pod/Job `serviceAccountName`、Role/RoleBinding/rules 和事件，不要因为 runtime Pod 有权限就推断 restore worker 也有权限。
+
+凭据和 TLS 轮换要明确支持边界。Secret 更新后是否触发参数重渲染、Pod 重启、action 重新读取、BackupPolicy/Job 使用新 Secret，不能从 Secret resourceVersion 直接推断。不能证明自动轮换时，应写成需要重启、重新执行 Ops 或人工更新。
+
+## 9. 配置和参数管理要串成闭环
+
+release-1.1 的参数链路由 ComponentDefinition configs、模板 ConfigMap、`ParametersDefinition`、`ParamConfigRenderer`、`ComponentParameter`、runtime ConfigMap、reload/restart 路径共同构成。新增或重写 addon 应使用 `ParametersDefinition` 和 `ParamConfigRenderer` 作为主路径。
+
+对象链：
+
+| 链路节点 | 语义 |
+| --- | --- |
+| `ComponentDefinition.spec.configs[*].name` | 配置 item 名称，参数链路绑定键 |
+| `ComponentDefinition.spec.configs[*].template` | 模板 ConfigMap 名 |
+| 模板 ConfigMap data[file] | 实际模板文件和可渲染内容 |
+| `ParametersDefinition.spec.fileName` | 参数定义绑定的文件名 |
+| `ParamConfigRenderer.spec.configs[*].templateName` | 绑定 CMPD `configs[*].name` |
+| `ComponentParameter` | controller 落地的参数 desired/status |
+| runtime ConfigMap | 最终挂进 Pod 的配置文件 |
+| reloadAction 或 restart | 参数真正生效路径 |
+| 进程内配置查询 | 最终业务证据 |
+
+实践规则：
+
+- `ParametersDefinition.spec.fileName` 必须是模板 ConfigMap data 中真实存在的文件名。
+- `ParamConfigRenderer.spec.componentDef` 要指向目标 ComponentDefinition；`parametersDefs` 要列出参与渲染的 PD；`configs[*].templateName` 要等于 CMPD `spec.configs[*].name`，不是模板 ConfigMap 名，也不是 runtime ConfigMap 名。
+- `staticParameters` 表示需要 restart，`dynamicParameters` 表示可 reload，`immutableParameters` 表示不应修改。没有分类证据时不要声明热更新。
+- release-1.1 PD 的 reload 语义受 `dynamicParameterSelectedPolicy`、`reloadAction`、`mergeReloadAndRestart`、`reloadStaticParamsBeforeRestart`、`deletedPolicy` 共同影响。每个字段只能说明 controller 执行路径，不能替代进程内查询。
+- 外部 ConfigMap、formatter、default value、Secret 进入配置文件等能力要单独证明；敏感值不要渲染进普通 ConfigMap。
+- `externalManaged` 表示配置交给 parameters 链路管理，不表示 `templateName` 可以指向底层 runtime ConfigMap。
+
+参数排查固定看三态：desired 看 `Parameter`/OpsRequest 和 ComponentParameter，rendered 看 runtime ConfigMap 和 revision/status，effective 看 SQL/CLI/config dump。OpsRequest 成功不等于进程已生效，runtime ConfigMap 更新也不等于进程已 reload。
+
+参数字段排查矩阵：
+
+| 问题 | 第一跳 | 第二跳 | 业务证据 |
+| --- | --- | --- | --- |
+| 找不到 ComponentParameter | CMPD `configs[*].externalManaged`、PCR componentDef、PD status | Component status、controllers/parameters 事件 | 不支持 reconfigure 时明确声明 |
+| ConfigMap 没生成或 data key 缺失 | CMPD `configs[*].template`、模板 ConfigMap | PD `fileName`、PCR `templateName` | Pod 内文件存在 |
+| 参数被写入错误文件 | PD `fileName`、PCR configs、template data | ComponentParameter spec/status、runtime ConfigMap | 进程读取目标文件 |
+| 动态参数没生效 | PD dynamic/static 分类、reloadAction | action 输出、Pod restart 状态 | 进程内查询值改变 |
+| 静态参数被热更新 | PD 分类、reloadStaticParamsBeforeRestart | OpsRequest 条件、restart 计划 | 重启后进程值正确 |
+| 删除参数行为异常 | `deletedPolicy`、template 默认值 | ComponentParameter desired、runtime ConfigMap | 进程内参数恢复或拒绝 |
+| 多 Pod 参数分裂 | action target、role、All/Role/Ordinal 选择 | 每个 Pod runtime ConfigMap | 每个实例进程值一致或差异符合预期 |
+| Secret 泄露 | template、runtime ConfigMap、action 输出 | Pod env/Secret mount | 普通 ConfigMap 不含敏感值 |
+
+半支持状态要显式处理。某些 addon 的配置形态如果本来不能通过 release-1.1 参数链路安全管理，不要为了让 OpsRequest 看起来成功而制造空 PD/PCR 或错误的 `externalManaged`。正确做法是显式拒绝、不提供 reconfigure example，或写成需要重启/人工修改的限制。
+
+ComponentParameter desired 会成为后续重渲染的输入。错误参数一旦写入 desired，可能在 scale、restart、reconfigure 或 controller 重试中持续污染 runtime ConfigMap。排查时要先保存旧对象，再判断是用户输入、PD 分类、模板渲染还是 merge 逻辑导致污染；不要直接改 controller 来吞掉错误参数。
+
+动态参数作用域要按引擎语义设计。某些参数是单实例本地参数，某些必须全组件一致，某些只允许在 primary 上执行后由引擎传播。reload action 的 target 选择必须和这个语义一致；单 Pod reload 成功不能证明 HA 集群参数一致。
+
+PD/PCR 设计要把文件格式和参数分类分开。`fileFormatConfig`、formatter、CUE schema、default value、unit、枚举和范围只能证明参数能被解析；`staticParameters`、`dynamicParameters`、`immutableParameters` 才表达变更执行路径。一个参数在语法上可写，不代表运行时可热更新；一个参数被列为 dynamic，也不代表所有 topology、所有 role、所有 serviceVersion 下都能热更新。
+
+多文件配置要避免“一个参数名多处出现”的隐式合同。相同 key 如果出现在多个文件，PD/PCR 要明确哪个 fileName 管理它，或者在文档中写明它是多个文件的组合参数。否则 reconfigure 时可能只更新一个文件，reload action 却读取另一个文件，最终形成 desired/rendered/effective 三态不一致。
+
+删参和默认值要单独验收。用户把参数设置为 nil、空字符串、删除 key、恢复默认值，是四种不同输入；`deletedPolicy`、模板默认值和引擎默认值也不是同一个概念。addon 要说明删除参数后 runtime ConfigMap 是删除 key、写空值、恢复模板默认，还是拒绝操作，并用进程内查询证明。
+
+参数和 Cluster overrides 的 ownership 要保持清楚。Cluster 创建时的 configs、后续 Parameter CR/OpsRequest、模板默认值、外部 ConfigMap、formatter 输出都可能参与最终文件。排查时先确定哪个对象拥有 desired，再看 controller 渲染结果；不要让用户同时修改 runtime ConfigMap 和 Parameter CR 来“碰运气”修复。
+
+参数测试至少覆盖八类用例：合法动态参数、合法静态参数、immutable 参数拒绝、未知参数拒绝、类型错误、删参、同一参数多次变更、scale/restart 后参数保持一致。缺少其中某类时，文档只能写该类未证明。
+
+## 10. 数据保护要同时提供策略和执行脚本
+
+release-1.1 的数据保护至少包括 `BackupPolicyTemplate`、`ActionSet`、`BackupRepo`、Backup/Restore CR 和执行脚本。BPT 负责让目标 Cluster 生成 BackupPolicy；真正执行的是 BackupPolicy/Backup/ActionSet/BackupRepo 组合。
+
+实践规则：
+
+- BPT `compDefs` 支持精确名、前缀或正则。每新增 ComponentDefinition 或 topology 都要验证 BackupPolicy 是否生成。
+- `backupMethods[*].snapshotVolumes=true` 可以走 CSI snapshot，不一定需要 ActionSet；非 snapshot method 必须有 `actionSetName`。
+- method-level target 可能覆盖全局 target。target role 在多副本和单副本场景要分别验收，不能把单副本 fallback 外推到 HA。
+- `versionMapping` 只证明 method 侧配置如何匹配 serviceVersion，不证明 restore、PITR、rebuild 或跨版本兼容。
+- ActionSet `onError` 支持 `Continue` 和 `Fail` 两个枚举；使用 `Continue` 时必须证明被忽略的步骤不会破坏 artifact、status 和恢复路径。
+- BackupRepo 必须 Ready。repo 不可用、default repo 冲突、Secret 轮换、PVC/PV retain/delete、BackupRepo 删除被已有 Backup/PVC 阻塞，都应作为数据保护排查入口。
+
+字段语义矩阵：
+
+| 字段 | addon 要表达的语义 | 必须同时验证 |
+| --- | --- | --- |
+| BPT `serviceKind`、`compDefs` | 哪类组件自动生成 BackupPolicy | resolved ComponentDefinition 只匹配预期 BPT |
+| BPT `target.role/fallbackRole/account/strategy` | 选哪个 Pod、用哪个系统账号连接数据库 | roles/roleProbe、systemAccounts、单副本和多副本选 Pod 行为 |
+| BPT `schedules/backoffLimit/retentionPolicy` | 默认备份计划、失败重试和保留策略 | 生成的 BackupPolicy/BackupSchedule、实际 Backup 创建 |
+| method `name` | 用户和 Backup CR 调用的稳定方法名 | method 名语义单一，不把 physical/logical/incremental/PITR 混用 |
+| method `compatibleMethod` | 增量或差异备份依赖的 full method | parent backup 链和 restore 顺序 |
+| method `snapshotVolumes` | 是否走 CSI snapshot | CMPD `volumes[*].needSnapshot`、StorageClass snapshot 支持 |
+| method `actionSetName` | 非 snapshot method 绑定执行定义 | ActionSet status Available，backup/restore 阶段都存在 |
+| method `targetVolumes` | backup workload 挂载目标 Pod 的哪些 volume | CMPD volume 名、容器 mountPath、restore PVC |
+| method `env/runtimeSettings/target` | method 级覆盖工具镜像、资源和选 Pod 策略 | versionMapping、资源请求、target 覆盖是否和全局 target 冲突 |
+| ActionSet `backupType` | Full、Incremental、Differential、Continuous、Selective 之一 | Backup/Restore 示例和 method 名一致 |
+| ActionSet `parametersSchema/withParameters` | Backup/Restore 参数名校验 | 脚本仍做值校验，不能只依赖 schema |
+| `backup.preBackup/backupData/postBackup/preDelete` | 备份前、备份主体、备份后和删除前动作 | 失败退出语义、重试幂等性、产物是否写到 repo 路径 |
+| `backupData.syncProgress` | 是否同步进度到 Backup status | 脚本输出、Backup status totalSize/duration/phase |
+| `restore.prepareData/postReady` | 数据准备到目标 PVC，目标组件 ready 后修复集群内状态 | 新集群恢复、rebuild、账号、TLS、拓扑兼容性 |
+| Restore `backup.sourceTargetName/restoreTime` | 从哪个 source target 和时间点恢复 | PITR、增量链路、source target 名称 |
+| Restore `prepareDataConfig/readyConfig/env/backoffLimit/parameters` | restore job 的 PVC、调度、env 合并、重试和参数 | 最终 env 合并结果、参数默认来源和脚本行为 |
+
+每个 backup method 都要建兼容矩阵：method name、backup type、target role、ActionSet、BackupRepo 需求、artifact 类型、是否支持新集群 restore、是否支持 PITR、是否支持 RebuildInstance、是否支持 scaleOut.fromBackup、是否支持 sharding/topology 变化、需要的账号/TLS/env、已验证 addon 示例。
+
+每个 topology 也要单独证明 BackupPolicyTemplate 是否生效。`standalone`、`replication`、`mgr`、`proxy`、`sharding`、`keeper` 这类拓扑可能使用不同 ComponentDefinition 名称、roleProbe、target role、账号和数据卷；BPT `compDefs` 命中一个普通组件，不代表它覆盖了 topology 专属组件。最小证据是该 topology 的 Cluster 生成了预期 BackupPolicy，Backup target selector 选中正确 Pod，ActionSet method 与该 topology 的账号、TLS、volume 和 serviceVersion 兼容。
+
+Backup `Completed` 不是 restore contract。每个 method 都应产出或能推导一份 artifact manifest：仓库路径、target 名称、数据文件、元数据文件、formatVersion、base/parent、加密信息、工具版本、必要模板或 keystore。restore preflight 要先检查这份 manifest 和目标 Cluster 条件，再开始覆盖 PVC；如果缺 artifact、路径不一致、工具镜像不兼容或目标 topology 不匹配，应清楚失败。
+
+加密、压缩和格式版本必须做 payload 级验证。API 字段、Secret 或 env 存在，只能证明执行面收到了配置；它不证明备份数据实际经过了支持该能力的工具链。使用 native client、数据库自带 backup 命令、datasafed、kopia、对象存储 SDK 或自写脚本时，要分别说明数据从哪里写出、是否经过加密/压缩、artifact manifest 在哪里、restore 用哪个工具读取，以及错误密钥、错误 formatVersion、缺少 keystore 或缺少模板文件时如何失败。
+
+空数据集、无增量或无变化也是合法场景，不能让备份脚本无限等待。addon 要定义空 full backup、空 incremental backup、没有 binlog/WAL/segment、没有 topic/table/slot 变化时的退出码、artifact 形状和 restore 结果。若该 method 不支持空数据或空增量，应在 method 文档和脚本前置检查里明确拒绝。
+
+BackupRepo 是独立依赖，不是 BackupPolicy 的附属字段。排查备份失败、恢复失败或仓库凭据轮换时，必须同时看 BackupRepo/Secret、BackupPolicy、BackupSchedule、Backup/Restore Job 的 env 和 mount。Repo Secret 轮换后，已经存在的 Job 不会因此自动换凭据，后续 Backup/Restore 是否消费新 Secret 要以最终 Job spec 为准。
+
+Continuous backup 和 PITR 的状态语义要单独写清楚。Continuous method 长期 `Running` 可能是正常归档状态，不等于一次性 Full Backup 未完成；addon 要验收归档产物持续生成、timeRange 可解释、`restoreTime` 落在可恢复窗口内，并实际演练 PITR。
+
+跨 topology、sharding 或 rebuild restore 必须有 target 映射表：同 topology 新集群恢复要证明 source target 到目标 component/volume 一一对应；rebuild instance 要证明 source backup 到目标 ordinal/PVC/实例身份对应；跨 topology 恢复要显式映射 source component 和目标 component；sharding restore 要说明 source shard/target 到目标 shard 的映射，目标 shard 多于或少于源 shard 时不能默认支持。
+
+从已有 `Backup` 恢复新 `Cluster` 时，release-1.1 的用户入口应写成 Restore `OpsRequest`。不要要求 addon 用户手写 `kubeblocks.io/restore-from-backup` annotation；该 annotation 是 operations restore handler 根据源 Backup 和 OpsRequest 输入生成的内部恢复 intent。独立 `dataprotection Restore` CR 只负责 PVC 数据准备和 postReady，不会替用户创建新的 Cluster。
+
+最小示例要包含目标 Cluster 名、源 Backup 名和必要的恢复选项：
+
+```yaml
+apiVersion: operations.kubeblocks.io/v1alpha1
+kind: OpsRequest
+metadata:
+  name: restore-acmedb
+  namespace: demo
+spec:
+  clusterName: acmedb-restore
+  type: Restore
+  restore:
+    backupName: acmedb-backup-20260605
+    backupNamespace: demo
+    restorePointInTime: "2026-06-05T08:00:00Z"
+    volumeRestorePolicy: Serial
+    deferPostReadyUntilClusterRunning: true
+    parameters:
+      - name: restore-mode
+        value: full
+```
+
+这个入口依赖源 Backup 中保存的 cluster snapshot annotation。controller 会先读取 `backupName/backupNamespace`，要求 Backup 已 Completed，continuous backup 则会校验 `restorePointInTime`；随后从 Backup 的 cluster snapshot 反序列化源 Cluster，改成 `spec.clusterName` 指定的新名字和 OpsRequest namespace，并写入恢复 annotation。后续 Cluster/Component reconcile 会基于 annotation 创建 `Restore` 对象、PVC 和 restore Job。addon README 的 restore 示例必须让用户先确认源 Backup 存在、phase 合法、component/sharding label 可识别、method 和 ActionSet 带 restore 阶段、artifact 可访问、Backup 中存在 cluster snapshot；否则新 Cluster 不会被可靠创建或无法完成数据恢复。
+
+Restore OpsRequest 派生出的目标 Cluster 不是源 Cluster 的逐字段复刻。LoadBalancer Service、NodePort、selector、offline instances、TLS issuer、sharding account SecretRef、调度 selector 等字段可能被重置、清理或重写；addon 的连接文档和验收脚本必须以恢复后 live Cluster、Service、Secret 和 Pod spec 为准，不从源 Cluster YAML 推断最终值。
+
+PVC 恢复只覆盖 Backup method `targetVolumes` 声明、且目标 Cluster volumeClaimTemplates 中存在的卷。target volume 名称对不上时，目标 PVC 可能只走普通 provision，不会恢复数据。sharding restore 要说明 source targets 数量和目标 shards 数量的关系；targets 多于 shards 应失败，目标 shards 多于 source targets 时额外 shard 的 skip 行为不能写成数据完整恢复。
+
+restore 示例还要写恢复后的检查链：先看 OpsRequest phase/message，再看新 Cluster 是否创建、Cluster annotation 是否被逐步清理、Component/PVC 是否带 restore intent，最后看 `Restore` phase、restore Job、postReady、业务数据、账号、TLS 和 Service。跨 namespace 时必须显式写 `backupNamespace` 并验证 BackupRepo/Secret/Job 执行面有权限；PITR 只能用于对应 continuous method 和可恢复 timeRange，不能把任意 `restorePointInTime` 当成通用字段。
+
+## 11. Day-2 运维以内置操作为主
+
+release-1.1 `OpsRequest.spec.type` 支持 Start、Stop、Restart、Switchover、VerticalScaling、HorizontalScaling、VolumeExpansion、Reconfiguring、Upgrade、Backup、Restore、Expose、RebuildInstance 等类型。addon 作者不要从 OpsRequest 入口推断能力已经成立；每种 Ops 都依赖底层合同。
+
+Ops 矩阵：
+
+| Ops | release-1.1 入口字段 | 依赖的 addon 合同 | 运行验收 | 常见误用 |
+| --- | --- | --- | --- | --- |
+| Start/Stop/Restart | `start/stop/restart` | 启动脚本幂等、readiness、一次性初始化保护 | Pod 重建或恢复后数据不丢 | restart 后重复初始化 |
+| HorizontalScaling | `horizontalScaling` | replicasLimit、memberJoin/memberLeave、sharding 边界 | 新成员加入或旧成员摘除 | 只看 Pod 数量 |
+| VerticalScaling | `verticalScaling` | 资源变更后引擎是否感知 | Pod/cgroup/进程资源状态 | 资源改了但数据库内部未更新 |
+| VolumeExpansion | `volumeExpansion` | VCT 名、PVC、mountPath、文件系统和引擎容量 | PVC、容器内 FS、引擎状态 | VCT 名和 volume 名不一致 |
+| Reconfiguring | `reconfigures` | PD/PCR/ComponentParameter、reload/restart | 文件和进程配置一致 | 只看 Ops Succeed |
+| Expose | `expose.services` | ComponentService、roleProbe、地址脚本 | Service/EndpointSlice/连接 | Service type 和 advertised address 混用 |
+| Switchover | `switchover` | roleProbe、switchover action、roleSelector Service | candidate 成为目标 role，服务切换 | action 成功后不查角色 |
+| Upgrade | `upgrade` | ComponentVersion、镜像、rollout、数据兼容 | old/new 版本和数据正确 | 只升级 runtime image |
+| Backup/Restore | `backup`、`restore` | BPT、ActionSet、BackupRepo、Restore 脚本 | Backup artifact 和 Restore 成功 | 只有 Backup 无 Restore |
+| RebuildInstance | `rebuildFrom` | Restore 兼容矩阵、目标 PVC、postReady、member lifecycle | 单实例恢复并重新加入 | 新集群 restore 成功就声称 rebuild 支持 |
+
+容易误用的 release-1.1 Ops 字段：
+
+| 场景 | 字段 | 1.1 行为要点 | addon 验收 |
+| --- | --- | --- | --- |
+| scale-out 从备份扩容 | `horizontalScaling.scaleOut.fromBackup` | operations 会为新增实例准备 restore 数据；字段只对非 sharding component 有效 | method 必须支持该目标实例、RestoreEnv、postReady、memberJoin |
+| rebuild 指定来源 | `rebuildFrom.backupName/sourceBackupTargetName/restoreEnv` | rebuild 路径把 restore 能力接入实例替换或 in-place | source target、env merge、PVC、成员重加都要验证 |
+| 单实例原地 rebuild | `rebuildFrom.inPlace` | 不等价于新建 Cluster restore | 先证明数据准备和进程重启不会破坏成员关系 |
+| shard 级操作 | sharding 相关字段 | 对象选择进入 shard Component 链路 | 不自动证明 rebalance 或跨 shard 数据一致 |
+| Expose | `expose.services[*].roleSelector/podSelector/serviceType` | 只创建或更新 Service | advertised address、EndpointSlice 和客户端连接要另验 |
+| force/cancel/ttl | OpsRequest 状态机字段 | 控制排队、取消和清理 | 不代表业务动作可安全中断或跳过 |
+
+几个 Day-2 边界要提前写成支持矩阵。`Start` 只恢复停止的 workload，不等于重新执行 `postProvision`；一次性初始化必须有幂等保护。Vertical scaling 不只看 OpsRequest 成功，要给出调度、Pod 重建或 in-place 变化、容器内 cgroup 资源和引擎内部资源感知的证据。
+
+`scaleOut.fromBackup` 是 Restore 能力的独立消费者，不能用“新建 Cluster restore 成功”替代。它要验收 source Backup、restoreTime 或 PITR 窗口、restoreEnv、目标新副本的 memberJoin、角色收敛和数据一致性。多 target Backup 场景必须声明 `sourceBackupTargetName` 到目标 component、volume、ordinal 或 shard 的映射。
+
+`RebuildInstance` 至少区分 in-place 和 replace 两条路径。in-place 路径要证明旧进程停机、文件锁、PVC 清理/复用、restore 覆盖和 postReady 幂等；replace 路径要证明新旧 Pod/Service endpoint 过渡、memberLeave/memberJoin、PVC 绑定、存储拓扑和客户端切流。
+
+交错 Ops 要么证明支持，要么写明禁止组合：升级期间是否允许 switchover，reconfigure 与 restart/vertical scaling 是否可并发，scale-in 期间是否允许 backup，stop 后 delete 是否保证 preTerminate。不能证明组合安全时，应写成禁止组合或需要人工确认。
+
+Ops 状态机排查要允许“状态”和“事实”短暂不一致。并发 Ops、precondition、force、cancel、timeout 和 TTL 先看 OpsRequest `phase/message/conditions` 与目标 Component 状态，再看是否已有 action 后置校验失败、status 更新失败或 partial success。事实已经改变但 Ops 失败时，不要直接重试，先用最终对象和业务自检判断是否幂等安全。
+
+复杂 rebalance、跨 topology 在线迁移、需要人工确认的数据迁移，不应包装成通用支持能力。
+
+## 12. 常见操作排障要从入口 CR 逐层向下查
+
+release-1.1 的运行问题通常跨多个控制器。排障顺序固定为：入口 CR 的 generation/observedGeneration/phase/message/conditions，被引用 definition/policy/action 的 Available 状态，controller 生成对象，最终 workload，脚本输出，业务自检。
+
+| 操作 | 先查入口对象 | 再查底层对象 | 常见 addon 问题 | 推荐处理 |
+| --- | --- | --- | --- | --- |
+| create | Cluster、ClusterDefinition、CMPD、CMPV | Component、InstanceSet、Pod、PVC、Service、ConfigMap | compDef/template/volume/script 名错 | 修 chart 引用，不改 controller |
+| delete | Cluster/Component deletionTimestamp、finalizers | InstanceSet、Pod、PVC、preTerminate/memberLeave | action 所需 Pod 已不存在 | 保留现场，解释执行面为何消失 |
+| reconfigure | OpsRequest/Parameter、PD、PCR | ComponentParameter、runtime ConfigMap、reload/restart、进程配置 | templateName/fileName 错、desired 污染 | 按 desired/rendered/effective 三态修复 |
+| horizontal scale | OpsRequest、Component replicas | InstanceSet、Pod、memberJoin/memberLeave | 成员关系未收敛 | 实现 member lifecycle 或声明限制 |
+| switchover | OpsRequest、roleProbe、Service | action output、role label、EndpointSlice、业务查询 | roleProbe 与 switchover 脱节 | 修 role 合同和服务选择 |
+| backup | BackupPolicy、Backup、BPT | target Pod、ActionSet、Repo、artifact | BPT 未匹配、target role 错、账号错 | 先看 BackupPolicy 生成和 target |
+| restore/rebuild | Restore/OpsRequest | Job/PVC、postReady、memberJoin、数据校验 | backup method 只支持 backup | 建 method 消费者矩阵 |
+| upgrade | Cluster serviceVersion、CMPV | Pod image、action image、PD/BPT 版本覆盖、rollout | 只覆盖 runtime image | 补工具镜像和数据兼容验证 |
+
+按问题域组织排查路径时，可以使用下面的固定入口：
+
+| 问题域 | 第一批对象和字段 | 下一跳证据 | 边界 |
+| --- | --- | --- | --- |
+| 资源引用和 status | 入口对象 namespace/source、CMPD/CD/CMPV/PD/BPT/ActionSet 的 `generation/observedGeneration/phase/message/conditions` | 引用它们的 Cluster、Component、BackupPolicy、ComponentParameter、OpsRequest、Job 和事件 | 不要只看 CR 是否存在；以引用方最终生成物为准 |
+| 名字和身份 | Cluster UID、spec name、generated Component name、status key、Pod/PVC/Service 名、selector label | 引擎成员 ID、备份 target、sharding component、持久数据里的身份记录 | 不把 Pod 名、generated component name、clusterUID 或 ordinal 当作不可重算业务身份 |
+| 终止和数据保留 | Cluster `terminationPolicy`、deletionTimestamp、finalizers、conditions | InstanceSet、Pod、PVC、Backup/BackupRepo、preTerminate action | PVC retention、备份仓库清理、脚本失败是不同层 |
+| 调度、PVC 和存储 | scheduling、runtimeClass、affinity/tolerations、volumeClaimTemplates、PVC retention | 最终 Pod spec、PVC ownerRef/labels、StorageClass、Pod/PVC events | backup/restore/action worker 是否继承调度字段，以实际 Job/Pod 为准 |
+| Service 和网络 | CMPD services、Expose spec、ServiceRef、serviceVarRef、hostNetwork/hostPort | Service type/ports/selector、EndpointSlice、Pod label、env、连接测试 | ServiceRef、publishNotReadyAddresses、advertised address 都按最终对象验收 |
+| ServiceAccount 和 RBAC | Cluster/Component serviceAccountName、Action/Restore 运行位置 | Pod/Job SA、Role/RoleBinding/rules、事件 | 组件 Pod、action、backup/restore Job 可能不是同一个权限面 |
+| Pod 更新和 InstanceTemplate | OpsRequest、podUpdatePolicy、podUpgradePolicy、instanceUpdateStrategy、InstanceTemplate | InstanceSet current/updatedReplicas、revision、partition、Instance/Pod/PVC 身份 | `OnDelete` 表示等待用户删除 Pod，不是 controller 卡死 |
+| Action、lifecycle 和 probe | preCondition、targetPodSelector、handler、container/image、timeout/retry | action worker、volumeMount、stdout/stderr、exit code、role label、Component Available 条件 | action 成功和业务收敛分开判断 |
+| variables、env 和外部依赖 | CMPD vars、Cluster env、ServiceDescriptor/ServiceRef、credential/tls var | Pod/action/backup/restore env、渲染后 config/script、真实连接 | Optional 缺失、变量顺序、delimiter 和外部值一致性都以最终注入结果为准 |
+| 参数和 reconfigure | PD、PCR、OpsRequest reconfigure、外部 ConfigMap key | ComponentParameter、runtime ConfigMap、file-level action、Pod restart、进程配置 dump | defaultValue、删参、多文件冲突、formatter 幂等要用文件与进程双重证据定位 |
+| 备份和 artifact | BPT、BackupPolicy、BackupSchedule、Backup | method/actionSet、target Pod、Repo、snapshot 或 repo artifact | 加密、snapshot、Selective、postBackup 失败和 repo 切换只在声明使用时验收 |
+| Restore、scaleOut 和 rebuild | Restore、scaleOut.fromBackup、RebuildInstance | restore Job/PVC、prepareData/postReady、sourceBackupTargetName、memberJoin/memberLeave | 新集群 restore、scaleOut.fromBackup、rebuild 是不同消费者 |
+| Ops 状态和失败现场 | OpsRequest `phase/message/conditions`、force/cancel/timeout/TTL/progress/lastConfiguration | Component、InstanceSet、Pod、PVC、action 输出、events、业务自检 | Ops 字段只是证据；采集完现场前不要过早清理失败对象 |
+| 非主 workload | Backup/Restore/action worker、Job、Pod | env、SA、node、volumeMount、resources、runtimeClass、events | 主组件 runtime 的字段不能自动外推到 worker |
+
+删除、卸载、scale-in 和 Stop 后删除要分流排查。Cluster 删除先看 terminationPolicy、Cluster finalizer、Component deletionTimestamp、orders；Component 删除看 Component finalizer、InstanceSet/Pod/PVC ownerRef、preTerminate action；scale-in 看 OpsRequest、目标实例、memberLeave、PVC retention；Stop 后删除要先判断 Pod 是否仍存在。Pod 已停止或删除时不能假设 preTerminate 可执行。
+
+如果删除卡在 lifecycle 下线动作，而目标 Pod、InstanceSet 或其它执行面已经不存在，先保留 Cluster、Component、InstanceSet/Pod、Event 和 action 状态证据，定位执行面为何提前消失。只有确认业务清理已经不需要、已经由外部补偿完成，或当前恢复目标明确要求释放资源时，才能按明确风险的运维恢复流程绕过该动作；绕过后的结果不能作为 addon 删除流程验收通过的证据。
+
+排障路径从入口 CR 开始，但不能停在入口 CR。常用停止条件是：引用对象不存在或未 Available，生成对象缺失，action/Job 明确失败，业务自检无法证明，或需求本身超出 release-1.1 API。到达这些停止条件后，应修 addon chart/script、补验收或记录 gap/ambiguity，不要为了单个失败样例修改 controller 合同。
+
+## 13. 最低验收标准
+
+每个 release-1.1 addon 至少提供以下验收证据：
+
+| 验收项 | 必须做 | 不能证明什么 |
+| --- | --- | --- |
+| Helm render | 覆盖 standalone、HA、proxy、sharding、TLS、serviceVersion、backup 开关 | 不证明 controller 消费成功 |
+| server dry-run | 对关键 examples 做 server-side dry-run | 不证明业务运行成功 |
+| 定义对象可用 | CD/CMPD/CMPV/PD/PCR/BPT/ActionSet status Available | 不证明所有 topology 可用 |
+| 最小 Cluster | Pod/PVC/Service/ConfigMap/script 全部生成并可启动 | 不证明参数、备份、升级可用 |
+| workload 身份 | Component、InstanceSet、Pod、PVC、Service、ownerRef 和 label 闭合 | 不证明数据库成员 ID 正确 |
+| role/lifecycle | roleProbe、memberJoin/Leave、switchover、preTerminate 均有输出和业务自检 | 不证明所有 failure path 幂等 |
+| 参数 | desired/rendered/effective 三态覆盖动态、静态、删参 | 不证明任意用户模板可 merge |
+| ServiceRef | declaration、Cluster binding、ServiceDescriptor、最终 env/config、连接自检 | 不证明凭据轮换自动生效 |
+| 账号/TLS/RBAC | runtime、action、backup、restore、proxy 执行面分别验 | 不证明其它工具镜像继承同一权限 |
+| 数据保护 | BackupPolicy、Backup、artifact、Restore、postReady、数据校验 | Backup 成功不证明 PITR/rebuild/scaleOut |
+| Day-2 | restart、scale、reconfigure、switchover、upgrade、delete 的入口和底层对象链 | OpsRequest 成功不证明业务收敛 |
+| 发布 | old/new render、server diff、live object、生成对象对比 | Git diff 不等于最终对象 |
+| 限制 | 不支持能力明确写清楚 | 不支持项不能靠脚本暗中拼接 |
+
+测试分层要区分：chart 单测验证 helper 和渲染闭合；server-side dry-run 验证 API schema；定义对象检查验证 controller 能引用；live smoke 验证最小运行；能力 smoke 验证参数、备份、restore、scale、switchover、upgrade；故障用例验证删除、重试、幂等、空数据、repo 不可用、凭据缺失和失败现场。
+
+每个能力声明都要有对应示例。README 写“支持 backup”时，examples 中至少要有 BackupRepo、Backup、Restore 或等价入口；写“支持 reconfigure”时，要有动态、静态和非法参数示例；写“支持 HA”时，要有 roleProbe、Service、switchover 或故障恢复示例；写“支持 upgrade”时，要有 old/new serviceVersion 和数据兼容说明。
+
+验收矩阵按能力声明组织，而不是按 CRD 类型组织。一个 addon 可以只支持 standalone + backup，不支持 HA；也可以支持 HA 但不支持 PITR；还可以支持普通 scale-out 但不支持 scaleOut.fromBackup。每个能力都要写清适用 topology、适用 serviceVersion、执行面、示例、失败路径和不支持项。
+
+验收结果要保留能复现的对象证据。最小集合包括 rendered manifests、server dry-run 结果、定义对象 status、Cluster/Component/InstanceSet/Pod/PVC/Service、ComponentParameter/runtime ConfigMap、Backup/Restore/Job、OpsRequest、events、脚本输出和业务自检命令结果。只保存截图、只保存最终 Succeed 状态、或只保存某个 Pod Ready，都不足以审计能力合同。
+
+失败用例也属于验收。参数非法、Secret key 缺失、ServiceRef 不存在、BackupRepo not ready、ActionSet 不可用、target role 不存在、restore artifact 缺失、scale-in memberLeave 失败、preTerminate target Pod 消失，这些问题应能给出可诊断错误和停止条件。没有负向用例时，addon 很容易把 controller 可接受字段误写成产品能力。
+
+## 14. 高风险能力验收矩阵
+
+字段存在但消费者不完整、语义不清或缺少真实 addon 证据的，只能写成“未证明”“需要验证”或进入 gap/ambiguity。
+
+### 14.1 Restore、Rebuild 和 scaleOut 要按消费者建矩阵
+
+release-1.1 同时存在 `Restore`、`RebuildInstance` 和 `HorizontalScaling.scaleOut.fromBackup`。它们可以共享 Backup、ActionSet 和 artifact，但不是同一个能力。一个 method 能 restore 到新集群，不等于能 rebuild 原实例，也不等于能用于 scaleOut 新副本。
+
+| 消费者 | release-1.1 入口 | 必须证明的对象链 | addon 必须自证的业务结果 | 不能外推的结论 |
+| --- | --- | --- | --- | --- |
+| 新集群 Restore | `dataprotection.kubeblocks.io/v1alpha1 Restore` | Backup、ActionSet restore、prepareData、ReadyConfig/postReady、Restore Job/PVC | 目标 Cluster/Component ready，数据可读写，账号/TLS 可用 | 不证明 RebuildInstance、scaleOut 或跨 topology restore |
+| PITR Restore | Restore `restoreTime` + continuous/PITR backup | base backup、parent chain、timeRange、archive artifact、restoreTime 格式 | 恢复到目标时间点，业务数据符合预期 | 不证明任意时间点都有可用归档 |
+| K8s 资源恢复 | Restore `resources.included` | 被 include 的 GroupResource、labelSelector、恢复后的 K8s 对象 | 资源对象恢复成功 | 不等于数据库数据恢复成功 |
+| RebuildInstance | OpsRequest `rebuildFrom` | backupName、sourceBackupTargetName、restoreEnv、目标 instance、inPlace/replace、postReady/memberJoin | 被 rebuild 实例数据正确并重新加入复制组 | 不证明逻辑备份可用于多副本 rebuild |
+| scaleOut.fromBackup | OpsRequest `horizontalScaling.scaleOut.fromBackup` | backup、newInstances/replica change、restore prepareData、memberJoin | 新实例从备份拉起并加入成员列表 | 字段只对非 sharding component 有效；不证明 shard scale 或 rebalance |
+
+### 14.2 网络、Service、RBAC 和 worker 执行面要分开验
+
+release-1.1 的主 Pod、lifecycle action、backup Job、restore Job、postReady Job 不是同一个执行面。主 Pod 能启动、Service 能连通、Secret 能读取，都不能自动外推到其它 worker。
+
+| 执行面 | 需要检查 | release-1.1 证据入口 | 常见错误 |
+| --- | --- | --- | --- |
+| runtime Pod | PodSpec、volumeMount、env、SA、ports、hostNetwork、hostNetworkVarRef | CMPD runtime、生成 Pod | 脚本读取 host IP/port，但 Service 或 env 格式不同 |
+| Service/Endpoint | Service type、selector、roleSelector、podService、EndpointSlice、publish/not-ready 行为 | CMPD services、生成 Service/EndpointSlice | Service 有 endpoint 但 role 不对或 advertised address 不对 |
+| ServiceRef | declaration、Cluster binding、ServiceDescriptor、credential、namespace | service reference resolver、ServiceDescriptor controller | 跨 namespace credential 被禁止或 Secret key 未校验到业务可用 |
+| lifecycle action | target、container/image、volumeMount、SA/RBAC、timeout/retry | lifecycle executor、kbagent、action output | 默认容器或工具镜像与 runtime 版本不一致 |
+| backup worker | BackupPolicy serviceAccountName、ActionSet env、BackupRepo mount/tool secret | Backup/ActionSet/BackupRepo controller 和 Job | runtime TLS/账号未传递到 backup 工具 |
+| restore worker | Restore serviceAccountName、prepareData scheduling、ReadyConfig、postReady | Restore API 和 restore manager | prepareData 成功但 postReady 或业务连接失败 |
+| RBAC | Component `policyRules`、runtime SA、Job/action SA | final Pod/Job SA、Role/RoleBinding、event | 组件 Pod 有权限，restore/action Job 没权限 |
+
+### 14.3 Controller 修改边界
+
+如果一个问题只能通过修改 KB controller 才能让单个 addon 跑通，但 API 合同、生成对象或业务自检证据不足，应先判定为 addon 合同问题、ambiguity 或 gap。只有 API 合同证据、controller 实现证据、生成对象证据和业务自检证据同时指向 controller 语义错误，才能讨论 controller 修改。
+
+判断 controller 修改前至少回答四个问题：字段语义是否能从 API 类型或注释推出；controller 当前实现是否违反该语义；真实 addon 是否按语义正确声明；运行时对象和业务自检是否证明错误发生在 controller 而不是 chart/script。只证明“某个样例改 controller 后跑通”不是合同证据。

--- a/docs/developer_docs/kubeblocks-addon-development-practice-guide.zh-CN.md
+++ b/docs/developer_docs/kubeblocks-addon-development-practice-guide.zh-CN.md
@@ -1,0 +1,1210 @@
+# KubeBlocks Addon 开发实践指南
+
+本文面向 addon 开发者和负责开发 addon 的 agent。它不是 API reference，而是一份实践指南：从设计一个完整数据库 addon 的过程出发，解释应该如何组合 KubeBlocks core API、真实 addon chart 模式和控制器实现。
+
+真实参考样本来自 `kubeblocks-addons` 仓库中的 addons。当 API 注释不够明确时，以 `kubeblocks` 仓库的 core controller 和 `pkg` 实现为准；仍然不确定或实现不完备的内容记录在 [addon-api-ambiguities.zh.md](addon-api-ambiguities.zh.md) 和 [addon-api-gaps.zh.md](addon-api-gaps.zh.md)。
+
+## 1. 各环节都要先写清楚合同
+
+addon 开发不是把 YAML 填满，而是为每个能力建立一组可验证合同。下面这张表是开发和 review 的主线。每个环节都要回答：addon 作者声明了什么、KB controller 实际消费什么、运行时应该看到什么、失败时先查 addon 还是查 KB。
+
+| 环节 | addon 必须声明的合同 | controller 主要消费点 | 常见误判 | 先查什么 |
+| --- | --- | --- | --- | --- |
+| Chart 组织 | helper 统一生成名称、label、selector、模板引用 | Helm 渲染后的 core CR | 样本 values 能跑就认为名称规则正确 | `helm template` 后所有引用是否闭合 |
+| ComponentDefinition | runtime、volumes、configs、scripts、services、roles、vars、accounts、TLS | component transformer 和 synthesized component | 把动态资源、运维状态塞进 CMPD | status Available、volumeMount/volume/config/script 名称是否对齐 |
+| ClusterDefinition | topology、component/sharding 组成、创建/删除/更新顺序 | cluster normalization 和 topology 解析 | 未设置 default 却假设选第一个 topology | resolved componentDef、orders、default topology |
+| 版本和匹配 | chart version、ComponentDefinition name、serviceVersion、ComponentVersion 关系 | componentDef matching、componentVersion compatibility | 用宽正则碰巧匹配“最新” | 每个 BPT/PD/ClusterDefinition 是否引用同一套 helper |
+| 配置参数 | config template name、template ConfigMap、fileName、schema、static/dynamic 分类 | parameters controller、reconfigure controller | 字段名相似就当成同一个对象 | PD、CMPD configs、template ConfigMap、ComponentParameter、runtime ConfigMap |
+| 变量和服务 | vars 来源、值格式、Service 类型、ServiceRef 绑定 | var resolver、service builder | 脚本私下约定变量格式，README 不写 | 渲染 env/action vars、service/podService、外部访问模式 |
+| 账号和 TLS | systemAccounts、accountProvision、secret 使用边界、证书路径 | component definition validation、lifecycle action | 账号存在就等于业务权限可用 | secret、accountProvision 输出、备份/探测/复制账号实际可用性 |
+| lifecycle | roleProbe、memberJoin/Leave、switchover、preTerminate 的业务语义 | lifecycle executor、kbagent、component deletion | 脚本能执行一次就等于幂等可靠 | action 输入变量、目标 Pod、重试、失败状态、资源是否还存在 |
+| 内置 Ops | 每种 Ops 的底层前提 | operations pkg 和各 domain controller | OpsRequest 失败就只看 operations 层 | restart/scale/reconfigure/backup/restore/switchover 各自依赖的底层合同 |
+| 数据保护 | BPT、ActionSet、backup methods、target role、脚本职责 | BPT driver、backup/restore controller | 只有 ActionSet 就声称支持备份 | BackupPolicy 是否生成、method/actionSet 是否一致、target 是否选中正确 Pod |
+| Restore/Rebuild | 恢复目标、版本/拓扑/TLS/账号兼容性、prepareData/postReady | restore manager、operations rebuild flow | Backup 成功就等于 Restore 成功 | Restore phase、PVC/Job、数据校验、重建实例路径 |
+| Upgrade/Rollout | 版本矩阵、镜像映射、兼容限制、更新顺序 | ComponentVersion、rollout、workload controller | 镜像能拉起就等于升级支持 | old/new serviceVersion、rollout 状态、数据兼容、回滚限制 |
+| Sharding | shard 模板、跨 shard 变量、scale shard 后处理、数据迁移语义 | sharding/component transformers | 多副本等同于 sharding | ShardingDefinition、shard lifecycle、rebalance 或限制说明 |
+| 操作排障 | 创建、删除和 day-2 ops 的资源链路 | cluster/component/operations/dataprotection 等控制器 | 只看最后一个报错 | 从入口 CR 到底层对象逐层查 |
+
+这张表用于开发和 review：每新增一个能力，都要能在对应行里说明对象关系、controller 消费方式、运行验证和限制边界。
+
+## 2. 先定义 addon 的工作边界
+
+实践中，一个 addon 首先是一个 Helm chart，而不是一个单独 CR。真实 addon 通常包含 `Chart.yaml`、`values.yaml`、`templates/`、`configs/`、`scripts/` 和 README。例如 MySQL、PostgreSQL、Redis、ClickHouse、Kafka、Etcd 都采用这种组织方式。
+
+本指南用一个合成 addon `acmedb` 作为叙述主线。`acmedb` 是一个有主从复制、可选 proxy、可选 sharding、支持参数变更和备份恢复的数据库。它不是新增到仓库里的真实 chart；它用于把真实 addon 中已经存在的模式串成一条完整开发路径。
+
+addon 作者开始前应先回答这些问题：
+
+- 引擎需要几个组件。单进程数据库可以只有一个 `ComponentDefinition`；带 proxy、keeper、controller/broker 或 sentinel 的系统应拆成多个组件。真实样例包括 Kafka 的 controller/broker、ClickHouse 的 clickhouse/keeper、Redis 的 redis/sentinel/twemproxy、MySQL 的 mysql/proxysql。
+- 是否需要多个拓扑。`ClusterDefinition` 应表达 standalone、HA、proxy、sharding 等用户可选拓扑，而不是把拓扑差异塞进脚本。
+- 哪些能力是内置 day-2 操作可以覆盖。扩缩容、重启、配置变更、备份恢复、切主、重建等优先通过内置能力完成；超出内置能力的需求应先记录边界和缺口，不在本指南中作为推荐路径展开。
+- 哪些功能只能记录为限制。当前 API 无法自然表达的需求不要用脚本和隐藏约定硬拼，应写入 gap 文档。
+
+推荐 chart 结构：
+
+```text
+addons/acmedb/
+  Chart.yaml
+  values.yaml
+  templates/
+    clusterdefinition.yaml
+    cmpd-storage.yaml
+    cmpd-proxy.yaml
+    cmpv-storage.yaml
+    paramsdef.yaml
+    backuppolicytemplate.yaml
+    actionset.yaml
+    config-templates.yaml
+    script-templates.yaml
+  configs/
+    acmedb.conf.tpl
+    constraints.cue
+    effects.yaml
+  scripts/
+    start.sh
+    role-probe.sh
+    member-join.sh
+    member-leave.sh
+    switchover.sh
+    reconfigure.sh
+    backup.sh
+    restore.sh
+```
+
+真实依据：MySQL 的 `templates/clusterdefinition.yaml`、`templates/cmpd-mysql80.yaml`、`templates/cmpv.yaml`、`templates/backuppolicytemplate.yaml`、`templates/actionset-xtrabackup.yaml`；PostgreSQL 的 `templates/cmpd.yaml`、`templates/cmpv.yaml`、`templates/paramsdef.yaml`；Redis 的 `templates/cmpd-redis.yaml`、`templates/cmpv-redis.yaml`、`templates/cmpv-redis-sentinel.yaml`；ClickHouse 的 `templates/cmpd-ch.yaml`、`templates/cmpv.yaml`；Etcd 的 `templates/cmpd.yaml`、`templates/cmpv.yaml`。
+
+chart 层还要先做闭合检查，再谈运行语义。`helm lint` 只能证明一部分语法；review 时必须用代表性 values 渲染 standalone、HA、proxy、sharding、TLS on/off、外部 ServiceRef、不同 serviceVersion 等组合，确认所有 `include` helper、ConfigMap key、script key、`templateName`、`compDef`、BPT `compDefs`、PD `componentDef/templateName/fileName` 和 examples 中的名字都能闭合。helper 名称要带 addon 前缀，不能让多个模板文件各自拼接同一个资源名；否则单个样例能跑，换 topology 或版本后就会出现引用漂移。
+
+历史 issue 反复暴露同一个问题：topology 不是 README 里的展示分类，而是必须单独验收的支持维度。只要 addon 声称支持 `standalone`、`replication`、`mgr`、`mgr-proxy`、`sharding`、`sentinel`、`keeper`、`proxy` 等 topology，就要分别证明该 topology 的 ComponentDefinition、ClusterDefinition、ComponentVersion、ParametersDefinition、BackupPolicyTemplate、ActionSet、Service/ServiceRef、systemAccounts、TLS、examples 都能闭合。某个 topology 的 Cluster 能 Running，不代表它的 BackupPolicy 会自动生成、proxy 会路由到 writer、roleSelector Service 会选到正确 Pod，或参数和 restore 能继续工作。
+
+发布和升级还要单独做资源治理。多数 definition、policy、action 类资源是 cluster-scoped 或被跨 namespace 引用的公共定义，名称不应把安装 namespace 拼进去；多 chart、多 release 共存时靠 addon 前缀、引擎大版本和稳定 helper 隔离，避免两个 namespace 安装同一个 addon 时互相污染。升级前后必须比较 `helm template` 新旧结果、server-side dry-run 结果和 apiserver 中的最终对象，不能只相信本地渲染或客户端 schema。被 values 关闭的功能也要有迁移策略：旧 `ComponentDefinition`、`ClusterDefinition`、`ComponentVersion`、`ParametersDefinition`、`BackupPolicyTemplate`、`ActionSet`、已生成 `BackupPolicy`、`BackupSchedule` 和示例测试资源，是保留、删除、改名还是标为不再支持，都要在 release checklist 里写清楚。否则旧资源仍可能被 ComponentVersion 匹配、BackupPolicy 继续消费，或者测试 ActionSet 混入发布包后被真实 BackupJob 使用。
+
+示例验收要看 server 端最终对象。推荐在每个关键 example 上执行 server-side dry-run，再把 dry-run 输出、实际 apply 后对象和下游生成的 Component/BackupPolicy/ComponentParameter 做 diff。若 dry-run 与实际对象不同，应以 apiserver 最终对象和 controller 生成物为准定位问题；本地 `helm template` 只能作为输入证据，不能证明 admission/defaulting/mutation 后的合同仍闭合。
+
+发布迁移要先把字段分成“可 patch”“只能创建期决定”“需要新建对象迁移”三类。至少应把下面这些 Cluster 层字段列入 release checklist：
+
+| 字段或对象关系 | 迁移原则 | 验收证据 |
+| --- | --- | --- |
+| Cluster `spec.clusterDef`、`spec.topology` | 不把拓扑切换设计成在线 patch；需要新建 Cluster、数据迁移或明确不支持 | 新旧 Cluster 的 topology、Component 列表、PVC/Backup/Restore 映射表 |
+| Cluster `spec.restore` | 视为创建期恢复入口；恢复源写错、Restore 阶段失败或 source target 选错时，优先新建恢复 Cluster 重试 | 源 Backup namespace/name/UID、Restore Job/PVC、目标 Cluster status 和清理策略 |
+| `componentSpecs[*].name/componentDef` 和 sharding 名称 | 组件身份变更等同迁移，不用改名 patch 伪装成原组件 | live Cluster spec、生成的 Component 名、InstanceSet/PVC ownerRef |
+| 已生成 `BackupPolicy`、`BackupSchedule`、`ComponentParameter` | 默认 repo、method、schedule 或参数模板变更不必然自动刷新旧对象 | 生成对象的当前 spec/status，而不是 chart 新默认值 |
+
+GitOps 和 server-side apply 要单独防 list 字段风险。`componentSpecs`、`shardings`、`services`、`configs`、`schedules` 这类列表可能有 merge key、retainKeys 或 controller 默认值；Git diff 中“删掉一项”不等于 apiserver 最终对象一定删除，反过来 apply 后的 retained 字段也可能继续被 controller 消费。发布前用 server-side dry-run、`kubectl diff --server-side`、live spec 和下游对象四层对照：输入 manifest、apiserver 最终对象、controller 生成对象、业务自检。最终判定只看 live 对象和生成物，不看 Git 仓库里某个 YAML 片段的意图。
+
+## 3. 用 ComponentDefinition 表达组件蓝图
+
+`ComponentDefinition` 是 addon 作者最重要的资源。它描述组件的静态蓝图：runtime PodSpec、配置模板、脚本、服务、变量、账号、TLS、角色、生命周期动作、更新策略和 RBAC。Cluster 或 Component 只提供实例化时的动态参数，例如副本数、资源、存储、调度和用户选择的 serviceVersion。
+
+最小可运行组件需要这些内容：
+
+```yaml
+apiVersion: apps.kubeblocks.io/v1
+kind: ComponentDefinition
+metadata:
+  name: acmedb-storage-1.0.0
+spec:
+  provider: acme
+  serviceKind: acmedb
+  serviceVersion: 1.0.0
+  runtime:
+    containers:
+      - name: acmedb
+        image: acme/acmedb:1.0.0
+        command: ["/scripts/start.sh"]
+        ports:
+          - name: client
+            containerPort: 5432
+        volumeMounts:
+          - name: data
+            mountPath: /var/lib/acmedb
+          - name: scripts
+            mountPath: /scripts
+  volumes:
+    - name: data
+      needSnapshot: true
+  scripts:
+    - name: acmedb-scripts
+      template: acmedb-scripts
+      volumeName: scripts
+      defaultMode: 0555
+```
+
+实践规则：
+
+- `runtime` 放引擎必需且跨实例稳定的 PodSpec。CPU、内存、PVC 大小、调度等动态内容留给 Cluster。
+- `volumes[*].name` 必须和 runtime 中的 volumeMount 名称、Cluster 的 `volumeClaimTemplates[*].name` 对齐。否则用户写了 PVC 也不会挂载到预期路径。
+- `scripts` 和 `configs` 应引用 chart 渲染出的 ConfigMap。真实 addon 通常把启动、探测、成员变更、重载、备份脚本拆成独立文件，再通过模板挂载。
+- `services` 用来声明 KB 管理的服务形态。常规 client service、roleSelector service、podService、disableAutoProvision 都应在组件蓝图中声明，再允许用户在 Cluster 侧按需覆盖。
+
+ComponentDefinition 的合同检查：
+
+- 每个 `runtime.containers[*].volumeMounts[*].name` 都能在 `spec.volumes`、`spec.configs[*].volumeName` 或 `spec.scripts[*].volumeName` 中找到来源。
+- 每个脚本路径都来自 mounted script volume，脚本 ConfigMap 的 key、defaultMode 和容器 command 对齐。
+- 每个 service 端口都能对应 runtime container port；roleSelector service 依赖的 role 必须由 roleProbe 产生。
+- 每个声明的 account、TLS、var 都要能在启动脚本、lifecycle action 或 backup/restore 中找到使用点。
+- `status.phase=Available` 是被引用前的最低门槛；不是仅看 CR 创建成功。
+
+控制器实现要求 `ComponentDefinition` 被引用时必须 `status.phase=Available`，且已观测最新 generation。实现依据见 `controllers/apps/component/transformer_component_load_resources.go`。这意味着实践中不能只检查资源存在，还要检查 status。
+
+所有会被其它对象引用的 definition、policy 和 action 资源都按同一套可用性口径排查：先确认入口对象和被引用对象在同一预期 namespace 或显式 source namespace 下，再看 `generation/observedGeneration`、`phase/message/conditions` 是否指向同一轮 reconcile，最后看引用方生成的 Component、BackupPolicy、ComponentParameter、Job 或事件是否已经消费到新对象。同名删除重建、`phase=Available` 但 message/condition 仍残留旧错误、direct `componentDef` Cluster 与无关 ClusterDefinition 报错并存时，都不要只凭对象名下结论；要回到引用关系和最终生成物取证。
+
+默认资源和数据目录初始化也是 ComponentDefinition 合同的一部分。values 里的 CPU、memory、storage、ulimit、文件句柄、临时目录和默认 JVM/进程参数必须满足引擎最低启动要求；否则 Pod OOMKilled、No space left on device 或启动探针失败会被误判成 KB 创建失败。启动脚本要区分真正空数据目录、只包含 `lost+found` 这类文件系统目录、已有业务数据、restore/rebuild 写入的数据和半初始化目录；不要用简单的“目录为空/非空”判断决定是否初始化或清空数据。
+
+写完 ComponentDefinition 后，必须立刻写一个最小 Cluster 样例来证明闭环。不要等到 HA、备份、参数都写完才发现基础对象没有实例化成功：
+
+```yaml
+apiVersion: apps.kubeblocks.io/v1
+kind: Cluster
+metadata:
+  name: acmedb-smoke
+spec:
+  clusterDef: acmedb
+  topology: ha
+  terminationPolicy: Delete
+  componentSpecs:
+    - name: storage
+      replicas: 1
+      serviceVersion: 1.0.0
+      resources:
+        requests:
+          cpu: 500m
+          memory: 1Gi
+      volumeClaimTemplates:
+        - name: data
+          spec:
+            accessModes: [ReadWriteOnce]
+            resources:
+              requests:
+                storage: 20Gi
+```
+
+这个样例要验证四个闭合点。第一，`componentSpecs[*].name` 等于 ClusterDefinition topology 里的 component name；如果绕过 ClusterDefinition 直接在 Cluster 里写 `componentDef`，则所有 componentSpecs 必须采用同一种写法，不能有的依赖 topology、有的直接指定 ComponentDefinition。第二，`serviceVersion` 在开发样例里要显式写出，避免未指定时 controller 选择最高语义版本导致误判。第三，`volumeClaimTemplates[*].name` 必须等于 CMPD `spec.volumes[*].name` 和容器 `volumeMounts[*].name`。第四，脚本和配置 volume 要能在 Pod 里看到对应文件和权限。
+
+最小验证链路是：
+
+```bash
+kubectl get cluster acmedb-smoke -o yaml
+kubectl get component -l app.kubernetes.io/instance=acmedb-smoke -o yaml
+kubectl get componentdefinition acmedb-storage-1.0.0 -o yaml
+kubectl get instancesets,pods,pvc,svc -l app.kubernetes.io/instance=acmedb-smoke
+kubectl describe pod -l app.kubernetes.io/instance=acmedb-smoke
+```
+
+从 Component 往下排查时，固定按 `Component -> InstanceSet -> Instance -> Pod -> PVC` 看实例身份。Component `Running` 不等于 InstanceSet `InstanceAvailable=True`；Pod Ready 后还可能受 `minReadySeconds`、availableProbe、roleProbe 或 update strategy 影响。InstanceTemplate 名称、默认补齐的 instances、flat ordinal、PVC 命名和 ownerRef 都会影响身份连续性；README 和排障步骤不要建议用户手工修改 KB 系统 label/selector，也不要用连续 ordinal 猜测实际 Pod/PVC。滚动类问题要看 InstanceSet `current/updatedReplicas`、revision、partition/canary/OnDelete 等状态，再判断是否真正完成 rollout。
+
+ComponentDefinition 中有几组字段特别容易被误读，应按下面的字段语义矩阵 review：
+
+| 字段 | addon 为什么要填 | 必须同时对齐 | 误用表现 |
+| --- | --- | --- | --- |
+| `spec.volumes[*].name` | 给数据卷、snapshot 和 volume expansion 建立稳定名字 | runtime `volumeMounts[*].name`、Cluster `volumeClaimTemplates[*].name`、BPT `targetVolumes` | PVC 创建了但没挂载到数据库目录；volume expansion 找不到模板 |
+| `spec.volumes[*].needSnapshot` | 标识 volume snapshot backup 的候选数据卷 | BPT `backupMethods[*].snapshotVolumes` 和 snapshot method 文档 | 声称支持 snapshot，但 BPT 和 volume 没有绑定 |
+| `spec.volumes[*].highWatermark` | 容量到阈值时切只读/恢复读写 | `lifecycleActions.readonly/readwrite`、引擎实际只读命令 | 到达阈值后 action 不存在或脚本不幂等 |
+| `spec.configs[*].name` | 参数链路绑定键 | `ParametersDefinition.spec.templateName`、Cluster `configs[*].name` | 参数 controller 解析不到 config item |
+| `spec.configs[*].template` | 模板 ConfigMap 名 | chart `config-templates.yaml` 的 ConfigMap 名 | 模板文件不存在，Pod 挂载空或渲染失败 |
+| `spec.configs[*].volumeName` 和 `spec.scripts[*].volumeName` | 决定文件挂到哪个 volume | runtime volumeMount、脚本路径、`defaultMode` | command 找不到脚本或权限不对 |
+| `spec.services[*].roleSelector` | 只把流量指向某类角色 | `roles`、`roleProbe`、role label | 服务选不到 Pod，或切主后服务仍指向旧角色 |
+| `spec.services[*].podService` | 每个 Pod 一个 Service | serviceVarRef 输出格式、外部访问脚本 | 误以为 roleSelector 仍生效；实际生成 `serviceName-ordinal` 多个 Service |
+| `spec.services[*].disableAutoProvision` | 定义可暴露能力但默认不创建 | Cluster/Ops expose 显式启用 | addon 里声明了服务，运行时却找不到 Service |
+| `spec.replicasLimit` | 给 horizontal scale 定边界 | README、examples、scale e2e | 用户 scale 到业务不支持的副本数 |
+| `spec.available.withPhases/withRole/withProbe` | 定义 Component Available 判定 | readiness、roleProbe、availableProbe | Pod Ready 但 Component 不 Available，或反过来 |
+| `spec.hostNetwork.containerPorts` | hostNetwork 动态端口分配 | container port 名、`hostNetworkVarRef`、advertised address 脚本 | hostNetwork 启动后脚本仍用固定端口 |
+| `podUpdatePolicy`、`podUpgradePolicy`、`instanceUpdateStrategy` | 控制规格变更和升级 rollout | `roles.updatePriority`、quorum、switchover | 升级顺序破坏可用性，或 in-place/recreate 预期不一致 |
+
+`defaultMode` 要按最终 Pod 和容器内文件权限验收。YAML、Helm values、JSON 和 Go template 对数字的处理不完全相同，`0555`、`365`、字符串再转整数这些写法容易在渲染链路里被误读。脚本和配置 volume 的权限验收应同时看渲染后的字段、Pod spec 中的 `defaultMode`，以及容器内 `stat` 看到的八进制权限；不能只看源码里写了一个看起来像八进制的数字。
+
+`replicasLimit` 是 addon 声明的 scale 支持范围，不是业务已经支持所有边界的证明。声明后至少要验收最小值、最大值、越界拒绝、HorizontalScaling Ops、README 示例和 0 副本语义。若引擎在 `replicas=0` 时没有可用入口、不能保留复制成员语义或不支持从 0 恢复，文档必须写成不支持或需要人工步骤；不要用 Cluster phase 推断业务入口可用。
+
+## 4. 用 ClusterDefinition 表达拓扑，不表达组件细节
+
+`ClusterDefinition` 当前主要表达拓扑：有哪些 component 或 sharding、默认拓扑是什么、组件创建/删除/更新顺序是什么。组件的 runtime、账号、脚本和配置不应该放在这里。
+
+`acmedb` 可以这样组织拓扑：
+
+```yaml
+apiVersion: apps.kubeblocks.io/v1
+kind: ClusterDefinition
+metadata:
+  name: acmedb
+spec:
+  topologies:
+    - name: ha
+      default: true
+      components:
+        - name: storage
+          compDef: ^acmedb-storage-.*
+    - name: proxy
+      components:
+        - name: storage
+          compDef: ^acmedb-storage-.*
+        - name: proxy
+          compDef: ^acmedb-proxy-.*
+      orders:
+        provision: [storage, proxy]
+        terminate: [proxy, storage]
+        update: [storage, proxy]
+```
+
+实践规则：
+
+- 每个用户可选部署形态都应该有明确 topology。MySQL 用 `semisync`、`mgr`、`orc-proxysql` 等 topology 表达差异；这比让用户猜组件组合可靠。
+- 多组件拓扑必须声明顺序。proxy 通常在 server 后创建、先删除；controller/keeper 类组件要根据真实依赖排序。
+- `default: true` 不是装饰字段。实现中未看到“没有 default 就选第一个 topology”的回退，Cluster 未指定 topology 时依赖默认 topology。
+- `compDef` 支持精确名、前缀和正则，但多匹配的选择需要谨慎。ComponentDefinition 匹配的实现会按 serviceVersion 和名称排序选择；命名规则必须稳定。
+- Cluster 有两种实例化写法：通过 `clusterDef/topology` 解析 component，或在 `componentSpecs[*].componentDef` 里直接指定 ComponentDefinition。一个示例或 README 场景里不要混用这两种写法；混用时 component name、orders、default topology 和 direct componentDef 的责任边界会变得不可审计。
+
+ClusterDefinition 的合同检查：
+
+- 每个 topology 都有用户可理解的业务含义，不能只是为了复用模板拼出来的名字。
+- 多 topology 只能有一个 default；没有 default 时不能假设 controller 会选择第一个。
+- 每个 topology 的 component name 都要和 Cluster 示例里的 `componentSpecs[*].name` 对齐。直接指定 `componentDef` 的样例应显式说明绕过了 ClusterDefinition topology，因此不能再引用 topology orders 或 topology component name 作为依据。
+- topology 中的普通 component 名和 sharding 名不要复用同一个名字。确实无法避免时，必须用渲染结果、Cluster/Component status、Service selector 和变量输出证明 orders、componentSelector、vars 都没有歧义。
+- `orders.provision/terminate/update` 要覆盖跨组件依赖，尤其是 proxy、keeper、controller/broker、sentinel 这类辅助组件。`orders` 中每个元素是一个阶段；同一字符串里用逗号分隔的对象表示可并行阶段，阶段之间按数组顺序执行。
+- `compDef` 正则要能稳定命中唯一预期集合；若同一正则可能命中多个版本，必须同时说明 serviceVersion 或版本选择策略。
+- sharding 拓扑要说明 shard 增删时的数据迁移、rebalance 或明确限制，不能只声明多个 shard component。
+- ClusterDefinition 的 default topology 也要看 status。多个 `default: true` 或 default 缺失这类问题不应只期待 admission 阻止；review 时先查 ClusterDefinition `status.phase/message` 是否 Available，再查 Cluster normalize 后的 topology 选择。
+
+真实依据：MySQL `templates/clusterdefinition.yaml` 把 server/proxy 顺序写在 topology；Redis 和 ClickHouse 分别用 sharding 和多组件定义表达复杂部署形态。
+
+什么时候用 component，什么时候用 sharding：多副本不是 sharding。一个 component 的 `replicas` 表示同一复制组里的多个实例；sharding 表示多个 shard component，每个 shard 可以再有自己的 replicas。只有当用户需要增加或减少 shard 数、跨 shard 组织变量、或者每个 shard 都是一套独立 Component 时，才应引入 `ShardingDefinition`。
+
+ClickHouse、Redis cluster 这类场景可以用下面的最小形状表达：
+
+```yaml
+apiVersion: apps.kubeblocks.io/v1
+kind: ShardingDefinition
+metadata:
+  name: acmedb-shard
+spec:
+  template:
+    compDef: ^acmedb-storage-.*
+  shardsLimit:
+    minShards: 1
+    maxShards: 32
+  provisionStrategy: Serial
+  updateStrategy: Serial
+  lifecycleActions:
+    shardAdd:
+      exec:
+        container: acmedb
+        command: ["/scripts/shard-add.sh"]
+    shardRemove:
+      exec:
+        container: acmedb
+        command: ["/scripts/shard-remove.sh"]
+---
+apiVersion: apps.kubeblocks.io/v1
+kind: ClusterDefinition
+metadata:
+  name: acmedb
+spec:
+  topologies:
+    - name: sharding
+      shardings:
+        - name: shard
+          shardingDef: acmedb-shard
+```
+
+Cluster 样例应通过 `spec.shardings[*].name`、`shards`、`template.replicas`、`template.volumeClaimTemplates` 来实例化 shard，而不是在 `componentSpecs` 里手写多个同名模式的组件。sharding template 里的 `name` 不应被脚本或变量当作真实 component 名；实际 shard component 的 spec name 来自 sharding name 和 shardID，底层对象名还可能带 cluster 前缀。sharding 场景下要同时打印或检查 componentName、shortName、Pod FQDN 和 Service endpoint，避免模板名、spec 名和对象名漂移。
+
+`ShardingDefinition.spec.lifecycleActions.shardAdd/shardRemove` 只给新增或删除 shard 的 hook；它不自动证明 rebalance、数据迁移、slot 迁移或跨 shard 元数据修复已经完成。真实 ClickHouse 里存在 `post-for-scale-out-shard.sh` 这类补偿脚本，说明 shard scale-out 后的业务收敛必须逐 addon 证明。无法证明的数据迁移和 rebalance 要写成限制或 gap。`offline` shard、ClusterService `componentSelector` 指向 sharding、`minShards=0` 这类边界不应在 guide 里写成固定 endpoint 或 Available 语义；addon 必须用 status、Service endpoints 和 e2e 说明是否支持，或避免作为公共样例。
+
+名字和身份要拆开记录。`componentSpecs[*].name`、sharding spec name、生成的 Component 对象名、status map key、Pod 名、Pod FQDN、selector label 和 PVC 名不是同一种身份；同名重建后 Cluster UID 也会变化。脚本可以把这些值作为运行时输入，但不要把 `clusterUID`、Pod 名、generated component name 或连续 ordinal 写入不可重算的数据库成员 ID、持久配置或备份元数据中。确实需要持久化成员身份时，应使用引擎自己的成员 ID 或可从业务元数据重建的映射，并在恢复、重建、sharding scale 和同名 Cluster 重建时验收映射仍然成立。
+
+## 5. 用 ComponentVersion 管理版本矩阵
+
+addon 的版本管理有四层容易混淆：chart 版本、ComponentDefinition 名称、ComponentVersion release、引擎 serviceVersion。实践中应让它们可追溯但不要混为一谈。
+
+推荐做法：
+
+- `ComponentDefinition.metadata.name` 包含引擎大版本或 chart 版本，例如 `acmedb-storage-1.0.0`。
+- `spec.serviceVersion` 表示数据库内核或服务协议版本，例如 `1.0.0`。
+- `ComponentVersion` 维护同一类组件的 release 矩阵：哪些 ComponentDefinition 可用哪些 release，每个 release 对应哪个 serviceVersion，以及容器、action 或外部应用镜像如何替换。
+- helper 中统一生成 componentDef 名称、前缀和正则，避免 README、ClusterDefinition、BackupPolicyTemplate、ParametersDefinition 各写一套。
+
+`acmedb` 可以这样声明一个 storage 组件版本矩阵：
+
+```yaml
+apiVersion: apps.kubeblocks.io/v1
+kind: ComponentVersion
+metadata:
+  name: acmedb-storage
+spec:
+  compatibilityRules:
+    - compDefs:
+        - ^acmedb-storage-.*
+      releases:
+        - acmedb-1.0.0
+        - acmedb-1.1.0
+  releases:
+    - name: acmedb-1.0.0
+      serviceVersion: 1.0.0
+      images:
+        acmedb: acme/acmedb:1.0.0
+    - name: acmedb-1.1.0
+      serviceVersion: 1.1.0
+      images:
+        acmedb: acme/acmedb:1.1.0
+```
+
+不要把 `compDef: acmedb` 这种宽前缀作为长期约定。真实实现中 ComponentDefinition 多匹配会选择某个“最新”候选，但这不是给 addon 作者逃避版本治理的理由。
+
+版本合同检查：
+
+- README、values、ClusterDefinition、ParametersDefinition、BackupPolicyTemplate、examples 必须引用同一套 helper 生成的名字。
+- 每个 serviceVersion 都要说明可用镜像、兼容的配置 schema、备份恢复方法和升级路径。
+- `ComponentVersion.spec.compatibilityRules[*].compDefs` 支持精确名、前缀或正则；release 名必须能在 `spec.releases[*].name` 中找到。
+- `ComponentVersion.spec.releases[*].serviceVersion` 会作为被选择 release 的 serviceVersion，覆盖 ComponentDefinition 自身的 serviceVersion 参与 Cluster 解析。
+- `images` 的 key 要对应 ComponentDefinition runtime container、init container 或 lifecycle action 字段名。lifecycle action 名匹配大小写不敏感，例如 `switchover` 可以命中 `Switchover` 字段；未知 key 目前不会强制失败，不能把它当成已验证的镜像替换。
+- action image fallback 的边界要写清楚：ComponentVersion 可以覆盖有 exec image 解析路径的 lifecycle action 镜像；但某个 action 没有独立 image key、没有 `exec.image`、或脚本依赖 runtime/init 产物时，不能仅凭 runtime 镜像升级推断 action 也已升级兼容。升级验收必须分别检查 runtime container image、init container image、kbagent/worker 执行 action 时使用的镜像和脚本挂载。
+- ComponentVersion controller 会校验 serviceVersion 语义版本、compDef pattern 和 release 是否至少匹配到 ComponentDefinition；实践中还要检查 `status.phase=Available` 和 `status.serviceVersions`。
+- release 名、compatibilityRules 或 compDef pattern 出错时，第一诊断入口是 ComponentVersion 的 `status.phase`、`status.message` 和 `status.serviceVersions`。不要只看 `spec.releases` 是否存在相近名字，也不要把 Cluster upgrade 失败直接归因到 Ops 层。
+- Cluster 未指定 serviceVersion 时，normalization 会在 ComponentDefinition 自身 serviceVersion 和兼容 ComponentVersion releases 中选择最高语义版本；这会影响最终 resolved componentDef 和 serviceVersion。
+- 每个 serviceVersion 都应有独立 Cluster 样例或 e2e，证明 resolved image、serviceVersion、参数定义、备份方法和升级路径一致。
+
+升级发布要把“已完成的事实”和“未来可用性”分开。一次 Upgrade 已经完成，只能说明当时解析到的 ComponentVersion、镜像和 rollout 路径可用；如果之后新的 `ComponentVersion` 或相关 `ComponentDefinition` 变为 `Unavailable`、被 Helm 删除或被旧残留资源遮蔽，已运行 Pod 不一定立刻回滚，但后续 scale、restart、rebuild、backup method 选择或再次 upgrade 都可能重新消费这些 definition。排查时先保留旧版和新版的 server-side dry-run 结果，再看 apiserver 中残留的 CMPD/CMPV/PD/BPT/ActionSet、Cluster/Component resolved serviceVersion、Pod image 和 action image。不要把“当前业务还能连上”解释成版本资源仍健康。
+
+升级闭环不能只看新镜像能启动。至少要准备 old/new 两个 Cluster 样例，以及一个最小 upgrade OpsRequest：
+
+```yaml
+apiVersion: operations.kubeblocks.io/v1alpha1
+kind: OpsRequest
+metadata:
+  name: acmedb-upgrade-110
+spec:
+  clusterName: acmedb-smoke
+  type: Upgrade
+  upgrade:
+    components:
+      - componentName: storage
+        serviceVersion: 1.1.0
+```
+
+验证时要同时看 `ComponentVersion.status.serviceVersions`、Cluster/Component resolved serviceVersion、Pod image、action image、参数 schema、BPT method 和 rollout 顺序。`ParametersDefinition.spec.serviceVersion` 的匹配对象要按当前实现单独验证；不要因为 ComponentVersion release 覆盖了 Cluster resolved serviceVersion，就默认 PD 会按最终 release serviceVersion 选择 schema。数据兼容、回滚限制、跨大版本恢复限制必须写进 README 或实现说明。
+
+版本矩阵还要覆盖工具镜像和镜像来源。runtime image 能启动，不代表 lifecycle action、backup/restore、postReady、ReadyConfig、formatter 或 sidecar 使用的工具镜像与该 serviceVersion 兼容，也不代表目标集群或云区域能拉到这些镜像。对 Elasticsearch、ClickHouse、Kafka、Redis 这类工具链敏感的 addon，每个 serviceVersion 至少要列出 runtime image、init image、action image、backup image、restore image、formatter image、镜像 registry 来源、artifact format 或客户端协议版本；不能验证的组合写成“不支持/未证明”。
+
+## 6. 生命周期动作要按数据库语义建模
+
+角色型或复制型数据库通常需要 `roles`、`roleProbe`、`memberJoin`、`memberLeave`、`switchover`。共识系统还要特别关注 update 顺序和 quorum。`Action` 应尽量幂等，因为 controller 或 worker 重试可能导致重复执行。
+
+`acmedb` 的 HA 组件可以这样声明：
+
+```yaml
+spec:
+  roles:
+    - name: primary
+      updatePriority: 2
+      isExclusive: true
+    - name: secondary
+      updatePriority: 1
+  updateStrategy: BestEffortParallel
+  lifecycleActions:
+    roleProbe:
+      exec:
+        container: acmedb
+        command: ["/scripts/role-probe.sh"]
+      periodSeconds: 5
+    memberJoin:
+      exec:
+        container: acmedb
+        command: ["/scripts/member-join.sh"]
+    memberLeave:
+      exec:
+        container: acmedb
+        command: ["/scripts/member-leave.sh"]
+    switchover:
+      exec:
+        container: acmedb
+        command: ["/scripts/switchover.sh"]
+```
+
+实践规则：
+
+- 如果 `roles` 被 service、update 或 backup target 使用，就必须实现可靠 `roleProbe`。否则 roleSelector service、leader backup、switchover 都会不可信。
+- `memberJoin` 用于新副本加入复制组，`memberLeave` 用于副本移出前的数据库内清理，不要把数据迁移、重分片、用户确认等复杂流程藏进一个不可审计脚本。
+- `switchover` 用于计划性角色转移。脚本会通过 KB 注入的 switchover 相关环境变量理解当前角色和候选 Pod。实现对有 candidate 和无 candidate 的成功判定不同：指定 candidate 时会继续观察 candidate 的 role 是否达到目标 role；未指定 candidate 时，action 调用成功后即可进入成功路径。因此脚本自身校验和 roleProbe 都必须可靠，不能只依赖 OpsRequest 进入 Succeed。
+- 对于补偿性质的动作，比如 scale-out shard 后修复，若不能自然挂到内置生命周期，应记录为能力缺口或明确写出人工运维限制，不要包装成已经由 core API 自然支持。
+- `roles[*].isExclusive` 只约束 KB 记录的 role label 视角，不能证明数据库内部没有 split-brain，也不能替代引擎级 fencing、租约或 quorum 校验。role label、业务角色、Service endpoint 和客户端写入成功要分四层验收。
+
+生命周期合同检查：
+
+- `roleProbe` 输出必须稳定且可被 controller 解析；它影响 service、备份 target、更新顺序和 switchover。
+- `memberJoin` 和 `memberLeave` 要能重复执行或安全失败，且不要依赖可能已删除的 peer service。
+- `switchover` 要明确候选 Pod、当前 primary、失败回滚和状态检查方式。
+- `preTerminate` 只适合“Pod 仍存在时执行”的下线动作；如果清理动作必须在 Pod 消失后执行，就不应设计成 preTerminate。
+- 每个 action 都要有脚本单测或至少有可复现的 kbagent/action 输出。
+
+quorum 和更新顺序要作为 HA addon 的显式验收项：
+
+| 验收点 | 需要证明 |
+| --- | --- |
+| `roles[*].participatesInQuorum` | 哪些角色参与多数派；滚动、scale-in、Stop、故障恢复时不会把多数派同时拿下 |
+| `roles[*].updatePriority` | leader/primary、follower/secondary、learner 等角色的升级顺序符合引擎安全要求；相同 priority 不代表 leader 一定最后更新 |
+| `roleProbe` 周期和 threshold | role label 收敛延迟在 switchover、backup target、roleSelector service 和 rollout 中可接受 |
+| `podUpdatePolicy/podUpgradePolicy/instanceUpdateStrategy` | 与 quorum、role priority 和 switchover 策略组合后，升级期间仍满足业务可用性或明确需要停机 |
+| 引擎自检 | KB role label 与引擎 membership、term/epoch、primary lease 或一致性读写结果一致 |
+
+常见 lifecycle/action 字段语义如下：
+
+| 字段 | 脚本输入或选择语义 | addon 要证明什么 |
+| --- | --- | --- |
+| `postProvision.preCondition` | `Immediately`、`RuntimeReady`、`ComponentReady`、`ClusterReady` 决定动作触发时机 | 脚本依赖的 Pod、Service、账号、角色在该时机已经存在 |
+| `preTerminate` | 删除或缩容前执行，controller 等待它成功后继续释放资源 | 脚本不依赖已不存在的 Pod；不需要执行时有明确跳过策略 |
+| `availableProbe` 和 `available.withProbe` | 用 action 结果判定可用性；设置后会覆盖 withPhases/withRole 的判定方式 | probe 输出和失败语义稳定，不会把初始化中状态误判为可服务 |
+| `switchover` | 注入 `KB_SWITCHOVER_CURRENT_NAME/FQDN`、`KB_SWITCHOVER_CANDIDATE_NAME/FQDN`、`KB_SWITCHOVER_ROLE`；candidate 为空时可能不注入 candidate 变量 | candidate 为空和非空两条路径都能处理；有 candidate 时 roleProbe 最终能把 candidate 报成目标 role；无 candidate 时脚本要自己确认切换结果 |
+| `memberJoin` | 注入 `KB_JOIN_MEMBER_POD_NAME`、`KB_JOIN_MEMBER_POD_FQDN` | 新 Pod Ready 后能加入复制组，重复执行不会破坏已有成员 |
+| `memberLeave` | 注入 `KB_LEAVE_MEMBER_POD_NAME`、`KB_LEAVE_MEMBER_POD_FQDN` | 删除前能摘除成员；如果需要数据迁移，要作为单独限制说明 |
+| `readonly/readwrite` | 由 volume highWatermark 等容量保护路径触发 | 引擎有真实只读/读写切换命令，且状态可回查 |
+| `dataDump/dataLoad` | dump 通过 stdout 输出，load 从 stdin 读取；dump 可获得 `KB_TARGET_POD_NAME` | 只用于实例初始化类数据复制，不等价于 Backup/Restore method |
+| `reconfigure` | 文件变更时可获得 `KB_CONFIG_FILES_CREATED/REMOVED/UPDATED` | 脚本按文件名和参数名校验输入，支持幂等重试 |
+| `accountProvision` | 注入 `KB_ACCOUNT_NAME`、`KB_ACCOUNT_PASSWORD`、`KB_ACCOUNT_STATEMENT` | SQL/CLI 执行有转义、脱敏和最小权限控制 |
+| `Action.targetPodSelector` 和 `matchingKey` | `Role` 时按 `matchingKey` 选 role；`Any/All` 不使用 matchingKey | 依赖 role 的动作必须先证明 roleProbe 可靠 |
+| `timeoutSeconds` 和 `retryPolicy` | 非 0 退出、HTTP 非 2xx、超时都会按策略失败或重试 | 脚本要能安全重试；长耗时动作不要用默认超时碰运气 |
+
+`preCondition` 要按脚本依赖选择，不要按“越晚越安全”猜：
+
+| preCondition | 适合场景 | 不适合场景 |
+| --- | --- | --- |
+| `Immediately` | 只依赖定义对象、Secret 或本地初始化，不需要 Pod Ready | 需要连接数据库、依赖 Service endpoint 或 role 的动作 |
+| `RuntimeReady` | 需要容器文件、挂载卷、基础进程或本 Pod endpoint | 需要整个组件达到业务可用或所有成员已加入 |
+| `ComponentReady` | 需要当前 Component 的副本、role 或 service 已收敛 | 脚本本身会阻塞 ComponentReady，容易形成 readiness 环 |
+| `ClusterReady` | 依赖其它 component，例如 proxy 等待 storage 完成后初始化 | 任何影响 ClusterReady 本身的必经初始化动作 |
+
+action 目标和执行面要拆开验收：
+
+| 动作类型 | targetPodSelector/matchingKey 设计 | 执行位置验收 |
+| --- | --- | --- |
+| roleProbe/availableProbe | 通常作用于每个候选 Pod，不依赖旧 role | stdout、退出码、周期噪声和 Instance role/status 写入要分开看 |
+| memberJoin | 目标是新加入成员或能管理复制组的成员，按引擎语义固定 | 新成员 Ready、复制元数据广播、老成员视图刷新都要验证 |
+| memberLeave/preTerminate | 目标成员必须仍存在，或选择能执行摘除命令的管理角色 | scale-in、删除、Stop 后删除分别证明；Pod 已消失时不能假设还能执行 |
+| switchover/readwrite/readonly | 通常依赖 `Role` 和 `matchingKey`，candidate 路径另测 | action 成功后还要看 roleProbe、Service endpoint 和引擎状态 |
+
+HTTP/GRPC action 要把接口当成版本化合同。HTTP action 至少固定 method、path、headers、body、成功状态码范围和 body assertion；`204` 无 body 时不要写依赖 body 的断言。GRPC action 至少固定 service/method、payload schema、是否 unary、是否依赖 reflection，以及工具镜像里客户端版本。接口、payload 或工具镜像随 serviceVersion 改变时，要和 runtime image、PD、BPT 一起进入版本矩阵。
+
+超时和 retry 只说明 controller 视角的执行结果，不证明远端副作用已回滚。长耗时 action 要有幂等键或业务状态检查：超时后先查远端是否已部分执行，再决定重试、补偿或标为需要人工处理。retry 期间 targetPodSelector 可能重新选到不同 Pod，依赖单一目标的动作要固定目标输入或在脚本里拒绝目标漂移。
+
+`highWatermark` 场景要同时验收只读进入和读写恢复。触发 readonly 后，检查引擎真实只读状态、写请求失败方式和告警给用户的限制；容量恢复或扩容后，`readwrite` action 必须能把引擎带回可写，并用业务写入或引擎状态查询证明，而不是只看 action 退出 0。
+
+真实依据：Etcd `templates/cmpd.yaml` 同时实现 `roleProbe`、`memberJoin`、`memberLeave`、`switchover`、`dataDump`、`dataLoad`；PostgreSQL `templates/cmpd.yaml` 使用 HTTP roleProbe 和 switchover；Redis `templates/cmpd-redis.yaml` 声明 primary/secondary 角色和账号。
+
+`available.withProbe` 只改变 Component Available 的判定入口，不替代角色发现。只要 roleSelector service、backup target、switchover 或 updatePriority 依赖 role，仍然必须实现可靠 roleProbe。`majority`、`strict`、stdout assertion 和 action 退出码要分开验收：stdout 包含期望文本不能替代成功退出，部分 Pod probe 失败时是否仍可 Available 也必须用 status 和 e2e 自证。2 副本这类偶数副本示例要特别说明 majority 判断是否符合业务预期。
+
+lifecycle 排障要把 action 执行成功和业务状态收敛分开。`postProvision` 只适合一次性初始化，scale-out 新成员加入应由 `memberJoin` 或等价流程证明；`preTerminate` 必须能处理 Pod、Service、PVC 已部分删除或重复执行的场景；switchover action 退出 0 后还要用 roleProbe、Instance role status 和 roleSelector Service endpoint 证明角色已收敛。显式指定 action container 或独立 action image 时，要单独验证该执行面能看到脚本、volumeMount、TLS/Secret 和工具二进制，不能默认继承 runtime container 的文件系统。
+
+`memberJoin` 和 `memberLeave` 要同时证明三件事：controller 视角的 action 已完成，业务成员关系已经收敛，重复执行或中途失败后不会把状态写坏。scale-out 期间 kbagent、Service、Pod env 或业务进程可能暂时不可用；脚本必须能识别成员已经存在、成员还未可见、成员加入失败这三类状态，不能把“命令返回 0”或“下一轮重试成功”当作完整合同。scale-in 也不能只等待固定时间：如果引擎因为 quorum、shard awareness、数据迁移、replica placement 或磁盘状态拒绝摘除成员，脚本要能给出可诊断错误、可恢复退出或明确人工处理步骤。
+
+拓扑变化后的 action 不要依赖创建时写入 Pod env 的成员列表。`componentVarRef.podNames/podFQDNs`、旧 `KB_*` 列表或脚本启动时缓存的 endpoint 只能证明 Pod 创建时的视图；scale-out、scale-in、switchover、rebuild 之后，脚本应优先使用 action-time 注入的目标 Pod/FQDN、当前 Service/EndpointSlice、业务 membership 查询或显式传入的 candidate，而不是遍历旧环境变量里的静态列表。
+
+## 7. 变量注入是契约，不是脚本私货
+
+复杂 addon 会大量依赖 `vars`。这些变量把 Cluster、Component、Service、Credential、TLS、hostNetwork、ServiceRef 等运行时信息注入到容器和 action 中。
+
+常用变量来源：
+
+- `clusterVarRef`：cluster name、namespace、uid。
+- `componentVarRef`：组件副本数、Pod 名称列表、FQDN 列表、某个 role 的 Pod。
+- `credentialVarRef`：system account 的用户名和密码。
+- `serviceVarRef`：同一 Cluster 内 KB 管理 Service 的 host、port、nodePort、loadBalancer。
+- `serviceRefVarRef`：Cluster 创建时绑定的外部服务或另一个 Cluster 服务。
+- `tlsVarRef`：TLS 是否启用。
+- `hostNetworkVarRef`：hostNetwork 场景下动态分配端口。
+
+实践规则：
+
+- 每个变量都要在脚本里有明确使用点。不要为了“可能以后有用”注入大量变量。
+- 避免 `runtime.containers[*].env`、CMPD `vars` 和 Cluster `componentSpecs[*].env` 定义同名变量。确实需要覆盖时，验收口径以最终 Pod env、action env 和渲染后的 config/script 为准，而不是以任一层 YAML 的书写顺序推断。
+- `KB_` 前缀变量视为 KB 注入保留空间，addon 自定义变量不要复用；Pod runtime、lifecycle action、backup/restore Job 的 env、volume、Secret、TLS 挂载是不同执行面，必须分别验收。
+- 多组件和多 shard 变量要明确值格式。真实 addon 中常见格式是逗号分隔 Pod 列表或 FQDN 列表，脚本经常用 `cut`、`awk`、`tr` 解析，这些格式必须在 README 或实现说明中固定下来。
+- 对外暴露地址要区分 ClusterIP、NodePort、LoadBalancer、hostNetwork。Kafka 模板中已经明确写到当前只支持 NodePort 和 ClusterIP，LoadBalancer 仍是能力缺口。
+- `ServiceRefDeclaration` 只声明依赖形状，不提供实际绑定。Cluster 创建时还要用 serviceRef 绑定具体服务。
+- 同一个 Cluster 内的 ServiceRef `name` 是依赖身份，必须全局唯一或显式声明共享同一个外部依赖。不要让两个 component 用同名 ServiceRef 指向不同 provider；否则 vars、脚本和用户示例会把两个依赖混成一个合同。
+
+变量和服务合同检查：
+
+- 变量值格式要在 addon 文档中固定，例如逗号分隔、`name:port` 列表、FQDN 列表、JSON 片段，不允许只在脚本里隐式约定。
+- `Optional` 变量缺失时脚本要有显式分支；`Required` 变量缺失应让问题尽早暴露。不要假设 Optional 一定渲染为空字符串：不同变量源可能表现为 env 不注入、模板值为空或解析结果为空，脚本应同时处理 unset 和 empty。
+- ServiceRef 要同时给出 declaration、Cluster 侧绑定示例和脚本读取方式。
+- 外部访问能力必须逐类型验证。ClusterIP、NodePort、LoadBalancer、hostNetwork 的地址来源和 DNS/端口语义不同，不能用一个 advertised address 模板覆盖所有模式。
+- 服务和依赖注入的验收顺序是最终 Service、EndpointSlice、Pod label/Ready、注入 env、真实连接。`serviceVarRef` 或 `ServiceRef` 有值只证明注入成功，不证明 DNS、端口、协议、凭据或外部 ServiceDescriptor 兼容。
+- `publishNotReadyAddresses` 只能说明 endpoint 可以早发布，不说明业务已经 ready；客户端是否会过早连接、是否有启动握手或重试，要由 addon 自己证明。默认 headless Service、额外 ComponentService、Expose 生成 Service 和 podService 的名称也要做冲突检查，以 apiserver 最终 Service 和 EndpointSlice 为准。
+
+ServiceRef 的开发必须写成 declaration、Cluster 绑定、变量读取三段式。例如 storage 组件依赖一个外部元数据服务：
+
+```yaml
+# ComponentDefinition
+spec:
+  serviceRefDeclarations:
+    - name: metadata
+      serviceRefDeclarationSpecs:
+        - serviceKind: etcd
+          serviceVersion: ^3\.
+      optional: false
+  vars:
+    - name: META_ENDPOINT
+      valueFrom:
+        serviceRefVarRef:
+          name: metadata
+          endpoint: Required
+    - name: META_USER
+      valueFrom:
+        serviceRefVarRef:
+          name: metadata
+          username: Optional
+    - name: META_PASSWORD
+      valueFrom:
+        serviceRefVarRef:
+          name: metadata
+          password: Optional
+```
+
+```yaml
+# Cluster
+spec:
+  componentSpecs:
+    - name: storage
+      replicas: 3
+      serviceRefs:
+        - name: metadata
+          clusterServiceSelector:
+            cluster: acmedb-meta
+            service:
+              component: etcd
+              service: headless
+              port: client
+            credential:
+              component: etcd
+              name: root
+```
+
+如果绑定外部服务，则 Cluster 侧使用 `serviceDescriptor` 指向 ServiceDescriptor 名称。`clusterServiceSelector` 和 `serviceDescriptor` 同时存在时，`clusterServiceSelector` 优先；引用另一个 KB Cluster 时，当前实现会从被引用 Cluster 组装一个内存中的 ServiceDescriptor，但不会按 declaration 强校验 `serviceKind/serviceVersion`，addon 文档和 e2e 必须自己证明兼容性。直接引用 ServiceDescriptor 时边界不同：controller 会要求 ServiceDescriptor `status.phase=Available`，并校验其 `spec.serviceKind/spec.serviceVersion` 至少匹配 declaration 中一条规则，`serviceVersion` 可按正则匹配。`Optional` 的 serviceRef 或变量不是“忽略错误”，脚本要写清楚缺失时是跳过、降级还是失败。
+
+外部依赖要设计变更生命周期，而不只是首次注入。provider 的 endpoint、host、port、credential、ServiceDescriptor status 或拓扑发生变化后，consumer 是否自动 re-render、是否需要 Reconfigure、Restart、重建或明确不支持，都要写成支持矩阵并用最终 Pod/action env、runtime ConfigMap 和真实连接证明。source ServiceDescriptor 更新不等于进程内连接池刷新；optional 依赖从缺失变为存在、required 依赖临时不可用、凭据轮换、provider 扩容缩容和多 Service 入口切换，都是不同路径。不能证明自动刷新时，文档应写“需要重启/重建/人工更新”或“未证明”，不要把旧注入值继续工作误判为兼容。
+
+网络覆盖只在 addon 声明使用时验收，不作为所有 addon 的必选项。声明 `hostAliases`、`dnsPolicy`、`dnsConfig`、`hostNetwork`、`hostPort`、自定义 advertised address 或跨 namespace ServiceRef 时，要按执行面拆开：
+
+| 执行面 | 要看什么 | 常见边界 |
+| --- | --- | --- |
+| runtime Pod | 最终 Pod spec、DNS 解析、hostAliases、hostNetwork 端口、hostPort 调度事件、Service/EndpointSlice | hostAliases 可能遮蔽 ServiceDescriptor 更新；hostNetwork 通常需要确认 `ClusterFirstWithHostNet` 或等价 DNS；hostPort 是节点级冲突 |
+| lifecycle/action worker | action 使用的 Pod、container/image、env、volumeMount、ServiceAccount、DNS 行为 | 不默认继承 runtime Pod 的 hostAliases、工具镜像、TLS trust store 或端口映射 |
+| backup/restore Job | Job Pod spec、node、runtimeClass、resources、Repo Secret、ServiceRef env、DNS 和仓库连通性 | target volume、target Pod node、仓库网络、provider Service 都要在 Job 执行面自证 |
+| restore postReady/ReadyConfig | postReady action 或 ready checker 的镜像、env、证书、Service 地址 | prepareData 成功不代表 postReady 工具链具备连接数据库和修复元数据的能力 |
+
+Service 暴露验收也要分端口来源。`hostPort`、container port、Service port、nodePort、LoadBalancer ingress、podService 生成的 per-pod Service 和 `serviceVarRef.port/loadBalancer` 输出不是同一个值；advertised address 脚本必须脱敏打印最终 host/port 来源，并分别覆盖 ClusterIP、NodePort、LoadBalancer、hostNetwork 或明确未证明。
+
+多 kind/version declaration 必须附协议矩阵。宽正则可以让 declaration 匹配多个 ServiceDescriptor，但脚本、客户端库和连接参数仍要逐分支验收。例如 `etcd 3.x`、`mysql 8.x`、`postgres 14/15` 或同一 provider 的 `rw/ro/admin` 入口，都应说明使用哪个 endpoint 字段、哪个端口名、是否需要 TLS、账号 key、超时和降级行为。多个外部依赖同时存在时，变量名要包含用途和 provider，例如 `META_ETCD_ENDPOINT`、`AUTH_REDIS_PASSWORD`，不要用 `ENDPOINT`、`USERNAME` 这类泛名；脚本自检只能打印脱敏后的来源、host、port 和变量是否为空，不能把 Secret 值写入运行输出或 ConfigMap。
+
+变量字段语义矩阵：
+
+| 字段 | 输出格式或限制 | 必须同时对齐 |
+| --- | --- | --- |
+| `VarOption: Required/Optional` | Required 解析失败应暴露问题；Optional 缺失时不保证固定默认值，可能为空或不注入 | 脚本分支和 README 限制 |
+| `value` | `$(VAR_NAME)` 只展开前面已经定义的变量，`$$` 用于转义 | 变量顺序，避免引用后定义变量 |
+| `expression` | Go template 只作用于已成功解析的非 credential 值；按 vars 定义顺序执行 | 表达式变量名中 `-` 要换成 `_` |
+| `credentialVarRef` | 只能用于 Pod/Action env，不用于渲染 config/script 模板 | systemAccounts 名称、Secret、脚本脱敏 |
+| `componentVarRef.podNames/podFQDNs` | `name1,name2` 或 `fqdn1,fqdn2` | 脚本解析 delimiter；副本数变化时重新验证 |
+| `componentVarRef.podNamesForRole/podFQDNsForRole` | 按 role 过滤后的逗号列表 | `roles`、`roleProbe`、角色稳定性 |
+| `serviceVarRef.host` | 普通 Service 输出 service name 或 FQDN；podService 输出按 service 名排序后的逗号列表 | 脚本 delimiter、FQDN/短名选择、pod ordinal 变化 |
+| `serviceVarRef.port` | 普通 Service 输出单个端口数字；NodePort 或分配 nodePort 的 LoadBalancer 优先输出 nodePort；podService 输出按 service 名排序后的 `serviceName:port` 逗号列表 | ComponentService 名称、Service 类型、port name、advertised address 脚本 |
+| `serviceVarRef.loadBalancer` | 只在 LoadBalancer Service 已有 ingress 时有值；podService 同样按 service 名排序后组合 | LoadBalancer 是否分配、脚本是否允许缺失或延迟 |
+| `serviceRefVarRef.endpoint/host/port/podFQDNs` | 来自 Cluster 绑定的 ServiceRef；pod FQDN 和多 service 仍是字符串约定 | declaration、Cluster `serviceRefs`、外部 ServiceDescriptor |
+| `multipleClusterObjectOption.strategy=individual` | 为每个匹配 component 生成带后缀的独立变量 | credential 这类不能按值组合的变量 |
+| `multipleClusterObjectOption.strategy=combined` | 默认 flatten 形如 `comp1:value,comp2:value`，delimiter 和 keyValueDelimiter 可调 | 多 shard 或多 component 脚本解析 |
+| `hostNetworkVarRef` | 读取 hostNetwork 分配后的端口 | CMPD `hostNetwork.containerPorts` 和 container port 名 |
+| `tlsVarRef.enabled` | 只告诉 TLS 是否启用，不表示引擎已经兼容 TLS | config、启动、探测、备份、恢复都要分别验证 |
+
+真实依据：Redis `templates/cmpd-redis.yaml` 使用 `serviceVarRef` 获取 advertised service 端口和 LB host；Kafka `templates/cmpd-broker.yaml` 用 podService 和服务变量构造 advertised listener；ClickHouse `templates/cmpd-ch.yaml` 使用 `multipleClusterObjectOption` 组织多 shard FQDN。
+
+变量高级选项也要按最终输出验收。`requireAllComponentObjects` 不能当成 provision 等待机制；它只能作为变量解析边界的一部分。`newVarSuffix` 和 `expression` 的执行顺序、同名变量覆盖、ServiceDescriptor 路径下是否能提供 podFQDNs 这类依赖 KB Pod 列表的字段，都必须通过 Pod/action env 和脚本单测证明，不应在 README 中写成默认成立。
+
+脚本对内置环境变量的依赖要保持最小化。`KB_*` 变量是 KB 执行面提供的输入，不应被 addon 当成无限稳定的公共 API 集合；尤其是成员列表、角色列表、候选 Pod、source target、restore target 这类会随操作变化的值，应优先从当前 action 注入、当前 Service/EndpointSlice、Component/Instance 状态或业务 membership 查询获得。跨组件共享配置也不要靠“某个 Pod env 里刚好有值”实现，应通过 ServiceRef、明确的 vars、Secret/ConfigMap 或实时查询建模，并在 scale、switchover、restore、rebuild 后重新验证。
+
+## 8. 账号和 TLS 要作为一等能力设计
+
+`systemAccounts` 用于数据库管理账号，例如初始化账号、备份账号、探测账号、复制账号。非 init account 通常需要 `lifecycleActions.accountProvision` 去执行创建语句。
+
+实践规则：
+
+- 区分用户账号和系统账号。系统账号由 KB 管理，用于备份、复制、探测和管理动作；用户账号不应混入这些系统流程。
+- 对非 init account，提供 `statement.create` 并实现 `accountProvision`。ComponentDefinition controller 会校验：存在非 init account 时，必须有 accountProvision。
+- accountProvision 应在能执行授权的目标 Pod 上运行。主从数据库通常选择 primary/leader。
+- TLS 的声明只定义挂载路径和文件名，具体引擎可能还需要在启动脚本里转换证书格式、更新配置或兼容 client。
+
+示例：
+
+```yaml
+spec:
+  systemAccounts:
+    - name: admin
+      initAccount: true
+    - name: kbdataprotection
+      statement:
+        create: CREATE USER ${KB_ACCOUNT_NAME} PASSWORD '${KB_ACCOUNT_PASSWORD}';
+  lifecycleActions:
+    accountProvision:
+      exec:
+        container: acmedb
+        command: ["/scripts/create-account.sh"]
+      targetPodSelector: Role
+      matchingKey: primary
+  tls:
+    volumeName: tls
+    mountPath: /etc/pki/tls
+    caFile: ca.pem
+    certFile: cert.pem
+    keyFile: key.pem
+```
+
+真实依据：PostgreSQL `templates/cmpd.yaml` 声明 postgres、kbadmin、kbdataprotection、kbprobe、kbreplicator 等账号，并用 accountProvision 执行 SQL；Redis 和 Kafka 也有各自账号初始化脚本。
+
+账号和 TLS 合同检查：
+
+- system account 名称要和 backup target、probe、replication 脚本一致。
+- 账号创建语句不能把密码写入命令输出；使用 shell eval 或模板拼 SQL 时要说明转义边界。
+- TLS 打开后，要验证启动、client 连接、roleProbe、backup/restore 是否都支持证书路径。
+- TLS 关闭时，脚本不能仍然强依赖证书文件存在。
+
+字段级实践矩阵：
+
+| 字段 | addon 要表达的语义 | 运行验证 |
+| --- | --- | --- |
+| `systemAccounts[*].initAccount` | 是否由初始化流程自然创建。非 init account 需要 accountProvision | Secret 是否生成；非 init account 是否真的在数据库内存在 |
+| `systemAccounts[*].statement.create/update/delete` | 传给 `KB_ACCOUNT_STATEMENT` 的模板语句 | 脚本如何转义用户名、密码；stdout/stderr 是否脱敏 |
+| `passwordGenerationPolicy.length/numDigits/numSymbols/symbolCharacters/letterCase` | 默认密码复杂度 | 引擎是否接受这些字符；备份/复制工具是否能正确引用 |
+| Cluster `componentSpecs[*].systemAccounts[*].disabled` | 用户禁用某个系统账号 | 禁用后依赖该账号的能力要同时禁用或失败得足够清楚 |
+| Cluster `componentSpecs[*].systemAccounts[*].passwordConfig` | 用户覆盖密码生成策略 | 覆盖后 accountProvision 仍可执行 |
+| Cluster `componentSpecs[*].systemAccounts[*].secretRef` | 用户提供密码 Secret | key 名默认 `password`；Secret namespace 和 RBAC 要可读 |
+| CMPD `tls.volumeName/mountPath/caFile/certFile/keyFile/defaultMode` | 定义 TLS secret 挂载到 Pod 的文件形状 | Pod 内路径、权限、引擎配置文件一致 |
+| Cluster `componentSpecs[*].tls` 和 `issuer` | 用户是否启用 TLS，以及证书由 KB 生成还是用户提供 | `UserProvided` 时 Secret key 映射到 `ca/cert/key`；TLS on/off 两套用例都能跑 |
+
+不要把 `tlsVarRef.enabled` 当作兼容性证明。它只是一位开关，真正的兼容性要看启动参数、配置模板、client 连接、roleProbe、accountProvision、Backup/Restore 脚本是否都走同一套证书路径。
+
+凭据要按使用面分开设计和验收：
+
+| 使用面 | 常见来源 | 必须证明 |
+| --- | --- | --- |
+| runtime 内部账号 | `systemAccounts`、`credentialVarRef`、Secret volume/env | 启动、复制、探测、roleProbe 和 accountProvision 使用的是同一账号语义 |
+| proxy/router/ACL 账号 | system account、用户 Secret、proxy 自身配置、路由表同步脚本 | proxy 到后端、客户端到 proxy、管理面修改路由或 ACL 三条路径分别具备最小权限 |
+| backup/restore 凭据 | BPT target account、ActionSet/Backup/Restore env、BackupRepo Secret | Backup Job、Restore Job、postReady action 能拿到正确账号和仓库凭据 |
+| 公开连接凭据 | user-provided Secret、暴露服务文档、client connection string | README 给出的账号、TLS、Service 地址与实际 Secret 和 Service 一致 |
+| 外部依赖凭据 | ServiceDescriptor credential、clusterServiceSelector credential、serviceRefVarRef | consumer env/config 更新、脱敏自检和真实连接都能对上 provider |
+
+Secret rotation 和 TLS rotation 不能从首次启动成功外推。Secret volume 文件可能被 kubelet 更新，但数据库进程、连接池、backup 工具或 action worker 是否热加载，需要 addon 自己证明；不能证明时就写成需要 restart、reconfigure 或重建。issuer 切换、用户提供证书、CA trust store 变化和 key 文件权限要逐项验收：看 Secret key、Pod 内文件内容、`defaultMode`、`securityContext/fsGroup`、引擎配置、client 连接和 backup/restore 工具链。
+
+多容器、init container、lifecycle action、Backup/Restore Job 和 postReady 不是同一个文件系统或权限面。每个会发起连接的执行面都要列出它需要的 Secret/TLS volume、env、serviceAccount、工具二进制和用户权限；不能因为主 runtime container 能连上数据库，就默认 action image、formatter image、backup image 或 restore job 也继承了相同挂载和 trust store。
+
+带 proxy、router、sentinel、keeper 或外部管理组件的 addon，要把“后端数据库账号”和“管理组件账号”分开。proxy 能连上后端不代表它有权修改路由表；备份账号能读数据不代表 restore 后可以重建 ACL；公开连接 Secret 能登录不代表 roleProbe、switchover 或 postReady 使用的是同一权限面。每个账号都要写清楚用途、创建方式、禁用后影响、TLS 要求和失败时的排查入口。
+
+## 9. 配置和参数管理要串成闭环
+
+参数管理不是只写一个 CUE 文件。完整链路是：
+
+1. `ComponentDefinition.spec.configs` 声明配置模板挂载到哪个 volume。
+2. chart 渲染出对应 ConfigMap 和模板文件。
+3. `ParametersDefinition` 绑定 componentDef、templateName、fileName 和 fileFormatConfig。
+4. CUE 或 OpenAPI schema 描述参数合法性。
+5. static/dynamic/immutable 分类决定 reload、restart 或禁止变更。
+6. `reconfigure` action 让参数变更真正落到进程。
+
+从 legacy `ConfigConstraint` 迁移到 `ParametersDefinition` 时按决策树处理：如果旧对象只用于描述某个 CMPD config file 的 schema，就迁到对应 PD，并让 `templateName/fileName/serviceVersion` 精确绑定该文件；如果旧对象还承载 reloadAction 或脚本输入约定，要把动作迁到 `ComponentFileTemplate.reconfigure` 或 lifecycle `reconfigure`，并保留兼容测试；如果同一文件被多个旧约束覆盖，先合并 schema 和参数分类，再迁移，不能让多个 PD 竞争同一 `fileName`；如果某个版本的配置文件格式、默认值或动态参数不同，就拆成按 `serviceVersion` 匹配的 PD。迁移验收入口不是旧 ConfigConstraint status，而是 PD status、ComponentParameter、runtime ConfigMap 和进程实际配置。
+
+示例：
+
+```yaml
+apiVersion: parameters.kubeblocks.io/v1alpha1
+kind: ParametersDefinition
+metadata:
+  name: acmedb-params
+spec:
+  componentDef: ^acmedb-storage-.*
+  templateName: acmedb-config
+  fileName: acmedb.conf
+  fileFormatConfig:
+    format: ini
+  parametersSchema:
+    cue: |-
+      #AcmeDB: {
+        "max_connections"?: int & >=1 & <=10000
+      }
+  staticParameters:
+    - data_dir
+```
+
+实践规则：
+
+- 新 addon 优先使用 ComponentDefinition file template 上的 `reconfigureAction` 或模板 `reconfigure`，不要依赖 legacy config-manager reloadAction。
+- `ParametersDefinition.spec.componentDef` 是前缀/正则匹配 ComponentDefinition 名称，`serviceVersion` 为空表示匹配任意 serviceVersion，不是“自动选 latest”。
+- `ParametersDefinition.spec.templateName` 绑定的是 `ComponentDefinition.spec.configs[*].name`，也就是 CMPD 里定义的配置模板标识，不是底层模板 ConfigMap 名。`ComponentFileTemplate.template` 才是引用的 ConfigMap 名；渲染后的运行时 ConfigMap 又是 controller 生成的另一个对象。
+- `externalManaged: true` 表示该配置文件交给 parameters 链路管理。它不会改变上一条匹配合同：PD 仍然应该指向 CMPD config template 的 `name`，而不是把 `templateName` 写成模板 ConfigMap 名。
+- `fileName` 是模板 ConfigMap data 中的文件 key，也是参数 schema 要作用的配置文件名。它必须能在对应 template ConfigMap 中找到。
+- 同一个配置文件不能被多个 ParametersDefinition 覆盖。实现会拒绝重复覆盖同一 fileName。
+- `ComponentParameter` 是 controller 内部执行模型和用户 desired 参数合并后的落地对象。调试 reconfigure 时应同时看 `ComponentParameter`、渲染 ConfigMap、InstanceSet/Pod 的配置状态和 OpsRequest 状态。
+- 如果某个参数实际需要重启，不要假装支持动态 reload。把 static/dynamic 分类写清楚，让 KB 走正确路径。
+- 修改 source template ConfigMap 不等于 runtime ConfigMap 自动重渲染。addon 发布时要验证触发路径：是 Helm upgrade 触发 definition/template 变化、用户发起 Reconfigure，还是需要重建 Component；没有实现证据时，不要把 ConfigMap `resourceVersion` 变化写成自动生效。
+- 参数输入要区分三态：缺省表示沿用 schema 或模板默认，空字符串是用户显式写入空值，`value=nil` 表示删除 desired 参数。schema、渲染器和 reconfigure 脚本必须分别覆盖这三种输入。
+- 每个 `serviceVersion` 都要验收 PD 渲染结果：`componentDef` 是否匹配该版本、`templateName/fileName` 是否存在、static/dynamic/immutable 分类是否渲染出来、formatter 或 reconfigure action 的工具镜像是否与该版本兼容。
+- `ComponentFileTemplate.variables[*].defaultValue` 只能作为模板输入的一部分验收，不能从字段名推断它一定进入最终文件。最小证据是 runtime ConfigMap 中目标 `fileName` 的最终内容、Pod 内挂载文件和进程读取后的配置值三者一致。
+- 使用外部 ConfigMap 或用户覆盖配置时，要把 `source.name/key`、模板 ConfigMap data key、PD `fileName`、runtime ConfigMap 文件名、`configHash`、`externalManaged` 和 reconfigure action 串成闭环。内容变了但 `configHash` 或触发信号不变时，不要假设 controller 会自动重渲染。
+- 参数 key 规范化规则必须由 addon 固定。API schema 中的 key、文件里的 key、formatter 输出的 key、引擎实际接受的 key 大小写、分隔符和别名可能不同；如果允许 `max-connections`、`max_connections`、`maxConnections` 这类变体，必须说明归一化方向、冲突处理和回显方式。
+- OpenAPI schema、CUE schema、formatter 和引擎配置解析要分别验收。formatter 必须幂等：同一 desired 参数重复 reconfigure 后，runtime ConfigMap 和进程配置不应产生无意义漂移。
+
+排障时优先检查这些对象关系：
+
+```text
+ComponentDefinition.spec.configs[*].name        # 参数绑定键，PD.templateName 应指向它
+ComponentDefinition.spec.configs[*].template    # 模板 ConfigMap 名，提供文件内容
+ParametersDefinition.spec.templateName          # CMPD config template name，不是 ConfigMap 名
+ParametersDefinition.spec.fileName              # 模板 ConfigMap data key
+ComponentParameter.spec.configItemDetails[*]    # 参数 controller 解析后的执行计划
+runtime ConfigMap                               # 最终挂载进 Pod 的渲染结果
+```
+
+如果 `ComponentParameter.spec.configItemDetails` 为空，先不要改 controller。应先证明 PD 是否匹配到正确 ComponentDefinition、`templateName` 是否等于 CMPD config template 的 `name`、`fileName` 是否存在、PD status 是否 Available、`externalManaged` 是否按预期开启。
+
+不是所有 addon 都天然支持 OpsRequest reconfigure。若引擎配置来自外部系统、多个动态文件、运行时生成文件或业务 API，而当前 PD/ComponentParameter/reconfigure action 无法自然表达，就应把该能力写成“不支持”或“未证明”，并让示例避免暴露 reconfigure 路径。不要只为了让 OpsRequest 创建成功而打开 `externalManaged`、生成空的 ComponentParameter 或把所有参数塞进一个文件；这种半链路会在 restart、scale、upgrade 后把错误 desired 状态继续带到新 Pod。
+
+参数 desired 是会被 controller 继续消费的状态，不是一次性命令。发现参数写错文件、effect scope 错误或 schema 误放行后，恢复步骤要同时清理或修正 OpsRequest、ComponentParameter desired、runtime ConfigMap 和进程真实配置；只回滚 chart 或删一个 ConfigMap 往往不能消除后续 reconcile 的输入。发布修复时要给出旧对象迁移说明：哪些 desired key 要删除，哪些参数要移到另一个 `templateName/fileName`，哪些 Cluster 需要 restart 或重新 reconfigure。
+
+参数字段和脚本合同矩阵：
+
+| 字段 | 实践语义 | 误用表现 |
+| --- | --- | --- |
+| `staticParameters` | 变更后需要 restart 的参数 | 实际需要重启却标成 dynamic，reload 后进程状态和配置不一致 |
+| `dynamicParameters` | 变更后可以由 reconfigure action 生效的参数 | 为空时不要默认“所有参数都可热更新” |
+| `immutableParameters` | 用户不应修改的参数 | 只写注释不写字段，变更请求仍进入执行链路 |
+| `mergeReloadAndRestart` | 同一次变更既有 reload 又有 restart 时是否只 restart | 设错会导致先 reload 后 restart，或跳过引擎需要的预处理 |
+| `reloadStaticParamsBeforeRestart` | 某些引擎要求静态参数先通过 SQL/CLI 预设再重启 | 没有引擎依据时不要打开 |
+| `ComponentFileTemplate.reconfigure` | 某个配置模板自己的 reload 动作；排查时先看该文件级 action，再看全局 lifecycle reconfigure | 多配置文件共用脚本时没有按文件名分支 |
+| Cluster `configs[*].reconfigureAction` | 用户提供外部配置时的自定义 reconfigure 动作 | 外部配置更新绕过 addon 默认 reload 逻辑 |
+| `KB_CONFIG_FILES_CREATED/REMOVED/UPDATED` | 文件级变更输入，不是强类型参数 diff | 脚本假设拿到了参数名和值，导致删参或多文件变更处理错误 |
+
+如果使用类似 MySQL、Redis、PostgreSQL 的 effect-scope 文件来生成 `staticParameters`、`dynamicParameters` 和 `immutableParameters`，生成结果要进入渲染后的 ParametersDefinition，而不是只存在于 chart helper 中。review 时要看 `helm template` 结果。reconfigure 脚本不能假设参数一定合法：即使 schema 已校验，脚本仍要检查参数名、文件名、值格式和当前引擎状态，并保证重复执行不会把配置写坏。
+
+OpsRequest reconfigure 的输入边界要分清楚。`reconfigures[*].parameters[*].key/value` 会进入 `ComponentParameter.spec.desired.assignments` 这类 desired 参数模型；`value=nil` 表示删除该参数。后续 action 侧主要拿到的是文件级变化环境变量和渲染后的配置结果，例如创建、删除、更新了哪些配置文件，而不是一份稳定的结构化参数 diff。只有 legacy reloadAction 路径会把参数 JSON 放进特定请求里，新 addon 不应把这个私有输入形状当成通用合同。通用 reconfigure 脚本应以文件名、渲染结果和引擎状态为准，再用参数名作为可选校验信息。
+
+动态参数还要定义作用域。某些引擎的参数只作用于当前 Pod，某些需要在 primary 执行并复制到全局，某些必须逐 Pod fan out。`ComponentFileTemplate.reconfigure` 或 lifecycle `reconfigure` 的 target 选择要和这个作用域一致：只改一个 Pod、只改 role Pod、还是改组件内所有 Pod，都要用进程配置 dump 或业务查询证明。不能用“一个 Pod reload 成功”代表整个 Component 参数一致。
+
+参数生效排查分三层：第一层是 `ParametersDefinition` status、schema、`fileFormatConfig` 和 `ComponentParameter` desired/observed 是否符合预期；第二层是 runtime ConfigMap 中目标文件的最终内容，删参要确认 key 已从文件删除，多文件参数要同时看每个 `templateName/fileName`；第三层是进程实际状态，例如引擎 config dump、SQL/CLI 查询或重启后启动参数。Reconfigure Ops 成功不承诺 Pod env 会变化，runtime ConfigMap 删除 key 也不等于进程已经忘记旧值；如果参数被误标为 dynamic/static/immutable，addon 要给出回滚、重启或拒绝变更的恢复路径。配置模板不得把 Secret 渲染进普通 ConfigMap，确需使用敏感值时应通过 env、Secret volume 或 action 运行面传递并脱敏记录。
+
+同一个文件同时声明 file-level reconfigure、全局 lifecycle reconfigure、`restartOnFileChange`、`mergeReloadAndRestart` 或 `reloadStaticParamsBeforeRestart` 时，不要从字段名推断固定先后或互斥关系。排查顺序应先看触发该文件的 `ComponentFileTemplate.reconfigure` 或外部 `Cluster configs[*].reconfigureAction` 输出，再看全局 lifecycle reconfigure、OpsRequest/ComponentParameter 状态和 Pod restart 结果。用户覆盖外部 reconfigureAction 后，addon 默认脚本只对自己声明的模板负责；外部模板的输入输出必须由用户 action 或 addon 文档另行证明。
+
+最小 reconfigure 用例：
+
+```yaml
+apiVersion: operations.kubeblocks.io/v1alpha1
+kind: OpsRequest
+metadata:
+  name: acmedb-reconfigure-max-conn
+spec:
+  clusterName: acmedb-smoke
+  type: Reconfiguring
+  reconfigures:
+    - componentName: storage
+      parameters:
+        - key: max_connections
+          value: "500"
+```
+
+验证顺序是 `OpsRequest` phase、`ParametersDefinition` status、`ComponentParameter.spec.configItemDetails`、runtime ConfigMap 内容、action 输出、Pod 是否按 static/dynamic 预期 reload 或 restart。`reconfigure.parameters[*].value=nil` 表示删除参数，脚本必须覆盖这个场景。
+
+真实依据：MySQL `templates/paramsdef-80.yaml`、PostgreSQL `templates/paramsdef.yaml`、ClickHouse `templates/paramsdef-config.yaml`。实现依据见 `pkg/parameters/config_util.go`、`controllers/parameters/componentparameter_controller.go` 和 `controllers/parameters/reconfigure/sync.go`。
+
+## 10. 数据保护要同时提供模板和执行脚本
+
+完整备份恢复能力至少需要：
+
+- `BackupPolicyTemplate`：告诉 KB 某个 ComponentDefinition 支持哪些 backup method、默认 schedule、目标 Pod 选择、账号和 volume mount。
+- `ActionSet`：定义备份、恢复各阶段如何执行脚本或 Job。
+- `scripts/backup.sh`、`scripts/restore.sh` 等脚本：真实执行引擎备份、推送数据、拉取数据、恢复、状态同步。
+- 用户示例：BackupRepo、Backup、Restore 或 Cluster restore。
+
+示例：
+
+```yaml
+apiVersion: dataprotection.kubeblocks.io/v1alpha1
+kind: BackupPolicyTemplate
+metadata:
+  name: acmedb-backup-policy-template
+spec:
+  serviceKind: acmedb
+  compDefs:
+    - ^acmedb-storage-.*
+  target:
+    role: secondary
+    fallbackRole: primary
+    account: kbdataprotection
+    useParentSelectedPods: true
+  backupMethods:
+    - name: physical
+      snapshotVolumes: false
+      actionSetName: acmedb-physical-br
+      targetVolumes:
+        volumes:
+          - data
+        volumeMounts:
+          - name: data
+            mountPath: /var/lib/acmedb
+```
+
+对应的最小 ActionSet 也要同时提供：
+
+```yaml
+apiVersion: dataprotection.kubeblocks.io/v1alpha1
+kind: ActionSet
+metadata:
+  name: acmedb-physical-br
+spec:
+  backupType: Full
+  backup:
+    backupData:
+      image: acme/acmedb-tools:1.0.0
+      command: ["/scripts/backup.sh"]
+      syncProgress:
+        enabled: true
+        intervalSeconds: 30
+  restore:
+    prepareData:
+      image: acme/acmedb-tools:1.0.0
+      command: ["/scripts/restore.sh"]
+      runOnTargetPodNode: true
+    postReady:
+      - exec:
+          container: acmedb
+          command: ["/scripts/post-restore.sh"]
+```
+
+实践规则：
+
+- 只写 `ActionSet` 不算支持备份；必须有 `BackupPolicyTemplate` 绑定到正确 `compDefs`，让 Cluster 自动生成 BackupPolicy。
+- 非 snapshot backup method 必须有 `actionSetName`。snapshotVolumes=true 的方法可以使用 CSI snapshot，不一定需要 ActionSet。
+- target role 和 fallbackRole 应和 ComponentDefinition 的 `roles`、`roleProbe` 一致。单副本时 controller 会调整 selector，不能只靠手写 label。
+- 脚本要遵守 dataprotection 注入的 `DP_*`、`DATASAFED_*`、状态文件和进度同步约定。失败状态不能只打印错误后继续执行。
+- PITR、增量备份、逻辑备份、volume snapshot 是不同 method，不要用一个 method 名掩盖多个语义。
+- Restore 到新集群、重建实例、PITR、跨拓扑恢复的限制必须写明。
+
+数据保护合同检查：
+
+- BPT 的 `compDefs` 必须命中 resolved ComponentDefinition；不能被多个 BPT 同时竞争同一个 ComponentDefinition。
+- 每个 backup method 的语义要单一。physical、logical、incremental、archive log、snapshot、PITR 不应混在一个 method 名下。
+- target role 要和 `roles/roleProbe` 对齐；多副本和单副本都要验证选 Pod 行为。
+- ActionSet 的 backup、restore、prepareData、postReady 阶段要说明输入环境变量、数据目录、状态文件、错误退出语义。
+- Restore 需要单独验证，不得用 Backup 成功替代。恢复后的数据、账号、TLS、配置、service 都要检查。
+- rebuild instance 是 Restore 能力的消费者；如果 restore 脚本只支持新集群恢复，就不能声称 rebuild 已支持。
+
+字段语义矩阵：
+
+| 字段 | addon 要表达的语义 | 必须同时验证 |
+| --- | --- | --- |
+| BPT `serviceKind`、`compDefs` | 哪类组件自动生成 BackupPolicy | resolved ComponentDefinition 只匹配一份 BPT |
+| BPT `target.role/fallbackRole/account/strategy` | 选哪个 Pod、用哪个系统账号连接数据库 | `roles/roleProbe`、systemAccounts、单副本和多副本选 Pod 行为 |
+| BPT `schedules/backoffLimit/retentionPolicy` | 默认备份计划、失败重试和保留策略 | 用户示例里能看到生成的 BackupPolicy |
+| method `name` | 用户和 Backup CR 调用的稳定方法名 | method 名语义单一，不把 physical/logical/incremental/PITR 混用 |
+| method `compatibleMethod` | 增量或差异备份依赖的 full method | parent backup 链和 restore 顺序 |
+| method `snapshotVolumes` | 是否走 CSI snapshot | CMPD `volumes[*].needSnapshot`、StorageClass snapshot 支持 |
+| method `actionSetName` | 非 snapshot method 绑定执行定义 | ActionSet status Available，backup/restore 阶段都存在 |
+| method `targetVolumes.volumes/volumeMounts` | backup workload 挂载目标 Pod 的哪些 volume | CMPD volume 名、容器 mountPath、restore PVC |
+| method `env/runtimeSettings/target` | method 级覆盖工具镜像、资源和选 Pod 策略 | versionMapping、资源请求、target 覆盖是否和全局 target 冲突 |
+| ActionSet `backupType` | Full、Incremental、Differential、Continuous、Selective 之一 | Backup/Restore 示例和 method 名一致 |
+| ActionSet `parametersSchema/withParameters` | Backup/Restore 参数名校验 | 脚本仍做值校验，不能只依赖 schema |
+| `backup.preBackup/backupData/postBackup/preDelete` | 备份前、备份主体、备份后和删除前动作 | 失败退出语义、重试幂等性、产物是否写到 datasafed 路径 |
+| `backupData.syncProgress` | 是否同步进度到 Backup status | 脚本输出、Backup status totalSize/duration/phase |
+| `restore.prepareData/postReady` | 数据准备到目标 PVC，目标组件 ready 后修复集群内状态 | 新集群恢复、rebuild、账号、TLS、拓扑兼容性 |
+| Restore `backup.sourceTargetName/restoreTime` | 从哪个 source target 和时间点恢复 | PITR、增量链路、source target 名称 |
+| Restore `prepareDataConfig/readyConfig/env/backoffLimit/parameters` | restore job 的 PVC、调度、env 合并、重试和参数 | 最终 env 合并结果、参数默认来源和脚本行为 |
+
+每个 backup method 都要附一张 restore 兼容矩阵，至少覆盖：新集群恢复、rebuild instance、PITR 或增量链、TLS on/off、系统账号、跨 serviceVersion、跨 topology、sharding 数变化。无法验证的格子写“不支持”或“未证明”，不要通过脚本假设补齐。
+
+每个 topology 也要单独证明 BackupPolicyTemplate 是否生效。`standalone`、`replication`、`mgr`、`proxy`、`sharding`、`keeper` 这类拓扑可能使用不同 ComponentDefinition 名称、roleProbe、target role、账号和数据卷；BPT `compDefs` 命中一个普通组件，不代表它覆盖了 topology 专属组件。最小证据是该 topology 的 Cluster 生成了预期 BackupPolicy，Backup target selector 选中正确 Pod，ActionSet method 与该 topology 的账号、TLS、volume 和 serviceVersion 兼容。
+
+从已有 `Backup` 恢复新 `Cluster` 要提供独立用户示例。这个示例不能只给 `Restore` CR，因为 `dataprotection Restore` 本身负责准备 PVC 数据和 postReady 动作，不负责声明目标 Cluster 的组件、拓扑、Service 和参数。addon 应按目标用户场景提供下面两类入口之一。
+
+显式声明目标 Cluster 时，在新 Cluster 上写 `spec.restore`，并同时写清楚目标 Cluster 的 topology、component、volume 和 serviceVersion：
+
+```yaml
+apiVersion: apps.kubeblocks.io/v1
+kind: Cluster
+metadata:
+  name: acmedb-restore
+  namespace: demo
+spec:
+  clusterDef: acmedb
+  topology: replication
+  terminationPolicy: Delete
+  restore:
+    source:
+      apiGroup: dataprotection.kubeblocks.io
+      kind: Backup
+      name: acmedb-backup-20260605
+      namespace: demo
+    pitr: "2026-06-05T08:00:00Z"
+    parameters:
+      dataprotection.kubeblocks.io/volume-restore-policy: Serial
+      dataprotection.kubeblocks.io/source-target-name: acmedb-storage-0
+      restore-mode: full
+  componentSpecs:
+    - name: storage
+      serviceVersion: "1.0.0"
+      replicas: 2
+      volumeClaimTemplates:
+        - name: data
+          spec:
+            resources:
+              requests:
+                storage: 20Gi
+```
+
+希望从 `Backup` 记录的 cluster snapshot 派生目标 Cluster 时，用 Restore OpsRequest。该入口会先读取源 Backup，要求源 Backup 已完成或是合法 continuous backup，并要求 Backup 带有 cluster snapshot；controller 会把目标 Cluster 名称改成 `spec.clusterName`，把恢复 intent 写入目标 Cluster，再由 Cluster/Component/PVC/Restore 链路完成数据准备和 postReady：
+
+```yaml
+apiVersion: operations.kubeblocks.io/v1alpha1
+kind: OpsRequest
+metadata:
+  name: restore-acmedb
+  namespace: demo
+spec:
+  clusterName: acmedb-restore
+  type: Restore
+  restore:
+    backupName: acmedb-backup-20260605
+    backupNamespace: demo
+    restorePointInTime: "2026-06-05T08:00:00Z"
+    volumeRestorePolicy: Serial
+    parameters:
+      - name: restore-mode
+        value: full
+```
+
+Restore OpsRequest 派生出的目标 Cluster 不是源 Cluster 的逐字段复刻。LoadBalancer Service、NodePort、selector、offline instances、TLS issuer、sharding account SecretRef、调度 selector 等字段可能被重置、清理或重写；addon 的连接文档和验收脚本必须以恢复后 live Cluster、Service、Secret 和 Pod spec 为准，不从源 Cluster YAML 推断最终值。
+
+`Cluster.spec.restore.parameters` 中的 `dataprotection.kubeblocks.io/volume-restore-policy`、`dataprotection.kubeblocks.io/source-target-name`、`dataprotection.kubeblocks.io/source-target-pod-name`、`dataprotection.kubeblocks.io/restore-env` 和 `dataprotection.kubeblocks.io/defer-post-ready-until-cluster-running` 是 KB restore 链路消费的控制参数；addon 自定义参数可以共存，但不要为这些语义另造字段名。使用 Restore OpsRequest 时，`volumeRestorePolicy`、`env` 和 `deferPostReadyUntilClusterRunning` 会被 handler 转成对应参数。
+
+PVC 恢复只覆盖 Backup method `targetVolumes` 声明、且目标 Cluster volumeClaimTemplates 中存在的卷。target volume 名称对不上时，目标 PVC 可能只走普通 provision，不会恢复数据。多 target 或 `PodSelectionStrategyAll` 场景要在示例中说明 `source-target-name`、`source-target-pod-name` 或等价映射如何选择；instanceTemplate ordinal 无法可靠推断时，不要让用户靠名字猜。
+
+addon README 中的 restore 示例要明确这些输入从哪里来：源 Backup 的 namespace/name、Backup phase、backup method、target/targets、artifact 或 snapshot、PITR timeRange、目标 Cluster 的 topology/component/volume 映射、是否允许跨 namespace、是否保留或重建账号/TLS/Service。恢复后至少检查目标 Cluster Running、PVC restore condition、生成的 `Restore` 对象、restore Job、postReady、数据读写、公开连接 Secret 和 TLS 连接；只看到 OpsRequest 或 Restore phase 成功，不足以证明业务恢复完成。
+
+数据保护的扩展能力只在 addon 声明使用时设计和验收。声明后要把字段、Secret、工具镜像、artifact 和恢复消费者连起来：
+
+| 扩展能力 | 需要设计的合同 | 验收证据 |
+| --- | --- | --- |
+| 加密备份 | passphrase Secret 的创建、引用、轮换、保留、删除和旧备份兼容策略 | Backup/Restore Job env 或 mount、旧备份用旧密钥可恢复、新密钥只影响后续备份 |
+| method `formatVersion` 或等价格式版本 | backup image、restore image、ActionSet、脚本参数和 artifact layout 的版本矩阵 | 每个格式版本至少一次 backup+restore；跨版本不支持时明确拒绝 |
+| snapshot method | VolumeSnapshot/PVC restore 与 repository artifact 分流 | snapshot handle/PVC、StorageClass/VolumeSnapshotClass、是否仍需要 datasafed/repo artifact |
+| repository artifact | `path`、`kopiaRepoPath`、parent/base metadata、target/targets status 的读取规则 | 仓库目录或对象存储产物、Backup status artifact 字段、restore 脚本输入一致 |
+| `postBackup` 后处理 | 失败后 artifact 是删除、标记不可用、允许复用还是需要人工清理 | 完整性标记、幂等重跑策略、retention/preDelete 对半成品的行为 |
+| `backupType=Selective` | 选择参数、默认值、允许对象、排除对象和 restore 参数闭环 | Backup 参数、artifact 清单、Restore 参数、恢复后只包含预期数据 |
+| `RestoreKubeResources` 或恢复 K8s 资源 | 允许覆盖的资源清单、禁止覆盖的资源、和 parameters/controller 重渲染的关系 | 目标 ConfigMap/Secret/ServiceAccount/RBAC diff、后续 ComponentParameter 是否覆盖恢复结果 |
+| `deferPostReadyUntilClusterRunning` | postReady 是依赖 Cluster Running，还是用于推动 Cluster Running | 没有等待环；ReadyConfig、postReady、Component/Cluster status 的先后关系可解释 |
+
+备份恢复 action 的 env 覆盖也按最终 workload 验收。BackupMethodTPL env、Backup env、Restore env、ActionSet env 或 parametersSchema 默认值存在同名或缺省时，guide 不替具体优先级背书；脚本应在脱敏后记录关键最终值来源，或者在测试中显式打印最终 env，便于区分是 method、用户 CR、ActionSet 还是脚本内部默认。声明 `syncProgress.enabled=true` 的 method 还应验收 Backup status 中的进度、大小或等价观测结果；否则只能说脚本上传成功，不能说进度同步能力已证明。
+
+加密、压缩和格式版本必须做 payload 级验证。API 字段、Secret 或 env 存在，只能证明执行面收到了配置；它不证明备份数据实际经过了支持该能力的工具链。使用 native client、数据库自带 backup 命令、datasafed、kopia、对象存储 SDK 或自写脚本时，要分别说明数据从哪里写出、是否经过加密/压缩、artifact manifest 在哪里、restore 用哪个工具读取，以及错误密钥、错误 formatVersion、缺少 keystore 或缺少模板文件时如何失败。
+
+Backup `Completed` 不是 restore contract。每个 method 都应产出或能推导一份 artifact manifest：仓库路径、target 名称、数据文件、元数据文件、formatVersion、base/parent、加密信息、工具版本、必要模板或 keystore。restore preflight 要先检查这份 manifest 和目标 Cluster 条件，再开始覆盖 PVC；如果缺 artifact、路径不一致、工具镜像不兼容或目标 topology 不匹配，应清楚失败，而不是在 postReady 阶段才暴露成业务不可用。
+
+空数据集、无增量或无变化也是合法场景，不能让备份脚本无限等待。addon 要定义空 full backup、空 incremental backup、没有 binlog/WAL/segment、没有 topic/table/slot 变化时的退出码、artifact 形状和 restore 结果。若该 method 不支持空数据或空增量，应在 method 文档和脚本前置检查里明确拒绝。
+
+BPT method env 的 `versionMapping` 使用 Cluster component spec 上的 `serviceVersion` 做匹配，通常是 Cluster normalize 后的 component serviceVersion，而不是直接读取某个 ComponentDefinition 或 ComponentVersion 对象字段。匹配语义是先精确匹配，再按前缀或正则匹配。开发时要用显式 serviceVersion 的 Cluster 样例验证每个 method env 的最终值；不要因为 BPT `compDefs` 命中了某个 CMPD，就推断 `versionMapping` 一定会按该 CMPD 的原始 `spec.serviceVersion` 选择。
+
+BackupRepo 是独立依赖，不是 BackupPolicy 的附属字段。排查备份失败、恢复失败或仓库凭据轮换时，必须同时看 BackupRepo/Secret、BackupPolicy、BackupSchedule、Backup/Restore Job 的 env 和 mount。Repo 临时不可用后，旧 Failed Backup 与新重试 Backup 要分开判断；Repo Secret 轮换后，已经存在的 Job 不会因此自动换凭据，后续 Backup/Restore 是否消费新 Secret 要以最终 Job spec 为准。删除 Backup 或清理 retention 时，也要区分 Kubernetes CR 链和仓库 artifact 链：parent/base metadata、Backup status 中的依赖关系、仓库目录或对象存储中的真实产物，都要能闭合。
+
+Continuous backup 和 PITR 的状态语义要单独写清楚。Continuous method 长期 `Running` 可能是正常归档状态，不等于一次性 Full Backup 未完成；addon 要验收归档产物持续生成、timeRange 可解释、`restoreTime` 落在可恢复窗口内，并实际演练 PITR。只给 `restoreTime` 或只看 Backup phase 不能证明 PITR 可用。
+
+跨 topology、sharding 或 rebuild restore 必须有 target 映射表：
+
+| 场景 | 映射要求 | 必须声明的边界 |
+| --- | --- | --- |
+| 同 topology 新集群恢复 | source target 到目标 component/volume 一一对应 | 账号、TLS、serviceVersion 和参数兼容 |
+| rebuild instance | source backup 到目标 ordinal/PVC/实例身份对应 | restore 脚本是否支持只修复单实例 |
+| 跨 topology 恢复 | source component 到目标 component 的显式映射 | 缺失 component、额外 component、proxy/keeper 是否重建 |
+| sharding restore | source shard/target 到目标 shard 的映射 | 空 shard、skip shard、目标 shard 多于或少于源 shard 时是否支持 |
+
+`skip`、空 shard 或 source target 缺失只能说明某个阶段被跳过，不等于目标 Cluster 数据完整。prepareData 成功但 postReady 失败时，PVC 和部分数据可能已经存在；重跑前先判断脚本幂等、仓库 artifact、目标 PVC 和业务元数据，再决定清理、继续或标为人工恢复。
+
+自动备份和 Restore 的收敛要单独排查。Backup target 误选时，从 BPT/BackupPolicy 的 target、生成 selector、Pod role label 和单副本 fallback 逐层看；Backup `Succeeded` 后还要证明 artifact 清单、repository 路径或 Backup status 中的产物信息可发现。BackupSchedule 不用泛化状态名代替真实字段，应检查 schedule name 是否唯一、`schedules[*].enabled`、`status.schedules`、`repoName`、关联 CronJob 以及实际 Backup 创建和失败事件；默认 repo 变更后，旧 BackupPolicy/BackupSchedule 是否刷新必须以生成对象为准。Cluster restore 要明确 source namespace、Backup 名称和 UID，避免同名源对象歧义；PITR 不能只看 `restoreTime`，还要看 continuous method、参数传递和 postReady/ReadyConfig 校验。Restore Job 完成后目标 Cluster 仍未 Running 时，继续查 prepareData/PVC mount、Component/InstanceSet status、ReadyConfig、postReady 和恢复后公开凭据来源，直到连接文档、systemAccounts 和实际 Secret 能对上。
+
+真实依据：MySQL `backuppolicytemplate.yaml` 同时提供 xtrabackup、incremental、volume-snapshot、archive-binlog、mydumper；PostgreSQL 支持 pg_basebackup、pgdump、wal-g 和 PITR；Kafka 的 topics backup 说明不是所有引擎备份都等价于块设备备份；Etcd target leader 并提供 dataDump/dataLoad。
+
+## 11. Day-2 运维以内置操作为主
+
+内置 `OpsRequest` 覆盖常见管理动作：restart、stop/start、horizontal scaling、vertical scaling、volume expansion、reconfigure、expose、switchover、upgrade、rebuild、backup、restore。addon 作者要确保 ComponentDefinition、参数、备份和生命周期动作提供这些操作所需的底层能力。
+
+内置操作失败时，先查 addon 是否提供了对应底层合同。例如 switchover 依赖可靠 roleProbe 和 switchover action，rebuild 依赖 restore 能力，reconfigure 依赖参数和配置链路，volume expansion 依赖 PVC 和存储类，delete 依赖生命周期动作能够收敛。
+
+运维字段矩阵：
+
+| Ops | 关键字段 | 依赖的 addon 合同 | 常见误用 |
+| --- | --- | --- | --- |
+| restart/stop/start | `restart/stop/start[*].componentName` | 启动脚本幂等、readiness 准确、一次性初始化有保护 | restart 后重复初始化破坏数据 |
+| horizontal scaling | `horizontalScaling[*].scaleOut/scaleIn`、`shards`、`offlineInstancesToOnline/onlineInstancesToOffline` | `memberJoin/memberLeave`，sharding 时还要 `ShardingDefinition` | 把 offline/online 当普通 replicas；`shards` 和 scaleOut/scaleIn 混用 |
+| scale out from backup | `scaleOut.fromBackup` | Backup/Restore method 支持作为新副本恢复 | 只验证新集群 Restore，未验证 standby/replica 场景 |
+| vertical scaling | `verticalScaling[*].resources/instances` | 引擎能感知资源变化，或声明需要 restart | 资源改了但进程内部参数没调整 |
+| volume expansion | `volumeExpansion[*].volumeClaimTemplates[*].name` | Cluster VCT 名、CMPD volumeMount、文件系统扩容 | VCT 名和 data volume 名不一致 |
+| reconfigure | `reconfigures[*].parameters[*].key/value` | PD、config template、参数分类、reconfigure action | `value=nil` 删除参数未处理 |
+| expose | `expose.services[*].name/serviceType/ports/roleSelector/podSelector` | ComponentService、roleProbe、外部访问脚本 | LoadBalancer/NodePort/ClusterIP 地址语义混用 |
+| switchover | `switchover[*].instanceName/candidateName` | roleProbe、roleSelector service、switchover action | candidate 和脚本预期不一致；role 为空时没有分支 |
+| upgrade | `upgrade.components[*].componentDefinitionName/serviceVersion` | ComponentVersion、镜像 key、rollout 策略、数据兼容 | 只升级 runtime image，action image/PD/BPT 没验证 |
+| backup/restore | `backup`、`restore` | BPT、ActionSet、BackupRepo、restore 脚本 | 只有 Backup 成功，没有 Restore 验证 |
+| rebuild instance | `rebuildFrom` 或 backup restore 路径 | Restore 兼容矩阵、目标 PVC、postReady | restore 脚本只支持新集群，却声称支持 rebuild |
+
+运维合同检查：
+
+- restart：脚本和进程管理要能接受重启；不要把一次性初始化逻辑写成每次启动都会破坏状态。
+- horizontal scale：scale out 需要 memberJoin 或等价加入逻辑；scale in 需要 memberLeave 或明确不需要。
+- vertical scale：资源变更后进程是否读取 cgroup/配置变化，是否需要 restart。
+- volume expansion：PVC 名、volumeClaimTemplates、mountPath、文件系统扩容路径要闭合。
+- reconfigure：参数分类、渲染结果、reload/restart 动作和状态必须一致。
+- switchover：roleProbe、roleSelector、switchover action 三者必须同时成立；指定 candidate 时验证 candidate 最终达到目标 role，未指定 candidate 时验证 action 自身确实完成切换并由后续 roleProbe 反映。
+- rebuild：必须能从 Backup/Restore 或 dataLoad 路径重建目标实例。
+
+几个 Day-2 边界要提前写成支持矩阵。`Start` 只恢复停止的 workload，不等于重新执行 `postProvision`；一次性初始化必须有幂等保护，Start/Restart 后只能依赖启动脚本、memberJoin 或显式恢复动作。Vertical scaling 不只看 OpsRequest 成功，要给出调度、Pod 重建或 in-place 变化、PVC attach/detach、容器内 cgroup 资源和引擎内部资源感知的证据。`RebuildInstance` 的 ordinal 是 KB 实例身份，不一定等于数据库业务成员 ID；脚本要从引擎元数据确认目标成员，而不是只用 Pod 名或 ordinal 拼业务命令。
+
+`scaleOut.fromBackup` 是 Restore 能力的独立消费者，不能用“新建 Cluster restore 成功”替代。它要验收 source Backup namespace/name、`restoreTime` 或 PITR 窗口、`restoreEnv`、目标新副本的 memberJoin、角色收敛和数据一致性；从备份恢复出的新副本是 standby、secondary 还是可投票成员，要由脚本和 roleProbe 共同证明。多 target Backup 场景必须声明 `sourceBackupTargetName` 到目标 component、volume、ordinal 或 shard 的映射；未映射的 target 不能默认为可安全跳过。
+
+`RebuildInstance` 至少区分 in-place 和 replace 两条路径。in-place 路径要证明旧进程停机、文件锁、PVC 清理/复用、restore 覆盖和 postReady 幂等；replace 路径要证明新旧 Pod/Service endpoint 过渡、memberLeave/memberJoin、PVC 绑定、存储拓扑和客户端切流。`targetNodeName` 只能表达调度偏好或目标节点，不证明旧 PV 一定可 attach；最终仍要看 PVC/PV、Pod events 和存储类约束。
+
+sharding Ops 字段要在示例里标注名字语义。例如 `shards` 指 shard spec 数量，sharding spec name 来自 `spec.shardings[*].name`，生成的 Component 对象名可能带 cluster 和 shard 后缀，`componentName`、`componentObjectName`、`instanceName` 不能混用。排查时同时打印 Cluster spec、Component 对象名、InstanceSet/Pod label 和 Service selector，避免把模板名当成可操作对象名。
+
+交错 Ops 要么证明支持，要么写明禁止组合：
+
+| 组合 | 支持前提 | 不支持时的文档边界 |
+| --- | --- | --- |
+| Upgrade + Switchover | roleProbe、updateStrategy、candidate 选择和 rollout 状态能同时收敛 | 升级期间禁止切主，或必须等 Component/InstanceSet 完成 |
+| Reconfigure + Restart/VerticalScaling | 参数 desired/observed、runtime ConfigMap 和进程状态能重试到一致 | 配置变更完成前禁止触发资源变更 |
+| Scale-in + Backup/Restore | target Pod、memberLeave、Backup target selector 不会选到即将删除成员 | 缩容期间禁止备份或恢复到该组件 |
+| Stop + Delete/Start | 停止状态下 preTerminate、PVC retention 和启动恢复路径都有明确语义 | Stop 后删除不保证执行 preTerminate；Start 不重放 postProvision |
+
+Ops 状态机排查要允许“状态”和“事实”短暂不一致。并发 Ops、precondition、force、`enqueueOnForce`、cancel、timeout 和 TTL 先看 OpsRequest `phase/message/conditions` 与目标 Component 状态，再看是否已有 action 后置校验失败、status 更新失败或 partial success；这些字段只说明队列和生命周期边界，不是业务最终事实。`progress` 不等于 Pod Ready，`lastConfiguration` 是该次 Ops 的前态证据，不是全局真实配置；TTL 清理 OpsRequest 后，要从 live Cluster/Component/InstanceSet/PVC/Job、events 和 GitOps 记录恢复证据。事实已经改变但 Ops 失败时，不要直接重试，先用最终对象和业务自检判断是否幂等安全。volume expansion 至少分三层验收：PVC capacity 变大、容器内文件系统可见、引擎内部容量或只读状态已更新；OpsRequest 成功只覆盖其中一部分证据。Stop/Start 这类操作如果输入列表为空，也要以 server 端最终 Ops spec、events 和目标 Component 变化判断默认作用范围，不从空数组字面推断。
+
+内置 Ops 的“支持”要按消费者分开声明。新建 Cluster restore 成功，不代表 `scaleOut.fromBackup` 和 `RebuildInstance` 都可用；普通 `scaleOut` 成功，不代表从备份恢复的新副本能加入投票成员；`Reconfigure` 成功，不代表所有 Pod 的动态参数一致。每个 Ops 至少要说明入口字段、目标对象、执行面、后置业务自检和不支持路径。当前 API 无法自然表达的需求，比如需要复杂 rebalance、跨 topology 自动迁移或需要人工确认的数据迁移，应写成限制或 gap，不要藏进一个脚本后宣称支持。
+
+## 12. 常见操作排障要从入口 CR 逐层向下查
+
+addon 的运行问题通常不是单点问题。一次创建、删除或 day-2 操作会跨过 Cluster、Component、InstanceSet/Pod、Parameters、Backup/Restore、OpsRequest 和脚本动作。排障时应先确认入口对象、resolved definition、底层对象和脚本动作是否闭环，再判断是 chart 合同、脚本行为、用户操作还是 API/实现缺口。
+
+排障时不要从最后一个错误倒推全部语义。更稳定的顺序是：先看入口 CR 的 `generation/observedGeneration`、`phase/message/conditions`，确认 controller 是否已经处理了当前 spec；再看被引用的 definition 或 policy 是否 `Available`；然后看生成对象和最终 workload；最后看脚本输出、事件和业务自检。对象存在不等于可引用，spec 写了字段也不等于最终 Pod、Job、Service、PVC 已按预期生成。
+
+删除、卸载、scale-in 和 Stop 后删除要分流排查：
+
+| 路径 | 先看 | 数据和外部资源边界 |
+| --- | --- | --- |
+| Cluster 删除 | `terminationPolicy`、Cluster finalizer、Component deletionTimestamp、orders | PVC retention、PV reclaim policy、BackupRepo artifact 和外部 ServiceRef 都是独立边界；外部依赖默认不归当前 Cluster 清理 |
+| Component 删除 | Component finalizer、InstanceSet/Pod/PVC ownerRef、preTerminate action | 只清当前 component 管理的对象；共享 Service、RBAC 或外部依赖清理由 chart 和文档自证 |
+| scale-in | OpsRequest、目标实例、`memberLeave`、PVC retention | 业务成员摘除和 PVC 保留是两件事；保留 PVC 不等于成员仍在复制组，删除 PVC 也不等于业务元数据已清理 |
+| Stop 后删除 | Stop Ops 状态、Pod 是否仍存在、Component phase | Pod 已停止或删除时不能假设 preTerminate 可执行；需要跳过时必须保留现场并写明风险 |
+| Helm uninstall/feature disable | release manifest、残留 cluster-scoped definition、Role/RoleBinding/SA | definition 删除不自动证明 RBAC、BackupPolicy、Schedule、Repo artifact 已清理；保留策略要写入发布说明 |
+
+如果删除卡在 lifecycle 下线动作，而目标 Pod、InstanceSet 或其它执行面已经不存在，先保留 Cluster、Component、InstanceSet/Pod、Event 和 action 状态证据，定位执行面为何提前消失。只有确认业务清理已经不需要、已经由外部补偿完成，或当前恢复目标明确要求释放资源时，才能按明确风险的运维恢复流程绕过该动作；绕过后的结果不能作为 addon 删除流程验收通过的证据。
+
+按问题域组织排查路径时，可以使用下面的固定入口：
+
+| 问题域 | 第一批对象和字段 | 下一跳证据 | 边界 |
+| --- | --- | --- | --- |
+| 资源引用和 status | 入口对象 namespace/source、`ComponentDefinition`、`ClusterDefinition`、`ComponentVersion`、`ParametersDefinition`、`BackupPolicyTemplate`、`ActionSet` 的 `generation/observedGeneration/phase/message/conditions` | 引用它们的 Cluster、Component、BackupPolicy、ComponentParameter、OpsRequest、Job 和事件 | 不要只看 CR 是否存在；同名删除重建、phase/message 不一致或 namespace 源歧义时，以引用方最终生成物为准 |
+| 发布迁移和 GitOps | 新旧渲染结果、server-side dry-run/diff、live Cluster spec、不可变或创建期字段 | 生成的 Component、InstanceSet/PVC、BackupPolicy、BackupSchedule、ComponentParameter | `clusterDef/topology/restore`、组件身份和 sharding 名称变更按迁移处理；list merge/retainKeys 以 server 最终对象为准 |
+| 名字和身份 | Cluster UID、spec name、generated Component name、status key、Pod/PVC/Service 名、selector label | 引擎成员 ID、备份 target、sharding component、持久数据里的身份记录 | 不把 Pod 名、generated component name、clusterUID 或 ordinal 当作不可重算业务身份 |
+| 终止和数据保留 | Cluster `terminationPolicy`、Component/Cluster deletionTimestamp、finalizers、conditions | InstanceSet、Pod、PVC、Backup/BackupRepo、preTerminate action | `Halt/Delete/WipeOut/DoNotTerminate` 与 PVC retention、备份仓库清理、脚本失败是不同层；删除失败不能直接归因到 lifecycle |
+| 调度、PVC 和存储 | Cluster/Component 的 scheduling、runtimeClass、affinity/tolerations、volumeClaimTemplates、PVC retention | 最终 Pod spec、PVC name/ownerRef/labels、StorageClass、Pod/PVC events | 调度和 runtimeClass 对 backup/restore/action worker 是否继承，必须看实际 Job/Pod；PVC adoption 以名称、ownerRef、label 和事件为准 |
+| Service、Expose 和网络覆盖 | CMPD `services`、ClusterService/Expose spec、ServiceRef、serviceVarRef、hostAliases、dnsPolicy/dnsConfig、hostNetwork/hostPort | 最终 Service type/ports/selector/annotations、EndpointSlice、Pod label、Pod/Job DNS、注入 env、连接测试 | 不覆盖 KB 系统 selector label；ServiceRef name 同 Cluster 内唯一或显式共享；publishNotReadyAddresses、Service 命名冲突、hostPort 调度和 advertised address 都按最终对象验收 |
+| ServiceAccount 和 RBAC | Cluster/Component `serviceAccountName`、Action/Restore 运行位置 | Pod/Job 使用的 SA、Role/RoleBinding/rules、action 或 restore 失败事件 | 组件 Pod、lifecycle action、backup/restore Job 可能不是同一个权限面；跨 namespace Secret 或外部资源访问必须单独自证 |
+| Pod 更新和 InstanceTemplate | OpsRequest、Component `podUpdatePolicy/podUpgradePolicy/instanceUpdateStrategy`、InstanceTemplate | InstanceSet `current/updatedReplicas`、revision、partition/canary/rolling budget、Instance/Pod/PVC 身份、OnDelete 等待状态 | `OnDelete` 表示等待用户删除 Pod，不是 controller 卡死；模板名、默认 instances、flat ordinal、PVC 名和系统 label 不要用连续数字或手工改 label 替代实际对象 |
+| Action、lifecycle 和 probe | lifecycle action 的 preCondition、targetPodSelector、handler、container/image、timeout/retry | action worker/Pod、volumeMount、stdout/stderr、exit code、role label、Instance role status、Component Available 条件 | 多 handler、默认容器、HTTP/GRPC 能力、retry 成功语义都不能靠字段名猜；脚本幂等、probe 阈值、roleProbe 输出和独立 action image 工具链要分别证明 |
+| variables、env 和外部依赖 | CMPD vars、Cluster env、ServiceDescriptor/ServiceRef、credential/tls/resource var、`KB_` 前缀 | 最终 Pod/action/backup/restore env、渲染后 config/script、脱敏后的脚本自检、真实连接 | 同名 env 覆盖、Optional 缺失、变量展开顺序、列表 delimiter/排序/转义和外部 ServiceDescriptor 值一致性，都以最终注入结果为准 |
+| 参数和 reconfigure | PD `status`、`templateName/fileName/fileFormatConfig/serviceVersion`、OpsRequest reconfigure、外部 ConfigMap key、`configHash` | ComponentParameter、runtime ConfigMap、file-level action、全局 reconfigure、Pod restart、进程配置 dump | 新 addon 优先 file-level reconfigure；defaultValue、删参、多文件冲突、Secret 泄露、formatter 幂等和 key 规范化要用文件与进程双重证据定位 |
+| 备份、自动备份和 artifact | BackupPolicyTemplate、生成的 BackupPolicy、BackupSchedule `schedules[*].name/enabled/status.schedules/repoName`、Backup | method/actionSet、backupType、target Pod、CronJob/Backup 结果、snapshot 或 repo artifact、passphrase Secret、formatVersion | 自动备份是否触发看 BackupSchedule、CronJob 和 Backup 结果；加密、snapshot、Selective、postBackup 失败和 repo 切换只在声明使用时验收 |
+| Restore、scaleOut 和 rebuild | Restore、Cluster restore spec、scaleOut.fromBackup、RebuildInstance | restore Job/PVC、prepareData/postReady、ReadyConfig、sourceBackupTargetName、memberJoin/memberLeave、Service endpoint | 新集群 restore、scaleOut.fromBackup、rebuild in-place/replace 是不同消费者；RestoreKubeResources、deferPostReady、PITR 和多 target 映射必须有矩阵或写未证明 |
+| Ops 状态和失败现场 | OpsRequest `phase/message/conditions`、precondition、并发、force/enqueueOnForce/cancel/timeout/TTL/progress/lastConfiguration | Component、InstanceSet/Instance、Pod、PVC、容器文件系统、action 输出、events、业务自检 | Ops 字段只是证据；partial success、Stop 空列表、sharding 字段名和 volume expansion 要按最终对象判断，事件和 action 输出采集完前不要过早清理失败现场 |
+| 非主 workload | Backup/Restore/action worker、Job、Pod | 实际 env、SA、node、volumeMount、resources、runtimeClass、events | 主组件 runtime 的字段不能自动外推到 worker；需要实现或 e2e 证据时，只写“未证明”或“需自证” |
+
+| 操作 | 先查入口对象 | 再查底层对象 | 常见 addon 问题 | 推荐处理 |
+| --- | --- | --- | --- | --- |
+| 创建 Cluster | Cluster topology、componentSpecs、serviceVersion、volumeClaimTemplates | resolved ComponentDefinition、ComponentVersion、Component、InstanceSet、Pod、Service | default topology 缺失；compDef 正则命中错误版本；PVC 名和 volumeMount 不一致；脚本 ConfigMap 没挂载 | 先修 chart 名称、topology、volume 和脚本挂载合同 |
+| 删除 Cluster/Component | Cluster/Component deletionTimestamp、phase、conditions、finalizers | ComponentDefinition lifecycle、InstanceSet、owned Pods、preTerminate action | preTerminate 依赖 Pod，但 Pod 已提前消失；删除顺序没有覆盖 proxy/server 依赖；脚本不幂等 | 先解释 Pod/InstanceSet 为何消失；确认已经不需要执行清理动作时，再按产品文档化的恢复机制显式跳过该动作 |
+| 参数变更 | OpsRequest reconfigure、ComponentParameter、ParametersDefinition | template ConfigMap、runtime ConfigMap、reconfigure action、Pod 重启状态 | PD.templateName 指错对象；fileName 不存在；static/dynamic 分类错误；reload 脚本没处理参数 diff | 按 PD -> ComponentParameter -> rendered ConfigMap -> action 输出逐层定位 |
+| restart/stop/start | OpsRequest、Component phase | InstanceSet、Pod、container command、postStart/preStop 脚本 | 启动脚本不是幂等的；一次性初始化反复执行；进程退出码和 readiness 不一致 | 修启动脚本幂等性和健康检查，不把 restart 失败归因到 Ops 层 |
+| horizontal scale | OpsRequest、Component replicas | InstanceSet replicas、Pod role、memberJoin/memberLeave | scale out 后未加入复制组；scale in 前未迁移或未摘除成员；roleProbe 没更新 | 补齐 member lifecycle 或明确该引擎不支持在线扩缩容 |
+| volume expansion | OpsRequest、Component volumeClaimTemplates | PVC、StorageClass、Pod mountPath、文件系统扩容 | volumeClaimTemplates 名称和 runtime mount 不一致；引擎需要内部扩容命令但脚本未提供 | 先验证 PVC 和挂载路径，再验证引擎是否感知新容量 |
+| switchover | OpsRequest、Component role 状态 | roleProbe、roleSelector service、switchover action、candidate Pod | roleProbe 不稳定；candidate 选择和脚本预期不一致；切主后服务没有选到新 primary | 先证明 roleProbe 和 roleSelector 正确，再调 switchover 脚本 |
+| backup | BackupPolicy、Backup、BackupPolicyTemplate | Backup target Pod、system account secret、ActionSet、data volume | BPT 没匹配 resolved compDef；target role 不存在；backup 账号缺权限；method 语义混乱 | 先看 BackupPolicy 是否由 BPT 生成，再看 target 和 ActionSet |
+| restore/rebuild | Restore 或 rebuild OpsRequest | Restore Job/PVC、prepareData/postReady、目标 Cluster/Component | 只验证 backup 未验证 restore；TLS、账号、拓扑或版本不兼容；restore 脚本只支持新集群不支持 rebuild | 每个 backup method 必须有独立 restore 验证和兼容矩阵 |
+| upgrade | Cluster/Component serviceVersion、ComponentVersion | resolved release、image、rollout、role/updateStrategy | cmpv release 没匹配到 cmpd；image key 不对应容器/action；升级后参数 schema 或备份方法不兼容 | 先证明 serviceVersion 解析、镜像替换和 rollout 顺序，再验证数据兼容 |
+
+这个排障表不是要求每个 addon 都支持所有操作，而是要求文档把“支持”“不支持”“需要停机”“需要人工步骤”分清楚。缺少底层合同的操作不能在 README 或 examples 中写成已支持。
+
+常用检查命令模板：
+
+```bash
+# 创建和基础实例化
+kubectl get cluster <cluster> -o yaml
+kubectl get component -l app.kubernetes.io/instance=<cluster> -o yaml
+kubectl get componentdefinition,componentversion,clusterdefinition | grep <addon-or-engine>
+kubectl get instancesets,pods,pvc,svc -l app.kubernetes.io/instance=<cluster>
+kubectl describe pod -l app.kubernetes.io/instance=<cluster>
+
+# 参数变更
+kubectl get opsrequest <ops> -o yaml
+kubectl get parametersdefinition <pd> -o yaml
+kubectl get componentparameter -l app.kubernetes.io/instance=<cluster> -o yaml
+kubectl get configmap -l app.kubernetes.io/instance=<cluster> -o yaml
+
+# 备份恢复
+kubectl get backuppolicy,backup,restore -l app.kubernetes.io/instance=<cluster> -o yaml
+kubectl get backuppolicytemplate <bpt> -o yaml
+kubectl get actionset <actionset> -o yaml
+kubectl get backupschedule -l app.kubernetes.io/instance=<cluster> -o yaml
+kubectl get cronjob,backup -l app.kubernetes.io/instance=<cluster> -o yaml
+kubectl get pods,jobs -l dataprotection.kubeblocks.io/backup-name=<backup>
+kubectl get pods,jobs -l dataprotection.kubeblocks.io/restore-name=<restore>
+
+# 运维操作
+kubectl get opsrequest <ops> -o yaml
+kubectl get component <component-object-name> -o yaml
+kubectl get pods -l apps.kubeblocks.io/component-name=<component-object-name> -o wide
+kubectl get pvc -l app.kubernetes.io/instance=<cluster>
+kubectl get svc,endpointslice -l app.kubernetes.io/instance=<cluster> -o yaml
+kubectl get serviceaccount,role,rolebinding -l app.kubernetes.io/instance=<cluster> -o yaml
+```
+
+## 13. 最低验收标准
+
+addon 功能不能只靠 README 声明。每个功能至少要有四类证据：
+
+- 实现文件：模板、脚本、values、CUE。
+- 渲染对象：`helm template` 后实际出现的资源。
+- 运行场景：用户或 e2e 如何触发。
+- 观测结果：status、condition、Pod、Backup、Restore、OpsRequest、action 输出。
+
+推荐验收清单：
+
+- `helm lint` 和 `helm template` 成功，关键资源都渲染出来；至少用覆盖 standalone/HA/sharding/TLS/external ServiceRef/多 serviceVersion 的 values 组合跑渲染闭合检查。
+- 对关键 examples 执行 server-side dry-run，并把 dry-run 输出、实际 apply 后对象、下游 Component/BackupPolicy/ComponentParameter/Job 做 diff；本地渲染和 server 最终对象不一致时，以 server 结果为准。
+- 测试分层要清楚：chart 单元测试验证模板和 helper，server-side dry-run 验证 API/schema/defaulting，生成对象检查验证 controller 消费链路，live smoke 验证 Pod/Service/Job/action 真能运行，故障用例验证排查路径和限制说明。缺哪一层，就不要把对应能力写成已证明。
+- 发布升级清单覆盖旧 definition/policy/action 资源、关闭功能后的残留 BackupPolicy/BackupSchedule、测试资源剔除和 cluster-scoped 命名冲突；每项写明保留、迁移、删除或不支持。
+- helper、模板引用和 examples 里的名字闭合：`clusterDef/topology/component name`、direct `componentDef` 样例、CMPD config/script volume、PD `templateName/fileName`、BPT `compDefs`、ActionSet 名称和 service 端口都能互相指到。
+- `ComponentDefinition`、`ClusterDefinition`、`ParametersDefinition`、`BackupPolicyTemplate`、`ActionSet` 进入 Available 或可被引用状态。
+- 会被其它对象引用的 definition、policy 和 action 资源，凡 status 暴露 `observedGeneration` 的，都要证明它已追上当前 `generation`；只看 `phase=Available` 不足以排除旧状态。
+- 最小 Cluster 创建成功，Pod Ready，Service 可连接。
+- 每个声明支持的 topology 都要独立验收，而不是只验默认 topology：ComponentDefinition/ComponentVersion、ClusterDefinition orders、ParametersDefinition、BackupPolicyTemplate、ActionSet、systemAccounts、TLS、Service/ServiceRef、examples 和最低 Backup/Restore 或限制说明都要闭合。
+- 声称支持 HA、TLS、backup、restore、upgrade、reconfigure 等组合能力时，不能只给一个 all-in-one example。至少要拆出每项能力的最小成功用例和一个能暴露边界的失败用例，例如缺 roleProbe 的 switchover、TLS on/off 的 backup/restore、非法参数或删参、旧版本升级、新集群 restore 与 rebuild 的差异。
+- HA 场景能识别 role，switchover 可执行；candidate 和无 candidate 两种路径至少证明一种已支持，未覆盖路径写限制。
+- 默认 resources、storage、数据目录初始化、脚本 defaultMode、工具镜像可拉取性和镜像 registry 来源要进入最低 smoke；这些问题一旦失败，表面现象经常是 Cluster 创建或 Pod Ready 问题，但根因属于 addon 合同。
+- 参数变更能正确区分 reload 和 restart，并覆盖参数删除、Optional 变量缺失、多配置文件和脚本重复执行。
+- backup 完成后能 restore，且 restore 后可读写或可执行明确的健康检查；artifact manifest、空数据集、加密 payload、formatVersion、TLS/账号、PITR、增量、rebuild、跨版本和跨拓扑未验证时必须标为未证明。
+- 升级验收同时检查 ComponentVersion resolved serviceVersion、runtime/init/action image、参数 schema、BPT method env `versionMapping` 和数据兼容矩阵。
+
+下面这些是“声明才验收”的扩展能力，不是所有 addon 的最低必选项。只要 README、values、examples、BPT、ActionSet、Cluster 示例或脚本声明了能力，就必须提供对应证据；没有证据时写“不支持”或“未证明”：
+
+- 网络覆盖：hostAliases、dnsPolicy/dnsConfig、hostNetwork、hostPort、LoadBalancer advertised address、跨 namespace ServiceRef。
+- Service 行为：publishNotReadyAddresses、podService、额外 ComponentService、Expose override、Service annotation/port 覆盖。
+- 身份和 HA：`replicas=0`、quorum role、`participatesInQuorum`、role updatePriority、业务 fencing。
+- 配置参数：外部 ConfigMap、`configHash`、`ComponentFileTemplate.variables.defaultValue`、formatter、参数 key 规范化。
+- 数据保护：备份加密 passphrase、method formatVersion、snapshot artifact、repository artifact、Selective backup/restore、RestoreKubeResources、PITR/continuous backup。
+- Restore 消费者：scaleOut.fromBackup、RebuildInstance in-place/replace、跨 topology/sharding restore、多 target `sourceBackupTargetName` 映射。
+- Ops 证据：force/enqueueOnForce、TTL、progress、lastConfiguration、Stop 空列表、sharding Ops 字段。
+
+故障类验收还要额外证明：
+
+- 参数链路失败时，能定位到 PD、ComponentParameter、template ConfigMap、runtime ConfigMap 中哪一层断开。
+- 创建、删除、reconfigure、scale、switchover、backup/restore、upgrade 这些操作失败时，能说明入口 CR、resolved definition、底层对象和脚本动作分别处于什么状态。
+- 所有绕过执行、清理或一致性检查的恢复手段，只能作为明确风险的运维恢复，不应掩盖 addon 设计错误。
+
+验收结论遵循一个原则：没有最终对象、执行面、脚本输出和业务自检证据的能力，只能标为“不支持”“未证明”或“当前 API 缺口”，不能写成已支持。


### PR DESCRIPTION
## Summary
- add formal KubeBlocks addon practice guide filenames for current, v1.1, and v1.0 docs
- keep only the three final guide documents in this commit

## Notes
- local intermediate QA, ambiguity, gap, and audit artifacts are intentionally not included