### PR TITLE
chore: add reconfigure diagnostic logs

### DIFF
--- a/pkg/controller/instance/reconciler_update.go
+++ b/pkg/controller/instance/reconciler_update.go
@@ -139,10 +139,34 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 			updatePolicy = recreatePolicy
 		}
 
+		reconfigureStartedAt := time.Now()
 		allUpdated, err := r.reconfigure(tree, inst, pod)
+		reconfigureDuration := time.Since(reconfigureStartedAt)
 		if err != nil {
+			tree.Logger.Info("pod reconfigure reconcile timing",
+				"pod", pod.Name,
+				"podResourceVersion", pod.ResourceVersion,
+				"podConfigHash", podConfigHashForLog(pod),
+				"desiredConfigHash", configHashesForLog(inst.Spec.Configs),
+				"updatePolicy", string(updatePolicy),
+				"specUpdatePolicy", string(specUpdatePolicy),
+				"reconfigureStartedAt", reconfigureStartedAt.Format(time.RFC3339Nano),
+				"reconfigureDuration", reconfigureDuration.String(),
+				"reconfigureDurationMillis", reconfigureDuration.Milliseconds(),
+				"error", err.Error())
 			return kubebuilderx.Continue, err
 		}
+		tree.Logger.Info("pod reconfigure reconcile timing",
+			"pod", pod.Name,
+			"podResourceVersion", pod.ResourceVersion,
+			"podConfigHash", podConfigHashForLog(pod),
+			"desiredConfigHash", configHashesForLog(inst.Spec.Configs),
+			"allConfigUpdated", allUpdated,
+			"updatePolicy", string(updatePolicy),
+			"specUpdatePolicy", string(specUpdatePolicy),
+			"reconfigureStartedAt", reconfigureStartedAt.Format(time.RFC3339Nano),
+			"reconfigureDuration", reconfigureDuration.String(),
+			"reconfigureDurationMillis", reconfigureDuration.Milliseconds())
 		if !allUpdated || updatePolicy != noOpsPolicy {
 			tree.Logger.Info("pod reconfigure update decision",
 				"pod", pod.Name,

--- a/pkg/controller/instance/reconciler_update.go
+++ b/pkg/controller/instance/reconciler_update.go
@@ -32,6 +32,7 @@ import (
 
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/kubebuilderx"
 	"github.com/apecloud/kubeblocks/pkg/controller/lifecycle"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
@@ -142,6 +143,16 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 		if err != nil {
 			return kubebuilderx.Continue, err
 		}
+		if !allUpdated || updatePolicy != noOpsPolicy {
+			tree.Logger.Info("pod reconfigure update decision",
+				"pod", pod.Name,
+				"podResourceVersion", pod.ResourceVersion,
+				"podConfigHash", podConfigHashForLog(pod),
+				"desiredConfigHash", configHashesForLog(inst.Spec.Configs),
+				"allConfigUpdated", allUpdated,
+				"updatePolicy", string(updatePolicy),
+				"specUpdatePolicy", string(specUpdatePolicy))
+		}
 		if !allUpdated && updatePolicy == noOpsPolicy {
 			continue
 		}
@@ -169,6 +180,7 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 						return kubebuilderx.Continue, err
 					}
 				}
+				logPodConfigHashUpdateScheduled(tree, pod, newMergedPod.(*corev1.Pod), "inPlaceUpdate")
 				err = tree.Update(newMergedPod)
 			}
 			if err != nil {
@@ -219,6 +231,13 @@ func (r *updateReconciler) reconfigure(tree *kubebuilderx.ObjectTree, inst *work
 	if err != nil {
 		return false, err
 	}
+	if len(toUpdate) > 0 {
+		tree.Logger.Info("pod has pending reconfigure configs",
+			"pod", pod.Name,
+			"podResourceVersion", pod.ResourceVersion,
+			"podConfigHash", podConfigHashForLog(pod),
+			"pendingConfigHash", configHashesForLog(toUpdate))
+	}
 	for _, config := range toUpdate {
 		if err = r.reconfigureInst(tree, inst, pod, config); err != nil {
 			return false, err
@@ -259,8 +278,42 @@ func (r *updateReconciler) reconfigureInst(tree *kubebuilderx.ObjectTree, inst *
 		}
 		return err
 	}
-	tree.Logger.Info("successfully reconfigure the pod", "pod", pod.Name, "configHash", ptr.Deref(config.ConfigHash, ""))
+	tree.Logger.Info("successfully reconfigure the pod",
+		"pod", pod.Name,
+		"podResourceVersion", pod.ResourceVersion,
+		"podConfigHashBeforeCommit", podConfigHashForLog(pod),
+		"configName", config.Name,
+		"desiredConfigHash", ptr.Deref(config.ConfigHash, ""))
 	return nil
+}
+
+func configHashesForLog(configs []workloads.ConfigTemplate) []string {
+	hashes := make([]string, 0, len(configs))
+	for _, config := range configs {
+		hashes = append(hashes, fmt.Sprintf("%s=%s", config.Name, ptr.Deref(config.ConfigHash, "")))
+	}
+	return hashes
+}
+
+func logPodConfigHashUpdateScheduled(tree *kubebuilderx.ObjectTree, oldPod, desiredPod *corev1.Pod, reason string) {
+	oldHash := podConfigHashForLog(oldPod)
+	desiredHash := podConfigHashForLog(desiredPod)
+	if oldHash == desiredHash {
+		return
+	}
+	tree.Logger.Info("scheduled pod config hash update",
+		"pod", oldPod.Name,
+		"reason", reason,
+		"oldResourceVersion", oldPod.ResourceVersion,
+		"oldConfigHash", oldHash,
+		"desiredConfigHash", desiredHash)
+}
+
+func podConfigHashForLog(pod *corev1.Pod) string {
+	if pod == nil || pod.Annotations == nil {
+		return ""
+	}
+	return pod.Annotations[constant.CMInsConfigurationHashLabelKey]
 }
 
 func reconfigureOptions(config workloads.ConfigTemplate) *lifecycle.Options {

--- a/pkg/controller/instance/reconciler_update.go
+++ b/pkg/controller/instance/reconciler_update.go
@@ -232,11 +232,14 @@ func (r *updateReconciler) reconfigure(tree *kubebuilderx.ObjectTree, inst *work
 		return false, err
 	}
 	if len(toUpdate) > 0 {
+		detectedAt := time.Now()
 		tree.Logger.Info("pod has pending reconfigure configs",
 			"pod", pod.Name,
 			"podResourceVersion", pod.ResourceVersion,
 			"podConfigHash", podConfigHashForLog(pod),
-			"pendingConfigHash", configHashesForLog(toUpdate))
+			"pendingConfigHash", configHashesForLog(toUpdate),
+			"detectedAt", detectedAt.Format(time.RFC3339Nano),
+			"detectedAtUnixNano", detectedAt.UnixNano())
 	}
 	for _, config := range toUpdate {
 		if err = r.reconfigureInst(tree, inst, pod, config); err != nil {
@@ -263,12 +266,32 @@ func (r *updateReconciler) reconfigureInst(tree *kubebuilderx.ObjectTree, inst *
 	}
 
 	opts := reconfigureOptions(config)
+	actionStartedAt := time.Now()
+	tree.Logger.Info("starting pod reconfigure action",
+		"pod", pod.Name,
+		"podResourceVersion", pod.ResourceVersion,
+		"podConfigHashBeforeAction", podConfigHashForLog(pod),
+		"configName", config.Name,
+		"desiredConfigHash", ptr.Deref(config.ConfigHash, ""),
+		"actionStartedAt", actionStartedAt.Format(time.RFC3339Nano),
+		"actionStartedAtUnixNano", actionStartedAt.UnixNano())
 	if len(config.ReconfigureActionName) == 0 {
 		err = lfa.Reconfigure(tree.Context, nil, opts, config.Parameters)
 	} else {
 		err = lfa.UserDefined(tree.Context, nil, opts, config.ReconfigureActionName, config.Reconfigure, config.Parameters)
 	}
+	actionDuration := time.Since(actionStartedAt)
 	if err != nil {
+		tree.Logger.Info("pod reconfigure action failed",
+			"pod", pod.Name,
+			"podResourceVersion", pod.ResourceVersion,
+			"podConfigHashBeforeAction", podConfigHashForLog(pod),
+			"configName", config.Name,
+			"desiredConfigHash", ptr.Deref(config.ConfigHash, ""),
+			"actionStartedAt", actionStartedAt.Format(time.RFC3339Nano),
+			"actionDuration", actionDuration.String(),
+			"actionDurationMillis", actionDuration.Milliseconds(),
+			"error", err.Error())
 		if errors.Is(err, lifecycle.ErrActionNotDefined) {
 			return nil
 		}
@@ -283,7 +306,10 @@ func (r *updateReconciler) reconfigureInst(tree *kubebuilderx.ObjectTree, inst *
 		"podResourceVersion", pod.ResourceVersion,
 		"podConfigHashBeforeCommit", podConfigHashForLog(pod),
 		"configName", config.Name,
-		"desiredConfigHash", ptr.Deref(config.ConfigHash, ""))
+		"desiredConfigHash", ptr.Deref(config.ConfigHash, ""),
+		"actionStartedAt", actionStartedAt.Format(time.RFC3339Nano),
+		"actionDuration", actionDuration.String(),
+		"actionDurationMillis", actionDuration.Milliseconds())
 	return nil
 }
 
@@ -306,7 +332,8 @@ func logPodConfigHashUpdateScheduled(tree *kubebuilderx.ObjectTree, oldPod, desi
 		"reason", reason,
 		"oldResourceVersion", oldPod.ResourceVersion,
 		"oldConfigHash", oldHash,
-		"desiredConfigHash", desiredHash)
+		"desiredConfigHash", desiredHash,
+		"scheduledAt", time.Now().Format(time.RFC3339Nano))
 }
 
 func podConfigHashForLog(pod *corev1.Pod) string {

--- a/pkg/controller/instanceset/reconciler_update.go
+++ b/pkg/controller/instanceset/reconciler_update.go
@@ -168,10 +168,36 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 		}
 
 		// Always call reconfigure to execute reconfigure actions
+		reconfigureStartedAt := time.Now()
 		allUpdated, err1 := r.reconfigure(tree, its, pod)
+		reconfigureDuration := time.Since(reconfigureStartedAt)
 		if err1 != nil {
+			tree.Logger.Info("pod reconfigure reconcile timing",
+				"pod", pod.Name,
+				"podResourceVersion", pod.ResourceVersion,
+				"podConfigHash", podConfigHashForLog(pod),
+				"desiredConfigHash", configHashesForLog(its.Spec.Configs),
+				"updatePolicy", string(updatePolicy),
+				"specUpdatePolicy", string(specUpdatePolicy),
+				"recreateReason", recreateReason,
+				"reconfigureStartedAt", reconfigureStartedAt.Format(time.RFC3339Nano),
+				"reconfigureDuration", reconfigureDuration.String(),
+				"reconfigureDurationMillis", reconfigureDuration.Milliseconds(),
+				"error", err1.Error())
 			return kubebuilderx.Continue, err1
 		}
+		tree.Logger.Info("pod reconfigure reconcile timing",
+			"pod", pod.Name,
+			"podResourceVersion", pod.ResourceVersion,
+			"podConfigHash", podConfigHashForLog(pod),
+			"desiredConfigHash", configHashesForLog(its.Spec.Configs),
+			"allConfigUpdated", allUpdated,
+			"updatePolicy", string(updatePolicy),
+			"specUpdatePolicy", string(specUpdatePolicy),
+			"recreateReason", recreateReason,
+			"reconfigureStartedAt", reconfigureStartedAt.Format(time.RFC3339Nano),
+			"reconfigureDuration", reconfigureDuration.String(),
+			"reconfigureDurationMillis", reconfigureDuration.Milliseconds())
 		if !allUpdated || updatePolicy != noOpsPolicy {
 			tree.Logger.Info("pod reconfigure update decision",
 				"pod", pod.Name,

--- a/pkg/controller/instanceset/reconciler_update.go
+++ b/pkg/controller/instanceset/reconciler_update.go
@@ -33,6 +33,7 @@ import (
 
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/instancetemplate"
 	"github.com/apecloud/kubeblocks/pkg/controller/kubebuilderx"
 	"github.com/apecloud/kubeblocks/pkg/controller/lifecycle"
@@ -171,6 +172,17 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 		if err1 != nil {
 			return kubebuilderx.Continue, err1
 		}
+		if !allUpdated || updatePolicy != noOpsPolicy {
+			tree.Logger.Info("pod reconfigure update decision",
+				"pod", pod.Name,
+				"podResourceVersion", pod.ResourceVersion,
+				"podConfigHash", podConfigHashForLog(pod),
+				"desiredConfigHash", configHashesForLog(its.Spec.Configs),
+				"allConfigUpdated", allUpdated,
+				"updatePolicy", string(updatePolicy),
+				"specUpdatePolicy", string(specUpdatePolicy),
+				"recreateReason", recreateReason)
+		}
 		if !allUpdated && updatePolicy == noOpsPolicy {
 			updatingPods++
 		}
@@ -198,6 +210,7 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 						return kubebuilderx.Continue, err
 					}
 				}
+				logPodConfigHashUpdateScheduled(tree, pod, newMergedPod.(*corev1.Pod), "inPlaceUpdate")
 				err = tree.Update(newMergedPod)
 			}
 			if err != nil {
@@ -302,6 +315,13 @@ func (r *updateReconciler) reconfigure(tree *kubebuilderx.ObjectTree, its *workl
 	if err != nil {
 		return false, err
 	}
+	if len(toUpdate) > 0 {
+		tree.Logger.Info("pod has pending reconfigure configs",
+			"pod", pod.Name,
+			"podResourceVersion", pod.ResourceVersion,
+			"podConfigHash", podConfigHashForLog(pod),
+			"pendingConfigHash", configHashesForLog(toUpdate))
+	}
 	for _, config := range toUpdate {
 		if err = r.reconfigureInst(tree, its, pod, config); err != nil {
 			return false, err
@@ -341,8 +361,42 @@ func (r *updateReconciler) reconfigureInst(tree *kubebuilderx.ObjectTree, its *w
 		}
 		return err
 	}
-	tree.Logger.Info("successfully reconfigure the pod", "pod", pod.Name, "configHash", ptr.Deref(config.ConfigHash, ""))
+	tree.Logger.Info("successfully reconfigure the pod",
+		"pod", pod.Name,
+		"podResourceVersion", pod.ResourceVersion,
+		"podConfigHashBeforeCommit", podConfigHashForLog(pod),
+		"configName", config.Name,
+		"desiredConfigHash", ptr.Deref(config.ConfigHash, ""))
 	return nil
+}
+
+func configHashesForLog(configs []workloads.ConfigTemplate) []string {
+	hashes := make([]string, 0, len(configs))
+	for _, config := range configs {
+		hashes = append(hashes, fmt.Sprintf("%s=%s", config.Name, ptr.Deref(config.ConfigHash, "")))
+	}
+	return hashes
+}
+
+func logPodConfigHashUpdateScheduled(tree *kubebuilderx.ObjectTree, oldPod, desiredPod *corev1.Pod, reason string) {
+	oldHash := podConfigHashForLog(oldPod)
+	desiredHash := podConfigHashForLog(desiredPod)
+	if oldHash == desiredHash {
+		return
+	}
+	tree.Logger.Info("scheduled pod config hash update",
+		"pod", oldPod.Name,
+		"reason", reason,
+		"oldResourceVersion", oldPod.ResourceVersion,
+		"oldConfigHash", oldHash,
+		"desiredConfigHash", desiredHash)
+}
+
+func podConfigHashForLog(pod *corev1.Pod) string {
+	if pod == nil || pod.Annotations == nil {
+		return ""
+	}
+	return pod.Annotations[constant.CMInsConfigurationHashLabelKey]
 }
 
 func reconfigureOptions(config workloads.ConfigTemplate) *lifecycle.Options {

--- a/pkg/controller/instanceset/reconciler_update.go
+++ b/pkg/controller/instanceset/reconciler_update.go
@@ -316,11 +316,14 @@ func (r *updateReconciler) reconfigure(tree *kubebuilderx.ObjectTree, its *workl
 		return false, err
 	}
 	if len(toUpdate) > 0 {
+		detectedAt := time.Now()
 		tree.Logger.Info("pod has pending reconfigure configs",
 			"pod", pod.Name,
 			"podResourceVersion", pod.ResourceVersion,
 			"podConfigHash", podConfigHashForLog(pod),
-			"pendingConfigHash", configHashesForLog(toUpdate))
+			"pendingConfigHash", configHashesForLog(toUpdate),
+			"detectedAt", detectedAt.Format(time.RFC3339Nano),
+			"detectedAtUnixNano", detectedAt.UnixNano())
 	}
 	for _, config := range toUpdate {
 		if err = r.reconfigureInst(tree, its, pod, config); err != nil {
@@ -346,12 +349,32 @@ func (r *updateReconciler) reconfigureInst(tree *kubebuilderx.ObjectTree, its *w
 	}
 
 	opts := reconfigureOptions(config)
+	actionStartedAt := time.Now()
+	tree.Logger.Info("starting pod reconfigure action",
+		"pod", pod.Name,
+		"podResourceVersion", pod.ResourceVersion,
+		"podConfigHashBeforeAction", podConfigHashForLog(pod),
+		"configName", config.Name,
+		"desiredConfigHash", ptr.Deref(config.ConfigHash, ""),
+		"actionStartedAt", actionStartedAt.Format(time.RFC3339Nano),
+		"actionStartedAtUnixNano", actionStartedAt.UnixNano())
 	if len(config.ReconfigureActionName) == 0 {
 		err = lfa.Reconfigure(tree.Context, nil, opts, config.Parameters)
 	} else {
 		err = lfa.UserDefined(tree.Context, nil, opts, config.ReconfigureActionName, config.Reconfigure, config.Parameters)
 	}
+	actionDuration := time.Since(actionStartedAt)
 	if err != nil {
+		tree.Logger.Info("pod reconfigure action failed",
+			"pod", pod.Name,
+			"podResourceVersion", pod.ResourceVersion,
+			"podConfigHashBeforeAction", podConfigHashForLog(pod),
+			"configName", config.Name,
+			"desiredConfigHash", ptr.Deref(config.ConfigHash, ""),
+			"actionStartedAt", actionStartedAt.Format(time.RFC3339Nano),
+			"actionDuration", actionDuration.String(),
+			"actionDurationMillis", actionDuration.Milliseconds(),
+			"error", err.Error())
 		if errors.Is(err, lifecycle.ErrActionNotDefined) {
 			return nil
 		}
@@ -366,7 +389,10 @@ func (r *updateReconciler) reconfigureInst(tree *kubebuilderx.ObjectTree, its *w
 		"podResourceVersion", pod.ResourceVersion,
 		"podConfigHashBeforeCommit", podConfigHashForLog(pod),
 		"configName", config.Name,
-		"desiredConfigHash", ptr.Deref(config.ConfigHash, ""))
+		"desiredConfigHash", ptr.Deref(config.ConfigHash, ""),
+		"actionStartedAt", actionStartedAt.Format(time.RFC3339Nano),
+		"actionDuration", actionDuration.String(),
+		"actionDurationMillis", actionDuration.Milliseconds())
 	return nil
 }
 
@@ -389,7 +415,8 @@ func logPodConfigHashUpdateScheduled(tree *kubebuilderx.ObjectTree, oldPod, desi
 		"reason", reason,
 		"oldResourceVersion", oldPod.ResourceVersion,
 		"oldConfigHash", oldHash,
-		"desiredConfigHash", desiredHash)
+		"desiredConfigHash", desiredHash,
+		"scheduledAt", time.Now().Format(time.RFC3339Nano))
 }
 
 func podConfigHashForLog(pod *corev1.Pod) string {

--- a/pkg/controller/kubebuilderx/controller.go
+++ b/pkg/controller/kubebuilderx/controller.go
@@ -130,6 +130,7 @@ func (c *controller) Commit() (ctrl.Result, error) {
 	}
 	if c.err = plan.Execute(); c.err != nil {
 		if apierrors.IsConflict(c.err) {
+			c.logger.Info("reconcile plan hit conflict, requeueing", "request", c.req, "error", c.err.Error())
 			return ctrl.Result{Requeue: true}, nil
 		}
 		return ctrl.Result{}, c.err

--- a/pkg/controller/kubebuilderx/plan_builder.go
+++ b/pkg/controller/kubebuilderx/plan_builder.go
@@ -30,6 +30,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
@@ -37,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
 )
@@ -283,8 +285,10 @@ func (b *PlanBuilder) updateObject(ctx context.Context, vertex *model.ObjectVert
 		reason = "SuccessfulUpdate"
 	}
 	if err != nil {
+		b.logPodConfigHashUpdate(ctx, vertex, err)
 		return fmt.Errorf("update %T %s failed: %w", vertex.Obj, klog.KObj(vertex.Obj), err)
 	}
+	b.logPodConfigHashUpdate(ctx, vertex, nil)
 	b.emitEvent(vertex.Obj, reason, model.UPDATE)
 	return nil
 }
@@ -351,6 +355,53 @@ func getTypeName(i any) string {
 		t = t.Elem()
 	}
 	return t.Name()
+}
+
+func (b *PlanBuilder) logPodConfigHashUpdate(ctx context.Context, vertex *model.ObjectVertex, updateErr error) {
+	pod, ok := vertex.Obj.(*corev1.Pod)
+	if !ok {
+		return
+	}
+	if podConfigHash(vertex.OriObj) == "" && podConfigHash(vertex.Obj) == "" {
+		return
+	}
+	values := []any{
+		"pod", klog.KObj(pod),
+		"subResource", vertex.SubResource,
+		"oldResourceVersion", objectResourceVersion(vertex.OriObj),
+		"desiredResourceVersion", objectResourceVersion(vertex.Obj),
+		"oldConfigHash", podConfigHash(vertex.OriObj),
+		"desiredConfigHash", podConfigHash(vertex.Obj),
+	}
+	if updateErr != nil {
+		b.transCtx.logger.Error(updateErr, "pod config hash update failed", values...)
+		return
+	}
+	livePod := &corev1.Pod{}
+	if err := b.cli.Get(ctx, types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, livePod); err != nil {
+		b.transCtx.logger.Error(err, "pod config hash update succeeded but readback failed", values...)
+		return
+	}
+	values = append(values,
+		"liveResourceVersion", livePod.ResourceVersion,
+		"liveConfigHash", podConfigHash(livePod),
+	)
+	b.transCtx.logger.Info("pod config hash update succeeded", values...)
+}
+
+func podConfigHash(obj client.Object) string {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok || pod == nil || pod.Annotations == nil {
+		return ""
+	}
+	return pod.Annotations[constant.CMInsConfigurationHashLabelKey]
+}
+
+func objectResourceVersion(obj client.Object) string {
+	if obj == nil {
+		return ""
+	}
+	return obj.GetResourceVersion()
 }
 
 // NewPlanBuilder returns a PlanBuilder

--- a/pkg/controller/kubebuilderx/plan_builder.go
+++ b/pkg/controller/kubebuilderx/plan_builder.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -277,6 +278,7 @@ func (b *PlanBuilder) createObject(ctx context.Context, vertex *model.ObjectVert
 func (b *PlanBuilder) updateObject(ctx context.Context, vertex *model.ObjectVertex) error {
 	var err error
 	var reason string
+	startedAt := time.Now()
 	if vertex.SubResource != "" {
 		err = b.cli.SubResource(vertex.SubResource).Update(ctx, vertex.Obj, clientOption(vertex))
 		reason = "SuccessfulUpdateSubResource"
@@ -285,10 +287,10 @@ func (b *PlanBuilder) updateObject(ctx context.Context, vertex *model.ObjectVert
 		reason = "SuccessfulUpdate"
 	}
 	if err != nil {
-		b.logPodConfigHashUpdate(ctx, vertex, err)
+		b.logPodConfigHashUpdate(ctx, vertex, err, startedAt)
 		return fmt.Errorf("update %T %s failed: %w", vertex.Obj, klog.KObj(vertex.Obj), err)
 	}
-	b.logPodConfigHashUpdate(ctx, vertex, nil)
+	b.logPodConfigHashUpdate(ctx, vertex, nil, startedAt)
 	b.emitEvent(vertex.Obj, reason, model.UPDATE)
 	return nil
 }
@@ -297,6 +299,7 @@ func (b *PlanBuilder) patchObject(ctx context.Context, vertex *model.ObjectVerte
 	var err error
 	var reason string
 	patch := client.MergeFrom(vertex.OriObj)
+	startedAt := time.Now()
 	if vertex.SubResource != "" {
 		err = b.cli.SubResource(vertex.SubResource).Patch(ctx, vertex.Obj, patch, clientOption(vertex))
 		reason = "SuccessfulPatchSubResource"
@@ -305,8 +308,10 @@ func (b *PlanBuilder) patchObject(ctx context.Context, vertex *model.ObjectVerte
 		reason = "SuccessfulPatch"
 	}
 	if err != nil {
+		b.logPodConfigHashUpdate(ctx, vertex, err, startedAt)
 		return fmt.Errorf("patch %T %s failed: %w", vertex.Obj, klog.KObj(vertex.Obj), err)
 	}
+	b.logPodConfigHashUpdate(ctx, vertex, nil, startedAt)
 	b.emitEvent(vertex.Obj, reason, model.PATCH)
 	return nil
 }
@@ -357,7 +362,7 @@ func getTypeName(i any) string {
 	return t.Name()
 }
 
-func (b *PlanBuilder) logPodConfigHashUpdate(ctx context.Context, vertex *model.ObjectVertex, updateErr error) {
+func (b *PlanBuilder) logPodConfigHashUpdate(ctx context.Context, vertex *model.ObjectVertex, updateErr error, startedAt time.Time) {
 	pod, ok := vertex.Obj.(*corev1.Pod)
 	if !ok {
 		return
@@ -372,6 +377,9 @@ func (b *PlanBuilder) logPodConfigHashUpdate(ctx context.Context, vertex *model.
 		"desiredResourceVersion", objectResourceVersion(vertex.Obj),
 		"oldConfigHash", podConfigHash(vertex.OriObj),
 		"desiredConfigHash", podConfigHash(vertex.Obj),
+		"commitStartedAt", startedAt.Format(time.RFC3339Nano),
+		"commitDuration", time.Since(startedAt).String(),
+		"commitDurationMillis", time.Since(startedAt).Milliseconds(),
 	}
 	if updateErr != nil {
 		b.transCtx.logger.Error(updateErr, "pod config hash update failed", values...)


### PR DESCRIPTION
## Status

Draft diagnostic PR only. This is not a functional fix and should not be routed as ready for human review or merge until a fresh reproduction uses the logs and produces direct evidence.

This replaces #10396 only to use a branch name that passes the repository pre-check. The code commit is unchanged: `cd2a82f8eaade47438b41f240329dbf79392190d`.

## Why

The current #10384 evidence proves that live pods can remain on the old config hash after repeated successful reconfigure actions, but it does not directly prove which controller write step failed or was skipped. This PR adds temporary logs to close that evidence gap.

## What this logs

- pending reconfigure configs with pod resourceVersion, current pod config hash, and desired config hash
- reconfigure success with pod resourceVersion, config name, and desired config hash
- update decision with updatePolicy, specUpdatePolicy, current hash, desired hash, and allConfigUpdated
- scheduled pod config hash update before `tree.Update`
- actual plan submit result for pod config hash updates, including failure details
- successful submit readback with live pod resourceVersion and live config hash
- formerly silent plan conflicts now log request and error before requeue

## Boundaries

- no change to resource comparison
- no change to reconfigure execution
- no change to update policy selection
- no change to tree commit behavior
- one extra read-only pod GET after a successful pod config hash update, for diagnostic evidence only

## Local validation

- `go test ./pkg/controller/kubebuilderx ./pkg/controller/instanceset ./pkg/controller/instance -count=1`

## Local diagnostic image

Built locally for pre-merge sideload testing:

- tag: `kubeblocks:diag-10384-cd2a82f-lily`
- source commit: `cd2a82f8eaade47438b41f240329dbf79392190d`
- platform: `linux/amd64`
- local image digest: `sha256:5ecd838db0aee89e770b11cff4328479c97dfda36d72ee66c4fbf34b4725b4bb`

The current machine has no Kubernetes context configured, so IDC sideload/import and focused SQL Server C01 reproduction still need to run from a machine or owner with the target cluster context.
