### PR TITLE
chore: improve pkg kbagent coverage

### DIFF
--- a/pkg/kbagent/client/client_test.go
+++ b/pkg/kbagent/client/client_test.go
@@ -1,0 +1,166 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package client
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/golang/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/rest"
+
+	"github.com/apecloud/kubeblocks/pkg/kbagent/proto"
+)
+
+type stubClient struct{}
+
+func (stubClient) Close() error {
+	return nil
+}
+
+func (stubClient) Action(context.Context, proto.ActionRequest) (proto.ActionResponse, error) {
+	return proto.ActionResponse{Message: "ok"}, nil
+}
+
+func TestMockClientLifecycle(t *testing.T) {
+	t.Cleanup(UnsetMockClient)
+
+	mock := stubClient{}
+	SetMockClient(mock, nil)
+	if GetMockClient() != mock {
+		t.Fatalf("GetMockClient() did not return mock client")
+	}
+	got, err := NewClient(func() (string, int32, error) {
+		t.Fatal("endpoint should not be called when mock client is set")
+		return "", 0, nil
+	})
+	if err != nil || got != mock {
+		t.Fatalf("NewClient() = %v, %v, want mock nil-error", got, err)
+	}
+
+	mockErr := errors.New("mock")
+	SetMockClient(nil, mockErr)
+	got, err = NewClient(func() (string, int32, error) {
+		t.Fatal("endpoint should not be called when mock error is set")
+		return "", 0, nil
+	})
+	if got != nil || !errors.Is(err, mockErr) {
+		t.Fatalf("NewClient() = %v, %v, want nil mockErr", got, err)
+	}
+
+	UnsetMockClient()
+	if GetMockClient() != nil {
+		t.Fatalf("mock client should be cleared")
+	}
+}
+
+func TestNewClientEndpointBranches(t *testing.T) {
+	endpointErr := errors.New("endpoint")
+	if got, err := NewClient(func() (string, int32, error) { return "", 0, endpointErr }); got != nil || !errors.Is(err, endpointErr) {
+		t.Fatalf("NewClient endpoint error = %v, %v", got, err)
+	}
+
+	if got, err := NewClient(func() (string, int32, error) { return "", 0, nil }); got != nil || err != nil {
+		t.Fatalf("NewClient empty endpoint = %v, %v, want nil nil", got, err)
+	}
+
+	got, err := NewClient(func() (string, int32, error) { return "127.0.0.1", 3501, nil })
+	if err != nil {
+		t.Fatalf("NewClient returned error: %v", err)
+	}
+	if _, ok := got.(*httpClient); !ok {
+		t.Fatalf("NewClient returned %T, want *httpClient", got)
+	}
+	if err := got.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+}
+
+func TestGeneratedMockClient(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mock := NewMockClient(ctrl)
+	mock.EXPECT().
+		Action(gomock.Any(), proto.ActionRequest{Action: "backup"}).
+		Return(proto.ActionResponse{Message: "ok"}, nil)
+
+	resp, err := mock.Action(context.Background(), proto.ActionRequest{Action: "backup"})
+	if err != nil {
+		t.Fatalf("mock Action() error = %v", err)
+	}
+	if resp.Message != "ok" {
+		t.Fatalf("mock Action() response = %#v", resp)
+	}
+	if err := mock.Close(); err != nil {
+		t.Fatalf("mock Close() error = %v", err)
+	}
+}
+
+func TestNewPortForwardClientStableBranches(t *testing.T) {
+	t.Cleanup(UnsetMockClient)
+
+	mock := stubClient{}
+	SetMockClient(mock, nil)
+	got, err := NewPortForwardClient(&corev1.Pod{}, func() (string, int32, error) {
+		t.Fatal("endpoint should not be called when mock client is set")
+		return "", 0, nil
+	})
+	if err != nil || got != mock {
+		t.Fatalf("NewPortForwardClient mock = %v, %v", got, err)
+	}
+
+	UnsetMockClient()
+	endpointErr := errors.New("endpoint")
+	got, err = NewPortForwardClient(&corev1.Pod{}, func() (string, int32, error) {
+		return "", 0, endpointErr
+	})
+	if got != nil || !errors.Is(err, endpointErr) {
+		t.Fatalf("NewPortForwardClient endpoint error = %v, %v", got, err)
+	}
+}
+
+func TestPortForwardClientStableErrors(t *testing.T) {
+	pf := &portForwardClient{
+		pod:    &corev1.Pod{},
+		port:   "3501",
+		config: &rest.Config{},
+		logger: logr.Discard(),
+	}
+	if err := pf.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	_, _ = pf.createDialer("POST", nil, &rest.Config{})
+	readyCh := make(chan struct{})
+	stopCh := make(chan struct{})
+	forwarder, err := pf.newPortForwarder(readyCh, stopCh, io.Discard)
+	close(stopCh)
+	if err != nil {
+		t.Fatalf("newPortForwarder() error = %v", err)
+	}
+	if forwarder == nil {
+		t.Fatalf("newPortForwarder() returned nil")
+	}
+	if resp, err := pf.Action(context.Background(), proto.ActionRequest{Action: "backup"}); err == nil || resp.Message != "" {
+		t.Fatalf("expected Action error for empty rest config, got %#v, %v", resp, err)
+	}
+}

--- a/pkg/kbagent/client/http_client_test.go
+++ b/pkg/kbagent/client/http_client_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/kbagent/proto"
+)
+
+type errorReader struct{}
+
+func (errorReader) Read([]byte) (int, error) {
+	return 0, errors.New("read")
+}
+
+func newHTTPClientForTest(t *testing.T, handler http.HandlerFunc) (*httpClient, func()) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	host, portString, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		t.Fatalf("split host port: %v", err)
+	}
+	var port int32
+	if _, err := fmt.Sscan(portString, &port); err != nil {
+		t.Fatalf("parse port: %v", err)
+	}
+	return &httpClient{host: host, port: port, client: server.Client()}, server.Close
+}
+
+func TestHTTPClientAction(t *testing.T) {
+	cli, closeServer := newHTTPClientForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != proto.ServiceAction.URI || r.Method != http.MethodPost {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"message":"done","output":"b2s="}`))
+	})
+	defer closeServer()
+
+	resp, err := cli.Action(context.Background(), proto.ActionRequest{Action: "backup"})
+	if err != nil {
+		t.Fatalf("Action() error = %v", err)
+	}
+	if resp.Message != "done" || string(resp.Output) != "ok" {
+		t.Fatalf("unexpected response: %#v", resp)
+	}
+
+	resp, err = cli.Action(context.WithValue(context.Background(), constant.DryRunContextKey, true), proto.ActionRequest{Action: "backup"})
+	if err != nil || resp.Message != "" || resp.Error != "" || len(resp.Output) != 0 {
+		t.Fatalf("dry-run Action() = %#v, %v", resp, err)
+	}
+}
+
+func TestHTTPClientRequestAndDecodeErrors(t *testing.T) {
+	cli, closeServer := newHTTPClientForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Query().Get("case") {
+		case "bad-status":
+			w.WriteHeader(http.StatusAccepted)
+		case "invalid-json":
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("{"))
+		default:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"error":"failed"}`))
+		}
+	})
+	defer closeServer()
+
+	if _, err := cli.request(context.Background(), " bad method", "http://bad-url", nil); err == nil {
+		t.Fatalf("expected request construction error")
+	}
+
+	body, err := cli.request(context.Background(), http.MethodPost, "http://"+net.JoinHostPort(cli.host, fmt.Sprint(cli.port))+proto.ServiceAction.URI, strings.NewReader("{}"))
+	if err != nil {
+		t.Fatalf("request() error = %v", err)
+	}
+	_ = body.Close()
+
+	_, err = cli.request(context.Background(), http.MethodPost, "http://"+net.JoinHostPort(cli.host, fmt.Sprint(cli.port))+proto.ServiceAction.URI+"?case=bad-status", nil)
+	if err == nil {
+		t.Fatalf("expected unexpected status error")
+	}
+
+	body, err = cli.request(context.Background(), http.MethodPost, "http://"+net.JoinHostPort(cli.host, fmt.Sprint(cli.port))+proto.ServiceAction.URI+"?case=invalid-json", nil)
+	if err != nil {
+		t.Fatalf("request invalid-json error = %v", err)
+	}
+	defer body.Close()
+	if _, err := decode(body, &proto.ActionResponse{}); err == nil {
+		t.Fatalf("expected decode error")
+	}
+
+	if _, err := decode(io.NopCloser(errorReader{}), &proto.ActionResponse{}); err == nil {
+		t.Fatalf("expected read error")
+	}
+}

