### PR TITLE
chore: improve pkg dataprotection coverage

### DIFF
--- a/pkg/dataprotection/action/action_stateful_test.go
+++ b/pkg/dataprotection/action/action_stateful_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package action
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	vsv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
+)
+
+func TestStatefulSetActionHelpers(t *testing.T) {
+	action := &StatefulSetAction{Name: "continuous"}
+
+	assert.Equal(t, "continuous", action.GetName())
+	assert.Equal(t, dpv1alpha1.ActionTypeStatefulSet, action.Type())
+	assert.Equal(t, "60s", action.getIntervalSeconds("@hourly"))
+	assert.Equal(t, "300s", action.getIntervalSeconds("*/5 * * * *"))
+	assert.Equal(t, "7200s", action.getIntervalSeconds("CRON_TZ=UTC 0 */2 * * *"))
+}
+
+func TestCreateVolumeSnapshotSmallHelpers(t *testing.T) {
+	pvc := corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "data-pvc"}}
+	wrapper := NewPersistentVolumeClaimWrapper(pvc, "data")
+	assert.Equal(t, "data", wrapper.VolumeName)
+	assert.Equal(t, "data-pvc", wrapper.PersistentVolumeClaim.Name)
+
+	message := "Failed to get snapshot class with error: missing default"
+	assert.True(t, isVolumeSnapshotConfigError(&vsv1.VolumeSnapshot{Status: &vsv1.VolumeSnapshotStatus{Error: &vsv1.VolumeSnapshotError{Message: &message}}}))
+	other := "transient api error"
+	assert.False(t, isVolumeSnapshotConfigError(&vsv1.VolumeSnapshot{Status: &vsv1.VolumeSnapshotStatus{Error: &vsv1.VolumeSnapshotError{Message: &other}}}))
+	assert.False(t, isVolumeSnapshotConfigError(&vsv1.VolumeSnapshot{}))
+}
+
+func TestStatusBuilderFluentFields(t *testing.T) {
+	start := metav1.NewTime(time.Now())
+	end := metav1.NewTime(start.Add(time.Hour))
+	status := newStatusBuilder(&StatefulSetAction{Name: "continuous"}).
+		phase(dpv1alpha1.ActionPhaseCompleted).
+		reason("done").
+		startTimestamp(&start).
+		completionTimestamp(&end).
+		totalSize("10Gi").
+		timeRange(&start, &end).
+		volumeSnapshots([]dpv1alpha1.VolumeSnapshotStatus{{Name: "snap", VolumeName: "data"}}).
+		objectRef(&corev1.ObjectReference{Name: "sts"}).
+		build()
+
+	assert.Equal(t, dpv1alpha1.ActionPhaseCompleted, status.Phase)
+	assert.Equal(t, "done", status.FailureReason)
+	assert.Equal(t, "10Gi", status.TotalSize)
+	assert.Equal(t, "snap", status.VolumeSnapshots[0].Name)
+	assert.Equal(t, "sts", status.ObjectRef.Name)
+	assert.Equal(t, start, *status.TimeRange.Start)
+
+	status = newStatusBuilder(&StatefulSetAction{Name: "continuous"}).withErr(errors.New("failed")).build()
+	assert.Equal(t, dpv1alpha1.ActionPhaseFailed, status.Phase)
+	assert.Equal(t, "failed", status.FailureReason)
+}
+
+func TestStatefulSetActionExecuteCreatesAndUpdates(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, corev1.AddToScheme(scheme))
+	assert.NoError(t, appsv1.AddToScheme(scheme))
+	assert.NoError(t, dpv1alpha1.AddToScheme(scheme))
+
+	backup := &dpv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "backup",
+			Namespace: "ns",
+			Labels: map[string]string{
+				dptypes.BackupScheduleLabelKey: "schedule",
+			},
+		},
+		Spec: dpv1alpha1.BackupSpec{BackupMethod: "continuous", RetentionPeriod: "2h"},
+	}
+	schedule := &dpv1alpha1.BackupSchedule{
+		ObjectMeta: metav1.ObjectMeta{Name: "schedule", Namespace: "ns"},
+		Spec:       dpv1alpha1.BackupScheduleSpec{Schedules: []dpv1alpha1.SchedulePolicy{{BackupMethod: "continuous", CronExpression: "*/10 * * * *"}}},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(backup, schedule).Build()
+	action := &StatefulSetAction{
+		Name:       "continuous",
+		Backup:     backup,
+		ObjectMeta: metav1.ObjectMeta{Name: "backup-sts", Namespace: "ns", Labels: map[string]string{"app": "backup"}},
+		Replicas:   pointer.Int32(1),
+		PodSpec:    &corev1.PodSpec{Containers: []corev1.Container{{Name: "manager", Image: "busybox"}}},
+	}
+
+	status, err := action.Execute(ActionContext{Ctx: context.Background(), Client: cli, Scheme: scheme})
+	assert.NoError(t, err)
+	assert.Equal(t, dpv1alpha1.ActionPhaseRunning, status.Phase)
+
+	sts := &appsv1.StatefulSet{}
+	assert.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: "backup-sts", Namespace: "ns"}, sts))
+	assert.Equal(t, corev1.RestartPolicyAlways, sts.Spec.Template.Spec.RestartPolicy)
+	env := sts.Spec.Template.Spec.Containers[0].Env
+	assert.Contains(t, env, corev1.EnvVar{Name: dptypes.DPArchiveInterval, Value: "600s"})
+	assert.Contains(t, env, corev1.EnvVar{Name: dptypes.DPContinuousTTLSeconds, Value: "7200"})
+
+	sts.Status.AvailableReplicas = 1
+	assert.NoError(t, cli.Status().Update(context.Background(), sts))
+	status, err = action.Execute(ActionContext{Ctx: context.Background(), Client: cli, Scheme: scheme})
+	assert.NoError(t, err)
+	assert.Equal(t, dpv1alpha1.ActionPhaseRunning, status.Phase)
+	assert.Equal(t, int32(1), *status.AvailableReplicas)
+	assert.Equal(t, dpv1alpha1.BackupPhaseRunning, backup.Status.Phase)
+}

