### PR TITLE
chore: improve pkg controllerutil coverage

### DIFF
--- a/pkg/controllerutil/container_util_test.go
+++ b/pkg/controllerutil/container_util_test.go
@@ -23,6 +23,10 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
 
 func TestGetContainerByName(t *testing.T) {
@@ -39,5 +43,49 @@ func TestGetContainerByName(t *testing.T) {
 	i, container = GetContainerByName(containers, "test3")
 	if i != -1 || container != nil {
 		t.Error("expected to return 0 and the corresponding index container!")
+	}
+}
+
+func TestInjectZeroResourceLimits(t *testing.T) {
+	container := &corev1.Container{}
+	InjectZeroResourcesLimitsIfEmpty(container)
+	if container.Resources.Limits.Cpu().String() != "0" {
+		t.Fatalf("expected zero cpu limit, got %s", container.Resources.Limits.Cpu().String())
+	}
+	if container.Resources.Limits.Memory().String() != "0" {
+		t.Fatalf("expected zero memory limit, got %s", container.Resources.Limits.Memory().String())
+	}
+
+	container = &corev1.Container{Resources: corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+	}}
+	InjectZeroResourceLimitIfEmpty(container, corev1.ResourceCPU)
+	if _, ok := container.Resources.Limits[corev1.ResourceCPU]; ok {
+		t.Fatalf("expected cpu limit to remain unset when request exists")
+	}
+}
+
+func TestInjectZeroResourceLimitsByFeatureFlags(t *testing.T) {
+	defer func() {
+		viper.Set(constant.CfgKeyDataProtectionZeroResourceForUnset, false)
+		viper.Set(constant.CfgKeyOperationZeroResourceForUnset, false)
+	}()
+
+	container := &corev1.Container{}
+	InjectZeroResourcesLimitsForDataProtection(container)
+	if len(container.Resources.Limits) != 0 {
+		t.Fatalf("expected dataprotection injection to be disabled by default")
+	}
+	viper.Set(constant.CfgKeyDataProtectionZeroResourceForUnset, true)
+	InjectZeroResourcesLimitsForDataProtection(container)
+	if len(container.Resources.Limits) != 2 {
+		t.Fatalf("expected dataprotection injection to set zero cpu and memory")
+	}
+
+	container = &corev1.Container{}
+	viper.Set(constant.CfgKeyOperationZeroResourceForUnset, true)
+	InjectZeroResourcesLimitsForOps(container)
+	if len(container.Resources.Limits) != 2 {
+		t.Fatalf("expected ops injection to set zero cpu and memory")
 	}
 }

--- a/pkg/controllerutil/instance_set_utils_test.go
+++ b/pkg/controllerutil/instance_set_utils_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package controllerutil
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
+)
+
+func TestGetPodListByInstanceSet(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := workloads.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "match", Namespace: "ns", Labels: map[string]string{"app": "mysql"}}},
+		&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "ns", Labels: map[string]string{"app": "pg"}}},
+	).Build()
+	its := &workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "mysql", Namespace: "ns"},
+		Spec: workloads.InstanceSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "mysql"}},
+		},
+	}
+
+	pods, err := GetPodListByInstanceSet(context.Background(), cli, its)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pods) != 1 || pods[0].Name != "match" {
+		t.Fatalf("expected only matching pod, got %#v", pods)
+	}
+}
+
+func TestWorkloadFQDNAndRuntimeMetrics(t *testing.T) {
+	defer func() {
+		viper.Set(constant.KubernetesClusterDomainEnv, "")
+		viper.Set(FeatureGateEnableRuntimeMetrics, false)
+	}()
+
+	viper.Set(constant.KubernetesClusterDomainEnv, "cluster.local")
+	if got := PodFQDN("default", "mysql", "mysql-0"); got != "mysql-0.mysql-headless.default.svc.cluster.local" {
+		t.Fatalf("unexpected pod fqdn %q", got)
+	}
+	if got := ServiceFQDN("default", "mysql"); got != "mysql.default.svc.cluster.local" {
+		t.Fatalf("unexpected service fqdn %q", got)
+	}
+
+	viper.Set(FeatureGateEnableRuntimeMetrics, true)
+	if !EnabledRuntimeMetrics() {
+		t.Fatalf("expected runtime metrics to be enabled")
+	}
+}

