### PR TITLE
fix: resolve sharded switchover component target

### DIFF
--- a/pkg/operations/switchover.go
+++ b/pkg/operations/switchover.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -296,11 +297,31 @@ func getCompSpecBySwitchover(ctx context.Context, cli client.Client, cluster *ap
 }
 
 func getSwitchoverClusterComponentName(ctx context.Context, cli client.Client, cluster *appsv1.Cluster, switchover opsv1alpha1.Switchover) (string, error) {
-	compSpec, err := getCompSpecBySwitchover(ctx, cli, cluster, switchover)
-	if err != nil {
+	if len(switchover.ComponentName) > 0 {
+		if cluster.Spec.GetComponentByName(switchover.ComponentName) != nil ||
+			cluster.Spec.GetShardingByName(switchover.ComponentName) != nil {
+			return switchover.ComponentName, nil
+		}
+		return "", fmt.Errorf(`component "%s" not found`, switchover.ComponentName)
+	}
+
+	compObj := &appsv1.Component{}
+	if err := cli.Get(ctx, client.ObjectKey{
+		Namespace: cluster.Namespace,
+		Name:      switchover.ComponentObjectName,
+	}, compObj); err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", fmt.Errorf(`component object "%s" not found`, switchover.ComponentObjectName)
+		}
 		return "", err
 	}
