### PR TITLE
fix: grant namespace access for backup deletion guard

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -45,6 +45,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - list

--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -79,6 +79,7 @@ type BackupReconciler struct {
 // +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshots/finalizers,verbs=update;patch
 // +kubebuilder:rbac:groups=snapshot.storage.k8s.io,resources=volumesnapshotclasses,verbs=get;list;watch
 
+// +kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
 

--- a/deploy/helm/config/rbac/role.yaml
+++ b/deploy/helm/config/rbac/role.yaml
@@ -45,6 +45,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - list


### PR DESCRIPTION
## Problem

PR #10343 added a namespace-termination guard before creating Backup deletion worker resources. That guard reads the Backup namespace before creating worker ServiceAccount/RoleBinding resources.

The DataProtection controller RBAC did not grant access to core `namespaces`, so the new guard can be blocked by namespace informer/list permission instead of reaching the Backup deletion flow.

## Symptoms

In Dameng backup cleanup validation with the #10343 patch image:

- the Backup stayed in `Deleting` with the `dataprotection.kubeblocks.io/finalizer`
- no delete-backup-files Job was created
- current namespace pods/jobs were empty, so the deletion was not blocked by leftover Backup worker pods
- controller logs repeatedly showed the `kb-kubeblocks` service account could not list core `namespaces`

Evidence boundary: the validation proves the deletion flow is blocked before creating the delete-backup-files worker Job. It does not prove that backup data deletion completed.

## Reproduction

1. Run a Backup with `deletionPolicy=Delete`.
2. Delete the Backup under a DataProtection controller image that includes #10343 but whose ClusterRole lacks core `namespaces` access.
3. Observe the Backup remaining in `Deleting`, no delete-backup-files Job, and namespace RBAC errors in the controller logs.

## Solution

Grant the DataProtection controller `get/list/watch` access to core `namespaces`:

- add the kubebuilder RBAC marker in `controllers/dataprotection/backup_controller.go`
- regenerate `config/rbac/role.yaml`
- regenerate `deploy/helm/config/rbac/role.yaml`

This is intentionally narrow. It only gives the controller enough permission to evaluate the namespace guard added by #10343.

## Verification

- `git diff --check` passed.
- `make manifests` regenerated the RBAC manifests, then failed in `client-sdk-gen` because `go mod tidy -compat=1.25` hit the existing `github.com/docker/docker/api` vs `github.com/moby/moby/api` module path mismatch. No `go.mod` or `go.sum` changes were produced.
- `go test ./controllers/dataprotection -run TestAPIs -count=1` was attempted but the local envtest asset `/usr/local/kubebuilder/bin/etcd` is missing.
- `go test ./pkg/dataprotection/backup -count=1` was attempted with the same local envtest asset blocker.

## Boundaries

This PR does not change Backup finalizer behavior, deletion policy semantics, worker Job creation logic, or data deletion safety rules.

Runtime PASS still requires a patched deployment with this RBAC and a Dameng backup cleanup rerun proving Backup NotFound, namespace cleanup, and no residue.

Fixes #10348
