### PR TITLE
chore: improve pkg operations coverage

### DIFF
--- a/pkg/operations/backup_test.go
+++ b/pkg/operations/backup_test.go
@@ -23,11 +23,16 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
 	opsv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 	"github.com/apecloud/kubeblocks/pkg/generics"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
 	testops "github.com/apecloud/kubeblocks/pkg/testutil/operations"
@@ -119,6 +124,77 @@ var _ = Describe("Backup OpsRequest", func() {
 			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)
 			Expect(err).ShouldNot(HaveOccurred())
 			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsFailedPhase))
+		})
+
+		It("builds backup specs from default policy, retention, and parent backup", func() {
+			fakeScheme := runtime.NewScheme()
+			Expect(dpv1alpha1.AddToScheme(fakeScheme)).Should(Succeed())
+			policy := &dpv1alpha1.BackupPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default-policy",
+					Namespace: testCtx.DefaultNamespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/instance": opsRes.Cluster.Name,
+					},
+					Annotations: map[string]string{
+						dptypes.DefaultBackupPolicyAnnotationKey: "true",
+					},
+				},
+				Spec: dpv1alpha1.BackupPolicySpec{
+					BackupMethods: []dpv1alpha1.BackupMethod{{
+						Name:            "snapshot",
+						SnapshotVolumes: func() *bool { v := true; return &v }(),
+					}},
+				},
+				Status: dpv1alpha1.BackupPolicyStatus{Phase: dpv1alpha1.AvailablePhase},
+			}
+			parentBackup := &dpv1alpha1.Backup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "parent-backup",
+					Namespace: testCtx.DefaultNamespace,
+					Labels: map[string]string{
+						"app.kubernetes.io/instance": opsRes.Cluster.Name,
+					},
+				},
+				Status: dpv1alpha1.BackupStatus{Phase: dpv1alpha1.BackupPhaseCompleted},
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(fakeScheme).WithObjects(policy, parentBackup).Build()
+
+			ops := createBackupOpsObj(clusterName, "backup-build-"+randomStr)
+			ops.Spec.Backup = &opsv1alpha1.Backup{
+				BackupName:       "explicit-backup",
+				RetentionPeriod:  "1d",
+				DeletionPolicy:   string(dpv1alpha1.BackupDeletionPolicyRetain),
+				ParentBackupName: parentBackup.Name,
+			}
+			backup, err := buildBackup(reqCtx, fakeClient, ops, opsRes.Cluster)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(backup.Name).Should(Equal("explicit-backup"))
+			Expect(backup.Spec.BackupPolicyName).Should(Equal(policy.Name))
+			Expect(backup.Spec.BackupMethod).Should(Equal("snapshot"))
+			Expect(backup.Spec.RetentionPeriod).Should(Equal(dpv1alpha1.RetentionPeriod("1d")))
+			Expect(backup.Spec.DeletionPolicy).Should(Equal(dpv1alpha1.BackupDeletionPolicyRetain))
+			Expect(backup.Spec.ParentBackupName).Should(Equal(parentBackup.Name))
+
+			ops.Spec.Backup.RetentionPeriod = "not-a-duration"
+			_, err = buildBackup(reqCtx, fakeClient, ops, opsRes.Cluster)
+			Expect(err).Should(HaveOccurred())
+		})
+
+		It("reports backup policy and method validation errors", func() {
+			fakeScheme := runtime.NewScheme()
+			Expect(dpv1alpha1.AddToScheme(fakeScheme)).Should(Succeed())
+			fakeClient := fake.NewClientBuilder().WithScheme(fakeScheme).Build()
+			ops := createBackupOpsObj(clusterName, "backup-errors-"+randomStr)
+			ops.Spec.Backup = &opsv1alpha1.Backup{BackupPolicyName: "missing", BackupMethod: "snapshot"}
+			_, err := buildBackup(reqCtx, fakeClient, ops, opsRes.Cluster)
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("backup method snapshot is not supported"))
+
+			ops.Spec.Backup = nil
+			_, err = getDefaultBackupPolicy(reqCtx, fakeClient, opsRes.Cluster, "")
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("not found any default backup policy"))
 		})
 	})
 })