--- a/pkg/controllerutil/instance_utils_test.go
+++ b/pkg/controllerutil/instance_utils_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package controllerutil
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+)
+
+func TestInstanceStatusHelpers(t *testing.T) {
+	inst := &workloads.Instance{
+		ObjectMeta: metav1.ObjectMeta{
+			Generation: 3,
+		},
+		Spec: workloads.InstanceSpec{
+			Roles: []workloads.ReplicaRole{{Name: "leader"}},
+		},
+		Status: workloads.InstanceStatus2{
+			ObservedGeneration: 3,
+			UpToDate:           true,
+			Role:               "leader",
+			Conditions: []metav1.Condition{
+				{Type: string(workloads.InstanceReady), Status: metav1.ConditionTrue},
+				{Type: string(workloads.InstanceAvailable), Status: metav1.ConditionTrue},
+				{Type: string(workloads.InstanceFailure), Status: metav1.ConditionFalse},
+			},
+		},
+	}
+
+	if !IsInstanceReady(inst) {
+		t.Fatalf("expected instance to be ready")
+	}
+	if !IsInstanceReadyWithRole(inst) {
+		t.Fatalf("expected instance to be ready with observed role")
+	}
+	if !IsInstanceAvailable(inst) {
+		t.Fatalf("expected instance to be available")
+	}
+	if IsInstanceFailure(inst) {
+		t.Fatalf("expected instance not to be failed")
+	}
+
+	inst.Status.Role = ""
+	if IsInstanceReadyWithRole(inst) {
+		t.Fatalf("role-aware readiness should require observed role when roles are configured")
+	}
+	inst.Spec.Roles = nil
+	if !IsInstanceReadyWithRole(inst) {
+		t.Fatalf("role-aware readiness should not require role when roles are not configured")
+	}
+
+	inst.Status.ObservedGeneration = 2
+	if IsInstanceReady(inst) || IsInstanceAvailable(inst) {
+		t.Fatalf("stale status should not be ready or available")
+	}
+}
+
+func TestInstanceTerminatingAndConditionLookup(t *testing.T) {
+	now := metav1.NewTime(time.Now())
+	inst := &workloads.Instance{
+		ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &now},
+		Status: workloads.InstanceStatus2{
+			Conditions: []metav1.Condition{{Type: string(workloads.InstanceFailure), Status: metav1.ConditionTrue}},
+		},
+	}
+
+	if !IsInstanceTerminating(inst) {
+		t.Fatalf("expected terminating instance")
+	}
+	if IsInstanceFailure(inst) {
+		t.Fatalf("terminating instance should not be considered failed")
+	}
+	idx, condition := getInstanceCondition(inst, workloads.InstanceFailure)
+	if idx != 0 || condition == nil || condition.Type != string(workloads.InstanceFailure) {
+		t.Fatalf("expected failure condition at index 0, got %d %#v", idx, condition)
+	}
+	idx, condition = getInstanceConditionFromList(nil, string(workloads.InstanceReady))
+	if idx != -1 || condition != nil {
+		t.Fatalf("expected nil condition list to return no match")
+	}
+}

--- a/pkg/controllerutil/pod_utils_test.go
+++ b/pkg/controllerutil/pod_utils_test.go
@@ -100,6 +100,147 @@ func TestGetPodRevision(t *testing.T) {
 	}
 }
 
