### PR TITLE
fix: converge reconfigure metadata after omitted-request resize

### DIFF
--- a/pkg/controller/instance/in_place_update_utils.go
+++ b/pkg/controller/instance/in_place_update_utils.go
@@ -142,9 +142,34 @@ func mergeInPlaceFields(src, dst *corev1.Pod) {
 					requests, limits := copyRequestsNLimitsFields(&container)
 					mergeResources(&requests, &dst.Spec.Containers[i].Resources.Requests)
 					mergeResources(&limits, &dst.Spec.Containers[i].Resources.Limits)
+					capOmittedRequestsToLimits(&container, &dst.Spec.Containers[i])
 				}
 				break
 			}
+		}
+	}
+}
+
+// capOmittedRequestsToLimits ensures that when the desired template omits a
+// CPU or memory request, the preserved live request does not exceed the new
+// limit. Kubernetes defaults omitted requests to limits, so after a
+// limit-only scale-down the live request (defaulted from the old higher
+// limit) would violate the request ≤ limit invariant and be rejected.
+func capOmittedRequestsToLimits(desired, merged *corev1.Container) {
+	for _, rn := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+		if _, specified := desired.Resources.Requests[rn]; specified {
+			continue
+		}
+		limit, hasLimit := merged.Resources.Limits[rn]
+		if !hasLimit {
+			continue
+		}
+		req, hasReq := merged.Resources.Requests[rn]
+		if !hasReq {
+			continue
+		}
+		if req.Cmp(limit) > 0 {
+			merged.Resources.Requests[rn] = limit.DeepCopy()
 		}
 	}
 }

--- a/pkg/controller/instance/in_place_update_utils.go
+++ b/pkg/controller/instance/in_place_update_utils.go
@@ -297,13 +297,16 @@ func equalResourcesInPlaceFields(old, new *corev1.Pod) bool {
 			return false
 		}
 		oc := old.Spec.Containers[index]
