### PR TITLE
fix(workloads): patch metadata-only pod updates

### DIFF
--- a/pkg/controller/instance/reconciler_update.go
+++ b/pkg/controller/instance/reconciler_update.go
@@ -164,12 +164,17 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 			if !equalResourcesInPlaceFields(pod, newPod) && supportResizeSubResource {
 				err = tree.Update(newMergedPod, kubebuilderx.WithSubResource("resize"))
 			} else {
-				if !safeMetadataOnlyInPlaceUpdate(pod, newPod) {
+				metadataOnlyUpdate := safeMetadataOnlyInPlaceUpdate(pod, newPod)
+				if !metadataOnlyUpdate {
 					if err = r.switchover(tree, inst, newMergedPod.(*corev1.Pod)); err != nil {
 						return kubebuilderx.Continue, err
 					}
 				}
-				err = tree.Update(newMergedPod)
+				if metadataOnlyUpdate {
+					err = tree.Update(newMergedPod, kubebuilderx.PatchObject(true))
+				} else {
+					err = tree.Update(newMergedPod)
+				}
 			}
 			if err != nil {
 				return kubebuilderx.Continue, err

--- a/pkg/controller/instance/reconciler_update_test.go
+++ b/pkg/controller/instance/reconciler_update_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package instance
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/builder"
+	"github.com/apecloud/kubeblocks/pkg/controller/kubebuilderx"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+)
+
+func TestUpdateReconcilerPatchesMetadataOnlyInPlaceUpdate(t *testing.T) {
+	origSupportResize := intctrlutil.SupportResizeSubResource
+	intctrlutil.SupportResizeSubResource = func() (bool, error) { return false, nil }
+	defer func() { intctrlutil.SupportResizeSubResource = origSupportResize }()
+
+	inst := builder.NewInstanceBuilder(testNamespace, "mysql-0").
+		SetUID(types.UID("12345678-1234-1234-1234-1234567890ab")).
+		SetContainers([]corev1.Container{{Name: "mysql", Image: "mysql:8.0"}}).
+		SetPodUpdatePolicy(kbappsv1.PreferInPlacePodUpdatePolicyType).
+		SetConfigs([]workloads.ConfigTemplate{{
+			Name:       "mysql-conf",
+			ConfigHash: ptr.To("old-hash"),
+		}}).
+		GetObject()
+
+	revision, err := buildInstancePodRevision(&inst.Spec.Template, inst)
+	if err != nil {
+		t.Fatalf("buildInstancePodRevision() error = %v", err)
+	}
+	inst.Status.UpdateRevision = revision
+
+	pod, err := buildInstancePod(inst, revision)
+	if err != nil {
+		t.Fatalf("buildInstancePod() error = %v", err)
+	}
+	pod.Status.Phase = corev1.PodRunning
+	pod.Status.Conditions = []corev1.PodCondition{{
+		Type:               corev1.PodReady,
+		Status:             corev1.ConditionTrue,
+		LastTransitionTime: metav1.Now(),
+	}}
+	oldConfigHashAnnotation := pod.Annotations[constant.CMInsConfigurationHashLabelKey]
+
+	inst.Spec.Configs[0].ConfigHash = ptr.To("new-hash")
+	tree := newTestTree(inst)
+	if err = tree.Add(pod); err != nil {
+		t.Fatalf("tree.Add() error = %v", err)
+	}
+
+	res, err := NewUpdateReconciler().Reconcile(tree)
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	if res != kubebuilderx.Continue {
+		t.Fatalf("Reconcile() result = %v, want %v", res, kubebuilderx.Continue)
+	}
+
+	obj, options, err := tree.GetWithOption(pod)
+	if err != nil {
+		t.Fatalf("tree.GetWithOption() error = %v", err)
+	}
+	updatedPod, ok := obj.(*corev1.Pod)
+	if !ok {
+		t.Fatalf("expected updated Pod, got %T", obj)
+	}
+	if !options.Patch {
+		t.Fatal("expected metadata-only pod update to be committed with Patch")
+	}
+	if updatedPod.Annotations[constant.CMInsConfigurationHashLabelKey] == oldConfigHashAnnotation {
+		t.Fatalf("expected config-hash annotation to be updated, got %q", updatedPod.Annotations[constant.CMInsConfigurationHashLabelKey])
+	}
+	configs, err := configsFromPod(updatedPod)
+	if err != nil {
+		t.Fatalf("configsFromPod() error = %v", err)
+	}
+	if len(configs) != 1 || configs[0].Name != "mysql-conf" || ptr.Deref(configs[0].ConfigHash, "") != "new-hash" {
+		t.Fatalf("unexpected updated configs: %#v", configs)
+	}
+}

--- a/pkg/controller/instanceset/reconciler_update.go
+++ b/pkg/controller/instanceset/reconciler_update.go
@@ -193,12 +193,17 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 			if !equalResourcesInPlaceFields(pod, newPod) && supportResizeSubResource {
 				err = tree.Update(newMergedPod, kubebuilderx.WithSubResource("resize"))
 			} else {
-				if !safeMetadataOnlyInPlaceUpdate(pod, newPod) {
+				metadataOnlyUpdate := safeMetadataOnlyInPlaceUpdate(pod, newPod)
+				if !metadataOnlyUpdate {
 					if err = r.switchover(tree, its, newMergedPod.(*corev1.Pod)); err != nil {
 						return kubebuilderx.Continue, err
 					}
 				}
-				err = tree.Update(newMergedPod)
+				if metadataOnlyUpdate {
+					err = tree.Update(newMergedPod, kubebuilderx.PatchObject(true))
+				} else {
+					err = tree.Update(newMergedPod)
+				}
 			}
 			if err != nil {
 				return kubebuilderx.Continue, err

--- a/pkg/controller/instanceset/reconciler_update_test.go
+++ b/pkg/controller/instanceset/reconciler_update_test.go
@@ -495,6 +495,10 @@ var _ = Describe("update reconciler test", func() {
 			updatedPod := postPods[0].(*corev1.Pod)
 			Expect(updatedPod.Annotations).Should(HaveKeyWithValue(constant.CMInsConfigurationHashLabelKey, "new-hash"),
 				"pod should be patched with the new config-hash annotation even though switchover is skipped")
+			_, options, err := tree.GetWithOption(updatedPod)
+			Expect(err).Should(BeNil())
+			Expect(options.Patch).Should(BeTrue(),
+				"metadata-only pod updates should commit with Patch to avoid resourceVersion conflicts with role probe annotations")
 			Expect(spy.switchoverCalls).Should(Equal(0),
 				"switchover must not be invoked when only the config-hash annotation differs")
 		})

--- a/pkg/controller/kubebuilderx/plan_builder.go
+++ b/pkg/controller/kubebuilderx/plan_builder.go
@@ -187,13 +187,16 @@ func buildOrderedVertices(transCtx *transformContext, currentTree *ObjectTree, d
 					transCtx.logger.Error(err, "can't get GVKName from object", "object", newObj.GetName())
 					return
 				}
-				var v *model.ObjectVertex
-				subResource := desiredTree.childrenOptions[*name].SubResource
-				if subResource != "" {
-					v = model.NewObjectVertex(oldObj, newObj, model.ActionUpdatePtr(), inDataContext4G(), model.WithSubResource(subResource))
-				} else {
-					v = model.NewObjectVertex(oldObj, newObj, model.ActionUpdatePtr(), inDataContext4G())
+				options := desiredTree.childrenOptions[*name]
+				action := model.ActionUpdatePtr()
+				if options.Patch {
+					action = model.ActionPatchPtr()
 				}
+				graphOptions := []model.GraphOption{inDataContext4G()}
+				if options.SubResource != "" {
+					graphOptions = append(graphOptions, model.WithSubResource(options.SubResource))
+				}
+				v := model.NewObjectVertex(oldObj, newObj, action, graphOptions...)
 				findAndAppend(v)
 			}
 		}

--- a/pkg/controller/kubebuilderx/plan_builder_test.go
+++ b/pkg/controller/kubebuilderx/plan_builder_test.go
@@ -286,6 +286,32 @@ var _ = Describe("plan builder test", func() {
 				}
 				Expect(found).To(BeTrue())
 			})
+
+			It("should append a patch vertex when object update is marked for patch", func() {
+				oldPod := builder.NewPodBuilder("ns", "pod").
+					AddAnnotations(constant.CMInsConfigurationHashLabelKey, "old").
+					GetObject()
+				newPod := oldPod.DeepCopy()
+				newPod.Annotations[constant.CMInsConfigurationHashLabelKey] = "new"
+
+				currentTree := NewObjectTree()
+				desiredTree := NewObjectTree()
+				currentTree.SetRoot(builder.NewInstanceSetBuilder("ns", "root").GetObject())
+				desiredTree.SetRoot(currentTree.GetRoot())
+				Expect(currentTree.Add(oldPod)).Should(Succeed())
+				Expect(desiredTree.Update(newPod, PatchObject(true))).Should(Succeed())
+
+				vertices := buildOrderedVertices(transCtx, currentTree, desiredTree)
+
+				found := false
+				for _, v := range vertices {
+					if pod, ok := v.Obj.(*corev1.Pod); ok && pod.Name == "pod" {
+						found = true
+						Expect(*v.Action).To(Equal(model.PATCH))
+					}
+				}
+				Expect(found).To(BeTrue())
+			})
 		})
 	})
 })

