### PR TITLE
chore: improve pkg controller coverage

### DIFF
--- a/pkg/controller/builder/builder_component_definition_test.go
+++ b/pkg/controller/builder/builder_component_definition_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package builder
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+)
+
+var _ = Describe("component definition builder", func() {
+	It("should set component definition spec fields", func() {
+		updateStrategy := appsv1.BestEffortParallelStrategy
+		obj := NewComponentDefinitionBuilder("mysql").
+			SetRuntime(&corev1.Container{Name: "mysql", Image: "mysql:8.0"}).
+			SetRuntime(&corev1.Container{Name: "mysql", Image: "mysql:8.4"}).
+			SetRuntime(&corev1.Container{Name: "metrics", Image: "exporter:1.0"}).
+			AddEnv("mysql", corev1.EnvVar{Name: "MYSQL_ROOT_HOST", Value: "%"}).
+			AddVolumeMounts("mysql", []corev1.VolumeMount{
+				{Name: "data", MountPath: "/old"},
+				{Name: "conf", MountPath: "/etc/mysql"},
+			}).
+			AddVolumeMounts("mysql", []corev1.VolumeMount{{Name: "data", MountPath: "/var/lib/mysql"}}).
+			AddVar(appsv1.EnvVar{Name: "MYSQL_PORT"}).
+			AddVolume("data", true, 80).
+			AddService("client", "mysql", 3306, "leader").
+			AddServiceExt("metrics", "mysql-metrics", corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{{Name: "metrics", Port: 9125}},
+			}, "").
+			SetPolicyRules([]rbacv1.PolicyRule{{Resources: []string{"pods"}, Verbs: []string{"get"}}}).
+			SetLabels(map[string]string{"engine": "mysql"}).
+			SetReplicasLimit(1, 5).
+			SetUpdateStrategy(&updateStrategy).
+			AddRole("leader", 10, true).
+			GetObject()
+
+		Expect(obj.Name).Should(Equal("mysql"))
+		Expect(obj.Spec.Runtime.Containers).Should(HaveLen(2))
+		Expect(obj.Spec.Runtime.Containers[0].Name).Should(Equal("mysql"))
+		Expect(obj.Spec.Runtime.Containers[0].Image).Should(Equal("mysql:8.4"))
+		Expect(obj.Spec.Runtime.Containers[0].Env).Should(Equal([]corev1.EnvVar{{Name: "MYSQL_ROOT_HOST", Value: "%"}}))
+		Expect(obj.Spec.Runtime.Containers[0].VolumeMounts).Should(ConsistOf(
+			corev1.VolumeMount{Name: "data", MountPath: "/var/lib/mysql"},
+			corev1.VolumeMount{Name: "conf", MountPath: "/etc/mysql"},
+		))
+		Expect(obj.Spec.Runtime.Containers[1]).Should(Equal(corev1.Container{Name: "metrics", Image: "exporter:1.0"}))
+		Expect(obj.Spec.Vars).Should(Equal([]appsv1.EnvVar{{Name: "MYSQL_PORT"}}))
+		Expect(obj.Spec.Volumes).Should(Equal([]appsv1.ComponentVolume{{Name: "data", NeedSnapshot: true, HighWatermark: 80}}))
+		Expect(obj.Spec.Services).Should(Equal([]appsv1.ComponentService{
+			{
+				Service: appsv1.Service{
+					Name:        "client",
+					ServiceName: "mysql",
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{{Port: 3306}},
+					},
+					RoleSelector: "leader",
+				},
+			},
+			{
+				Service: appsv1.Service{
+					Name:        "metrics",
+					ServiceName: "mysql-metrics",
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{{Name: "metrics", Port: 9125}},
+					},
+				},
+			},
+		}))
+		Expect(obj.Spec.PolicyRules).Should(Equal([]rbacv1.PolicyRule{{Resources: []string{"pods"}, Verbs: []string{"get"}}}))
+		Expect(obj.Spec.Labels).Should(Equal(map[string]string{"engine": "mysql"}))
+		Expect(obj.Spec.ReplicasLimit).Should(Equal(&appsv1.ReplicasLimit{MinReplicas: 1, MaxReplicas: 5}))
+		Expect(obj.Spec.UpdateStrategy).Should(Equal(&updateStrategy))
+		Expect(obj.Spec.Roles).Should(Equal([]appsv1.ReplicaRole{{Name: "leader", UpdatePriority: 10, ParticipatesInQuorum: true}}))
+	})
+
+	It("should ignore nil runtime and unknown container mutations", func() {
+		obj := NewComponentDefinitionBuilder("mysql").
+			SetRuntime(nil).
+			AddEnv("missing", corev1.EnvVar{Name: "IGNORED"}).
+			AddVolumeMounts("missing", []corev1.VolumeMount{{Name: "ignored"}}).
+			GetObject()
+
+		Expect(obj.Spec.Runtime.Containers).Should(BeNil())
+	})
+})

--- a/pkg/controller/builder/builder_component_parameter_test.go
+++ b/pkg/controller/builder/builder_component_parameter_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package builder
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/utils/ptr"
+
+	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
+)
+
+var _ = Describe("component parameter builder", func() {
+	It("should set component parameter spec fields", func() {
+		initial := &parametersv1alpha1.ParameterInputs{
+			Assignments: map[string]*string{
+				"max_connections": ptr.To("100"),
+			},
+		}
+
+		obj := NewComponentParameterBuilder("default", "mysql-params").
+			SetClusterName("cluster").
+			SetCompName("mysql").
+			SetInitial(initial).
+			GetObject()
+
+		Expect(obj.Namespace).Should(Equal("default"))
+		Expect(obj.Name).Should(Equal("mysql-params"))
+		Expect(obj.Spec.ClusterName).Should(Equal("cluster"))
+		Expect(obj.Spec.ComponentName).Should(Equal("mysql"))
+		Expect(obj.Spec.Initial).Should(Equal(initial))
+	})
+})