-	return compSpec.Name, nil
+	if shardingName := compObj.Labels[constant.KBAppShardingNameLabelKey]; len(shardingName) > 0 {
+		return shardingName, nil
+	}
+	if compName := compObj.Labels[constant.KBAppComponentLabelKey]; len(compName) > 0 {
+		return compName, nil
+	}
+	return "", fmt.Errorf(`component object "%s" has no component label`, switchover.ComponentObjectName)
 }
 
 func buildSynthesizedComp(ctx context.Context, cli client.Client, opsRes *OpsResource, switchover opsv1alpha1.Switchover) (*component.SynthesizedComponent, error) {
@@ -311,12 +332,35 @@ func buildSynthesizedComp(ctx context.Context, cli client.Client, opsRes *OpsRes
 	componentObjectName := constant.GenerateClusterComponentName(opsRes.Cluster.Name, clusterCompSpec.Name)
 	if len(switchover.ComponentObjectName) > 0 {
 		componentObjectName = switchover.ComponentObjectName
+	} else if opsRes.Cluster.Spec.GetShardingByName(switchover.ComponentName) != nil {
+		componentObjectName, err = getShardingComponentObjectNameByInstance(ctx, cli, opsRes.Cluster, switchover.ComponentName, switchover.InstanceName)
+		if err != nil {
+			return nil, err
+		}
 	}
 	compObj, compDefObj, err := component.GetCompNCompDefByName(ctx, cli, opsRes.Cluster.Namespace, componentObjectName)
 	if err != nil {
 		return nil, err
 	}
 	return component.BuildSynthesizedComponent(ctx, cli, compDefObj, compObj)
+}
+
+func getShardingComponentObjectNameByInstance(ctx context.Context, cli client.Client, cluster *appsv1.Cluster, shardingName, instanceName string) (string, error) {
+	pod := &corev1.Pod{}
+	if err := cli.Get(ctx, client.ObjectKey{Namespace: cluster.Namespace, Name: instanceName}, pod); err != nil {
+		return "", err
+	}
+	if pod.Labels[constant.AppInstanceLabelKey] != cluster.Name {
+		return "", intctrlutil.NewFatalError(fmt.Sprintf(`instance "%s" does not belong to cluster "%s"`, instanceName, cluster.Name))
+	}
+	if pod.Labels[constant.KBAppShardingNameLabelKey] != shardingName {
+		return "", intctrlutil.NewFatalError(fmt.Sprintf(`instance "%s" does not belong to sharding "%s"`, instanceName, shardingName))
+	}
+	componentName := pod.Labels[constant.KBAppComponentLabelKey]
+	if componentName == "" {
+		return "", intctrlutil.NewFatalError(fmt.Sprintf(`instance "%s" does not have component label`, instanceName))
+	}
+	return constant.GenerateClusterComponentName(cluster.Name, componentName), nil
 }
 
 func handleProgressDetail(

--- a/pkg/operations/switchover_test.go
+++ b/pkg/operations/switchover_test.go
@@ -246,5 +246,112 @@ var _ = Describe("", func() {
 		It("Test switchover OpsRequest with candidate and specified a component object name", func() {
 			testSwitchoverWithCandidate(true)
 		})
+
+		It("Test switchover OpsRequest with sharding component name", func() {
+			const (
+				shardingName       = "shard"
+				shardingTemplate   = "redis"
+				shardComponentName = "shard-abc"
+			)
+
+			By("creating a sharding cluster whose template name differs from the sharding name")
+			shardingCluster := testapps.NewClusterFactory(testCtx.DefaultNamespace, clusterName, "").
+				WithRandomName().
+				AddSharding(shardingName, "", compDefObj.Name).
+				SetShardingReplicas(2).
+				Create(&testCtx).GetObject()
+			Expect(testapps.ChangeObj(&testCtx, shardingCluster, func(cluster *appsv1.Cluster) {
+				cluster.Spec.Shardings[0].Template.Name = shardingTemplate
+			})).Should(Succeed())
+
+			By("creating the concrete shard component")
+			testapps.NewComponentFactory(testCtx.DefaultNamespace, shardingCluster.Name+"-"+shardComponentName, compDefObj.Name).
+				AddAppManagedByLabel().
+				AddAppInstanceLabel(shardingCluster.Name).
+				AddAppComponentLabel(shardComponentName).
+				AddLabels(constant.KBAppShardingNameLabelKey, shardingName).
+				AddAnnotations(constant.KBAppClusterUIDKey, string(shardingCluster.UID)).
+				SetReplicas(2).
+				Create(&testCtx).
+				GetObject()
+
+			By("creating an instanceset and pods for the concrete shard")
+			container := corev1.Container{
+				Name:            "mock-container-name",
+				Image:           testapps.ApeCloudMySQLImage,
+				ImagePullPolicy: corev1.PullIfNotPresent,
+			}
+			its := testapps.NewInstanceSetFactory(testCtx.DefaultNamespace,
+				shardingCluster.Name+"-"+shardComponentName, shardingCluster.Name, shardComponentName).
+				AddFinalizers([]string{constant.DBClusterFinalizerName}).
+				AddContainer(container).
+				AddAppInstanceLabel(shardingCluster.Name).
+				AddAppComponentLabel(shardComponentName).
+				AddLabels(constant.KBAppShardingNameLabelKey, shardingName).
+				AddAppManagedByLabel().
+				SetReplicas(2).
+				Create(&testCtx).GetObject()
+
+			for i := int32(0); i < *its.Spec.Replicas; i++ {
+				_ = testapps.NewPodFactory(testCtx.DefaultNamespace, fmt.Sprintf("%s-%d", its.Name, i)).
+					AddContainer(container).
+					AddLabelsInMap(its.Labels).
+					AddRoleLabel(defaultRole(i)).
+					Create(&testCtx).GetObject()
+			}
+
+			By("mocking the sharding cluster status as Running")
+			Expect(testapps.ChangeObjStatus(&testCtx, shardingCluster, func() {
+				shardingCluster.Status.Phase = appsv1.RunningClusterPhase
+				shardingCluster.Status.Components = map[string]appsv1.ClusterComponentStatus{
+					shardingName: {
+						Phase: appsv1.RunningComponentPhase,
+					},
+				}
+				shardingCluster.Status.Shardings = map[string]appsv1.ClusterShardingStatus{
+					shardingName: {
+						Phase: appsv1.RunningComponentPhase,
+					},
+				}
+			})).Should(Succeed())
+
+			opsRes.Cluster = shardingCluster
+			ops := testops.NewOpsRequestObj("ops-switchover-"+testCtx.GetRandomStr(), testCtx.DefaultNamespace,
+				shardingCluster.Name, opsv1alpha1.SwitchoverType)
+			instanceName := fmt.Sprintf("%s-%d", its.Name, 1)
+			ops.Spec.SwitchoverList = []opsv1alpha1.Switchover{
+				{
+					ComponentName: shardingName,
+					InstanceName:  instanceName,
+				},
+			}
+			opsRes.OpsRequest = testops.CreateOpsRequest(ctx, testCtx, ops)
+			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsPendingPhase
+
+			By("mock switchover OpsRequest phase is Creating")
+			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsCreatingPhase))
+
+			By("do switchover action")
+			_, err = GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(meta.FindStatusCondition(opsRes.OpsRequest.Status.Conditions, opsv1alpha1.ConditionTypeFailed)).Should(BeNil())
+			Expect(opsRes.OpsRequest.Status.Components).Should(HaveKey(shardingName))
+			Expect(opsRes.OpsRequest.Status.Components).ShouldNot(HaveKey(shardingTemplate))
+
+			testapps.MockKBAgentClient(func(recorder *kbacli.MockClientMockRecorder) {
+				recorder.Action(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(func(ctx context.Context, req kbagentproto.ActionRequest) (kbagentproto.ActionResponse, error) {
+					GinkgoWriter.Printf("ActionRequest: %#v\n", req)
+					Expect(req.Parameters["KB_SWITCHOVER_CURRENT_NAME"]).Should(Equal(instanceName))
+					rsp := kbagentproto.ActionResponse{Message: "mock success"}
+					return rsp, nil
+				})
+			})
+
+			By("do reconcile switchover action")
+			_, err = GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
 	})
 })


### PR DESCRIPTION
## Problem

Redis sharded clusters use a sharding spec name such as `shard`, while the template component inside that sharding can have a different name such as `redis`.

Switchover OpsRequest currently resolves `spec.switchover[].componentName` through the component template and then uses the template name as the OpsRequest component key and Component object name. For `componentName: shard`, that makes Switchover look for `<cluster>-redis` instead of the concrete shard Component such as `<cluster>-shard-abc`.

Redis PR #2809 is blocked by this: Reconfiguring and Custom accept `componentName: shard` on the same sharded cluster, but Switchover gets stuck before the lifecycle action runs.

## Fix

- Keep the OpsRequest/runtime component key as the user-provided component or sharding name.
- When Switchover targets a sharding spec by `componentName`, resolve the concrete Component object from the target instance Pod labels.
- Keep `componentObjectName` support for callers that already target a concrete Component object.
- Add a regression test where the sharding name is `shard` and the template name is `redis`.

## Tests

- `make test-go-generate`
- `KUBEBUILDER_ASSETS="/Users/wei/Library/Application Support/io.kubebuilder.envtest/k8s/1.26.1-darwin-arm64" go test ./pkg/operations -run TestAPIs -count=1`
- `KUBEBUILDER_ASSETS="/Users/wei/Library/Application Support/io.kubebuilder.envtest/k8s/1.26.1-darwin-arm64" go test ./pkg/operations -count=1`

## Validation boundary

This is a controller-side fix with local controller tests only. Redis runtime validation for PR #2809 still needs a fresh run against a candidate image, so this PR stays draft until that validation is available.

Fixes #10358