### PR TITLE
fix(kbagent): preserve roleProbe event time for delivered repeats

### DIFF
--- a/controllers/workloads/role_event_handler_test.go
+++ b/controllers/workloads/role_event_handler_test.go
@@ -161,6 +161,14 @@ func TestAcceptRoleProbeEventSingleTokenAcceptsNewerEventTime(t *testing.T) {
 	}
 }
 
+func TestAcceptRoleProbeEventSingleTokenRejectsEqualEventTime(t *testing.T) {
+	pod := podWithAnnotations(map[string]string{constant.LastRoleEventVersionAnnotationKey: "1779550600000000"})
+	parsed := roleProbeOutput{role: "primary"}
+	if acceptRoleProbeEvent(pod, "1779550600000000", parsed) {
+		t.Fatalf("expected repeated single-token result with equal EventTime to be rejected")
+	}
+}
+
 func TestAcceptRoleProbeEventSingleTokenRejectsOlderEventTime(t *testing.T) {
 	pod := podWithAnnotations(map[string]string{constant.LastRoleEventVersionAnnotationKey: "1779550600000000"})
 	parsed := roleProbeOutput{role: "primary"}

--- a/pkg/kbagent/service/probe.go
+++ b/pkg/kbagent/service/probe.go
@@ -71,7 +71,7 @@ type probeService struct {
 	actionService        *actionService
 	probes               map[string]*proto.Probe
 	runners              map[string]*probeRunner
-	sendEventWithMessage func(logger *logr.Logger, reason string, message string, sync bool) error
+	sendEventWithMessage func(logger *logr.Logger, reason string, message string, sync bool, preserveEventTimeOnUpdate bool) error
 }
 
 var _ Service = &probeService{}
@@ -114,7 +114,7 @@ type probeRunner struct {
 	failedCount          int64
 	latestOutput         []byte
 	latestEvent          chan proto.ProbeEvent
-	sendEventWithMessage func(logger *logr.Logger, reason string, message string, sync bool) error
+	sendEventWithMessage func(logger *logr.Logger, reason string, message string, sync bool, preserveEventTimeOnUpdate bool) error
 }
 
 type fileChangeWatch struct {
@@ -384,6 +384,9 @@ func (r *probeRunner) launchReportLoop(probe *proto.Probe) {
 
 		var event proto.ProbeEvent
 		var hasEvent bool
+		needsRetry := false
+		var lastDeliveredMessage string
+		hasDeliveredMessage := false
 
 		output := func() string {
 			prefixLen := min(len(event.Output), 32)
@@ -405,17 +408,23 @@ func (r *probeRunner) launchReportLoop(probe *proto.Probe) {
 				return true
 			}
 
-			msg, err := json.Marshal(event)
+			msgBytes, err := json.Marshal(event)
 			if err != nil {
 				log(err, "failed to marshal the probe event", retry, periodically)
 				return true
 			}
+			msg := string(msgBytes)
 
 			if r.sendEventWithMessage == nil {
-				r.sendEventWithMessage = util.SendEventWithMessage
+				r.sendEventWithMessage = util.SendEventWithMessageWithEventTimeOption
 			}
-			err = r.sendEventWithMessage(&r.logger, event.Probe, string(msg), true)
+			// A delivered same-output roleProbe re-report is the same observation,
+			// whether it came from the report ticker or a file-change trigger.
+			preserveEventTimeOnUpdate := event.Probe == "roleProbe" && hasDeliveredMessage && msg == lastDeliveredMessage
+			err = r.sendEventWithMessage(&r.logger, event.Probe, msg, true, preserveEventTimeOnUpdate)
 			if err == nil {
+				lastDeliveredMessage = msg
+				hasDeliveredMessage = true
 				log(nil, "succeed to send the probe event", retry, periodically)
 			} else {
 				log(err, "failed to send the probe event, will retry later", retry, periodically)
@@ -423,7 +432,6 @@ func (r *probeRunner) launchReportLoop(probe *proto.Probe) {
 			return err == nil
 		}
 
-		needsRetry := false
 		for {
 			select {
 			case latest := <-r.latestEvent:

--- a/pkg/kbagent/service/probe_test.go
+++ b/pkg/kbagent/service/probe_test.go
@@ -123,7 +123,7 @@ var _ = Describe("probe", func() {
 				reason  string
 				message string
 			}, 128)
-			service.sendEventWithMessage = func(_ *logr.Logger, reason string, message string, _ bool) error {
+			service.sendEventWithMessage = func(_ *logr.Logger, reason string, message string, _ bool, _ bool) error {
 				eventChan <- struct{ reason, message string }{reason, message}
 				return nil
 			}
@@ -159,11 +159,16 @@ var _ = Describe("probe", func() {
 
 			By("mock send event function")
 			eventChan := make(chan struct {
-				reason  string
-				message string
+				reason                    string
+				message                   string
+				preserveEventTimeOnUpdate bool
 			}, 128)
-			service.sendEventWithMessage = func(_ *logr.Logger, reason string, message string, _ bool) error {
-				eventChan <- struct{ reason, message string }{reason, message}
+			service.sendEventWithMessage = func(_ *logr.Logger, reason string, message string, _ bool, preserveEventTimeOnUpdate bool) error {
+				eventChan <- struct {
+					reason                    string
+					message                   string
+					preserveEventTimeOnUpdate bool
+				}{reason, message, preserveEventTimeOnUpdate}
 				return nil
 			}
 
@@ -171,8 +176,13 @@ var _ = Describe("probe", func() {
 			Expect(service.Start()).Should(Succeed())
 
 			By("drain initial event")
-			var receivedData struct{ reason, message string }
+			var receivedData struct {
+				reason                    string
+				message                   string
+				preserveEventTimeOnUpdate bool
+			}
 			Eventually(eventChan).Should(Receive(&receivedData))
+			Expect(receivedData.preserveEventTimeOnUpdate).Should(BeFalse())
 
 			By("update watched file")
 			Expect(os.WriteFile(triggerPath, []byte("changed"), 0644)).Should(Succeed())
@@ -180,11 +190,119 @@ var _ = Describe("probe", func() {
 			By("check received event even though probe output has not changed")
 			Eventually(eventChan, 5*time.Second).Should(Receive(&receivedData))
 			Expect(receivedData.reason).Should(Equal(probeName))
+			Expect(receivedData.preserveEventTimeOnUpdate).Should(BeTrue())
 			var event proto.ProbeEvent
 			Expect(json.Unmarshal([]byte(receivedData.message), &event)).Should(Succeed())
 			Expect(event.Probe).Should(Equal(probeName))
 			Expect(event.Code).Should(Equal(int32(0)))
 			Expect(event.Output).Should(Equal([]byte("leader")))
+		})
+
+		It("preserves event time when periodically re-reporting unchanged roleProbe output", func() {
+			probesWithReport := append([]proto.Probe(nil), probes...)
+			probesWithReport[0].ReportPeriodSeconds = 1
+
+			service, err := newProbeService(logr.New(nil), actionSvc, probesWithReport)
+			Expect(err).Should(BeNil())
+			Expect(service).ShouldNot(BeNil())
+
+			eventChan := make(chan struct {
+				reason                    string
+				message                   string
+				preserveEventTimeOnUpdate bool
+			}, 128)
+			service.sendEventWithMessage = func(_ *logr.Logger, reason string, message string, _ bool, preserveEventTimeOnUpdate bool) error {
+				eventChan <- struct {
+					reason                    string
+					message                   string
+					preserveEventTimeOnUpdate bool
+				}{reason, message, preserveEventTimeOnUpdate}
+				return nil
+			}
+
+			Expect(service.Start()).Should(Succeed())
+
+			var receivedData struct {
+				reason                    string
+				message                   string
+				preserveEventTimeOnUpdate bool
+			}
+			Eventually(eventChan).Should(Receive(&receivedData))
+			Expect(receivedData.reason).Should(Equal(probeName))
+			Expect(receivedData.preserveEventTimeOnUpdate).Should(BeFalse())
+
+			Eventually(eventChan, 3*time.Second).Should(Receive(&receivedData))
+			Expect(receivedData.reason).Should(Equal(probeName))
+			Expect(receivedData.preserveEventTimeOnUpdate).Should(BeTrue())
+		})
+
+		It("refreshes event time when periodically retrying an unsent roleProbe observation", func() {
+			probesWithReport := append([]proto.Probe(nil), probes...)
+			probesWithReport[0].ReportPeriodSeconds = 1
+
+			service, err := newProbeService(logr.New(nil), actionSvc, probesWithReport)
+			Expect(err).Should(BeNil())
+			Expect(service).ShouldNot(BeNil())
+
+			var count int
+			eventChan := make(chan bool, 128)
+			service.sendEventWithMessage = func(_ *logr.Logger, _ string, _ string, _ bool, preserveEventTimeOnUpdate bool) error {
+				count++
+				eventChan <- preserveEventTimeOnUpdate
+				if count == 1 {
+					return fmt.Errorf("API server error")
+				}
+				return nil
+			}
+
+			Expect(service.Start()).Should(Succeed())
+
+			var preserve bool
+			Eventually(eventChan).Should(Receive(&preserve))
+			Expect(preserve).Should(BeFalse())
+			Eventually(eventChan, 3*time.Second).Should(Receive(&preserve))
+			Expect(preserve).Should(BeFalse())
+		})
+
+		It("refreshes event time when periodically re-reporting non-roleProbe output", func() {
+			availableProbeName := "availableProbe"
+			availableActions := []proto.Action{
+				{
+					Name: availableProbeName,
+					Exec: &proto.ExecAction{
+						Commands: []string{"/bin/bash", "-c", "echo -n ok"},
+					},
+				},
+			}
+			availableProbes := []proto.Probe{
+				{
+					Action:              availableProbeName,
+					PeriodSeconds:       1,
+					SuccessThreshold:    1,
+					FailureThreshold:    1,
+					ReportPeriodSeconds: 1,
+				},
+			}
+
+			availableActionSvc, err := newActionService(logr.New(nil), availableActions)
+			Expect(err).Should(BeNil())
+			service, err := newProbeService(logr.New(nil), availableActionSvc, availableProbes)
+			Expect(err).Should(BeNil())
+			Expect(service).ShouldNot(BeNil())
+
+			eventChan := make(chan bool, 128)
+			service.sendEventWithMessage = func(_ *logr.Logger, _ string, _ string, _ bool, preserveEventTimeOnUpdate bool) error {
+				eventChan <- preserveEventTimeOnUpdate
+				return nil
+			}
+
+			Expect(service.Start()).Should(Succeed())
+
+			var preserve bool
+			Eventually(eventChan).Should(Receive(&preserve))
+			Expect(preserve).Should(BeFalse())
+			Eventually(eventChan, 3*time.Second).Should(Receive(&preserve))
+			Expect(preserve).Should(BeFalse())
 		})
 
 		It("matches file-change events by configured path type", func() {
@@ -227,7 +345,7 @@ var _ = Describe("probe", func() {
 			var (
 				count = 0
 			)
-			service.sendEventWithMessage = func(_ *logr.Logger, reason string, message string, _ bool) error {
+			service.sendEventWithMessage = func(_ *logr.Logger, reason string, message string, _ bool, _ bool) error {
 				count += 1
 				return fmt.Errorf("API server error")
 			}
@@ -255,7 +373,7 @@ var _ = Describe("probe", func() {
 					message string
 				}, 128)
 			)
-			service.sendEventWithMessage = func(_ *logr.Logger, reason string, message string, _ bool) error {
+			service.sendEventWithMessage = func(_ *logr.Logger, reason string, message string, _ bool, _ bool) error {
 				count += 1
 				if count <= 2 {
 					return fmt.Errorf("API server error")

--- a/pkg/kbagent/util/event.go
+++ b/pkg/kbagent/util/event.go
@@ -46,8 +46,15 @@ const (
 )
 
 func SendEventWithMessage(logger *logr.Logger, reason string, message string, sync bool) error {
+	return SendEventWithMessageWithEventTimeOption(logger, reason, message, sync, false)
+}
+
+// SendEventWithMessageWithEventTimeOption sends a Kubernetes Event and can keep
+// an existing Event's EventTime when the caller is retrying delivery without a
+// new observation.
+func SendEventWithMessageWithEventTimeOption(logger *logr.Logger, reason string, message string, sync bool, preserveEventTimeOnUpdate bool) error {
 	send := func(retryInterval time.Duration, retryAttempts int32) error {
-		err := createOrUpdateEvent(reason, message, retryInterval, retryAttempts)
+		err := createOrUpdateEvent(reason, message, retryInterval, retryAttempts, preserveEventTimeOnUpdate)
 		if err != nil && logger != nil {
 			logger.Error(err, "failed to send event", "reason", reason, "message", message)
 		}
@@ -93,7 +100,7 @@ func newEvent(reason string, message string) *corev1.Event {
 	}
 }
 
-func createOrUpdateEvent(reason, message string, retryInterval time.Duration, retryAttempts int32) error {
+func createOrUpdateEvent(reason, message string, retryInterval time.Duration, retryAttempts int32, preserveEventTimeOnUpdate bool) error {
 	clientSet, err := getK8sClientSet()
 	if err != nil {
 		return err
@@ -107,10 +114,12 @@ func createOrUpdateEvent(reason, message string, retryInterval time.Duration, re
 		event, err = eventsClient.Get(context.Background(), eventName, metav1.GetOptions{})
 		if err == nil {
 			event.Count++
-			// the granularity of lastTimestamp is second and it is not enough for the event.
-			// there may multiple events in the same second, so we need to use EventTime here.
-			// event.LastTimestamp = metav1.Now()
-			event.EventTime = metav1.NowMicro()
+			if !preserveEventTimeOnUpdate {
+				// the granularity of lastTimestamp is second and it is not enough for the event.
+				// there may multiple events in the same second, so we need to use EventTime here.
+				// event.LastTimestamp = metav1.Now()
+				event.EventTime = metav1.NowMicro()
+			}
 			_, err = eventsClient.Update(context.Background(), event, metav1.UpdateOptions{})
 		} else if k8serrors.IsNotFound(err) {
 			event = newEvent(reason, message)

--- a/pkg/kbagent/util/event_test.go
+++ b/pkg/kbagent/util/event_test.go
@@ -63,7 +63,7 @@ func TestSendEventWithMessageSyncConfigError(t *testing.T) {
 	if err := SendEventWithMessage(&logger, "Ready", "ok", true); err == nil {
 		t.Fatalf("expected kube config error")
 	}
-	if err := createOrUpdateEvent("Ready", "ok", 0, 0); err == nil {
+	if err := createOrUpdateEvent("Ready", "ok", 0, 0, false); err == nil {
 		t.Fatalf("expected create event kube config error")
 	}
 	if clientSet, err := getK8sClientSet(); clientSet != nil || err == nil {


### PR DESCRIPTION
Fixes #10384

## Summary
- Keep delivered same-output roleProbe re-reports from refreshing EventTime.
- Cover both report-ticker repeats and Pod metadata file-change repeats.
- Continue refreshing EventTime for real new observations: first successful delivery, changed probe output, or a message that has not yet been delivered.
- Keep non-roleProbe reports refreshing EventTime.
- Rebased on current main after #10401 so this fix layers on the metadata-only update patch.

## Root cause scope
- SQL Server roleProbe reports unversioned output such as `primary` / `secondary`.
- For unversioned roleProbe output, the workload controller uses Kubernetes EventTime as the ordering key and records it in `last-role-snapshot-version`.
- When kbagent repeats an already delivered identical roleProbe message but refreshes EventTime, the controller treats the same observation as newer and writes Pod metadata again.
- In the SQL Server C01 window this repeated Pod metadata write raced with configHash metadata updates and produced stale-object update conflicts.
- SQL Server addon config uses a short roleProbe period; KubeBlocks clamps repeat-reporting to at least 15s, so repeated Event updates can be much more frequent than the default 60s path.

## Tests
- `go test ./pkg/kbagent/... -count=1`
- `go test ./controllers/workloads -run 'TestAcceptRoleProbeEvent' -count=1`
- `go test ./pkg/kbagent/service -run TestAPIs -ginkgo.focus 'send event when report-on-file-change trigger fires with unchanged output' -count=1 -v`
- `git diff --check HEAD~1..HEAD`

## Boundary
- PR remains draft until patched tools image is built/sideloaded and SQL Server C01 fresh validation runs.
- Current focused C01 evidence should confirm the live SQL Server roleProbe period, Event Count/EventTime behavior, and controller `staleRoleEventVersion` handling.
- Full `go test ./controllers/workloads -count=1` is still outside this local validation scope; the focused role-event gate covered the touched controller behavior.