--- a/pkg/controller/builder/builder_component_test.go
+++ b/pkg/controller/builder/builder_component_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package builder
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+)
+
+var _ = Describe("component builder", func() {
+	It("should set component spec fields", func() {
+		podUpdatePolicy := appsv1.PreferInPlacePodUpdatePolicyType
+		podUpgradePolicy := appsv1.ReCreatePodUpdatePolicyType
+		instanceUpdateStrategy := &appsv1.InstanceUpdateStrategy{
+			Type: appsv1.OnDeleteStrategyType,
+		}
+		concurrency := intstr.FromString("50%")
+		issuer := &appsv1.Issuer{Name: appsv1.IssuerKubeBlocks}
+		disableExporter := true
+		stop := true
+		enableInstanceAPI := true
+		runtimeClassName := "kata"
+		resources := corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("500m"),
+			},
+		}
+		retentionPolicy := &appsv1.PersistentVolumeClaimRetentionPolicy{
+			WhenDeleted: appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+			WhenScaled:  appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+		}
+		schedulingPolicy := &appsv1.SchedulingPolicy{
+			SchedulerName: "custom-scheduler",
+			NodeSelector:  map[string]string{"disk": "ssd"},
+		}
+		network := &appsv1.ComponentNetwork{
+			HostNetwork: true,
+		}
+		configName := "config"
+
+		obj := NewComponentBuilder("default", "mysql", "mysql-def").
+			SetTerminationPolicy(appsv1.Delete).
+			SetServiceVersion("8.0.30").
+			SetLabels(map[string]string{"app": "mysql"}).
+			SetAnnotations(map[string]string{"owner": "test"}).
+			SetEnv([]corev1.EnvVar{{Name: "MYSQL_ROOT_HOST", Value: "%"}}).
+			SetSchedulingPolicy(schedulingPolicy).
+			SetReplicas(3).
+			SetConfigs([]appsv1.ClusterComponentConfig{{Name: &configName}}).
+			SetServiceAccountName("mysql-sa").
+			SetParallelPodManagementConcurrency(&concurrency).
+			SetPodUpdatePolicy(&podUpdatePolicy).
+			SetPodUpgradePolicy(&podUpgradePolicy).
+			SetInstanceUpdateStrategy(instanceUpdateStrategy).
+			SetResources(resources).
+			SetDisableExporter(&disableExporter).
+			SetTLSConfig(true, issuer).
+			SetVolumeClaimTemplates([]appsv1.PersistentVolumeClaimTemplate{{Name: "data"}}).
+			SetPVCRetentionPolicy(retentionPolicy).
+			SetVolumes([]corev1.Volume{{Name: "scripts"}}).
+			SetNetwork(network).
+			SetServices([]appsv1.ClusterComponentService{{
+				Name:        "primary",
+				ServiceType: corev1.ServiceTypeClusterIP,
+				Annotations: map[string]string{
+					"service": "primary",
+				},
+				PodService: ptr.To(true),
+			}}).
+			SetSystemAccounts([]appsv1.ComponentSystemAccount{{Name: "root"}}).
+			SetServiceRefs([]appsv1.ServiceRef{{Name: "redis"}}).
+			SetInstances([]appsv1.InstanceTemplate{{Name: "az-a"}}).
+			SetOrdinals(appsv1.Ordinals{Ranges: []appsv1.Range{{Start: 1, End: 3}}}).
+			SetFlatInstanceOrdinal(true).
+			SetOfflineInstances([]string{"mysql-1"}).
+			SetRuntimeClassName(&runtimeClassName).
+			SetStop(&stop).
+			SetSidecars([]appsv1.Sidecar{{Name: "metrics", Owner: "mysql", SidecarDef: "metrics-def"}}).
+			SetEnableInstanceAPI(&enableInstanceAPI).
+			GetObject()
+
+		Expect(obj.Namespace).Should(Equal("default"))
+		Expect(obj.Name).Should(Equal("mysql"))
+		Expect(obj.Spec.CompDef).Should(Equal("mysql-def"))
+		Expect(obj.Spec.TerminationPolicy).Should(Equal(appsv1.Delete))
+		Expect(obj.Spec.ServiceVersion).Should(Equal("8.0.30"))
+		Expect(obj.Spec.Labels).Should(Equal(map[string]string{"app": "mysql"}))
+		Expect(obj.Spec.Annotations).Should(Equal(map[string]string{"owner": "test"}))
+		Expect(obj.Spec.Env).Should(Equal([]corev1.EnvVar{{Name: "MYSQL_ROOT_HOST", Value: "%"}}))
+		Expect(obj.Spec.SchedulingPolicy).Should(Equal(schedulingPolicy))
+		Expect(obj.Spec.Replicas).Should(Equal(int32(3)))
+		Expect(obj.Spec.Configs).Should(Equal([]appsv1.ClusterComponentConfig{{Name: &configName}}))
+		Expect(obj.Spec.ServiceAccountName).Should(Equal("mysql-sa"))
+		Expect(obj.Spec.ParallelPodManagementConcurrency).Should(Equal(&concurrency))
+		Expect(obj.Spec.PodUpdatePolicy).Should(Equal(&podUpdatePolicy))
+		Expect(obj.Spec.PodUpgradePolicy).Should(Equal(&podUpgradePolicy))
+		Expect(obj.Spec.InstanceUpdateStrategy).Should(Equal(instanceUpdateStrategy))
+		Expect(obj.Spec.Resources).Should(Equal(resources))
+		Expect(obj.Spec.DisableExporter).Should(Equal(&disableExporter))
+		Expect(obj.Spec.TLSConfig).Should(Equal(&appsv1.TLSConfig{Enable: true, Issuer: issuer}))
+		Expect(obj.Spec.VolumeClaimTemplates).Should(Equal([]appsv1.PersistentVolumeClaimTemplate{{Name: "data"}}))
+		Expect(obj.Spec.PersistentVolumeClaimRetentionPolicy).Should(Equal(retentionPolicy))
+		Expect(obj.Spec.Volumes).Should(Equal([]corev1.Volume{{Name: "scripts"}}))
+		Expect(obj.Spec.Network).Should(Equal(network))
+		Expect(obj.Spec.Services).Should(Equal([]appsv1.ComponentService{{
+			Service: appsv1.Service{
+				Name: "primary",
+				Annotations: map[string]string{
+					"service": "primary",
+				},
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeClusterIP,
+				},
+			},
+			PodService: ptr.To(true),
+		}}))
+		Expect(obj.Spec.SystemAccounts).Should(Equal([]appsv1.ComponentSystemAccount{{Name: "root"}}))
+		Expect(obj.Spec.ServiceRefs).Should(Equal([]appsv1.ServiceRef{{Name: "redis"}}))
+		Expect(obj.Spec.Instances).Should(Equal([]appsv1.InstanceTemplate{{Name: "az-a"}}))
+		Expect(obj.Spec.Ordinals).Should(Equal(appsv1.Ordinals{Ranges: []appsv1.Range{{Start: 1, End: 3}}}))
+		Expect(obj.Spec.FlatInstanceOrdinal).Should(BeTrue())
+		Expect(obj.Spec.OfflineInstances).Should(Equal([]string{"mysql-1"}))
+		Expect(obj.Spec.RuntimeClassName).Should(Equal(&runtimeClassName))
+		Expect(obj.Spec.Stop).Should(Equal(&stop))
+		Expect(obj.Spec.Sidecars).Should(Equal([]appsv1.Sidecar{{Name: "metrics", Owner: "mysql", SidecarDef: "metrics-def"}}))
+		Expect(obj.Spec.EnableInstanceAPI).Should(Equal(&enableInstanceAPI))
+	})
+
+	It("should leave TLS config and runtime class unset when disabled", func() {
+		obj := NewComponentBuilder("default", "mysql", "mysql-def").
+			SetTLSConfig(false, &appsv1.Issuer{Name: appsv1.IssuerKubeBlocks}).
+			SetRuntimeClassName(nil).
+			GetObject()
+
+		Expect(obj.Spec.TLSConfig).Should(BeNil())
+		Expect(obj.Spec.RuntimeClassName).Should(BeNil())
+	})
+})

