### PR TITLE
chore: improve pkg parameters coverage

### DIFF
--- a/pkg/parameters/config_metadata_test.go
+++ b/pkg/parameters/config_metadata_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package parameters
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
+)
+
+var _ = Describe("parameter metadata helpers", func() {
+	It("finds config descriptions by name and template", func() {
+		configs := []parametersv1alpha1.ComponentConfigDescription{
+			{Name: "mysql.cnf", TemplateName: "mysql-template"},
+			{Name: "proxy.cnf", TemplateName: "proxy-template"},
+			{Name: "mysql-extra.cnf", TemplateName: "mysql-template"},
+		}
+
+		Expect(GetComponentConfigDescription(configs, "mysql.cnf")).To(Equal(&configs[0]))
+		Expect(GetComponentConfigDescription(configs, "missing.cnf")).To(BeNil())
+		Expect(GetComponentConfigDescriptions(configs, "mysql-template")).To(Equal([]parametersv1alpha1.ComponentConfigDescription{
+			configs[0],
+			configs[2],
+		}))
+		Expect(GetComponentConfigDescriptions(configs, "missing-template")).To(BeEmpty())
+		Expect(HasValidParameterTemplate(configs)).To(BeTrue())
+		Expect(HasValidParameterTemplate(nil)).To(BeFalse())
+	})
+})

--- a/pkg/parameters/core/config_util_test.go
+++ b/pkg/parameters/core/config_util_test.go
@@ -19,6 +19,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 package core
 
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+
+	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
+)
+
 // import (
 // 	"reflect"
 // 	"strings"
@@ -186,6 +198,105 @@ package core
 // 		})
 // 	}
 // }
+
+func TestMergeUpdatedConfig(t *testing.T) {
+	base := map[string]string{
+		"mysql.cnf": "[mysqld]",
+		"proxy.cnf": "port=3306",
+	}
+	updated := map[string]string{
+		"mysql.cnf": "[mysqld]\nmax_connections=200",
+		"extra.cnf": "ignored=true",
+	}
+
+	got := MergeUpdatedConfig(base, updated)
+	require.Equal(t, map[string]string{
+		"mysql.cnf": "[mysqld]\nmax_connections=200",
+		"proxy.cnf": "port=3306",
+	}, got)
+}
+
+func TestFromStringMap(t *testing.T) {
+	port := "3306"
+	hosts := `["mysql-0","mysql-1"]`
+	params := map[string]*string{
+		"port":   &port,
+		"unset":  nil,
+		"@hosts": &hosts,
+	}
+
+	got, err := FromStringMap(params, ValueTransformerFunc(func(value string, fieldName string) (any, error) {
+		if fieldName == "port" {
+			return "tcp:" + value, nil
+		}
+		return value, nil
+	}))
+	require.NoError(t, err)
+	require.Equal(t, "tcp:3306", got["port"])
+	require.Nil(t, got["unset"])
+	require.Equal(t, []interface{}{"mysql-0", "mysql-1"}, got["hosts"])
+
+	_, err = FromStringMap(map[string]*string{"port": &port}, ValueTransformerFunc(func(string, string) (any, error) {
+		return nil, errors.New("bad value")
+	}))
+	require.ErrorContains(t, err, "bad value")
+}
+
+func TestApplyConfigPatch(t *testing.T) {
+	base := []byte("[mysqld]\nmax_connections=100\nold_value=keep\n")
+	format := &parametersv1alpha1.FileFormatConfig{
+		Format: parametersv1alpha1.Ini,
+		FormatterAction: parametersv1alpha1.FormatterAction{
+			IniConfig: &parametersv1alpha1.IniConfig{SectionName: "mysqld"},
+		},
+	}
+
+	got, err := ApplyConfigPatch(base, map[string]*string{
+		"max_connections": ptr.To("200"),
+		"old_value":       nil,
+	}, format, nil)
+	require.NoError(t, err)
+	require.Contains(t, got, "[mysqld]")
+	require.Contains(t, got, "max_connections=200")
+
+	_, err = ApplyConfigPatch([]byte(":"), map[string]*string{"max_connections": ptr.To("200")}, format, nil)
+	require.Error(t, err)
+}
+
+func TestIsWatchModuleForShellTrigger(t *testing.T) {
+	sync := true
+	async := false
+
+	tests := []struct {
+		name    string
+		trigger *parametersv1alpha1.ShellTrigger
+		want    bool
+	}{
+		{name: "nil trigger", want: true},
+		{name: "nil sync", trigger: &parametersv1alpha1.ShellTrigger{}, want: true},
+		{name: "sync trigger", trigger: &parametersv1alpha1.ShellTrigger{Sync: &sync}, want: false},
+		{name: "async trigger", trigger: &parametersv1alpha1.ShellTrigger{Sync: &async}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, IsWatchModuleForShellTrigger(tt.trigger))
+		})
+	}
+}
+
+func TestArrayFieldHelpers(t *testing.T) {
+	require.True(t, hasArrayField("@hosts"))
+	require.False(t, hasArrayField("hosts"))
+	require.Equal(t, "@hosts", transArrayFieldName("hosts"))
+	require.Equal(t, "hosts", GetValidFieldName("@hosts"))
+	require.Equal(t, "hosts", GetValidFieldName("hosts"))
+	require.Equal(t, "", transJSONString(nil))
+	require.Equal(t, []any{}, fromJSONString(ptr.To("")))
+	require.True(t, reflect.DeepEqual([]any{"a"}, fromJSONString(ptr.To(`["a"]`))))
+	require.True(t, strings.HasPrefix(transJSONString([]string{"a"}), "["))
+}
+
 //
 // func TestApplyConfigPatch(t *testing.T) {
 // 	type args struct {