--- a/pkg/controller/kubebuilderx/reconciler.go
+++ b/pkg/controller/kubebuilderx/reconciler.go
@@ -43,6 +43,9 @@ type ObjectOptions struct {
 
 	// if true, the object should not be reconciled
 	SkipToReconcile bool
+
+	// if true, update action should use Patch instead of Update
+	Patch bool
 }
 
 type WithSubResource string
@@ -55,6 +58,12 @@ type SkipToReconcile bool
 
 func (o SkipToReconcile) ApplyToObject(opts *ObjectOptions) {
 	opts.SkipToReconcile = bool(o)
+}
+
+type PatchObject bool
+
+func (o PatchObject) ApplyToObject(opts *ObjectOptions) {
+	opts.Patch = bool(o)
 }
 
 type ObjectTree struct {


### PR DESCRIPTION
### What

Fixes #10384.

This PR changes metadata-only Pod in-place updates to commit through PATCH instead of full-object UPDATE:

- adds a `PatchObject(true)` option to the ObjectTree commit path
- routes that option to a PATCH vertex in the plan builder
- uses PATCH for InstanceSet and Instance in-place Pod updates when only labels/annotations change
- keeps spec changes, resize-subresource changes, and recreate paths on the existing update/delete behavior

### Why

A focused SQL Server C01 diagnostic run showed reconfigure could execute successfully while the OpsRequest stayed `Running`: the controller then tried to write the new config-hash annotation with a full Pod UPDATE, but role-probe metadata writes advanced the Pod `resourceVersion` at the same time. The full UPDATE repeatedly hit Kubernetes `object has been modified` conflicts, so the config-hash annotation never committed.

Using merge PATCH for the metadata-only path narrows the write to the changed label/annotation keys and avoids failing solely because unrelated Pod metadata changed concurrently.

### Validation

- `go test ./pkg/controller/kubebuilderx ./pkg/controller/instanceset ./pkg/controller/instance -count=1`
- `git diff --check origin/main..HEAD`

Not run locally: `go test ./controllers/workloads -count=1` because this machine is missing `/usr/local/kubebuilder/bin/etcd` for envtest.

### Current state

Draft until a patched controller image passes the SQL Server C01 runtime validation.
