### PR TITLE
fix: preserve ComponentDefinition template refs in conversion

### DIFF
--- a/apis/apps/v1alpha1/componentdefinition_conversion.go
+++ b/apis/apps/v1alpha1/componentdefinition_conversion.go
@@ -65,6 +65,7 @@ func (r *ComponentDefinition) ConvertFrom(srcRaw conversion.Hub) error {
 	if err := incrementConvertFrom(r, src, &componentDefinitionConverter{}); err != nil {
 		return err
 	}
+	r.fromV1Templates(src)
 
 	// status
 	if err := copier.Copy(&r.Status, &src.Status); err != nil {
@@ -138,6 +139,19 @@ func (r *ComponentDefinition) incrementConvertFrom(srcRaw metav1.Object, ic incr
 	r.Spec.SystemAccounts = c.SystemAccounts
 	// changed
 	return r.changesFromComponentDefinition(srcRaw.(*appsv1.ComponentDefinition))
+}
+
+func (r *ComponentDefinition) fromV1Templates(cmpd *appsv1.ComponentDefinition) {
+	for i := range r.Spec.Scripts {
+		if i < len(cmpd.Spec.Scripts) {
+			r.Spec.Scripts[i].TemplateRef = cmpd.Spec.Scripts[i].Template
+		}
+	}
+	for i := range r.Spec.Configs {
+		if i < len(cmpd.Spec.Configs) {
+			r.Spec.Configs[i].TemplateRef = cmpd.Spec.Configs[i].Template
+		}
+	}
 }
 
 func (r *ComponentDefinition) changesToComponentDefinition(cmpd *appsv1.ComponentDefinition) error {

--- a/apis/apps/v1alpha1/componentdefinition_conversion_test.go
+++ b/apis/apps/v1alpha1/componentdefinition_conversion_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+)
+
+func TestComponentDefinitionConvertFromPreservesTemplates(t *testing.T) {
+	src := &appsv1.ComponentDefinition{
+		Spec: appsv1.ComponentDefinitionSpec{
+			Configs: []appsv1.ComponentFileTemplate{
+				{
+					Name:     "postgresql-configuration",
+					Template: "postgresql12-configuration-1.2.0-alpha.0",
+				},
+			},
+			Scripts: []appsv1.ComponentFileTemplate{
+				{
+					Name:     "postgresql-scripts",
+					Template: "postgresql-scripts-1.2.0-alpha.0",
+				},
+			},
+		},
+	}
+
+	var dst ComponentDefinition
+	if err := dst.ConvertFrom(src); err != nil {
+		t.Fatalf("ConvertFrom() error = %v", err)
+	}
+
+	if got, want := dst.Spec.Configs[0].TemplateRef, src.Spec.Configs[0].Template; got != want {
+		t.Fatalf("configs[0].TemplateRef = %q, want %q", got, want)
+	}
+	if got, want := dst.Spec.Scripts[0].TemplateRef, src.Spec.Scripts[0].Template; got != want {
+		t.Fatalf("scripts[0].TemplateRef = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Supersedes #10406, which was closed by the branch rename needed to satisfy PR branch policy.

## Problem

PostgreSQL KB1.1 release-final R1 hit a controller-side blocker tracked in #10405: an `apps.kubeblocks.io/v1` ComponentDefinition accepts `spec.configs[].template` / `spec.scripts[].template`, but the v1alpha1 storage shape uses `templateRef`. During v1 -> v1alpha1 storage conversion, `copier.Copy()` does not map `Template` to `TemplateRef`, so the stored object loses the config/script template reference and the controller later reports `config/script template has no template specified`.

## Fix

Add the missing v1 -> v1alpha1 mapping in ComponentDefinition `ConvertFrom`:

- `spec.configs[].template` -> `spec.configs[].templateRef`
- `spec.scripts[].template` -> `spec.scripts[].templateRef`

The mapping runs after the optional increment-converter restore so direct v1 create/storage conversion and annotated round-trips both retain the hub template values.

## Test

Added `TestComponentDefinitionConvertFromPreservesTemplates` covering configs and scripts.

Local validation on this machine:

- `git diff --check` passed
- `go` / `gofmt` are not installed on this host, so Go test execution is left to CI

## Validation boundary

This PR is a controller conversion fix only. It does not make the PostgreSQL addon release-ready by itself. PostgreSQL KB1.1 still needs a matched/patched controller build identity, CRD/storage readback, and focused PG12+PG18 create gate before a fresh release-final restart.

Closes #10405
