### PR TITLE
chore: improve controllers parameters coverage

### DIFF
--- a/controllers/parameters/parameterview_controller_test.go
+++ b/controllers/parameters/parameterview_controller_test.go
@@ -1776,6 +1776,48 @@ var _ = Describe("ParameterView Controller", func() {
 	BeforeEach(cleanEnv)
 	AfterEach(cleanEnv)
 
+	It("resolves helper state for parameter value maps and failure messages", func() {
+		By("cloning parameter value maps without sharing value pointers")
+		Expect(cloneParameterValueMap(nil)).Should(BeNil())
+		source := map[string]*string{
+			"keep":   ptr.To("1"),
+			"delete": nil,
+		}
+		cloned := cloneParameterValueMap(source)
+		Expect(cloned).Should(Equal(source))
+		Expect(cloned["keep"]).ShouldNot(BeIdenticalTo(source["keep"]))
+
+		By("comparing desired parameter maps with nil-aware semantics")
+		Expect(equalParameterValueMap(source, cloned)).Should(BeTrue())
+		Expect(equalParameterValueMap(source, map[string]*string{"keep": ptr.To("1")})).Should(BeFalse())
+		Expect(equalParameterValueMap(source, map[string]*string{"keep": ptr.To("2"), "delete": nil})).Should(BeFalse())
+		Expect(equalParameterValueMap(source, map[string]*string{"keep": nil, "delete": nil})).Should(BeFalse())
+
+		By("checking desired parameter containment")
+		Expect(desiredParametersContain(nil, source)).Should(BeFalse())
+		Expect(desiredParametersContain(&parametersv1alpha1.ParameterInputs{}, source)).Should(BeFalse())
+		Expect(desiredParametersContain(&parametersv1alpha1.ParameterInputs{Assignments: source}, nil)).Should(BeFalse())
+		Expect(desiredParametersContain(&parametersv1alpha1.ParameterInputs{Assignments: source}, cloned)).Should(BeTrue())
+		Expect(desiredParametersContain(&parametersv1alpha1.ParameterInputs{Assignments: source}, map[string]*string{"keep": ptr.To("2")})).Should(BeFalse())
+		Expect(desiredParametersContain(&parametersv1alpha1.ParameterInputs{Assignments: source}, map[string]*string{"missing": ptr.To("1")})).Should(BeFalse())
+
+		By("choosing the most specific config item failure message")
+		Expect(configItemFailureMessage(nil, "")).Should(Equal("component parameter reconfigure failed"))
+		Expect(configItemFailureMessage(nil, "fallback")).Should(Equal("fallback"))
+		Expect(configItemFailureMessage(&parametersv1alpha1.ConfigTemplateItemDetailStatus{
+			ReconcileDetail: &parametersv1alpha1.ReconcileDetail{ErrMessage: "err-message", ExecResult: "exec-result"},
+		}, "fallback")).Should(Equal("err-message"))
+		Expect(configItemFailureMessage(&parametersv1alpha1.ConfigTemplateItemDetailStatus{
+			ReconcileDetail: &parametersv1alpha1.ReconcileDetail{ExecResult: "exec-result"},
+		}, "fallback")).Should(Equal("exec-result"))
+		Expect(configItemFailureMessage(&parametersv1alpha1.ConfigTemplateItemDetailStatus{
+			Message: ptr.To("status-message"),
+		}, "fallback")).Should(Equal("status-message"))
+		Expect(configItemFailureMessage(&parametersv1alpha1.ConfigTemplateItemDetailStatus{
+			Message: ptr.To(""),
+		}, "fallback")).Should(Equal("fallback"))
+	})
+
 	It("writes PlainText content back to ComponentParameter desired parameters", func() {
 		_, _, _, _, _ = mockReconcileResource()
 

--- a/controllers/parameters/reconfigure/restart_test.go
+++ b/controllers/parameters/reconfigure/restart_test.go
@@ -36,6 +36,12 @@ import (
 
 var _ = ginkgo.Describe("restartPolicy test", func() {
 	ginkgo.Context("restart policy", func() {
+		ginkgo.It("should reject unsupported task policies", func() {
+			status, err := Task{Policy: Policy("unsupported")}.Reconfigure()
+			Expect(err).Should(MatchError(ContainSubstring("not support reload action[unsupported]")))
+			Expect(status).Should(Equal(Status{}))
+		})
+
 		ginkgo.It("should success without error", func() {
 			configHash := "test-hash"
 			mockParam := Context{

--- a/controllers/parameters/reconfigure_controller_test.go
+++ b/controllers/parameters/reconfigure_controller_test.go
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package parameters
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -50,7 +51,200 @@ var _ = Describe("Reconfigure Controller", func() {
 	AfterEach(cleanEnv)
 
 	Context("reconfigure policy", func() {
-		// TODO: impl
+		It("classifies reload action predicates", func() {
+			Expect(isValidReloadPolicy(parametersv1alpha1.ReloadAction{})).Should(BeFalse())
+			Expect(isValidReloadPolicy(parametersv1alpha1.ReloadAction{
+				AutoTrigger: &parametersv1alpha1.AutoTrigger{ProcessName: "mysql"},
+			})).Should(BeTrue())
+			Expect(isValidReloadPolicy(parametersv1alpha1.ReloadAction{
+				ShellTrigger: &parametersv1alpha1.ShellTrigger{Command: []string{"reload"}},
+			})).Should(BeTrue())
+
+			Expect(isAutoReload(nil)).Should(BeFalse())
+			Expect(isAutoReload(&parametersv1alpha1.ReloadAction{
+				ShellTrigger: &parametersv1alpha1.ShellTrigger{Command: []string{"reload"}},
+			})).Should(BeFalse())
+			Expect(isAutoReload(&parametersv1alpha1.ReloadAction{
+				AutoTrigger: &parametersv1alpha1.AutoTrigger{ProcessName: "mysql"},
+			})).Should(BeTrue())
+		})
+
+		It("enables sync shell triggers only for synchronous shell actions", func() {
+			reconciler := &ReconfigureReconciler{}
+			Expect(reconciler.enableSyncTrigger(nil)).Should(BeFalse())
+			Expect(reconciler.enableSyncTrigger(&parametersv1alpha1.ReloadAction{
+				AutoTrigger: &parametersv1alpha1.AutoTrigger{ProcessName: "mysql"},
+			})).Should(BeFalse())
+			Expect(reconciler.enableSyncTrigger(&parametersv1alpha1.ReloadAction{
+				ShellTrigger: &parametersv1alpha1.ShellTrigger{Command: []string{"reload"}},
+			})).Should(BeFalse())
+			Expect(reconciler.enableSyncTrigger(&parametersv1alpha1.ReloadAction{
+				ShellTrigger: &parametersv1alpha1.ShellTrigger{Command: []string{"reload"}, Sync: ptr.To(false)},
+			})).Should(BeFalse())
+			Expect(reconciler.enableSyncTrigger(&parametersv1alpha1.ReloadAction{
+				ShellTrigger: &parametersv1alpha1.ShellTrigger{Command: []string{"reload"}, Sync: ptr.To(true)},
+			})).Should(BeTrue())
+		})
+
+		It("builds reload tasks with resolved config context", func() {
+			configHashData := map[string]string{
+				testparameters.MysqlConfigFile: "max_connections=100",
+			}
+			configMap := &corev1.ConfigMap{
+				Data: configHashData,
+			}
+			cluster := &appsv1.Cluster{}
+			componentSpec := &appsv1.ClusterComponentSpec{Name: defaultCompName}
+			its := &workloads.InstanceSet{}
+			templateSpec := &appsv1.ComponentFileTemplate{
+				Name: configSpecName,
+			}
+			configDesc := &parametersv1alpha1.ComponentConfigDescription{
+				Name: testparameters.MysqlConfigFile,
+			}
+			pd := &parametersv1alpha1.ParametersDefinition{
+				Spec: parametersv1alpha1.ParametersDefinitionSpec{
+					DynamicParameters: []string{"max_connections"},
+				},
+			}
+			patch := &parameterscore.ConfigPatchInfo{
+				UpdateConfig: map[string][]byte{
+					testparameters.MysqlConfigFile: []byte(`{"max_connections":"200"}`),
+				},
+			}
+			rctx := &reconcileContext{
+				ResourceFetcher: parameters.ResourceFetcher[reconcileContext]{
+					ResourceCtx: &render.ResourceCtx{
+						ComponentName: defaultCompName,
+					},
+					ConfigMapObj:  configMap,
+					ClusterObj:    cluster,
+					ClusterComObj: componentSpec,
+				},
+				its:       its,
+				configMap: configMap,
+			}
+
+			task := (&ReconfigureReconciler{}).buildReloadTask(
+				reconfigure.SyncDynamicReloadPolicy,
+				templateSpec,
+				rctx,
+				pd,
+				configDesc,
+				patch,
+			)
+
+			Expect(task.Policy).Should(Equal(reconfigure.SyncDynamicReloadPolicy))
+			Expect(task.Ctx.ConfigTemplate).Should(Equal(*templateSpec))
+			Expect(task.Ctx.ConfigHash).ShouldNot(BeNil())
+			Expect(*task.Ctx.ConfigHash).Should(Equal(*computeTargetConfigHash(nil, configHashData)))
+			Expect(task.Ctx.Cluster).Should(BeIdenticalTo(cluster))
+			Expect(task.Ctx.ClusterComponent).Should(BeIdenticalTo(componentSpec))
+			Expect(task.Ctx.ITS).Should(BeIdenticalTo(its))
+			Expect(task.Ctx.ConfigDescription).Should(BeIdenticalTo(configDesc))
+			Expect(task.Ctx.ParametersDef).Should(BeIdenticalTo(&pd.Spec))
+			Expect(task.Ctx.Patch).Should(BeIdenticalTo(patch))
+		})
+
+		It("falls back to restart tasks when reload tasks are not applicable", func() {
+			reconciler := &ReconfigureReconciler{}
+			templateSpec := &appsv1.ComponentFileTemplate{Name: configSpecName}
+			rctx := &reconcileContext{
+				ResourceFetcher: parameters.ResourceFetcher[reconcileContext]{
+					ResourceCtx: &render.ResourceCtx{},
+				},
+				configMap: &corev1.ConfigMap{
+					Data: map[string]string{testparameters.MysqlConfigFile: "max_connections=100"},
+				},
+				configDescs: []parametersv1alpha1.ComponentConfigDescription{{
+					Name: testparameters.MysqlConfigFile,
+					FileFormatConfig: &parametersv1alpha1.FileFormatConfig{
+						Format: parametersv1alpha1.Ini,
+						FormatterAction: parametersv1alpha1.FormatterAction{
+							IniConfig: &parametersv1alpha1.IniConfig{SectionName: "mysqld"},
+						},
+					},
+				}},
+				parametersDefs: map[string]*parametersv1alpha1.ParametersDefinition{},
+			}
+
+			tasks, err := reconciler.buildReconfigureTasks(templateSpec, rctx, nil, false)
+			Expect(err).Should(Succeed())
+			Expect(tasks).Should(HaveLen(1))
+			Expect(tasks[0].Policy).Should(Equal(reconfigure.RestartPolicy))
+
+			tasks, err = reconciler.buildReconfigureTasks(templateSpec, rctx, &parameterscore.ConfigPatchInfo{
+				UpdateConfig: map[string][]byte{
+					testparameters.MysqlConfigFile: []byte(`{"mysqld":{"max_connections":"200"}}`),
+				},
+			}, false)
+			Expect(err).Should(Succeed())
+			Expect(tasks).Should(HaveLen(1))
+			Expect(tasks[0].Policy).Should(Equal(reconfigure.RestartPolicy))
+		})
+
+		It("builds dynamic reload tasks from supported config patches", func() {
+			reconciler := &ReconfigureReconciler{}
+			templateSpec := &appsv1.ComponentFileTemplate{
+				Name: configSpecName,
+				Reconfigure: &appsv1.Action{
+					Exec: &appsv1.ExecAction{Command: []string{"reload"}},
+				},
+			}
+			rctx := &reconcileContext{
+				ResourceFetcher: parameters.ResourceFetcher[reconcileContext]{
+					ResourceCtx: &render.ResourceCtx{},
+				},
+				configMap: &corev1.ConfigMap{
+					Data: map[string]string{testparameters.MysqlConfigFile: "max_connections=100"},
+				},
+				configDescs: []parametersv1alpha1.ComponentConfigDescription{{
+					Name: testparameters.MysqlConfigFile,
+					FileFormatConfig: &parametersv1alpha1.FileFormatConfig{
+						Format: parametersv1alpha1.Ini,
+						FormatterAction: parametersv1alpha1.FormatterAction{
+							IniConfig: &parametersv1alpha1.IniConfig{SectionName: "mysqld"},
+						},
+					},
+				}},
+				parametersDefs: map[string]*parametersv1alpha1.ParametersDefinition{
+					testparameters.MysqlConfigFile: {
+						Spec: parametersv1alpha1.ParametersDefinitionSpec{
+							DynamicParameters: []string{"max_connections"},
+						},
+					},
+				},
+			}
+
+			tasks, err := reconciler.buildReconfigureTasks(templateSpec, rctx, &parameterscore.ConfigPatchInfo{
+				UpdateConfig: map[string][]byte{
+					testparameters.MysqlConfigFile: []byte(`{"mysqld":{"max_connections":"200"}}`),
+				},
+			}, false)
+			Expect(err).Should(Succeed())
+			Expect(tasks).Should(HaveLen(1))
+			Expect(tasks[0].Policy).Should(Equal(reconfigure.SyncDynamicReloadPolicy))
+			Expect(tasks[0].Ctx.ConfigDescription.Name).Should(Equal(testparameters.MysqlConfigFile))
+		})
+
+		It("applies failed result options", func() {
+			status := reconfigure.Status{
+				Status:        reconfigure.StatusFailed,
+				Reason:        "original",
+				ExpectedCount: 2,
+				SucceedCount:  1,
+			}
+
+			retryResult := reconciled(status, string(reconfigure.SyncDynamicReloadPolicy), parametersv1alpha1.CFailedPhase, withFailed(nil, true))
+			Expect(retryResult.Retry).Should(BeTrue())
+			Expect(retryResult.Failed).Should(BeFalse())
+			Expect(retryResult.Message).Should(Equal("original"))
+
+			pauseResult := reconciled(status, string(reconfigure.SyncDynamicReloadPolicy), parametersv1alpha1.CFailedAndPausePhase, withFailed(errors.New("reload failed"), false))
+			Expect(pauseResult.Retry).Should(BeFalse())
+			Expect(pauseResult.Failed).Should(BeTrue())
+			Expect(pauseResult.Message).Should(Equal("reload failed"))
+		})
 	})
 
 	Context("reconfigure", func() {


### PR DESCRIPTION
## Summary
- add focused Ginkgo/Gomega coverage for ParameterView helper state and failure-message selection
- add Reconfigure controller coverage for reload predicates, task construction, fallback restart tasks, and failed result options
- add reconfigure task dispatch coverage for unsupported policies
- raise controllers/parameters coverage from 78.2% to 80.3%
- no production code changes

## Tests
- KUBEBUILDER_ASSETS=<envtest-assets> GOFLAGS=-mod=mod GOCACHE=<go-build-cache> go test ./controllers/parameters/... -coverprofile=<tmp-cover>
- GOCACHE=<go-build-cache> go tool cover -func=<tmp-cover>