--- a/pkg/dataprotection/backup/deleter_test.go
+++ b/pkg/dataprotection/backup/deleter_test.go
@@ -20,21 +20,71 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package backup
 
 import (
+	"context"
+	"testing"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/stretchr/testify/assert"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	ctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 	"github.com/apecloud/kubeblocks/pkg/generics"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
 	testdp "github.com/apecloud/kubeblocks/pkg/testutil/dataprotection"
 	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
+
+func TestDeleterDoPreDeleteActionCreatesAndReusesJob(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, corev1.AddToScheme(scheme))
+	assert.NoError(t, batchv1.AddToScheme(scheme))
+	assert.NoError(t, dpv1alpha1.AddToScheme(scheme))
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	backup := &dpv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: "backup", Namespace: "ns", UID: types.UID("backup-uid")},
+		Status:     dpv1alpha1.BackupStatus{BackupMethod: &dpv1alpha1.BackupMethod{Env: []corev1.EnvVar{{Name: "IMAGE_TAG", Value: "1.0"}}}},
+	}
+	repo := &dpv1alpha1.BackupRepo{Spec: dpv1alpha1.BackupRepoSpec{}, Status: dpv1alpha1.BackupRepoStatus{BackupPVCName: "repo-pvc"}}
+	deleter := &Deleter{
+		RequestCtx:           ctrlutil.RequestCtx{Ctx: context.Background()},
+		Client:               cli,
+		Scheme:               scheme,
+		WorkerServiceAccount: "worker",
+		actionSet:            &dpv1alpha1.ActionSet{Spec: dpv1alpha1.ActionSetSpec{Env: []corev1.EnvVar{{Name: "ACTION_ENV", Value: "set"}}}},
+	}
+
+	job, err := deleter.doPreDeleteAction(backup, repo, &dpv1alpha1.BaseJobActionSpec{Image: "deleter:$(IMAGE_TAG)", Command: []string{"delete"}}, "", "/backup/path")
+	assert.NoError(t, err)
+	assert.Empty(t, job.Name)
+
+	got := &batchv1.Job{}
+	assert.NoError(t, cli.Get(context.Background(), BuildDeleteBackupFilesJobKey(backup, true), got))
+	assert.Contains(t, got.Spec.Template.Spec.Containers[0].Image, "deleter:1.0")
+	assert.Equal(t, "worker", got.Spec.Template.Spec.ServiceAccountName)
+	envMap := map[string]string{}
+	for _, env := range got.Spec.Template.Spec.Containers[0].Env {
+		envMap[env.Name] = env.Value
+	}
+	assert.Equal(t, "/backup/path", envMap[dptypes.DPBackupBasePath])
+	assert.Equal(t, "set", envMap["ACTION_ENV"])
+
+	job, err = deleter.doPreDeleteAction(backup, repo, &dpv1alpha1.BaseJobActionSpec{Image: "deleter:$(IMAGE_TAG)", Command: []string{"delete"}}, "", "/backup/path")
+	assert.NoError(t, err)
+	assert.Equal(t, got.Name, job.Name)
+}
 
 var _ = Describe("Backup Deleter Test", func() {
 	const (

--- a/pkg/dataprotection/backup/request_test.go
+++ b/pkg/dataprotection/backup/request_test.go
@@ -20,20 +20,146 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package backup
 
 import (
+	"context"
+	"testing"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	ctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	"github.com/apecloud/kubeblocks/pkg/dataprotection/action"
+	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 	"github.com/apecloud/kubeblocks/pkg/dataprotection/utils/boolptr"
 	"github.com/apecloud/kubeblocks/pkg/generics"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
 	testdp "github.com/apecloud/kubeblocks/pkg/testutil/dataprotection"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
+
+func newRequestTestFixture(t *testing.T) (*Request, *corev1.Pod) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, corev1.AddToScheme(scheme))
+	assert.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Namespace: "ns", Labels: map[string]string{constant.RoleLabelKey: "leader"}},
+		Spec: corev1.PodSpec{
+			NodeName: "node-0",
+			Containers: []corev1.Container{{
+				Name:  "db",
+				Env:   []corev1.EnvVar{{Name: "EXISTING", Value: "old"}},
+				Ports: []corev1.ContainerPort{{Name: "mysql", ContainerPort: 3306}},
+			}},
+			Volumes: []corev1.Volume{{Name: "data", VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "data-pvc"}}}},
+		},
+	}
+	req := &Request{
+		RequestCtx: ctrlutil.RequestCtx{Ctx: context.Background(), Req: ctrl.Request{}},
+		Client:     fake.NewClientBuilder().WithScheme(scheme).Build(),
+		Backup: &dpv1alpha1.Backup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "backup", Namespace: "ns", UID: types.UID("1234567890abcdef"),
+				Labels: map[string]string{dptypes.ClusterUIDLabelKey: "uid", constant.AppInstanceLabelKey: "cluster", constant.KBAppComponentLabelKey: "mysql"},
+			},
+			Spec: dpv1alpha1.BackupSpec{RetentionPeriod: "7d"},
+		},
+		BackupPolicy: &dpv1alpha1.BackupPolicy{Spec: dpv1alpha1.BackupPolicySpec{BackoffLimit: func() *int32 { v := int32(1); return &v }(), PathPrefix: "policy-path"}},
+		BackupRepo:   &dpv1alpha1.BackupRepo{Spec: dpv1alpha1.BackupRepoSpec{PathPrefix: "repo-path"}, Status: dpv1alpha1.BackupRepoStatus{BackupPVCName: "repo-pvc"}},
+		BackupMethod: &dpv1alpha1.BackupMethod{Env: []corev1.EnvVar{{Name: "EXISTING", Value: "method"}}},
+		Target: &dpv1alpha1.BackupTarget{
+			Name:        "target",
+			PodSelector: &dpv1alpha1.PodSelector{Strategy: dpv1alpha1.PodSelectionStrategyAll},
+		},
+		TargetPods:           []*corev1.Pod{pod},
+		WorkerServiceAccount: "worker",
+	}
+	return req, pod
+}
+
+func TestRequestGetBackupType(t *testing.T) {
+	req, _ := newRequestTestFixture(t)
+	assert.Empty(t, req.GetBackupType())
+
+	req.BackupMethod.SnapshotVolumes = func() *bool { v := true; return &v }()
+	assert.Equal(t, string(dpv1alpha1.BackupTypeFull), req.GetBackupType())
+
+	req.ActionSet = &dpv1alpha1.ActionSet{Spec: dpv1alpha1.ActionSetSpec{BackupType: dpv1alpha1.BackupTypeIncremental}}
+	assert.Equal(t, string(dpv1alpha1.BackupTypeIncremental), req.GetBackupType())
+}
+
+func TestRequestBuildActionBranches(t *testing.T) {
+	oldNamespace := viper.GetString(constant.CfgKeyCtrlrMgrNS)
+	oldServiceAccount := viper.GetString(dptypes.CfgKeyExecWorkerServiceAccountName)
+	defer func() {
+		viper.Set(constant.CfgKeyCtrlrMgrNS, oldNamespace)
+		viper.Set(dptypes.CfgKeyExecWorkerServiceAccountName, oldServiceAccount)
+	}()
+	viper.Set(constant.CfgKeyCtrlrMgrNS, "kb-system")
+	viper.Set(dptypes.CfgKeyExecWorkerServiceAccountName, "exec-worker")
+
+	req, pod := newRequestTestFixture(t)
+	_, err := req.buildAction(pod, "invalid", &dpv1alpha1.ActionSpec{})
+	assert.Error(t, err)
+	_, err = req.buildAction(pod, "invalid", &dpv1alpha1.ActionSpec{Exec: &dpv1alpha1.ExecActionSpec{}, Job: &dpv1alpha1.JobActionSpec{}})
+	assert.Error(t, err)
+
+	execAction, err := req.buildAction(pod, "exec", &dpv1alpha1.ActionSpec{Exec: &dpv1alpha1.ExecActionSpec{Command: []string{"echo", "ok"}}})
+	assert.NoError(t, err)
+	assert.IsType(t, &action.ExecAction{}, execAction)
+	assert.Equal(t, "exec", execAction.GetName())
+
+	jobAction, err := req.buildAction(pod, "job", &dpv1alpha1.ActionSpec{Job: &dpv1alpha1.JobActionSpec{BaseJobActionSpec: dpv1alpha1.BaseJobActionSpec{Image: "busybox:$(EXISTING)", Command: []string{"backup"}}}})
+	assert.NoError(t, err)
+	assert.IsType(t, &action.JobAction{}, jobAction)
+	assert.Equal(t, dpv1alpha1.ActionTypeJob, jobAction.Type())
+}
+
+func TestRequestBuildBackupDataActions(t *testing.T) {
+	req, pod := newRequestTestFixture(t)
+	req.ActionSet = &dpv1alpha1.ActionSet{Spec: dpv1alpha1.ActionSetSpec{BackupType: dpv1alpha1.BackupTypeFull, Backup: &dpv1alpha1.BackupActionSpec{BackupData: &dpv1alpha1.BackupDataActionSpec{JobActionSpec: dpv1alpha1.JobActionSpec{BaseJobActionSpec: dpv1alpha1.BaseJobActionSpec{Image: "busybox"}}}}}}
+	backupDataAction, err := req.buildBackupDataAction(pod, "backup-data")
+	assert.NoError(t, err)
+	assert.IsType(t, &action.JobAction{}, backupDataAction)
+
+	req.ActionSet.Spec.BackupType = dpv1alpha1.BackupTypeContinuous
+	backupDataAction, err = req.buildBackupDataAction(pod, "continuous")
+	assert.NoError(t, err)
+	assert.IsType(t, &action.StatefulSetAction{}, backupDataAction)
+	assert.Contains(t, req.buildContinuousSyncProgressCommand(), "retryTimes")
+
+	req.ActionSet.Spec.BackupType = dpv1alpha1.BackupType("Unknown")
+	_, err = req.buildBackupDataAction(pod, "unsupported")
+	assert.Error(t, err)
+}
+
+func TestRequestBuildActionsIncludesPreAndPostHooks(t *testing.T) {
+	req, pod := newRequestTestFixture(t)
+	req.ActionSet = &dpv1alpha1.ActionSet{Spec: dpv1alpha1.ActionSetSpec{
+		BackupType: dpv1alpha1.BackupTypeFull,
+		Backup: &dpv1alpha1.BackupActionSpec{
+			PreBackup:  []dpv1alpha1.ActionSpec{{Exec: &dpv1alpha1.ExecActionSpec{Command: []string{"pre"}}}},
+			BackupData: &dpv1alpha1.BackupDataActionSpec{JobActionSpec: dpv1alpha1.JobActionSpec{BaseJobActionSpec: dpv1alpha1.BaseJobActionSpec{Image: "busybox", Command: []string{"backup"}}}},
+			PostBackup: []dpv1alpha1.ActionSpec{{Job: &dpv1alpha1.JobActionSpec{BaseJobActionSpec: dpv1alpha1.BaseJobActionSpec{Image: "busybox", Command: []string{"post"}}}}},
+		},
+	}}
+
+	actions, err := req.BuildActions()
+	assert.NoError(t, err)
+	assert.Len(t, actions[pod.Name], 3)
+	assert.Equal(t, dpv1alpha1.ActionTypeJob, actions[pod.Name][0].Type())
+	assert.Equal(t, dpv1alpha1.ActionTypeJob, actions[pod.Name][1].Type())
+	assert.Equal(t, dpv1alpha1.ActionTypeJob, actions[pod.Name][2].Type())
+}
 
 var _ = Describe("Request Test", func() {
 	buildRequest := func() *Request {

--- a/pkg/dataprotection/backup/scheduler_test.go
+++ b/pkg/dataprotection/backup/scheduler_test.go
@@ -20,22 +20,210 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package backup
 
 import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/stretchr/testify/assert"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	opsv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	ctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 	"github.com/apecloud/kubeblocks/pkg/generics"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
 	testdp "github.com/apecloud/kubeblocks/pkg/testutil/dataprotection"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
+
+func newSchedulerTestScheme(t *testing.T) *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, corev1.AddToScheme(scheme))
+	assert.NoError(t, batchv1.AddToScheme(scheme))
+	assert.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	assert.NoError(t, opsv1alpha1.AddToScheme(scheme))
+	return scheme
+}
+
+func newSchedulerForTest(t *testing.T, objs ...client.Object) *Scheduler {
+	scheme := newSchedulerTestScheme(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	schedule := &dpv1alpha1.BackupSchedule{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "schedule",
+			Namespace: "ns",
+			UID:       types.UID("schedule-uid"),
+			Labels:    map[string]string{"custom": "label"},
+		},
+		Spec: dpv1alpha1.BackupScheduleSpec{BackupPolicyName: "policy"},
+	}
+	policy := &dpv1alpha1.BackupPolicy{
+		ObjectMeta: v1.ObjectMeta{Name: "policy", Namespace: "ns"},
+		Spec: dpv1alpha1.BackupPolicySpec{
+			BackoffLimit: pointer.Int32(2),
+			Target: &dpv1alpha1.BackupTarget{PodSelector: &dpv1alpha1.PodSelector{LabelSelector: &v1.LabelSelector{MatchLabels: map[string]string{
+				constant.AppInstanceLabelKey: "cluster",
+			}}}},
+			BackupMethods: []dpv1alpha1.BackupMethod{{Name: "full", ActionSetName: "full-action"}, {Name: "incremental", ActionSetName: "incremental-action", CompatibleMethod: "full"}},
+		},
+	}
+	return &Scheduler{
+		RequestCtx:           ctrlutil.RequestCtx{Ctx: context.Background(), Req: ctrl.Request{NamespacedName: client.ObjectKey{Namespace: "ns", Name: "schedule"}}},
+		Client:               cli,
+		Scheme:               scheme,
+		BackupSchedule:       schedule,
+		BackupPolicy:         policy,
+		WorkerServiceAccount: "worker",
+	}
+}
+
+func TestSchedulerBuildCronJobAndPodSpec(t *testing.T) {
+	oldToolsImage := viper.GetString(constant.KBToolsImage)
+	defer viper.Set(constant.KBToolsImage, oldToolsImage)
+	viper.Set(constant.KBToolsImage, "tools:test")
+
+	fullActionSet := &dpv1alpha1.ActionSet{ObjectMeta: v1.ObjectMeta{Name: "full-action"}, Spec: dpv1alpha1.ActionSetSpec{BackupType: dpv1alpha1.BackupTypeFull}}
+	incrementalActionSet := &dpv1alpha1.ActionSet{ObjectMeta: v1.ObjectMeta{Name: "incremental-action"}, Spec: dpv1alpha1.ActionSetSpec{BackupType: dpv1alpha1.BackupTypeIncremental}}
+	s := newSchedulerForTest(t, fullActionSet, incrementalActionSet)
+	sp := &dpv1alpha1.SchedulePolicy{
+		Name: "daily", BackupMethod: "incremental", Enabled: pointer.Bool(true),
+		CronExpression: "0 1 * * *", RetentionPeriod: "7d",
+		Parameters: []dpv1alpha1.ParameterPair{{Name: "p", Value: "v"}},
+	}
+	s.BackupSchedule.Spec.Schedules = []dpv1alpha1.SchedulePolicy{*sp}
+
+	assert.Equal(t, "cluster-daily-$(date -u +'%Y%m%d%H%M%S')", s.generateBackupName(sp))
+
+	checkCommand, err := s.buildCheckCommand(sp)
+	assert.NoError(t, err)
+	assert.Contains(t, checkCommand, "No completed full backups found")
+	assert.Contains(t, checkCommand, "spec.backupMethod==\"full\"")
+
+	podSpec, err := s.buildPodSpec(sp)
+	assert.NoError(t, err)
+	assert.Equal(t, "worker", podSpec.ServiceAccountName)
+	assert.Equal(t, corev1.RestartPolicyNever, podSpec.RestartPolicy)
+	assert.Equal(t, "tools:test", podSpec.Containers[0].Image)
+	assert.Contains(t, podSpec.Containers[0].Args[0], "parameters:")
+	assert.Contains(t, podSpec.Containers[0].Args[0], "backupMethod: incremental")
+
+	cronJob, err := s.buildCronJob(sp, "")
+	assert.NoError(t, err)
+	assert.Equal(t, GenerateCRNameByScheduleNameAndMethod(s.BackupSchedule, sp.BackupMethod, sp.Name), cronJob.Name)
+	assert.Equal(t, batchv1.ForbidConcurrent, cronJob.Spec.ConcurrencyPolicy)
+	assert.Equal(t, "label", cronJob.Labels["custom"])
+	assert.Equal(t, dptypes.AppName, cronJob.Labels[constant.AppManagedByLabelKey])
+	assert.Contains(t, cronJob.Finalizers, dptypes.DataProtectionFinalizerName)
+}
+
+func TestSchedulerReconcileCronJobCreatesPatchesAndDeletes(t *testing.T) {
+	fullActionSet := &dpv1alpha1.ActionSet{ObjectMeta: v1.ObjectMeta{Name: "full-action"}, Spec: dpv1alpha1.ActionSetSpec{BackupType: dpv1alpha1.BackupTypeFull}}
+	s := newSchedulerForTest(t, fullActionSet)
+	sp := &dpv1alpha1.SchedulePolicy{Name: "daily", BackupMethod: "full", Enabled: pointer.Bool(true), CronExpression: "0 1 * * *", RetentionPeriod: "7d"}
+	s.BackupSchedule.Spec.Schedules = []dpv1alpha1.SchedulePolicy{*sp}
+	deadline := int64(5)
+	s.BackupSchedule.Spec.StartingDeadlineMinutes = &deadline
+
+	assert.NoError(t, s.reconcileCronJob(sp))
+	cronJobName := GenerateCRNameByScheduleNameAndMethod(s.BackupSchedule, sp.BackupMethod, sp.Name)
+	cronJob := &batchv1.CronJob{}
+	assert.NoError(t, s.Client.Get(context.Background(), client.ObjectKey{Name: cronJobName, Namespace: "ns"}, cronJob))
+	assert.Equal(t, int64(300), *cronJob.Spec.StartingDeadlineSeconds)
+
+	sp.CronExpression = "0 2 * * *"
+	assert.NoError(t, s.reconcileCronJob(sp))
+	assert.NoError(t, s.Client.Get(context.Background(), client.ObjectKey{Name: cronJobName, Namespace: "ns"}, cronJob))
+	assert.True(t, strings.Contains(cronJob.Spec.Schedule, "0 2 * * *"))
+
+	sp.Enabled = pointer.Bool(false)
+	assert.NoError(t, s.reconcileCronJob(sp))
+	err := s.Client.Get(context.Background(), client.ObjectKey{Name: cronJobName, Namespace: "ns"}, cronJob)
+	assert.True(t, client.IgnoreNotFound(err) == nil)
+}
+
+func TestSchedulerConfigAnnotationHelpers(t *testing.T) {
+	s := newSchedulerForTest(t)
+	s.BackupSchedule.Annotations = map[string]string{
+		constant.LastAppliedConfigAnnotationKey: `{"old":"config"}`,
+		dptypes.ReConfigureGenerationKey:        "2",
+	}
+
+	s.convertLastAppliedConfigs("continuous")
+	assert.Contains(t, s.BackupSchedule.Annotations, dptypes.LastAppliedConfigsAnnotationKey)
+	configs, err := s.getLastAppliedConfigsMap()
+	assert.NoError(t, err)
+	assert.Equal(t, `{"old":"config"}`, configs["continuous"])
+
+	generation, err := s.getReconfigureGenerationKey()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, generation)
+
+	s.BackupSchedule.Annotations[dptypes.ReConfigureGenerationKey] = "bad"
+	_, err = s.getReconfigureGenerationKey()
+	assert.Error(t, err)
+
+	s.BackupSchedule.Annotations[dptypes.LastAppliedConfigsAnnotationKey] = "{bad"
+	_, err = s.getLastAppliedConfigsMap()
+	assert.Error(t, err)
+}
+
+func TestSchedulerReconfigureEarlyReturns(t *testing.T) {
+	s := newSchedulerForTest(t)
+	sp := &dpv1alpha1.SchedulePolicy{BackupMethod: "full", Enabled: pointer.Bool(false)}
+	assert.NoError(t, s.reconfigure(sp))
+
+	value := "v"
+	refBytes, err := json.Marshal(backupReconfigureRef{Disable: parameterPairs{"full": []opsv1alpha1.ParameterPair{{Key: "p", Value: &value}}}})
+	assert.NoError(t, err)
+	s.BackupSchedule.Annotations = map[string]string{dptypes.ReconfigureRefAnnotationKey: string(refBytes)}
+	assert.NoError(t, s.reconfigure(sp))
+
+	sp.Enabled = pointer.Bool(true)
+	s.BackupSchedule.Annotations[dptypes.LastAppliedConfigsAnnotationKey] = `{"full":"[{\"name\":\"p\",\"value\":\"v\"}]"}`
+	assert.NoError(t, s.reconfigure(sp))
+}
+
+func TestSchedulerReconcileReconfigureOpsStates(t *testing.T) {
+	failedOps := &opsv1alpha1.OpsRequest{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "failed", Namespace: "ns",
+			CreationTimestamp: v1.Now(),
+			Labels:            map[string]string{dptypes.BackupScheduleLabelKey: "schedule"},
+		},
+		Status: opsv1alpha1.OpsRequestStatus{Phase: opsv1alpha1.OpsFailedPhase},
+	}
+	s := newSchedulerForTest(t, failedOps)
+	err := s.reconcileReconfigure(s.BackupSchedule)
+	assert.Error(t, err)
+
+	runningOps := failedOps.DeepCopy()
+	runningOps.Name = "running"
+	runningOps.Status.Phase = opsv1alpha1.OpsRunningPhase
+	s = newSchedulerForTest(t, runningOps)
+	err = s.reconcileReconfigure(s.BackupSchedule)
+	assert.Error(t, err)
+
+	succeedOps := failedOps.DeepCopy()
+	succeedOps.Name = "succeed"
+	succeedOps.Status.Phase = opsv1alpha1.OpsSucceedPhase
+	s = newSchedulerForTest(t, succeedOps)
+	assert.NoError(t, s.reconcileReconfigure(s.BackupSchedule))
+}
 
 var _ = Describe("Scheduler Test", func() {
 	buildScheduler := func() *Scheduler {

--- a/pkg/dataprotection/backup/utils_test.go
+++ b/pkg/dataprotection/backup/utils_test.go
@@ -20,13 +20,19 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package backup
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
@@ -229,4 +235,121 @@ func TestSetExpirationTime(t *testing.T) {
 			tt.verify(t, tt.backup)
 		})
 	}
+}
+
+func TestBackupNameAndPathHelpers(t *testing.T) {
+	backup := &dpv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "backup-name",
+			Namespace: "ns",
+			UID:       types.UID("1234567890abcdef"),
+			Labels: map[string]string{
+				constant.KBAppComponentLabelKey: "excluded",
+				"keep":                          "value",
+			},
+		},
+	}
+	target := &dpv1alpha1.BackupTarget{Name: "target", PodSelector: &dpv1alpha1.PodSelector{Strategy: dpv1alpha1.PodSelectionStrategyAll}}
+
+	labels := BuildBackupWorkloadLabels(backup)
+	assert.Equal(t, "value", labels["keep"])
+	assert.NotContains(t, labels, constant.KBAppComponentLabelKey)
+	assert.Equal(t, backup.Name, labels[dptypes.BackupNameLabelKey])
+
+	assert.Equal(t, "dp-backup-backup-name-12345678", GenerateBackupJobName(backup, "dp-backup"))
+	longName := GenerateBackupJobName(&dpv1alpha1.Backup{ObjectMeta: metav1.ObjectMeta{Name: "very-long-backup-name-that-should-be-trimmed-for-job-label-limits", UID: types.UID("1234567890abcdef")}}, "prefix")
+	assert.LessOrEqual(t, len(longName), 63)
+	assert.False(t, longName[len(longName)-1:] == "-")
+
+	assert.Equal(t, "dp-target-backup-name", GenerateBackupStatefulSetName(backup, "target", "dp"))
+	assert.Equal(t, "backup-name", GenerateBackupStatefulSetName(backup, "", "dp"))
+	assert.Equal(t, "/repo/ns/path/backup-name", BuildBaseBackupPath(backup, "/repo/", "/path/"))
+	assert.Equal(t, "/repo/ns/path/backup-name/target/pod-0", BuildBackupPathByTarget(backup, target, "/repo/", "/path/", "pod-0"))
+	assert.Equal(t, "target/pod-0", BuildTargetRelativePath(target, "pod-0"))
+	assert.Equal(t, "/repo/ns/path/kopia", BuildKopiaRepoPath(backup, "/repo/", "/path/"))
+}
+
+func TestBackupScheduleNameHelpers(t *testing.T) {
+	schedule := &dpv1alpha1.BackupSchedule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "schedule",
+			Namespace: "namespace",
+			UID:       types.UID("schedule-uid"),
+			OwnerReferences: []metav1.OwnerReference{{
+				UID: types.UID("owneruid-123456"),
+			}},
+		},
+		Spec: dpv1alpha1.BackupScheduleSpec{Schedules: []dpv1alpha1.SchedulePolicy{{Name: "daily", BackupMethod: "full"}, {BackupMethod: "log"}}},
+	}
+	assert.Equal(t, "owneruid-schedule-namespace-full", GenerateCRNameByBackupSchedule(schedule, "full"))
+	assert.Equal(t, "owneruid-schedule-namespace-cron", GenerateCRNameByScheduleNameAndMethod(schedule, "full", "cron"))
+	assert.Equal(t, "owneruid-schedule-namespace-full", GenerateCRNameByScheduleNameAndMethod(schedule, "full", ""))
+	assert.Equal(t, "schedule-schedule-namespace-full", GenerateLegacyCRNameByBackupSchedule(schedule, "full"))
+	assert.Equal(t, "daily", GetSchedulePolicyByMethod(schedule, "full").Name)
+	assert.Nil(t, GetSchedulePolicyByMethod(schedule, "missing"))
+}
+
+func TestBackupVolumeHelpers(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "ns"},
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{
+				{Name: "data", VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "data-pvc"}}},
+				{Name: "config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{}}},
+			},
+		},
+	}
+	info := &dpv1alpha1.TargetVolumeInfo{Volumes: []string{"data", "missing"}}
+	assert.Equal(t, []corev1.Volume{pod.Spec.Volumes[0]}, getVolumesByVolumeInfo(pod, info))
+	assert.Nil(t, getVolumesByVolumeInfo(pod, nil))
+
+	mountInfo := &dpv1alpha1.TargetVolumeInfo{VolumeMounts: []corev1.VolumeMount{{Name: "config", MountPath: "/cfg"}, {Name: "missing", MountPath: "/missing"}}}
+	assert.Equal(t, []corev1.Volume{pod.Spec.Volumes[1]}, getVolumesByVolumeInfo(pod, mountInfo))
+	assert.Equal(t, []corev1.VolumeMount{{Name: "config", MountPath: "/cfg"}}, getVolumeMountsByVolumeInfo(pod, mountInfo))
+	assert.Nil(t, getVolumeMountsByVolumeInfo(pod, nil))
+
+	scheme := runtime.NewScheme()
+	assert.NoError(t, corev1.AddToScheme(scheme))
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "data-pvc", Namespace: "ns"}}).Build()
+	pvcs, err := getPVCsByVolumeNames(cli, pod, []string{"data"})
+	assert.NoError(t, err)
+	assert.Len(t, pvcs, 1)
+	assert.Equal(t, "data", pvcs[0].VolumeName)
+	_, err = getPVCsByVolumeNames(cli, pod, []string{"missing-pvc"})
+	assert.NoError(t, err)
+}
+
+func TestStopStatefulSetsWhenFailed(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, appsv1.AddToScheme(scheme))
+	assert.NoError(t, dpv1alpha1.AddToScheme(scheme))
+
+	backup := &dpv1alpha1.Backup{ObjectMeta: metav1.ObjectMeta{Name: "backup", Namespace: "ns"}, Status: dpv1alpha1.BackupStatus{Phase: dpv1alpha1.BackupPhaseFailed}}
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: GenerateBackupStatefulSetName(backup, "target", BackupDataJobNamePrefix), Namespace: "ns"},
+		Spec:       appsv1.StatefulSetSpec{Replicas: pointer.Int32(1)},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sts).Build()
+	assert.NoError(t, StopStatefulSetsWhenFailed(context.Background(), cli, backup, "target"))
+
+	got := &appsv1.StatefulSet{}
+	assert.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: sts.Name, Namespace: sts.Namespace}, got))
+	assert.Equal(t, int32(0), *got.Spec.Replicas)
+
+	backup.Status.Phase = dpv1alpha1.BackupPhaseCompleted
+	got.Spec.Replicas = pointer.Int32(2)
+	assert.NoError(t, cli.Update(context.Background(), got))
+	assert.NoError(t, StopStatefulSetsWhenFailed(context.Background(), cli, backup, "target"))
+	assert.NoError(t, cli.Get(context.Background(), types.NamespacedName{Name: sts.Name, Namespace: sts.Namespace}, got))
+	assert.Equal(t, int32(2), *got.Spec.Replicas)
+}
+
+func TestBuildParametersManifest(t *testing.T) {
+	manifest, err := BuildParametersManifest(nil)
+	assert.NoError(t, err)
+	assert.Empty(t, manifest)
+
+	manifest, err = BuildParametersManifest([]dpv1alpha1.ParameterPair{{Name: "p", Value: "v"}})
+	assert.NoError(t, err)
+	assert.JSONEq(t, `[{"name":"p","value":"v"}]`, manifest[len("\n  parameters: "):])
 }

