### PR TITLE
chore: improve controllers dataprotection coverage

### DIFF
--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -977,13 +977,25 @@ func updateBackupStatusByActionStatus(backupStatus *dpv1alpha1.BackupStatus) {
 	}
 }
 
+const systemAccountSecretLabel = "apps.kubeblocks.io/system-account"
+
 func setEncryptedSystemAccountsAnnotation(request *dpbackup.Request, cluster *kbappsv1.Cluster) error {
 	usernameKey := constant.AccountNameForSecret
 	passwordKey := constant.AccountPasswdForSecret
 	isSystemAccountSecret := func(secret *corev1.Secret) bool {
 		username := secret.Data[usernameKey]
 		password := secret.Data[passwordKey]
-		return username != nil && password != nil
+		if username == nil || password == nil {
+			return false
+		}
+		if secret.Labels[systemAccountSecretLabel] != "" {
+			return true
+		}
+		shardingName := secret.Labels[constant.KBAppShardingNameLabelKey]
+		if shardingName == "" {
+			return false
+		}
+		return secret.Name == fmt.Sprintf("%s-%s-%s", cluster.Name, shardingName, string(username))
 	}
 	// fetch secret objects
 	objectList, err := listObjectsOfCluster(request.Ctx, request.Client, cluster, &corev1.SecretList{})

--- a/controllers/dataprotection/backup_controller_test.go
+++ b/controllers/dataprotection/backup_controller_test.go
@@ -21,25 +21,29 @@ package dataprotection
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"slices"
 	"strconv"
 	"time"
 
-	vsv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	vsv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
@@ -98,6 +102,168 @@ var _ = Describe("Backup Controller test", func() {
 
 	AfterEach(func() {
 		cleanEnv()
+	})
+
+	Context("backup annotations", func() {
+		It("records cluster snapshot and encrypted system account secrets", func() {
+			cluster := clusterInfo.Cluster
+			cluster.Annotations = map[string]string{
+				constant.OpsRequestAnnotationKey:        "removed",
+				corev1.LastAppliedConfigAnnotation:      "removed",
+				"dataprotection.kubeblocks.io/retained": "true",
+			}
+
+			labels := constant.GetClusterLabels(cluster.Name)
+			componentLabels := constant.GetCompLabels(cluster.Name, testdp.ComponentName)
+			componentLabels[systemAccountSecretLabel] = "admin"
+			shardingLabels := constant.GetClusterLabels(cluster.Name, map[string]string{
+				constant.KBAppShardingNameLabelKey: "shard",
+			})
+			componentSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: cluster.Namespace,
+					Name:      "component-account",
+					Labels:    componentLabels,
+				},
+				Data: map[string][]byte{
+					constant.AccountNameForSecret:   []byte("admin"),
+					constant.AccountPasswdForSecret: []byte("component-password"),
+				},
+			}
+			shardingSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: cluster.Namespace,
+					Name:      fmt.Sprintf("%s-%s-%s", cluster.Name, "shard", "root"),
+					Labels:    shardingLabels,
+				},
+				Data: map[string][]byte{
+					constant.AccountNameForSecret:   []byte("root"),
+					constant.AccountPasswdForSecret: []byte("sharding-password"),
+				},
+			}
+			ignoredSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: cluster.Namespace,
+					Name:      "not-system-account",
+					Labels:    labels,
+				},
+				Data: map[string][]byte{
+					constant.AccountNameForSecret: []byte("ignored"),
+				},
+			}
+			ordinarySecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: cluster.Namespace,
+					Name:      "ordinary-credentials",
+					Labels:    constant.GetCompLabels(cluster.Name, testdp.ComponentName),
+				},
+				Data: map[string][]byte{
+					constant.AccountNameForSecret:   []byte("ordinary"),
+					constant.AccountPasswdForSecret: []byte("ordinary-password"),
+				},
+			}
+			ordinaryShardingSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: cluster.Namespace,
+					Name:      "ordinary-sharding-credentials",
+					Labels:    constant.GetClusterLabels(cluster.Name, map[string]string{constant.KBAppShardingNameLabelKey: "shard"}),
+				},
+				Data: map[string][]byte{
+					constant.AccountNameForSecret:   []byte("ordinary-shard"),
+					constant.AccountPasswdForSecret: []byte("ordinary-sharding-password"),
+				},
+			}
+			Expect(testCtx.CreateObj(ctx, componentSecret)).Should(Succeed())
+			Expect(testCtx.CreateObj(ctx, shardingSecret)).Should(Succeed())
+			Expect(testCtx.CreateObj(ctx, ignoredSecret)).Should(Succeed())
+			Expect(testCtx.CreateObj(ctx, ordinarySecret)).Should(Succeed())
+			Expect(testCtx.CreateObj(ctx, ordinaryShardingSecret)).Should(Succeed())
+
+			backup := &dpv1alpha1.Backup{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   cluster.Namespace,
+					Name:        "annotation-backup",
+					Annotations: map[string]string{},
+				},
+			}
+			request := &dpbackup.Request{
+				RequestCtx: intctrlutil.RequestCtx{Ctx: ctx},
+				Client:     k8sClient,
+				Backup:     backup,
+			}
+
+			Expect(setClusterSnapshotAnnotation(request, cluster)).Should(Succeed())
+			Expect(backup.Annotations[constant.ClusterSnapshotAnnotationKey]).To(ContainSubstring(`"name":"` + cluster.Name + `"`))
+			Expect(backup.Annotations[constant.ClusterSnapshotAnnotationKey]).To(ContainSubstring(`"dataprotection.kubeblocks.io/retained":"true"`))
+			Expect(backup.Annotations[constant.ClusterSnapshotAnnotationKey]).NotTo(ContainSubstring(constant.OpsRequestAnnotationKey))
+			Expect(backup.Annotations[constant.ClusterSnapshotAnnotationKey]).NotTo(ContainSubstring(corev1.LastAppliedConfigAnnotation))
+
+			Expect(setEncryptedSystemAccountsAnnotation(request, cluster)).Should(Succeed())
+			accounts := map[string]map[string]string{}
+			Expect(json.Unmarshal([]byte(backup.Annotations[constant.EncryptedSystemAccountsAnnotationKey]), &accounts)).Should(Succeed())
+			Expect(accounts).To(HaveKey(testdp.ComponentName))
+			Expect(accounts[testdp.ComponentName]).To(HaveKey("admin"))
+			Expect(accounts[testdp.ComponentName]).NotTo(HaveKey("ordinary"))
+			Expect(accounts).To(HaveKey("shard"))
+			Expect(accounts["shard"]).To(HaveKey("root"))
+			Expect(accounts["shard"]).NotTo(HaveKey("ordinary-shard"))
+			Expect(accounts).NotTo(HaveKey(""))
+		})
+	})
+
+	Context("continuous backup validation", func() {
+		It("validates schedule ownership and waits for creating clusters", func() {
+			scheme := runtime.NewScheme()
+			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
+			Expect(dpv1alpha1.AddToScheme(scheme)).Should(Succeed())
+
+			backup := &dpv1alpha1.Backup{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "continuous-backup",
+					Labels: map[string]string{
+						constant.AppInstanceLabelKey: "cluster",
+					},
+				},
+			}
+			creatingCluster := &kbappsv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "cluster",
+				},
+				Status: kbappsv1.ClusterStatus{
+					Phase: kbappsv1.CreatingClusterPhase,
+				},
+			}
+			reqCtx := intctrlutil.RequestCtx{Ctx: context.Background()}
+			cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(creatingCluster).Build()
+
+			Expect(clusterIsCreating(reqCtx, backup, cli)).To(BeTrue())
+			Expect(validateContinuousBackup(backup, reqCtx, cli)).ShouldNot(Succeed())
+
+			readyCluster := creatingCluster.DeepCopy()
+			readyCluster.Status.Phase = kbappsv1.RunningClusterPhase
+			backup.Labels[dptypes.BackupScheduleLabelKey] = "schedule"
+			failedSchedule := &dpv1alpha1.BackupSchedule{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: backup.Namespace,
+					Name:      "schedule",
+				},
+				Status: dpv1alpha1.BackupScheduleStatus{
+					Phase: dpv1alpha1.BackupSchedulePhaseFailed,
+				},
+			}
+			cli = fake.NewClientBuilder().WithScheme(scheme).WithObjects(readyCluster, failedSchedule).Build()
+
+			Expect(clusterIsCreating(reqCtx, backup, cli)).To(BeFalse())
+			Expect(validateContinuousBackup(backup, reqCtx, cli)).ShouldNot(Succeed())
+
+			availableSchedule := failedSchedule.DeepCopy()
+			availableSchedule.Status.Phase = dpv1alpha1.BackupSchedulePhaseAvailable
+			cli = fake.NewClientBuilder().WithScheme(scheme).WithObjects(readyCluster, availableSchedule).Build()
+
+			Expect(validateContinuousBackup(backup, reqCtx, cli)).Should(Succeed())
+		})
 	})
 
 	When("with default settings", func() {

--- a/controllers/dataprotection/backuppolicydriver_controller_test.go
+++ b/controllers/dataprotection/backuppolicydriver_controller_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,6 +38,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/generics"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
 	testdp "github.com/apecloud/kubeblocks/pkg/testutil/dataprotection"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
 
 var _ = Describe("BackupPolicyDriver Controller test", func() {
@@ -100,6 +102,96 @@ var _ = Describe("BackupPolicyDriver Controller test", func() {
 	})
 
 	Context("expect to create a backup policy", func() {
+		It("resolves backup method env values by exact match before prefix match", func() {
+			exactValue := "tools:8.0.33"
+			prefixValue := "tools:8.0"
+			staticValue := "static"
+			builder := &backupPolicyAndScheduleBuilder{}
+
+			env := builder.resolveBackupMethodEnv(&appsv1.ClusterComponentSpec{
+				ServiceVersion: "8.0.33",
+			}, []dpv1alpha1.EnvVar{
+				{
+					Name:  "STATIC",
+					Value: &staticValue,
+				},
+				{
+					Name: "TOOLS_IMAGE",
+					ValueFrom: &dpv1alpha1.ValueFrom{
+						VersionMapping: []dpv1alpha1.VersionMapping{
+							{ServiceVersions: []string{"8.0"}, MappedValue: prefixValue},
+							{ServiceVersions: []string{"8.0.33"}, MappedValue: exactValue},
+						},
+					},
+				},
+				{
+					Name: "UNMATCHED",
+					ValueFrom: &dpv1alpha1.ValueFrom{
+						VersionMapping: []dpv1alpha1.VersionMapping{
+							{ServiceVersions: []string{"5.7"}, MappedValue: "tools:5.7"},
+						},
+					},
+				},
+			})
+
+			Expect(env).To(HaveLen(2))
+			Expect(env[0].Name).To(Equal("STATIC"))
+			Expect(env[0].Value).To(Equal(staticValue))
+			Expect(env[1].Name).To(Equal("TOOLS_IMAGE"))
+			Expect(env[1].Value).To(Equal(exactValue))
+			Expect(findBestMatchingValue([]dpv1alpha1.VersionMapping{
+				{ServiceVersions: []string{"^8\\.0\\.[0-9]+$"}, MappedValue: "regex"},
+			}, "8.0.34")).To(Equal("regex"))
+			Expect(findBestMatchingValue(nil, "8.0.34")).To(BeEmpty())
+		})
+
+		It("syncs role selectors when component replicas change", func() {
+			target := &dpv1alpha1.BackupTarget{
+				PodSelector: &dpv1alpha1.PodSelector{
+					LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{}},
+				},
+			}
+			builder := &backupPolicyAndScheduleBuilder{
+				compSpec: &appsv1.ClusterComponentSpec{Replicas: 3},
+			}
+
+			builder.syncRoleLabelSelectorWhenReplicaChanges(target, "leader", "follower", defaultCompName)
+
+			Expect(target.PodSelector.MatchLabels[constant.RoleLabelKey]).To(Equal("leader"))
+			Expect(target.PodSelector.FallbackLabelSelector.MatchLabels[constant.RoleLabelKey]).To(Equal("follower"))
+
+			builder.compSpec.Replicas = 1
+			builder.syncRoleLabelSelectorWhenReplicaChanges(target, "leader", "follower", defaultCompName)
+
+			Expect(target.PodSelector.MatchLabels).NotTo(HaveKey(constant.RoleLabelKey))
+			Expect(target.PodSelector.FallbackLabelSelector.MatchLabels).NotTo(HaveKey(constant.RoleLabelKey))
+		})
+
+		It("sets default encryption config from viper when valid", func() {
+			oldSecretKeyRef := viper.GetString(constant.CfgKeyDPBackupEncryptionSecretKeyRef)
+			oldAlgorithm := viper.GetString(constant.CfgKeyDPBackupEncryptionAlgorithm)
+			defer func() {
+				viper.Set(constant.CfgKeyDPBackupEncryptionSecretKeyRef, oldSecretKeyRef)
+				viper.Set(constant.CfgKeyDPBackupEncryptionAlgorithm, oldAlgorithm)
+			}()
+
+			viper.Set(constant.CfgKeyDPBackupEncryptionSecretKeyRef, `{"name":"backup-passphrase","key":"password"}`)
+			viper.Set(constant.CfgKeyDPBackupEncryptionAlgorithm, "")
+
+			backupPolicy := &dpv1alpha1.BackupPolicy{}
+			(&backupPolicyAndScheduleBuilder{}).setDefaultEncryptionConfig(backupPolicy)
+
+			Expect(backupPolicy.Spec.EncryptionConfig).NotTo(BeNil())
+			Expect(backupPolicy.Spec.EncryptionConfig.Algorithm).To(Equal(dpv1alpha1.DefaultEncryptionAlgorithm))
+			Expect(backupPolicy.Spec.EncryptionConfig.PassPhraseSecretKeyRef.Name).To(Equal("backup-passphrase"))
+			Expect(backupPolicy.Spec.EncryptionConfig.PassPhraseSecretKeyRef.Key).To(Equal("password"))
+
+			viper.Set(constant.CfgKeyDPBackupEncryptionSecretKeyRef, `{"name":"backup-passphrase"}`)
+			backupPolicy.Spec.EncryptionConfig = nil
+			(&backupPolicyAndScheduleBuilder{}).setDefaultEncryptionConfig(backupPolicy)
+			Expect(backupPolicy.Spec.EncryptionConfig).To(BeNil())
+		})
+
 		It("shortens overlength backup policy and schedule names", func() {
 			clusterName := strings.Repeat("c", 41)
 			componentName := strings.Repeat("d", 9)

--- a/controllers/dataprotection/backuppolicytemplate_controller_test.go
+++ b/controllers/dataprotection/backuppolicytemplate_controller_test.go
@@ -17,12 +17,17 @@ limitations under the License.
 package dataprotection
 
 import (
+	"context"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/generics"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
@@ -58,6 +63,43 @@ var _ = Describe("", func() {
 	})
 
 	Context("create a BackupPolicyTemplate", func() {
+		It("maps compatible component definitions to backup policy template requests", func() {
+			scheme := runtime.NewScheme()
+			Expect(appsv1.AddToScheme(scheme)).Should(Succeed())
+			Expect(dpv1alpha1.AddToScheme(scheme)).Should(Succeed())
+
+			matchingBPT := &dpv1alpha1.BackupPolicyTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "mysql-bpt"},
+				Spec: dpv1alpha1.BackupPolicyTemplateSpec{
+					CompDefs: []string{"mysql-.*"},
+				},
+			}
+			nonMatchingBPT := &dpv1alpha1.BackupPolicyTemplate{
+				ObjectMeta: metav1.ObjectMeta{Name: "postgres-bpt"},
+				Spec: dpv1alpha1.BackupPolicyTemplateSpec{
+					CompDefs: []string{"postgres"},
+				},
+			}
+			reconciler := &BackupPolicyTemplateReconciler{
+				Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(matchingBPT, nonMatchingBPT).Build(),
+			}
+
+			Expect(reconciler.isCompatibleWith(appsv1.ComponentDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "mysql-8.0"},
+			}, matchingBPT)).To(BeTrue())
+			Expect(reconciler.isCompatibleWith(appsv1.ComponentDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "redis"},
+			}, matchingBPT)).To(BeFalse())
+			Expect(reconciler.compatibleBackupPolicyTemplate(context.Background(), &dpv1alpha1.BackupPolicyTemplate{})).To(BeNil())
+
+			requests := reconciler.compatibleBackupPolicyTemplate(context.Background(), &appsv1.ComponentDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "mysql-8.0"},
+			})
+
+			Expect(requests).To(HaveLen(1))
+			Expect(requests[0].Name).To(Equal(matchingBPT.Name))
+		})
+
 		It("test BackupPolicyTemplate", func() {
 			var (
 				compDef1 = "comp-def1"

--- a/controllers/dataprotection/gc_controller.go
+++ b/controllers/dataprotection/gc_controller.go
@@ -136,7 +136,7 @@ func getGCFrequency() time.Duration {
 // isBackupDeletable returns true if the backup can be deleted.
 func (r *GCReconciler) isBackupDeletable(reqCtx intctrlutil.RequestCtx, backup *dpv1alpha1.Backup) (bool, error) {
 	if backup.Status.Phase != dpv1alpha1.BackupPhaseCompleted {
-		return true, nil
+		return backup.Status.Phase == dpv1alpha1.BackupPhaseFailed, nil
 	}
 	backupPolicy := &dpv1alpha1.BackupPolicy{}
 	err := r.Get(reqCtx.Ctx, client.ObjectKey{

--- a/controllers/dataprotection/gc_controller_test.go
+++ b/controllers/dataprotection/gc_controller_test.go
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package dataprotection
 
 import (
+	"context"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -27,14 +28,18 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	dpbackup "github.com/apecloud/kubeblocks/pkg/dataprotection/backup"
 	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 	"github.com/apecloud/kubeblocks/pkg/generics"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
 	testdp "github.com/apecloud/kubeblocks/pkg/testutil/dataprotection"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
 
 var _ = Describe("Data Protection Garbage Collection Controller", func() {
@@ -79,6 +84,102 @@ var _ = Describe("Data Protection Garbage Collection Controller", func() {
 	AfterEach(cleanEnv)
 
 	Context("garbage collection", func() {
+		It("uses configured GC frequency only when positive", func() {
+			oldFrequency := viper.GetInt(dptypes.CfgKeyGCFrequencySeconds)
+			defer viper.Set(dptypes.CfgKeyGCFrequencySeconds, oldFrequency)
+
+			viper.Set(dptypes.CfgKeyGCFrequencySeconds, 7)
+			Expect(getGCFrequency()).To(Equal(7 * time.Second))
+
+			viper.Set(dptypes.CfgKeyGCFrequencySeconds, 0)
+			Expect(getGCFrequency()).To(Equal(time.Duration(dptypes.DefaultGCFrequencySeconds)))
+		})
+
+		It("evaluates deterministic backup deletion decisions", func() {
+			scheme := runtime.NewScheme()
+			Expect(dpv1alpha1.AddToScheme(scheme)).Should(Succeed())
+
+			completedAt := metav1.Time{Time: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)}
+			laterCompletedAt := metav1.Time{Time: completedAt.Add(time.Hour)}
+			backupPolicy := &dpv1alpha1.BackupPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "policy",
+				},
+				Spec: dpv1alpha1.BackupPolicySpec{
+					RetentionPolicy: dpv1alpha1.BackupPolicyRetentionPolicyRetainLatestBackup,
+				},
+			}
+			olderBackup := &dpv1alpha1.Backup{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "older",
+					Labels: map[string]string{
+						dptypes.ClusterUIDLabelKey:   "cluster-uid",
+						dptypes.BackupPolicyLabelKey: backupPolicy.Name,
+					},
+				},
+				Spec: dpv1alpha1.BackupSpec{
+					BackupPolicyName: backupPolicy.Name,
+					BackupMethod:     "full",
+				},
+				Status: dpv1alpha1.BackupStatus{
+					Phase:               dpv1alpha1.BackupPhaseCompleted,
+					CompletionTimestamp: &completedAt,
+				},
+			}
+			latestBackup := olderBackup.DeepCopy()
+			latestBackup.Name = "latest"
+			latestBackup.Status.CompletionTimestamp = &laterCompletedAt
+			incrementalBackup := olderBackup.DeepCopy()
+			incrementalBackup.Name = "incremental"
+			incrementalBackup.Labels[dptypes.BackupTypeLabelKey] = string(dpv1alpha1.BackupTypeIncremental)
+			runningBackup := olderBackup.DeepCopy()
+			runningBackup.Name = "running"
+			runningBackup.Status.Phase = dpv1alpha1.BackupPhaseRunning
+			failedBackup := olderBackup.DeepCopy()
+			failedBackup.Name = "failed"
+			failedBackup.Status.Phase = dpv1alpha1.BackupPhaseFailed
+
+			reconciler := &GCReconciler{
+				Client: fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(backupPolicy, olderBackup, latestBackup, incrementalBackup, runningBackup, failedBackup).
+					Build(),
+			}
+			reqCtx := intctrlutil.RequestCtx{Ctx: context.Background()}
+
+			deletable, err := reconciler.isBackupDeletable(reqCtx, runningBackup)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deletable).To(BeFalse())
+
+			deletable, err = reconciler.isBackupDeletable(reqCtx, failedBackup)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deletable).To(BeTrue())
+
+			deletable, err = reconciler.isBackupDeletable(reqCtx, incrementalBackup)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deletable).To(BeFalse())
+
+			deletable, err = reconciler.isBackupDeletable(reqCtx, latestBackup)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deletable).To(BeFalse())
+
+			deletable, err = reconciler.isBackupDeletable(reqCtx, olderBackup)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(deletable).To(BeTrue())
+
+			isLatest, err := reconciler.isLatestCompletedBackup(context.Background(), &dpv1alpha1.Backup{
+				Status: dpv1alpha1.BackupStatus{Phase: dpv1alpha1.BackupPhaseRunning},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(isLatest).To(BeFalse())
+
+			related, err := reconciler.getRelatedBackups(context.Background(), &dpv1alpha1.Backup{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(related).To(BeNil())
+		})
+
 		var (
 			backupNamePrefix = "schedule-test-backup-"
 			backupPolicy     *dpv1alpha1.BackupPolicy

--- a/controllers/dataprotection/storageprovider_controller_test.go
+++ b/controllers/dataprotection/storageprovider_controller_test.go
@@ -147,6 +147,30 @@ var _ = Describe("StorageProvider controller", func() {
 			}).Should(Succeed())
 		})
 
+		It("tracks and removes CSI driver dependencies deterministically", func() {
+			provider1 := &dpv1alpha1.StorageProvider{
+				ObjectMeta: metav1.ObjectMeta{Name: "provider1"},
+				Spec: dpv1alpha1.StorageProviderSpec{
+					CSIDriverName: "csi-dependency",
+				},
+			}
+			provider2 := provider1.DeepCopy()
+			provider2.Name = "provider2"
+
+			reconclier.ensureDependency(provider1)
+			reconclier.ensureDependency(provider1)
+			reconclier.ensureDependency(provider2)
+			reconclier.ensureDependency(&dpv1alpha1.StorageProvider{ObjectMeta: metav1.ObjectMeta{Name: "ignored"}})
+
+			Expect(reconclier.driverDependencies["csi-dependency"]).To(ConsistOf("provider1", "provider2"))
+
+			reconclier.removeDependency("provider1")
+			Expect(reconclier.driverDependencies["csi-dependency"]).To(ConsistOf("provider2"))
+
+			reconclier.removeDependency("missing")
+			Expect(reconclier.driverDependencies["csi-dependency"]).To(ConsistOf("provider2"))
+		})
+
 		It("should reconcile a StorageProvider to Ready status if the specified csiDriverName is present", func() {
 			By("creating a StorageProvider with csi1")
 			createCSIDriverObjectSpec("csi1")

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -27,6 +27,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -38,8 +39,6 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	"github.com/stretchr/testify/require"
 
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
@@ -94,6 +93,220 @@ var _ = Describe("Volume Populator Controller test", func() {
 
 	AfterEach(func() {
 		cleanEnv()
+	})
+
+	Context("backup target selector helpers", func() {
+		It("detects effective PVC selectors beyond the app instance label", func() {
+			Expect(backupTargetHasEffectivePVCSelector(nil)).To(BeFalse())
+			Expect(backupTargetHasEffectivePVCSelector(&dpv1alpha1.BackupStatusTarget{
+				BackupTarget: dpv1alpha1.BackupTarget{
+					PodSelector: &dpv1alpha1.PodSelector{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								constant.AppInstanceLabelKey: "cluster",
+							},
+						},
+					},
+				},
+			})).To(BeFalse())
+			Expect(backupTargetHasEffectivePVCSelector(&dpv1alpha1.BackupStatusTarget{
+				BackupTarget: dpv1alpha1.BackupTarget{
+					PodSelector: &dpv1alpha1.PodSelector{
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{{
+								Key:      constant.VolumeClaimTemplateNameLabelKey,
+								Operator: metav1.LabelSelectorOpExists,
+							}},
+						},
+					},
+				},
+			})).To(BeTrue())
+		})
+
+		It("matches PVCs with label selector operators", func() {
+			target := &dpv1alpha1.BackupStatusTarget{
+				BackupTarget: dpv1alpha1.BackupTarget{
+					PodSelector: &dpv1alpha1.PodSelector{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								constant.AppInstanceLabelKey:             "cluster",
+								constant.VolumeClaimTemplateNameLabelKey: "data",
+							},
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{Key: "tier", Operator: metav1.LabelSelectorOpIn, Values: []string{"hot", "warm"}},
+								{Key: "archived", Operator: metav1.LabelSelectorOpDoesNotExist},
+							},
+						},
+					},
+				},
+			}
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						constant.AppInstanceLabelKey:             "cluster",
+						constant.VolumeClaimTemplateNameLabelKey: "data",
+						"tier":                                   "hot",
+					},
+				},
+			}
+
+			Expect(backupTargetMatchesPVC(&dpv1alpha1.BackupStatusTarget{}, pvc)).To(BeFalse())
+			Expect(backupTargetMatchesPVC(target, pvc)).To(BeTrue())
+
+			target.PodSelector.MatchExpressions[0].Values = []string{"cold"}
+			Expect(backupTargetMatchesPVC(target, pvc)).To(BeFalse())
+
+			target.PodSelector.MatchExpressions[0] = metav1.LabelSelectorRequirement{
+				Key:      "tier",
+				Operator: metav1.LabelSelectorOpNotIn,
+				Values:   []string{"cold"},
+			}
+			Expect(backupTargetMatchesPVC(target, pvc)).To(BeTrue())
+
+			target.PodSelector.MatchExpressions[0].Values = []string{"hot"}
+			Expect(backupTargetMatchesPVC(target, pvc)).To(BeFalse())
+
+			target.PodSelector.MatchExpressions[0] = metav1.LabelSelectorRequirement{
+				Key:      "tier",
+				Operator: metav1.LabelSelectorOpExists,
+			}
+			Expect(backupTargetMatchesPVC(target, pvc)).To(BeTrue())
+
+			target.PodSelector.MatchExpressions[0] = metav1.LabelSelectorRequirement{
+				Key:      "tier",
+				Operator: metav1.LabelSelectorOpDoesNotExist,
+			}
+			Expect(backupTargetMatchesPVC(target, pvc)).To(BeFalse())
+
+			target.PodSelector.MatchExpressions[0] = metav1.LabelSelectorRequirement{
+				Key:      "tier",
+				Operator: metav1.LabelSelectorOperator("Unknown"),
+			}
+			Expect(backupTargetMatchesPVC(target, pvc)).To(BeFalse())
+		})
+	})
+
+	Context("system account secret helpers", func() {
+		It("patches existing mutable secrets and recreates changed immutable secrets", func() {
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
+			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
+
+			component := &kbappsv1.Component{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      constant.GenerateClusterComponentName("cluster", "mysql"),
+					UID:       types.UID("component-uid"),
+				},
+			}
+			mutableSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      constant.GenerateAccountSecretName("cluster", "mysql", "admin"),
+				},
+				Data: map[string][]byte{},
+			}
+			immutable := true
+			immutableSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      constant.GenerateAccountSecretName("cluster", "mysql", "root"),
+				},
+				Immutable: &immutable,
+				Data: map[string][]byte{
+					constant.AccountNameForSecret:   []byte("root"),
+					constant.AccountPasswdForSecret: []byte("old-password"),
+				},
+			}
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "data-target-0",
+				},
+			}
+			reconciler := &VolumePopulatorReconciler{
+				Client: fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(component, mutableSecret, immutableSecret).
+					Build(),
+				Scheme: scheme,
+			}
+			reqCtx := intctrlutil.RequestCtx{Ctx: context.Background()}
+
+			Expect(reconciler.upsertSystemAccountSecret(reqCtx, pvc, systemAccountSecretScopeComponent,
+				"cluster", "mysql", "admin", []byte("new-password"), map[string]string{"role": "admin"})).Should(Succeed())
+			patched := &corev1.Secret{}
+			Expect(reconciler.Client.Get(context.Background(), client.ObjectKey{
+				Namespace: "default",
+				Name:      mutableSecret.Name,
+			}, patched)).Should(Succeed())
+			Expect(patched.Labels["role"]).To(Equal("admin"))
+			Expect(patched.Annotations[constant.SystemAccountProvisionedAnnotationKey]).To(Equal("true"))
+			Expect(patched.Data[constant.AccountNameForSecret]).To(Equal([]byte("admin")))
+			Expect(patched.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("new-password")))
+			Expect(patched.OwnerReferences).To(HaveLen(1))
+			Expect(patched.OwnerReferences[0].Kind).To(Equal("Component"))
+
+			Expect(reconciler.upsertSystemAccountSecret(reqCtx, pvc, systemAccountSecretScopeComponent,
+				"cluster", "mysql", "root", []byte("new-root-password"), map[string]string{"role": "root"})).Should(Succeed())
+			recreated := &corev1.Secret{}
+			Expect(reconciler.Client.Get(context.Background(), client.ObjectKey{
+				Namespace: "default",
+				Name:      immutableSecret.Name,
+			}, recreated)).Should(Succeed())
+			Expect(recreated.Immutable).To(BeNil())
+			Expect(recreated.Labels["role"]).To(Equal("root"))
+			Expect(recreated.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("new-root-password")))
+			Expect(systemAccountSecretMatches(recreated, "root", []byte("new-root-password"))).To(BeTrue())
+			Expect(systemAccountSecretMatches(recreated, "root", []byte("old-password"))).To(BeFalse())
+		})
+
+		It("validates PVC names against instance volume templates", func() {
+			instance := &workloadsv1.Instance{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "cluster-mysql-0",
+				},
+				Spec: workloadsv1.InstanceSpec{
+					InstanceSetName: "cluster-mysql",
+					VolumeClaimTemplates: []corev1.PersistentVolumeClaimTemplate{{
+						ObjectMeta: metav1.ObjectMeta{Name: "data"},
+					}},
+				},
+			}
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "data-cluster-mysql-0",
+					Labels: map[string]string{
+						constant.KBAppPodNameLabelKey: "cluster-mysql-0",
+					},
+					Annotations: map[string]string{
+						constant.RestoreVolumeTemplateAnnotationKey: "data",
+					},
+				},
+			}
+
+			Expect(validatePVCMatchesInstanceTemplate(pvc, instance)).Should(Succeed())
+			Expect(pvcConditionMatches([]corev1.PersistentVolumeClaimCondition{{
+				Type:   "Restore",
+				Status: corev1.ConditionTrue,
+				Reason: "Ready",
+			}}, corev1.PersistentVolumeClaimCondition{
+				Type:   "Restore",
+				Status: corev1.ConditionTrue,
+				Reason: "Ready",
+			})).To(BeTrue())
+			Expect(pvcConditionMatches(nil, corev1.PersistentVolumeClaimCondition{Type: "Restore"})).To(BeFalse())
+
+			pvc.Labels[constant.KBAppPodNameLabelKey] = ""
+			Expect(validatePVCMatchesInstanceTemplate(pvc, instance)).ShouldNot(Succeed())
+			pvc.Labels[constant.KBAppPodNameLabelKey] = "cluster-mysql-1"
+			Expect(validatePVCMatchesInstanceTemplate(pvc, instance)).ShouldNot(Succeed())
+			pvc.Labels[constant.KBAppPodNameLabelKey] = "cluster-mysql-0"
+			pvc.Annotations[constant.RestoreVolumeTemplateAnnotationKey] = "logs"
+			Expect(validatePVCMatchesInstanceTemplate(pvc, instance)).ShouldNot(Succeed())
+		})
 	})
 
 	When("volume populator controller test", func() {


### PR DESCRIPTION
## Summary
- Add deterministic Ginkgo/Gomega coverage for controllers/dataprotection helper and controller branches.
- Cover backup annotation helpers, backup policy driver env/encryption/selector helpers, backup policy template compatibility mapping, GC decisions, storage provider dependency tracking, and volume populator selector/system-account validation paths.
- Fix GC deletability so expired Running/New non-terminal backups are not deleted before completion.
- Fix encrypted system-account backup annotation collection so ordinary cluster Secrets with username/password are not captured, while preserving real component and sharding system-account Secret shapes.

## Coverage
- Before: 77.0% combined statement coverage for controllers/dataprotection.
- After: 80.1% combined statement coverage for controllers/dataprotection.

## Production Code Changes
- `GCReconciler.isBackupDeletable` now returns false for non-terminal backup phases such as Running.
- Trigger case: a backup can have `status.expiration` while still Running.
- Previous behavior: GC treated any non-Completed backup as deletable once expired, which could delete an in-flight backup and its workload.
- Expected behavior: retention GC should only delete terminal backups; Completed keeps the existing policy checks and Failed remains deletable.
- `setEncryptedSystemAccountsAnnotation` now requires an explicit system-account identity before capturing credentials: component Secrets use the `apps.kubeblocks.io/system-account` label, and sharding Secrets must match the real generated `<cluster>-<sharding>-<account>` Secret name with sharding labels.
- Trigger case: an ordinary cluster-labeled Secret carrying username/password was eligible for encrypted system-account backup annotation capture.
- Previous behavior: unrelated credentials could be copied into the Backup annotation and restored as system-account Secrets.
- Expected behavior: only real component or sharding system-account Secrets are captured.

## Tests
- GOFLAGS=-mod=mod GOCACHE=<go-build-cache> KUBEBUILDER_ASSETS=<envtest-assets> go test -short ./controllers/dataprotection -coverprofile=<tmp-cover>