--- a/pkg/operations/custom/utils_test.go
+++ b/pkg/operations/custom/utils_test.go
@@ -1,0 +1,939 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package custom
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	opsv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+)
+
+func TestCustom(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Custom Ops Action Suite")
+}
+
+var _ = Describe("custom ops helpers", func() {
+	const (
+		namespace = "default"
+		cluster   = "cluster"
+		compName  = "mysql"
+	)
+
+	var (
+		scheme *runtime.Scheme
+		reqCtx intctrlutil.RequestCtx
+	)
+
+	BeforeEach(func() {
+		scheme = runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).Should(Succeed())
+		Expect(batchv1.AddToScheme(scheme)).Should(Succeed())
+		Expect(appsv1.AddToScheme(scheme)).Should(Succeed())
+		Expect(opsv1alpha1.AddToScheme(scheme)).Should(Succeed())
+		reqCtx = intctrlutil.RequestCtx{Ctx: context.Background()}
+	})
+
+	newFakeClient := func(objs ...client.Object) client.Client {
+		return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	}
+
+	envByName := func(envs []corev1.EnvVar) map[string]corev1.EnvVar {
+		result := map[string]corev1.EnvVar{}
+		for i := range envs {
+			result[envs[i].Name] = envs[i]
+		}
+		return result
+	}
+
+	newOpsRequest := func() *opsv1alpha1.OpsRequest {
+		return &opsv1alpha1.OpsRequest{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: opsv1alpha1.GroupVersion.String(),
+				Kind:       "OpsRequest",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "custom-ops",
+				Namespace: namespace,
+				UID:       types.UID("1234567890abcdef"),
+			},
+			Spec: opsv1alpha1.OpsRequestSpec{
+				SpecificOpsRequest: opsv1alpha1.SpecificOpsRequest{
+					CustomOps: &opsv1alpha1.CustomOps{},
+				},
+			},
+		}
+	}
+
+	newCluster := func() *appsv1.Cluster {
+		return &appsv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: cluster, Namespace: namespace},
+			Spec: appsv1.ClusterSpec{
+				ComponentSpecs: []appsv1.ClusterComponentSpec{{
+					Name:         compName,
+					ComponentDef: "cmpd",
+					Replicas:     2,
+				}},
+			},
+		}
+	}
+
+	newComponentSpec := func() *appsv1.ClusterComponentSpec {
+		return &appsv1.ClusterComponentSpec{
+			Name:           compName,
+			ComponentDef:   "cmpd",
+			ServiceVersion: "8.0.30",
+			Replicas:       2,
+		}
+	}
+
+	newTargetPod := func(name string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels: map[string]string{
+					constant.KBAppComponentLabelKey: compName,
+				},
+			},
+			Spec: corev1.PodSpec{
+				NodeName: "node-1",
+				Containers: []corev1.Container{{
+					Name: "db",
+					Env: []corev1.EnvVar{
+						{Name: "DIRECT", Value: "direct"},
+						{
+							Name: "POD_NAME",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"},
+							},
+						},
+					},
+					EnvFrom: []corev1.EnvFromSource{
+						{
+							Prefix: "CFG_",
+							ConfigMapRef: &corev1.ConfigMapEnvSource{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "settings"},
+							},
+						},
+						{
+							Prefix: "SEC_",
+							SecretRef: &corev1.SecretEnvSource{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "creds"},
+							},
+						},
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+					},
+				}},
+				Volumes: []corev1.Volume{{
+					Name: "data",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				}},
+			},
+		}
+	}
+
+	It("matches component infos by exact, prefix, and regex definitions", func() {
+		Expect(getComponentInfo(nil, "mysql")).Should(BeNil())
+
+		opsDef := &opsv1alpha1.OpsDefinition{
+			Spec: opsv1alpha1.OpsDefinitionSpec{
+				ComponentInfos: []opsv1alpha1.ComponentInfo{
+					{ComponentDefinitionName: "postgres"},
+					{ComponentDefinitionName: "mysql-8.0"},
+					{ComponentDefinitionName: "^redis-[0-9]+$"},
+				},
+			},
+		}
+		Expect(getComponentInfo(opsDef, "mysql-8.0.30")).ShouldNot(BeNil())
+		Expect(getComponentInfo(opsDef, "redis-7")).ShouldNot(BeNil())
+		Expect(getComponentInfo(opsDef, "mongodb")).Should(BeNil())
+	})
+
+	It("builds env vars from pod env, envFrom, field paths, and optional missing refs", func() {
+		targetPod := newTargetPod("target-0")
+		cli := newFakeClient(
+			&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "settings", Namespace: namespace},
+				Data:       map[string]string{"port": "3306"},
+			},
+			&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "creds", Namespace: namespace},
+				Data:       map[string][]byte{"password": []byte("secret")},
+			},
+		)
+
+		envs, err := buildEnvVars(reqCtx, cli, targetPod, []opsv1alpha1.OpsEnvVar{
+			{
+				Name: "COPIED_DIRECT",
+				ValueFrom: &opsv1alpha1.OpsVarSource{
+					EnvVarRef: &opsv1alpha1.EnvVarRef{TargetContainerName: "db", EnvName: "DIRECT"},
+				},
+			},
+			{
+				Name: "COPIED_FIELD_REF",
+				ValueFrom: &opsv1alpha1.OpsVarSource{
+					EnvVarRef: &opsv1alpha1.EnvVarRef{TargetContainerName: "db", EnvName: "POD_NAME"},
+				},
+			},
+			{
+				Name: "FROM_CONFIGMAP",
+				ValueFrom: &opsv1alpha1.OpsVarSource{
+					EnvVarRef: &opsv1alpha1.EnvVarRef{TargetContainerName: "db", EnvName: "CFG_port"},
+				},
+			},
+			{
+				Name: "FROM_SECRET",
+				ValueFrom: &opsv1alpha1.OpsVarSource{
+					EnvVarRef: &opsv1alpha1.EnvVarRef{TargetContainerName: "db", EnvName: "SEC_password"},
+				},
+			},
+			{
+				Name: "POD_NAMESPACE",
+				ValueFrom: &opsv1alpha1.OpsVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{FieldPath: ".metadata.namespace"},
+				},
+			},
+			{
+				Name:     "OPTIONAL_MISSING",
+				Optional: ptr.To(true),
+				ValueFrom: &opsv1alpha1.OpsVarSource{
+					EnvVarRef: &opsv1alpha1.EnvVarRef{TargetContainerName: "db", EnvName: "missing"},
+				},
+			},
+		})
+
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(envs).Should(HaveLen(5))
+		envMap := envByName(envs)
+		Expect(envMap["COPIED_DIRECT"].Value).Should(Equal("direct"))
+		Expect(envMap["COPIED_FIELD_REF"].Value).Should(Equal("target-0"))
+		Expect(envMap["FROM_CONFIGMAP"].Value).Should(Equal("3306"))
+		Expect(envMap["FROM_SECRET"].ValueFrom.SecretKeyRef.Name).Should(Equal("creds"))
+		Expect(envMap["FROM_SECRET"].ValueFrom.SecretKeyRef.Key).Should(Equal("password"))
+		Expect(envMap["POD_NAMESPACE"].Value).Should(Equal(namespace))
+		Expect(envMap).ShouldNot(HaveKey("OPTIONAL_MISSING"))
+	})
+
+	It("returns fatal errors for missing required env refs", func() {
+		targetPod := newTargetPod("target-0")
+		_, err := buildEnvVars(reqCtx, newFakeClient(), targetPod, []opsv1alpha1.OpsEnvVar{{
+			Name: "MISSING",
+			ValueFrom: &opsv1alpha1.OpsVarSource{
+				EnvVarRef: &opsv1alpha1.EnvVarRef{TargetContainerName: "db", EnvName: "missing"},
+			},
+		}})
+		Expect(err).Should(HaveOccurred())
+		Expect(intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal)).Should(BeTrue())
+	})
+
+	It("handles target extractor and field path edge cases", func() {
+		opsDef := &opsv1alpha1.OpsDefinition{Spec: opsv1alpha1.OpsDefinitionSpec{
+			PodInfoExtractors: []opsv1alpha1.PodInfoExtractor{{Name: "target"}},
+		}}
+		Expect(getTargetPodInfoExtractor(opsDef, "missing")).Should(BeNil())
+		extractor, pod, err := getTargetTemplateAndPod(reqCtx.Ctx, newFakeClient(), opsDef, "target", "", namespace)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(extractor).Should(BeNil())
+		Expect(pod).Should(BeNil())
+
+		_, err = buildVarWithFieldPath(newTargetPod("target-0"), "[")
+		Expect(err).Should(HaveOccurred())
+		_, err = buildVarWithFieldPath(newTargetPod("target-0"), ".missing.field")
+		Expect(err).Should(HaveOccurred())
+
+		clusterWithToleration := newCluster()
+		clusterWithToleration.Spec.SchedulingPolicy = &appsv1.SchedulingPolicy{
+			Tolerations: []corev1.Toleration{{Key: "dedicated", Operator: corev1.TolerationOpExists}},
+		}
+		Expect(getTolerations(clusterWithToleration, newComponentSpec())).Should(ContainElement(corev1.Toleration{
+			Key:      "dedicated",
+			Operator: corev1.TolerationOpExists,
+		}))
+	})
+
+	It("builds action pod env with built-ins and parameter sources", func() {
+		configMapKeyRef := &corev1.ConfigMapKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "param-cm"},
+			Key:                  "statement",
+		}
+		secretKeyRef := &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: "param-secret"},
+			Key:                  "password",
+		}
+		envs, err := buildActionPodEnv(
+			reqCtx,
+			newFakeClient(),
+			newCluster(),
+			&opsv1alpha1.OpsDefinition{},
+			newOpsRequest(),
+			newComponentSpec(),
+			&opsv1alpha1.CustomOpsComponent{
+				ComponentOps: opsv1alpha1.ComponentOps{ComponentName: "logical"},
+				Parameters: []opsv1alpha1.Parameter{
+					{Name: "SQL", Value: "select 1"},
+					{Name: "FROM_CM", ValueFrom: &opsv1alpha1.ParameterSource{ConfigMapKeyRef: configMapKeyRef}},
+					{Name: "FROM_SECRET", ValueFrom: &opsv1alpha1.ParameterSource{SecretKeyRef: secretKeyRef}},
+					{Name: "EMPTY_VALUE"},
+				},
+			},
+			nil,
+			newTargetPod("target-0"),
+		)
+
+		Expect(err).ShouldNot(HaveOccurred())
+		envMap := envByName(envs)
+		Expect(envMap[KBEnvOpsName].Value).Should(Equal("custom-ops"))
+		Expect(envMap[KbEnvOpsNamespace].Value).Should(Equal(namespace))
+		Expect(envMap[constant.KBEnvClusterName].Value).Should(Equal(cluster))
+		Expect(envMap[constant.KBEnvCompName].Value).Should(Equal(compName))
+		Expect(envMap[constant.KBEnvCompReplicas].Value).Should(Equal("2"))
+		Expect(envMap["SQL"].Value).Should(Equal("select 1"))
+		Expect(envMap["FROM_CM"].ValueFrom.ConfigMapKeyRef).Should(Equal(configMapKeyRef))
+		Expect(envMap["FROM_SECRET"].ValueFrom.SecretKeyRef).Should(Equal(secretKeyRef))
+		Expect(envMap["EMPTY_VALUE"].Value).Should(BeEmpty())
+	})
+
+	It("adds component definition service and account env vars when requested", func() {
+		fullCompName := constant.GenerateClusterComponentName(cluster, compName)
+		cli := newFakeClient(
+			&appsv1.Component{
+				ObjectMeta: metav1.ObjectMeta{Name: fullCompName, Namespace: namespace},
+				Spec:       appsv1.ComponentSpec{CompDef: "cmpd"},
+			},
+			&appsv1.ComponentDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "cmpd"},
+				Spec: appsv1.ComponentDefinitionSpec{
+					ServiceVersion: "8.0.30",
+					Services: []appsv1.ComponentService{{
+						Service: appsv1.Service{
+							Name:        "client",
+							ServiceName: "mysql",
+							Spec: corev1.ServiceSpec{
+								Ports: []corev1.ServicePort{{Name: "mysql-port", Port: 3306}},
+							},
+						},
+					}},
+				},
+			},
+		)
+		envs := []corev1.EnvVar{}
+		err := buildComponentEnvs(
+			reqCtx,
+			cli,
+			newCluster(),
+			&opsv1alpha1.OpsDefinition{Spec: opsv1alpha1.OpsDefinitionSpec{
+				ComponentInfos: []opsv1alpha1.ComponentInfo{{
+					ComponentDefinitionName: "cmpd",
+					AccountName:             "root",
+					ServiceName:             "client",
+				}},
+			}},
+			&envs,
+			newComponentSpec(),
+			compName,
+		)
+
+		Expect(err).ShouldNot(HaveOccurred())
+		envMap := envByName(envs)
+		Expect(envMap[kbEnvCompServiceVersion].Value).Should(Equal("8.0.30"))
+		Expect(envMap[kbEnvAccountUserName].Value).Should(Equal("root"))
+		Expect(envMap[kbEnvAccountPassword].ValueFrom.SecretKeyRef.Name).Should(Equal("cluster-mysql-account-root"))
+		Expect(envMap[kbEnvCompSVCName].Value).Should(Equal("cluster-mysql-mysql"))
+		Expect(envMap[kbEnvCompSVCPortPrefix+"MYSQL_PORT"].Value).Should(Equal("3306"))
+	})
+
+	It("selects sharding target pods by role and availability policy", func() {
+		clusterObj := newCluster()
+		clusterObj.Spec.Shardings = []appsv1.ClusterSharding{{Name: "shard", Shards: 2}}
+		labels := constant.GetClusterLabels(cluster)
+		labels[constant.KBAppShardingNameLabelKey] = "shard"
+		labels[constant.RoleLabelKey] = "leader"
+
+		availablePod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-b", Namespace: namespace, Labels: labels},
+			Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "db"}}},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				Conditions: []corev1.PodCondition{{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				}},
+			},
+		}
+		unavailablePod := availablePod.DeepCopy()
+		unavailablePod.Name = "pod-a"
+		unavailablePod.Status.Conditions[0].Status = corev1.ConditionFalse
+
+		pods, err := getTargetPods(
+			reqCtx.Ctx,
+			newFakeClient(unavailablePod, availablePod),
+			clusterObj,
+			opsv1alpha1.PodSelector{Role: "leader", MultiPodSelectionPolicy: opsv1alpha1.Any},
+			"shard",
+		)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(pods).Should(HaveLen(1))
+		Expect(pods[0].Name).Should(Equal("pod-b"))
+
+		pods, err = getTargetPods(
+			reqCtx.Ctx,
+			newFakeClient(unavailablePod, availablePod),
+			clusterObj,
+			opsv1alpha1.PodSelector{Role: "leader", MultiPodSelectionPolicy: opsv1alpha1.All},
+			"shard",
+		)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(pods).Should(HaveLen(2))
+	})
+
+	It("builds workload pod specs with extracted volumes, envs, defaults, and image mappings", func() {
+		opsRequest := newOpsRequest()
+		targetPod := newTargetPod("target-0")
+		cli := newFakeClient(&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      constant.GenerateDefaultServiceAccountName("cmpd"),
+				Namespace: namespace,
+			},
+		})
+		workloadAction := &WorkloadAction{
+			OpsRequest: opsRequest,
+			Cluster:    newCluster(),
+			OpsDef:     &opsv1alpha1.OpsDefinition{},
+			CustomCompOps: &opsv1alpha1.CustomOpsComponent{
+				ComponentOps: opsv1alpha1.ComponentOps{ComponentName: compName},
+				Parameters:   []opsv1alpha1.Parameter{{Name: "SQL", Value: "select 1"}},
+			},
+			Comp: newComponentSpec(),
+		}
+		actionCtx := ActionContext{
+			ReqCtx: reqCtx,
+			Client: cli,
+			Action: &opsv1alpha1.OpsAction{
+				Name: "work",
+				Workload: &opsv1alpha1.OpsWorkloadAction{
+					Type: opsv1alpha1.PodWorkload,
+					PodSpec: corev1.PodSpec{
+						Containers:     []corev1.Container{{Name: "runner", Image: "old"}},
+						InitContainers: []corev1.Container{{Name: "init"}},
+					},
+				},
+			},
+			Images: map[string]string{"runner": "new"},
+		}
+		podSpec, err := workloadAction.buildPodSpec(
+			actionCtx,
+			&opsv1alpha1.PodInfoExtractor{VolumeMounts: []corev1.VolumeMount{{Name: "data", MountPath: "/data"}}},
+			targetPod,
+		)
+
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(podSpec.RestartPolicy).Should(Equal(corev1.RestartPolicyNever))
+		Expect(podSpec.NodeSelector).Should(HaveKeyWithValue(corev1.LabelHostname, "node-1"))
+		Expect(podSpec.ServiceAccountName).Should(Equal(constant.GenerateDefaultServiceAccountName("cmpd")))
+		Expect(podSpec.Containers[0].Image).Should(Equal("new"))
+		Expect(podSpec.Containers[0].Env).Should(ContainElement(corev1.EnvVar{Name: "SQL", Value: "select 1"}))
+		Expect(podSpec.Containers[0].VolumeMounts).Should(ContainElement(corev1.VolumeMount{Name: "data", MountPath: "/data"}))
+		Expect(podSpec.Containers[0].VolumeMounts).Should(ContainElement(corev1.VolumeMount{Name: "ops-utils", MountPath: "/scripts"}))
+		Expect(podSpec.InitContainers).Should(HaveLen(2))
+		Expect(podSpec.Volumes).Should(ContainElement(corev1.Volume{Name: "ops-utils", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}))
+	})
+
+	It("builds exec pod specs with kubectl exec args and default container selection", func() {
+		execAction := &ExecAction{
+			OpsRequest:    newOpsRequest(),
+			Cluster:       newCluster(),
+			OpsDef:        &opsv1alpha1.OpsDefinition{},
+			CustomCompOps: &opsv1alpha1.CustomOpsComponent{ComponentOps: opsv1alpha1.ComponentOps{ComponentName: compName}},
+			Comp:          newComponentSpec(),
+		}
+		actionCtx := ActionContext{
+			ReqCtx: reqCtx,
+			Client: newFakeClient(),
+			Action: &opsv1alpha1.OpsAction{
+				Name: "exec",
+				Exec: &opsv1alpha1.OpsExecAction{
+					Command: []string{"sh", "-c", "echo ok"},
+				},
+			},
+		}
+
+		podSpec, err := execAction.buildExecPodSpec(actionCtx, nil, newTargetPod("target-0"))
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(podSpec.Containers).Should(HaveLen(1))
+		Expect(podSpec.Containers[0].Command).Should(Equal([]string{"kubectl"}))
+		Expect(podSpec.Containers[0].Args).Should(Equal([]string{
+			"-n", namespace, "exec", "target-0", "-c", "db", "--", "sh", "-c", "echo ok",
+		}))
+		Expect(podSpec.RestartPolicy).Should(BeEmpty())
+	})
+
+	It("checks pod action task status and retry paths", func() {
+		succeededPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "succeeded", Namespace: namespace},
+			Status:     corev1.PodStatus{Phase: corev1.PodSucceeded},
+		}
+		failedPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "failed", Namespace: namespace},
+			Status:     corev1.PodStatus{Phase: corev1.PodFailed},
+		}
+		actionCtx := ActionContext{ReqCtx: reqCtx, Client: newFakeClient(succeededPod, failedPod)}
+
+		completed, failed, err := actionCtx.checkPodTaskStatus(
+			&opsv1alpha1.ActionTask{Namespace: namespace, ObjectKey: "Pod/succeeded"},
+			1,
+			func() error { return nil },
+		)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(completed).Should(BeTrue())
+		Expect(failed).Should(BeFalse())
+
+		retryTask := &opsv1alpha1.ActionTask{Namespace: namespace, ObjectKey: "Pod/failed"}
+		recreated := false
+		completed, failed, err = actionCtx.checkPodTaskStatus(retryTask, 1, func() error {
+			recreated = true
+			return nil
+		})
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(completed).Should(BeFalse())
+		Expect(failed).Should(BeFalse())
+		Expect(retryTask.Retries).Should(Equal(int32(1)))
+		Expect(recreated).Should(BeTrue())
+
+		completed, failed, err = actionCtx.checkPodTaskStatus(
+			&opsv1alpha1.ActionTask{Namespace: namespace, ObjectKey: "Pod/failed", Retries: 1},
+			1,
+			func() error { return nil },
+		)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(completed).Should(BeTrue())
+		Expect(failed).Should(BeTrue())
+	})
+
+	It("checks aggregate action status and syncs completed task statuses", func() {
+		actionCtx := ActionContext{ReqCtx: reqCtx, Client: newFakeClient()}
+		status, err := actionCtx.checkActionStatus(
+			opsv1alpha1.ProgressStatusDetail{ActionTasks: []opsv1alpha1.ActionTask{
+				{Namespace: namespace, ObjectKey: "Pod/one"},
+				{Namespace: namespace, ObjectKey: "Pod/two"},
+			}},
+			func(_ ActionContext, task *opsv1alpha1.ActionTask, index int) (bool, bool, error) {
+				return true, index == 1, nil
+			},
+		)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(status.IsCompleted).Should(BeTrue())
+		Expect(status.ExistFailure).Should(BeTrue())
+		Expect(status.ActionTasks[0].Status).Should(Equal(opsv1alpha1.SucceedActionTaskStatus))
+		Expect(status.ActionTasks[1].Status).Should(Equal(opsv1alpha1.FailedActionTaskStatus))
+	})
+
+	It("checks job action task status from job conditions", func() {
+		workloadAction := &WorkloadAction{OpsRequest: newOpsRequest()}
+		actionCtx := ActionContext{
+			ReqCtx: reqCtx,
+			Client: newFakeClient(
+				&batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{Name: "complete", Namespace: namespace},
+					Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
+						Type:   batchv1.JobComplete,
+						Status: corev1.ConditionTrue,
+					}}},
+				},
+				&batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{Name: "failed", Namespace: namespace},
+					Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
+						Type:   batchv1.JobFailed,
+						Status: corev1.ConditionTrue,
+					}}},
+				},
+				&batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{Name: "running", Namespace: namespace},
+					Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{{
+						Type:   batchv1.JobFailed,
+						Status: corev1.ConditionFalse,
+					}}},
+				},
+			),
+		}
+
+		completed, failed, err := workloadAction.checkJobStatus(actionCtx, &opsv1alpha1.ActionTask{
+			Namespace: namespace,
+			ObjectKey: "Job/complete",
+		}, 0)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(completed).Should(BeTrue())
+		Expect(failed).Should(BeFalse())
+
+		completed, failed, err = workloadAction.checkJobStatus(actionCtx, &opsv1alpha1.ActionTask{
+			Namespace: namespace,
+			ObjectKey: "Job/failed",
+		}, 0)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(completed).Should(BeTrue())
+		Expect(failed).Should(BeTrue())
+
+		completed, failed, err = workloadAction.checkJobStatus(actionCtx, &opsv1alpha1.ActionTask{
+			Namespace: namespace,
+			ObjectKey: "Job/running",
+		}, 0)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(completed).Should(BeFalse())
+		Expect(failed).Should(BeFalse())
+	})
+
+	It("checks workload action status through pod and job workload switches", func() {
+		podAction := NewWorkloadAction(
+			newOpsRequest(),
+			newCluster(),
+			&opsv1alpha1.OpsDefinition{},
+			&opsv1alpha1.CustomOpsComponent{ComponentOps: opsv1alpha1.ComponentOps{ComponentName: compName}},
+			newComponentSpec(),
+			opsv1alpha1.ProgressStatusDetail{ActionTasks: []opsv1alpha1.ActionTask{
+				{Namespace: namespace, ObjectKey: "Pod/done", Status: opsv1alpha1.SucceedActionTaskStatus},
+				{Namespace: namespace, ObjectKey: "Pod/failed", Status: opsv1alpha1.FailedActionTaskStatus},
+			}},
+		)
+		status, err := podAction.CheckStatus(ActionContext{
+			ReqCtx: reqCtx,
+			Client: newFakeClient(),
+			Action: &opsv1alpha1.OpsAction{
+				Workload: &opsv1alpha1.OpsWorkloadAction{Type: opsv1alpha1.PodWorkload},
+			},
+		})
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(status.IsCompleted).Should(BeTrue())
+		Expect(status.ExistFailure).Should(BeTrue())
+		Expect(status.ActionTasks[0].Status).Should(Equal(opsv1alpha1.SucceedActionTaskStatus))
+		Expect(status.ActionTasks[1].Status).Should(Equal(opsv1alpha1.FailedActionTaskStatus))
+
+		jobAction := NewWorkloadAction(
+			newOpsRequest(),
+			newCluster(),
+			&opsv1alpha1.OpsDefinition{},
+			&opsv1alpha1.CustomOpsComponent{ComponentOps: opsv1alpha1.ComponentOps{ComponentName: compName}},
+			newComponentSpec(),
+			opsv1alpha1.ProgressStatusDetail{ActionTasks: []opsv1alpha1.ActionTask{
+				{Namespace: namespace, ObjectKey: "Job/done", Status: opsv1alpha1.SucceedActionTaskStatus},
+			}},
+		)
+		status, err = jobAction.CheckStatus(ActionContext{
+			ReqCtx: reqCtx,
+			Client: newFakeClient(),
+			Action: &opsv1alpha1.OpsAction{
+				Workload: &opsv1alpha1.OpsWorkloadAction{Type: opsv1alpha1.JobWorkload},
+			},
+		})
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(status.IsCompleted).Should(BeTrue())
+		Expect(status.ExistFailure).Should(BeFalse())
+	})
+
+	It("extracts names from action object keys", func() {
+		Expect(getNameFromObjectKey("Pod/action-pod")).Should(Equal("action-pod"))
+		Expect(getNameFromObjectKey("action-pod")).Should(Equal("action-pod"))
+	})
+
+	It("executes workload pod actions without a target pod extractor", func() {
+		opsRequest := newOpsRequest()
+		workloadAction := NewWorkloadAction(
+			opsRequest,
+			newCluster(),
+			&opsv1alpha1.OpsDefinition{},
+			&opsv1alpha1.CustomOpsComponent{
+				ComponentOps: opsv1alpha1.ComponentOps{ComponentName: compName},
+				Parameters:   []opsv1alpha1.Parameter{{Name: "SQL", Value: "select 1"}},
+			},
+			newComponentSpec(),
+			opsv1alpha1.ProgressStatusDetail{},
+		)
+		actionCtx := ActionContext{
+			ReqCtx: reqCtx,
+			Client: newFakeClient(),
+			Action: &opsv1alpha1.OpsAction{
+				Name: "pod-action",
+				Workload: &opsv1alpha1.OpsWorkloadAction{
+					Type: opsv1alpha1.PodWorkload,
+					PodSpec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "runner", Image: "busybox"}},
+					},
+				},
+			},
+		}
+
+		status, err := workloadAction.Execute(actionCtx)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(status.ActionTasks).Should(HaveLen(1))
+		Expect(status.ActionTasks[0].Namespace).Should(Equal(namespace))
+		Expect(status.ActionTasks[0].ObjectKey).Should(HavePrefix("Pod/"))
+		Expect(status.ActionTasks[0].Status).Should(Equal(opsv1alpha1.ProcessingActionTaskStatus))
+
+		pod := &corev1.Pod{}
+		Expect(actionCtx.Client.Get(reqCtx.Ctx, client.ObjectKey{
+			Namespace: namespace,
+			Name:      getNameFromObjectKey(status.ActionTasks[0].ObjectKey),
+		}, pod)).Should(Succeed())
+		Expect(pod.Labels).Should(HaveKeyWithValue(constant.OpsRequestNameLabelKey, opsRequest.Name))
+		Expect(pod.Labels).Should(HaveKeyWithValue(KBOpsActionNameLabelKey, "pod-action"))
+		Expect(pod.Spec.RestartPolicy).Should(Equal(corev1.RestartPolicyNever))
+
+		duplicateTask, err := workloadAction.createPod(actionCtx, &pod.Spec, "", 0, 0)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(duplicateTask.ObjectKey).Should(Equal(status.ActionTasks[0].ObjectKey))
+	})
+
+	It("executes workload job actions and checks invalid workload types", func() {
+		opsRequest := newOpsRequest()
+		workloadAction := NewWorkloadAction(
+			opsRequest,
+			newCluster(),
+			&opsv1alpha1.OpsDefinition{},
+			&opsv1alpha1.CustomOpsComponent{ComponentOps: opsv1alpha1.ComponentOps{ComponentName: compName}},
+			newComponentSpec(),
+			opsv1alpha1.ProgressStatusDetail{},
+		)
+		actionCtx := ActionContext{
+			ReqCtx: reqCtx,
+			Client: newFakeClient(),
+			Action: &opsv1alpha1.OpsAction{
+				Name: "job-action",
+				Workload: &opsv1alpha1.OpsWorkloadAction{
+					Type:         opsv1alpha1.JobWorkload,
+					BackoffLimit: 2,
+					PodSpec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "runner", Image: "busybox"}},
+					},
+				},
+			},
+		}
+
+		status, err := workloadAction.Execute(actionCtx)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(status.ActionTasks).Should(HaveLen(1))
+		Expect(status.ActionTasks[0].ObjectKey).Should(HavePrefix("Job/"))
+
+		job := &batchv1.Job{}
+		Expect(actionCtx.Client.Get(reqCtx.Ctx, client.ObjectKey{
+			Namespace: namespace,
+			Name:      getNameFromObjectKey(status.ActionTasks[0].ObjectKey),
+		}, job)).Should(Succeed())
+		Expect(job.Spec.BackoffLimit).Should(Equal(ptr.To[int32](2)))
+
+		actionCtx.Action.Workload.Type = opsv1alpha1.OpsWorkloadType("Unknown")
+		_, err = workloadAction.createWorkload(actionCtx, &corev1.PodSpec{}, "", 0)
+		Expect(err).Should(HaveOccurred())
+		Expect(intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal)).Should(BeTrue())
+
+		_, err = workloadAction.CheckStatus(actionCtx)
+		Expect(err).Should(HaveOccurred())
+		Expect(intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal)).Should(BeTrue())
+	})
+
+	It("executes workload actions for all selected target pods", func() {
+		clusterObj := newCluster()
+		clusterObj.Spec.Shardings = []appsv1.ClusterSharding{{
+			Name:     "shard",
+			Shards:   2,
+			Template: *newComponentSpec(),
+		}}
+		labels := constant.GetClusterLabels(cluster)
+		labels[constant.KBAppShardingNameLabelKey] = "shard"
+		targetPodA := newTargetPod("target-a")
+		targetPodA.Labels = labels
+		targetPodA.Labels[constant.KBAppComponentLabelKey] = "shard-0"
+		targetPodB := newTargetPod("target-b")
+		targetPodB.Labels = labels
+		targetPodB.Labels[constant.KBAppComponentLabelKey] = "shard-1"
+
+		opsRequest := newOpsRequest()
+		workloadAction := NewWorkloadAction(
+			opsRequest,
+			clusterObj,
+			&opsv1alpha1.OpsDefinition{Spec: opsv1alpha1.OpsDefinitionSpec{
+				PodInfoExtractors: []opsv1alpha1.PodInfoExtractor{{
+					Name: "targets",
+					PodSelector: opsv1alpha1.PodSelector{
+						MultiPodSelectionPolicy: opsv1alpha1.All,
+					},
+					VolumeMounts: []corev1.VolumeMount{{Name: "data", MountPath: "/data"}},
+				}},
+			}},
+			&opsv1alpha1.CustomOpsComponent{
+				ComponentOps: opsv1alpha1.ComponentOps{ComponentName: "shard"},
+				Parameters:   []opsv1alpha1.Parameter{{Name: "SQL", Value: "select 1"}},
+			},
+			newComponentSpec(),
+			opsv1alpha1.ProgressStatusDetail{},
+		)
+		actionCtx := ActionContext{
+			ReqCtx: reqCtx,
+			Client: newFakeClient(targetPodA, targetPodB),
+			Action: &opsv1alpha1.OpsAction{
+				Name: "workload-all",
+				Workload: &opsv1alpha1.OpsWorkloadAction{
+					Type:                 opsv1alpha1.PodWorkload,
+					PodInfoExtractorName: "targets",
+					PodSpec: corev1.PodSpec{
+						Containers: []corev1.Container{{Name: "runner", Image: "busybox"}},
+					},
+				},
+			},
+		}
+
+		status, err := workloadAction.Execute(actionCtx)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(status.ActionTasks).Should(HaveLen(2))
+		Expect(status.ActionTasks[0].TargetPodName).Should(Equal("target-a"))
+		Expect(status.ActionTasks[1].TargetPodName).Should(Equal("target-b"))
+		for i := range status.ActionTasks {
+			pod := &corev1.Pod{}
+			Expect(actionCtx.Client.Get(reqCtx.Ctx, client.ObjectKey{
+				Namespace: namespace,
+				Name:      getNameFromObjectKey(status.ActionTasks[i].ObjectKey),
+			}, pod)).Should(Succeed())
+			Expect(pod.Spec.NodeSelector).Should(HaveKeyWithValue(corev1.LabelHostname, "node-1"))
+			Expect(pod.Spec.Containers[0].Env).Should(ContainElement(corev1.EnvVar{Name: "SQL", Value: "select 1"}))
+			Expect(pod.Spec.Containers[0].VolumeMounts).Should(ContainElement(corev1.VolumeMount{Name: "data", MountPath: "/data"}))
+		}
+	})
+
+	It("executes exec actions against selected sharding pods", func() {
+		clusterObj := newCluster()
+		clusterObj.Spec.Shardings = []appsv1.ClusterSharding{{
+			Name:     "shard",
+			Shards:   1,
+			Template: *newComponentSpec(),
+		}}
+		labels := constant.GetClusterLabels(cluster)
+		labels[constant.KBAppShardingNameLabelKey] = "shard"
+		labels[constant.KBAppComponentLabelKey] = "shard-0"
+		targetPod := newTargetPod("target-0")
+		targetPod.Labels = labels
+		targetPod.Status.Phase = corev1.PodRunning
+		targetPod.Status.Conditions = []corev1.PodCondition{{
+			Type:   corev1.PodReady,
+			Status: corev1.ConditionTrue,
+		}}
+		opsRequest := newOpsRequest()
+		opsRequest.Spec.CustomOps.ServiceAccountName = ptr.To("custom-sa")
+
+		execAction := NewExecAction(
+			opsRequest,
+			clusterObj,
+			&opsv1alpha1.OpsDefinition{Spec: opsv1alpha1.OpsDefinitionSpec{
+				PodInfoExtractors: []opsv1alpha1.PodInfoExtractor{{
+					Name: "target",
+					PodSelector: opsv1alpha1.PodSelector{
+						MultiPodSelectionPolicy: opsv1alpha1.Any,
+					},
+				}},
+			}},
+			&opsv1alpha1.CustomOpsComponent{ComponentOps: opsv1alpha1.ComponentOps{ComponentName: "shard"}},
+			newComponentSpec(),
+			opsv1alpha1.ProgressStatusDetail{},
+		)
+		actionCtx := ActionContext{
+			ReqCtx: reqCtx,
+			Client: newFakeClient(targetPod),
+			Action: &opsv1alpha1.OpsAction{
+				Name: "exec-action",
+				Exec: &opsv1alpha1.OpsExecAction{
+					PodInfoExtractorName: "target",
+					Command:              []string{"echo", "ok"},
+				},
+			},
+		}
+
+		status, err := execAction.Execute(actionCtx)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(status.ActionTasks).Should(HaveLen(1))
+		Expect(status.ActionTasks[0].TargetPodName).Should(Equal("target-0"))
+		Expect(status.ActionTasks[0].ObjectKey).Should(HavePrefix("Pod/"))
+
+		pod := &corev1.Pod{}
+		Expect(actionCtx.Client.Get(reqCtx.Ctx, client.ObjectKey{
+			Namespace: namespace,
+			Name:      getNameFromObjectKey(status.ActionTasks[0].ObjectKey),
+		}, pod)).Should(Succeed())
+		Expect(pod.Spec.ServiceAccountName).Should(Equal("custom-sa"))
+		Expect(pod.Spec.Containers[0].Args).Should(Equal([]string{
+			"-n", namespace, "exec", "target-0", "-c", "db", "--", "echo", "ok",
+		}))
+
+		Expect(actionCtx.Client.Delete(reqCtx.Ctx, pod)).Should(Succeed())
+		execAction.progressDetail = opsv1alpha1.ProgressStatusDetail{ActionTasks: status.ActionTasks}
+		status, err = execAction.CheckStatus(actionCtx)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(status.IsCompleted).Should(BeFalse())
+		Expect(status.ActionTasks[0].ObjectKey).Should(HavePrefix("Pod/"))
+		Expect(actionCtx.Client.Get(reqCtx.Ctx, client.ObjectKey{
+			Namespace: namespace,
+			Name:      getNameFromObjectKey(status.ActionTasks[0].ObjectKey),
+		}, &corev1.Pod{})).Should(Succeed())
+	})
+
+	It("returns nil when action payloads do not match their action type", func() {
+		opsRequest := newOpsRequest()
+		emptyWorkload := NewWorkloadAction(
+			opsRequest,
+			newCluster(),
+			&opsv1alpha1.OpsDefinition{},
+			&opsv1alpha1.CustomOpsComponent{ComponentOps: opsv1alpha1.ComponentOps{ComponentName: compName}},
+			newComponentSpec(),
+			opsv1alpha1.ProgressStatusDetail{},
+		)
+		status, err := emptyWorkload.Execute(ActionContext{ReqCtx: reqCtx, Client: newFakeClient(), Action: &opsv1alpha1.OpsAction{}})
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(status).Should(BeNil())
+
+		emptyExec := NewExecAction(
+			opsRequest,
+			newCluster(),
+			&opsv1alpha1.OpsDefinition{},
+			&opsv1alpha1.CustomOpsComponent{ComponentOps: opsv1alpha1.ComponentOps{ComponentName: compName}},
+			newComponentSpec(),
+			opsv1alpha1.ProgressStatusDetail{},
+		)
+		status, err = emptyExec.Execute(ActionContext{ReqCtx: reqCtx, Client: newFakeClient(), Action: &opsv1alpha1.OpsAction{}})
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(status).Should(BeNil())
+	})
+})