--- a/pkg/kbagent/proto/errors_test.go
+++ b/pkg/kbagent/proto/errors_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package proto
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestError2Type(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "nil", want: ""},
+		{name: "not defined", err: ErrNotDefined, want: "notDefined"},
+		{name: "not implemented", err: ErrNotImplemented, want: "notImplemented"},
+		{name: "precondition failed", err: ErrPreconditionFailed, want: "preconditionFailed"},
+		{name: "bad request", err: ErrBadRequest, want: "badRequest"},
+		{name: "in progress", err: ErrInProgress, want: "inProgress"},
+		{name: "busy", err: ErrBusy, want: "busy"},
+		{name: "timed out", err: ErrTimedOut, want: "timedOut"},
+		{name: "failed", err: ErrFailed, want: "failed"},
+		{name: "internal error", err: ErrInternalError, want: "internalError"},
+		{name: "wrapped", err: errors.Join(ErrBusy), want: "busy"},
+		{name: "unknown", err: errors.New("other"), want: "unknown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Error2Type(tt.err); got != tt.want {
+				t.Fatalf("Error2Type() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestType2Error(t *testing.T) {
+	tests := []struct {
+		errType string
+		want    error
+	}{
+		{errType: "", want: nil},
+		{errType: "notDefined", want: ErrNotDefined},
+		{errType: "notImplemented", want: ErrNotImplemented},
+		{errType: "preconditionFailed", want: ErrPreconditionFailed},
+		{errType: "badRequest", want: ErrBadRequest},
+		{errType: "inProgress", want: ErrInProgress},
+		{errType: "busy", want: ErrBusy},
+		{errType: "timedOut", want: ErrTimedOut},
+		{errType: "failed", want: ErrFailed},
+		{errType: "internalError", want: ErrInternalError},
+		{errType: "unknown-type", want: ErrUnknown},
+	}
+	for _, tt := range tests {
+		t.Run(tt.errType, func(t *testing.T) {
+			if got := Type2Error(tt.errType); !errors.Is(got, tt.want) {
+				t.Fatalf("Type2Error() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/kbagent/server/http_server_test.go
+++ b/pkg/kbagent/server/http_server_test.go
@@ -1,0 +1,170 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package server
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/valyala/fasthttp"
+	"k8s.io/klog/v2/ktesting"
+
+	"github.com/apecloud/kubeblocks/pkg/kbagent/proto"
+	"github.com/apecloud/kubeblocks/pkg/kbagent/service"
+)
+
+type serverFakeService struct {
+	kind       string
+	uri        string
+	output     []byte
+	err        error
+	connCalled chan net.Conn
+}
+
+func (s *serverFakeService) Kind() string {
+	return s.kind
+}
+
+func (s *serverFakeService) URI() string {
+	return s.uri
+}
+
+func (s *serverFakeService) Start() error {
+	return nil
+}
+
+func (s *serverFakeService) HandleConn(_ context.Context, conn net.Conn) error {
+	if s.connCalled != nil {
+		s.connCalled <- conn
+	}
+	return s.err
+}
+
+func (s *serverFakeService) HandleRequest(_ context.Context, payload []byte) ([]byte, error) {
+	if string(payload) == "error" {
+		return nil, s.err
+	}
+	return s.output, nil
+}
+
+func TestNewHTTPServer(t *testing.T) {
+	logger := ktesting.NewLogger(t, ktesting.NewConfig())
+	srv := NewHTTPServer(logger, Config{Port: 3501}, nil)
+	if srv == nil {
+		t.Fatalf("NewHTTPServer() returned nil")
+	}
+	if _, ok := srv.(*httpServer); !ok {
+		t.Fatalf("NewHTTPServer() returned %T, want *httpServer", srv)
+	}
+}
+
+func TestHTTPServerStartNonBlockingNoEndpoint(t *testing.T) {
+	logger := ktesting.NewLogger(t, ktesting.NewConfig())
+	srv := &httpServer{
+		logger: logger,
+		config: Config{Address: "256.256.256.256", Port: 3501},
+	}
+	if err := srv.StartNonBlocking(); err == nil {
+		t.Fatalf("expected no endpoint error")
+	}
+}
+
+func TestHTTPServerStartNonBlockingTCP(t *testing.T) {
+	logger := ktesting.NewLogger(t, ktesting.NewConfig())
+	srv := &httpServer{
+		logger: logger,
+		config: Config{Address: "127.0.0.1", Port: 0},
+	}
+	if err := srv.StartNonBlocking(); err != nil {
+		t.Fatalf("StartNonBlocking() error = %v", err)
+	}
+	if len(srv.servers) != 1 {
+		t.Fatalf("servers = %d, want 1", len(srv.servers))
+	}
+	if srv.servers[0].Concurrency != defaultMaxConcurrency {
+		t.Fatalf("concurrency = %d, want %d", srv.servers[0].Concurrency, defaultMaxConcurrency)
+	}
+}
+
+func TestHTTPServerClose(t *testing.T) {
+	logger := ktesting.NewLogger(t, ktesting.NewConfig())
+	srv := &httpServer{
+		logger:  logger,
+		servers: []*fasthttp.Server{{}},
+	}
+	if err := srv.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+}
+
+func TestHTTPServerRouterDispatcherAndRespond(t *testing.T) {
+	logger := ktesting.NewLogger(t, ktesting.NewConfig())
+	svc := &serverFakeService{
+		kind:   proto.ServiceAction.Kind,
+		uri:    proto.ServiceAction.URI,
+		output: []byte(`{"ok":true}`),
+		err:    errors.New("failed"),
+	}
+	srv := &httpServer{
+		logger:   logger,
+		config:   Config{Logging: true},
+		services: []service.Service{svc},
+	}
+	handler := srv.router()
+
+	ctx := runFastHTTP(handler, fasthttp.MethodPost, proto.ServiceAction.URI, "ok")
+	if ctx.Response.StatusCode() != fasthttp.StatusOK {
+		t.Fatalf("status = %d, want 200", ctx.Response.StatusCode())
+	}
+	if string(ctx.Response.Body()) != `{"ok":true}` {
+		t.Fatalf("body = %q", ctx.Response.Body())
+	}
+	if string(ctx.Response.Header.ContentType()) != jsonContentTypeHeader {
+		t.Fatalf("content type = %q", ctx.Response.Header.ContentType())
+	}
+
+	ctx = runFastHTTP(handler, fasthttp.MethodPost, proto.ServiceAction.URI, "error")
+	if ctx.Response.StatusCode() != fasthttp.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", ctx.Response.StatusCode())
+	}
+	if string(ctx.Response.Body()) != "failed" {
+		t.Fatalf("error body = %q", ctx.Response.Body())
+	}
+
+	ctx = &fasthttp.RequestCtx{}
+	httpRespond(ctx, fasthttp.StatusAccepted, nil, nil)
+	if ctx.Response.StatusCode() != fasthttp.StatusAccepted || len(ctx.Response.Body()) != 0 {
+		t.Fatalf("empty response = %d %q", ctx.Response.StatusCode(), ctx.Response.Body())
+	}
+}
+
+func runFastHTTP(handler fasthttp.RequestHandler, method, uri, body string) *fasthttp.RequestCtx {
+	var req fasthttp.Request
+	req.Header.SetMethod(method)
+	req.SetRequestURI(uri)
+	req.SetBodyString(body)
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Init(&req, nil, nil)
+	handler(ctx)
+	return ctx
+}

--- a/pkg/kbagent/server/streaming_server_test.go
+++ b/pkg/kbagent/server/streaming_server_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package server
+
+import (
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"k8s.io/klog/v2/ktesting"
+
+	"github.com/apecloud/kubeblocks/pkg/kbagent/proto"
+)
+
+type errorCloser struct {
+	err error
+}
+
+func (c errorCloser) Close() error {
+	return c.err
+}
+
+func TestNewStreamingServer(t *testing.T) {
+	logger := ktesting.NewLogger(t, ktesting.NewConfig())
+	svc := &serverFakeService{kind: proto.ServiceStreaming.Kind, uri: proto.ServiceStreaming.URI}
+	srv := NewStreamingServer(logger, Config{StreamingPort: 3502}, svc)
+	if srv == nil {
+		t.Fatalf("NewStreamingServer() returned nil")
+	}
+	if _, ok := srv.(*streamingServer); !ok {
+		t.Fatalf("NewStreamingServer() returned %T, want *streamingServer", srv)
+	}
+}
+
+func TestStreamingServerStartNonBlockingStableBranches(t *testing.T) {
+	logger := ktesting.NewLogger(t, ktesting.NewConfig())
+	srv := &streamingServer{logger: logger}
+	if err := srv.StartNonBlocking(); err != nil {
+		t.Fatalf("StartNonBlocking without service error = %v", err)
+	}
+
+	srv = &streamingServer{
+		logger:  logger,
+		config:  Config{Address: "256.256.256.256", StreamingPort: 3502},
+		service: &serverFakeService{kind: proto.ServiceStreaming.Kind, uri: proto.ServiceStreaming.URI},
+	}
+	if err := srv.StartNonBlocking(); err == nil {
+		t.Fatalf("expected listen error")
+	}
+}
+
+func TestStreamingServerStartNonBlockingAcceptsConnection(t *testing.T) {
+	logger := ktesting.NewLogger(t, ktesting.NewConfig())
+	called := make(chan net.Conn, 1)
+	srv := &streamingServer{
+		logger: logger,
+		config: Config{Address: "127.0.0.1", StreamingPort: 0},
+		service: &serverFakeService{
+			kind:       proto.ServiceStreaming.Kind,
+			uri:        proto.ServiceStreaming.URI,
+			connCalled: called,
+		},
+	}
+	if err := srv.StartNonBlocking(); err != nil {
+		t.Fatalf("StartNonBlocking() error = %v", err)
+	}
+	conn, err := net.Dial("tcp", srv.listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial streaming listener: %v", err)
+	}
+	defer conn.Close()
+
+	select {
+	case accepted := <-called:
+		if accepted == nil {
+			t.Fatalf("accepted nil conn")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for accepted connection")
+	}
+}
+
+func TestStreamingServerCloseHelpers(t *testing.T) {
+	logger := ktesting.NewLogger(t, ktesting.NewConfig())
+	srv := &streamingServer{logger: logger}
+	if err := srv.Close(); err != nil {
+		t.Fatalf("Close nil listener error = %v", err)
+	}
+	if err := srv.close(nil); err != nil {
+		t.Fatalf("close nil error = %v", err)
+	}
+
+	closeErr := errors.New("close")
+	if err := srv.close(errorCloser{err: closeErr}); !errors.Is(err, closeErr) {
+		t.Fatalf("close error = %v, want %v", err, closeErr)
+	}
+	srv.silentClose(errorCloser{err: closeErr})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv.listener = listener
+	if err := srv.Close(); err != nil {
+		t.Fatalf("Close listener error = %v", err)
+	}
+}
+
+func TestStreamingServerHandleConn(t *testing.T) {
+	logger := ktesting.NewLogger(t, ktesting.NewConfig())
+	called := make(chan net.Conn, 1)
+	srv := &streamingServer{
+		logger: logger,
+		service: &serverFakeService{
+			kind:       proto.ServiceStreaming.Kind,
+			uri:        proto.ServiceStreaming.URI,
+			connCalled: called,
+		},
+	}
+	serverConn, clientConn := net.Pipe()
+	defer func() {
+		_ = clientConn.Close()
+	}()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		srv.handleConn(serverConn)
+	}()
+
+	select {
+	case conn := <-called:
+		if conn == nil {
+			t.Fatalf("HandleConn received nil conn")
+		}
+	case <-done:
+		t.Fatalf("handleConn returned before service was called")
+	}
+	<-done
+
+	if _, err := clientConn.Read(make([]byte, 1)); err == nil {
+		t.Fatalf("expected closed pipe after handleConn")
+	}
+}

--- a/pkg/kbagent/service/action_test.go
+++ b/pkg/kbagent/service/action_test.go
@@ -20,10 +20,105 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package service
 
 import (
+	"bytes"
+	"encoding/json"
+
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+
+	"github.com/apecloud/kubeblocks/pkg/kbagent/proto"
 )
 
 var _ = Describe("action", func() {
 	Context("action", func() {
+		It("exposes service metadata and no-op methods", func() {
+			svc, err := newActionService(logr.New(nil), nil)
+			Expect(err).Should(BeNil())
+			Expect(svc.Kind()).Should(Equal(proto.ServiceAction.Kind))
+			Expect(svc.URI()).Should(Equal(proto.ServiceAction.URI))
+			Expect(svc.Start()).Should(Succeed())
+			Expect(svc.HandleConn(ctx, nil)).Should(Succeed())
+		})
+
+		It("decodes and encodes action responses", func() {
+			svc, err := newActionService(logr.New(nil), nil)
+			Expect(err).Should(BeNil())
+
+			req, err := svc.decode([]byte(`{"action":"backup"}`))
+			Expect(err).Should(BeNil())
+			Expect(req.Action).Should(Equal("backup"))
+
+			_, err = svc.decode([]byte("{"))
+			Expect(errors.Is(err, proto.ErrBadRequest)).Should(BeTrue())
+
+			data := svc.encode([]byte("ok"), nil)
+			resp := &proto.ActionResponse{}
+			Expect(json.Unmarshal(data, resp)).Should(Succeed())
+			Expect(resp.Output).Should(Equal([]byte("ok")))
+
+			data = svc.encode(nil, proto.ErrNotDefined)
+			resp = &proto.ActionResponse{}
+			Expect(json.Unmarshal(data, resp)).Should(Succeed())
+			Expect(resp.Error).Should(Equal("notDefined"))
+			Expect(resp.Message).Should(ContainSubstring(proto.ErrNotDefined.Error()))
+		})
+
+		It("handles request errors through encoded responses", func() {
+			svc, err := newActionService(logr.New(nil), nil)
+			Expect(err).Should(BeNil())
+
+			data, err := svc.HandleRequest(ctx, []byte("{"))
+			Expect(err).Should(BeNil())
+			resp := &proto.ActionResponse{}
+			Expect(json.Unmarshal(data, resp)).Should(Succeed())
+			Expect(resp.Error).Should(Equal("badRequest"))
+
+			data, err = svc.HandleRequest(ctx, []byte(`{"action":"missing"}`))
+			Expect(err).Should(BeNil())
+			resp = &proto.ActionResponse{}
+			Expect(json.Unmarshal(data, resp)).Should(Succeed())
+			Expect(resp.Error).Should(Equal("notDefined"))
+		})
+
+		It("handles non-blocking in-progress and completion states", func() {
+			svc, err := newActionService(logr.New(nil), []proto.Action{{
+				Name: "async",
+				Exec: &proto.ExecAction{Commands: []string{"/bin/bash", "-c", "echo -n unused"}},
+			}})
+			Expect(err).Should(BeNil())
+
+			resultChan := make(chan *asyncResult, 1)
+			svc.runningActions["async"] = &runningAction{resultChan: resultChan}
+			req := &proto.ActionRequest{Action: "async"}
+
+			out, err := svc.handleRequestNonBlocking(ctx, req, svc.actions["async"], nil)
+			Expect(out).Should(BeNil())
+			Expect(errors.Is(err, proto.ErrInProgress)).Should(BeTrue())
+
+			resultChan <- &asyncResult{stdout: bytes.NewBufferString("done"), stderr: bytes.NewBuffer(nil)}
+			out, err = svc.handleRequestNonBlocking(ctx, req, svc.actions["async"], nil)
+			Expect(err).Should(BeNil())
+			Expect(string(out)).Should(Equal("done"))
+			Expect(svc.runningActions).ShouldNot(HaveKey("async"))
+		})
+
+		It("rejects runtime arguments for non-exec actions in blocking and non-blocking calls", func() {
+			action := &proto.Action{HTTP: &proto.HTTPAction{Port: "80"}}
+			_, err := callActionWithRetry(ctx, action, nil, [][]string{{"arg"}}, nil, nil)
+			Expect(errors.Is(err, proto.ErrBadRequest)).Should(BeTrue())
+
+			_, err = nonBlockingCallActionWithRetry(ctx, action, nil, [][]string{{"arg"}}, nil, nil)
+			Expect(errors.Is(err, proto.ErrBadRequest)).Should(BeTrue())
+		})
+
+		It("resolves timeout preference", func() {
+			actionTimeout := int32(10)
+			requestTimeout := int32(1)
+			Expect(resolveTimeout(&actionTimeout, &requestTimeout)).Should(Equal(&requestTimeout))
+			Expect(resolveTimeout(&actionTimeout, nil)).Should(Equal(&actionTimeout))
+		})
 	})
 })

--- a/pkg/kbagent/service/action_utils_test.go
+++ b/pkg/kbagent/service/action_utils_test.go
@@ -606,6 +606,31 @@ var _ = Describe("action utils", func() {
 			Expect(err.Error()).Should(ContainSubstring("internal server error"))
 			Expect(output).Should(BeNil())
 		})
+
+		It("returns template and URL construction errors before issuing requests", func() {
+			method, url := httpActionMethodNURL(&proto.HTTPAction{Port: "3501"})
+			Expect(method).Should(Equal(defaultHTTPMethod))
+			Expect(url).Should(Equal("HTTP://127.0.0.1:3501/"))
+
+			action := &proto.Action{
+				HTTP: &proto.HTTPAction{
+					Port: port,
+					Body: "{{ .missing }}",
+				},
+			}
+			_, err := nonBlockingCallActionX(ctx, action, nil, nil, nil, nil, nil, nil)
+			Expect(err).ShouldNot(BeNil())
+
+			action.HTTP.Body = ""
+			action.HTTP.Headers = []proto.HTTPHeader{{Name: "x-test", Value: "{{ .missing }}"}}
+			_, err = nonBlockingCallActionX(ctx, action, nil, nil, nil, nil, nil, nil)
+			Expect(err).ShouldNot(BeNil())
+
+			action.HTTP.Headers = nil
+			action.HTTP.Method = " bad method"
+			_, err = nonBlockingCallActionX(ctx, action, nil, nil, nil, nil, nil, nil)
+			Expect(err).ShouldNot(BeNil())
+		})
 	})
 
 	Context("grpc", func() {
@@ -1020,5 +1045,74 @@ message EchoResponse {
 			Expect(err.Error()).Should(ContainSubstring("error"))
 			Expect(output).Should(BeNil())
 		})
+
+		It("sets and gets dynamic grpc message fields", func() {
+			fd := dynamicGRPCFieldFile()
+			msgDesc := fd.Messages().ByName("Dynamic")
+			msg := dynamicpb.NewMessage(msgDesc)
+
+			Expect(setGRPCMessageField(msg, "name", "redis")).Should(Succeed())
+			Expect(setGRPCMessageField(msg, "count", "3")).Should(Succeed())
+			Expect(setGRPCMessageField(msg, "enabled", "true")).Should(Succeed())
+			Expect(setGRPCMessageField(msg, "labels", `{"role":"primary"}`)).Should(Succeed())
+
+			name, err := getGRPCMessageField(msg, "name")
+			Expect(err).Should(BeNil())
+			Expect(name).Should(Equal("redis"))
+			count, err := getGRPCMessageField(msg, "count")
+			Expect(err).Should(BeNil())
+			Expect(count).Should(Equal("3"))
+			enabled, err := getGRPCMessageField(msg, "enabled")
+			Expect(err).Should(BeNil())
+			Expect(enabled).Should(Equal("true"))
+
+			Expect(setGRPCMessageField(msg, "missing", "value")).Should(MatchError(ContainSubstring("field missing not found")))
+			Expect(setGRPCMessageField(msg, "count", "bad")).ShouldNot(Succeed())
+			Expect(setGRPCMessageField(msg, "enabled", "bad")).ShouldNot(Succeed())
+			Expect(setGRPCMessageField(msg, "labels", "{")).ShouldNot(Succeed())
+
+			_, err = getGRPCMessageField(msg, "missing")
+			Expect(err).Should(MatchError(ContainSubstring("field missing not found")))
+			_, err = getGRPCMessageField(msg, "labels")
+			Expect(err).Should(MatchError(ContainSubstring("unsupported field type")))
+		})
 	})
 })