--- a/pkg/controller/builder/builder_instance_test.go
+++ b/pkg/controller/builder/builder_instance_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package builder
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+)
+
+var _ = Describe("instance builder", func() {
+	It("should set instance spec fields", func() {
+		activeDeadlineSeconds := int64(60)
+		selectorLabels := map[string]string{"app": "mysql"}
+		affinity := &corev1.Affinity{}
+		topologySpreadConstraints := []corev1.TopologySpreadConstraint{{TopologyKey: "zone"}}
+		securityContext := corev1.PodSecurityContext{RunAsUser: ptr.To(int64(1000))}
+		retentionPolicy := &workloads.PersistentVolumeClaimRetentionPolicy{
+			WhenDeleted: appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+			WhenScaled:  appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+		}
+		instanceUpdateStrategy := &workloads.InstanceUpdateStrategy{
+			Type: appsv1.OnDeleteStrategyType,
+		}
+		lifecycleActions := &workloads.LifecycleActions{}
+		assistantObjects := []workloads.InstanceAssistantObject{
+			{ConfigMap: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "conf"}}},
+		}
+
+		obj := NewInstanceBuilder("default", "mysql-0").
+			AddFinalizers([]string{"cleanup"}).
+			SetFinalizers().
+			SetPodTemplate(corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"template": "base"},
+				},
+			}).
+			SetContainers([]corev1.Container{{Name: "mysql", Image: "mysql:8.0"}}).
+			SetInitContainers([]corev1.Container{{Name: "init"}}).
+			SetNodeName(types.NodeName("node-1")).
+			SetHostname("mysql-0").
+			SetSubdomain("mysql-headless").
+			AddInitContainer(corev1.Container{Name: "prepare"}).
+			AddContainer(corev1.Container{Name: "metrics", Image: "exporter:1.0"}).
+			AddVolumes(corev1.Volume{Name: "data"}, corev1.Volume{Name: "scripts"}).
+			SetRestartPolicy(corev1.RestartPolicyAlways).
+			SetSecurityContext(securityContext).
+			AddTolerations(corev1.Toleration{Key: "dedicated", Value: "db"}).
+			AddServiceAccount("mysql-sa").
+			SetNodeSelector(map[string]string{"disk": "ssd"}).
+			SetAffinity(affinity).
+			SetTopologySpreadConstraints(topologySpreadConstraints).
+			SetActiveDeadlineSeconds(&activeDeadlineSeconds).
+			SetImagePullSecrets([]corev1.LocalObjectReference{{Name: "registry"}}).
+			SetSelectorMatchLabels(selectorLabels).
+			SetMinReadySeconds(10).
+			AddVolumeClaimTemplate(corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "data"},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				},
+			}).
+			SetPVCRetentionPolicy(retentionPolicy).
+			SetInstanceSetName("mysql").
+			SetInstanceTemplateName("az-a").
+			SetInstanceUpdateStrategyType(instanceUpdateStrategy).
+			SetPodUpdatePolicy(appsv1.PreferInPlacePodUpdatePolicyType).
+			SetPodUpgradePolicy(appsv1.ReCreatePodUpdatePolicyType).
+			SetRoles([]workloads.ReplicaRole{{Name: "leader", UpdatePriority: 10}}).
+			SetLifecycleActions(lifecycleActions).
+			SetConfigs([]workloads.ConfigTemplate{{Name: "mysql-conf"}}).
+			SetInstanceAssistantObjects(assistantObjects).
+			GetObject()
+
+		selectorLabels["app"] = "changed"
+
+		Expect(obj.Namespace).Should(Equal("default"))
+		Expect(obj.Name).Should(Equal("mysql-0"))
+		Expect(obj.Finalizers).Should(BeNil())
+		Expect(obj.Spec.Template.Labels).Should(Equal(map[string]string{"template": "base"}))
+		Expect(obj.Spec.Template.Spec.Containers).Should(Equal([]corev1.Container{
+			{Name: "mysql", Image: "mysql:8.0"},
+			{Name: "metrics", Image: "exporter:1.0"},
+		}))
+		Expect(obj.Spec.Template.Spec.InitContainers).Should(Equal([]corev1.Container{{Name: "init"}, {Name: "prepare"}}))
+		Expect(obj.Spec.Template.Spec.NodeName).Should(Equal("node-1"))
+		Expect(obj.Spec.Template.Spec.Hostname).Should(Equal("mysql-0"))
+		Expect(obj.Spec.Template.Spec.Subdomain).Should(Equal("mysql-headless"))
+		Expect(obj.Spec.Template.Spec.Volumes).Should(Equal([]corev1.Volume{{Name: "data"}, {Name: "scripts"}}))
+		Expect(obj.Spec.Template.Spec.RestartPolicy).Should(Equal(corev1.RestartPolicyAlways))
+		Expect(obj.Spec.Template.Spec.SecurityContext).Should(Equal(&securityContext))
+		Expect(obj.Spec.Template.Spec.Tolerations).Should(Equal([]corev1.Toleration{{Key: "dedicated", Value: "db"}}))
+		Expect(obj.Spec.Template.Spec.ServiceAccountName).Should(Equal("mysql-sa"))
+		Expect(obj.Spec.Template.Spec.NodeSelector).Should(Equal(map[string]string{"disk": "ssd"}))
+		Expect(obj.Spec.Template.Spec.Affinity).Should(Equal(affinity))
+		Expect(obj.Spec.Template.Spec.TopologySpreadConstraints).Should(Equal(topologySpreadConstraints))
+		Expect(obj.Spec.Template.Spec.ActiveDeadlineSeconds).Should(Equal(&activeDeadlineSeconds))
+		Expect(obj.Spec.Template.Spec.ImagePullSecrets).Should(Equal([]corev1.LocalObjectReference{{Name: "registry"}}))
+		Expect(obj.Spec.Selector.MatchLabels).Should(Equal(map[string]string{"app": "mysql"}))
+		Expect(obj.Spec.MinReadySeconds).Should(Equal(int32(10)))
+		Expect(obj.Spec.VolumeClaimTemplates).Should(HaveLen(1))
+		Expect(obj.Spec.VolumeClaimTemplates[0].Name).Should(Equal("data"))
+		Expect(obj.Spec.PersistentVolumeClaimRetentionPolicy).Should(Equal(retentionPolicy))
+		Expect(obj.Spec.InstanceSetName).Should(Equal("mysql"))
+		Expect(obj.Spec.InstanceTemplateName).Should(Equal("az-a"))
+		Expect(obj.Spec.InstanceUpdateStrategyType).Should(Equal(&instanceUpdateStrategy.Type))
+		Expect(obj.Spec.PodUpdatePolicy).Should(Equal(appsv1.PreferInPlacePodUpdatePolicyType))
+		Expect(obj.Spec.PodUpgradePolicy).Should(Equal(appsv1.ReCreatePodUpdatePolicyType))
+		Expect(obj.Spec.Roles).Should(Equal([]workloads.ReplicaRole{{Name: "leader", UpdatePriority: 10}}))
+		Expect(obj.Spec.LifecycleActions).Should(Equal(lifecycleActions))
+		Expect(obj.Spec.Configs).Should(Equal([]workloads.ConfigTemplate{{Name: "mysql-conf"}}))
+		Expect(obj.Spec.InstanceAssistantObjects).Should(Equal(assistantObjects))
+	})
+
+	It("should leave update strategy unset when strategy is nil", func() {
+		obj := NewInstanceBuilder("default", "mysql-0").
+			SetInstanceUpdateStrategyType(nil).
+			GetObject()
+
+		Expect(obj.Spec.InstanceUpdateStrategyType).Should(BeNil())
+	})
+})

