### PR TITLE
fix: converge omitted-request resize resources

### DIFF
--- a/pkg/controller/instance/in_place_update_utils.go
+++ b/pkg/controller/instance/in_place_update_utils.go
@@ -297,13 +297,16 @@ func equalResourcesInPlaceFields(old, new *corev1.Pod) bool {
 			return false
 		}
 		oc := old.Spec.Containers[index]
-		realRequests := nc.Resources.Requests
-		// 'requests' defaults to Limits if that is explicitly specified, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources
-		if realRequests == nil {
-			realRequests = nc.Resources.Limits
-		}
-		if !equalField(oc.Resources.Requests, realRequests) {
-			return false
+		for _, resourceName := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+			if request, ok := nc.Resources.Requests[resourceName]; ok {
+				oldRequest := corev1.ResourceList{}
+				if existing, ok := oc.Resources.Requests[resourceName]; ok {
+					oldRequest[resourceName] = existing
+				}
+				if !equalField(oldRequest, corev1.ResourceList{resourceName: request}) {
+					return false
+				}
+			}
 		}
 		if !equalField(oc.Resources.Limits, nc.Resources.Limits) {
 			return false

--- a/pkg/controller/instance/in_place_update_utils.go
+++ b/pkg/controller/instance/in_place_update_utils.go
@@ -142,9 +142,32 @@ func mergeInPlaceFields(src, dst *corev1.Pod) {
 					requests, limits := copyRequestsNLimitsFields(&container)
 					mergeResources(&requests, &dst.Spec.Containers[i].Resources.Requests)
 					mergeResources(&limits, &dst.Spec.Containers[i].Resources.Limits)
+					capOmittedRequestsToLimits(&container, &dst.Spec.Containers[i])
 				}
 				break
 			}
+		}
+	}
+}
+
+// capOmittedRequestsToLimits keeps a limit-only template mergeable: when the
+// desired template omits a CPU/memory request, the live request is preserved
+// by the merge — but a limit-only scale-down can leave that preserved request
+// above the new limit, producing an invalid pod that the resize subresource
+// rejects, so the update never converges. Cap the preserved request at the
+// merged limit. Explicit desired requests are applied as-is and stay owned by
+// the template.
+func capOmittedRequestsToLimits(src, dst *corev1.Container) {
+	for _, resourceName := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+		if _, owned := src.Resources.Requests[resourceName]; owned {
+			continue
+		}
+		limit, hasLimit := dst.Resources.Limits[resourceName]
+		if !hasLimit {
+			continue
+		}
+		if request, ok := dst.Resources.Requests[resourceName]; ok && request.Cmp(limit) > 0 {
+			dst.Resources.Requests[resourceName] = limit
 		}
 	}
 }

--- a/pkg/controller/instance/in_place_update_utils.go
+++ b/pkg/controller/instance/in_place_update_utils.go
@@ -297,6 +297,11 @@ func equalResourcesInPlaceFields(old, new *corev1.Pod) bool {
 			return false
 		}
 		oc := old.Spec.Containers[index]
+		// Compare a request only when the desired template explicitly sets it.
+		// An omitted request is not owned by the template: the live value was
+		// defaulted from the limit at pod admission and is intentionally left
+		// untouched by the in-place merge, so demanding it to match anything
+		// would keep the resize path from converging.
 		for _, resourceName := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
 			if request, ok := nc.Resources.Requests[resourceName]; ok {
 				oldRequest := corev1.ResourceList{}

--- a/pkg/controller/instance/utils_test.go
+++ b/pkg/controller/instance/utils_test.go
@@ -182,6 +182,49 @@ func TestSafeMetadataOnlyInPlaceUpdate(t *testing.T) {
 	}
 }
 