+
+func dynamicGRPCFieldFile() protoreflect.FileDescriptor {
+	str := func(v string) *string { return &v }
+	i32 := func(v int32) *int32 { return &v }
+	boolp := func(v bool) *bool { return &v }
+
+	labelOptional := descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL
+	labelRepeated := descriptorpb.FieldDescriptorProto_LABEL_REPEATED
+	typeString := descriptorpb.FieldDescriptorProto_TYPE_STRING
+	typeInt32 := descriptorpb.FieldDescriptorProto_TYPE_INT32
+	typeBool := descriptorpb.FieldDescriptorProto_TYPE_BOOL
+	typeMessage := descriptorpb.FieldDescriptorProto_TYPE_MESSAGE
+
+	fd, err := protodesc.NewFile(&descriptorpb.FileDescriptorProto{
+		Name:    str("dynamic.proto"),
+		Package: str("test"),
+		Syntax:  str("proto3"),
+		MessageType: []*descriptorpb.DescriptorProto{{
+			Name: str("Dynamic"),
+			Field: []*descriptorpb.FieldDescriptorProto{
+				{Name: str("name"), Number: i32(1), Label: &labelOptional, Type: &typeString, JsonName: str("name")},
+				{Name: str("count"), Number: i32(2), Label: &labelOptional, Type: &typeInt32, JsonName: str("count")},
+				{Name: str("enabled"), Number: i32(3), Label: &labelOptional, Type: &typeBool, JsonName: str("enabled")},
+				{Name: str("labels"), Number: i32(4), Label: &labelRepeated, Type: &typeMessage, TypeName: str(".test.Dynamic.LabelsEntry"), JsonName: str("labels")},
+			},
+			NestedType: []*descriptorpb.DescriptorProto{{
+				Name: str("LabelsEntry"),
+				Field: []*descriptorpb.FieldDescriptorProto{
+					{Name: str("key"), Number: i32(1), Label: &labelOptional, Type: &typeString, JsonName: str("key")},
+					{Name: str("value"), Number: i32(2), Label: &labelOptional, Type: &typeString, JsonName: str("value")},
+				},
+				Options: &descriptorpb.MessageOptions{MapEntry: boolp(true)},
+			}},
+		}},
+	}, nil)
+	Expect(err).Should(BeNil())
+	return fd
+}