-		realRequests := nc.Resources.Requests
-		// 'requests' defaults to Limits if that is explicitly specified, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources
-		if realRequests == nil {
-			realRequests = nc.Resources.Limits
-		}
-		if !equalField(oc.Resources.Requests, realRequests) {
-			return false
+		for _, resourceName := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+			if request, ok := nc.Resources.Requests[resourceName]; ok {
+				oldRequest := corev1.ResourceList{}
+				if existing, ok := oc.Resources.Requests[resourceName]; ok {
+					oldRequest[resourceName] = existing
+				}
+				if !equalField(oldRequest, corev1.ResourceList{resourceName: request}) {
+					return false
+				}
+			}
 		}
 		if !equalField(oc.Resources.Limits, nc.Resources.Limits) {
 			return false

--- a/pkg/controller/instance/reconciler_update.go
+++ b/pkg/controller/instance/reconciler_update.go
@@ -161,13 +161,14 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 
 			// if already updating using subresource, don't update it again, because without subresource, those fields are considered immutable.
 			// Another reconciliation will be triggered since pod status will be updated.
-			if !equalResourcesInPlaceFields(pod, newPod) && supportResizeSubResource {
+			switch {
+			case !equalResourcesInPlaceFields(pod, newPod) && supportResizeSubResource:
 				err = tree.Update(newMergedPod, kubebuilderx.WithSubResource("resize"))
-			} else {
-				if !safeMetadataOnlyInPlaceUpdate(pod, newPod) {
-					if err = r.switchover(tree, inst, newMergedPod.(*corev1.Pod)); err != nil {
-						return kubebuilderx.Continue, err
-					}
+			case safeMetadataOnlyInPlaceUpdate(pod, newPod):
+				err = tree.Update(newMergedPod, kubebuilderx.WithPatch(true))
+			default:
+				if err = r.switchover(tree, inst, newMergedPod.(*corev1.Pod)); err != nil {
+					return kubebuilderx.Continue, err
 				}
 				err = tree.Update(newMergedPod)
 			}

--- a/pkg/controller/instance/utils_test.go
+++ b/pkg/controller/instance/utils_test.go
@@ -20,18 +20,26 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package instance
 
 import (
+	"context"
 	"reflect"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/builder"
+	"github.com/apecloud/kubeblocks/pkg/controller/kubebuilderx"
+	"github.com/apecloud/kubeblocks/pkg/controller/lifecycle"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
 
 func TestReconfigureOptions(t *testing.T) {
@@ -562,4 +570,194 @@ func TestCopyAndMergeObjects(t *testing.T) {
 		mergedPod.Spec.Containers[0].Resources.Requests.Cpu().String() != "1" {
 		t.Fatalf("unexpected merged pod: %#v", mergedPod)
 	}
+}
+
+func TestUpdateReconcilerConvergesResizeAfterConfigMetadataWithOmittedRequest(t *testing.T) {
+	oldFeatureGate := viper.GetBool(constant.FeatureGateInPlacePodVerticalScaling)
+	defer viper.Set(constant.FeatureGateInPlacePodVerticalScaling, oldFeatureGate)
+	viper.Set(constant.FeatureGateInPlacePodVerticalScaling, true)
+
+	origSupportResize := intctrlutil.SupportResizeSubResource
+	intctrlutil.SupportResizeSubResource = func() (bool, error) { return true, nil }
+	defer func() { intctrlutil.SupportResizeSubResource = origSupportResize }()
+
+	spy := &instanceLifecycleCallSpy{}
+	origNewLifecycleAction := newLifecycleAction
+	newLifecycleAction = func(_ *workloads.Instance, _ []*corev1.Pod, _ *corev1.Pod) (lifecycle.Lifecycle, error) {
+		return spy, nil
+	}
+	defer func() { newLifecycleAction = origNewLifecycleAction }()
+
+	inst := builder.NewInstanceBuilder("default", "valkey-0").
+		SetPodUpdatePolicy(kbappsv1.PreferInPlacePodUpdatePolicyType).
+		SetConfigs([]workloads.ConfigTemplate{{
+			Name:       "valkey-replication-config",
+			ConfigHash: ptr.To("old-hash"),
+			Reconfigure: &kbappsv1.Action{
+				Exec: &kbappsv1.ExecAction{Command: []string{"true"}},
+			},
+		}}).
+		SetLifecycleActions(&workloads.LifecycleActions{
+			Switchover: &kbappsv1.Action{
+				Exec: &kbappsv1.ExecAction{Command: []string{"true"}},
+			},
+		}).
+		AddContainer(corev1.Container{
+			Name:  "valkey",
+			Image: "valkey:8",
+			Resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+			},
+		}).
+		GetObject()
+
+	revision, err := buildInstancePodRevision(&inst.Spec.Template, inst)
+	if err != nil {
+		t.Fatalf("buildInstancePodRevision() error = %v", err)
+	}
+	inst.Status.UpdateRevision = revision
+
+	pod, err := buildInstancePod(inst, revision)
+	if err != nil {
+		t.Fatalf("buildInstancePod() error = %v", err)
+	}
+	pod.Status.Phase = corev1.PodRunning
+	pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
+		Type:               corev1.PodReady,
+		Status:             corev1.ConditionTrue,
+		LastTransitionTime: metav1.NewTime(time.Now().Add(-10 * time.Second)),
+	})
+	pod.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+		Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+	}
+	if err = configsToPod(inst.Spec.Configs, pod); err != nil {
+		t.Fatalf("configsToPod() error = %v", err)
+	}
+
+	inst.Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+	}
+	inst.Spec.Configs[0].ConfigHash = ptr.To("new-hash")
+
+	tree := kubebuilderx.NewObjectTree()
+	tree.SetRoot(inst)
+	if err = tree.Add(pod); err != nil {
+		t.Fatalf("tree.Add() error = %v", err)
+	}
+
+	res, err := NewUpdateReconciler().Reconcile(tree)
+	if err != nil {
+		t.Fatalf("first Reconcile() error = %v", err)
+	}
+	if res != kubebuilderx.Continue {
+		t.Fatalf("expected Continue, got %v", res)
+	}
+
+	pods := tree.List(&corev1.Pod{})
+	if len(pods) != 1 {
+		t.Fatalf("expected one pod, got %d", len(pods))
+	}
+	updatedPod := pods[0].(*corev1.Pod)
+	if got := updatedPod.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU]; !got.Equal(resource.MustParse("1")) {
+		t.Fatalf("expected resize to update CPU limit, got %s", got.String())
+	}
+	if got := updatedPod.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]; !got.Equal(resource.MustParse("500m")) {
+		t.Fatalf("expected resize to preserve omitted CPU request, got %s", got.String())
+	}
+	_, option, err := tree.GetWithOption(updatedPod)
+	if err != nil {
+		t.Fatalf("GetWithOption() error = %v", err)
+	}
+	if option.SubResource != "resize" {
+		t.Fatalf("expected resize subresource, got %q", option.SubResource)
+	}
+	if spy.reconfigureCalls != 1 {
+		t.Fatalf("expected one reconfigure call, got %d", spy.reconfigureCalls)
+	}
+
+	// Simulate real API behavior: resize subresource does not persist
+	// metadata changes. Restore the old annotation.
+	updatedPod.Annotations[constant.CMInsConfigurationHashLabelKey] = `{"valkey-replication-config":"old-hash"}`
+	if err = tree.Update(updatedPod); err != nil {
+		t.Fatalf("tree.Update() to simulate resize metadata drop error = %v", err)
+	}
+
+	res, err = NewUpdateReconciler().Reconcile(tree)
+	if err != nil {
+		t.Fatalf("second Reconcile() error = %v", err)
+	}
+	if res != kubebuilderx.Continue {
+		t.Fatalf("expected Continue after second reconcile, got %v", res)
+	}
+
+	pods = tree.List(&corev1.Pod{})
+	if len(pods) != 1 {
+		t.Fatalf("expected one pod after metadata patch, got %d", len(pods))
+	}
+	patchedPod := pods[0].(*corev1.Pod)
+	if got := patchedPod.Annotations[constant.CMInsConfigurationHashLabelKey]; got != `{"valkey-replication-config":"new-hash"}` {
+		t.Fatalf("expected config hash annotation to be committed, got %q", got)
+	}
+	if got := patchedPod.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]; !got.Equal(resource.MustParse("500m")) {
+		t.Fatalf("expected omitted CPU request to be treated as converged, got %s", got.String())
+	}
+	_, option, err = tree.GetWithOption(patchedPod)
+	if err != nil {
+		t.Fatalf("GetWithOption() after metadata patch error = %v", err)
+	}
+	if option.SubResource != "" {
+		t.Fatalf("expected normal metadata patch after resize converged, got subresource %q", option.SubResource)
+	}
+
+	policy, _, err := getPodUpdatePolicy(inst, patchedPod)
+	if err != nil {
+		t.Fatalf("getPodUpdatePolicy() after resize error = %v", err)
+	}
+	if policy != noOpsPolicy {
+		t.Fatalf("expected omitted desired request to be converged after resize, got policy %q", policy)
+	}
+}
+
+type instanceLifecycleCallSpy struct {
+	switchoverCalls  int
+	reconfigureCalls int
+}
+
+func (s *instanceLifecycleCallSpy) PostProvision(_ context.Context, _ client.Reader, _ *lifecycle.Options) error {
+	return nil
+}
+
+func (s *instanceLifecycleCallSpy) PreTerminate(_ context.Context, _ client.Reader, _ *lifecycle.Options) error {
+	return nil
+}
+
+func (s *instanceLifecycleCallSpy) RoleProbe(_ context.Context, _ client.Reader, _ *lifecycle.Options) ([]byte, error) {
+	return nil, nil
+}
+
+func (s *instanceLifecycleCallSpy) Switchover(_ context.Context, _ client.Reader, _ *lifecycle.Options, _ string) error {
+	s.switchoverCalls++
+	return nil
+}
+
+func (s *instanceLifecycleCallSpy) MemberJoin(_ context.Context, _ client.Reader, _ *lifecycle.Options) error {
+	return nil
+}
+
+func (s *instanceLifecycleCallSpy) MemberLeave(_ context.Context, _ client.Reader, _ *lifecycle.Options) error {
+	return nil
+}
+
+func (s *instanceLifecycleCallSpy) Reconfigure(_ context.Context, _ client.Reader, _ *lifecycle.Options, _ map[string]string) error {
+	s.reconfigureCalls++
+	return nil
+}
+
+func (s *instanceLifecycleCallSpy) AccountProvision(_ context.Context, _ client.Reader, _ *lifecycle.Options, _, _, _ string) error {
+	return nil
+}
+
+func (s *instanceLifecycleCallSpy) UserDefined(_ context.Context, _ client.Reader, _ *lifecycle.Options, _ string, _ *kbappsv1.Action, _ map[string]string) error {
+	return nil
 }

