### PR TITLE
fix: match backup targets to restore PVC labels

### DIFF
--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -562,6 +562,9 @@ func backupTargetMatchesPVC(target *dpv1alpha1.BackupStatusTarget, pvc *corev1.P
 		}
 		pvcValue, exists := pvc.Labels[k]
 		if !exists {
+			if backupTargetSelectorKeyScopesPVC(k) {
+				return false, true
+			}
 			continue
 		}
 		effective = true
@@ -575,6 +578,9 @@ func backupTargetMatchesPVC(target *dpv1alpha1.BackupStatusTarget, pvc *corev1.P
 		}
 		value, exists := pvc.Labels[expression.Key]
 		if !exists {
+			if backupTargetSelectorKeyScopesPVC(expression.Key) {
+				return false, true
+			}
 			continue
 		}
 		effective = true
@@ -600,6 +606,15 @@ func backupTargetMatchesPVC(target *dpv1alpha1.BackupStatusTarget, pvc *corev1.P
 		}
 	}
 	return true, effective
+}
+
+func backupTargetSelectorKeyScopesPVC(key string) bool {
+	switch key {
+	case constant.KBAppComponentLabelKey, constant.KBAppShardingNameLabelKey, constant.VolumeClaimTemplateNameLabelKey:
+		return true
+	default:
+		return false
+	}
 }
 
 func requiredPolicyForPVC(target *dpv1alpha1.BackupStatusTarget, pvc *corev1.PersistentVolumeClaim) (*dpv1alpha1.RequiredPolicyForAllPodSelection, error) {

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -444,7 +444,8 @@ func (r *VolumePopulatorReconciler) resolveSourceTargetFromBackup(reqCtx intctrl
 	var matched []*dpv1alpha1.BackupStatusTarget
 	for i := range backup.Status.Targets {
 		target := &backup.Status.Targets[i]
-		if backupTargetMatchesPVC(target, pvc) {
+		matches, effective := backupTargetMatchesPVC(target, pvc)
+		if effective && matches {
 			matched = append(matched, target)
 		}
 	}
@@ -462,7 +463,8 @@ func (r *VolumePopulatorReconciler) resolveSourceTargetFromBackup(reqCtx intctrl
 }
 
 func resolveSingleSourceTargetForPVC(target *dpv1alpha1.BackupStatusTarget, pvc *corev1.PersistentVolumeClaim) (*dpv1alpha1.BackupStatusTarget, bool, error) {
-	if backupTargetHasEffectivePVCSelector(target) && !backupTargetMatchesPVC(target, pvc) {
+	matched, effective := backupTargetMatchesPVC(target, pvc)
+	if effective && !matched {
 		return nil, true, nil
 	}
 	return target, false, nil
@@ -548,27 +550,9 @@ func componentLogicalName(component *appsv1.Component) string {
 	return component.Name
 }
 
-func backupTargetHasEffectivePVCSelector(target *dpv1alpha1.BackupStatusTarget) bool {
+func backupTargetMatchesPVC(target *dpv1alpha1.BackupStatusTarget, pvc *corev1.PersistentVolumeClaim) (bool, bool) {
 	if target == nil || target.PodSelector == nil || target.PodSelector.LabelSelector == nil {
-		return false
-	}
-	selector := target.PodSelector.LabelSelector
-	for k := range selector.MatchLabels {
-		if k != constant.AppInstanceLabelKey {
-			return true
-		}
-	}
-	for _, expression := range selector.MatchExpressions {
-		if expression.Key != constant.AppInstanceLabelKey {
-			return true
-		}
-	}
-	return false
-}
-
-func backupTargetMatchesPVC(target *dpv1alpha1.BackupStatusTarget, pvc *corev1.PersistentVolumeClaim) bool {
-	if target.PodSelector == nil || target.PodSelector.LabelSelector == nil {
-		return false
+		return false, false
 	}
 	selector := target.PodSelector.LabelSelector
 	var effective bool
@@ -576,39 +560,46 @@ func backupTargetMatchesPVC(target *dpv1alpha1.BackupStatusTarget, pvc *corev1.P
 		if k == constant.AppInstanceLabelKey {
 			continue
 		}
+		pvcValue, exists := pvc.Labels[k]
+		if !exists {
+			continue
+		}
 		effective = true
-		if pvc.Labels[k] != v {
-			return false
+		if pvcValue != v {
+			return false, true
 		}
 	}
 	for _, expression := range selector.MatchExpressions {
 		if expression.Key == constant.AppInstanceLabelKey {
 			continue
 		}
-		effective = true
 		value, exists := pvc.Labels[expression.Key]
+		if !exists {
+			continue
+		}
+		effective = true
 		switch expression.Operator {
 		case metav1.LabelSelectorOpIn:
-			if !exists || !slices.Contains(expression.Values, value) {
-				return false
+			if !slices.Contains(expression.Values, value) {
+				return false, true
 			}
 		case metav1.LabelSelectorOpNotIn:
 			if exists && slices.Contains(expression.Values, value) {
-				return false
+				return false, true
 			}
 		case metav1.LabelSelectorOpExists:
 			if !exists {
-				return false
+				return false, true
 			}
 		case metav1.LabelSelectorOpDoesNotExist:
 			if exists {
-				return false
+				return false, true
 			}
 		default:
-			return false
+			return false, true
 		}
 	}
-	return effective
+	return true, effective
 }
 
 func requiredPolicyForPVC(target *dpv1alpha1.BackupStatusTarget, pvc *corev1.PersistentVolumeClaim) (*dpv1alpha1.RequiredPolicyForAllPodSelection, error) {

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -635,6 +635,38 @@ func TestDecidePVCRestoreKeepsSingleBackupTargetScopedToMatchingComponent(t *tes
 	require.Nil(t, decision.sourceTarget)
 }
 
+func TestDecidePVCRestoreIgnoresPodOnlyTargetLabelsForPVCMatch(t *testing.T) {
+	reconciler := &VolumePopulatorReconciler{}
+	backup := newBackupForRestoreDecision([]string{"data"}, []string{"valkey"})
+	backup.Status.Targets[0].PodSelector = &dpv1alpha1.PodSelector{
+		LabelSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				constant.AppInstanceLabelKey:    "source-cluster",
+				constant.KBAppComponentLabelKey: "valkey",
+				constant.RoleLabelKey:           "secondary",
+			},
+		},
+		Strategy: dpv1alpha1.PodSelectionStrategyAny,
+	}
+
+	pvc := newPVCForRestoreDecision("data", "valkey", "")
+	decision, err := reconciler.decidePVCRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup, nil)
+
+	require.NoError(t, err)
+	require.Equal(t, pvcRestoreModeRestoreData, decision.mode)
+	require.False(t, decision.skipPostReady)
+	require.NotNil(t, decision.sourceTarget)
+	require.Equal(t, "valkey", decision.sourceTarget.Name)
+
+	pvc = newPVCForRestoreDecision("data", "valkey-sentinel", "")
+	decision, err = reconciler.decidePVCRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup, nil)
+
+	require.NoError(t, err)
+	require.Equal(t, pvcRestoreModeProvisionOnly, decision.mode)
+	require.True(t, decision.skipPostReady)
+	require.Nil(t, decision.sourceTarget)
+}
+
 func TestDecidePVCRestoreTreatsNilTargetVolumesAsProvisionOnly(t *testing.T) {
 	reconciler := &VolumePopulatorReconciler{}
 	backup := newBackupForRestoreDecision(nil, nil)

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -667,6 +667,30 @@ func TestDecidePVCRestoreIgnoresPodOnlyTargetLabelsForPVCMatch(t *testing.T) {
 	require.Nil(t, decision.sourceTarget)
 }
 
+func TestDecidePVCRestoreRequiresPVCScopedTargetLabels(t *testing.T) {
+	reconciler := &VolumePopulatorReconciler{}
+	backup := newBackupForRestoreDecision([]string{"data"}, []string{"valkey"})
+	backup.Status.Targets[0].PodSelector = &dpv1alpha1.PodSelector{
+		LabelSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				constant.AppInstanceLabelKey:    "source-cluster",
+				constant.KBAppComponentLabelKey: "valkey",
+				constant.RoleLabelKey:           "secondary",
+			},
+		},
+		Strategy: dpv1alpha1.PodSelectionStrategyAny,
+	}
+
+	pvc := newPVCForRestoreDecision("data", "valkey", "")
+	delete(pvc.Labels, constant.KBAppComponentLabelKey)
+	decision, err := reconciler.decidePVCRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup, nil)
+
+	require.NoError(t, err)
+	require.Equal(t, pvcRestoreModeProvisionOnly, decision.mode)
+	require.True(t, decision.skipPostReady)
+	require.Nil(t, decision.sourceTarget)
+}
+
 func TestDecidePVCRestoreTreatsNilTargetVolumesAsProvisionOnly(t *testing.T) {
 	reconciler := &VolumePopulatorReconciler{}
 	backup := newBackupForRestoreDecision(nil, nil)


### PR DESCRIPTION
## Problem

Backup dataSource PVC restore can be incorrectly classified as provision-only when the Backup target pod selector contains labels that exist only on Pods.

In the Valkey rerun, restore intent projection was present: the restore Cluster had spec.restore.source and restore PVCs had Backup dataSource/dataSourceRef. VolumePopulator still emitted provision-only events and skipped the data restore branch.

Fixes #10352

## What changed

- Changed VolumePopulator target-to-PVC matching to evaluate only selector labels that are present on PVCs.
- Kept component-scoped target matching intact, so non-target components such as sentinel PVCs still stay provision-only.
- Added a focused unit test covering a Backup target selector with both component label and pod-only role label.

## Verification

Passed:

```bash
go test ./controllers/dataprotection -run 'TestDecidePVCRestore(IgnoresPodOnlyTargetLabelsForPVCMatch|KeepsSingleBackupTargetScopedToMatchingComponent|UsesTargetVolumes|TreatsNilTargetVolumesAsProvisionOnly)' -count=1
```

Full package (previously blocked locally by missing etcd, now verified with envtest assets):

```bash
go test ./controllers/dataprotection -count=1   # ok, 46s
```

## Runtime boundary

Draft PR only. Runtime acceptance is not complete yet. Valkey needs a patched controller rerun and should capture Backup target, PVC dataSourceRef, VolumePopulator events, PVC/PV status, and restore readback.

This is not Valkey release PASS and not a Valkey product FAIL.