--- a/pkg/dataprotection/errors/errors_test.go
+++ b/pkg/dataprotection/errors/errors_test.go
@@ -77,6 +77,18 @@ func TestNewErrors(t *testing.T) {
 	if !intctrlutil.IsTargetError(jobFailed, ErrorTypeBackupJobFailed) {
 		t.Error("should be error of BackupJobFailed")
 	}
+	invalidLogfileName := NewInvalidLogfileBackupName("policy")
+	if !intctrlutil.IsTargetError(invalidLogfileName, ErrorTypeInvalidLogfileBackupName) {
+		t.Error("should be error of InvalidLogfileBackupName")
+	}
+	scheduleDisabled := NewBackupScheduleDisabled("logfile", "policy")
+	if !intctrlutil.IsTargetError(scheduleDisabled, ErrorTypeBackupScheduleDisabled) {
+		t.Error("should be error of BackupScheduleDisabled")
+	}
+	logfileScheduleDisabled := NewBackupLogfileScheduleDisabled("tool")
+	if !intctrlutil.IsTargetError(logfileScheduleDisabled, ErrorTypeLogfileScheduleDisabled) {
+		t.Error("should be error of LogfileScheduleDisabled")
+	}
 }
 
 func TestUnwrapControllerError(t *testing.T) {

--- a/pkg/dataprotection/restore/utils_test.go
+++ b/pkg/dataprotection/restore/utils_test.go
@@ -20,13 +20,22 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package restore
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 )
 