--- a/pkg/controller/instance/utils_test.go
+++ b/pkg/controller/instance/utils_test.go
@@ -25,6 +25,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
@@ -204,5 +206,360 @@ func TestConfigsToUpdateStillReportsRealConfigHashMismatch(t *testing.T) {
 	}
 	if toUpdate[0].Name != "valkey-replication-config" {
 		t.Fatalf("unexpected config name %q", toUpdate[0].Name)
+	}
+}
+
+func TestInstanceObjectHelpers(t *testing.T) {
+	inst := builder.NewInstanceBuilder("default", "mysql-0").
+		SetRoles([]workloads.ReplicaRole{
+			{Name: "Leader", UpdatePriority: 10},
+			{Name: "Follower", UpdatePriority: 1},
+		}).
+		GetObject()
+
+	if got := podName(inst); got != "mysql-0" {
+		t.Fatalf("podName() = %q, want mysql-0", got)
+	}
+	pod := podObj(inst)
+	if pod.Namespace != "default" || pod.Name != "mysql-0" {
+		t.Fatalf("unexpected pod object key: %s/%s", pod.Namespace, pod.Name)
+	}
+
+	roleMap := composeRoleMap(inst)
+	if roleMap["leader"].UpdatePriority != 10 || roleMap["follower"].UpdatePriority != 1 {
+		t.Fatalf("unexpected role map: %#v", roleMap)
+	}
+
+	pod.Labels = map[string]string{constant.RoleLabelKey: "Leader"}
+	if got := getRoleName(pod); got != "leader" {
+		t.Fatalf("getRoleName() = %q, want leader", got)
+	}
+	if !isRoleReady(pod, inst.Spec.Roles) {
+		t.Fatal("pod with role label should be role-ready")
+	}
+	delete(pod.Labels, constant.RoleLabelKey)
+	if isRoleReady(pod, inst.Spec.Roles) {
+		t.Fatal("pod without role label should not be role-ready when roles are configured")
+	}
+	if !isRoleReady(pod, nil) {
+		t.Fatal("pod should be role-ready when roles are not configured")
+	}
+}
+
+func TestPodStateHelpers(t *testing.T) {
+	now := metav1.Now()
+	tests := []struct {
+		name        string
+		pod         *corev1.Pod
+		created     bool
+		terminating bool
+		pending     bool
+	}{
+		{
+			name:    "empty pod",
+			pod:     &corev1.Pod{},
+			created: false,
+		},
+		{
+			name: "pending pod",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{Phase: corev1.PodPending},
+			},
+			created: true,
+			pending: true,
+		},
+		{
+			name: "terminating pod",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &now},
+				Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+			},
+			created:     true,
+			terminating: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isCreated(tt.pod); got != tt.created {
+				t.Fatalf("isCreated() = %v, want %v", got, tt.created)
+			}
+			if got := isTerminating(tt.pod); got != tt.terminating {
+				t.Fatalf("isTerminating() = %v, want %v", got, tt.terminating)
+			}
+			if got := isPodPending(tt.pod); got != tt.pending {
+				t.Fatalf("isPodPending() = %v, want %v", got, tt.pending)
+			}
+		})
+	}
+}
+
+func TestIsImageMatched(t *testing.T) {
+	if !isImageMatched(&corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "mysql", Image: "mysql:8.0"}},
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{{Name: "sidecar", Image: "sidecar:1.0"}},
+		},
+	}) {
+		t.Fatal("missing matching status should be ignored")
+	}
+
+	if !isImageMatched(&corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "mysql", Image: "docker.io/library/mysql:8.0"}},
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:  "mysql",
+				Image: "mysql:8.0",
+			}},
+		},
+	}) {
+		t.Fatal("equivalent image references should match")
+	}
+
+	if isImageMatched(&corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "mysql", Image: "mysql:8.0"}},
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:  "mysql",
+				Image: "mysql:8.4",
+			}},
+		},
+	}) {
+		t.Fatal("different image references should not match")
+	}
+}
+
+func TestBuildInstancePodAndPVCs(t *testing.T) {
+	inst := builder.NewInstanceBuilder("default", "mysql-0").
+		SetUID(types.UID("12345678-1234-1234-1234-1234567890ab")).
+		AddAnnotations("instance-annotation", "true").
+		SetPodTemplate(corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels:      map[string]string{"template-label": "true"},
+				Annotations: map[string]string{"template-annotation": "true"},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "mysql", Image: "mysql:8.0"}},
+				Volumes:    []corev1.Volume{{Name: "config"}},
+			},
+		}).
+		SetInstanceSetName("mysql").
+		SetInstanceTemplateName("az-a").
+		SetConfigs([]workloads.ConfigTemplate{{Name: "mysql-conf", ConfigHash: ptr.To("hash")}}).
+		AddVolumeClaimTemplate(corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "data",
+				Labels:      map[string]string{"pvc-label": "true"},
+				Annotations: map[string]string{"pvc-annotation": "true"},
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				},
+			},
+		}).
+		GetObject()
+
+	pod, err := buildInstancePod(inst, "revision")
+	if err != nil {
+		t.Fatalf("buildInstancePod() error = %v", err)
+	}
+	if pod.Name != "mysql-0" || pod.Namespace != "default" {
+		t.Fatalf("unexpected pod key: %s/%s", pod.Namespace, pod.Name)
+	}
+	if pod.Labels[constant.KBAppInstanceNameLabelKey] != "mysql-0" ||
+		pod.Labels[constant.KBAppPodNameLabelKey] != "mysql-0" ||
+		pod.Labels[constant.KBAppInstanceTemplateLabelKey] != "az-a" ||
+		pod.Labels["template-label"] != "true" {
+		t.Fatalf("unexpected pod labels: %#v", pod.Labels)
+	}
+	if pod.Annotations["template-annotation"] != "true" ||
+		pod.Annotations[constant.CMInsConfigurationHashLabelKey] == "" {
+		t.Fatalf("unexpected pod annotations: %#v", pod.Annotations)
+	}
+	if len(pod.Spec.Volumes) != 2 {
+		t.Fatalf("pod volumes = %d, want 2: %#v", len(pod.Spec.Volumes), pod.Spec.Volumes)
+	}
+	if len(pod.OwnerReferences) != 1 || pod.OwnerReferences[0].Name != "mysql-0" {
+		t.Fatalf("unexpected pod owner references: %#v", pod.OwnerReferences)
+	}
+
+	pvcs, err := buildInstancePVCs(inst)
+	if err != nil {
+		t.Fatalf("buildInstancePVCs() error = %v", err)
+	}
+	if len(pvcs) != 1 {
+		t.Fatalf("pvcs = %d, want 1", len(pvcs))
+	}
+	pvc := pvcs[0]
+	if pvc.Labels[constant.KBAppPodNameLabelKey] != "mysql-0" ||
+		pvc.Labels[constant.VolumeClaimTemplateNameLabelKey] != "data" ||
+		pvc.Labels[constant.KBAppInstanceTemplateLabelKey] != "az-a" ||
+		pvc.Labels["pvc-label"] != "true" {
+		t.Fatalf("unexpected pvc labels: %#v", pvc.Labels)
+	}
+	if pvc.Annotations["pvc-annotation"] != "true" {
+		t.Fatalf("unexpected pvc annotations: %#v", pvc.Annotations)
+	}
+	if len(pvc.OwnerReferences) != 1 || pvc.OwnerReferences[0].Name != "mysql-0" {
+		t.Fatalf("unexpected pvc owner references: %#v", pvc.OwnerReferences)
+	}
+}
+
+func TestConfigsFromPod(t *testing.T) {
+	pod := builder.NewPodBuilder("default", "mysql-0").GetObject()
+	if got, err := configsFromPod(pod); err != nil || got != nil {
+		t.Fatalf("empty configsFromPod() = %#v, %v; want nil, nil", got, err)
+	}
+
+	if err := configsToPod([]workloads.ConfigTemplate{
+		{Name: "z-config", ConfigHash: ptr.To("z")},
+		{Name: "a-config", ConfigHash: ptr.To("a")},
+	}, pod); err != nil {
+		t.Fatalf("configsToPod() error = %v", err)
+	}
+	got, err := configsFromPod(pod)
+	if err != nil {
+		t.Fatalf("configsFromPod() error = %v", err)
+	}
+	want := []workloads.ConfigTemplate{
+		{Name: "a-config", ConfigHash: ptr.To("a")},
+		{Name: "z-config", ConfigHash: ptr.To("z")},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("configsFromPod() = %#v, want %#v", got, want)
+	}
+
+	pod.Annotations[constant.CMInsConfigurationHashLabelKey] = "not-json"
+	if _, err := configsFromPod(pod); err == nil {
+		t.Fatal("expected invalid config hash annotation error")
+	}
+}
+
+func TestHasConfigRestart(t *testing.T) {
+	inst := builder.NewInstanceBuilder("default", "mysql-0").
+		SetConfigs([]workloads.ConfigTemplate{
+			{Name: "restart-conf", ConfigHash: ptr.To("new"), Restart: ptr.To(true)},
+			{Name: "reload-conf", ConfigHash: ptr.To("new"), Restart: ptr.To(false)},
+		}).
+		GetObject()
+	pod := builder.NewPodBuilder("default", "mysql-0").GetObject()
+	if err := configsToPod([]workloads.ConfigTemplate{
+		{Name: "restart-conf", ConfigHash: ptr.To("old")},
+		{Name: "reload-conf", ConfigHash: ptr.To("old")},
+	}, pod); err != nil {
+		t.Fatalf("configsToPod() error = %v", err)
+	}
+
+	needRestart, names, err := hasConfigRestart(inst, pod)
+	if err != nil {
+		t.Fatalf("hasConfigRestart() error = %v", err)
+	}
+	if !needRestart || !reflect.DeepEqual(names, []string{"restart-conf"}) {
+		t.Fatalf("hasConfigRestart() = %v, %v; want true, [restart-conf]", needRestart, names)
+	}
+
+	pod.Annotations[constant.CMInsConfigurationHashLabelKey] = "not-json"
+	if _, _, err := hasConfigRestart(inst, pod); err == nil {
+		t.Fatal("expected invalid config annotation error")
+	}
+}
+
+func TestCopyAndMergeObjects(t *testing.T) {
+	if got := copyAndMerge(&corev1.Service{}, &corev1.ConfigMap{}); got != nil {
+		t.Fatalf("type mismatch should return nil, got %T", got)
+	}
+
+	oldCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "conf",
+			Finalizers: []string{"old"},
+			OwnerReferences: []metav1.OwnerReference{{
+				UID:  types.UID("old"),
+				Name: "old",
+			}},
+		},
+		Data:       map[string]string{"old": "value"},
+		BinaryData: map[string][]byte{"old": []byte("value")},
+	}
+	newCM := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "conf",
+			Finalizers: []string{"new"},
+			OwnerReferences: []metav1.OwnerReference{{
+				UID:  types.UID("new"),
+				Name: "new",
+			}},
+		},
+		Data:       map[string]string{"new": "value"},
+		BinaryData: map[string][]byte{"new": []byte("value")},
+	}
+	mergedCM := copyAndMerge(oldCM, newCM).(*corev1.ConfigMap)
+	if !reflect.DeepEqual(mergedCM.Finalizers, []string{"old", "new"}) ||
+		len(mergedCM.OwnerReferences) != 2 ||
+		!reflect.DeepEqual(mergedCM.Data, newCM.Data) ||
+		!reflect.DeepEqual(mergedCM.BinaryData, newCM.BinaryData) {
+		t.Fatalf("unexpected merged configmap: %#v", mergedCM)
+	}
+
+	oldPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "data",
+			Labels: map[string]string{"old": "kept"},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+			},
+		},
+	}
+	newPVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "data",
+			Labels: map[string]string{"new": "added"},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("2Gi")},
+			},
+		},
+	}
+	mergedPVC := copyAndMerge(oldPVC, newPVC).(*corev1.PersistentVolumeClaim)
+	if !reflect.DeepEqual(mergedPVC.Labels, map[string]string{"old": "kept", "new": "added"}) ||
+		mergedPVC.Spec.Resources.Requests.Storage().String() != "2Gi" {
+		t.Fatalf("unexpected merged pvc: %#v", mergedPVC)
+	}
+
+	newPod := builder.NewPodBuilder("default", "mysql-0").
+		AddAnnotations("new", "added").
+		AddLabels("new", "added").
+		SetContainers([]corev1.Container{{
+			Name:  "mysql",
+			Image: "mysql:8.4",
+			Resources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+			},
+		}}).
+		GetObject()
+	oldPod := builder.NewPodBuilder("default", "mysql-0").
+		SetContainers([]corev1.Container{{Name: "mysql", Image: "mysql:8.0"}}).
+		GetObject()
+	mergedPod := copyAndMerge(oldPod, newPod).(*corev1.Pod)
+	if mergedPod.Labels["new"] != "added" ||
+		mergedPod.Annotations["new"] != "added" ||
+		mergedPod.Spec.Containers[0].Image != "mysql:8.4" ||
+		mergedPod.Spec.Containers[0].Resources.Requests.Cpu().String() != "1" {
+		t.Fatalf("unexpected merged pod: %#v", mergedPod)
 	}
 }