--- a/pkg/kbagent/service/probe_test.go
+++ b/pkg/kbagent/service/probe_test.go
@@ -73,6 +73,8 @@ var _ = Describe("probe", func() {
 			Expect(err).Should(BeNil())
 			Expect(service).ShouldNot(BeNil())
 			Expect(service.Kind()).Should(Equal(proto.ServiceProbe.Kind))
+			Expect(service.URI()).Should(Equal(proto.ServiceProbe.URI))
+			Expect(service.HandleConn(ctx, nil)).Should(Succeed())
 		})
 
 		It("start", func() {

--- a/pkg/kbagent/service/reconfigure_test.go
+++ b/pkg/kbagent/service/reconfigure_test.go
@@ -83,6 +83,38 @@ var _ = Describe("reconfigure", func() {
 			Expect(errors.Is(err, proto.ErrBadRequest)).Should(BeTrue())
 		})
 
+		It("checks created and removed files", func() {
+			file, _ := createFile()
+			defer removeFile()
+
+			req := &proto.ActionRequest{
+				Action: "udf-reconfigure",
+				Parameters: map[string]string{
+					configFilesCreated: file,
+				},
+			}
+			Expect(checkReconfigure(ctx, req)).Should(Succeed())
+
+			req.Parameters = map[string]string{
+				configFilesCreated: file + ".missing",
+			}
+			err := checkReconfigure(ctx, req)
+			Expect(err).ShouldNot(BeNil())
+			Expect(errors.Is(err, proto.ErrPreconditionFailed)).Should(BeTrue())
+
+			req.Parameters = map[string]string{
+				configFilesRemoved: file + ".missing",
+			}
+			Expect(checkReconfigure(ctx, req)).Should(Succeed())
+
+			req.Parameters = map[string]string{
+				configFilesRemoved: file,
+			}
+			err = checkReconfigure(ctx, req)
+			Expect(err).ShouldNot(BeNil())
+			Expect(errors.Is(err, proto.ErrPreconditionFailed)).Should(BeTrue())
+		})
+
 		It("check failed", func() {
 			file, checksum := createFile()
 			defer removeFile()

--- a/pkg/kbagent/service/streaming_test.go
+++ b/pkg/kbagent/service/streaming_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package service
+
+import (
+	"net"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+
+	"github.com/apecloud/kubeblocks/pkg/kbagent/proto"
+)
+
+var _ = Describe("streaming", func() {
+	Context("streaming", func() {
+		It("exposes service metadata and request unsupported error", func() {
+			actionSvc, err := newActionService(logr.New(nil), []proto.Action{{
+				Name: "dump",
+				Exec: &proto.ExecAction{Commands: []string{"/bin/bash", "-c", "cat"}},
+			}})
+			Expect(err).Should(BeNil())
+			svc, err := newStreamingService(logr.New(nil), actionSvc, []string{"dump"})
+			Expect(err).Should(BeNil())
+
+			Expect(svc.Kind()).Should(Equal(proto.ServiceStreaming.Kind))
+			Expect(svc.URI()).Should(Equal(proto.ServiceStreaming.URI))
+			Expect(svc.Start()).Should(Succeed())
+			out, err := svc.HandleRequest(ctx, []byte("{}"))
+			Expect(out).Should(BeNil())
+			Expect(errors.Is(err, proto.ErrNotImplemented)).Should(BeTrue())
+		})
+
+		It("rejects unsupported handshake actions", func() {
+			actionSvc, err := newActionService(logr.New(nil), []proto.Action{{
+				Name: "dump",
+				Exec: &proto.ExecAction{Commands: []string{"/bin/bash", "-c", "cat"}},
+			}})
+			Expect(err).Should(BeNil())
+			svc, err := newStreamingService(logr.New(nil), actionSvc, []string{"dump"})
+			Expect(err).Should(BeNil())
+
+			serverConn, clientConn := net.Pipe()
+			defer clientConn.Close()
+			go func() {
+				defer GinkgoRecover()
+				_, _ = clientConn.Write([]byte(`{"action":"missing"}`))
+			}()
+
+			err = svc.HandleConn(ctx, serverConn)
+			Expect(err).Should(MatchError(ContainSubstring("missing is not supported")))
+		})
+
+		It("returns bad request for invalid handshake packets", func() {
+			svc := &streamingService{}
+			serverConn, clientConn := net.Pipe()
+			defer clientConn.Close()
+			go func() {
+				defer GinkgoRecover()
+				_, _ = clientConn.Write([]byte("{"))
+				_ = clientConn.Close()
+			}()
+
+			req, err := svc.handshake(ctx, serverConn)
+			Expect(req).Should(BeNil())
+			Expect(errors.Is(err, proto.ErrBadRequest)).Should(BeTrue())
+		})
+
+		It("handles supported streaming actions", func() {
+			actionSvc, err := newActionService(logr.New(nil), []proto.Action{{
+				Name: "dump",
+				Exec: &proto.ExecAction{Commands: []string{"/bin/bash", "-c", "true"}},
+			}})
+			Expect(err).Should(BeNil())
+			svc, err := newStreamingService(logr.New(nil), actionSvc, []string{"dump"})
+			Expect(err).Should(BeNil())
+
+			serverConn, clientConn := net.Pipe()
+			defer clientConn.Close()
+			go func() {
+				defer GinkgoRecover()
+				_, _ = clientConn.Write([]byte(`{"action":"dump"}`))
+			}()
+
+			Expect(svc.HandleConn(ctx, serverConn)).Should(Succeed())
+			Expect(serverConn.Close()).Should(Succeed())
+		})
+	})
+})

--- a/pkg/kbagent/service/task_test.go
+++ b/pkg/kbagent/service/task_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/go-logr/logr"
+
+	"github.com/apecloud/kubeblocks/pkg/kbagent/proto"
+)
+
+type fakeTask struct {
+	statusCalled chan struct{}
+}
+
+func (t fakeTask) run(context.Context) (chan error, error) {
+	ch := make(chan error, 1)
+	ch <- nil
+	return ch, nil
+}
+
+func (t fakeTask) status(_ context.Context, _ *proto.TaskEvent) {
+	t.statusCalled <- struct{}{}
+}
+
+var _ = Describe("task", func() {
+	Context("task", func() {
+		It("runs no-op task lists through exported helper", func() {
+			GinkgoT().Setenv("KB_AGENT_POD_NAME", "pod-0")
+			actionSvc, err := newActionService(logr.New(nil), nil)
+			Expect(err).Should(BeNil())
+			Expect(RunTasks(logr.New(nil), actionSvc, []proto.Task{{Replicas: "pod-1"}})).Should(Succeed())
+		})
+
+		It("handles wait channel states", func() {
+			svc := &taskService{}
+			Expect(svc.wait(nil)).Should(Succeed())
+
+			ch := make(chan error, 1)
+			ch <- errors.New("failed")
+			Expect(svc.wait(ch)).Should(MatchError("failed"))
+
+			closed := make(chan error)
+			close(closed)
+			Expect(svc.wait(closed)).Should(MatchError(ContainSubstring("error chan closed unexpectedly")))
+		})
+
+		It("creates new replica tasks and returns stable validation errors", func() {
+			GinkgoT().Setenv("KB_AGENT_POD_NAME", "pod-0")
+			actionSvc, err := newActionService(logr.New(nil), []proto.Action{{
+				Name: newReplicaDataLoad,
+				Exec: &proto.ExecAction{Commands: []string{"/bin/bash", "-c", "cat"}},
+			}})
+			Expect(err).Should(BeNil())
+			svc := &taskService{logger: logr.New(nil), actionService: actionSvc}
+
+			Expect(svc.newTask(proto.Task{})).Should(BeNil())
+			Expect(svc.newTask(proto.Task{NewReplica: &proto.NewReplicaTask{}})).ShouldNot(BeNil())
+
+			err = svc.runTask(ctx, proto.Task{
+				Instance: "inst",
+				Task:     "new-replica",
+				UID:      "u1",
+				NewReplica: &proto.NewReplicaTask{
+					Port: 3502,
+				},
+			})
+			Expect(err).Should(MatchError("remote server is required"))
+		})
+
+		It("runs matching replica tasks and propagates task errors", func() {
+			GinkgoT().Setenv("KB_AGENT_POD_NAME", "pod-0")
+			actionSvc, err := newActionService(logr.New(nil), []proto.Action{{
+				Name: newReplicaDataLoad,
+				Exec: &proto.ExecAction{Commands: []string{"/bin/bash", "-c", "cat"}},
+			}})
+			Expect(err).Should(BeNil())
+			svc := &taskService{
+				logger:        logr.New(nil),
+				actionService: actionSvc,
+				tasks: []proto.Task{{
+					Instance:   "inst",
+					Task:       "new-replica",
+					UID:        "u1",
+					Replicas:   "pod-0,pod-1",
+					NewReplica: &proto.NewReplicaTask{Port: 3502},
+				}},
+			}
+
+			Expect(svc.runTasks(ctx)).Should(MatchError("remote server is required"))
+		})
+
+		It("reports task status until stopped", func() {
+			svc := &taskService{logger: logr.New(nil)}
+			fake := fakeTask{statusCalled: make(chan struct{}, 1)}
+			exit, exited := svc.report(ctx, proto.Task{ReportPeriodSeconds: 1}, fake, proto.TaskEvent{})
+			Expect(exit).ShouldNot(BeNil())
+			Expect(exited).ShouldNot(BeNil())
+
+			select {
+			case <-fake.statusCalled:
+			case <-time.After(2 * time.Second):
+				Fail("timed out waiting for status report")
+			}
+			close(exit)
+			Eventually(exited).Should(BeClosed())
+
+			exit, exited = svc.report(ctx, proto.Task{}, fake, proto.TaskEvent{})
+			Expect(exit).Should(BeNil())
+			Expect(exited).Should(BeNil())
+		})
+
+		It("keeps the run error when finish notification also fails", func() {
+			GinkgoT().Setenv("KB_AGENT_POD_NAME", "pod-0")
+			GinkgoT().Setenv("KUBECONFIG", "/path/to/missing/kubeconfig")
+			actionSvc, err := newActionService(logr.New(nil), []proto.Action{{
+				Name: newReplicaDataLoad,
+				Exec: &proto.ExecAction{Commands: []string{"/bin/bash", "-c", "cat"}},
+			}})
+			Expect(err).Should(BeNil())
+			svc := &taskService{logger: logr.New(nil), actionService: actionSvc}
+
+			err = svc.runTask(ctx, proto.Task{
+				Instance:       "inst",
+				Task:           "new-replica",
+				UID:            "u1",
+				NotifyAtFinish: true,
+				NewReplica:     &proto.NewReplicaTask{Port: 3502},
+			})
+			Expect(err).Should(MatchError("remote server is required"))
+		})
+
+		It("writes a new-replica handshake packet to the remote server", func() {
+			GinkgoT().Setenv("KB_AGENT_POD_NAME", "pod-0")
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			Expect(err).Should(BeNil())
+			defer listener.Close()
+
+			accepted := make(chan proto.ActionRequest, 1)
+			go func() {
+				defer GinkgoRecover()
+				conn, err := listener.Accept()
+				Expect(err).Should(BeNil())
+				defer conn.Close()
+				req := proto.ActionRequest{}
+				Expect(json.NewDecoder(conn).Decode(&req)).Should(Succeed())
+				accepted <- req
+			}()
+
+			_, port, err := net.SplitHostPort(listener.Addr().String())
+			Expect(err).Should(BeNil())
+			var portNumber int
+			_, err = fmt.Sscanf(port, "%d", &portNumber)
+			Expect(err).Should(BeNil())
+
+			task := &newReplicaTask{
+				task: &proto.NewReplicaTask{
+					Remote:     "127.0.0.1",
+					Port:       int32(portNumber),
+					Parameters: map[string]string{"foo": "bar"},
+				},
+			}
+			conn, err := task.handshake(ctx)
+			Expect(err).Should(BeNil())
+			Expect(conn.Close()).Should(Succeed())
+
+			req := <-accepted
+			Expect(req.Action).Should(Equal(newReplicaDataDump))
+			Expect(req.Parameters).Should(HaveKeyWithValue("foo", "bar"))
+			Expect(req.Parameters).Should(HaveKeyWithValue(targetPodNameEnv, "pod-0"))
+
+			event := &proto.TaskEvent{Code: -1, Message: "old", Output: []byte("old")}
+			task.status(ctx, event)
+			Expect(event.Code).Should(BeZero())
+			Expect(event.Message).Should(BeEmpty())
+			Expect(event.Output).Should(BeNil())
+		})
+
+		It("validates remote connection settings", func() {
+			task := &newReplicaTask{task: &proto.NewReplicaTask{Remote: "127.0.0.1"}}
+			conn, err := task.connectToRemote(ctx)
+			Expect(conn).Should(BeNil())
+			Expect(err).Should(MatchError("remote port is required"))
+		})
+	})
+})

--- a/pkg/kbagent/setup_test.go
+++ b/pkg/kbagent/setup_test.go
@@ -1,0 +1,256 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package kbagent
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2/ktesting"
+
+	"github.com/apecloud/kubeblocks/pkg/kbagent/proto"
+	"github.com/apecloud/kubeblocks/pkg/kbagent/server"
+	"github.com/apecloud/kubeblocks/pkg/kbagent/service"
+)
+
+type setupFakeService struct {
+	kind     string
+	uri      string
+	startErr error
+}
+
+func (s setupFakeService) Kind() string {
+	return s.kind
+}
+
+func (s setupFakeService) URI() string {
+	return s.uri
+}
+
+func (s setupFakeService) Start() error {
+	return s.startErr
+}
+
+func (s setupFakeService) HandleConn(context.Context, net.Conn) error {
+	return nil
+}
+
+func (s setupFakeService) HandleRequest(context.Context, []byte) ([]byte, error) {
+	return nil, nil
+}
+
+func TestBuildEnv4Server(t *testing.T) {
+	env, err := BuildEnv4Server(
+		[]proto.Action{{Name: "backup", Exec: &proto.ExecAction{Commands: []string{"echo"}}}},
+		[]proto.Probe{{Instance: "pod", Action: "backup"}},
+		[]string{"backup"},
+	)
+	if err != nil {
+		t.Fatalf("BuildEnv4Server() error = %v", err)
+	}
+
+	got := envVarMap(env)
+	if got[actionEnvName] == "" || got[probeEnvName] == "" || got[streamingEnvName] != "backup" {
+		t.Fatalf("unexpected env: %#v", got)
+	}
+
+	actions, probes, err := deserializeActionNProbe(got[actionEnvName], got[probeEnvName])
+	if err != nil {
+		t.Fatalf("deserialize action/probe: %v", err)
+	}
+	if len(actions) != 1 || actions[0].Name != "backup" || len(probes) != 1 || probes[0].Action != "backup" {
+		t.Fatalf("unexpected action/probe: %#v %#v", actions, probes)
+	}
+}
+
+func TestBuildAndUpdateEnv4Worker(t *testing.T) {
+	taskEnv, err := BuildEnv4Worker([]proto.Task{{Instance: "inst", Task: "new-replica", UID: "u1", Replicas: "pod-0"}})
+	if err != nil {
+		t.Fatalf("BuildEnv4Worker() error = %v", err)
+	}
+	if taskEnv.Name != taskEnvName || taskEnv.Value == "" {
+		t.Fatalf("unexpected task env: %#v", taskEnv)
+	}
+
+	updated, err := UpdateEnv4Worker(map[string]string{taskEnvName: taskEnv.Value}, func(task proto.Task) *proto.Task {
+		task.Replicas = "pod-1"
+		return &task
+	})
+	if err != nil {
+		t.Fatalf("UpdateEnv4Worker() error = %v", err)
+	}
+	tasks, err := deserializeTask(updated.Value)
+	if err != nil {
+		t.Fatalf("deserialize task: %v", err)
+	}
+	if len(tasks) != 1 || tasks[0].Replicas != "pod-1" {
+		t.Fatalf("unexpected updated tasks: %#v", tasks)
+	}
+
+	updated, err = UpdateEnv4Worker(map[string]string{taskEnvName: taskEnv.Value}, func(proto.Task) *proto.Task { return nil })
+	if err != nil {
+		t.Fatalf("UpdateEnv4Worker remove error = %v", err)
+	}
+	tasks, err = deserializeTask(updated.Value)
+	if err != nil {
+		t.Fatalf("deserialize removed tasks: %v", err)
+	}
+	if len(tasks) != 0 {
+		t.Fatalf("expected removed tasks, got %#v", tasks)
+	}
+
+	if updated, err = UpdateEnv4Worker(nil, nil); updated != nil || err != nil {
+		t.Fatalf("UpdateEnv4Worker(nil) = %#v, %v", updated, err)
+	}
+	if updated, err = UpdateEnv4Worker(map[string]string{}, nil); updated != nil || err != nil {
+		t.Fatalf("UpdateEnv4Worker(no task) = %#v, %v", updated, err)
+	}
+	if updated, err = UpdateEnv4Worker(map[string]string{taskEnvName: "{"}, nil); updated != nil || err == nil {
+		t.Fatalf("expected invalid task env error, got %#v, %v", updated, err)
+	}
+}
+
+func TestInitializeAndEnvAccessors(t *testing.T) {
+	logger := ktesting.NewLogger(t, ktesting.NewConfig())
+	actionsEnv, _, err := serializeActionNProbe([]proto.Action{{Name: "dump", Exec: &proto.ExecAction{Commands: []string{"echo"}}}}, nil)
+	if err != nil {
+		t.Fatalf("serialize action/probe: %v", err)
+	}
+
+	services, err := initialize(logger, map[string]string{actionEnvName: actionsEnv, streamingEnvName: "dump"})
+	if err != nil {
+		t.Fatalf("initialize() error = %v", err)
+	}
+	if actionService(services) == nil || streamingService(services) == nil {
+		t.Fatalf("expected action and streaming services, got %#v", services)
+	}
+
+	if services, err = initialize(logger, nil); services != nil || err != nil {
+		t.Fatalf("initialize(nil) = %#v, %v", services, err)
+	}
+	if services, err = initialize(logger, map[string]string{actionEnvName: "{"}); services != nil || err == nil {
+		t.Fatalf("expected invalid action env error, got %#v, %v", services, err)
+	}
+
+	da, dp, ds := getActionProbeNStreamingEnvValues(map[string]string{
+		actionEnvName:    "a",
+		probeEnvName:     "p",
+		streamingEnvName: "s",
+	})
+	if da != "a" || dp != "p" || ds != "s" {
+		t.Fatalf("unexpected env values: %q %q %q", da, dp, ds)
+	}
+	da, dp, ds = getActionProbeNStreamingEnvValues(map[string]string{probeEnvName: "p"})
+	if da != "" || dp != "" || ds != "" {
+		t.Fatalf("unexpected missing action values: %q %q %q", da, dp, ds)
+	}
+}
+
+func TestSerializeDeserializeTask(t *testing.T) {
+	serialized, err := serializeTask([]proto.Task{{Instance: "inst", Task: "task", UID: "u1"}})
+	if err != nil {
+		t.Fatalf("serializeTask() error = %v", err)
+	}
+	tasks, err := deserializeTask(serialized)
+	if err != nil {
+		t.Fatalf("deserializeTask() error = %v", err)
+	}
+	if len(tasks) != 1 || tasks[0].UID != "u1" {
+		t.Fatalf("unexpected tasks: %#v", tasks)
+	}
+	if tasks, err = deserializeTask("{"); tasks != nil || err == nil {
+		t.Fatalf("expected invalid task error, got %#v, %v", tasks, err)
+	}
+}
+
+func TestRunAsServerStableErrors(t *testing.T) {
+	logger := ktesting.NewLogger(t, ktesting.NewConfig())
+	if err := runAsServer(logger, server.Config{Port: 3501, StreamingPort: 3501}, nil); err == nil {
+		t.Fatalf("expected same port error")
+	}
+
+	startErr := errors.New("start")
+	err := runAsServer(logger, server.Config{Port: 3501, StreamingPort: 3502}, []service.Service{
+		setupFakeService{kind: proto.ServiceAction.Kind, uri: proto.ServiceAction.URI, startErr: startErr},
+	})
+	if !errors.Is(err, startErr) {
+		t.Fatalf("runAsServer start error = %v, want %v", err, startErr)
+	}
+}
+
+func TestRunAsServerStartsHTTPWithNoStreamingService(t *testing.T) {
+	logger := ktesting.NewLogger(t, ktesting.NewConfig())
+	err := runAsServer(logger, server.Config{Address: "127.0.0.1", Port: 0, StreamingPort: 3502}, []service.Service{
+		setupFakeService{kind: proto.ServiceAction.Kind, uri: proto.ServiceAction.URI},
+	})
+	if err != nil {
+		t.Fatalf("runAsServer() error = %v", err)
+	}
+}
+
+func TestRunAsWorkerStableBranches(t *testing.T) {
+	logger := ktesting.NewLogger(t, ktesting.NewConfig())
+	if err := runAsWorker(logger, nil, nil); err != nil {
+		t.Fatalf("runAsWorker(nil env) error = %v", err)
+	}
+	if err := runAsWorker(logger, nil, map[string]string{taskEnvName: "{"}); err == nil {
+		t.Fatalf("expected invalid task error")
+	}
+}
+
+func TestLaunchWorkerWithoutTask(t *testing.T) {
+	t.Setenv(actionEnvName, "")
+	logger := ktesting.NewLogger(t, ktesting.NewConfig())
+	serverMode, err := Launch(logger, server.Config{})
+	if err != nil {
+		t.Fatalf("Launch() error = %v", err)
+	}
+	if serverMode {
+		t.Fatalf("expected worker mode")
+	}
+}
+
+func TestServiceSelectors(t *testing.T) {
+	services := []service.Service{
+		setupFakeService{kind: proto.ServiceProbe.Kind, uri: proto.ServiceProbe.URI},
+		setupFakeService{kind: proto.ServiceAction.Kind, uri: proto.ServiceAction.URI},
+		setupFakeService{kind: proto.ServiceStreaming.Kind, uri: proto.ServiceStreaming.URI},
+	}
+	if actionService(services) == nil {
+		t.Fatalf("expected action service")
+	}
+	if streamingService(services) == nil {
+		t.Fatalf("expected streaming service")
+	}
+	if actionService(nil) != nil || streamingService(nil) != nil {
+		t.Fatalf("expected nil selectors for empty services")
+	}
+}
+
+func envVarMap(vars []corev1.EnvVar) map[string]string {
+	got := make(map[string]string, len(vars))
+	for _, env := range vars {
+		got[env.Name] = env.Value
+	}
+	return got
+}

--- a/pkg/kbagent/util/env_test.go
+++ b/pkg/kbagent/util/env_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package util
+
+import "testing"
+
+func TestEnvListMapConversion(t *testing.T) {
+	got := EnvL2M([]string{"A=1", "B=two=parts", "EMPTY"})
+	if got["A"] != "1" || got["B"] != "two=parts" || got["EMPTY"] != "" {
+		t.Fatalf("unexpected env map: %#v", got)
+	}
+
+	roundTrip := EnvL2M(EnvM2L(map[string]string{"A": "1", "B": ""}))
+	if roundTrip["A"] != "1" || roundTrip["B"] != "" {
+		t.Fatalf("unexpected round trip map: %#v", roundTrip)
+	}
+}
+
+func TestDefaultEnvVarsAndAccessors(t *testing.T) {
+	envVars := DefaultEnvVars()
+	if len(envVars) != 4 {
+		t.Fatalf("DefaultEnvVars() length = %d, want 4", len(envVars))
+	}
+	fields := map[string]string{}
+	for _, env := range envVars {
+		if env.ValueFrom == nil || env.ValueFrom.FieldRef == nil {
+			t.Fatalf("env %s should use fieldRef", env.Name)
+		}
+		fields[env.Name] = env.ValueFrom.FieldRef.FieldPath
+	}
+	if fields[kbEnvNamespace] != "metadata.namespace" ||
+		fields[kbEnvPodName] != "metadata.name" ||
+		fields[kbEnvPodUID] != "metadata.uid" ||
+		fields[kbEnvNodeName] != "spec.nodeName" {
+		t.Fatalf("unexpected field refs: %#v", fields)
+	}
+
+	t.Setenv(kbEnvNamespace, "ns")
+	t.Setenv(kbEnvPodName, "pod")
+	t.Setenv(kbEnvPodUID, "uid")
+	t.Setenv(kbEnvNodeName, "node")
+	if namespace() != "ns" || PodName() != "pod" || podName() != "pod" || podUID() != "uid" || nodeName() != "node" {
+		t.Fatalf("unexpected env accessors: namespace=%q pod=%q uid=%q node=%q", namespace(), podName(), podUID(), nodeName())
+	}
+}

--- a/pkg/kbagent/util/event_test.go
+++ b/pkg/kbagent/util/event_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+
+	"github.com/apecloud/kubeblocks/pkg/kbagent/proto"
+)
+
+func TestNewEventAndName(t *testing.T) {
+	t.Setenv(kbEnvNamespace, "ns")
+	t.Setenv(kbEnvPodName, "pod")
+	t.Setenv(kbEnvPodUID, "uid")
+	t.Setenv(kbEnvNodeName, "node")
+
+	eventName := generateEventName("Ready", "ok")
+	if eventName == "" || eventName == generateEventName("Ready", "changed") {
+		t.Fatalf("unexpected generated event names")
+	}
+
+	event := newEvent("Ready", "ok")
+	if event.Name != eventName || event.Namespace != "ns" {
+		t.Fatalf("unexpected event identity: %s/%s", event.Namespace, event.Name)
+	}
+	if event.InvolvedObject.Name != "pod" || string(event.InvolvedObject.UID) != "uid" {
+		t.Fatalf("unexpected involved object: %#v", event.InvolvedObject)
+	}
+	if event.Source.Component != proto.ProbeEventSourceComponent || event.Source.Host != "node" {
+		t.Fatalf("unexpected event source: %#v", event.Source)
+	}
+	if event.ReportingController != proto.ProbeEventReportingController || event.ReportingInstance != "pod" {
+		t.Fatalf("unexpected reporting fields: %#v", event)
+	}
+	if event.Action != "Ready" || event.Type != "Normal" || event.Count != 1 {
+		t.Fatalf("unexpected event fields: %#v", event)
+	}
+}
+
+func TestSendEventWithMessageSyncConfigError(t *testing.T) {
+	t.Setenv("KUBECONFIG", "/path/to/missing/kubeconfig")
+
+	logger := logr.Discard()
+	if err := SendEventWithMessage(&logger, "Ready", "ok", true); err == nil {
+		t.Fatalf("expected kube config error")
+	}
+	if err := createOrUpdateEvent("Ready", "ok", 0, 0); err == nil {
+		t.Fatalf("expected create event kube config error")
+	}
+	if clientSet, err := getK8sClientSet(); clientSet != nil || err == nil {
+		t.Fatalf("expected nil clientset and kube config error, got %#v, %v", clientSet, err)
+	}
+}


### PR DESCRIPTION
## Summary
- add focused pkg/kbagent unit tests for proto errors, env/event utilities, client branches, server dispatch/streaming helpers, setup env/task paths, and service action/streaming/task/reconfigure branches
- keep coverage tests on stable local-only paths with httptest, net.Pipe, fake services, and controlled localhost listeners

## Validation
- env GOFLAGS=-mod=mod GOCACHE=<go-build-cache> go test -short ./pkg/kbagent/... -coverprofile=<tmp-cover>
- env GOCACHE=<go-build-cache> go tool cover -func=<tmp-cover>
- combined statement coverage: 80.2%

## Notes
- no production code changes