@@ -75,4 +84,264 @@ func TestBuildPVCVolumeAndMountShortensDerivedVolumeName(t *testing.T) {
 	if volume.VolumeSource.PersistentVolumeClaim == nil || volume.VolumeSource.PersistentVolumeClaim.ClaimName != wantSource.PersistentVolumeClaim.ClaimName {
 		t.Fatalf("volume claim name = %q, want %q", volume.VolumeSource.PersistentVolumeClaim.ClaimName, claimName)
 	}
+}
+
+func TestRestoreBuilderCommonVolumesAndSourceMountPath(t *testing.T) {
+	builder := &restoreJobBuilder{
+		backupSet: BackupActionSet{Backup: &dpv1alpha1.Backup{Status: dpv1alpha1.BackupStatus{BackupMethod: &dpv1alpha1.BackupMethod{TargetVolumes: &dpv1alpha1.TargetVolumeInfo{VolumeMounts: []corev1.VolumeMount{{Name: "data", MountPath: "/data"}}}}}}},
+	}
+	assert.Equal(t, "/data", getMountPathWithSourceVolume(builder.backupSet.Backup, "data"))
+	assert.Empty(t, getMountPathWithSourceVolume(builder.backupSet.Backup, "missing"))
+
+	volume := &corev1.Volume{Name: "data"}
+	mount := &corev1.VolumeMount{Name: "data", MountPath: "/data"}
+	assert.Same(t, builder, builder.addToCommonVolumesAndMounts(volume, mount))
+	assert.Equal(t, []corev1.Volume{*volume}, builder.commonVolumes)
+	assert.Equal(t, []corev1.VolumeMount{*mount}, builder.commonVolumeMounts)
+	builder.addToCommonVolumesAndMounts(nil, nil)
+	assert.Len(t, builder.commonVolumes, 1)
+}
+
+func TestRestoreConditionAndStatusHelpers(t *testing.T) {
+	restore := &dpv1alpha1.Restore{}
+	SetRestoreCheckBackupRepoCondition(restore, ReasonCheckBackupRepoSuccessfully, "ok")
+	assert.Equal(t, metav1.ConditionTrue, restore.Status.Conditions[0].Status)
+	assert.Equal(t, ConditionTypeRestoreCheckBackupRepo, restore.Status.Conditions[0].Type)
+
+	SetRestoreValidationCondition(restore, "Invalid", "bad")
+	assert.Equal(t, metav1.ConditionFalse, restore.Status.Conditions[1].Status)
+	assert.Equal(t, ConditionTypeRestoreValidationPassed, restore.Status.Conditions[1].Type)
+
+	SetRestoreStageCondition(restore, dpv1alpha1.PostReady, ReasonSucceed, "done")
+	assert.Equal(t, metav1.ConditionTrue, restore.Status.Conditions[2].Status)
+	assert.Equal(t, ConditionTypeRestorePostReady, restore.Status.Conditions[2].Type)
+
+	actions := []dpv1alpha1.RestoreStatusAction{}
+	SetRestoreStatusAction(&actions, dpv1alpha1.RestoreStatusAction{ObjectKey: "Job/job", Status: dpv1alpha1.RestoreActionProcessing})
+	assert.Len(t, actions, 1)
+	assert.NotNil(t, actions[0].StartTime)
+	assert.Contains(t, actions[0].Message, "processing")
+
+	SetRestoreStatusAction(&actions, dpv1alpha1.RestoreStatusAction{ObjectKey: "Job/job", Status: dpv1alpha1.RestoreActionCompleted})
+	assert.Equal(t, dpv1alpha1.RestoreActionCompleted, actions[0].Status)
+	assert.NotNil(t, actions[0].EndTime)
+	assert.Contains(t, actions[0].Message, "successfully")
+	assert.Nil(t, FindRestoreStatusAction(actions, "missing"))
+
+	var nilActions *[]dpv1alpha1.RestoreStatusAction
+	SetRestoreStatusAction(nilActions, dpv1alpha1.RestoreStatusAction{ObjectKey: "noop"})
+}
+
+func TestRestoreTimeAndPathHelpers(t *testing.T) {
+	start := metav1.NewTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	end := metav1.NewTime(start.Add(2 * time.Hour))
+	assert.Equal(t, "2h0m0s", GetRestoreDuration(dpv1alpha1.RestoreStatus{StartTimestamp: &start, CompletionTimestamp: &end}).Duration.String())
+	assert.Nil(t, GetRestoreDuration(dpv1alpha1.RestoreStatus{StartTimestamp: &start}))
+
+	assert.Equal(t, time.RFC3339, getTimeFormat(nil))
+	assert.Equal(t, "custom", getTimeFormat([]corev1.EnvVar{{Name: dptypes.DPTimeFormat, Value: "custom"}}))
+
+	shifted, err := transformTimeWithZone(&start, "+08:30")
+	assert.NoError(t, err)
+	_, offset := shifted.Time.Zone()
+	assert.Equal(t, 8*3600+30*60, offset)
+	_, err = transformTimeWithZone(&start, "bad")
+	assert.Error(t, err)
+
+	assert.Equal(t, "Job/restore-job", BuildJobKeyForActionStatus("restore-job"))
+	assert.Equal(t, "target/pod-0", GetTargetRelativePath("target", "pod-0"))
+	assert.Equal(t, "pod-0", GetTargetRelativePath("", "pod-0"))
+	assert.Empty(t, BackupFilePathEnv("", "target", "pod-0"))
+	envs := BackupFilePathEnv("/repo/ns/path/backup", "target", "pod-0")
+	assert.Equal(t, dptypes.DPTargetRelativePath, envs[0].Name)
+	assert.Equal(t, "target/pod-0", envs[0].Value)
+
+	short := cutJobName("short")
+	assert.Equal(t, "short", short)
+	long := cutJobName("restore-job-name-that-is-far-too-long-to-fit-in-the-kubernetes-job-name-limit")
+	assert.LessOrEqual(t, len(long), 63)
+}
+
+func TestFormatRestoreTimeAndValidate(t *testing.T) {
+	start := metav1.NewTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	end := metav1.NewTime(start.Add(2 * time.Hour))
+	backup := &dpv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: "continuous", Namespace: "ns", Labels: map[string]string{constant.AppInstanceLabelKey: "cluster"}},
+		Status:     dpv1alpha1.BackupStatus{TimeRange: &dpv1alpha1.BackupTimeRange{Start: &start, End: &end}},
+	}
+
+	got, err := FormatRestoreTimeAndValidate("2026-01-01T01:00:00Z", backup)
+	assert.NoError(t, err)
+	assert.Equal(t, "2026-01-01T01:00:00Z", got)
+
+	got, err = FormatRestoreTimeAndValidate("Jan 01,2026 01:00:00 UTC+0000", backup)
+	assert.NoError(t, err)
+	assert.Equal(t, "2026-01-01T01:00:00Z", got)
+
+	_, err = FormatRestoreTimeAndValidate("2026-01-02T00:00:00Z", backup)
+	assert.Error(t, err)
+	_, err = FormatRestoreTimeAndValidate("not a time", backup)
+	assert.Error(t, err)
+	assert.Equal(t, "", func() string { got, _ := FormatRestoreTimeAndValidate("", backup); return got }())
+}
+
+func TestRestoreSourcePodAndSnapshotHelpers(t *testing.T) {
+	target := &dpv1alpha1.BackupStatusTarget{
+		BackupTarget:       dpv1alpha1.BackupTarget{PodSelector: &dpv1alpha1.PodSelector{Strategy: dpv1alpha1.PodSelectionStrategyAny}},
+		SelectedTargetPods: []string{"pod-0", "pod-1"},
+	}
+	podName, err := GetSourcePodNameFromTarget(target, nil, 0)
+	assert.NoError(t, err)
+	assert.Empty(t, podName)
+
+	target.PodSelector.Strategy = dpv1alpha1.PodSelectionStrategyAll
+	_, err = GetSourcePodNameFromTarget(target, nil, 0)
+	assert.Error(t, err)
+	podName, err = GetSourcePodNameFromTarget(target, &dpv1alpha1.RequiredPolicyForAllPodSelection{DataRestorePolicy: dpv1alpha1.OneToOneRestorePolicy}, 1)
+	assert.NoError(t, err)
+	assert.Equal(t, "pod-1", podName)
+	podName, err = GetSourcePodNameFromTarget(target, &dpv1alpha1.RequiredPolicyForAllPodSelection{DataRestorePolicy: dpv1alpha1.OneToManyRestorePolicy, SourceOfOneToMany: &dpv1alpha1.SourceOfOneToMany{TargetPodName: "pod-0"}}, 5)
+	assert.NoError(t, err)
+	assert.Equal(t, "pod-0", podName)
+
+	backup := &dpv1alpha1.Backup{Status: dpv1alpha1.BackupStatus{Actions: []dpv1alpha1.ActionStatus{
+		{TargetPodName: "pod-x", VolumeSnapshots: []dpv1alpha1.VolumeSnapshotStatus{{VolumeName: "ignored", Name: "snap-x"}}},
+		{TargetPodName: "pod-1", VolumeSnapshots: []dpv1alpha1.VolumeSnapshotStatus{{VolumeName: "data", Name: "snap-data"}}},
+	}}}
+	assert.Equal(t, map[string]string{"data": "snap-data"}, GetVolumeSnapshotsBySourcePod(backup, target, "pod-1"))
+	assert.Nil(t, GetVolumeSnapshotsBySourcePod(backup, target, "missing"))
+}
+
+func TestValidateParentBackupSet(t *testing.T) {
+	now := metav1.NewTime(time.Now())
+	later := metav1.NewTime(now.Add(time.Hour))
+	parent := &dpv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: "parent"},
+		Spec:       dpv1alpha1.BackupSpec{BackupPolicyName: "policy", BackupMethod: "full"},
+		Status:     dpv1alpha1.BackupStatus{Phase: dpv1alpha1.BackupPhaseCompleted, CompletionTimestamp: &now, BackupRepoName: "repo"},
+	}
+	child := &dpv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: "child"},
+		Spec:       dpv1alpha1.BackupSpec{BackupPolicyName: "policy", BackupMethod: "inc"},
+		Status: dpv1alpha1.BackupStatus{
+			Phase: dpv1alpha1.BackupPhaseCompleted, CompletionTimestamp: &later, BackupRepoName: "repo",
+			BackupMethod:   &dpv1alpha1.BackupMethod{CompatibleMethod: "full"},
+			BaseBackupName: "parent",
+		},
+	}
+	assert.NoError(t, ValidateParentBackupSet(
+		&BackupActionSet{Backup: parent, ActionSet: &dpv1alpha1.ActionSet{Spec: dpv1alpha1.ActionSetSpec{BackupType: dpv1alpha1.BackupTypeFull}}},
+		&BackupActionSet{Backup: child},
+	))
+
+	child.Status.BackupRepoName = "other"
+	assert.Error(t, ValidateParentBackupSet(
+		&BackupActionSet{Backup: parent, ActionSet: &dpv1alpha1.ActionSet{Spec: dpv1alpha1.ActionSetSpec{BackupType: dpv1alpha1.BackupTypeFull}}},
+		&BackupActionSet{Backup: child},
+	))
+	assert.Error(t, ValidateParentBackupSet(&BackupActionSet{}, &BackupActionSet{Backup: child}))
+}
+
+func TestRestoreManagerBuildIncrementalAndDifferentialBackupSets(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, dpv1alpha1.AddToScheme(scheme))
+
+	now := metav1.NewTime(time.Now())
+	later := metav1.NewTime(now.Add(time.Hour))
+	restoreSpec := &dpv1alpha1.RestoreActionSpec{PrepareData: &dpv1alpha1.JobActionSpec{BaseJobActionSpec: dpv1alpha1.BaseJobActionSpec{Image: "busybox", Command: []string{"restore"}}}}
+	fullActionSet := &dpv1alpha1.ActionSet{ObjectMeta: metav1.ObjectMeta{Name: "full-action"}, Spec: dpv1alpha1.ActionSetSpec{BackupType: dpv1alpha1.BackupTypeFull, Restore: restoreSpec}}
+	incrementalActionSet := &dpv1alpha1.ActionSet{ObjectMeta: metav1.ObjectMeta{Name: "inc-action"}, Spec: dpv1alpha1.ActionSetSpec{BackupType: dpv1alpha1.BackupTypeIncremental, Restore: restoreSpec}}
+	full := &dpv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: "full", Namespace: "ns"},
+		Spec:       dpv1alpha1.BackupSpec{BackupPolicyName: "policy", BackupMethod: "full"},
+		Status: dpv1alpha1.BackupStatus{
+			Phase: dpv1alpha1.BackupPhaseCompleted, CompletionTimestamp: &now, BackupRepoName: "repo",
+			BackupMethod: &dpv1alpha1.BackupMethod{Name: "full", ActionSetName: "full-action"},
+		},
+	}
+	child := &dpv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: "child", Namespace: "ns"},
+		Spec:       dpv1alpha1.BackupSpec{BackupPolicyName: "policy", BackupMethod: "inc"},
+		Status: dpv1alpha1.BackupStatus{
+			Phase: dpv1alpha1.BackupPhaseCompleted, CompletionTimestamp: &later, BackupRepoName: "repo",
+			ParentBackupName: "full", BaseBackupName: "full",
+			BackupMethod: &dpv1alpha1.BackupMethod{Name: "inc", ActionSetName: "inc-action", CompatibleMethod: "full"},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(fullActionSet, incrementalActionSet, full, child).Build()
+	reqCtx := intctrlutil.RequestCtx{Ctx: context.Background(), Req: ctrl.Request{NamespacedName: client.ObjectKey{Namespace: "ns", Name: "restore"}}}
+	mgr := &RestoreManager{}
+
+	err := mgr.BuildIncrementalBackupActionSet(reqCtx, cli, BackupActionSet{Backup: child, ActionSet: incrementalActionSet})
+	assert.NoError(t, err)
+	assert.Len(t, mgr.PrepareDataBackupSets, 1)
+	assert.Equal(t, "full", mgr.PrepareDataBackupSets[0].BaseBackup.Name)
+
+	mgr = &RestoreManager{}
+	child.Spec.ParentBackupName = "full"
+	err = mgr.BuildDifferentialBackupActionSets(reqCtx, cli, BackupActionSet{Backup: child, ActionSet: incrementalActionSet})
+	assert.NoError(t, err)
+	assert.Len(t, mgr.PrepareDataBackupSets, 2)
+
+	_, err = mgr.GetBackupActionSetByNamespaced(reqCtx, cli, "missing", "ns")
+	assert.Error(t, err)
+}
+
+func TestValidateAndInitRestoreMGRFullBackup(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, dpv1alpha1.AddToScheme(scheme))
+
+	actionSet := &dpv1alpha1.ActionSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "full-action"},
+		Spec: dpv1alpha1.ActionSetSpec{
+			BackupType: dpv1alpha1.BackupTypeFull,
+			Restore:    &dpv1alpha1.RestoreActionSpec{PrepareData: &dpv1alpha1.JobActionSpec{BaseJobActionSpec: dpv1alpha1.BaseJobActionSpec{Image: "busybox", Command: []string{"restore"}}}},
+		},
+	}
+	backup := &dpv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: "backup", Namespace: "ns"},
+		Status: dpv1alpha1.BackupStatus{
+			Phase:        dpv1alpha1.BackupPhaseCompleted,
+			BackupMethod: &dpv1alpha1.BackupMethod{Name: "full", ActionSetName: "full-action"},
+		},
+	}
+	restoreObj := &dpv1alpha1.Restore{ObjectMeta: metav1.ObjectMeta{Name: "restore", Namespace: "ns"}, Spec: dpv1alpha1.RestoreSpec{Backup: dpv1alpha1.BackupRef{Name: "backup", Namespace: "ns"}}}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(actionSet, backup).Build()
+	reqCtx := intctrlutil.RequestCtx{Ctx: context.Background(), Req: ctrl.Request{NamespacedName: client.ObjectKey{Namespace: "ns", Name: "restore"}}}
+	mgr := &RestoreManager{Restore: restoreObj}
+
+	assert.NoError(t, ValidateAndInitRestoreMGR(reqCtx, cli, mgr))
+	assert.Len(t, mgr.PrepareDataBackupSets, 1)
+
+	backup.Status.Phase = dpv1alpha1.BackupPhaseFailed
+	assert.NoError(t, cli.Update(context.Background(), backup))
+	mgr = &RestoreManager{Restore: restoreObj}
+	assert.Error(t, ValidateAndInitRestoreMGR(reqCtx, cli, mgr))
+}
+
+func TestRestoreManagerStopsManagerContainer(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, corev1.AddToScheme(scheme))
+	assert.NoError(t, batchv1.AddToScheme(scheme))
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "restore-job-pod", Namespace: "ns", Labels: map[string]string{"job-name": "restore-job"}},
+		Status: corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{
+			Name:  Restore,
+			State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 1}},
+		}}},
+	}
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "restore-job", Namespace: "ns"}}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod, job).Build()
+	mgr := &RestoreManager{Client: cli}
+
+	normalTerminated, err := mgr.CheckIfRestoreContainerTerminated(job)
+	assert.NoError(t, err)
+	assert.False(t, normalTerminated)
+
+	got := &corev1.Pod{}
+	assert.NoError(t, cli.Get(context.Background(), client.ObjectKey{Name: pod.Name, Namespace: pod.Namespace}, got))
+	assert.Equal(t, "true", got.Annotations[DataProtectionStopRestoreManagerAnnotationKey])
+	assert.NoError(t, mgr.StopManagerContainer(got))
+	assert.NoError(t, mgr.StopManagerContainerByJob(job))
 }

