### PR TITLE
fix: isolate template render parse state

### DIFF
--- a/controllers/apps/component/transformer_component_template.go
+++ b/controllers/apps/component/transformer_component_template.go
@@ -313,12 +313,12 @@ func (t *componentFileTemplateTransformer) renderFileTemplateData(transCtx *comp
 	}
 
 	tpl := template.New(fileTemplate.Name).Option("missingkey=error").Funcs(sprig.TxtFuncMap())
-	for _, key := range slices.Sorted(maps.Keys(data)) {
+	for key, val := range data {
 		ptpl, err := tpl.Clone()
 		if err != nil {
 			return nil, err
 		}
-		ptpl, err = ptpl.Parse(data[key])
+		ptpl, err = ptpl.Parse(val)
 		if err != nil {
 			return nil, err
 		}

--- a/controllers/apps/component/transformer_component_template.go
+++ b/controllers/apps/component/transformer_component_template.go
@@ -313,8 +313,12 @@ func (t *componentFileTemplateTransformer) renderFileTemplateData(transCtx *comp
 	}
 
 	tpl := template.New(fileTemplate.Name).Option("missingkey=error").Funcs(sprig.TxtFuncMap())
-	for key, val := range data {
-		ptpl, err := tpl.Parse(val)
+	for _, key := range slices.Sorted(maps.Keys(data)) {
+		ptpl, err := tpl.Clone()
+		if err != nil {
+			return nil, err
+		}
+		ptpl, err = ptpl.Parse(data[key])
 		if err != nil {
 			return nil, err
 		}

--- a/controllers/apps/component/transformer_component_template_test.go
+++ b/controllers/apps/component/transformer_component_template_test.go
@@ -280,6 +280,22 @@ var _ = Describe("file templates transformer test", func() {
 			})
 		})
 
+		It("keeps empty template file content empty", func() {
+			logConfCM.Data["member_leave.sh"] = "member_leave"
+			logConfCM.Data["role_probe.sh"] = "role_probe"
+			logConfCM.Data["switchover.sh"] = ""
+
+			transformer := &componentFileTemplateTransformer{}
+			Expect(transformer.Transform(transCtx, dag)).Should(BeNil())
+
+			checkTemplateObject("logConf", func(obj *corev1.ConfigMap) {
+				Expect(obj.Labels).Should(HaveKeyWithValue(kubeBlockFileTemplateLabelKey, "true"))
+				Expect(obj.Data).Should(HaveKeyWithValue("member_leave.sh", "member_leave"))
+				Expect(obj.Data).Should(HaveKeyWithValue("role_probe.sh", "role_probe"))
+				Expect(obj.Data).Should(HaveKeyWithValue("switchover.sh", ""))
+			})
+		})
+
 		It("udf reconfigure", func() {
 			transCtx.SynthesizeComponent.FileTemplates[0].ReconfigureRequired = ptr.To(true)
 			transCtx.SynthesizeComponent.FileTemplates[0].ReconfigureAction = &appsv1.Action{

--- a/pkg/gotemplate/tpl_engine.go
+++ b/pkg/gotemplate/tpl_engine.go
@@ -113,7 +113,11 @@ func (t *TplEngine) GetTplEngine() *template.Template {
 
 func (t *TplEngine) Render(context string) (string, error) {
 	var buf strings.Builder
-	tpl, err := t.tpl.Parse(context)
+	tpl, err := t.tpl.Clone()
+	if err != nil {
+		return "", err
+	}
+	tpl, err = tpl.Parse(context)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/gotemplate/tpl_engine_test.go
+++ b/pkg/gotemplate/tpl_engine_test.go
@@ -83,6 +83,26 @@ my friend name is test2
 			Expect(err).NotTo(HaveOccurred())
 			Expect(context).To(Equal(expectString))
 		})
+
+		It("Should render empty template content as empty", func() {
+			engine := NewTplEngine(&TplValues{}, nil, "for_test", nil, nil)
+
+			rendered, err := engine.Render("member-leave")
+			Expect(err).Should(Succeed())
+			Expect(rendered).Should(Equal("member-leave"))
+
+			rendered, err = engine.Render("")
+			Expect(err).Should(Succeed())
+			Expect(rendered).Should(Equal(""))
+
+			rendered, err = engine.Render("role-probe")
+			Expect(err).Should(Succeed())
+			Expect(rendered).Should(Equal("role-probe"))
+
+			rendered, err = engine.Render("")
+			Expect(err).Should(Succeed())
+			Expect(rendered).Should(Equal(""))
+		})
 	})
 
 	// A call funcB.1 in B module


### PR DESCRIPTION
## Summary
- Fix `TplEngine.Render` so each render parses into a cloned template instead of mutating the shared template instance.
- Fix ComponentDefinition file-template rendering so each ConfigMap key is parsed and executed with isolated template state.
- Add regressions proving empty template strings stay empty after previous non-empty renders in both paths.

## Problem
Issue #10356 reports that an empty ConfigMap template key can render with another key's content. The reported ConfigMap is marked `apps.kubeblocks.io/file-template=true`, so the affected controller path includes `controllers/apps/component/transformer_component_template.go` in addition to the generic render helper.

## Root Cause
Go `text/template` treats a template definition whose body contains only whitespace/comments as empty, and it does not replace an existing template body. The old implementations parsed sequential ConfigMap key bodies into reused template instances. After rendering one non-empty key, parsing an empty key did not clear the previous parse tree, so executing the reused template could return the previous key's content. Because ConfigMap data is a Go map, the previous non-empty key can vary between runs or clusters.

## Fix
`TplEngine.Render` now clones the base template before parsing the current input. `renderFileTemplateData` now also clones the file-template base template per ConfigMap key and renders the ConfigMap data directly. This keeps registered funcs, options, and delimiters while isolating parse state between ConfigMap keys and other sequential render calls.

## Tests
- `KUBEBUILDER_ASSETS="/Users/wei/Library/Application Support/io.kubebuilder.envtest/k8s/1.26.1-darwin-arm64" go test ./controllers/apps/component -run TestAPIs -count=1 -timeout=600s`
- `go test ./pkg/gotemplate -count=1`
- `go test ./pkg/controller/render -count=1`
- `git diff --check`

## Boundary
Draft until CI completes. Runtime addon validation is not included in this PR.

Fixes #10356