--- a/pkg/controller/instanceset2/assistant_object_utils_test.go
+++ b/pkg/controller/instanceset2/assistant_object_utils_test.go
@@ -1,0 +1,241 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package instanceset2
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/kubebuilderx"
+	"github.com/apecloud/kubeblocks/pkg/controller/model"
+)
+
+func TestObjectReferenceToObject(t *testing.T) {
+	tests := []struct {
+		name string
+		kind string
+		want client.Object
+	}{
+		{name: "configmap", kind: "ConfigMap", want: &corev1.ConfigMap{}},
+		{name: "secret", kind: "Secret", want: &corev1.Secret{}},
+		{name: "service account", kind: "ServiceAccount", want: &corev1.ServiceAccount{}},
+		{name: "service", kind: "Service", want: &corev1.Service{}},
+		{name: "role", kind: "Role", want: &rbacv1.Role{}},
+		{name: "role binding", kind: "RoleBinding", want: &rbacv1.RoleBinding{}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := objectReferenceToObject(corev1.ObjectReference{
+				Kind:      tt.kind,
+				Namespace: "default",
+				Name:      "obj",
+			})
+			if err != nil {
+				t.Fatalf("objectReferenceToObject() error = %v", err)
+			}
+			if reflect.TypeOf(got) != reflect.TypeOf(tt.want) {
+				t.Fatalf("objectReferenceToObject() type = %T, want %T", got, tt.want)
+			}
+			if got.GetNamespace() != "default" || got.GetName() != "obj" {
+				t.Fatalf("unexpected object key: %s/%s", got.GetNamespace(), got.GetName())
+			}
+		})
+	}
+}
+
+func TestObjectReferenceToObjectUnknownKind(t *testing.T) {
+	_, err := objectReferenceToObject(corev1.ObjectReference{Kind: "Unsupported", Name: "obj"})
+	if err == nil {
+		t.Fatal("expected unknown kind error")
+	}
+}
+
+func TestLoadInstanceAssistantObject(t *testing.T) {
+	ctx := context.Background()
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "conf",
+		},
+		Data: map[string]string{"key": "value"},
+	}
+	reader := fake.NewClientBuilder().
+		WithScheme(model.GetScheme()).
+		WithObjects(cm).
+		Build()
+
+	got, err := loadInstanceAssistantObject(ctx, reader, corev1.ObjectReference{
+		Kind:      "ConfigMap",
+		Namespace: "default",
+		Name:      "conf",
+	})
+	if err != nil {
+		t.Fatalf("loadInstanceAssistantObject() error = %v", err)
+	}
+	if !reflect.DeepEqual(got.(*corev1.ConfigMap).Data, cm.Data) {
+		t.Fatalf("unexpected loaded configmap data: %#v", got.(*corev1.ConfigMap).Data)
+	}
+
+	missing, err := loadInstanceAssistantObject(ctx, reader, corev1.ObjectReference{
+		Kind:      "ConfigMap",
+		Namespace: "default",
+		Name:      "missing",
+	})
+	if err != nil {
+		t.Fatalf("loadInstanceAssistantObject() missing error = %v", err)
+	}
+	if missing != nil {
+		t.Fatalf("expected nil missing object, got %T", missing)
+	}
+}
+
+func TestLoadInstanceAssistantObjects(t *testing.T) {
+	ctx := context.Background()
+	reader := fake.NewClientBuilder().
+		WithScheme(model.GetScheme()).
+		WithObjects(&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "conf",
+			},
+		}).
+		Build()
+	tree := kubebuilderx.NewObjectTree()
+	tree.SetRoot(&workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "mysql",
+			Annotations: map[string]string{
+				constant.KBAppMultiClusterPlacementKey: "cluster-a",
+			},
+		},
+		Spec: workloads.InstanceSetSpec{
+			InstanceAssistantObjects: []corev1.ObjectReference{{
+				Kind:      "ConfigMap",
+				Namespace: "default",
+				Name:      "conf",
+			}},
+		},
+	})
+
+	if err := loadInstanceAssistantObjects(ctx, reader, tree); err != nil {
+		t.Fatalf("loadInstanceAssistantObjects() error = %v", err)
+	}
+	if got := tree.List(&corev1.ConfigMap{}); len(got) != 1 {
+		t.Fatalf("loaded configmaps = %d, want 1", len(got))
+	}
+
+	emptyTree := kubebuilderx.NewObjectTree()
+	if err := loadInstanceAssistantObjects(ctx, reader, emptyTree); err != nil {
+		t.Fatalf("loadInstanceAssistantObjects() empty tree error = %v", err)
+	}
+}
+
+func TestCloneInstanceAssistantObjects(t *testing.T) {
+	tree := kubebuilderx.NewObjectTree()
+	if err := tree.Add(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "conf",
+			Labels:    map[string]string{"app": "mysql"},
+		},
+		Data: map[string]string{"key": "value"},
+	}); err != nil {
+		t.Fatalf("tree.Add() error = %v", err)
+	}
+
+	objs, err := cloneInstanceAssistantObjects(tree, &workloads.InstanceSet{
+		Spec: workloads.InstanceSetSpec{
+			InstanceAssistantObjects: []corev1.ObjectReference{{
+				Kind:      "ConfigMap",
+				Namespace: "default",
+				Name:      "conf",
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("cloneInstanceAssistantObjects() error = %v", err)
+	}
+	if len(objs) != 1 || objs[0].ConfigMap == nil {
+		t.Fatalf("unexpected cloned objects: %#v", objs)
+	}
+	if !reflect.DeepEqual(objs[0].ConfigMap.Data, map[string]string{"key": "value"}) {
+		t.Fatalf("unexpected cloned configmap data: %#v", objs[0].ConfigMap.Data)
+	}
+}
+
+func TestInstanceAssistantObject(t *testing.T) {
+	meta := metav1.ObjectMeta{
+		Namespace:   "default",
+		Name:        "obj",
+		Labels:      map[string]string{"app": "mysql"},
+		Annotations: map[string]string{"owner": "test"},
+	}
+
+	if got := instanceAssistantObject(&corev1.Service{
+		ObjectMeta: meta,
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+		},
+	}); got.Service == nil || got.Service.Spec.Type != corev1.ServiceTypeClusterIP {
+		t.Fatalf("unexpected service assistant object: %#v", got)
+	}
+	if got := instanceAssistantObject(&corev1.ConfigMap{
+		ObjectMeta: meta,
+		Data:       map[string]string{"key": "value"},
+	}); got.ConfigMap == nil || got.ConfigMap.Data["key"] != "value" {
+		t.Fatalf("unexpected configmap assistant object: %#v", got)
+	}
+	if got := instanceAssistantObject(&corev1.Secret{
+		ObjectMeta: meta,
+		Data:       map[string][]byte{"key": []byte("value")},
+	}); got.Secret == nil || string(got.Secret.Data["key"]) != "value" {
+		t.Fatalf("unexpected secret assistant object: %#v", got)
+	}
+	if got := instanceAssistantObject(&corev1.ServiceAccount{
+		ObjectMeta: meta,
+		Secrets:    []corev1.ObjectReference{{Name: "token"}},
+	}); got.ServiceAccount == nil || got.ServiceAccount.Secrets[0].Name != "token" {
+		t.Fatalf("unexpected service account assistant object: %#v", got)
+	}
+	if got := instanceAssistantObject(&rbacv1.Role{
+		ObjectMeta: meta,
+		Rules:      []rbacv1.PolicyRule{{Resources: []string{"pods"}}},
+	}); got.Role == nil || got.Role.Rules[0].Resources[0] != "pods" {
+		t.Fatalf("unexpected role assistant object: %#v", got)
+	}
+	if got := instanceAssistantObject(&rbacv1.RoleBinding{
+		ObjectMeta: meta,
+		Subjects:   []rbacv1.Subject{{Name: "sa"}},
+		RoleRef:    rbacv1.RoleRef{Name: "role"},
+	}); got.RoleBinding == nil || got.RoleBinding.RoleRef.Name != "role" {
+		t.Fatalf("unexpected role binding assistant object: %#v", got)
+	}
+}

--- a/pkg/controller/instanceset2/instance_util_test.go
+++ b/pkg/controller/instanceset2/instance_util_test.go
@@ -1,0 +1,242 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package instanceset2
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+)
+
+func TestParseParentNameAndOrdinal(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantParent  string
+		wantOrdinal int
+	}{
+		{name: "with ordinal", input: "mysql-leader-12", wantParent: "mysql-leader", wantOrdinal: 12},
+		{name: "without dash", input: "mysql", wantParent: "mysql", wantOrdinal: -1},
+		{name: "non numeric suffix", input: "mysql-leader", wantParent: "mysql-leader", wantOrdinal: -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotParent, gotOrdinal := parseParentNameAndOrdinal(tt.input)
+			if gotParent != tt.wantParent || gotOrdinal != tt.wantOrdinal {
+				t.Fatalf("parseParentNameAndOrdinal() = %q, %d; want %q, %d",
+					gotParent, gotOrdinal, tt.wantParent, tt.wantOrdinal)
+			}
+		})
+	}
+}
+
+func TestSortObjects(t *testing.T) {
+	pods := []*corev1.Pod{
+		{ObjectMeta: metav1.ObjectMeta{Name: "mysql-0", Labels: map[string]string{constant.RoleLabelKey: "leader"}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "mysql-2", Labels: map[string]string{constant.RoleLabelKey: "follower"}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "mysql-1", Labels: map[string]string{constant.RoleLabelKey: "follower"}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "mysql-unknown", Labels: map[string]string{}}},
+	}
+	rolePriorityMap := map[string]int{"": 0, "follower": 1, "leader": 2}
+
+	sortObjects(pods, rolePriorityMap, false)
+	got := []string{pods[0].Name, pods[1].Name, pods[2].Name, pods[3].Name}
+	want := []string{"mysql-unknown", "mysql-2", "mysql-1", "mysql-0"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("sorted pods = %v, want %v", got, want)
+	}
+
+	sortObjects(pods, rolePriorityMap, true)
+	got = []string{pods[0].Name, pods[1].Name, pods[2].Name, pods[3].Name}
+	want = []string{"mysql-0", "mysql-1", "mysql-2", "mysql-unknown"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("reverse sorted pods = %v, want %v", got, want)
+	}
+}
+
+func TestCopyAndMergeService(t *testing.T) {
+	oldSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "mysql",
+			Namespace:   "default",
+			Labels:      map[string]string{"old": "kept", "override": "old"},
+			Annotations: map[string]string{"old": "kept"},
+			Finalizers:  []string{"old-finalizer"},
+			OwnerReferences: []metav1.OwnerReference{{
+				UID:  types.UID("old-owner"),
+				Name: "old",
+			}},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"old": "selector"},
+			Type:     corev1.ServiceTypeClusterIP,
+			Ports:    []corev1.ServicePort{{Name: "old", Port: 3306}},
+		},
+	}
+	newSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "mysql",
+			Namespace:   "default",
+			Labels:      map[string]string{"new": "added", "override": "new"},
+			Annotations: map[string]string{"new": "added"},
+			Finalizers:  []string{"new-finalizer"},
+			OwnerReferences: []metav1.OwnerReference{{
+				UID:  types.UID("new-owner"),
+				Name: "new",
+			}},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector:                 map[string]string{"app": "mysql"},
+			Type:                     corev1.ServiceTypeNodePort,
+			PublishNotReadyAddresses: true,
+			Ports:                    []corev1.ServicePort{{Name: "new", Port: 3307}},
+		},
+	}
+
+	got := copyAndMerge(oldSvc, newSvc).(*corev1.Service)
+
+	if !reflect.DeepEqual(got.Finalizers, []string{"old-finalizer", "new-finalizer"}) {
+		t.Fatalf("unexpected finalizers: %#v", got.Finalizers)
+	}
+	if len(got.OwnerReferences) != 2 {
+		t.Fatalf("owner references = %d, want 2", len(got.OwnerReferences))
+	}
+	if !reflect.DeepEqual(got.Labels, map[string]string{"old": "kept", "new": "added", "override": "new"}) {
+		t.Fatalf("unexpected labels: %#v", got.Labels)
+	}
+	if !reflect.DeepEqual(got.Annotations, map[string]string{"old": "kept", "new": "added"}) {
+		t.Fatalf("unexpected annotations: %#v", got.Annotations)
+	}
+	if !reflect.DeepEqual(got.Spec.Selector, map[string]string{"app": "mysql"}) ||
+		got.Spec.Type != corev1.ServiceTypeNodePort ||
+		!got.Spec.PublishNotReadyAddresses ||
+		!reflect.DeepEqual(got.Spec.Ports, []corev1.ServicePort{{Name: "new", Port: 3307}}) {
+		t.Fatalf("unexpected service spec: %#v", got.Spec)
+	}
+	if oldSvc.Spec.Type != corev1.ServiceTypeClusterIP {
+		t.Fatalf("copyAndMerge should not mutate old service, got type %s", oldSvc.Spec.Type)
+	}
+}
+
+func TestCopyAndMerge(t *testing.T) {
+	if got := copyAndMerge(&corev1.Service{}, &corev1.ConfigMap{}); got != nil {
+		t.Fatalf("type mismatch should return nil, got %T", got)
+	}
+
+	newCM := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "new"}}
+	if got := copyAndMerge(&corev1.ConfigMap{}, newCM); got != newCM {
+		t.Fatalf("non-service object should return new object")
+	}
+}
+
+func TestCopyAndMergeInstance(t *testing.T) {
+	oldInst := &workloads.Instance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "mysql-0",
+			Labels:      map[string]string{"old": "kept"},
+			Annotations: map[string]string{"old": "kept"},
+		},
+		Spec: workloads.InstanceSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "mysql", Image: "mysql:8.0"}},
+				},
+			},
+			InstanceSetName: "mysql",
+		},
+	}
+	newInst := &workloads.Instance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "mysql-0",
+			Labels:      map[string]string{"new": "added"},
+			Annotations: map[string]string{"new": "added"},
+		},
+		Spec: workloads.InstanceSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "mysql", Image: "mysql:8.4"}},
+				},
+			},
+			Selector:             &metav1.LabelSelector{MatchLabels: map[string]string{"app": "mysql"}},
+			MinReadySeconds:      10,
+			InstanceSetName:      "mysql",
+			InstanceTemplateName: "az-a",
+			Configs:              []workloads.ConfigTemplate{{Name: "mysql-conf"}},
+		},
+	}
+
+	got := copyAndMergeInstance(oldInst, newInst)
+	if got == nil {
+		t.Fatal("expected merged instance")
+	}
+	if got.Spec.Template.Spec.Containers[0].Image != "mysql:8.4" {
+		t.Fatalf("unexpected merged image: %s", got.Spec.Template.Spec.Containers[0].Image)
+	}
+	if !reflect.DeepEqual(got.Labels, map[string]string{"old": "kept", "new": "added"}) {
+		t.Fatalf("unexpected merged labels: %#v", got.Labels)
+	}
+	if !reflect.DeepEqual(got.Annotations, map[string]string{"old": "kept", "new": "added"}) {
+		t.Fatalf("unexpected merged annotations: %#v", got.Annotations)
+	}
+
+	if got := copyAndMergeInstance(got, got.DeepCopy()); got != nil {
+		t.Fatalf("unchanged instance should return nil, got %#v", got)
+	}
+}
+
+func TestGetInstanceTemplateMap(t *testing.T) {
+	got, err := getInstanceTemplateMap(nil)
+	if err != nil || got != nil {
+		t.Fatalf("nil annotations = %#v, %v; want nil, nil", got, err)
+	}
+
+	got, err = getInstanceTemplateMap(map[string]string{"other": "value"})
+	if err != nil || got != nil {
+		t.Fatalf("missing template annotation = %#v, %v; want nil, nil", got, err)
+	}
+
+	got, err = getInstanceTemplateMap(map[string]string{
+		templateRefAnnotationKey: `{"mysql-0":"az-a","mysql-1":"az-b"}`,
+	})
+	if err != nil {
+		t.Fatalf("getInstanceTemplateMap() error = %v", err)
+	}
+	if !reflect.DeepEqual(got, map[string]string{"mysql-0": "az-a", "mysql-1": "az-b"}) {
+		t.Fatalf("unexpected template map: %#v", got)
+	}
+
+	_, err = getInstanceTemplateMap(map[string]string{templateRefAnnotationKey: "not-json"})
+	if err == nil {
+		t.Fatal("expected invalid json error")
+	}
+}
+
+func TestGetHeadlessSvcName(t *testing.T) {
+	if got := getHeadlessSvcName("mysql"); got != "mysql-headless" {
+		t.Fatalf("getHeadlessSvcName() = %q, want mysql-headless", got)
+	}
+}