--- a/pkg/dataprotection/utils/utils_test.go
+++ b/pkg/dataprotection/utils/utils_test.go
@@ -20,12 +20,30 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package utils
 
 import (
+	"context"
 	"errors"
+	"strings"
 	"testing"
+	"time"
 
+	vsv1beta1 "github.com/kubernetes-csi/external-snapshotter/client/v3/apis/volumesnapshot/v1beta1"
+	vsv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	"github.com/stretchr/testify/assert"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
 
 func TestGetBackupStatusTarget(t *testing.T) {
@@ -53,4 +71,302 @@ func TestGetBackupStatusTarget(t *testing.T) {
 	if target != nil {
 		assert.Error(t, errors.New("backup status target should be empty"))
 	}
+}
+
+func TestDataprotectionUtilityHelpers(t *testing.T) {
+	assert.Equal(t, "backup-0-data", GetBackupVolumeSnapshotName("backup", "data", 0))
+	assert.Equal(t, "backup-data", GetOldBackupVolumeSnapshotName("backup", "data"))
+
+	env := MergeEnv([]corev1.EnvVar{{Name: "A", Value: "1"}, {Name: "B", Value: "2"}}, []corev1.EnvVar{{Name: "B", Value: "override"}, {Name: "C", Value: "3"}})
+	assert.Equal(t, map[string]string{"A": "1", "B": "override", "C": "3"}, CovertEnvToMap(env))
+	assert.NotContains(t, CovertEnvToMap([]corev1.EnvVar{{Name: "FROM", ValueFrom: &corev1.EnvVarSource{}}}), "FROM")
+
+	assert.Equal(t, "  one\n  two", PrependSpaces("one\ntwo", 2))
+	assert.True(t, ExistTargetVolume(&dpv1alpha1.TargetVolumeInfo{Volumes: []string{"data"}}, "data"))
+	assert.True(t, ExistTargetVolume(&dpv1alpha1.TargetVolumeInfo{VolumeMounts: []corev1.VolumeMount{{Name: "logs"}}}, "logs"))
+	assert.False(t, ExistTargetVolume(&dpv1alpha1.TargetVolumeInfo{Volumes: []string{"data"}}, "logs"))
+
+	assert.Equal(t, dpv1alpha1.BackupTypeFull, GetBackupType(nil, pointer.Bool(true)))
+	assert.Empty(t, GetBackupType(nil, pointer.Bool(false)))
+	assert.Equal(t, dpv1alpha1.BackupTypeIncremental, GetBackupType(&dpv1alpha1.ActionSet{Spec: dpv1alpha1.ActionSetSpec{BackupType: dpv1alpha1.BackupTypeIncremental}}, pointer.Bool(true)))
+}
+
+func TestJobAndPodHelpers(t *testing.T) {
+	finished, conditionType, message := IsJobFinished(nil)
+	assert.False(t, finished)
+	assert.Empty(t, conditionType)
+	assert.Empty(t, message)
+
+	finished, conditionType, message = IsJobFinished(&batchv1.Job{Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{
+		{Type: batchv1.JobFailed, Status: corev1.ConditionFalse},
+		{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
+	}}})
+	assert.True(t, finished)
+	assert.Equal(t, batchv1.JobComplete, conditionType)
+	assert.Empty(t, message)
+
+	finished, conditionType, message = IsJobFinished(&batchv1.Job{Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{
+		{Type: batchv1.JobFailed, Status: corev1.ConditionTrue, Reason: "Backoff", Message: "failed"},
+	}}})
+	assert.True(t, finished)
+	assert.Equal(t, batchv1.JobFailed, conditionType)
+	assert.Equal(t, "Backoff:failed", message)
+
+	pods := &corev1.PodList{Items: []corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{Name: "pod-1"}, Status: corev1.PodStatus{Phase: corev1.PodPending}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "pod-0"}, Status: corev1.PodStatus{Phase: corev1.PodRunning, Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}}},
+	}}
+	assert.Equal(t, "pod-0", GetFirstIndexRunningPod(pods).Name)
+	assert.Equal(t, "pod-1", GetPodByName(pods, "pod-1").Name)
+	assert.Nil(t, GetPodByName(pods, "missing"))
+
+	pod := &corev1.Pod{Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "db", Ports: []corev1.ContainerPort{{Name: "mysql", ContainerPort: 3306}}}}}}
+	assert.Equal(t, int32(3306), GetPodFirstContainerPort(pod))
+	env, err := GetDPDBPortEnv(pod, &dpv1alpha1.ContainerPort{ContainerName: "db", PortName: "mysql"})
+	assert.NoError(t, err)
+	assert.Equal(t, "3306", env.Value)
+	_, err = GetDPDBPortEnv(pod, &dpv1alpha1.ContainerPort{ContainerName: "db", PortName: "missing"})
+	assert.Error(t, err)
+}
+
+func TestFakeClientHelpers(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, corev1.AddToScheme(scheme))
+	assert.NoError(t, dpv1alpha1.AddToScheme(scheme))
+
+	ctx := context.Background()
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "ns", Labels: map[string]string{"app": "db"}}}
+	jobPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "job-pod", Namespace: "ns", Labels: map[string]string{"job-name": "backup-job"}}}
+	backupPolicy := &dpv1alpha1.BackupPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "policy", Namespace: "ns"},
+		Spec:       dpv1alpha1.BackupPolicySpec{BackupMethods: []dpv1alpha1.BackupMethod{{Name: "full", SnapshotVolumes: pointer.Bool(true)}}},
+	}
+	actionSet := &dpv1alpha1.ActionSet{ObjectMeta: metav1.ObjectMeta{Name: "action-set"}, Spec: dpv1alpha1.ActionSetSpec{BackupType: dpv1alpha1.BackupTypeFull}}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod, jobPod, backupPolicy, actionSet).Build()
+	reqCtx := intctrlutil.RequestCtx{Ctx: ctx, Req: ctrl.Request{NamespacedName: client.ObjectKey{Namespace: "ns", Name: "req"}}}
+
+	pods, err := GetPodListByLabelSelector(reqCtx, cli, &metav1.LabelSelector{MatchLabels: map[string]string{"app": "db"}})
+	assert.NoError(t, err)
+	assert.Len(t, pods.Items, 1)
+
+	jobPods, err := GetAssociatedPodsOfJob(ctx, cli, "ns", "backup-job")
+	assert.NoError(t, err)
+	assert.Len(t, jobPods.Items, 1)
+
+	gotPolicy, err := GetBackupPolicyByName(reqCtx, cli, "policy")
+	assert.NoError(t, err)
+	assert.Equal(t, "policy", gotPolicy.Name)
+	assert.Equal(t, "full", GetBackupMethodByName("full", gotPolicy).Name)
+	assert.Nil(t, GetBackupMethodByName("missing", gotPolicy))
+
+	gotActionSet, err := GetActionSetByName(reqCtx, cli, "action-set")
+	assert.NoError(t, err)
+	assert.Equal(t, dpv1alpha1.BackupTypeFull, gotActionSet.Spec.BackupType)
+	gotType, err := GetBackupTypeByMethodName(reqCtx, cli, "full", gotPolicy)
+	assert.NoError(t, err)
+	assert.Equal(t, dpv1alpha1.BackupTypeFull, gotType)
+	gotType, err = GetBackupTypeByMethodName(reqCtx, cli, "missing", gotPolicy)
+	assert.NoError(t, err)
+	assert.Empty(t, gotType)
+
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm", Namespace: "ns", Finalizers: []string{dptypes.DataProtectionFinalizerName}}}
+	assert.NoError(t, cli.Create(ctx, cm))
+	assert.NoError(t, RemoveDataProtectionFinalizer(ctx, cli, cm))
+	assert.Empty(t, cm.Finalizers)
+}
+
+func TestBuildEnvByTargetAndParameters(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Namespace: "ns"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "db", Ports: []corev1.ContainerPort{{Name: "mysql", ContainerPort: 3306}}}}},
+	}
+
+	envs, err := BuildEnvByTarget(pod, nil, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, dptypes.DPDBHost, envs[0].Name)
+	assert.Equal(t, dptypes.DPDBPort, envs[1].Name)
+	assert.Equal(t, "3306", envs[1].Value)
+
+	envs, err = BuildEnvByTarget(pod, &dpv1alpha1.ConnectionCredential{
+		SecretName:  "conn",
+		HostKey:     "host",
+		PortKey:     "port",
+		UsernameKey: "user",
+		PasswordKey: "password",
+	}, nil)
+	assert.NoError(t, err)
+	assert.Len(t, envs, 4)
+	for _, env := range envs {
+		assert.Equal(t, "conn", env.ValueFrom.SecretKeyRef.Name)
+	}
+
+	params := BuildEnvByParameters([]dpv1alpha1.ParameterPair{{Name: "P1", Value: "v1"}})
+	assert.Equal(t, []corev1.EnvVar{{Name: "P1", Value: "v1"}}, params)
+}
+
+func TestBackupPolicyAndScheduleHelpers(t *testing.T) {
+	policies := &dpv1alpha1.BackupPolicyList{Items: []dpv1alpha1.BackupPolicy{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "default", Annotations: map[string]string{dptypes.DefaultBackupPolicyAnnotationKey: "true"}},
+			Status:     dpv1alpha1.BackupPolicyStatus{Phase: dpv1alpha1.AvailablePhase},
+			Spec:       dpv1alpha1.BackupPolicySpec{BackupMethods: []dpv1alpha1.BackupMethod{{Name: "snapshot", SnapshotVolumes: pointer.Bool(true)}, {Name: "logical"}}},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "named", Annotations: map[string]string{}},
+			Status:     dpv1alpha1.BackupPolicyStatus{Phase: dpv1alpha1.AvailablePhase},
+			Spec:       dpv1alpha1.BackupPolicySpec{BackupMethods: []dpv1alpha1.BackupMethod{{Name: "named-method"}}},
+		},
+	}}
+	defaultMethod, methods := GetBackupMethodsFromBackupPolicy(policies, "")
+	assert.Equal(t, "snapshot", defaultMethod)
+	assert.Contains(t, methods, "logical")
+
+	defaultMethod, methods = GetBackupMethodsFromBackupPolicy(policies, "named")
+	assert.Empty(t, defaultMethod)
+	assert.Contains(t, methods, "named-method")
+
+	assert.NoError(t, ValidateScheduleNames([]dpv1alpha1.SchedulePolicy{{Name: "daily", BackupMethod: "full"}, {BackupMethod: "log"}}))
+	assert.Error(t, ValidateScheduleNames([]dpv1alpha1.SchedulePolicy{{Name: "same", BackupMethod: "full"}, {Name: "same", BackupMethod: "log"}}))
+}
+
+func TestDatasafedInjectionHelpers(t *testing.T) {
+	oldImage := viper.GetString("DATASAFED_IMAGE")
+	defer viper.Set("DATASAFED_IMAGE", oldImage)
+	viper.Set("DATASAFED_IMAGE", "example/datasafed:test")
+
+	podSpec := &corev1.PodSpec{Containers: []corev1.Container{{Name: "main"}}}
+	InjectDatasafedWithPVC(podSpec, "repo-pvc", "/repo", "/kopia")
+	assert.Len(t, podSpec.InitContainers, 1)
+	assert.Equal(t, "repo-pvc", podSpec.Volumes[0].PersistentVolumeClaim.ClaimName)
+	assert.Contains(t, CovertEnvToMap(podSpec.Containers[0].Env), dptypes.DPDatasafedKopiaRepoRoot)
+
+	podSpec = &corev1.PodSpec{Containers: []corev1.Container{{Name: "main"}}}
+	InjectDatasafed(podSpec, &dpv1alpha1.BackupRepo{
+		Spec:   dpv1alpha1.BackupRepoSpec{AccessMethod: dpv1alpha1.AccessMethodTool},
+		Status: dpv1alpha1.BackupRepoStatus{ToolConfigSecretName: "tool-secret"},
+	}, "/repo", &dpv1alpha1.EncryptionConfig{
+		Algorithm:              "AES256",
+		PassPhraseSecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "enc"}, Key: "key"},
+	}, "/kopia")
+	assert.Equal(t, "tool-secret", podSpec.Volumes[0].Secret.SecretName)
+	envMap := CovertEnvToMap(podSpec.Containers[0].Env)
+	assert.Equal(t, "AES256", envMap[dptypes.DPDatasafedEncryptionAlgorithm])
+	assert.True(t, strings.Contains(podSpec.InitContainers[0].Command[2], "/bin/datasafed"))
+}
+
+func TestValidationAndComparisonHelpers(t *testing.T) {
+	schema := &apiextensionsv1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]apiextensionsv1.JSONSchemaProps{
+			"name":  {Type: "string"},
+			"count": {Type: "integer"},
+		},
+	}
+	actionSet := &dpv1alpha1.ActionSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "as"},
+		Spec: dpv1alpha1.ActionSetSpec{
+			Backup:           &dpv1alpha1.BackupActionSpec{WithParameters: []string{"name", "count"}},
+			ParametersSchema: &dpv1alpha1.ActionSetParametersSchema{OpenAPIV3Schema: schema},
+		},
+	}
+	assert.NoError(t, ValidateParameters(actionSet, []dpv1alpha1.ParameterPair{{Name: "name", Value: "kb"}, {Name: "count", Value: "2"}}, true))
+	assert.Error(t, ValidateParameters(actionSet, []dpv1alpha1.ParameterPair{{Name: "unknown", Value: "x"}}, true))
+	assert.Error(t, ValidateParameters(nil, []dpv1alpha1.ParameterPair{{Name: "name", Value: "kb"}}, true))
+
+	start := metav1.NewTime(time.Now())
+	later := metav1.NewTime(start.Add(time.Hour))
+	assert.True(t, CompareWithBackupStopTime(
+		dpv1alpha1.Backup{ObjectMeta: metav1.ObjectMeta{Name: "a"}, Status: dpv1alpha1.BackupStatus{CompletionTimestamp: &start}},
+		dpv1alpha1.Backup{ObjectMeta: metav1.ObjectMeta{Name: "b"}, Status: dpv1alpha1.BackupStatus{CompletionTimestamp: &later}},
+	))
+	assert.True(t, CompareWithBackupStopTime(
+		dpv1alpha1.Backup{ObjectMeta: metav1.ObjectMeta{Name: "a"}, Status: dpv1alpha1.BackupStatus{CompletionTimestamp: &start}},
+		dpv1alpha1.Backup{ObjectMeta: metav1.ObjectMeta{Name: "b"}},
+	))
+	assert.False(t, CompareWithBackupStopTime(dpv1alpha1.Backup{}, dpv1alpha1.Backup{}))
+
+	targets := GetBackupTargets(
+		&dpv1alpha1.BackupPolicy{Spec: dpv1alpha1.BackupPolicySpec{Targets: []dpv1alpha1.BackupTarget{{Name: "policy-target"}}}},
+		&dpv1alpha1.BackupMethod{Targets: []dpv1alpha1.BackupTarget{{Name: "method-target"}}},
+	)
+	assert.Equal(t, "method-target", targets[0].Name)
+}
+
+func TestAddTolerationsFromViper(t *testing.T) {
+	oldTolerations := viper.GetString(constant.CfgKeyCtrlrMgrTolerations)
+	oldAffinity := viper.GetString(constant.CfgKeyCtrlrMgrAffinity)
+	oldNodeSelector := viper.GetString(constant.CfgKeyCtrlrMgrNodeSelector)
+	defer func() {
+		viper.Set(constant.CfgKeyCtrlrMgrTolerations, oldTolerations)
+		viper.Set(constant.CfgKeyCtrlrMgrAffinity, oldAffinity)
+		viper.Set(constant.CfgKeyCtrlrMgrNodeSelector, oldNodeSelector)
+	}()
+	viper.Set(constant.CfgKeyCtrlrMgrTolerations, `[{"key":"dedicated","operator":"Equal","value":"dp","effect":"NoSchedule"}]`)
+	viper.Set(constant.CfgKeyCtrlrMgrAffinity, `{"nodeAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":{"nodeSelectorTerms":[{"matchExpressions":[{"key":"disk","operator":"In","values":["ssd"]}]}]}}}`)
+	viper.Set(constant.CfgKeyCtrlrMgrNodeSelector, `{"node":"dp"}`)
+
+	podSpec := &corev1.PodSpec{}
+	assert.NoError(t, AddTolerations(podSpec))
+	assert.Equal(t, "dedicated", podSpec.Tolerations[0].Key)
+	assert.Equal(t, "dp", podSpec.NodeSelector["node"])
+
+	viper.Set(constant.CfgKeyCtrlrMgrNodeSelector, `{invalid`)
+	assert.Error(t, AddTolerations(&corev1.PodSpec{}))
+}
+
+func TestSetControllerReferenceNilOwner(t *testing.T) {
+	assert.NoError(t, SetControllerReference(nil, &corev1.ConfigMap{}, runtime.NewScheme()))
+	assert.NoError(t, SetControllerReference((*corev1.ConfigMap)(nil), &corev1.ConfigMap{}, runtime.NewScheme()))
+}
+
+func TestVolumeSnapshotEnabledWithFakeClient(t *testing.T) {
+	oldSupportsVolumeSnapshotV1 := supportsVolumeSnapshotV1
+	defer func() { supportsVolumeSnapshotV1 = oldSupportsVolumeSnapshotV1 }()
+	supportsVolumeSnapshotV1 = pointer.Bool(true)
+
+	scheme := runtime.NewScheme()
+	assert.NoError(t, corev1.AddToScheme(scheme))
+	assert.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	assert.NoError(t, vsv1.AddToScheme(scheme))
+	assert.NoError(t, vsv1beta1.AddToScheme(scheme))
+
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "ns"}, Spec: corev1.PodSpec{Volumes: []corev1.Volume{{Name: "config", VolumeSource: corev1.VolumeSource{ConfigMap: &corev1.ConfigMapVolumeSource{}}}}}}
+	ok, err := VolumeSnapshotEnabled(context.Background(), fake.NewClientBuilder().WithScheme(scheme).Build(), pod, []string{"config"})
+	assert.False(t, ok)
+	assert.Error(t, err)
+
+	ok, err = VolumeSnapshotEnabled(context.Background(), fake.NewClientBuilder().WithScheme(scheme).Build(), pod, []string{"missing"})
+	assert.False(t, ok)
+	assert.Error(t, err)
+
+	pv := &corev1.PersistentVolume{ObjectMeta: metav1.ObjectMeta{Name: "pv"}, Spec: corev1.PersistentVolumeSpec{PersistentVolumeSource: corev1.PersistentVolumeSource{CSI: &corev1.CSIPersistentVolumeSource{Driver: "driver"}}}}
+	vsc := &vsv1.VolumeSnapshotClass{ObjectMeta: metav1.ObjectMeta{Name: "class"}, Driver: "driver"}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pv, vsc).Build()
+	ok, err = IsVolumeSnapshotEnabled(context.Background(), cli, "pv")
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	ok, err = IsVolumeSnapshotEnabled(context.Background(), cli, "")
+	assert.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestEventsToString(t *testing.T) {
+	events := &corev1.EventList{Items: []corev1.Event{{
+		ObjectMeta:     metav1.ObjectMeta{Name: "event"},
+		Type:           corev1.EventTypeWarning,
+		Reason:         "Failed",
+		Message:        "backup failed",
+		Count:          1,
+		LastTimestamp:  metav1.Now(),
+		FirstTimestamp: metav1.Now(),
+	}}}
+	got := EventsToString(events)
+	assert.Contains(t, got, "Failed")
+	assert.Contains(t, got, "backup failed")
+}
+
+func TestPeriodicalEnqueueSourceString(t *testing.T) {
+	assert.Contains(t, (&PeriodicalEnqueueSource{objList: &corev1.PodList{}}).String(), "PodList")
+	assert.Equal(t, "periodical enqueue source: unknown type", (&PeriodicalEnqueueSource{}).String())
 }


### PR DESCRIPTION
## Summary
- Add focused tests for dataprotection action stateful helpers, backup request/deleter/scheduler branches, restore manager utilities, error helpers, and snapshot/backup utility behavior.
- No production behavior changes.

## Coverage
- Before: 48.3% combined statement coverage for pkg/dataprotection.
- After: 80.1% combined statement coverage for pkg/dataprotection.

## Tests
- GOFLAGS=-mod=mod GOCACHE=<go-build-cache> KUBEBUILDER_ASSETS=<envtest-assets> go test -short ./pkg/dataprotection/... -coverprofile=<tmp-cover>