--- a/pkg/controller/instance/utils_test.go
+++ b/pkg/controller/instance/utils_test.go
@@ -719,6 +719,92 @@ func TestUpdateReconcilerConvergesResizeAfterConfigMetadataWithOmittedRequest(t 
 	}
 }
 
+func TestLimitOnlyScaleDownConvergesWithOmittedRequest(t *testing.T) {
+	oldFeatureGate := viper.GetBool(constant.FeatureGateInPlacePodVerticalScaling)
+	defer viper.Set(constant.FeatureGateInPlacePodVerticalScaling, oldFeatureGate)
+	viper.Set(constant.FeatureGateInPlacePodVerticalScaling, true)
+
+	origSupportResize := intctrlutil.SupportResizeSubResource
+	intctrlutil.SupportResizeSubResource = func() (bool, error) { return true, nil }
+	defer func() { intctrlutil.SupportResizeSubResource = origSupportResize }()
+
+	spy := &instanceLifecycleCallSpy{}
+	origNewLifecycleAction := newLifecycleAction
+	newLifecycleAction = func(_ *workloads.Instance, _ []*corev1.Pod, _ *corev1.Pod) (lifecycle.Lifecycle, error) {
+		return spy, nil
+	}
+	defer func() { newLifecycleAction = origNewLifecycleAction }()
+
+	// Start with limits=1, requests omitted (K8s defaults requests=1)
+	inst := builder.NewInstanceBuilder("default", "valkey-0").
+		SetPodUpdatePolicy(kbappsv1.PreferInPlacePodUpdatePolicyType).
+		SetLifecycleActions(&workloads.LifecycleActions{
+			Switchover: &kbappsv1.Action{
+				Exec: &kbappsv1.ExecAction{Command: []string{"true"}},
+			},
+		}).
+		AddContainer(corev1.Container{
+			Name:  "valkey",
+			Image: "valkey:8",
+			Resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+			},
+		}).
+		GetObject()
+
+	revision, err := buildInstancePodRevision(&inst.Spec.Template, inst)
+	if err != nil {
+		t.Fatalf("buildInstancePodRevision() error = %v", err)
+	}
+	inst.Status.UpdateRevision = revision
+
+	pod, err := buildInstancePod(inst, revision)
+	if err != nil {
+		t.Fatalf("buildInstancePod() error = %v", err)
+	}
+	pod.Status.Phase = corev1.PodRunning
+	pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
+		Type:               corev1.PodReady,
+		Status:             corev1.ConditionTrue,
+		LastTransitionTime: metav1.NewTime(time.Now().Add(-10 * time.Second)),
+	})
+	// Simulate K8s defaulting: live pod has requests = old limits
+	pod.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+		Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+	}
+
+	// Scale down: desired limits=500m, requests omitted
+	inst.Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+	}
+
+	tree := kubebuilderx.NewObjectTree()
+	tree.SetRoot(inst)
+	if err = tree.Add(pod); err != nil {
+		t.Fatalf("tree.Add() error = %v", err)
+	}
+
+	res, err := NewUpdateReconciler().Reconcile(tree)
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if res != kubebuilderx.Continue {
+		t.Fatalf("expected Continue, got %v", res)
+	}
+
+	pods := tree.List(&corev1.Pod{})
+	if len(pods) != 1 {
+		t.Fatalf("expected one pod, got %d", len(pods))
+	}
+	updatedPod := pods[0].(*corev1.Pod)
+	limit := updatedPod.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU]
+	req := updatedPod.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+	if req.Cmp(limit) > 0 {
+		t.Fatalf("preserved request must not exceed new limit after scale-down; got request=%s limit=%s", req.String(), limit.String())
+	}
+}
+
 type instanceLifecycleCallSpy struct {
 	switchoverCalls  int
 	reconfigureCalls int

--- a/pkg/controller/instance/utils_test.go
+++ b/pkg/controller/instance/utils_test.go
@@ -709,6 +709,9 @@ func TestUpdateReconcilerConvergesResizeAfterConfigMetadataWithOmittedRequest(t 
 	if option.SubResource != "" {
 		t.Fatalf("expected normal metadata patch after resize converged, got subresource %q", option.SubResource)
 	}
+	if !option.Patch {
+		t.Fatalf("expected metadata-only config-hash commit to use PATCH instead of full Pod UPDATE")
+	}
 
 	policy, _, err := getPodUpdatePolicy(inst, patchedPod)
 	if err != nil {

--- a/pkg/controller/instanceset/in_place_update_util.go
+++ b/pkg/controller/instanceset/in_place_update_util.go
@@ -151,9 +151,34 @@ func mergeInPlaceFields(src, dst *corev1.Pod) {
 					requests, limits := copyRequestsNLimitsFields(&container)
 					mergeResources(&requests, &dst.Spec.Containers[i].Resources.Requests)
 					mergeResources(&limits, &dst.Spec.Containers[i].Resources.Limits)
+					capOmittedRequestsToLimits(&container, &dst.Spec.Containers[i])
 				}
 				break
 			}
+		}
+	}
+}
+
+// capOmittedRequestsToLimits ensures that when the desired template omits a
+// CPU or memory request, the preserved live request does not exceed the new
+// limit. Kubernetes defaults omitted requests to limits, so after a
+// limit-only scale-down the live request (defaulted from the old higher
+// limit) would violate the request ≤ limit invariant and be rejected.
+func capOmittedRequestsToLimits(desired, merged *corev1.Container) {
+	for _, rn := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+		if _, specified := desired.Resources.Requests[rn]; specified {
+			continue
+		}
+		limit, hasLimit := merged.Resources.Limits[rn]
+		if !hasLimit {
+			continue
+		}
+		req, hasReq := merged.Resources.Requests[rn]
+		if !hasReq {
+			continue
+		}
+		if req.Cmp(limit) > 0 {
+			merged.Resources.Requests[rn] = limit.DeepCopy()
 		}
 	}
 }