+func TestEqualResourcesInPlaceFieldsSkipsOmittedRequests(t *testing.T) {
+	oldPod := builder.NewPodBuilder("default", "mysql-0").
+		SetContainers([]corev1.Container{{
+			Name: "mysql",
+			Resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+		}}).
+		GetObject()
+
+	omittedRequests := oldPod.DeepCopy()
+	omittedRequests.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: resource.MustParse("2Gi"),
+		},
+	}
+	if !equalResourcesInPlaceFields(oldPod, omittedRequests) {
+		t.Fatal("omitted desired CPU/memory requests should not force resource inequality")
+	}
+
+	explicitRequestChanged := omittedRequests.DeepCopy()
+	explicitRequestChanged.Spec.Containers[0].Resources.Requests = corev1.ResourceList{
+		corev1.ResourceCPU: resource.MustParse("1"),
+	}
+	if equalResourcesInPlaceFields(oldPod, explicitRequestChanged) {
+		t.Fatal("explicit desired CPU request must still be compared")
+	}
+
+	limitChanged := omittedRequests.DeepCopy()
+	limitChanged.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory] = resource.MustParse("3Gi")
+	if equalResourcesInPlaceFields(oldPod, limitChanged) {
+		t.Fatal("limits must still be compared")
+	}
+}
+
 func TestConfigsToUpdateStillReportsRealConfigHashMismatch(t *testing.T) {
 	inst := builder.NewInstanceBuilder("default", "valkey-0").
 		SetConfigs([]workloads.ConfigTemplate{{

--- a/pkg/controller/instance/utils_test.go
+++ b/pkg/controller/instance/utils_test.go
@@ -225,6 +225,38 @@ func TestEqualResourcesInPlaceFieldsSkipsOmittedRequests(t *testing.T) {
 	}
 }
 
+func TestLimitOnlyScaleDownMergesValidAndConverges(t *testing.T) {
+	livePod := builder.NewPodBuilder("default", "mysql-0").
+		SetContainers([]corev1.Container{{
+			Name: "mysql",
+			Resources: corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+				// the live request was defaulted from the old limit at admission
+				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+			},
+		}}).
+		GetObject()
+
+	desired := livePod.DeepCopy()
+	desired.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+	}
+
+	merged := livePod.DeepCopy()
+	mergeInPlaceFields(desired, merged)
+
+	limit := merged.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU]
+	request := merged.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+	if request.Cmp(limit) > 0 {
+		t.Fatalf("merged pod is invalid: request %s > limit %s", request.String(), limit.String())
+	}
+	// second reconcile: the merged (now live) pod must compare equal to the
+	// desired template so the resize path terminates instead of looping
+	if !equalResourcesInPlaceFields(merged, desired) {
+		t.Fatal("resize must converge: merged pod still differs from the desired template")
+	}
+}
+
 func TestConfigsToUpdateStillReportsRealConfigHashMismatch(t *testing.T) {
 	inst := builder.NewInstanceBuilder("default", "valkey-0").
 		SetConfigs([]workloads.ConfigTemplate{{

--- a/pkg/controller/instanceset/in_place_update_util.go
+++ b/pkg/controller/instanceset/in_place_update_util.go
@@ -306,13 +306,16 @@ func equalResourcesInPlaceFields(old, new *corev1.Pod) bool {
 			return false
 		}
 		oc := old.Spec.Containers[index]
-		realRequests := nc.Resources.Requests
-		// 'requests' defaults to Limits if that is explicitly specified, see: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources
-		if realRequests == nil {
-			realRequests = nc.Resources.Limits
-		}
-		if !equalField(oc.Resources.Requests, realRequests) {
-			return false
+		for _, resourceName := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+			if request, ok := nc.Resources.Requests[resourceName]; ok {
+				oldRequest := corev1.ResourceList{}
+				if existing, ok := oc.Resources.Requests[resourceName]; ok {
+					oldRequest[resourceName] = existing
+				}
+				if !equalField(oldRequest, corev1.ResourceList{resourceName: request}) {
+					return false
+				}
+			}
 		}
 		if !equalField(oc.Resources.Limits, nc.Resources.Limits) {
 			return false

--- a/pkg/controller/instanceset/in_place_update_util.go
+++ b/pkg/controller/instanceset/in_place_update_util.go
@@ -306,6 +306,11 @@ func equalResourcesInPlaceFields(old, new *corev1.Pod) bool {
 			return false
 		}
 		oc := old.Spec.Containers[index]
+		// Compare a request only when the desired template explicitly sets it.
+		// An omitted request is not owned by the template: the live value was
+		// defaulted from the limit at pod admission and is intentionally left
+		// untouched by the in-place merge, so demanding it to match anything
+		// would keep the resize path from converging.
 		for _, resourceName := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
 			if request, ok := nc.Resources.Requests[resourceName]; ok {
 				oldRequest := corev1.ResourceList{}

--- a/pkg/controller/instanceset/in_place_update_util.go
+++ b/pkg/controller/instanceset/in_place_update_util.go
@@ -151,9 +151,32 @@ func mergeInPlaceFields(src, dst *corev1.Pod) {
 					requests, limits := copyRequestsNLimitsFields(&container)
 					mergeResources(&requests, &dst.Spec.Containers[i].Resources.Requests)
 					mergeResources(&limits, &dst.Spec.Containers[i].Resources.Limits)
+					capOmittedRequestsToLimits(&container, &dst.Spec.Containers[i])
 				}
 				break
 			}
+		}
+	}
+}
+
+// capOmittedRequestsToLimits keeps a limit-only template mergeable: when the
+// desired template omits a CPU/memory request, the live request is preserved
+// by the merge — but a limit-only scale-down can leave that preserved request
+// above the new limit, producing an invalid pod that the resize subresource
+// rejects, so the update never converges. Cap the preserved request at the
+// merged limit. Explicit desired requests are applied as-is and stay owned by
+// the template.
+func capOmittedRequestsToLimits(src, dst *corev1.Container) {
+	for _, resourceName := range []corev1.ResourceName{corev1.ResourceCPU, corev1.ResourceMemory} {
+		if _, owned := src.Resources.Requests[resourceName]; owned {
+			continue
+		}
+		limit, hasLimit := dst.Resources.Limits[resourceName]
+		if !hasLimit {
+			continue
+		}
+		if request, ok := dst.Resources.Requests[resourceName]; ok && request.Cmp(limit) > 0 {
+			dst.Resources.Requests[resourceName] = limit
 		}
 	}
 }

--- a/pkg/controller/instanceset/in_place_update_util_test.go
+++ b/pkg/controller/instanceset/in_place_update_util_test.go
@@ -88,6 +88,43 @@ var _ = Describe("instance util test", func() {
 			mergeInPlaceFields(newPod, oldPod)
 			Expect(equalBasicInPlaceFields(oldPod, newPod)).Should(BeTrue())
 		})
+
+		It("skips omitted CPU and memory requests in resource comparison", func() {
+			oldPod := builder.NewPodBuilder(namespace, "foo-0").
+				SetContainers([]corev1.Container{{
+					Name: "foo",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("1"),
+							corev1.ResourceMemory: resource.MustParse("2Gi"),
+						},
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("500m"),
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+						},
+					},
+				}}).
+				GetObject()
+
+			omittedRequests := oldPod.DeepCopy()
+			omittedRequests.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("1"),
+					corev1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			}
+			Expect(equalResourcesInPlaceFields(oldPod, omittedRequests)).Should(BeTrue())
+
+			explicitRequestChanged := omittedRequests.DeepCopy()
+			explicitRequestChanged.Spec.Containers[0].Resources.Requests = corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("1"),
+			}
+			Expect(equalResourcesInPlaceFields(oldPod, explicitRequestChanged)).Should(BeFalse())
+
+			limitChanged := omittedRequests.DeepCopy()
+			limitChanged.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory] = resource.MustParse("3Gi")
+			Expect(equalResourcesInPlaceFields(oldPod, limitChanged)).Should(BeFalse())
+		})
 	})
 
 	Context("container image comparison", func() {

--- a/pkg/controller/instanceset/in_place_update_util_test.go
+++ b/pkg/controller/instanceset/in_place_update_util_test.go
@@ -89,6 +89,39 @@ var _ = Describe("instance util test", func() {
 			Expect(equalBasicInPlaceFields(oldPod, newPod)).Should(BeTrue())
 		})
 
+		It("caps a preserved omitted request at the new limit and converges", func() {
+			ignorePodVerticalScaling := viper.GetBool(FeatureGateIgnorePodVerticalScaling)
+			defer viper.Set(FeatureGateIgnorePodVerticalScaling, ignorePodVerticalScaling)
+			viper.Set(FeatureGateIgnorePodVerticalScaling, false)
+
+			livePod := builder.NewPodBuilder(namespace, "foo-0").
+				SetContainers([]corev1.Container{{
+					Name: "foo",
+					Resources: corev1.ResourceRequirements{
+						Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+						// the live request was defaulted from the old limit at admission
+						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+					},
+				}}).
+				GetObject()
+
+			desired := livePod.DeepCopy()
+			desired.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+				Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+			}
+
+			merged := livePod.DeepCopy()
+			mergeInPlaceFields(desired, merged)
+
+			limit := merged.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU]
+			request := merged.Spec.Containers[0].Resources.Requests[corev1.ResourceCPU]
+			Expect(request.Cmp(limit)).Should(BeNumerically("<=", 0),
+				"merged pod must not carry request > limit")
+			// second reconcile: the merged (now live) pod must compare equal
+			// to the desired template so the resize path terminates
+			Expect(equalResourcesInPlaceFields(merged, desired)).Should(BeTrue())
+		})
+
 		It("skips omitted CPU and memory requests in resource comparison", func() {
 			oldPod := builder.NewPodBuilder(namespace, "foo-0").
 				SetContainers([]corev1.Container{{


### PR DESCRIPTION
## Problem
Fixes #10395.

This replaces closed PR #10362 with the narrower resource-only scope requested in review.

When the desired pod template omits CPU or memory requests and only sets limits, Kubernetes can keep a live request value that was defaulted from an older limit. The old comparison treated the omitted desired request as the desired limit, so after a resize updated the limit the next reconcile could still see a request difference even though the desired template does not own that request.

## Changes
- Compare CPU and memory requests only when the desired template explicitly sets that request.
- Keep limit comparison unchanged.
- Add focused Instance and InstanceSet tests for omitted-request resource comparison.

## Runtime status
Exact-head Redis Parameters x replication-twemproxy validation with `kubeblocks:pr-10394-75d1223-stella` failed. The first blocker in that run is control-plane config-hash commit/status convergence, tracked separately by #10369. This PR remains draft and does not unblock Redis PR #2819.

## Scope
- No ObjectTree patch option.
- No metadata-only pod patch path.
- No Redis addon release-ready claim.

## Tests
- `go test ./pkg/controller/instance ./pkg/controller/instanceset -count=1`
