### PR TITLE
fix(parameters): handle uint64 overflow in parameter assignment validation

### DIFF
--- a/pkg/common/openapiv3schema.go
+++ b/pkg/common/openapiv3schema.go
@@ -68,7 +68,11 @@ func ConvertStringToInterfaceBySchemaType(openAPIV3Schema *apiextensionsv1.JSONS
 		}
 		switch p.Type {
 		case "integer":
-			out[k], err = strconv.ParseInt(v, 10, 64)
+			if isUnsignedIntegerFormat(p.Format) {
+				out[k], err = strconv.ParseUint(v, 10, 64)
+			} else {
+				out[k], err = strconv.ParseInt(v, 10, 64)
+			}
 		case "number":
 			out[k], err = strconv.ParseFloat(v, 64)
 		case "boolean":
@@ -84,4 +88,12 @@ func ConvertStringToInterfaceBySchemaType(openAPIV3Schema *apiextensionsv1.JSONS
 		}
 	}
 	return out, nil
+}
+
+func isUnsignedIntegerFormat(format string) bool {
+	switch format {
+	case "uint", "uint8", "uint16", "uint32", "uint64":
+		return true
+	}
+	return false
 }

--- a/pkg/common/openapiv3schema_test.go
+++ b/pkg/common/openapiv3schema_test.go
@@ -87,6 +87,40 @@ func TestConvertStringToInterfaceBySchemaType(t *testing.T) {
 	}
 }
 
+func TestConvertStringToInterfaceBySchemaTypeUint64(t *testing.T) {
+	schema := &apiextensionsv1.JSONSchemaProps{
+		Properties: map[string]apiextensionsv1.JSONSchemaProps{
+			"max_queries": {Type: "integer", Format: "uint64"},
+		},
+	}
+
+	got, err := ConvertStringToInterfaceBySchemaType(schema, map[string]string{"max_queries": "50"})
+	if err != nil {
+		t.Fatalf("expected uint64 parse to succeed, got %v", err)
+	}
+	if got["max_queries"] != uint64(50) {
+		t.Fatalf("expected uint64(50), got %T(%v)", got["max_queries"], got["max_queries"])
+	}
+
+	_, err = ConvertStringToInterfaceBySchemaType(schema, map[string]string{"max_queries": "-1"})
+	if err == nil {
+		t.Fatalf("expected parse error for negative value with uint64 format")
+	}
+}
+
+func TestValidateDataWithSchemaUint64(t *testing.T) {
+	schema := &apiextensionsv1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]apiextensionsv1.JSONSchemaProps{
+			"max_queries": {Type: "integer", Format: "uint64", Minimum: ptrFloat64(0)},
+		},
+	}
+
+	if err := ValidateDataWithSchema(schema, map[string]interface{}{"max_queries": uint64(50)}); err != nil {
+		t.Fatalf("expected uint64(50) to pass validation, got %v", err)
+	}
+}
+
 func ptrFloat64(v float64) *float64 {
 	return &v
 }

--- a/pkg/parameters/openapi/utils_test.go
+++ b/pkg/parameters/openapi/utils_test.go
@@ -21,6 +21,7 @@ package openapi
 
 import (
 	"encoding/json"
+	"math"
 	"testing"
 
 	"cuelang.org/go/cue"
@@ -92,6 +93,37 @@ func TestGetFieldByLabel(t *testing.T) {
 				assert.NotNil(t, got)
 			}
 		})
+	}
+}
+
+func TestGenerateOpenAPISchemaUint64(t *testing.T) {
+	cueString := `
+#T: {
+	clickhouse: {
+		u: uint64 | *0
+	}
+}
+`
+	schema, err := GenerateOpenAPISchema(cueString, "T")
+	assert.Nil(t, err)
+	assert.NotNil(t, schema)
+
+	specSchema, ok := schema.Properties[DefaultSchemaName]
+	assert.True(t, ok)
+	chProps, ok := specSchema.Properties["clickhouse"]
+	assert.True(t, ok)
+	uProp, ok := chProps.Properties["u"]
+	assert.True(t, ok)
+	assert.Equal(t, "integer", uProp.Type)
+
+	if uProp.Minimum != nil {
+		assert.True(t, *uProp.Minimum >= 0, "minimum should be non-negative for uint64")
+	}
+	if uProp.Maximum != nil {
+		assert.True(t, *uProp.Maximum > float64(math.MaxInt64),
+			"maximum should exceed MaxInt64 (generated from CUE uint64 bounds)")
+		assert.True(t, *uProp.Maximum > 0,
+			"maximum must be positive (not corrupted by overflow)")
 	}
 }
 

