### PR TITLE
fix(component): handle externalManaged file templates with empty Template

### DIFF
--- a/controllers/apps/component/transformer_component_template.go
+++ b/controllers/apps/component/transformer_component_template.go
@@ -92,8 +92,9 @@ func (t *componentFileTemplateTransformer) Transform(ctx graph.TransformContext,
 func (t *componentFileTemplateTransformer) instanceAssistantObject(transCtx *componentTransformContext,
 	tpl component.SynthesizedFileTemplate, protoObjs map[string]*corev1.ConfigMap) client.Object {
 	if isExternalManaged(tpl) {
-		if len(tpl.Template) == 0 {
-			return nil
+		name := tpl.Template
+		if len(name) == 0 {
+			name = fileTemplateObjectName(transCtx.SynthesizeComponent, tpl.Name)
 		}
 		namespace := tpl.Namespace
 		if len(namespace) == 0 {
@@ -102,7 +103,7 @@ func (t *componentFileTemplateTransformer) instanceAssistantObject(transCtx *com
 		return &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
-				Name:      tpl.Template,
+				Name:      name,
 			},
 		}
 	}
@@ -112,6 +113,9 @@ func (t *componentFileTemplateTransformer) instanceAssistantObject(transCtx *com
 
 func (t *componentFileTemplateTransformer) precheck(transCtx *componentTransformContext) error {
 	for _, tpl := range transCtx.SynthesizeComponent.FileTemplates {
+		if isExternalManaged(tpl) {
+			continue
+		}
 		if len(tpl.Template) == 0 {
 			return fmt.Errorf("config/script template has no template specified: %s", tpl.Name)
 		}
@@ -148,7 +152,7 @@ func (t *componentFileTemplateTransformer) buildPodVolumes(transCtx *componentTr
 	for _, tpl := range synthesizedComp.FileTemplates {
 		objName := fileTemplateObjectName(transCtx.SynthesizeComponent, tpl.Name)
 		// If the file template is managed by external, the volume mount object should be the external object.
-		if isExternalManaged(tpl) {
+		if isExternalManaged(tpl) && len(tpl.Template) > 0 {
 			objName = tpl.Template
 		}
 		createFn := func(_ string) corev1.Volume {

--- a/controllers/apps/component/transformer_component_template_test.go
+++ b/controllers/apps/component/transformer_component_template_test.go
@@ -362,8 +362,24 @@ var _ = Describe("file templates transformer test", func() {
 
 			transformer := &componentFileTemplateTransformer{}
 			err := transformer.Transform(transCtx, dag)
-			Expect(err).ShouldNot(BeNil())
-			Expect(err.Error()).Should(ContainSubstring("config/script template has no template specified"))
+			Expect(err).Should(BeNil())
+
+			computedName := fileTemplateObjectName(transCtx.SynthesizeComponent, "serverConf")
+			checkAssistantObject("ConfigMap", transCtx.SynthesizeComponent.Namespace, computedName)
+
+			podSpec := transCtx.SynthesizeComponent.PodSpec
+			expectedVol := corev1.Volume{
+				Name: "serverConf",
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: computedName,
+						},
+						DefaultMode: ptr.To[int32](0444),
+					},
+				},
+			}
+			Expect(podSpec.Volumes).Should(ContainElement(expectedVol))
 		})
 	})
 })


### PR DESCRIPTION
## Summary
- Skip `externalManaged` entries in `precheck()` — they legitimately have empty `Template` after `synthesizeFileTemplate` merge clears it when no user ConfigMap override is provided
- Fall back to computed CM name (`fileTemplateObjectName`) in `instanceAssistantObject` and `buildPodVolumes` when `Template` is empty for externalManaged configs — the computed name matches `GetComponentCfgName` used by the Parameter controller
- Update test "external managed - w/o template" to expect success and verify both assistant object and Pod volume reference the computed CM name

## Context
When `externalManaged: true` is set on a ComponentDefinition config entry (to delegate parameter lifecycle to the Parameter controller) and no user-level ConfigMap override exists in the Cluster CR, `synthesizeFileTemplate` intentionally clears the `Template` field. However, three downstream functions did not handle this case:
1. `precheck` rejected it as invalid
2. `instanceAssistantObject` returned nil (no workload CM dependency)
3. `buildPodVolumes` used the empty string as the volume CM name

This caused `Cluster` to get stuck in `Creating`/`Failed` with error `config/script template has no template specified`.

## Test plan
- [ ] Unit test "external managed - w/o template" updated: verifies `Transform` succeeds, assistant object uses computed CM name, Pod volume `ConfigMap.Name` matches computed name with correct `DefaultMode`
- [ ] Validated on live ClickHouse addon cluster with `externalManaged: true` — cluster transitions from `Failed` to `Running`

🤖 Generated with [Claude Code](https://claude.com/claude-code)