### PR TITLE
chore(parameters): treat nil and empty ConfigItemDetails as equal

### DIFF
--- a/controllers/parameters/componentdrivenparameter_controller.go
+++ b/controllers/parameters/componentdrivenparameter_controller.go
@@ -142,6 +142,9 @@ func (r *ComponentDrivenParameterReconciler) delete(reqCtx intctrlutil.RequestCt
 
 func (r *ComponentDrivenParameterReconciler) update(reqCtx intctrlutil.RequestCtx, expected, existing *parametersv1alpha1.ComponentParameter) (ctrl.Result, error) {
 	mergedObject := r.mergeComponentParameter(expected, existing)
+	if len(mergedObject.Spec.ConfigItemDetails) == 0 && len(existing.Spec.ConfigItemDetails) == 0 {
+		mergedObject.Spec.ConfigItemDetails = existing.Spec.ConfigItemDetails
+	}
 	if reflect.DeepEqual(mergedObject, existing) {
 		return intctrlutil.Reconciled()
 	}


### PR DESCRIPTION
## Summary

Backport of #10417 to release-1.1.

- Normalize nil/empty `ConfigItemDetails` before full-object `DeepEqual` comparison to prevent infinite reconcile loop
- On release-1.1, the comparison is at the full-object level in `ComponentDrivenParameterReconciler.update`, adapted accordingly

Closes #10414

## Test plan

- [x] `go build ./controllers/parameters/...` clean
- [x] Original fix peer-reviewed by Rocco (GREEN / 0 blocker)