--- a/pkg/controller/instanceset/in_place_update_util.go
+++ b/pkg/controller/instanceset/in_place_update_util.go
@@ -306,13 +306,16 @@ func equalResourcesInPlaceFields(old, new *corev1.Pod) bool {
 			return false
 		}
 		oc := old.Spec.Containers[index]
-		realRequests := nc.Resources.Requests
-		// 'requests' defaults to Limits if that is explicitly specified, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources
-		if realRequests == nil {
-			realRequests = nc.Resources.Limits
-		}
-		if !equalField(oc.Resources.Requests, realRequests) {
-			return false
+		for _, resourceName := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+			if request, ok := nc.Resources.Requests[resourceName]; ok {
+				oldRequest := corev1.ResourceList{}
+				if existing, ok := oc.Resources.Requests[resourceName]; ok {
+					oldRequest[resourceName] = existing
+				}
+				if !equalField(oldRequest, corev1.ResourceList{resourceName: request}) {
+					return false
+				}
+			}
 		}
 		if !equalField(oc.Resources.Limits, nc.Resources.Limits) {
 			return false

--- a/pkg/controller/instanceset/reconciler_update.go
+++ b/pkg/controller/instanceset/reconciler_update.go
@@ -190,13 +190,14 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 
 			// if already updating using subresource, don't update it again, because without subresource, those fields are considered immutable.
 			// Another reconciliation will be triggered since pod status will be updated.
-			if !equalResourcesInPlaceFields(pod, newPod) && supportResizeSubResource {
+			switch {
+			case !equalResourcesInPlaceFields(pod, newPod) && supportResizeSubResource:
 				err = tree.Update(newMergedPod, kubebuilderx.WithSubResource("resize"))
-			} else {
-				if !safeMetadataOnlyInPlaceUpdate(pod, newPod) {
-					if err = r.switchover(tree, its, newMergedPod.(*corev1.Pod)); err != nil {
-						return kubebuilderx.Continue, err
-					}
+			case safeMetadataOnlyInPlaceUpdate(pod, newPod):
+				err = tree.Update(newMergedPod, kubebuilderx.WithPatch(true))
+			default:
+				if err = r.switchover(tree, its, newMergedPod.(*corev1.Pod)); err != nil {
+					return kubebuilderx.Continue, err
 				}
 				err = tree.Update(newMergedPod)
 			}

--- a/pkg/controller/instanceset/reconciler_update_test.go
+++ b/pkg/controller/instanceset/reconciler_update_test.go
@@ -526,6 +526,8 @@ var _ = Describe("update reconciler test", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(option.SubResource).Should(BeEmpty(),
 				"second reconcile should use normal pod patch, not resize subresource")
+			Expect(option.Patch).Should(BeTrue(),
+				"metadata-only config-hash commit should use PATCH to avoid full Pod update conflicts with kubelet status writes")
 
 			updatePolicy, _, _, err := getPodUpdatePolicy(its, patchedPod)
 			Expect(err).NotTo(HaveOccurred())
@@ -670,6 +672,10 @@ var _ = Describe("update reconciler test", func() {
 				"pod should be patched with the new config-hash annotation even though switchover is skipped")
 			Expect(spy.switchoverCalls).Should(Equal(0),
 				"switchover must not be invoked when only the config-hash annotation differs")
+			_, option, err := tree.GetWithOption(updatedPod)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(option.Patch).Should(BeTrue(),
+				"metadata-only in-place updates should use PATCH instead of full Pod UPDATE")
 		})
 	})
 })