--- a/pkg/controller/plan/restore_test.go
+++ b/pkg/controller/plan/restore_test.go
@@ -1,0 +1,326 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package plan
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/component"
+)
+
+func newRestoreManagerForTest() *RestoreManager {
+	return &RestoreManager{
+		Cluster: &appsv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "cluster",
+				UID:       types.UID("12345678-1234-1234-1234-1234567890ab"),
+			},
+		},
+		namespace:           "default",
+		replicas:            2,
+		startingIndex:       1,
+		volumeRestorePolicy: dpv1alpha1.VolumeClaimRestorePolicyParallel,
+		restoreLabels:       map[string]string{"restore": "true"},
+	}
+}
+
+func TestBackupSourceTargetForRestore(t *testing.T) {
+	statusTarget := &dpv1alpha1.BackupStatusTarget{
+		BackupTarget: dpv1alpha1.BackupTarget{
+			Name: "status-target",
+		},
+	}
+	tests := []struct {
+		name     string
+		backup   *dpv1alpha1.Backup
+		wantName string
+		wantNil  bool
+	}{
+		{name: "nil backup", wantNil: true},
+		{
+			name: "status target wins",
+			backup: &dpv1alpha1.Backup{
+				Status: dpv1alpha1.BackupStatus{Target: statusTarget},
+			},
+		},
+		{
+			name: "single target returns name",
+			backup: &dpv1alpha1.Backup{
+				Status: dpv1alpha1.BackupStatus{
+					Targets: []dpv1alpha1.BackupStatusTarget{{
+						BackupTarget: dpv1alpha1.BackupTarget{Name: "target-a"},
+					}},
+				},
+			},
+			wantName: "target-a",
+		},
+		{
+			name: "multiple targets are ambiguous",
+			backup: &dpv1alpha1.Backup{
+				Status: dpv1alpha1.BackupStatus{
+					Targets: []dpv1alpha1.BackupStatusTarget{
+						{BackupTarget: dpv1alpha1.BackupTarget{Name: "target-a"}},
+						{BackupTarget: dpv1alpha1.BackupTarget{Name: "target-b"}},
+					},
+				},
+			},
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotTarget := backupSourceTargetForRestore(tt.backup)
+			if gotName != tt.wantName {
+				t.Fatalf("source target name = %q, want %q", gotName, tt.wantName)
+			}
+			if tt.wantNil && gotTarget != nil {
+				t.Fatalf("source target = %#v, want nil", gotTarget)
+			}
+			if !tt.wantNil && gotTarget == nil {
+				t.Fatal("source target is nil")
+			}
+		})
+	}
+}
+
+func TestRestoreManagerBuildRequiredPolicy(t *testing.T) {
+	manager := newRestoreManagerForTest()
+	if got := manager.buildRequiredPolicy(nil); got != nil {
+		t.Fatalf("nil source target policy = %#v, want nil", got)
+	}
+	if got := manager.buildRequiredPolicy(&dpv1alpha1.BackupStatusTarget{
+		BackupTarget: dpv1alpha1.BackupTarget{
+			PodSelector: &dpv1alpha1.PodSelector{Strategy: dpv1alpha1.PodSelectionStrategyAny},
+		},
+	}); got != nil {
+		t.Fatalf("any strategy policy = %#v, want nil", got)
+	}
+	got := manager.buildRequiredPolicy(&dpv1alpha1.BackupStatusTarget{
+		BackupTarget: dpv1alpha1.BackupTarget{
+			PodSelector: &dpv1alpha1.PodSelector{Strategy: dpv1alpha1.PodSelectionStrategyAll},
+		},
+	})
+	if got == nil || got.DataRestorePolicy != dpv1alpha1.OneToOneRestorePolicy {
+		t.Fatalf("unexpected all strategy policy: %#v", got)
+	}
+}
+
+func TestRestoreManagerBuildSchedulingSpec(t *testing.T) {
+	manager := newRestoreManagerForTest()
+	comp := &component.SynthesizedComponent{
+		PodSpec: &corev1.PodSpec{
+			NodeSelector:  map[string]string{"disk": "ssd"},
+			SchedulerName: "default-scheduler",
+			NodeName:      "node-a",
+			Tolerations:   []corev1.Toleration{{Key: "dedicated", Value: "db"}},
+		},
+	}
+
+	got := manager.buildSchedulingSpec(comp, nil)
+	if !reflect.DeepEqual(got.NodeSelector, comp.PodSpec.NodeSelector) ||
+		got.SchedulerName != "default-scheduler" ||
+		got.NodeName != "node-a" ||
+		!reflect.DeepEqual(got.Tolerations, comp.PodSpec.Tolerations) {
+		t.Fatalf("component scheduling spec not copied: %#v", got)
+	}
+
+	template := &appsv1.InstanceTemplate{
+		SchedulingPolicy: &appsv1.SchedulingPolicy{
+			NodeSelector:  map[string]string{"zone": "east"},
+			SchedulerName: "template-scheduler",
+			NodeName:      "node-b",
+		},
+	}
+	got = manager.buildSchedulingSpec(comp, template)
+	if !reflect.DeepEqual(got.NodeSelector, map[string]string{"zone": "east"}) ||
+		got.SchedulerName != "template-scheduler" ||
+		got.NodeName != "node-b" {
+		t.Fatalf("template scheduling spec not preferred: %#v", got)
+	}
+
+	if got = manager.buildSchedulingSpec(&component.SynthesizedComponent{}, nil); !reflect.DeepEqual(got, dpv1alpha1.SchedulingSpec{}) {
+		t.Fatalf("empty component scheduling spec = %#v, want empty", got)
+	}
+}
+
+func TestRestoreManagerGetConnectionCredential(t *testing.T) {
+	manager := newRestoreManagerForTest()
+	if got := manager.getConnectionCredential(&component.SynthesizedComponent{}); got != nil {
+		t.Fatalf("empty system accounts credential = %#v, want nil", got)
+	}
+
+	comp := &component.SynthesizedComponent{
+		Name: "mysql",
+		SystemAccounts: []appsv1.SystemAccount{
+			{Name: "readonly"},
+			{Name: "root", InitAccount: true},
+		},
+	}
+	got := manager.getConnectionCredential(comp)
+	if got == nil {
+		t.Fatal("connection credential is nil")
+	}
+	if got.SecretName != constant.GenerateAccountSecretName("cluster", "mysql", "root") ||
+		got.UsernameKey != constant.AccountNameForSecret ||
+		got.PasswordKey != constant.AccountPasswdForSecret {
+		t.Fatalf("unexpected credential: %#v", got)
+	}
+}
+
+func TestBuildPersistentVolumeClaimLabels(t *testing.T) {
+	pvc := &corev1.PersistentVolumeClaim{}
+	BuildPersistentVolumeClaimLabels(&component.SynthesizedComponent{}, pvc, "data", "az-a")
+	if pvc.Labels[constant.VolumeClaimTemplateNameLabelKey] != "data" ||
+		pvc.Labels[constant.KBAppInstanceTemplateLabelKey] != "az-a" {
+		t.Fatalf("unexpected pvc labels: %#v", pvc.Labels)
+	}
+
+	BuildPersistentVolumeClaimLabels(nil, pvc, "ignored", "ignored")
+	BuildPersistentVolumeClaimLabels(&component.SynthesizedComponent{}, nil, "ignored", "ignored")
+}
+
+func TestRestoreManagerBuildPrepareDataRestore(t *testing.T) {
+	manager := newRestoreManagerForTest()
+	comp := &component.SynthesizedComponent{
+		Name:     "mysql",
+		Replicas: 2,
+		Labels:   map[string]string{"component-label": "true"},
+		StaticLabels: map[string]string{
+			"static-label": "true",
+		},
+		DynamicLabels: map[string]string{
+			"dynamic-label": "true",
+		},
+		VolumeClaimTemplates: []corev1.PersistentVolumeClaimTemplate{{
+			ObjectMeta: metav1.ObjectMeta{Name: "data"},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			},
+		}},
+	}
+	template := &appsv1.InstanceTemplate{
+		Name: "az-a",
+		Ordinals: appsv1.Ordinals{
+			Ranges: []appsv1.Range{{Start: 3, End: 4}},
+		},
+		SchedulingPolicy: &appsv1.SchedulingPolicy{NodeName: "node-a"},
+	}
+	backup := &dpv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: "backup"},
+		Status: dpv1alpha1.BackupStatus{
+			Targets: []dpv1alpha1.BackupStatusTarget{{
+				BackupTarget: dpv1alpha1.BackupTarget{
+					Name: "target-a",
+					PodSelector: &dpv1alpha1.PodSelector{
+						Strategy: dpv1alpha1.PodSelectionStrategyAll,
+					},
+				},
+			}},
+			BackupMethod: &dpv1alpha1.BackupMethod{
+				Name: "snapshot",
+				TargetVolumes: &dpv1alpha1.TargetVolumeInfo{
+					Volumes: []string{"data"},
+				},
+			},
+		},
+	}
+
+	restore, err := manager.BuildPrepareDataRestore(comp, backup, template)
+	if err != nil {
+		t.Fatalf("BuildPrepareDataRestore() error = %v", err)
+	}
+	if restore == nil {
+		t.Fatal("restore is nil")
+	}
+	if restore.Spec.Backup.Name != "backup" ||
+		restore.Spec.Backup.Namespace != "default" ||
+		restore.Spec.Backup.SourceTargetName != "target-a" {
+		t.Fatalf("unexpected backup ref: %#v", restore.Spec.Backup)
+	}
+	cfg := restore.Spec.PrepareDataConfig
+	if cfg == nil {
+		t.Fatal("prepare data config is nil")
+	}
+	if cfg.RequiredPolicyForAllPodSelection == nil ||
+		cfg.RequiredPolicyForAllPodSelection.DataRestorePolicy != dpv1alpha1.OneToOneRestorePolicy {
+		t.Fatalf("unexpected required policy: %#v", cfg.RequiredPolicyForAllPodSelection)
+	}
+	if cfg.SchedulingSpec.NodeName != "node-a" {
+		t.Fatalf("unexpected scheduling spec: %#v", cfg.SchedulingSpec)
+	}
+	if cfg.RestoreVolumeClaimsTemplate.Replicas != 2 ||
+		cfg.RestoreVolumeClaimsTemplate.StartingIndex != 3 ||
+		len(cfg.RestoreVolumeClaimsTemplate.Templates) != 1 {
+		t.Fatalf("unexpected restore volume claim template: %#v", cfg.RestoreVolumeClaimsTemplate)
+	}
+	labels := cfg.RestoreVolumeClaimsTemplate.Templates[0].Labels
+	if labels[constant.VolumeClaimTemplateNameLabelKey] != "data" ||
+		labels[constant.KBAppInstanceTemplateLabelKey] != "az-a" ||
+		labels["component-label"] != "true" ||
+		labels["static-label"] != "true" ||
+		labels["dynamic-label"] != "true" {
+		t.Fatalf("unexpected restore pvc labels: %#v", labels)
+	}
+}
+
+func TestRestoreManagerBuildPrepareDataRestoreWithoutVolumes(t *testing.T) {
+	manager := newRestoreManagerForTest()
+	comp := &component.SynthesizedComponent{
+		Name: "mysql",
+		VolumeClaimTemplates: []corev1.PersistentVolumeClaimTemplate{{
+			ObjectMeta: metav1.ObjectMeta{Name: "data"},
+		}},
+	}
+
+	restore, err := manager.BuildPrepareDataRestore(comp, &dpv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: "backup"},
+		Status: dpv1alpha1.BackupStatus{
+			BackupMethod: &dpv1alpha1.BackupMethod{
+				Name: "action",
+			},
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BuildPrepareDataRestore() error = %v", err)
+	}
+	if restore != nil {
+		t.Fatalf("restore = %#v, want nil", restore)
+	}
+}
+
+func TestRestoreManagerBuildPrepareDataRestoreRequiresBackupMethod(t *testing.T) {
+	manager := newRestoreManagerForTest()
+	_, err := manager.BuildPrepareDataRestore(&component.SynthesizedComponent{}, &dpv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: "backup"},
+	}, nil)
+	if err == nil {
+		t.Fatal("expected missing backup method error")
+	}
+}


### PR DESCRIPTION
## Summary
- Add stable unit coverage for pkg/controller builder helpers, instance utilities, instanceset2 assistant object utilities, and restore planning helpers.
- Keep tests on the existing package test styles: Ginkgo for builder and standard testing for instance, instanceset2, and plan helper coverage.
- No production code changes.

## Coverage
Before:
- pkg/controller/builder: 49.5%
- pkg/controller/instance: 22.0%
- pkg/controller/instanceset2: 2.2%
- pkg/controller/plan: 16.5%

After:
- pkg/controller/builder: 82.5%
- pkg/controller/instance: 35.9%
- pkg/controller/instanceset2: 19.8%
- pkg/controller/plan: 54.1%

## Verification
- go test -short ./pkg/controller/builder ./pkg/controller/instance ./pkg/controller/instanceset2
- go test -short ./pkg/controller/plan
- go test -short ./pkg/controller/builder -coverprofile=cover.out
- go test -short ./pkg/controller/instance -coverprofile=cover.out
- go test -short ./pkg/controller/instanceset2 -coverprofile=cover.out
- go test -short ./pkg/controller/plan -coverprofile=cover.out

## Production Changes
None.