--- a/pkg/parameters/parameter_assignment.go
+++ b/pkg/parameters/parameter_assignment.go
@@ -21,6 +21,7 @@ package parameters
 
 import (
 	"fmt"
+	"math"
 
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
@@ -44,10 +45,11 @@ func ValidateComponentParameterAssignments(assignments parametersv1alpha1.Compon
 		if value == nil {
 			continue
 		}
+		validationSchema := capUint64Maximum(paramSchema)
 		schema := &apiext.JSONSchemaProps{
 			Type: "object",
 			Properties: map[string]apiext.JSONSchemaProps{
-				key: paramSchema,
+				key: validationSchema,
 			},
 		}
 		typedValue, err := common.ConvertStringToInterfaceBySchemaType(schema, map[string]string{key: *value})
@@ -68,6 +70,19 @@ func hasParameterSchema(paramsDefs []*parametersv1alpha1.ParametersDefinition) b
 		}
 	}
 	return false
+}
+
+// capUint64Maximum returns a copy of the schema with Maximum capped to MaxInt64
+// when it exceeds int64 range. The kube-openapi validator converts float64 Maximum
+// to int64 internally; values like CUE uint64's 2^64-1 overflow to MinInt64,
+// causing all positive values to fail validation. Capping preserves validation
+// for the int64 value range that ConvertStringToInterfaceBySchemaType can produce.
+func capUint64Maximum(schema apiext.JSONSchemaProps) apiext.JSONSchemaProps {
+	if schema.Type == "integer" && schema.Maximum != nil && *schema.Maximum > float64(math.MaxInt64) {
+		maxInt64 := float64(math.MaxInt64)
+		schema.Maximum = &maxInt64
+	}
+	return schema
 }
 
 func findParameterSchema(paramsDefs []*parametersv1alpha1.ParametersDefinition, key string) (apiext.JSONSchemaProps, bool) {

--- a/pkg/parameters/parameter_assignment.go
+++ b/pkg/parameters/parameter_assignment.go
@@ -72,15 +72,15 @@ func hasParameterSchema(paramsDefs []*parametersv1alpha1.ParametersDefinition) b
 	return false
 }
 