--- a/pkg/controller/instanceset/reconciler_update_test.go
+++ b/pkg/controller/instanceset/reconciler_update_test.go
@@ -426,6 +426,113 @@ var _ = Describe("update reconciler test", func() {
 			testInplacePodVerticalScaling(true)
 		})
 
+		It("converges resize when desired CPU/memory request is omitted", func() {
+			oldFeatureGate := viper.GetBool(constant.FeatureGateInPlacePodVerticalScaling)
+			defer viper.Set(constant.FeatureGateInPlacePodVerticalScaling, oldFeatureGate)
+			viper.Set(constant.FeatureGateInPlacePodVerticalScaling, true)
+
+			origSupportResize := intctrlutil.SupportResizeSubResource
+			intctrlutil.SupportResizeSubResource = func() (bool, error) { return true, nil }
+			defer func() { intctrlutil.SupportResizeSubResource = origSupportResize }()
+
+			spy := &lifecycleCallSpy{}
+			origNewLifecycleAction := newLifecycleAction
+			newLifecycleAction = func(_ *workloads.InstanceSet, _ *kubebuilderx.ObjectTree, _ *corev1.Pod) (lifecycle.Lifecycle, error) {
+				return spy, nil
+			}
+			defer func() { newLifecycleAction = origNewLifecycleAction }()
+
+			tree := kubebuilderx.NewObjectTree()
+			its.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+			its.Spec.Replicas = ptr.To[int32](1)
+			its.Spec.PodUpdatePolicy = kbappsv1.PreferInPlacePodUpdatePolicyType
+			its.Spec.LifecycleActions = &workloads.LifecycleActions{
+				Switchover: &kbappsv1.Action{
+					Exec: &kbappsv1.ExecAction{Command: []string{"true"}},
+				},
+			}
+			its.Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+			}
+			its.Spec.Configs = []workloads.ConfigTemplate{
+				{
+					Name:       "redis-replication-config",
+					ConfigHash: ptr.To("old-hash"),
+					Reconfigure: &kbappsv1.Action{
+						Exec: &kbappsv1.ExecAction{Command: []string{"true"}},
+					},
+				},
+			}
+			tree.SetRoot(its)
+			prepareForUpdate(tree)
+
+			pods := tree.List(&corev1.Pod{})
+			Expect(pods).Should(HaveLen(1))
+			pod := pods[0].(*corev1.Pod)
+			pod.Status.Phase = corev1.PodRunning
+			pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
+				Type:               corev1.PodReady,
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: metav1.NewTime(time.Now().Add(-1 * minReadySeconds * time.Second)),
+			})
+			pod.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+				Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+			}
+			pod.Annotations[constant.CMInsConfigurationHashLabelKey] = `{"redis-replication-config":"old-hash"}`
+
+			its.Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+			}
+			its.Spec.Configs[0].ConfigHash = ptr.To("new-hash")
+
+			reconciler = NewUpdateReconciler()
+			res, err := reconciler.Reconcile(tree)
+			Expect(err).Should(BeNil())
+			Expect(res).Should(Equal(kubebuilderx.Continue))
+
+			postPods := tree.List(&corev1.Pod{})
+			Expect(postPods).Should(HaveLen(1))
+			updatedPod := postPods[0].(*corev1.Pod)
+			Expect(updatedPod.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU]).Should(Equal(resource.MustParse("1")),
+				"resize subresource should update the desired limit")
+			Expect(updatedPod.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]).Should(Equal(resource.MustParse("500m")),
+				"omitted desired request must not be forced to the desired limit during resize")
+			_, option, err := tree.GetWithOption(updatedPod)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(option.SubResource).Should(Equal("resize"))
+			Expect(spy.reconfigureCalls).Should(Equal(1))
+
+			// Simulate real API behavior: resize subresource does not persist
+			// metadata changes (like config-hash annotation). Restore the old
+			// annotation before the second reconcile.
+			updatedPod.Annotations[constant.CMInsConfigurationHashLabelKey] = `{"redis-replication-config":"old-hash"}`
+			Expect(tree.Update(updatedPod)).Should(Succeed())
+
+			res, err = reconciler.Reconcile(tree)
+			Expect(err).Should(BeNil())
+			Expect(res).Should(Equal(kubebuilderx.Continue))
+
+			postPods = tree.List(&corev1.Pod{})
+			Expect(postPods).Should(HaveLen(1))
+			patchedPod := postPods[0].(*corev1.Pod)
+			Expect(patchedPod.Annotations).Should(HaveKeyWithValue(
+				constant.CMInsConfigurationHashLabelKey,
+				`{"redis-replication-config":"new-hash"}`))
+			Expect(patchedPod.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU]).Should(Equal(resource.MustParse("1")))
+			Expect(patchedPod.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]).Should(Equal(resource.MustParse("500m")),
+				"the second reconcile must treat the omitted desired request as converged instead of issuing resize again")
+			_, option, err = tree.GetWithOption(patchedPod)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(option.SubResource).Should(BeEmpty(),
+				"second reconcile should use normal pod patch, not resize subresource")
+
+			updatePolicy, _, _, err := getPodUpdatePolicy(its, patchedPod)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatePolicy).Should(Equal(noOpsPolicy),
+				"after resize updates the desired limit, the omitted desired request must not keep resourceUpdate true")
+		})
+
 		It("patches pod without calling switchover for metadata-only in-place updates", func() {
 			// This test exercises the Reconcile call site (not just the
 			// safeMetadataOnlyInPlaceUpdate helper) to assert the contract

--- a/pkg/controller/instanceset/reconciler_update_test.go
+++ b/pkg/controller/instanceset/reconciler_update_test.go
@@ -533,6 +533,72 @@ var _ = Describe("update reconciler test", func() {
 				"after resize updates the desired limit, the omitted desired request must not keep resourceUpdate true")
 		})
 
+		It("converges limit-only scale-down when desired request is omitted", func() {
+			oldFeatureGate := viper.GetBool(constant.FeatureGateInPlacePodVerticalScaling)
+			defer viper.Set(constant.FeatureGateInPlacePodVerticalScaling, oldFeatureGate)
+			viper.Set(constant.FeatureGateInPlacePodVerticalScaling, true)
+
+			origSupportResize := intctrlutil.SupportResizeSubResource
+			intctrlutil.SupportResizeSubResource = func() (bool, error) { return true, nil }
+			defer func() { intctrlutil.SupportResizeSubResource = origSupportResize }()
+
+			spy := &lifecycleCallSpy{}
+			origNewLifecycleAction := newLifecycleAction
+			newLifecycleAction = func(_ *workloads.InstanceSet, _ *kubebuilderx.ObjectTree, _ *corev1.Pod) (lifecycle.Lifecycle, error) {
+				return spy, nil
+			}
+			defer func() { newLifecycleAction = origNewLifecycleAction }()
+
+			tree := kubebuilderx.NewObjectTree()
+			its.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+			its.Spec.Replicas = ptr.To[int32](1)
+			its.Spec.PodUpdatePolicy = kbappsv1.PreferInPlacePodUpdatePolicyType
+			its.Spec.LifecycleActions = &workloads.LifecycleActions{
+				Switchover: &kbappsv1.Action{
+					Exec: &kbappsv1.ExecAction{Command: []string{"true"}},
+				},
+			}
+			// Live pod: limits=1, requests=1 (K8s defaulted requests to limits)
+			its.Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+			}
+			tree.SetRoot(its)
+			prepareForUpdate(tree)
+
+			pods := tree.List(&corev1.Pod{})
+			Expect(pods).Should(HaveLen(1))
+			pod := pods[0].(*corev1.Pod)
+			pod.Status.Phase = corev1.PodRunning
+			pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
+				Type:               corev1.PodReady,
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: metav1.NewTime(time.Now().Add(-1 * minReadySeconds * time.Second)),
+			})
+			// Simulate K8s defaulting: live pod has requests = old limits
+			pod.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+				Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+			}
+
+			// Scale down: new desired limits=500m, requests omitted
+			its.Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+			}
+
+			reconciler = NewUpdateReconciler()
+			res, err := reconciler.Reconcile(tree)
+			Expect(err).Should(BeNil())
+			Expect(res).Should(Equal(kubebuilderx.Continue))
+
+			postPods := tree.List(&corev1.Pod{})
+			Expect(postPods).Should(HaveLen(1))
+			updatedPod := postPods[0].(*corev1.Pod)
+			Expect(updatedPod.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU]).Should(Equal(resource.MustParse("500m")))
+			req := updatedPod.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+			Expect(req.Cmp(updatedPod.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU])).Should(BeNumerically("<=", 0),
+				"preserved request must not exceed new limit after scale-down; got request=%s limit=%s", req.String(), "500m")
+		})
+
 		It("patches pod without calling switchover for metadata-only in-place updates", func() {
 			// This test exercises the Reconcile call site (not just the
 			// safeMetadataOnlyInPlaceUpdate helper) to assert the contract

--- a/pkg/controller/kubebuilderx/plan_builder.go
+++ b/pkg/controller/kubebuilderx/plan_builder.go
@@ -187,12 +187,18 @@ func buildOrderedVertices(transCtx *transformContext, currentTree *ObjectTree, d
 					transCtx.logger.Error(err, "can't get GVKName from object", "object", newObj.GetName())
 					return
 				}
-				var v *model.ObjectVertex
-				subResource := desiredTree.childrenOptions[*name].SubResource
+				var (
+					v           *model.ObjectVertex
+					subResource = desiredTree.childrenOptions[*name].SubResource
+					action      = model.ActionUpdatePtr()
+				)
+				if desiredTree.childrenOptions[*name].Patch {
+					action = model.ActionPatchPtr()
+				}
 				if subResource != "" {
-					v = model.NewObjectVertex(oldObj, newObj, model.ActionUpdatePtr(), inDataContext4G(), model.WithSubResource(subResource))
+					v = model.NewObjectVertex(oldObj, newObj, action, inDataContext4G(), model.WithSubResource(subResource))
 				} else {
-					v = model.NewObjectVertex(oldObj, newObj, model.ActionUpdatePtr(), inDataContext4G())
+					v = model.NewObjectVertex(oldObj, newObj, action, inDataContext4G())
 				}
 				findAndAppend(v)
 			}

--- a/pkg/controller/kubebuilderx/plan_builder_test.go
+++ b/pkg/controller/kubebuilderx/plan_builder_test.go
@@ -98,6 +98,27 @@ var _ = Describe("plan builder test", func() {
 			Expect(planBuilder.defaultWalkFunc(v)).Should(Succeed())
 		})
 
+		It("should patch object", func() {
+			svcOrig := builder.NewServiceBuilder(namespace, name).GetObject()
+			svc := svcOrig.DeepCopy()
+			svc.Labels = map[string]string{"patched": "true"}
+			v := &model.ObjectVertex{
+				OriObj: svcOrig,
+				Obj:    svc,
+				Action: model.ActionPatchPtr(),
+			}
+			k8sMock.EXPECT().
+				Patch(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, obj *corev1.Service, _ client.Patch, _ ...client.PatchOption) error {
+					Expect(obj).ShouldNot(BeNil())
+					Expect(obj.Namespace).Should(Equal(svc.Namespace))
+					Expect(obj.Name).Should(Equal(svc.Name))
+					Expect(obj.Labels).Should(Equal(svc.Labels))
+					return nil
+				}).Times(1)
+			Expect(planBuilder.defaultWalkFunc(v)).Should(Succeed())
+		})
+
 		It("should update pvc object", func() {
 			pvcOrig := builder.NewPVCBuilder(namespace, name).GetObject()
 			pvc := pvcOrig.DeepCopy()
@@ -282,6 +303,30 @@ var _ = Describe("plan builder test", func() {
 					if pod, ok := v.Obj.(*corev1.Pod); ok && pod.Name == "pod" && v.SubResource == subResource {
 						found = true
 						Expect(*v.Action).To(Equal(model.UPDATE))
+					}
+				}
+				Expect(found).To(BeTrue())
+			})
+
+			It("should append a patch vertex when requested by object options", func() {
+				oldPod := builder.NewPodBuilder("ns", "pod").GetObject()
+				newPod := oldPod.DeepCopy()
+				newPod.Labels = map[string]string{"patched": "true"}
+
+				currentTree := NewObjectTree()
+				desiredTree := NewObjectTree()
+				currentTree.SetRoot(builder.NewInstanceSetBuilder("ns", "root").GetObject())
+				desiredTree.SetRoot(currentTree.GetRoot())
+				Expect(currentTree.Add(oldPod)).Should(Succeed())
+				Expect(desiredTree.Update(newPod, WithPatch(true))).Should(Succeed())
+
+				vertices := buildOrderedVertices(transCtx, currentTree, desiredTree)
+
+				found := false
+				for _, v := range vertices {
+					if pod, ok := v.Obj.(*corev1.Pod); ok && pod.Name == "pod" {
+						found = true
+						Expect(*v.Action).To(Equal(model.PATCH))
 					}
 				}
 				Expect(found).To(BeTrue())

--- a/pkg/controller/kubebuilderx/reconciler.go
+++ b/pkg/controller/kubebuilderx/reconciler.go
@@ -41,6 +41,9 @@ type ObjectOptions struct {
 	// if not empty, action should be done on the specified subresource
 	SubResource string
 
+	// if true, the object should be patched instead of fully updated.
+	Patch bool
+
 	// if true, the object should not be reconciled
 	SkipToReconcile bool
 }
@@ -49,6 +52,12 @@ type WithSubResource string
 
 func (w WithSubResource) ApplyToObject(opts *ObjectOptions) {
 	opts.SubResource = string(w)
+}
+
+type WithPatch bool
+
+func (w WithPatch) ApplyToObject(opts *ObjectOptions) {
+	opts.Patch = bool(w)
 }
 
 type SkipToReconcile bool


### PR DESCRIPTION
Fixes #10369

## Problem

A reconfigure can finish in the database runtime while the KubeBlocks control-plane state stays stale. The concrete Redis Parameters x replication-twemproxy failure showed Redis already using the new value, but the Pod config-hash annotation stayed old and the OpsRequest remained Running.

The current fix covers three related controller edges in that path:

1. Desired templates may specify CPU or memory `limits` while omitting `requests`.
2. Kubernetes may preserve a live request that was defaulted from an older limit after the resize subresource changes the limit.
3. When the resource side has converged and the remaining diff is only Pod metadata, a full Pod UPDATE can conflict with concurrent kubelet/status writes; the config-hash commit should use PATCH.

There is also a limit-only scale-down edge: if the live request was defaulted from the old higher limit, preserving it unchanged can produce `request > limit` in the resize patch, which Kubernetes rejects.

## Fix

- Compare CPU and memory requests only when the desired template explicitly specifies that request.
- When the desired request is omitted and the limit is scaled down, cap the preserved live request to the new limit before issuing the resize patch.
- Add an explicit ObjectTree patch option and use merge PATCH for metadata-only in-place Pod updates in the InstanceSet and Instance reconcilers.

With this fix, the first reconcile can resize resources, a later reconcile treats the omitted request as converged once the desired limit is live, and the config-hash-only metadata commit uses PATCH instead of a full Pod UPDATE.

## Current code scope

- `pkg/controller/instanceset/in_place_update_util.go`: omitted-request resource comparison and scale-down request cap.
- `pkg/controller/instance/in_place_update_utils.go`: same resource comparison and cap for the Instance API path.
- `pkg/controller/kubebuilderx`: `WithPatch`, PATCH vertex planning, and `client.MergeFrom(oldObj)` PATCH execution.
- `pkg/controller/instanceset/reconciler_update.go`: metadata-only in-place Pod updates use PATCH after resource diffs have converged.
- `pkg/controller/instance/reconciler_update.go`: same metadata-only PATCH path for Instance.
- Focused tests cover two-reconcile resize/config-hash convergence, limit-only scale-down, and PATCH planning/execution.

## Verification

Local current head `bccd65862`:

- `go test ./pkg/controller/instance ./pkg/controller/instanceset ./pkg/controller/kubebuilderx -count=1`
- `git diff --check`

CI:

- Current head `bccd65862`: CI passed, including `push-pre-check (test)` and `make-test`.

Runtime evidence:

- Previous cleaned head `bfc3b224b` failed the Redis Parameters x replication-twemproxy focused gate: Redis runtime config changed to `allkeys-lru`, but Pod config-hash annotation stayed stale and the OpsRequest remained Running. Evidence: `evidence/redis-r12-pr10362-bfc3b224/redis-pr10362-bfc3b224-parameters-twemproxy-20260616T2038/RESULT.md`.
- Current head `bccd65862` passed the Redis Parameters x replication-twemproxy focused gate: PASS 34 / FAIL 0 / SKIP 0.
- Runtime image identity: `kubeblocks:pr-10362-bccd658-stella`, `imagePullPolicy: Never`, live manager pod `kubeblocks-75fcf9cf68-xc95j`, imageID `sha256:7c96c3b8146beee3b52ba15f7242dba63e10b838d523280a583cdec6a40a6e20`, startTime `2026-06-17T09:53:21Z`, restartCount `0`.
- Sideload identity: all 3 vcluster nodes list `docker.io/library/kubeblocks:pr-10362-bccd658-stella` with digest `sha256:5331773fc114a8a7da5738f4af156b60974fc4d9ea6ec69685f7a9cc85638437`.
- Evidence package: `redis-pr10362-bccd65862-parameters-twemproxy-20260617T1735-v2.tgz`, sha256 `591f0d83bdadba67772ec172dfe7affdede169589bb257df9c101ad6bf9675b5`.

## Boundary

Runtime validation is a focused Redis Parameters x replication-twemproxy gate for PR #10362 current head. It is not a full Redis addon release gate.
