### PR TITLE
chore: validate PD config template references

### DIFF
--- a/controllers/parameters/parametersdefinition_controller.go
+++ b/controllers/parameters/parametersdefinition_controller.go
@@ -23,20 +23,22 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"time"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
-	"github.com/apecloud/kubeblocks/pkg/parameters"
+	paramutil "github.com/apecloud/kubeblocks/pkg/parameters"
 	cfgcore "github.com/apecloud/kubeblocks/pkg/parameters/core"
 	"github.com/apecloud/kubeblocks/pkg/parameters/openapi"
 	"github.com/apecloud/kubeblocks/pkg/parameters/validate"
@@ -84,29 +86,127 @@ func (r *ParametersDefinitionReconciler) Reconcile(ctx context.Context, req ctrl
 func (r *ParametersDefinitionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return intctrlutil.NewControllerManagedBy(mgr).
 		For(&parametersv1alpha1.ParametersDefinition{}).
+		Watches(
+			&appsv1.ComponentDefinition{},
+			handler.EnqueueRequestsFromMapFunc(r.mapCmpdToPDs),
+		).
 		Complete(r)
 }
 
 func (r *ParametersDefinitionReconciler) reconcile(reqCtx intctrlutil.RequestCtx, parametersDef *parametersv1alpha1.ParametersDefinition) (ctrl.Result, error) {
 
-	if parameters.ParametersDefinitionTerminalPhases(parametersDef.Status, parametersDef.Generation) {
-		return intctrlutil.Reconciled()
-	}
-
-	if ok, err := checkParametersSchema(reqCtx, parametersDef); !ok || err != nil {
-		return intctrlutil.RequeueAfter(time.Second, reqCtx.Log, "ValidateConfigurationTemplate")
+	if err := r.validate(reqCtx, parametersDef); err != nil {
+		return r.failed(reqCtx, parametersDef, err)
 	}
 
 	// Automatically convert cue to openAPISchema.
 	if err := updateParametersSchema(parametersDef, r.Client, reqCtx.Ctx); err != nil {
-		return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, errors.Wrap(err, "failed to generate openAPISchema").Error())
+		return r.failed(reqCtx, parametersDef, err)
 	}
 
-	if err := updateParamDefinitionStatus(r.Client, reqCtx, parametersDef, parametersv1alpha1.PDAvailablePhase); err != nil {
+	phaseChanged, err := r.status(reqCtx, parametersDef, parametersv1alpha1.PDAvailablePhase)
+	if err != nil {
 		return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "")
 	}
-	intctrlutil.RecordCreatedEvent(r.Recorder, parametersDef)
+	if phaseChanged {
+		intctrlutil.RecordCreatedEvent(r.Recorder, parametersDef)
+	}
 	return intctrlutil.Reconciled()
+}
+
+func (r *ParametersDefinitionReconciler) validate(reqCtx intctrlutil.RequestCtx, parametersDef *parametersv1alpha1.ParametersDefinition) error {
+	if err := validateSchema(parametersDef); err != nil {
+		return err
+	}
+	if err := r.validateTemplateName(reqCtx.Ctx, parametersDef); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *ParametersDefinitionReconciler) failed(reqCtx intctrlutil.RequestCtx, parametersDef *parametersv1alpha1.ParametersDefinition, err error) (ctrl.Result, error) {
+	if _, err1 := r.status(reqCtx, parametersDef, parametersv1alpha1.PDUnavailablePhase); err1 != nil {
+		return intctrlutil.CheckedRequeueWithError(err1, reqCtx.Log, "")
+	}
+	return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "")
+}
+
+func (r *ParametersDefinitionReconciler) status(reqCtx intctrlutil.RequestCtx, parametersDef *parametersv1alpha1.ParametersDefinition, phase parametersv1alpha1.ParametersDescPhase) (bool, error) {
+	base := parametersDef.DeepCopy()
+	patch := client.MergeFrom(base)
+	phaseChanged := parametersDef.Status.Phase != phase
+	parametersDef.Status.Phase = phase
+	parametersDef.Status.ObservedGeneration = parametersDef.Generation
+	if reflect.DeepEqual(parametersDef.Status, base.Status) {
+		return false, nil
+	}
+	return phaseChanged, r.Client.Status().Patch(reqCtx.Ctx, parametersDef, patch)
+}
+
+func (r *ParametersDefinitionReconciler) mapCmpdToPDs(ctx context.Context, obj client.Object) []reconcile.Request {
+	cmpd, ok := obj.(*appsv1.ComponentDefinition)
+	if !ok {
+		return nil
+	}
+	paramsDefList := &parametersv1alpha1.ParametersDefinitionList{}
+	if err := r.Client.List(ctx, paramsDefList); err != nil {
+		log.FromContext(ctx).WithName("ParametersDefinitionReconcile").Error(err,
+			"failed to list ParametersDefinitions for ComponentDefinition watch", "ComponentDefinition", cmpd.Name)
+		return nil
+	}
+	requests := make([]reconcile.Request, 0, len(paramsDefList.Items))
+	for i := range paramsDefList.Items {
+		paramsDef := &paramsDefList.Items[i]
+		matched, err := paramutil.MatchParametersDefinition(cmpd, paramsDef)
+		if err != nil {
+			log.FromContext(ctx).WithName("ParametersDefinitionReconcile").Error(err,
+				"failed to match ParametersDefinition for ComponentDefinition watch",
+				"ParametersDefinition", paramsDef.Name,
+				"ComponentDefinition", cmpd.Name)
+			continue
+		}
+		if !matched {
+			continue
+		}
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: paramsDef.Name},
+		})
+	}
+	return requests
+}
+
+func (r *ParametersDefinitionReconciler) validateTemplateName(ctx context.Context, parametersDef *parametersv1alpha1.ParametersDefinition) error {
+	if parametersDef.Spec.ComponentDef == "" || parametersDef.Spec.TemplateName == "" {
+		return nil
+	}
+	cmpdList := &appsv1.ComponentDefinitionList{}
+	if err := r.Client.List(ctx, cmpdList); err != nil {
+		return err
+	}
+	for i := range cmpdList.Items {
+		cmpd := &cmpdList.Items[i]
+		matched, err := paramutil.MatchParametersDefinition(cmpd, parametersDef)
+		if err != nil {
+			return err
+		}
+		if !matched {
+			continue
+		}
+		if !hasConfigTemplate(cmpd, parametersDef.Spec.TemplateName) {
+			return fmt.Errorf("parametersdefinition[%s] references config template[%s], but matched ComponentDefinition[%s] does not define it",
+				parametersDef.Name, parametersDef.Spec.TemplateName, cmpd.Name)
+		}
+	}
+	return nil
+}
+
+func hasConfigTemplate(cmpd *appsv1.ComponentDefinition, templateName string) bool {
+	for _, config := range cmpd.Spec.Configs {
+		if config.Name == templateName {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *ParametersDefinitionReconciler) deletionHandler(parametersDef *parametersv1alpha1.ParametersDefinition, reqCtx intctrlutil.RequestCtx) func() (*ctrl.Result, error) {
@@ -117,7 +217,7 @@ func (r *ParametersDefinitionReconciler) deletionHandler(parametersDef *paramete
 
 	return func() (*ctrl.Result, error) {
 		if parametersDef.Status.Phase != parametersv1alpha1.PDDeletingPhase {
-			err := updateParamDefinitionStatus(r.Client, reqCtx, parametersDef, parametersv1alpha1.PDDeletingPhase)
+			_, err := r.status(reqCtx, parametersDef, parametersv1alpha1.PDDeletingPhase)
 			if err != nil {
 				return nil, err
 			}
@@ -131,30 +231,12 @@ func (r *ParametersDefinitionReconciler) deletionHandler(parametersDef *paramete
 	}
 }
 
-func updateParamDefinitionStatus(cli client.Client, ctx intctrlutil.RequestCtx, parametersDef *parametersv1alpha1.ParametersDefinition, phase parametersv1alpha1.ParametersDescPhase) error {
-	patch := client.MergeFrom(parametersDef.DeepCopy())
-	parametersDef.Status.Phase = phase
-	parametersDef.Status.ObservedGeneration = parametersDef.Generation
-	return cli.Status().Patch(ctx.Ctx, parametersDef, patch)
-}
-
-func checkParametersSchema(ctx intctrlutil.RequestCtx, parametersDef *parametersv1alpha1.ParametersDefinition) (bool, error) {
-	// validate configuration template
-	validateConfigSchema := func(ccSchema *parametersv1alpha1.ParametersSchema) (bool, error) {
-		if ccSchema == nil || len(ccSchema.CUE) == 0 {
-			return true, nil
-		}
-		err := validate.CueValidate(ccSchema.CUE)
-		return err == nil, err
+func validateSchema(parametersDef *parametersv1alpha1.ParametersDefinition) error {
+	schema := parametersDef.Spec.ParametersSchema
+	if schema == nil || len(schema.CUE) == 0 {
+		return nil
 	}
-
-	// validate schema
-	if ok, err := validateConfigSchema(parametersDef.Spec.ParametersSchema); !ok || err != nil {
-		ctx.Log.Error(err, "failed to validate template schema!",
-			"configMapName", fmt.Sprintf("%v", parametersDef.Spec.ParametersSchema))
-		return ok, err
-	}
-	return true, nil
+	return validate.CueValidate(schema.CUE)
 }
 
 func updateParametersSchema(parametersDef *parametersv1alpha1.ParametersDefinition, cli client.Client, ctx context.Context) error {

--- a/controllers/parameters/parametersdefinition_controller_test.go
+++ b/controllers/parameters/parametersdefinition_controller_test.go
@@ -27,6 +27,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
 	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
@@ -50,6 +51,7 @@ var _ = Describe("ConfigConstraint Controller", func() {
 		inNS := client.InNamespace(testCtx.DefaultNamespace)
 		ml := client.HasLabels{testCtx.TestObjLabelKey}
 		// non-namespaced
+		testapps.ClearResources(&testCtx, intctrlutil.ComponentDefinitionSignature, ml)
 		testapps.ClearResources(&testCtx, intctrlutil.ParametersDefinitionSignature, ml)
 		// namespaced
 		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, intctrlutil.ConfigMapSignature, true, inNS, ml)
@@ -124,6 +126,126 @@ client?: {
 				GetObject()
 
 			By("check config constraint status")
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(parametersDef),
+				func(g Gomega, tpl *parametersv1alpha1.ParametersDefinition) {
+					g.Expect(tpl.Status.Phase).Should(BeEquivalentTo(parametersv1alpha1.PDAvailablePhase))
+				})).Should(Succeed())
+		})
+	})
+
+	Context("Validate referenced config template", func() {
+		It("Should not be available when templateName is not defined in matched ComponentDefinition configs", func() {
+			configmap := testparameters.NewComponentTemplateFactory("pd-template-check-cm",
+				testCtx.DefaultNamespace).
+				Create(&testCtx).
+				GetObject()
+
+			compDef := testapps.NewComponentDefinitionFactory("pd-template-check-compdef").
+				SetDefaultSpec().
+				AddConfigTemplate(configSpecName, configmap.Name, testCtx.DefaultNamespace, configVolumeName, false).
+				Create(&testCtx).
+				GetObject()
+			Expect(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKeyFromObject(compDef), func(obj *appsv1.ComponentDefinition) {
+				obj.Status.Phase = appsv1.AvailablePhase
+			})()).Should(Succeed())
+
+			parametersDef := testparameters.NewParametersDefinitionFactory("pd-template-check-params").
+				SetComponentDefinition(compDef.Name).
+				SetTemplateName("missing-config").
+				Create(&testCtx).
+				GetObject()
+
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(parametersDef),
+				func(g Gomega, tpl *parametersv1alpha1.ParametersDefinition) {
+					g.Expect(tpl.Status.Phase).Should(BeEquivalentTo(parametersv1alpha1.PDUnavailablePhase))
+				})).Should(Succeed())
+
+			Expect(testapps.GetAndChangeObj(&testCtx, client.ObjectKeyFromObject(parametersDef), func(obj *parametersv1alpha1.ParametersDefinition) {
+				obj.Spec.TemplateName = configSpecName
+			})()).Should(Succeed())
+
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(parametersDef),
+				func(g Gomega, tpl *parametersv1alpha1.ParametersDefinition) {
+					g.Expect(tpl.Status.Phase).Should(BeEquivalentTo(parametersv1alpha1.PDAvailablePhase))
+				})).Should(Succeed())
+
+			Expect(testapps.GetAndChangeObj(&testCtx, client.ObjectKeyFromObject(compDef), func(obj *appsv1.ComponentDefinition) {
+				obj.Spec.Configs = nil
+			})()).Should(Succeed())
+
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(parametersDef),
+				func(g Gomega, tpl *parametersv1alpha1.ParametersDefinition) {
+					g.Expect(tpl.Status.Phase).Should(BeEquivalentTo(parametersv1alpha1.PDUnavailablePhase))
+				})).Should(Succeed())
+		})
+
+		It("Should not be available when any matched ComponentDefinition misses templateName", func() {
+			configmap := testparameters.NewComponentTemplateFactory("pd-template-check-cm2",
+				testCtx.DefaultNamespace).
+				Create(&testCtx).
+				GetObject()
+
+			validCompDef := testapps.NewComponentDefinitionFactory("pd-template-check-valid").
+				SetDefaultSpec().
+				AddConfigTemplate(configSpecName, configmap.Name, testCtx.DefaultNamespace, configVolumeName, false).
+				Create(&testCtx).
+				GetObject()
+			Expect(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKeyFromObject(validCompDef), func(obj *appsv1.ComponentDefinition) {
+				obj.Status.Phase = appsv1.AvailablePhase
+			})()).Should(Succeed())
+
+			missingCompDef := testapps.NewComponentDefinitionFactory("pd-template-check-missing").
+				SetDefaultSpec().
+				Create(&testCtx).
+				GetObject()
+			Expect(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKeyFromObject(missingCompDef), func(obj *appsv1.ComponentDefinition) {
+				obj.Status.Phase = appsv1.AvailablePhase
+			})()).Should(Succeed())
+
+			parametersDef := testparameters.NewParametersDefinitionFactory("pd-template-check-params2").
+				SetComponentDefinition("pd-template-check").
+				SetTemplateName(configSpecName).
+				Create(&testCtx).
+				GetObject()
+
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(parametersDef),
+				func(g Gomega, tpl *parametersv1alpha1.ParametersDefinition) {
+					g.Expect(tpl.Status.Phase).Should(BeEquivalentTo(parametersv1alpha1.PDUnavailablePhase))
+				})).Should(Succeed())
+		})
+
+		It("Should ignore ComponentDefinitions with unmatched serviceVersion", func() {
+			configmap := testparameters.NewComponentTemplateFactory("pd-template-check-cm3",
+				testCtx.DefaultNamespace).
+				Create(&testCtx).
+				GetObject()
+
+			validCompDef := testapps.NewComponentDefinitionFactory("pd-template-check-v8").
+				SetDefaultSpec().
+				SetServiceVersion("8.0").
+				AddConfigTemplate(configSpecName, configmap.Name, testCtx.DefaultNamespace, configVolumeName, false).
+				Create(&testCtx).
+				GetObject()
+			Expect(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKeyFromObject(validCompDef), func(obj *appsv1.ComponentDefinition) {
+				obj.Status.Phase = appsv1.AvailablePhase
+			})()).Should(Succeed())
+
+			unmatchedCompDef := testapps.NewComponentDefinitionFactory("pd-template-check-v9").
+				SetDefaultSpec().
+				SetServiceVersion("9.0").
+				Create(&testCtx).
+				GetObject()
+			Expect(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKeyFromObject(unmatchedCompDef), func(obj *appsv1.ComponentDefinition) {
+				obj.Status.Phase = appsv1.AvailablePhase
+			})()).Should(Succeed())
+
+			parametersDef := testparameters.NewParametersDefinitionFactory("pd-template-check-params3").
+				SetComponentDefinition("pd-template-check").
+				SetServiceVersion("8.0").
+				SetTemplateName(configSpecName).
+				Create(&testCtx).
+				GetObject()
+
 			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(parametersDef),
 				func(g Gomega, tpl *parametersv1alpha1.ParametersDefinition) {
 					g.Expect(tpl.Status.Phase).Should(BeEquivalentTo(parametersv1alpha1.PDAvailablePhase))

--- a/pkg/parameters/config_util.go
+++ b/pkg/parameters/config_util.go
@@ -313,7 +313,7 @@ func ResolveCmpdParametersDefs(ctx context.Context, reader client.Reader, cmpd *
 	coveredFiles := make(map[string]string)
 	for i := range paramsDefList.Items {
 		paramsDef := &paramsDefList.Items[i]
-		matched, err := matchParametersDefinition(cmpd, paramsDef)
+		matched, err := MatchParametersDefinition(cmpd, paramsDef)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -385,7 +385,8 @@ func resolveCmpdParametersDefsByConfigRender(ctx context.Context, reader client.
 	return slices.Clone(configRender.Spec.Configs), paramsDefs, nil
 }
 
-func matchParametersDefinition(cmpd *appsv1.ComponentDefinition, paramsDef *parametersv1alpha1.ParametersDefinition) (bool, error) {
+// MatchParametersDefinition reports whether a ParametersDefinition applies to the ComponentDefinition.
+func MatchParametersDefinition(cmpd *appsv1.ComponentDefinition, paramsDef *parametersv1alpha1.ParametersDefinition) (bool, error) {
 	if cmpd == nil || paramsDef == nil {
 		return false, nil
 	}


### PR DESCRIPTION
## What
- Validate ParametersDefinition `spec.templateName` against matched ComponentDefinition config template names.
- Requeue ParametersDefinitions when matching ComponentDefinitions change.
- Add controller coverage for invalid templateName becoming Unavailable and recovering after correction.

## Why
Invalid PD template names previously surfaced later in parameter/component reconciliation. This makes the incompatibility visible earlier on the PD status.

## Validation
- `go test ./controllers/parameters`