### PR TITLE
fix: isolate template render parse state

### DIFF
--- a/pkg/gotemplate/tpl_engine.go
+++ b/pkg/gotemplate/tpl_engine.go
@@ -113,7 +113,11 @@ func (t *TplEngine) GetTplEngine() *template.Template {
 
 func (t *TplEngine) Render(context string) (string, error) {
 	var buf strings.Builder
-	tpl, err := t.tpl.Parse(context)
+	tpl, err := t.tpl.Clone()
+	if err != nil {
+		return "", err
+	}
+	tpl, err = tpl.Parse(context)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/gotemplate/tpl_engine_test.go
+++ b/pkg/gotemplate/tpl_engine_test.go
@@ -83,6 +83,26 @@ my friend name is test2
 			Expect(err).NotTo(HaveOccurred())
 			Expect(context).To(Equal(expectString))
 		})
+
+		It("Should render empty template content as empty", func() {
+			engine := NewTplEngine(&TplValues{}, nil, "for_test", nil, nil)
+
+			rendered, err := engine.Render("member-leave")
+			Expect(err).Should(Succeed())
+			Expect(rendered).Should(Equal("member-leave"))
+
+			rendered, err = engine.Render("")
+			Expect(err).Should(Succeed())
+			Expect(rendered).Should(Equal(""))
+
+			rendered, err = engine.Render("role-probe")
+			Expect(err).Should(Succeed())
+			Expect(rendered).Should(Equal("role-probe"))
+
+			rendered, err = engine.Render("")
+			Expect(err).Should(Succeed())
+			Expect(rendered).Should(Equal(""))
+		})
 	})
 
 	// A call funcB.1 in B module


### PR DESCRIPTION
## Summary
- Fix `TplEngine.Render` so each render parses into a cloned template instead of mutating the shared template instance.
- Add a regression test proving an empty template string stays empty after previous non-empty renders.

## Problem
Issue #10356 reports that an empty ConfigMap template key can render with another key's content. The local regression reproduces the same root behavior: one `TplEngine` renders `member-leave`, then rendering an empty string returns `member-leave` before this fix.

## Fix
`TplEngine.Render` now clones the base template before parsing the current input. This keeps registered funcs, options, and delimiters while isolating parse state between ConfigMap keys and other sequential Render calls.

## Tests
- `go test ./pkg/gotemplate -count=1`
- `go test ./pkg/controller/render -count=1`
- `git diff --check`

## Boundary
Draft until CI and peer review complete. Runtime addon validation is not included in this PR.

Fixes #10356