-// capUint64Maximum returns a copy of the schema with Maximum capped to MaxInt64
-// when it exceeds int64 range. The kube-openapi validator converts float64 Maximum
-// to int64 internally; values like CUE uint64's 2^64-1 overflow to MinInt64,
-// causing all positive values to fail validation. Capping preserves validation
-// for the int64 value range that ConvertStringToInterfaceBySchemaType can produce.
+// capUint64Maximum returns a copy of the schema with Maximum capped to the largest
+// float64 that fits in int64. The kube-openapi validator converts float64 Maximum
+// to int64 internally; float64(math.MaxInt64) rounds up to 2^63 which still
+// overflows to MinInt64. math.Nextafter(2^63, 0) gives 2^63-1024, the largest
+// float64 that survives int64 truncation.
 func capUint64Maximum(schema apiext.JSONSchemaProps) apiext.JSONSchemaProps {
-	if schema.Type == "integer" && schema.Maximum != nil && *schema.Maximum > float64(math.MaxInt64) {
-		maxInt64 := float64(math.MaxInt64)
-		schema.Maximum = &maxInt64
+	if schema.Type == "integer" && schema.Maximum != nil && *schema.Maximum >= math.Exp2(63) {
+		safeMax := math.Nextafter(math.Exp2(63), 0)
+		schema.Maximum = &safeMax
 	}
 	return schema
 }

--- a/pkg/parameters/parameter_assignment_test.go
+++ b/pkg/parameters/parameter_assignment_test.go
@@ -20,6 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package parameters
 
 import (
+	"fmt"
+	"math"
 	"testing"
 
 	"k8s.io/utils/pointer"
@@ -97,6 +99,57 @@ parameter: {
 			name: "reject deletion for unknown parameter",
 			assignments: parametersv1alpha1.ComponentParameters{
 				"not-a-real-parameter": nil,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateComponentParameterAssignments(tt.assignments, []*parametersv1alpha1.ParametersDefinition{paramsDef})
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected validation error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no validation error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateComponentParameterAssignmentsUint64(t *testing.T) {
+	paramsDef := testparameters.NewParametersDefinitionFactory("clickhouse-params").
+		SetTemplateName("clickhouse-config").
+		SetConfigFile("config.xml").
+		SetFileFormatConfig(parametersv1alpha1.FileFormatConfig{Format: parametersv1alpha1.XML}).
+		Schema(`
+parameter: {
+  max_concurrent_queries?: uint64 | *0
+}`).
+		GetObject()
+
+	tests := []struct {
+		name        string
+		assignments parametersv1alpha1.ComponentParameters
+		wantErr     bool
+	}{
+		{
+			name: "valid uint64 value",
+			assignments: parametersv1alpha1.ComponentParameters{
+				"max_concurrent_queries": pointer.String("50"),
+			},
+		},
+		{
+			name: "reject negative value for uint64",
+			assignments: parametersv1alpha1.ComponentParameters{
+				"max_concurrent_queries": pointer.String("-1"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "reject value exceeding int64 range",
+			assignments: parametersv1alpha1.ComponentParameters{
+				"max_concurrent_queries": pointer.String(fmt.Sprintf("%d", uint64(math.MaxInt64)+1)),
 			},
 			wantErr: true,
 		},

--- a/pkg/parameters/value_transformer.go
+++ b/pkg/parameters/value_transformer.go
@@ -43,6 +43,9 @@ func (d *defaultValueTransformer) resolveValueWithType(value string, fieldName s
 	default:
 		return value, nil
 	case "integer":
+		if isUnsignedIntegerFormat(schema.Format) {
+			return strconv.ParseUint(value, 10, 64)
+		}
 		return strconv.ParseInt(value, 10, 64)
 	case "number":
 		return strconv.ParseFloat(value, 64)
@@ -82,6 +85,14 @@ func (v *valueManager) BuildValueTransformer(key string) core.ValueTransformerFu
 		openapi.FlattenSchema(schema.Properties[openapi.DefaultSchemaName]),
 	}
 	return defaultTransformer.resolveValueWithType
+}
+
+func isUnsignedIntegerFormat(format string) bool {
+	switch format {
+	case "uint", "uint8", "uint16", "uint32", "uint64":
+		return true
+	}
+	return false
 }
 
 func NewValueManager(paramsDefs []*parametersv1alpha1.ParametersDefinition, configs []parametersv1alpha1.ComponentConfigDescription) *valueManager {


### PR DESCRIPTION
Closes #10413

## Summary

- CUE `uint64` bounds generate correct `maximum: ~2^64` in PD SchemaInJSON
- kube-openapi validator internally converts `float64` Maximum to `int64`, overflowing `2^64` to `MinInt64` (`-9223372036854775808`)
- All positive values for any `uint64` CUE parameter are rejected (e.g. `max_concurrent_queries=50` fails with "should be less than or equal to -9223372036854775808")
- Any addon using `uint64` in CUE schemas is affected (ClickHouse has 100+ such fields)

## Changes

1. **`capUint64Maximum`** (`pkg/parameters/parameter_assignment.go`): Caps Maximum to `MaxInt64` in the validation-time schema copy when it exceeds int64 range. Does NOT modify the live PD schema.
2. **`ConvertStringToInterfaceBySchemaType`** (`pkg/common/openapiv3schema.go`): Uses `ParseUint` instead of `ParseInt` when schema format is `uint*`
3. **Value transformer** (`pkg/parameters/value_transformer.go`): Same `ParseUint` fix for JSON/YAML/TOML config value parsing

## Test plan

- [x] Unit test: `TestGenerateOpenAPISchemaUint64` — CUE uint64 → OpenAPI Maximum > MaxInt64 and positive
- [x] Unit test: `TestConvertStringToInterfaceBySchemaTypeUint64` — uint64 parse and negative rejection
- [x] Unit test: `TestValidateDataWithSchemaUint64` — schema validation with uint64 value
- [x] Unit test: `TestValidateComponentParameterAssignmentsUint64` — end-to-end: "50" passes, "-1" fails, MaxInt64+1 fails
- [ ] Integration: ClickHouse reconfigure `max_concurrent_queries=50` with patched image

🤖 Generated with [Claude Code](https://claude.com/claude-code)