--- a/pkg/operations/custom_test.go
+++ b/pkg/operations/custom_test.go
@@ -83,6 +83,76 @@ var _ = Describe("CustomOps", func() {
 
 	AfterEach(cleanEnv)
 
+	It("runs workflow status transitions without executing new actions", func() {
+		opsRequest := testops.NewOpsRequestObj("workflow-ops-"+randomStr, testCtx.DefaultNamespace,
+			clusterName, opsv1alpha1.CustomType)
+		opsRequest.Spec.CustomOps = &opsv1alpha1.CustomOps{
+			CustomOpsComponents: []opsv1alpha1.CustomOpsComponent{{
+				ComponentOps: opsv1alpha1.ComponentOps{ComponentName: defaultCompName},
+			}},
+		}
+		clusterObj := &appsv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: testCtx.DefaultNamespace},
+			Spec: appsv1.ClusterSpec{ComponentSpecs: []appsv1.ClusterComponentSpec{{
+				Name:           defaultCompName,
+				ComponentDef:   "cmpd",
+				ServiceVersion: "8.0.30",
+			}}},
+		}
+		opsDefinition := &opsv1alpha1.OpsDefinition{Spec: opsv1alpha1.OpsDefinitionSpec{
+			Actions: []opsv1alpha1.OpsAction{
+				{Name: "ignore-failed", FailurePolicy: opsv1alpha1.FailurePolicyIgnore},
+				{Name: "done", FailurePolicy: opsv1alpha1.FailurePolicyFail},
+			},
+			ComponentInfos: []opsv1alpha1.ComponentInfo{{
+				ComponentDefinitionName: "cmpd",
+				ImageMappings: []opsv1alpha1.ImageMappings{{
+					ServiceVersions: []string{"8.0.30"},
+					Images:          map[string]string{"runner": "custom:8.0.30"},
+				}},
+			}},
+		}}
+		opsRequest.Status.Components = map[string]opsv1alpha1.OpsRequestComponentStatus{
+			defaultCompName: {
+				ProgressDetails: []opsv1alpha1.ProgressStatusDetail{
+					{ActionName: "ignore-failed", Status: opsv1alpha1.FailedProgressStatus},
+					{ActionName: "done", Status: opsv1alpha1.SucceedProgressStatus},
+				},
+			},
+		}
+		opsResource := &OpsResource{OpsRequest: opsRequest, Cluster: clusterObj, OpsDef: opsDefinition}
+		workflow := NewWorkflowContext(intctrlutil.RequestCtx{Ctx: testCtx.Ctx}, k8sClient, opsResource)
+		Expect(workflow.getImages(&clusterObj.Spec.ComponentSpecs[0])).Should(HaveKeyWithValue("runner", "custom:8.0.30"))
+		Expect(workflow.getImages(&appsv1.ClusterComponentSpec{ComponentDef: "other"})).Should(BeNil())
+
+		status, err := workflow.Run(&opsRequest.Spec.CustomOps.CustomOpsComponents[0])
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(status.IsCompleted).Should(BeTrue())
+		Expect(status.ExistFailure).Should(BeFalse())
+		Expect(status.CompletedCount).Should(Equal(2))
+
+		opsDefinition.Spec.Actions[0].FailurePolicy = opsv1alpha1.FailurePolicyFail
+		opsRequest.Status.Components[defaultCompName] = opsv1alpha1.OpsRequestComponentStatus{
+			ProgressDetails: []opsv1alpha1.ProgressStatusDetail{
+				{ActionName: "ignore-failed", Status: opsv1alpha1.FailedProgressStatus},
+			},
+		}
+		status, err = workflow.Run(&opsRequest.Spec.CustomOps.CustomOpsComponents[0])
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(status.IsCompleted).Should(BeTrue())
+		Expect(status.ExistFailure).Should(BeTrue())
+		Expect(status.CompletedCount).Should(Equal(1))
+
+		opsRequest.Status.Components[defaultCompName] = opsv1alpha1.OpsRequestComponentStatus{}
+		status, err = workflow.Run(&opsRequest.Spec.CustomOps.CustomOpsComponents[0])
+		Expect(status).Should(BeNil())
+		Expect(err).Should(HaveOccurred())
+		Expect(intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal)).Should(BeTrue())
+
+		Expect(workflow.getAction(opsv1alpha1.OpsAction{ResourceModifier: &opsv1alpha1.OpsResourceModifierAction{}},
+			&opsRequest.Spec.CustomOps.CustomOpsComponents[0], &clusterObj.Spec.ComponentSpecs[0], opsv1alpha1.ProgressStatusDetail{})).Should(BeNil())
+	})
+
 	createCustomOps := func(comp string, params []opsv1alpha1.Parameter) *opsv1alpha1.OpsRequest {
 		opsName := "custom-ops-" + testCtx.GetRandomStr()
 		ops := testops.NewOpsRequestObj(opsName, testCtx.DefaultNamespace,

--- a/pkg/operations/expose_test.go
+++ b/pkg/operations/expose_test.go
@@ -24,9 +24,13 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	opsv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	"github.com/apecloud/kubeblocks/pkg/generics"
@@ -142,6 +146,120 @@ var _ = Describe("", func() {
 			By("Test OpsManager.MainEnter function")
 			_, err = GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
 			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("builds and removes cluster services from expose service specs", func() {
+			reqCtx := intctrlutil.RequestCtx{Ctx: testCtx.Ctx}
+			handler := ExposeOpsHandler{}
+			compDef := &appsv1.ComponentDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "expose-cmpd-" + randomStr},
+				Spec: appsv1.ComponentDefinitionSpec{
+					Services: []appsv1.ComponentService{
+						{
+							Service: appsv1.Service{
+								Name: "default",
+								Spec: corev1.ServiceSpec{
+									Type: corev1.ServiceTypeClusterIP,
+									Ports: []corev1.ServicePort{
+										{Name: "mysql", Protocol: corev1.ProtocolTCP, Port: 3306, TargetPort: intstr.FromInt(3306)},
+										{Name: "mysql-dup", Protocol: corev1.ProtocolTCP, Port: 3306, TargetPort: intstr.FromInt(3306)},
+									},
+								},
+							},
+						},
+						{
+							Service: appsv1.Service{
+								Name: "skip-node-port",
+								Spec: corev1.ServiceSpec{
+									Type:  corev1.ServiceTypeNodePort,
+									Ports: []corev1.ServicePort{{Name: "skip", Port: 30000}},
+								},
+							},
+						},
+					},
+				},
+			}
+			fakeScheme := runtime.NewScheme()
+			Expect(appsv1.AddToScheme(fakeScheme)).Should(Succeed())
+			fakeClient := fake.NewClientBuilder().WithScheme(fakeScheme).WithObjects(compDef).Build()
+
+			cluster := &appsv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: testCtx.DefaultNamespace}}
+			ipFamilyPolicy := corev1.IPFamilyPolicyPreferDualStack
+			internalTrafficPolicy := corev1.ServiceInternalTrafficPolicyCluster
+			err := handler.buildClusterServices(reqCtx, fakeClient, cluster, defaultCompName, compDef.Name, []opsv1alpha1.OpsService{
+				{
+					Name:                  "client",
+					Annotations:           map[string]string{"service.beta.kubernetes.io/test": "true"},
+					ServiceType:           corev1.ServiceTypeLoadBalancer,
+					IPFamilyPolicy:        &ipFamilyPolicy,
+					IPFamilies:            []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol},
+					ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyLocal,
+					InternalTrafficPolicy: &internalTrafficPolicy,
+					PodSelector:           map[string]string{"app": "mysql"},
+				},
+				{
+					Name:        "explicit",
+					ServiceType: corev1.ServiceTypeNodePort,
+					Ports: []corev1.ServicePort{{
+						Name:       "http",
+						Port:       80,
+						TargetPort: intstr.FromInt(8080),
+					}},
+					RoleSelector: "leader",
+				},
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(cluster.Spec.Services).Should(HaveLen(2))
+			Expect(cluster.Spec.Services[0].Name).Should(Equal(defaultCompName + "-client"))
+			Expect(cluster.Spec.Services[0].Spec.Ports).Should(HaveLen(1))
+			Expect(cluster.Spec.Services[0].Spec.IPFamilyPolicy).Should(Equal(&ipFamilyPolicy))
+			Expect(cluster.Spec.Services[0].Spec.ExternalTrafficPolicy).Should(Equal(corev1.ServiceExternalTrafficPolicyLocal))
+			Expect(cluster.Spec.Services[0].Spec.InternalTrafficPolicy).Should(Equal(&internalTrafficPolicy))
+			Expect(cluster.Spec.Services[1].Spec.Ports[0].TargetPort.IntVal).Should(Equal(int32(8080)))
+			Expect(cluster.Spec.Services[1].RoleSelector).Should(Equal("leader"))
+
+			err = handler.buildClusterServices(reqCtx, fakeClient, cluster, defaultCompName, compDef.Name, []opsv1alpha1.OpsService{{Name: "client"}})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(cluster.Spec.Services).Should(HaveLen(2))
+
+			Expect(handler.removeClusterServices(cluster, defaultCompName, []opsv1alpha1.OpsService{{Name: "client"}})).Should(Succeed())
+			Expect(cluster.Spec.Services).Should(HaveLen(1))
+			Expect(cluster.Spec.Services[0].Name).Should(Equal(defaultCompName + "-explicit"))
+			Expect(handler.removeClusterServices(nil, defaultCompName, []opsv1alpha1.OpsService{{Name: "client"}})).Should(Succeed())
+			Expect(handler.buildClusterServices(reqCtx, fakeClient, nil, defaultCompName, compDef.Name, []opsv1alpha1.OpsService{{Name: "client"}})).Should(Succeed())
+		})
+
+		It("validates expose defaults when component definitions are incomplete", func() {
+			reqCtx := intctrlutil.RequestCtx{Ctx: testCtx.Ctx}
+			handler := ExposeOpsHandler{}
+			cluster := &appsv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: testCtx.DefaultNamespace}}
+			fakeScheme := runtime.NewScheme()
+			Expect(appsv1.AddToScheme(fakeScheme)).Should(Succeed())
+			fakeClient := fake.NewClientBuilder().WithScheme(fakeScheme).Build()
+
+			err := handler.buildClusterServices(reqCtx, fakeClient, cluster, defaultCompName, "", []opsv1alpha1.OpsService{{Name: "client"}})
+			Expect(err).Should(HaveOccurred())
+			Expect(intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal)).Should(BeTrue())
+
+			compDef := &appsv1.ComponentDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "role-cmpd-" + randomStr},
+				Spec: appsv1.ComponentDefinitionSpec{
+					Roles: []appsv1.ReplicaRole{{Name: "leader"}},
+					Services: []appsv1.ComponentService{{
+						Service: appsv1.Service{
+							Name: "default",
+							Spec: corev1.ServiceSpec{
+								Type:  corev1.ServiceTypeClusterIP,
+								Ports: []corev1.ServicePort{{Name: "mysql", Port: 3306}},
+							},
+						},
+					}},
+				},
+			}
+			fakeClient = fake.NewClientBuilder().WithScheme(fakeScheme).WithObjects(compDef).Build()
+			err = handler.buildClusterServices(reqCtx, fakeClient, cluster, defaultCompName, compDef.Name, []opsv1alpha1.OpsService{{Name: "client"}})
+			Expect(err).Should(HaveOccurred())
+			Expect(intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal)).Should(BeTrue())
 		})
 	})
 })