+func TestPodUtilitySmallHelpers(t *testing.T) {
+	pod := corev1.Pod{
+		Spec: corev1.PodSpec{
+			Hostname:  "mysql-0",
+			Subdomain: "mysql-headless",
+			Containers: []corev1.Container{{
+				Name:  "mysql",
+				Ports: []corev1.ContainerPort{{Name: "mysql", ContainerPort: 3306}},
+			}},
+		},
+		Status: corev1.PodStatus{PodIP: "10.0.0.1"},
+	}
+	if got := BuildPodHostDNS(&pod); got != "mysql-0.mysql-headless" {
+		t.Fatalf("expected host dns, got %q", got)
+	}
+	pod.Spec.Subdomain = ""
+	if got := BuildPodHostDNS(&pod); got != "10.0.0.1" {
+		t.Fatalf("expected pod ip dns fallback, got %q", got)
+	}
+	if got := BuildPodHostDNS(nil); got != "" {
+		t.Fatalf("expected empty dns for nil pod, got %q", got)
+	}
+
+	port, err := GetPortByName(pod, "mysql", "mysql")
+	if err != nil || port != 3306 {
+		t.Fatalf("expected mysql port 3306, got %d %v", port, err)
+	}
+	if _, err = GetPortByName(pod, "mysql", "missing"); err == nil {
+		t.Fatalf("expected missing port error")
+	}
+	if vm := GetVolumeMountByVolume(&corev1.Container{VolumeMounts: []corev1.VolumeMount{{Name: "config"}}}, "config"); vm == nil || vm.Name != "config" {
+		t.Fatalf("expected config volume mount")
+	}
+	if vm := GetVolumeMountByVolume(&corev1.Container{}, "missing"); vm != nil {
+		t.Fatalf("expected nil volume mount")
+	}
+
+	if container := GetPodContainer(&pod, ""); container == nil || container.Name != "mysql" {
+		t.Fatalf("expected first container")
+	}
+	if container := GetPodContainer(&pod, "missing"); container != nil {
+		t.Fatalf("expected nil for missing container")
+	}
+}
+
+func TestPodFailureAndDefaultResolution(t *testing.T) {
+	oldMode := int32(0644)
+	newSpec := corev1.PodSpec{
+		Volumes: []corev1.Volume{{
+			Name: "config",
+			VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{
+				DefaultMode: &oldMode,
+			}},
+		}},
+		Containers: []corev1.Container{{
+			Name:                     "mysql",
+			ImagePullPolicy:          corev1.PullIfNotPresent,
+			TerminationMessagePath:   "/dev/termination-log",
+			TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+			LivenessProbe: &corev1.Probe{
+				TimeoutSeconds:   3,
+				PeriodSeconds:    4,
+				SuccessThreshold: 1,
+				FailureThreshold: 5,
+				ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{
+					Scheme: corev1.URISchemeHTTP,
+				}},
+			},
+		}},
+		RestartPolicy:                 corev1.RestartPolicyAlways,
+		DNSPolicy:                     corev1.DNSClusterFirst,
+		TerminationGracePeriodSeconds: ptrInt64(30),
+	}
+	proto := corev1.PodSpec{
+		Volumes: []corev1.Volume{{
+			Name:         "config",
+			VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{}},
+		}},
+		Containers: []corev1.Container{{
+			Name:          "mysql",
+			LivenessProbe: &corev1.Probe{ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{}}},
+		}},
+	}
+
+	ResolvePodSpecDefaultFields(newSpec, &proto)
+	if proto.RestartPolicy != corev1.RestartPolicyAlways ||
+		proto.DNSPolicy != corev1.DNSClusterFirst ||
+		*proto.TerminationGracePeriodSeconds != 30 ||
+		*proto.Volumes[0].ConfigMap.DefaultMode != oldMode {
+		t.Fatalf("expected pod defaults to be copied")
+	}
+	if proto.Containers[0].ImagePullPolicy != corev1.PullIfNotPresent ||
+		proto.Containers[0].LivenessProbe.TimeoutSeconds != 3 ||
+		proto.Containers[0].LivenessProbe.HTTPGet.Scheme != corev1.URISchemeHTTP {
+		t.Fatalf("expected container defaults to be copied")
+	}
+
+	pod := &corev1.Pod{Status: corev1.PodStatus{
+		InitContainerStatuses: []corev1.ContainerStatus{{
+			Name: "init",
+			State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+				Message: "init failed",
+			}},
+		}},
+		Conditions: []corev1.PodCondition{{
+			Type:               corev1.PodInitialized,
+			LastTransitionTime: metav1.NewTime(time.Now().Add(-PodContainerFailedTimeout - time.Second)),
+		}},
+	}}
+	failed, timedOut, message := IsPodFailedAndTimedOut(pod)
+	if !failed || !timedOut || message != "init failed" {
+		t.Fatalf("expected timed out init failure, got failed=%v timedOut=%v message=%q", failed, timedOut, message)
+	}
+}
+
+func TestBuildImagePullSecrets(t *testing.T) {
+	defer viper.Set(constant.KBImagePullSecrets, "")
+	viper.Set(constant.KBImagePullSecrets, `[{"name":"regcred"}]`)
+	secrets := BuildImagePullSecrets()
+	if len(secrets) != 1 || secrets[0].Name != "regcred" {
+		t.Fatalf("expected regcred image pull secret, got %#v", secrets)
+	}
+}
+
+func TestIsMatchConfigVersion(t *testing.T) {
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"config-hash": "v1"}}}
+	if !IsMatchConfigVersion(pod, "config-hash", "v1") {
+		t.Fatalf("expected matching config version")
+	}
+	if IsMatchConfigVersion(pod, "config-hash", "v2") {
+		t.Fatalf("expected mismatched config version")
+	}
+	if IsMatchConfigVersion(&corev1.Pod{}, "config-hash", "v1") {
+		t.Fatalf("expected missing labels not to match")
+	}
+}
+
+func ptrInt64(v int64) *int64 {
+	return &v
+}
+
 var _ = Describe("pod utils", func() {
 	var (
 		statefulSet     *appsv1.StatefulSet

--- a/pkg/controllerutil/predicate_test.go
+++ b/pkg/controllerutil/predicate_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package controllerutil
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
+)
+
+func TestAPIVersionSupported(t *testing.T) {
+	defer viper.Set(constant.APIVersionSupported, "")
+
+	if !IsAPIVersionSupported(appsv1.GroupVersion.String()) {
+		t.Fatalf("expected built-in apps api version to be supported")
+	}
+	if IsAPIVersionSupported("example.io/v1") {
+		t.Fatalf("unexpected support for arbitrary api version")
+	}
+
+	viper.Set(constant.APIVersionSupported, `^example\.io/v[0-9]+$`)
+	if !IsAPIVersionSupported("example.io/v2") {
+		t.Fatalf("expected configured api version regex to match")
+	}
+}
+
+func TestObjectAPIVersionSupported(t *testing.T) {
+	cluster := &appsv1.Cluster{}
+	if !ObjectAPIVersionSupported(cluster) {
+		t.Fatalf("cluster without api version annotation should be accepted for api version resolution")
+	}
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Annotations: map[string]string{constant.CRDAPIVersionAnnotationKey: appsv1.GroupVersion.String()},
+	}}
+	if !ObjectAPIVersionSupported(pod) {
+		t.Fatalf("object with supported api version annotation should be accepted")
+	}
+
+	pod.Annotations[constant.CRDAPIVersionAnnotationKey] = "example.io/v1"
+	if ObjectAPIVersionSupported(pod) {
+		t.Fatalf("object with unsupported api version annotation should be rejected")
+	}
+}
+
+func TestNamespacePredicateFilter(t *testing.T) {
+	namespacesKey := strings.ReplaceAll(constant.ManagedNamespacesFlag, "-", "_")
+	defer func() {
+		managedNamespaces = nil
+		viper.Set(namespacesKey, "")
+	}()
+
+	managedNamespaces = nil
+	viper.Set(namespacesKey, "ns-a,ns-b")
+	if !namespacePredicateFilter(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns-a"}}) {
+		t.Fatalf("expected configured namespace to pass")
+	}
+	if namespacePredicateFilter(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns-c"}}) {
+		t.Fatalf("expected non-configured namespace to be filtered")
+	}
+	if !namespacePredicateFilter(&corev1.Node{}) {
+		t.Fatalf("cluster-scoped objects should pass namespace filter")
+	}
+
+	managedNamespaces = &sets.Set[string]{}
+	if !namespacePredicateFilter(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "ns-c"}}) {
+		t.Fatalf("empty managed namespace set should allow all namespaces")
+	}
+}

