### PR TITLE
fix: require serviceVersion and compDef for user-defined rollouts

### DIFF
--- a/controllers/apps/rollout/rollout_controller_test.go
+++ b/controllers/apps/rollout/rollout_controller_test.go
@@ -368,6 +368,9 @@ var _ = Describe("rollout controller", func() {
 		if processor != nil {
 			processor(f)
 		}
+		if f.Get().Spec.Components[0].ServiceVersion != nil && f.Get().Spec.Components[0].CompDef == nil {
+			f.SetCompCompDef(compDefName)
+		}
 		rolloutObj = f.Create(&testCtx).GetObject()
 		rolloutKey = client.ObjectKeyFromObject(rolloutObj)
 	}
@@ -380,6 +383,9 @@ var _ = Describe("rollout controller", func() {
 			AddSharding(shardingName)
 		if processor != nil {
 			processor(f)
+		}
+		if f.Get().Spec.Shardings[0].ServiceVersion != nil && f.Get().Spec.Shardings[0].CompDef == nil {
+			f.SetShardingCompDef(compDefName)
 		}
 		rolloutObj = f.Create(&testCtx).GetObject()
 		rolloutKey = client.ObjectKeyFromObject(rolloutObj)

--- a/controllers/apps/rollout/transformer_rollout_setup.go
+++ b/controllers/apps/rollout/transformer_rollout_setup.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"reflect"
 
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
@@ -47,7 +48,7 @@ func (t *rolloutSetupTransformer) Transform(ctx graph.TransformContext, dag *gra
 	)
 
 	// pre-check
-	if err := t.precheck(rollout); err != nil {
+	if err := t.precheck(transCtx.Cluster, rollout); err != nil {
 		return err
 	}
 
@@ -60,16 +61,19 @@ func (t *rolloutSetupTransformer) Transform(ctx graph.TransformContext, dag *gra
 	return t.initRolloutStatus(transCtx, dag, rollout)
 }
 
-func (t *rolloutSetupTransformer) precheck(rollout *appsv1alpha1.Rollout) error {
-	if err := t.compPrecheck(rollout); err != nil {
+func (t *rolloutSetupTransformer) precheck(cluster *appsv1.Cluster, rollout *appsv1alpha1.Rollout) error {
+	if err := t.compPrecheck(cluster, rollout); err != nil {
 		return err
 	}
-	return t.shardingPrecheck(rollout)
+	return t.shardingPrecheck(cluster, rollout)
 }
 
-func (t *rolloutSetupTransformer) compPrecheck(rollout *appsv1alpha1.Rollout) error {
+func (t *rolloutSetupTransformer) compPrecheck(cluster *appsv1.Cluster, rollout *appsv1alpha1.Rollout) error {
 	for _, comp := range rollout.Spec.Components {
 		// target serviceVersion & componentDef
+		if withClusterUserDefined(cluster) && (comp.ServiceVersion == nil || comp.CompDef == nil) {
+			return fmt.Errorf("serviceVersion and compDef must be defined for component %s when rolling out a user-defined cluster", comp.Name)
+		}
 		if comp.ServiceVersion == nil && comp.CompDef == nil {
 			return fmt.Errorf("neither serviceVersion nor compDef is defined for component %s", comp.Name)
 		}
@@ -80,9 +84,12 @@ func (t *rolloutSetupTransformer) compPrecheck(rollout *appsv1alpha1.Rollout) er
 	return nil
 }
 
-func (t *rolloutSetupTransformer) shardingPrecheck(rollout *appsv1alpha1.Rollout) error {
+func (t *rolloutSetupTransformer) shardingPrecheck(cluster *appsv1.Cluster, rollout *appsv1alpha1.Rollout) error {
 	for _, sharding := range rollout.Spec.Shardings {
 		// target shardingDef & serviceVersion & componentDef
+		if withClusterUserDefined(cluster) && (sharding.ServiceVersion == nil || sharding.CompDef == nil) {
+			return fmt.Errorf("serviceVersion and compDef must be defined for sharding %s when rolling out a user-defined cluster", sharding.Name)
+		}
 		if sharding.ShardingDef == nil && sharding.ServiceVersion == nil && sharding.CompDef == nil {
 			return fmt.Errorf("neither shardingDef, serviceVersion nor compDef is defined for sharding %s", sharding.Name)
 		}
@@ -91,6 +98,35 @@ func (t *rolloutSetupTransformer) shardingPrecheck(rollout *appsv1alpha1.Rollout
 		}
 	}
 	return nil
+}
+
+func withClusterUserDefined(cluster *appsv1.Cluster) bool {
+	if cluster == nil || len(cluster.Spec.ClusterDef) > 0 || len(cluster.Spec.Topology) > 0 {
+		return false
+	}
+	hasDefSet := func(comp appsv1.ClusterComponentSpec, sharding appsv1.ClusterSharding) bool {
+		return len(comp.ComponentDef) > 0 || len(sharding.ShardingDef) > 0
+	}
+	return clusterCompCnt(cluster) == clusterCompCntWithFunc(cluster, hasDefSet)
+}
+
+func clusterCompCnt(cluster *appsv1.Cluster) int {
+	return clusterCompCntWithFunc(cluster, func(appsv1.ClusterComponentSpec, appsv1.ClusterSharding) bool { return true })
+}
+
+func clusterCompCntWithFunc(cluster *appsv1.Cluster, match func(comp appsv1.ClusterComponentSpec, sharding appsv1.ClusterSharding) bool) int {
+	cnt := 0
+	for _, spec := range cluster.Spec.ComponentSpecs {
+		if match(spec, appsv1.ClusterSharding{}) {
+			cnt++
+		}
+	}
+	for _, sharding := range cluster.Spec.Shardings {
+		if match(sharding.Template, sharding) {
+			cnt += int(sharding.Shards)
+		}
+	}
+	return cnt
 }
 
 func (t *rolloutSetupTransformer) checkRolloutStrategy(kind, name string, strategy appsv1alpha1.RolloutStrategy) error {

--- a/controllers/apps/rollout/transformer_rollout_setup_test.go
+++ b/controllers/apps/rollout/transformer_rollout_setup_test.go
@@ -1,0 +1,218 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package rollout
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/utils/ptr"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
+)
+
+func userDefinedComponentCluster() *appsv1.Cluster {
+	return &appsv1.Cluster{
+		Spec: appsv1.ClusterSpec{
+			ComponentSpecs: []appsv1.ClusterComponentSpec{
+				{
+					Name:         "mysql",
+					ComponentDef: "mysql-8.0-1.0.5",
+				},
+			},
+		},
+	}
+}
+
+func userDefinedShardingCluster() *appsv1.Cluster {
+	return &appsv1.Cluster{
+		Spec: appsv1.ClusterSpec{
+			Shardings: []appsv1.ClusterSharding{
+				{
+					Name:        "mysql",
+					ShardingDef: "mysql-sharding",
+					Shards:      1,
+					Template: appsv1.ClusterComponentSpec{
+						ComponentDef: "mysql-8.0-1.0.5",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestRolloutSetupPrecheckRejectsServiceVersionOnlyForUserDefinedComponent(t *testing.T) {
+	cluster := userDefinedComponentCluster()
+	rollout := &appsv1alpha1.Rollout{
+		Spec: appsv1alpha1.RolloutSpec{
+			Components: []appsv1alpha1.RolloutComponent{
+				{
+					Name:           "mysql",
+					ServiceVersion: ptr.To("8.0.37"),
+					Strategy: appsv1alpha1.RolloutStrategy{
+						Replace: &appsv1alpha1.RolloutStrategyReplace{},
+					},
+				},
+			},
+		},
+	}
+
+	err := (&rolloutSetupTransformer{}).precheck(cluster, rollout)
+	if err == nil || !strings.Contains(err.Error(), "serviceVersion and compDef must be defined for component mysql") {
+		t.Fatalf("expected serviceVersion-only validation error, got %v", err)
+	}
+}
+
+func TestRolloutSetupPrecheckRejectsCompDefOnlyForUserDefinedComponent(t *testing.T) {
+	cluster := userDefinedComponentCluster()
+	rollout := &appsv1alpha1.Rollout{
+		Spec: appsv1alpha1.RolloutSpec{
+			Components: []appsv1alpha1.RolloutComponent{
+				{
+					Name:    "mysql",
+					CompDef: ptr.To("mysql-8.0-1.0.5"),
+					Strategy: appsv1alpha1.RolloutStrategy{
+						Replace: &appsv1alpha1.RolloutStrategyReplace{},
+					},
+				},
+			},
+		},
+	}
+
+	err := (&rolloutSetupTransformer{}).precheck(cluster, rollout)
+	if err == nil || !strings.Contains(err.Error(), "serviceVersion and compDef must be defined for component mysql") {
+		t.Fatalf("expected compDef-only validation error, got %v", err)
+	}
+}
+
+func TestRolloutSetupPrecheckAllowsServiceVersionWithCompDefForUserDefinedComponent(t *testing.T) {
+	cluster := userDefinedComponentCluster()
+	rollout := &appsv1alpha1.Rollout{
+		Spec: appsv1alpha1.RolloutSpec{
+			Components: []appsv1alpha1.RolloutComponent{
+				{
+					Name:           "mysql",
+					ServiceVersion: ptr.To("8.0.37"),
+					CompDef:        ptr.To("mysql-8.0-1.0.5"),
+					Strategy: appsv1alpha1.RolloutStrategy{
+						Replace: &appsv1alpha1.RolloutStrategyReplace{},
+					},
+				},
+			},
+		},
+	}
+
+	if err := (&rolloutSetupTransformer{}).precheck(cluster, rollout); err != nil {
+		t.Fatalf("expected precheck to allow explicit serviceVersion and compDef, got %v", err)
+	}
+}
+
+func TestRolloutSetupPrecheckAllowsServiceVersionOnlyForTopologyComponent(t *testing.T) {
+	cluster := &appsv1.Cluster{
+		Spec: appsv1.ClusterSpec{
+			ClusterDef: "mysql",
+			Topology:   "semisync",
+		},
+	}
+	rollout := &appsv1alpha1.Rollout{
+		Spec: appsv1alpha1.RolloutSpec{
+			Components: []appsv1alpha1.RolloutComponent{
+				{
+					Name:           "mysql",
+					ServiceVersion: ptr.To("8.0.37"),
+					Strategy: appsv1alpha1.RolloutStrategy{
+						Replace: &appsv1alpha1.RolloutStrategyReplace{},
+					},
+				},
+			},
+		},
+	}
+
+	if err := (&rolloutSetupTransformer{}).precheck(cluster, rollout); err != nil {
+		t.Fatalf("expected topology-based cluster to allow serviceVersion-only rollout, got %v", err)
+	}
+}
+
+func TestRolloutSetupPrecheckRejectsServiceVersionOnlyForUserDefinedSharding(t *testing.T) {
+	cluster := userDefinedShardingCluster()
+	rollout := &appsv1alpha1.Rollout{
+		Spec: appsv1alpha1.RolloutSpec{
+			Shardings: []appsv1alpha1.RolloutSharding{
+				{
+					Name:           "mysql",
+					ServiceVersion: ptr.To("8.0.37"),
+					Strategy: appsv1alpha1.RolloutStrategy{
+						Replace: &appsv1alpha1.RolloutStrategyReplace{},
+					},
+				},
+			},
+		},
+	}
+
+	err := (&rolloutSetupTransformer{}).precheck(cluster, rollout)
+	if err == nil || !strings.Contains(err.Error(), "serviceVersion and compDef must be defined for sharding mysql") {
+		t.Fatalf("expected serviceVersion-only validation error, got %v", err)
+	}
+}
+
+func TestRolloutSetupPrecheckRejectsCompDefOnlyForUserDefinedSharding(t *testing.T) {
+	cluster := userDefinedShardingCluster()
+	rollout := &appsv1alpha1.Rollout{
+		Spec: appsv1alpha1.RolloutSpec{
+			Shardings: []appsv1alpha1.RolloutSharding{
+				{
+					Name:    "mysql",
+					CompDef: ptr.To("mysql-8.0-1.0.5"),
+					Strategy: appsv1alpha1.RolloutStrategy{
+						Replace: &appsv1alpha1.RolloutStrategyReplace{},
+					},
+				},
+			},
+		},
+	}
+
+	err := (&rolloutSetupTransformer{}).precheck(cluster, rollout)
+	if err == nil || !strings.Contains(err.Error(), "serviceVersion and compDef must be defined for sharding mysql") {
+		t.Fatalf("expected compDef-only validation error, got %v", err)
+	}
+}
+
+func TestRolloutSetupPrecheckAllowsServiceVersionWithCompDefForUserDefinedSharding(t *testing.T) {
+	cluster := userDefinedShardingCluster()
+	rollout := &appsv1alpha1.Rollout{
+		Spec: appsv1alpha1.RolloutSpec{
+			Shardings: []appsv1alpha1.RolloutSharding{
+				{
+					Name:           "mysql",
+					ServiceVersion: ptr.To("8.0.37"),
+					CompDef:        ptr.To("mysql-8.0-1.0.5"),
+					Strategy: appsv1alpha1.RolloutStrategy{
+						Replace: &appsv1alpha1.RolloutStrategyReplace{},
+					},
+				},
+			},
+		},
+	}
+
+	if err := (&rolloutSetupTransformer{}).precheck(cluster, rollout); err != nil {
+		t.Fatalf("expected precheck to allow explicit serviceVersion and compDef, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- align rollout user-defined Cluster detection with the apps Cluster validation semantics
- require both serviceVersion and compDef for component and sharding rollouts on user-defined Clusters
- keep topology-based Cluster rollouts compatible with serviceVersion-only requests

## Root cause
User-defined Clusters do not have a topology or ClusterDefinition constraint to bound ComponentDefinition resolution. A rollout that omits either serviceVersion or compDef leaves the target ambiguous for this usage pattern, so the setup precheck now requires both fields explicitly.

## Validation
- go test -mod=mod ./controllers/apps/rollout -run TestRolloutSetupPrecheck -count=1
- go test -mod=mod ./controllers/apps/rollout -count=1