--- a/pkg/operations/ops_runtime_test.go
+++ b/pkg/operations/ops_runtime_test.go
@@ -102,6 +102,11 @@ func TestOpsRuntimeBuildsInstanceAPIView(t *testing.T) {
 			Affinity: &corev1.Affinity{
 				NodeAffinity: &corev1.NodeAffinity{},
 			},
+			TopologySpreadConstraints: []corev1.TopologySpreadConstraint{{
+				MaxSkew:           1,
+				TopologyKey:       corev1.LabelHostname,
+				WhenUnsatisfiable: corev1.ScheduleAnyway,
+			}},
 		},
 		Status: corev1.PodStatus{
 			Phase: corev1.PodRunning,
@@ -203,6 +208,50 @@ func TestOpsRuntimeBuildsInstanceAPIView(t *testing.T) {
 	if instance.GetStatusImage("mysql") != "mysql@sha256:abc" {
 		t.Fatalf("unexpected status image: %s", instance.GetStatusImage("mysql"))
 	}
+	if instance.GetStatusImage("") != "mysql@sha256:abc" {
+		t.Fatalf("unexpected default status image: %s", instance.GetStatusImage(""))
+	}
+	if instance.GetStatusImage("missing") != "" {
+		t.Fatalf("expected empty missing status image")
+	}
+	if instance.GetImage("") != "mysql:8.0.36" {
+		t.Fatalf("unexpected default image: %s", instance.GetImage(""))
+	}
+	if instance.GetImage("missing") != "mysql:8.0.36" {
+		t.Fatalf("expected missing image lookup to fall back to first container")
+	}
+	if instance.GetNodeName() != "node-a" {
+		t.Fatalf("unexpected node name: %s", instance.GetNodeName())
+	}
+	if len(instance.GetTolerations()) != 1 {
+		t.Fatalf("expected tolerations")
+	}
+	if instance.GetAffinity() == nil {
+		t.Fatalf("expected affinity")
+	}
+	if len(instance.GetTopologySpreadConstraints()) != 1 {
+		t.Fatalf("expected topology spread constraints")
+	}
+	if len(instance.GetPodVolumes()) != 1 {
+		t.Fatalf("expected pod volumes")
+	}
+	if len(instance.GetVolumeMounts("mysql")) != 1 {
+		t.Fatalf("expected mysql volume mounts")
+	}
+	if len(instance.GetVolumeMounts("missing")) != 1 {
+		t.Fatalf("expected missing container volume mounts to fall back to first container")
+	}
+	resources := instance.GetResources("mysql")
+	if resources.Requests.Cpu().String() != "100m" {
+		t.Fatalf("unexpected resources")
+	}
+	if len(instance.GetResources("missing").Requests) == 0 {
+		t.Fatalf("expected missing container resources to fall back to first container")
+	}
+	creationTimestamp := instance.GetCreationTimestamp()
+	if creationTimestamp.IsZero() {
+		t.Fatalf("expected creation timestamp")
+	}
 	if !instance.IsAvailable(15, true) {
 		t.Fatalf("expected instance to be available")
 	}
@@ -212,5 +261,115 @@ func TestOpsRuntimeBuildsInstanceAPIView(t *testing.T) {
 	}
 	if volume.GetClaimName() != "data-"+instanceName {
 		t.Fatalf("unexpected pvc name: %s", volume.GetClaimName())
+	}
+	requestedStorage := volume.GetRequestedStorage()
+	if requestedStorage.String() != "2Gi" {
+		t.Fatalf("unexpected requested storage: %s", requestedStorage.String())
+	}
+	capacity := volume.GetCapacity()
+	if capacity.String() != "2Gi" {
+		t.Fatalf("unexpected capacity: %s", capacity.String())
+	}
+	if !volume.IsBound() {
+		t.Fatalf("expected volume to be bound")
+	}
+	if volume.IsExpanding() {
+		t.Fatalf("did not expect volume to be expanding")
+	}
+}
+
+func TestDefaultInstanceAndVolumeNilBranches(t *testing.T) {
+	instance := &defaultInstance{name: "missing", componentName: "mysql"}
+	if instance.GetComponentName() != "mysql" {
+		t.Fatalf("unexpected component name: %s", instance.GetComponentName())
+	}
+	if instance.GetName() != "missing" {
+		t.Fatalf("unexpected instance name: %s", instance.GetName())
+	}
+	creationTimestamp := instance.GetCreationTimestamp()
+	if !creationTimestamp.IsZero() {
+		t.Fatalf("expected zero creation timestamp")
+	}
+	if instance.IsDeleting() {
+		t.Fatalf("nil pod should not be deleting")
+	}
+	if instance.GetRole() != "" {
+		t.Fatalf("expected empty role")
+	}
+	if instance.IsAvailable(0, false) {
+		t.Fatalf("nil pod should not be available")
+	}
+	if instance.IsFailedAndTimedOut() {
+		t.Fatalf("nil pod should not be failed and timed out")
+	}
+	if instance.GetNodeName() != "" {
+		t.Fatalf("expected empty node name")
+	}
+	if instance.GetTolerations() != nil {
+		t.Fatalf("expected nil tolerations")
+	}
+	if instance.GetAffinity() != nil {
+		t.Fatalf("expected nil affinity")
+	}
+	if instance.GetTopologySpreadConstraints() != nil {
+		t.Fatalf("expected nil topology constraints")
+	}
+	if instance.GetPodVolumes() != nil {
+		t.Fatalf("expected nil pod volumes")
+	}
+	if instance.GetVolumeMounts("") != nil {
+		t.Fatalf("expected nil volume mounts")
+	}
+
+	now := metav1.Now()
+	deleting := &defaultInstance{pod: &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "deleting",
+			DeletionTimestamp: &now,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	}}
+	if !deleting.IsDeleting() {
+		t.Fatalf("expected deleting pod")
+	}
+	if deleting.IsAvailable(0, false) {
+		t.Fatalf("deleting pod should not be available")
+	}
+
+	volume := &instanceVolume{}
+	if volume.GetClaimName() != "" {
+		t.Fatalf("expected empty claim name")
+	}
+	requestedStorage := volume.GetRequestedStorage()
+	if !requestedStorage.IsZero() {
+		t.Fatalf("expected zero requested storage")
+	}
+	capacity := volume.GetCapacity()
+	if !capacity.IsZero() {
+		t.Fatalf("expected zero capacity")
+	}
+	if volume.IsBound() {
+		t.Fatalf("nil pvc should not be bound")
+	}
+	if volume.IsExpanding() {
+		t.Fatalf("nil pvc should not be expanding")
+	}
+
+	expanding := &instanceVolume{pvc: &corev1.PersistentVolumeClaim{
+		Status: corev1.PersistentVolumeClaimStatus{
+			Conditions: []corev1.PersistentVolumeClaimCondition{{
+				Type:   corev1.PersistentVolumeClaimResizing,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	}}
+	if !expanding.IsExpanding() {
+		t.Fatalf("expected resizing pvc to be expanding")
 	}
 }

--- a/pkg/operations/ops_util_test.go
+++ b/pkg/operations/ops_util_test.go
@@ -95,6 +95,56 @@ var _ = Describe("OpsUtil functions", func() {
 			Expect(PatchClusterNotFound(ctx, k8sClient, opsRes)).Should(Succeed())
 		})
 
+		It("handles timeout and precondition deadline timing branches", func() {
+			By("init operations resources ")
+			opsRes, _, _ := initOperationsResources(compDefName, clusterName)
+			reqCtx := intctrlutil.RequestCtx{Ctx: ctx}
+
+			ops := testops.NewOpsRequestObj("timeout-ops-"+randomStr, testCtx.DefaultNamespace,
+				clusterName, opsv1alpha1.RestartType)
+			ops.Spec.RestartList = []opsv1alpha1.ComponentOps{{ComponentName: defaultCompName}}
+			timeoutSeconds := int32(1)
+			ops.Spec.TimeoutSeconds = &timeoutSeconds
+			opsRes.OpsRequest = testops.CreateOpsRequest(ctx, testCtx, ops)
+			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsRunningPhase
+			opsRes.OpsRequest.Status.StartTimestamp = metav1.NewTime(time.Now().Add(-2 * time.Second))
+
+			requeueAfter, err := GetOpsManager().checkAndHandleOpsTimeout(reqCtx, k8sClient, opsRes, time.Minute)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(requeueAfter).Should(BeZero())
+			Expect(opsRes.OpsRequest.Status.Phase).Should(Equal(opsv1alpha1.OpsAbortedPhase))
+
+			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsRunningPhase
+			opsRes.OpsRequest.Status.StartTimestamp = metav1.Now()
+			opsRes.OpsRequest.Spec.TimeoutSeconds = &timeoutSeconds
+			requeueAfter, err = GetOpsManager().checkAndHandleOpsTimeout(reqCtx, k8sClient, opsRes, time.Minute)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(requeueAfter).Should(BeNumerically(">", 0))
+			Expect(requeueAfter).Should(BeNumerically("<", time.Minute))
+
+			requeueAfter, err = GetOpsManager().checkAndHandleOpsTimeout(reqCtx, k8sClient, opsRes, time.Millisecond)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(requeueAfter).Should(Equal(time.Millisecond))
+
+			opsRes.OpsRequest.Spec.TimeoutSeconds = nil
+			requeueAfter, err = GetOpsManager().checkAndHandleOpsTimeout(reqCtx, k8sClient, opsRes, time.Second)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(requeueAfter).Should(Equal(time.Second))
+
+			Expect(preConditionDeadlineSecondsIsSet(opsRes.OpsRequest)).Should(BeFalse())
+			preConditionDeadlineSeconds := int32(60)
+			opsRes.OpsRequest.Spec.PreConditionDeadlineSeconds = &preConditionDeadlineSeconds
+			opsRes.OpsRequest.CreationTimestamp = metav1.Now()
+			Expect(preConditionDeadlineSecondsIsSet(opsRes.OpsRequest)).Should(BeTrue())
+			Expect(needWaitPreConditionDeadline(opsRes.OpsRequest)).Should(BeTrue())
+			opsRes.OpsRequest.Annotations = map[string]string{
+				constant.QueueEndTimeAnnotationKey: time.Now().Add(-2 * time.Minute).Format(time.RFC3339),
+			}
+			Expect(needWaitPreConditionDeadline(opsRes.OpsRequest)).Should(BeFalse())
+			opsRes.OpsRequest.Annotations[constant.QueueEndTimeAnnotationKey] = time.Now().Format(time.RFC3339)
+			Expect(needWaitPreConditionDeadline(opsRes.OpsRequest)).Should(BeTrue())
+		})
+
 		It("Test opsRequest failed cases", func() {
 			By("init operations resources ")
 			opsRes, _, _ := initOperationsResources(compDefName, clusterName)

--- a/pkg/operations/rebuild_instance_test.go
+++ b/pkg/operations/rebuild_instance_test.go
@@ -29,8 +29,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
@@ -215,6 +217,187 @@ var _ = Describe("OpsUtil functions", func() {
 			}
 			_, _ = GetOpsManager().Do(reqCtx, k8sClient, opsRes)
 			Expect(opsRes.OpsRequest.Status.Phase).Should(Equal(opsv1alpha1.OpsCreatingPhase))
+		})
+
+		It("covers in-place rebuild pvc and pv metadata helpers", func() {
+			reqCtx := intctrlutil.RequestCtx{Ctx: testCtx.Ctx}
+			fakeScheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(fakeScheme)).Should(Succeed())
+			Expect(opsv1alpha1.AddToScheme(fakeScheme)).Should(Succeed())
+
+			targetPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: constant.GenerateClusterComponentName(clusterName, defaultCompName) + "-0", Namespace: testCtx.DefaultNamespace},
+				Spec: corev1.PodSpec{
+					Volumes: []corev1.Volume{{
+						Name: "data",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "source-pvc"},
+						},
+					}},
+				},
+			}
+			synthesizedComp := &component.SynthesizedComponent{
+				Namespace:   testCtx.DefaultNamespace,
+				ClusterName: clusterName,
+				Name:        defaultCompName,
+				VolumeClaimTemplates: []corev1.PersistentVolumeClaimTemplate{{
+					ObjectMeta: metav1.ObjectMeta{Name: "data"},
+					Spec:       corev1.PersistentVolumeClaimSpec{},
+				}},
+			}
+			opsRequest := &opsv1alpha1.OpsRequest{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: opsv1alpha1.GroupVersion.String(),
+					Kind:       "OpsRequest",
+				},
+				ObjectMeta: metav1.ObjectMeta{Name: "rebuild-ops", Namespace: testCtx.DefaultNamespace, UID: types.UID("12345678abcd")},
+			}
+			opsRes := &OpsResource{
+				Cluster:    &appsv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: testCtx.DefaultNamespace}},
+				OpsRequest: opsRequest,
+			}
+
+			pvcMap, volumes, volumeMounts, err := getPVCMapAndVolumes(opsRes, synthesizedComp, targetPod, "rebuild", 0, false)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(pvcMap).Should(HaveKey("source-pvc"))
+			Expect(volumes).Should(HaveLen(1))
+			Expect(volumeMounts).Should(ContainElement(corev1.VolumeMount{Name: "data", MountPath: "/kb-tmp/0"}))
+			Expect(pvcMap["source-pvc"].Annotations).Should(HaveKeyWithValue(rebuildFromAnnotation, opsRequest.Name))
+
+			pvcMap, volumes, volumeMounts, err = getPVCMapAndVolumes(opsRes, synthesizedComp, targetPod, "rebuild", 0, true)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(pvcMap["source-pvc"].Name).Should(Equal("source-pvc"))
+			Expect(volumes).Should(BeEmpty())
+			Expect(volumeMounts).Should(BeEmpty())
+
+			templateName, ordinal, err := getTemplateNameAndOrdinal(constant.GenerateWorkloadNamePattern(clusterName, defaultCompName), targetPod.Name)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(templateName).Should(BeEmpty())
+			Expect(ordinal).Should(Equal(int32(0)))
+			templateName, ordinal, err = getTemplateNameAndOrdinal("cluster-comp", "cluster-comp-template-3")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(templateName).Should(Equal("template"))
+			Expect(ordinal).Should(Equal(int32(3)))
+			_, _, err = getTemplateNameAndOrdinal("cluster-comp", "cluster-comp-template-")
+			Expect(err).Should(HaveOccurred())
+			_, _, err = getTemplateNameAndOrdinal("cluster-comp", "cluster-comp-template-x")
+			Expect(err).Should(HaveOccurred())
+
+			helper := &inplaceRebuildHelper{synthesizedComp: synthesizedComp, targetPod: targetPod}
+			tmpPVCForPod := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "tmp-pod-pvc", Namespace: testCtx.DefaultNamespace},
+			}
+			helper.pvcMap = map[string]*corev1.PersistentVolumeClaim{"source-pvc": tmpPVCForPod}
+			helper.volumes = []corev1.Volume{{
+				Name: "data",
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: tmpPVCForPod.Name},
+				},
+			}}
+			helper.volumeMounts = []corev1.VolumeMount{{Name: "data", MountPath: "/data"}}
+			helper.instance = opsv1alpha1.Instance{TargetNodeName: targetNodeName}
+			cli := fake.NewClientBuilder().WithScheme(fakeScheme).Build()
+			Expect(helper.createTmpPVCsAndPod(reqCtx, cli, opsRequest, "tmp-rebuild-pod")).Should(Succeed())
+			Expect(cli.Get(reqCtx.Ctx, client.ObjectKey{Name: tmpPVCForPod.Name, Namespace: tmpPVCForPod.Namespace}, &corev1.PersistentVolumeClaim{})).Should(Succeed())
+			createdPod := &corev1.Pod{}
+			Expect(cli.Get(reqCtx.Ctx, client.ObjectKey{Name: "tmp-rebuild-pod", Namespace: targetPod.Namespace}, createdPod)).Should(Succeed())
+			Expect(createdPod.Spec.RestartPolicy).Should(Equal(corev1.RestartPolicyNever))
+			Expect(createdPod.Spec.NodeSelector).Should(HaveKeyWithValue(corev1.LabelHostname, targetNodeName))
+
+			builtTmpPVC := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "tmp-pvc", Namespace: testCtx.DefaultNamespace}}
+			cli = fake.NewClientBuilder().WithScheme(fakeScheme).Build()
+			liveTmpPVC, err := helper.getLiveTmpPVCOrBuilt(reqCtx, cli, builtTmpPVC)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(liveTmpPVC).Should(Equal(builtTmpPVC))
+
+			existingTmpPVC := builtTmpPVC.DeepCopy()
+			existingTmpPVC.Labels = map[string]string{"live": "true"}
+			cli = fake.NewClientBuilder().WithScheme(fakeScheme).WithObjects(existingTmpPVC).Build()
+			liveTmpPVC, err = helper.getLiveTmpPVCOrBuilt(reqCtx, cli, builtTmpPVC)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(liveTmpPVC.Labels).Should(HaveKeyWithValue("live", "true"))
+			_, err = helper.getSourcePVC(reqCtx, cli, "missing", testCtx.DefaultNamespace)
+			Expect(apierrors.IsNotFound(err)).Should(BeTrue())
+
+			sourcePV := &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: "source-pv"},
+				Spec:       corev1.PersistentVolumeSpec{PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimDelete},
+			}
+			sourcePVC := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "source-pvc", Namespace: testCtx.DefaultNamespace, UID: types.UID("source-uid")},
+				Spec:       corev1.PersistentVolumeClaimSpec{VolumeName: sourcePV.Name},
+			}
+			restoredPV := &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: "restored-pv"},
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimDelete,
+					ClaimRef: &corev1.ObjectReference{
+						Name:      builtTmpPVC.Name,
+						Namespace: builtTmpPVC.Namespace,
+					},
+				},
+			}
+			cli = fake.NewClientBuilder().WithScheme(fakeScheme).WithObjects(sourcePV, sourcePVC, restoredPV, builtTmpPVC).Build()
+
+			foundPV, err := helper.getRestoredPV(reqCtx, cli, &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "tmp-by-volume", Namespace: testCtx.DefaultNamespace},
+				Spec:       corev1.PersistentVolumeClaimSpec{VolumeName: restoredPV.Name},
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(foundPV.Name).Should(Equal(restoredPV.Name))
+
+			Expect(helper.retainAndAnnotatePV(reqCtx, cli, opsRequest.Name, restoredPV, builtTmpPVC, sourcePVC)).Should(Succeed())
+			Expect(cli.Get(reqCtx.Ctx, client.ObjectKey{Name: restoredPV.Name}, restoredPV)).Should(Succeed())
+			Expect(restoredPV.Spec.PersistentVolumeReclaimPolicy).Should(Equal(corev1.PersistentVolumeReclaimRetain))
+			Expect(restoredPV.Labels).Should(HaveKeyWithValue(rebuildTmpPVCNameLabel, builtTmpPVC.Name))
+			Expect(restoredPV.Annotations).Should(HaveKeyWithValue(rebuildFromAnnotation, opsRequest.Name))
+			Expect(restoredPV.Annotations).Should(HaveKeyWithValue(sourcePVReclaimPolicyAnnotation, string(corev1.PersistentVolumeReclaimDelete)))
+
+			Expect(helper.preBindPVToSourcePVC(reqCtx, cli, restoredPV, builtTmpPVC, sourcePVC.Name, sourcePVC)).Should(Succeed())
+			Expect(cli.Get(reqCtx.Ctx, client.ObjectKey{Name: restoredPV.Name}, restoredPV)).Should(Succeed())
+			Expect(restoredPV.Spec.ClaimRef.Name).Should(Equal(sourcePVC.Name))
+			Expect(restoredPV.Spec.ClaimRef.UID).Should(BeEmpty())
+
+			activeOwner := &opsv1alpha1.OpsRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "other-rebuild", Namespace: testCtx.DefaultNamespace},
+				Status:     opsv1alpha1.OpsRequestStatus{Phase: opsv1alpha1.OpsRunningPhase},
+			}
+			activeSourcePV := &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "active-source-pv",
+					Annotations: map[string]string{rebuildFromAnnotation: activeOwner.Name},
+				},
+				Spec: corev1.PersistentVolumeSpec{
+					ClaimRef: &corev1.ObjectReference{Name: sourcePVC.Name, Namespace: sourcePVC.Namespace},
+				},
+			}
+			activeSourcePVC := sourcePVC.DeepCopy()
+			activeSourcePVC.Spec.VolumeName = activeSourcePV.Name
+			cli = fake.NewClientBuilder().WithScheme(fakeScheme).WithObjects(activeOwner, activeSourcePV, activeSourcePVC).Build()
+			err = helper.failIfSourcePVCBoundToOtherActiveRebuildPV(reqCtx, cli, opsRequest, activeSourcePVC, restoredPV)
+			Expect(err).Should(HaveOccurred())
+			Expect(intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal)).Should(BeTrue())
+
+			activeOwner.Status.Phase = opsv1alpha1.OpsSucceedPhase
+			cli = fake.NewClientBuilder().WithScheme(fakeScheme).WithObjects(activeOwner, activeSourcePV, activeSourcePVC).Build()
+			Expect(helper.failIfSourcePVCBoundToOtherActiveRebuildPV(reqCtx, cli, opsRequest, activeSourcePVC, restoredPV)).Should(Succeed())
+
+			activeSourcePV.Annotations = nil
+			cli = fake.NewClientBuilder().WithScheme(fakeScheme).WithObjects(activeSourcePV, activeSourcePVC).Build()
+			Expect(helper.failIfSourcePVCBoundToOtherActiveRebuildPV(reqCtx, cli, opsRequest, activeSourcePVC, restoredPV)).Should(Succeed())
+
+			restoredByLabel := &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{Name: "restored-by-label", Labels: map[string]string{rebuildTmpPVCNameLabel: builtTmpPVC.Name}},
+			}
+			cli = fake.NewClientBuilder().WithScheme(fakeScheme).WithObjects(restoredByLabel).Build()
+			foundPV, err = helper.getRestoredPV(reqCtx, cli, builtTmpPVC)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(foundPV.Name).Should(Equal(restoredByLabel.Name))
+
+			cli = fake.NewClientBuilder().WithScheme(fakeScheme).Build()
+			_, err = helper.getRestoredPV(reqCtx, cli, builtTmpPVC)
+			Expect(err).Should(HaveOccurred())
+			Expect(intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal)).Should(BeTrue())
 		})
 
 		sourcePVCsShouldRebindPVs := func(reqCtx intctrlutil.RequestCtx, opsRes *OpsResource, pvcList *corev1.PersistentVolumeClaimList) {

--- a/pkg/operations/restore_test.go
+++ b/pkg/operations/restore_test.go
@@ -84,6 +84,76 @@ var _ = Describe("Restore OpsRequest", func() {
 		Expect(cluster.OwnerReferences).Should(BeEmpty())
 	})
 
+	It("normalizes restored scheduling labels and clears sharding account secret refs", func() {
+		cluster := &appsv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{Name: restoreClusterName},
+			Spec: appsv1.ClusterSpec{
+				Shardings: []appsv1.ClusterSharding{{
+					Name: "shard",
+					Template: appsv1.ClusterComponentSpec{
+						SystemAccounts: []appsv1.ComponentSystemAccount{{
+							Name:      "root",
+							SecretRef: &appsv1.ProvisionSecretRef{Name: "old-secret"},
+						}},
+					},
+				}},
+			},
+		}
+		oldClusterName := "source-cluster"
+		schedulePolicy := &appsv1.SchedulingPolicy{
+			TopologySpreadConstraints: []corev1.TopologySpreadConstraint{{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{constant.AppInstanceLabelKey: oldClusterName},
+					MatchExpressions: []metav1.LabelSelectorRequirement{{
+						Key:      constant.AppInstanceLabelKey,
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{oldClusterName},
+					}},
+				},
+			}},
+			Affinity: &corev1.Affinity{
+				PodAffinity: &corev1.PodAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{constant.AppInstanceLabelKey: oldClusterName},
+						},
+					}},
+					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{
+						Weight: 1,
+						PodAffinityTerm: corev1.PodAffinityTerm{
+							LabelSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{{
+									Key:      constant.AppInstanceLabelKey,
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{oldClusterName},
+								}},
+							},
+						},
+					}},
+				},
+				PodAntiAffinity: &corev1.PodAntiAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{constant.AppInstanceLabelKey: oldClusterName},
+						},
+					}},
+				},
+			},
+		}
+
+		restoreHandler.normalizeSchedulePolicy(cluster, nil)
+		restoreHandler.normalizeSchedulePolicy(cluster, schedulePolicy)
+		Expect(schedulePolicy.TopologySpreadConstraints[0].LabelSelector.MatchLabels[constant.AppInstanceLabelKey]).Should(Equal(restoreClusterName))
+		Expect(schedulePolicy.TopologySpreadConstraints[0].LabelSelector.MatchExpressions[0].Values).Should(Equal([]string{restoreClusterName}))
+		Expect(schedulePolicy.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0].LabelSelector.MatchLabels[constant.AppInstanceLabelKey]).Should(Equal(restoreClusterName))
+		Expect(schedulePolicy.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0].PodAffinityTerm.LabelSelector.MatchExpressions[0].Values).Should(Equal([]string{restoreClusterName}))
+		Expect(schedulePolicy.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0].LabelSelector.MatchLabels[constant.AppInstanceLabelKey]).Should(Equal(restoreClusterName))
+
+		restoreHandler.rebuildShardAccountSecrets(&appsv1.Cluster{})
+		restoreHandler.rebuildShardAccountSecrets(cluster)
+		Expect(cluster.Spec.Shardings[0].Template.SystemAccounts[0].SecretRef).Should(BeNil())
+	})
+
 	It("re-enters when target Cluster already belongs to the same restore OpsRequest", func() {
 		opsRequest := createRestoreOpsObj(restoreClusterName, restoreOpsName, backupName)
 		opsRequest.Labels = nil


### PR DESCRIPTION
## Summary
- Add focused tests for pkg/operations custom action helpers, workflow status transitions, ops runtime accessors, backup/expose/restore helpers, timeout handling, and rebuild-in-place helper branches.
- No production behavior changes.

## Coverage
- Before: about 66.1% baseline for pkg/operations.
- After: 80.011% combined statement coverage (3018/3772) with coverprofile=<tmp-cover>.

## Tests
- GOFLAGS=-mod=mod GOCACHE=<go-build-cache> go test ./pkg/operations/custom -coverprofile=<tmp-cover>
- GOFLAGS=-mod=mod GOCACHE=<go-build-cache> KUBEBUILDER_ASSETS=<envtest-assets> go test ./pkg/operations -coverprofile=<tmp-cover>
- GOFLAGS=-mod=mod GOCACHE=<go-build-cache> KUBEBUILDER_ASSETS=<envtest-assets> go test ./pkg/operations/... -coverprofile=<tmp-cover>