--- a/pkg/parameters/core/reconfigure_util_test.go
+++ b/pkg/parameters/core/reconfigure_util_test.go
@@ -244,3 +244,165 @@ func TestHasDynamicParameterUpdate(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateConfigPatch(t *testing.T) {
+	configs := []parametersv1alpha1.ComponentConfigDescription{{
+		Name: "mysql.cnf",
+		FileFormatConfig: &parametersv1alpha1.FileFormatConfig{
+			Format: parametersv1alpha1.Ini,
+			FormatterAction: parametersv1alpha1.FormatterAction{
+				IniConfig: &parametersv1alpha1.IniConfig{SectionName: "mysqld"},
+			},
+		},
+	}}
+
+	require.NoError(t, ValidateConfigPatch(&ConfigPatchInfo{}, configs))
+	require.NoError(t, ValidateConfigPatch(&ConfigPatchInfo{
+		IsModify:     true,
+		UpdateConfig: map[string][]byte{"mysql.cnf": []byte(`{"mysqld":{"max_connections":"200"}}`)},
+	}, configs))
+
+	err := ValidateConfigPatch(&ConfigPatchInfo{
+		IsModify:     true,
+		UpdateConfig: map[string][]byte{"mysql.cnf": []byte(`{"mysqld":{"max_connections":null}}`)},
+	}, configs)
+	require.ErrorContains(t, err, "delete config parameter [max_connections] is not support")
+}
+
+func TestIsUpdateDynamicParameters(t *testing.T) {
+	config := &parametersv1alpha1.FileFormatConfig{
+		Format: parametersv1alpha1.Ini,
+		FormatterAction: parametersv1alpha1.FormatterAction{
+			IniConfig: &parametersv1alpha1.IniConfig{SectionName: "mysqld"},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		def     *parametersv1alpha1.ParametersDefinitionSpec
+		patch   *ConfigPatchInfo
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "delete config requires restart",
+			def:  &parametersv1alpha1.ParametersDefinitionSpec{},
+			patch: &ConfigPatchInfo{
+				DeleteConfig: map[string]interface{}{"mysql.cnf": map[string]interface{}{"max_connections": "200"}},
+			},
+			want: false,
+		},
+		{
+			name:  "empty update is dynamic",
+			def:   &parametersv1alpha1.ParametersDefinitionSpec{},
+			patch: &ConfigPatchInfo{},
+			want:  true,
+		},
+		{
+			name: "invalid update patch",
+			def:  &parametersv1alpha1.ParametersDefinitionSpec{},
+			patch: &ConfigPatchInfo{
+				UpdateConfig: map[string][]byte{"mysql.cnf": []byte(`{`)},
+			},
+			wantErr: true,
+		},
+		{
+			name: "dynamic parameter only",
+			def: &parametersv1alpha1.ParametersDefinitionSpec{
+				DynamicParameters: []string{"max_connections"},
+			},
+			patch: &ConfigPatchInfo{
+				UpdateConfig: map[string][]byte{"mysql.cnf": []byte(`{"mysqld":{"max_connections":"200"}}`)},
+			},
+			want: true,
+		},
+		{
+			name: "static parameter is not dynamic",
+			def: &parametersv1alpha1.ParametersDefinitionSpec{
+				StaticParameters: []string{"max_connections"},
+			},
+			patch: &ConfigPatchInfo{
+				UpdateConfig: map[string][]byte{"mysql.cnf": []byte(`{"mysqld":{"max_connections":"200"}}`)},
+			},
+			want: false,
+		},
+		{
+			name: "unknown parameter with dynamic list is not dynamic",
+			def: &parametersv1alpha1.ParametersDefinitionSpec{
+				DynamicParameters: []string{"innodb_buffer_pool_size"},
+			},
+			patch: &ConfigPatchInfo{
+				UpdateConfig: map[string][]byte{"mysql.cnf": []byte(`{"mysqld":{"max_connections":"200"}}`)},
+			},
+			want: false,
+		},
+		{
+			name: "static list without dynamic list defaults to reload for non-static update",
+			def: &parametersv1alpha1.ParametersDefinitionSpec{
+				StaticParameters: []string{"innodb_buffer_pool_size"},
+			},
+			patch: &ConfigPatchInfo{
+				UpdateConfig: map[string][]byte{"mysql.cnf": []byte(`{"mysqld":{"max_connections":"200"}}`)},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := IsUpdateDynamicParameters(config, tt.def, tt.patch)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCheckUpdateDynamicParameters(t *testing.T) {
+	config := &parametersv1alpha1.FileFormatConfig{
+		Format: parametersv1alpha1.Ini,
+		FormatterAction: parametersv1alpha1.FormatterAction{
+			IniConfig: &parametersv1alpha1.IniConfig{SectionName: "mysqld"},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		def     *parametersv1alpha1.ParametersDefinitionSpec
+		patch   string
+		want    bool
+		wantErr bool
+	}{
+		{name: "empty patch", def: &parametersv1alpha1.ParametersDefinitionSpec{}, want: true},
+		{name: "invalid patch", def: &parametersv1alpha1.ParametersDefinitionSpec{}, patch: `{`, wantErr: true},
+		{
+			name: "dynamic parameter",
+			def: &parametersv1alpha1.ParametersDefinitionSpec{
+				DynamicParameters: []string{"max_connections"},
+			},
+			patch: `{"mysqld":{"max_connections":"200"}}`,
+			want:  true,
+		},
+		{
+			name:  "no parameter lists defaults to restart",
+			def:   &parametersv1alpha1.ParametersDefinitionSpec{},
+			patch: `{"mysqld":{"max_connections":"200"}}`,
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CheckUpdateDynamicParameters(config, tt.def, tt.patch)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/parameters/mutation_test.go
+++ b/pkg/parameters/mutation_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package parameters
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
+)
+
+var _ = Describe("component parameter mutation", func() {
+	It("merges labels, owners, additions, deletions, and updated items", func() {
+		expected := &parametersv1alpha1.ComponentParameter{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"expected": "true",
+					"shared":   "expected",
+				},
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "apps.kubeblocks.io/v1",
+					Kind:       "Cluster",
+					Name:       "mysql",
+					UID:        "uid",
+				}},
+			},
+			Spec: parametersv1alpha1.ComponentParameterSpec{
+				ConfigItemDetails: []parametersv1alpha1.ConfigTemplateItemDetail{
+					{Name: "keep"},
+					{Name: "add"},
+				},
+			},
+		}
+		existing := &parametersv1alpha1.ComponentParameter{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"existing": "true",
+					"shared":   "existing",
+				},
+			},
+			Spec: parametersv1alpha1.ComponentParameterSpec{
+				ConfigItemDetails: []parametersv1alpha1.ConfigTemplateItemDetail{
+					{Name: "keep"},
+					{Name: "delete"},
+				},
+			},
+		}
+
+		updated := MergeComponentParameter(expected, existing, func(dest, expected *parametersv1alpha1.ConfigTemplateItemDetail) {
+			dest.Payload = parametersv1alpha1.Payload{
+				"source": []byte(`"mutated"`),
+			}
+		})
+
+		Expect(updated).NotTo(BeIdenticalTo(existing))
+		Expect(updated.Labels).To(Equal(map[string]string{
+			"expected": "true",
+			"existing": "true",
+			"shared":   "expected",
+		}))
+		Expect(updated.OwnerReferences).To(Equal(expected.OwnerReferences))
+		Expect(updated.Spec.ConfigItemDetails).To(HaveLen(2))
+		Expect(updated.Spec.ConfigItemDetails[0].Name).To(Equal("keep"))
+		Expect(updated.Spec.ConfigItemDetails[0].Payload).To(HaveKey("source"))
+		Expect(updated.Spec.ConfigItemDetails[1].Name).To(Equal("add"))
+	})
+
+	It("keeps existing owners when expected owners are empty", func() {
+		existing := &parametersv1alpha1.ComponentParameter{
+			ObjectMeta: metav1.ObjectMeta{
+				OwnerReferences: []metav1.OwnerReference{{Name: "existing-owner"}},
+			},
+		}
+
+		updated := MergeComponentParameter(&parametersv1alpha1.ComponentParameter{}, existing, func(dest, expected *parametersv1alpha1.ConfigTemplateItemDetail) {})
+		Expect(updated.OwnerReferences).To(Equal(existing.OwnerReferences))
+		Expect(updated.Spec.ConfigItemDetails).To(BeEmpty())
+	})
+})

--- a/pkg/parameters/parameter_schema_test.go
+++ b/pkg/parameters/parameter_schema_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package parameters
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
+)
+
+var _ = Describe("parameter schema status helpers", func() {
+	It("detects terminal phases", func() {
+		Expect(ParametersDefinitionTerminalPhases(parametersv1alpha1.ParametersDefinitionStatus{
+			ObservedGeneration: 2,
+			Phase:              parametersv1alpha1.PDAvailablePhase,
+		}, 2)).To(BeTrue())
+		Expect(ParametersDefinitionTerminalPhases(parametersv1alpha1.ParametersDefinitionStatus{
+			ObservedGeneration: 1,
+			Phase:              parametersv1alpha1.PDAvailablePhase,
+		}, 2)).To(BeFalse())
+
+		Expect(IsParameterFinished(parametersv1alpha1.CFinishedPhase)).To(BeTrue())
+		Expect(IsParameterFinished(parametersv1alpha1.CMergeFailedPhase)).To(BeTrue())
+		Expect(IsParameterFinished(parametersv1alpha1.CRunningPhase)).To(BeFalse())
+		Expect(IsFailedPhase(parametersv1alpha1.CFailedAndPausePhase)).To(BeTrue())
+		Expect(IsFailedPhase(parametersv1alpha1.CFinishedPhase)).To(BeFalse())
+	})
+
+	It("finds item status and specs by name", func() {
+		status := &parametersv1alpha1.ComponentParameterStatus{
+			ConfigurationItemStatus: []parametersv1alpha1.ConfigTemplateItemDetailStatus{
+				{Name: "mysql"},
+				{Name: "proxy"},
+			},
+		}
+		spec := &parametersv1alpha1.ComponentParameterSpec{
+			ConfigItemDetails: []parametersv1alpha1.ConfigTemplateItemDetail{
+				{Name: "mysql"},
+				{Name: "proxy"},
+			},
+		}
+
+		Expect(GetItemStatus(status, "proxy")).To(Equal(&status.ConfigurationItemStatus[1]))
+		Expect(GetItemStatus(status, "missing")).To(BeNil())
+		Expect(GetConfigTemplateItem(spec, "mysql")).To(Equal(&spec.ConfigItemDetails[0]))
+		Expect(GetConfigTemplateItem(spec, "missing")).To(BeNil())
+	})
+})

--- a/pkg/parameters/remove_marker_test.go
+++ b/pkg/parameters/remove_marker_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package parameters
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/utils/ptr"
+)
+
+var _ = Describe("parameter overlay markers", func() {
+	It("encodes nil values and decodes markers", func() {
+		Expect(EncodeParameterOverlay(nil)).To(BeNil())
+		Expect(DecodeParameterOverlay(nil)).To(BeNil())
+
+		encoded := EncodeParameterOverlay(map[string]*string{
+			"remove": nil,
+			"keep":   ptr.To("value"),
+		})
+		Expect(encoded["remove"]).NotTo(BeNil())
+		Expect(*encoded["remove"]).To(Equal(parameterRemoveMarker))
+		Expect(encoded["keep"]).To(Equal(ptr.To("value")))
+
+		decoded := DecodeParameterOverlay(encoded)
+		Expect(decoded["remove"]).To(BeNil())
+		Expect(decoded["keep"]).To(Equal(ptr.To("value")))
+	})
+})


### PR DESCRIPTION
## Summary
- add test-only coverage for pkg/parameters metadata, mutation, config utility, and reconfigure utility behavior
- raise pkg/parameters coverage from 72.9% to 82.2%
- no production code changes

## Tests
- KUBEBUILDER_ASSETS=<envtest-assets> GOFLAGS=-mod=mod go test -short ./pkg/parameters/... -coverprofile=<tmp-cover>