### PR TITLE
fix(operations): pre-validate reconfigure parameters before patching CP desired

### DIFF
--- a/pkg/operations/reconfigure.go
+++ b/pkg/operations/reconfigure.go
@@ -33,6 +33,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/sharding"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	pkgparameters "github.com/apecloud/kubeblocks/pkg/parameters"
 	parameterscore "github.com/apecloud/kubeblocks/pkg/parameters/core"
 )
 
@@ -90,6 +91,9 @@ func (r *reconfigureAction) Action(reqCtx intctrlutil.RequestCtx, cli client.Cli
 	for _, reconfigure := range resource.OpsRequest.Spec.Reconfigures {
 		if len(reconfigure.Parameters) == 0 {
 			return intctrlutil.NewErrorf(intctrlutil.ErrorTypeFatal, "invalid reconfigure request for component %s: no parameters", reconfigure.ComponentName)
+		}
+		if err := r.validateReconfigureParameters(reqCtx, cli, resource.Cluster, reconfigure); err != nil {
+			return err
 		}
 		compNames, err := r.resolveReconfigureComponents(reqCtx.Ctx, cli, resource.Cluster, reconfigure.ComponentName)
 		if err != nil {
@@ -192,4 +196,38 @@ func (r *reconfigureAction) getRunningComponentParameter(ctx context.Context, cl
 		return nil, err
 	}
 	return compParam, nil
+}
+
+func (r *reconfigureAction) validateReconfigureParameters(reqCtx intctrlutil.RequestCtx, cli client.Client,
+	cluster *appsv1.Cluster, reconfigure opsv1alpha1.Reconfigure) error {
+	compDefName := r.resolveCompDefName(cluster, reconfigure.ComponentName)
+	if compDefName == "" {
+		return nil
+	}
+	cmpd := &appsv1.ComponentDefinition{}
+	if err := cli.Get(reqCtx.Ctx, client.ObjectKey{Name: compDefName}, cmpd); err != nil {
+		return err
+	}
+	_, paramsDefs, err := pkgparameters.ResolveCmpdParametersDefs(reqCtx.Ctx, cli, cmpd)
+	if err != nil {
+		return err
+	}
+	assignments := make(parametersv1alpha1.ComponentParameters, len(reconfigure.Parameters))
+	for _, param := range reconfigure.Parameters {
+		assignments[param.Key] = param.Value
+	}
+	if err := pkgparameters.ValidateComponentParameterAssignments(assignments, paramsDefs); err != nil {
+		return intctrlutil.NewFatalError(err.Error())
+	}
+	return nil
+}
+
+func (r *reconfigureAction) resolveCompDefName(cluster *appsv1.Cluster, compName string) string {
+	if compSpec := cluster.Spec.GetComponentByName(compName); compSpec != nil {
+		return compSpec.ComponentDef
+	}
+	if sharding := cluster.Spec.GetShardingByName(compName); sharding != nil {
+		return sharding.Template.ComponentDef
+	}
+	return ""
 }

--- a/pkg/operations/reconfigure_test.go
+++ b/pkg/operations/reconfigure_test.go
@@ -202,6 +202,140 @@ parameter: {
 			Expect(err).Should(BeNil())
 		})
 
+		It("rejects unknown parameter before patching CP desired", func() {
+			By("init operations resources ")
+			reqCtx := intctrlutil.RequestCtx{Ctx: ctx}
+			opsRes, _, _ := initOperationsResources(compDefName, clusterName)
+			testapps.MockInstanceSetComponent(&testCtx, clusterName, defaultCompName)
+
+			By("prepare configuration metadata and component parameter")
+			template := testparameters.NewComponentTemplateFactory("mysql-config", testCtx.DefaultNamespace).
+				Create(&testCtx).
+				GetObject()
+			paramsDef := testparameters.NewParametersDefinitionFactory("mysql-params-" + randomStr).
+				SetComponentDefinition(compDefName).
+				SetTemplateName("mysql-config").
+				Schema(`
+parameter: {
+  max_connections?: string
+  gtid_mode?: string
+}`).
+				Create(&testCtx).
+				GetObject()
+			Expect(testapps.ChangeObjStatus(&testCtx, paramsDef, func() {
+				paramsDef.Status.Phase = parametersv1alpha1.PDAvailablePhase
+			})).Should(Succeed())
+			Expect(testapps.GetAndChangeObj(&testCtx, client.ObjectKey{Name: compDefName}, func(compDef *appsv1.ComponentDefinition) {
+				compDef.Spec.ServiceVersion = "8.0.30"
+				compDef.Spec.Configs = []appsv1.ComponentFileTemplate{
+					{
+						Name:            "mysql-config",
+						Template:        template.Name,
+						Namespace:       template.Namespace,
+						VolumeName:      "mysql-config",
+						ExternalManaged: pointer.Bool(true),
+					},
+				}
+			})()).Should(Succeed())
+
+			componentParameter := builder.NewComponentParameterBuilder(testCtx.DefaultNamespace, parameterscore.GenerateComponentConfigurationName(clusterName, defaultCompName)).
+				AddLabelsInMap(constant.GetCompLabelsWithDef(clusterName, defaultCompName, compDefName)).
+				SetClusterName(clusterName).
+				SetCompName(defaultCompName).
+				GetObject()
+			componentParameter.Spec.ConfigItemDetails = []parametersv1alpha1.ConfigTemplateItemDetail{{
+				Name: "mysql-config",
+				ConfigSpec: &appsv1.ComponentFileTemplate{
+					Name:            "mysql-config",
+					Template:        template.Name,
+					Namespace:       template.Namespace,
+					VolumeName:      "mysql-config",
+					ExternalManaged: pointer.Bool(true),
+				},
+			}}
+			Expect(testCtx.CreateObj(ctx, componentParameter)).Should(Succeed())
+
+			Expect(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKeyFromObject(componentParameter), func(cp *parametersv1alpha1.ComponentParameter) {
+				cp.Status.ObservedGeneration = cp.Generation
+				cp.Status.Phase = parametersv1alpha1.CFinishedPhase
+				cp.Status.ConfigurationItemStatus = []parametersv1alpha1.ConfigTemplateItemDetailStatus{{
+					Name:  cp.Spec.ConfigItemDetails[0].Name,
+					Phase: parametersv1alpha1.CFinishedPhase,
+				}}
+			})()).Should(Succeed())
+
+			By("create reconfigure with unknown parameter http_port")
+			ops := testops.NewOpsRequestObj("reject-unknown-"+randomStr, testCtx.DefaultNamespace,
+				clusterName, opsv1alpha1.ReconfiguringType)
+			ops.Spec.Reconfigures = []opsv1alpha1.Reconfigure{
+				{
+					ComponentOps: opsv1alpha1.ComponentOps{ComponentName: defaultCompName},
+					Parameters: []opsv1alpha1.ParameterPair{
+						{
+							Key:   "http_port",
+							Value: pointer.String("9999"),
+						},
+					},
+				},
+			}
+			opsRes.OpsRequest = testops.CreateOpsRequest(ctx, testCtx, ops)
+			Expect(opsutil.UpdateClusterOpsAnnotations(ctx, k8sClient, opsRes.Cluster, nil)).Should(Succeed())
+
+			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsPendingPhase
+			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsCreatingPhase))
+
+			By("Action should reject the unknown parameter with a fatal error")
+			_, err = GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest), func(g Gomega, fetched *opsv1alpha1.OpsRequest) {
+				g.Expect(fetched.Status.Phase).Should(Equal(opsv1alpha1.OpsFailedPhase))
+				condition := meta.FindStatusCondition(fetched.Status.Conditions, opsv1alpha1.ConditionTypeFailed)
+				g.Expect(condition).ShouldNot(BeNil())
+				g.Expect(condition.Message).Should(ContainSubstring("http_port"))
+			})).Should(Succeed())
+
+			By("CP desired must NOT contain http_port")
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(componentParameter), func(g Gomega, cp *parametersv1alpha1.ComponentParameter) {
+				if cp.Spec.Desired != nil && cp.Spec.Desired.Assignments != nil {
+					g.Expect(cp.Spec.Desired.Assignments).ShouldNot(HaveKey("http_port"))
+				}
+			})).Should(Succeed())
+
+			By("subsequent valid parameter should succeed")
+			validOps := testops.NewOpsRequestObj("valid-after-reject-"+randomStr, testCtx.DefaultNamespace,
+				clusterName, opsv1alpha1.ReconfiguringType)
+			validOps.Spec.Reconfigures = []opsv1alpha1.Reconfigure{
+				{
+					ComponentOps: opsv1alpha1.ComponentOps{ComponentName: defaultCompName},
+					Parameters: []opsv1alpha1.ParameterPair{
+						{
+							Key:   "max_connections",
+							Value: pointer.String("300"),
+						},
+					},
+				},
+			}
+			opsRes.OpsRequest = testops.CreateOpsRequest(ctx, testCtx, validOps)
+			Expect(opsutil.UpdateClusterOpsAnnotations(ctx, k8sClient, opsRes.Cluster, nil)).Should(Succeed())
+
+			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsPendingPhase
+			_, err = GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsCreatingPhase))
+
+			_, err = GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(componentParameter), func(g Gomega, cp *parametersv1alpha1.ComponentParameter) {
+				g.Expect(cp.Spec.Desired).ShouldNot(BeNil())
+				g.Expect(cp.Spec.Desired.Assignments).Should(HaveKeyWithValue("max_connections", pointer.String("300")))
+				g.Expect(cp.Spec.Desired.Assignments).ShouldNot(HaveKey("http_port"))
+			})).Should(Succeed())
+		})
+
 		It("propagates ComponentParameter merge failure", func() {
 			By("init operations resources ")
 			reqCtx := intctrlutil.RequestCtx{Ctx: ctx}


### PR DESCRIPTION
## Summary

- OpsRequest reconfigure controller writes parameters to `ComponentParameter.spec.desired.assignments` **before** any schema validation. If the OpsRequest is rejected (e.g. unknown parameter like `http_port`), the invalid assignments remain in CP desired and pollute all subsequent reconfigure operations — causing unrelated valid parameters (e.g. `max_connections`) to fail with `parameter not found in schema`.
- Add `validateReconfigureParameters()` in the `Action` path to validate parameters against `ParametersDefinition` schemas before writing to CP desired.
- Validation failure returns `FatalError` → OpsRequest transitions to `Failed` without modifying CP desired.
- Components without `ParametersDefinition` schemas keep legacy behavior (no pre-validation).
- Supports both regular components and sharding templates.

Fixes #10416

## Test plan

- [x] New envtest: unknown parameter (`http_port=9999`) → OpsRequest `Failed`, CP desired does NOT contain `http_port`
- [x] New envtest: subsequent valid parameter (`max_connections=300`) → OpsRequest succeeds, CP desired contains `max_connections`
- [x] Existing envtest: valid reconfigure flow unaffected
- [x] Existing envtest: CP controller merge failure still propagates correctly
- [ ] CI gate: lint, generate, manifests, test

## Related

- Root cause discovered via S12 reconfigure test failure in ClickHouse addon (#289)
- S11 `http_port=9999` OpsRequest Failed but left residue in CP `spec.desired.assignments`, blocking all subsequent reconfigures