--- a/pkg/controllerutil/util_test.go
+++ b/pkg/controllerutil/util_test.go
@@ -98,6 +98,37 @@ func TestGetUncachedObjects(t *testing.T) {
 	GetUncachedObjects()
 }
 
+func TestMergeMetadataMaps(t *testing.T) {
+	original := map[string]string{"a": "1"}
+	got := MergeMetadataMaps(original, map[string]string{"a": "override", "b": "2"}, map[string]string{"c": "3"})
+	assert.Equal(t, map[string]string{"a": "1", "b": "2", "c": "3"}, got)
+	assert.Equal(t, map[string]string{"a": "1"}, original)
+}
+
+func TestMergeMetadataMapInplace(t *testing.T) {
+	var target map[string]string
+	MergeMetadataMapInplace(map[string]string{"a": "1"}, &target)
+	assert.Equal(t, map[string]string{"a": "1"}, target)
+	MergeMetadataMapInplace(map[string]string{"a": "2", "b": "3"}, &target)
+	assert.Equal(t, map[string]string{"a": "2", "b": "3"}, target)
+	MergeMetadataMapInplace(nil, &target)
+	assert.Equal(t, map[string]string{"a": "2", "b": "3"}, target)
+}
+
+func TestSupportResizeSubResourceImpl(t *testing.T) {
+	defer viper.Set(constant.CfgKeyServerInfo, nil)
+
+	viper.Set(constant.CfgKeyServerInfo, version.Info{GitVersion: "v1.31.0"})
+	supported, err := supportResizeSubResourceImpl()
+	assert.NoError(t, err)
+	assert.False(t, supported)
+
+	viper.Set(constant.CfgKeyServerInfo, version.Info{GitVersion: "v1.32.0"})
+	supported, err = supportResizeSubResourceImpl()
+	assert.NoError(t, err)
+	assert.True(t, supported)
+}
+
 func TestRequestCtxMisc(t *testing.T) {
 	itFuncs := func(reqCtx *RequestCtx) {
 		reqCtx.Event(nil, "type", "reason", "msg")

--- a/pkg/controllerutil/volume_util_test.go
+++ b/pkg/controllerutil/volume_util_test.go
@@ -24,8 +24,11 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
 
 var _ = Describe("volume util", func() {
@@ -52,5 +55,37 @@ var _ = Describe("volume util", func() {
 		Expect(pvcts).Should(HaveLen(1))
 		Expect(pvcts[0].Spec.DataSourceRef).Should(Equal(ref))
 		Expect(pvcts[0].Annotations[templateAnnotationKey]).Should(Equal("data"))
+	})
+
+	It("uses explicit and configured default storage class when converting app templates", func() {
+		defer viper.Set(constant.CfgKeyDefaultStorageClass, "")
+		explicit := "fast"
+		viper.Set(constant.CfgKeyDefaultStorageClass, "standard")
+
+		pvcts := ToCoreV1PVCTs([]appsv1.PersistentVolumeClaimTemplate{
+			{Name: "data", Spec: corev1.PersistentVolumeClaimSpec{StorageClassName: &explicit}},
+			{Name: "log"},
+		})
+
+		Expect(pvcts).Should(HaveLen(2))
+		Expect(*pvcts[0].Spec.StorageClassName).Should(Equal("fast"))
+		Expect(*pvcts[1].Spec.StorageClassName).Should(Equal("standard"))
+	})
+
+	It("creates missing volumes and composes pvc names", func() {
+		volumes := CreateVolumeIfNotExist(nil, "config", func(volumeName string) corev1.Volume {
+			return corev1.Volume{Name: volumeName}
+		})
+		Expect(volumes).Should(HaveLen(1))
+		volumes = CreateVolumeIfNotExist(volumes, "config", func(volumeName string) corev1.Volume {
+			return corev1.Volume{Name: volumeName + "-new"}
+		})
+		Expect(volumes).Should(HaveLen(1))
+
+		template := corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "data"}}
+		Expect(ComposePVCName(template, "its", "its-0")).Should(Equal("data-its-0"))
+		template.Annotations = map[string]string{constant.PVCNamePrefixAnnotationKey: "custom"}
+		Expect(ComposePVCName(template, "its", "its-0")).Should(Equal("custom-0"))
+		Expect(ComposePVCName(template, "its", "other")).Should(Equal("custom"))
 	})
 })


### PR DESCRIPTION
## Summary
- add stable unit coverage for controllerutil instance, predicate, pod, volume, container, and metadata helpers
- raise pkg/controllerutil coverage from 64.5% to 81.0%
- no production code changes

## Tests
- KUBEBUILDER_ASSETS=<envtest-assets> GOFLAGS=-mod=mod go test -short ./pkg/controllerutil -coverprofile=<tmp-cover>