### PR TITLE
fix(dp): postReady-only redirect for multi-component logical backup restore

### DIFF
--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -468,28 +468,46 @@ func resolveSingleSourceTargetForPVC(target *dpv1alpha1.BackupStatusTarget, pvc 
 	return target, false, nil
 }
 
-// backupTargetComponentName extracts the component name from the backup's target
-// PodSelector labels. Used for postReady-only ActionSets where the PVC's component
-// differs from the backup target component (e.g., TiDB logical backup: backup target
-// is "tidb" but data PVCs are in "pd"/"tikv").
+// backupTargetComponentName resolves the backup target and extracts the component name
+// from its PodSelector labels. Resolves from the same source-target contract as
+// resolveSourceTargetFromBackup (Status.Target or Status.Targets[0]).
+// Returns fatal error if the target cannot be resolved to a component name.
 func (r *VolumePopulatorReconciler) backupTargetComponentName(reqCtx intctrlutil.RequestCtx,
-	pvc *corev1.PersistentVolumeClaim) (string, error) {
+	pvc *corev1.PersistentVolumeClaim) (string, *dpv1alpha1.BackupStatusTarget, error) {
 	backupNamespace, err := backupNamespaceFromPVC(pvc)
 	if err != nil {
-		return "", intctrlutil.NewFatalError(err.Error())
+		return "", nil, intctrlutil.NewFatalError(err.Error())
 	}
 	backup := &dpv1alpha1.Backup{}
 	if err = r.Client.Get(reqCtx.Ctx, types.NamespacedName{
 		Namespace: backupNamespace,
 		Name:      pvc.Spec.DataSourceRef.Name,
 	}, backup); err != nil {
-		return "", err
+		return "", nil, err
 	}
-	target := backup.Status.Target
-	if target == nil || target.PodSelector == nil || target.PodSelector.LabelSelector == nil {
-		return "", nil
+	var target *dpv1alpha1.BackupStatusTarget
+	if backup.Status.Target != nil {
+		target = backup.Status.Target
+	} else if len(backup.Status.Targets) == 1 {
+		target = &backup.Status.Targets[0]
 	}
-	return target.PodSelector.MatchLabels[constant.KBAppComponentLabelKey], nil
+	if target == nil {
+		return "", nil, intctrlutil.NewFatalError(fmt.Sprintf(
+			"postReady-only redirect: cannot resolve unique backup target for PVC %s/%s (target=%v, targets=%d)",
+			pvc.Namespace, pvc.Name, backup.Status.Target != nil, len(backup.Status.Targets)))
+	}
+	if target.PodSelector == nil || target.PodSelector.LabelSelector == nil {
+		return "", nil, intctrlutil.NewFatalError(fmt.Sprintf(
+			"postReady-only redirect: backup target %q has no PodSelector for PVC %s/%s",
+			target.Name, pvc.Namespace, pvc.Name))
+	}
+	compName := target.PodSelector.MatchLabels[constant.KBAppComponentLabelKey]
+	if compName == "" {
+		return "", nil, intctrlutil.NewFatalError(fmt.Sprintf(
+			"postReady-only redirect: backup target %q PodSelector has no %s label for PVC %s/%s",
+			target.Name, constant.KBAppComponentLabelKey, pvc.Namespace, pvc.Name))
+	}
+	return compName, target, nil
 }
 
 func (r *VolumePopulatorReconciler) resolveShardingSourceTarget(reqCtx intctrlutil.RequestCtx,
@@ -1179,14 +1197,14 @@ func (r *VolumePopulatorReconciler) ensurePostReadyRestoreCompleted(reqCtx intct
 	}
 	// For postReady-only with skipPostReady (non-matching PVC), resolve the backup target
 	// component and use it for the Restore CR context instead of the PVC's component.
+	var backupTarget *dpv1alpha1.BackupStatusTarget
 	if restoreCtx.skipPostReady {
-		targetCompName, err := r.backupTargetComponentName(reqCtx, pvc)
+		var targetCompName string
+		targetCompName, backupTarget, err = r.backupTargetComponentName(reqCtx, pvc)
 		if err != nil {
 			return false, err
 		}
-		if targetCompName != "" {
-			componentName = targetCompName
-		}
+		componentName = targetCompName
 	}
 	comp := &appsv1.Component{}
 	if err = r.Client.Get(reqCtx.Ctx, types.NamespacedName{
@@ -1217,7 +1235,7 @@ func (r *VolumePopulatorReconciler) ensurePostReadyRestoreCompleted(reqCtx intct
 			return false, nil
 		}
 	}
-	postReadyRestore, err := r.buildPostReadyRestore(reqCtx, pvc, restoreMgr, comp, componentName)
+	postReadyRestore, err := r.buildPostReadyRestore(reqCtx, pvc, restoreMgr, comp, componentName, backupTarget)
 	if err != nil {
 		return false, err
 	}
@@ -1263,7 +1281,8 @@ func (r *VolumePopulatorReconciler) buildPostReadyRestore(reqCtx intctrlutil.Req
 	pvc *corev1.PersistentVolumeClaim,
 	restoreMgr *dprestore.RestoreManager,
 	comp *appsv1.Component,
-	targetComponentName string) (*dpv1alpha1.Restore, error) {
+	targetComponentName string,
+	redirectTarget *dpv1alpha1.BackupStatusTarget) (*dpv1alpha1.Restore, error) {
 	clusterName := pvc.Labels[constant.AppInstanceLabelKey]
 	componentName := targetComponentName
 	if componentName == "" {
@@ -1347,16 +1366,8 @@ func (r *VolumePopulatorReconciler) buildPostReadyRestore(reqCtx intctrlutil.Req
 	}
 	if sourceTarget != nil {
 		restore.Spec.Backup.SourceTargetName = sourceTarget.Name
-	} else if targetComponentName != "" && targetComponentName != restoreComponentName(pvc) {
-		// postReady-only redirect: PVC doesn't match backup target, but we need the
-		// target name for the Restore CR. Read it from the backup status.
-		backup := &dpv1alpha1.Backup{}
-		if err = r.Client.Get(reqCtx.Ctx, types.NamespacedName{Namespace: backupNamespace, Name: pvc.Spec.DataSourceRef.Name}, backup); err != nil {
-			return nil, err
-		}
-		if backup.Status.Target != nil {
-			restore.Spec.Backup.SourceTargetName = backup.Status.Target.Name
-		}
+	} else if redirectTarget != nil {
+		restore.Spec.Backup.SourceTargetName = redirectTarget.Name
 	}
 	if err = controllerutil.SetOwnerReference(comp, restore, r.Scheme); err != nil {
 		return nil, err

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -1212,9 +1212,6 @@ func (r *VolumePopulatorReconciler) ensurePostReadyRestoreCompleted(reqCtx intct
 		Name:      constant.GenerateClusterComponentName(clusterName, componentName),
 	}, comp); err != nil {
 		if restoreCtx.skipPostReady && apierrors.IsNotFound(err) {
-			if err = r.updatePVCConditionsIfPopulateNotReleased(reqCtx, pvc, "Waiting for backup target component to be created"); err != nil {
-				return false, err
-			}
 			return false, nil
 		}
 		return false, err

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -1183,7 +1183,13 @@ func (r *VolumePopulatorReconciler) ensurePostReadyRestoreCompleted(reqCtx intct
 	if pvc.Annotations[constant.RestoreSourceKindAnnotationKey] == "" {
 		return true, nil
 	}
-	allBound, err := r.allRestorePVCsForComponentBound(reqCtx, pvc)
+	var allBound bool
+	var err error
+	if restoreCtx.skipPostReady {
+		allBound, err = r.allRestorePVCsForClusterBound(reqCtx, pvc)
+	} else {
+		allBound, err = r.allRestorePVCsForComponentBound(reqCtx, pvc)
+	}
 	if err != nil || !allBound {
 		if err == nil {
 			err = r.updatePVCConditionsIfPopulateNotReleased(reqCtx, pvc, "Waiting for all restore PVCs to finish prepareData")
@@ -1435,6 +1441,59 @@ func (r *VolumePopulatorReconciler) allRestorePVCsForComponentBound(reqCtx intct
 		}
 	}
 	return true, nil
+}
+
+func (r *VolumePopulatorReconciler) allRestorePVCsForClusterBound(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim) (bool, error) {
+	pvcs, err := r.listRestorePVCsForCluster(reqCtx, pvc)
+	if err != nil {
+		return false, err
+	}
+	for i := range pvcs {
+		item := &pvcs[i]
+		cond := findPVCConditionByType(item, appsv1.ConditionTypeRestore)
+		if cond != nil && cond.Status == corev1.ConditionFalse {
+			return false, intctrlutil.NewFatalError(fmt.Sprintf("restore PVC %s/%s failed: %s", item.Namespace, item.Name, cond.Message))
+		}
+		if item.Spec.VolumeName == "" {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (r *VolumePopulatorReconciler) listRestorePVCsForCluster(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim) ([]corev1.PersistentVolumeClaim, error) {
+	clusterName := pvc.Labels[constant.AppInstanceLabelKey]
+	if clusterName == "" || pvc.Spec.DataSourceRef == nil {
+		return []corev1.PersistentVolumeClaim{*pvc}, nil
+	}
+	pvcList := &corev1.PersistentVolumeClaimList{}
+	if err := r.Client.List(reqCtx.Ctx, pvcList, client.InNamespace(pvc.Namespace),
+		client.MatchingLabels(constant.GetClusterLabels(clusterName))); err != nil {
+		return nil, err
+	}
+	var result []corev1.PersistentVolumeClaim
+	sourceNamespace, err := r.authorizedBackupNamespaceFromPVC(reqCtx, pvc)
+	if err != nil {
+		return nil, intctrlutil.NewFatalError(err.Error())
+	}
+	for i := range pvcList.Items {
+		item := pvcList.Items[i]
+		if item.Spec.DataSourceRef == nil || item.Spec.DataSourceRef.Name != pvc.Spec.DataSourceRef.Name {
+			continue
+		}
+		if item.Annotations[constant.RestoreSourceKindAnnotationKey] == "" {
+			continue
+		}
+		itemSourceNamespace, err := r.authorizedBackupNamespaceFromPVC(reqCtx, &item)
+		if err != nil {
+			return nil, intctrlutil.NewFatalError(err.Error())
+		}
+		if itemSourceNamespace != sourceNamespace {
+			continue
+		}
+		result = append(result, item)
+	}
+	return result, nil
 }
 
 func findPVCConditionByType(pvc *corev1.PersistentVolumeClaim, conditionType string) *corev1.PersistentVolumeClaimCondition {

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -468,6 +468,30 @@ func resolveSingleSourceTargetForPVC(target *dpv1alpha1.BackupStatusTarget, pvc 
 	return target, false, nil
 }
 
+// backupTargetComponentName extracts the component name from the backup's target
+// PodSelector labels. Used for postReady-only ActionSets where the PVC's component
+// differs from the backup target component (e.g., TiDB logical backup: backup target
+// is "tidb" but data PVCs are in "pd"/"tikv").
+func (r *VolumePopulatorReconciler) backupTargetComponentName(reqCtx intctrlutil.RequestCtx,
+	pvc *corev1.PersistentVolumeClaim) (string, error) {
+	backupNamespace, err := backupNamespaceFromPVC(pvc)
+	if err != nil {
+		return "", intctrlutil.NewFatalError(err.Error())
+	}
+	backup := &dpv1alpha1.Backup{}
+	if err = r.Client.Get(reqCtx.Ctx, types.NamespacedName{
+		Namespace: backupNamespace,
+		Name:      pvc.Spec.DataSourceRef.Name,
+	}, backup); err != nil {
+		return "", err
+	}
+	target := backup.Status.Target
+	if target == nil || target.PodSelector == nil || target.PodSelector.LabelSelector == nil {
+		return "", nil
+	}
+	return target.PodSelector.MatchLabels[constant.KBAppComponentLabelKey], nil
+}
+
 func (r *VolumePopulatorReconciler) resolveShardingSourceTarget(reqCtx intctrlutil.RequestCtx,
 	pvc *corev1.PersistentVolumeClaim,
 	backup *dpv1alpha1.Backup) (*dpv1alpha1.BackupStatusTarget, bool, error) {
@@ -1131,7 +1155,12 @@ func (r *VolumePopulatorReconciler) ensurePostReadyRestoreCompleted(reqCtx intct
 		return true, nil
 	}
 	if restoreCtx.skipPostReady {
-		return true, nil
+		if len(restoreMgr.PrepareDataBackupSets) > 0 {
+			return true, nil
+		}
+		// postReady-only ActionSet with non-matching PVC: redirect to backup target component.
+		// This handles multi-component addons where the backup target (e.g., tidb) has no data
+		// PVC but the postReady restore must run exactly once in that component's context.
 	}
 	if pvc.Annotations[constant.RestoreSourceKindAnnotationKey] == "" {
 		return true, nil
@@ -1147,6 +1176,17 @@ func (r *VolumePopulatorReconciler) ensurePostReadyRestoreCompleted(reqCtx intct
 	componentName := restoreComponentName(pvc)
 	if clusterName == "" || componentName == "" {
 		return false, intctrlutil.NewFatalError(fmt.Sprintf("missing cluster/component labels for PVC %s/%s postReady restore", pvc.Namespace, pvc.Name))
+	}
+	// For postReady-only with skipPostReady (non-matching PVC), resolve the backup target
+	// component and use it for the Restore CR context instead of the PVC's component.
+	if restoreCtx.skipPostReady {
+		targetCompName, err := r.backupTargetComponentName(reqCtx, pvc)
+		if err != nil {
+			return false, err
+		}
+		if targetCompName != "" {
+			componentName = targetCompName
+		}
 	}
 	comp := &appsv1.Component{}
 	if err = r.Client.Get(reqCtx.Ctx, types.NamespacedName{
@@ -1177,7 +1217,7 @@ func (r *VolumePopulatorReconciler) ensurePostReadyRestoreCompleted(reqCtx intct
 			return false, nil
 		}
 	}
-	postReadyRestore, err := r.buildPostReadyRestore(reqCtx, pvc, restoreMgr, comp)
+	postReadyRestore, err := r.buildPostReadyRestore(reqCtx, pvc, restoreMgr, comp, componentName)
 	if err != nil {
 		return false, err
 	}
@@ -1222,9 +1262,13 @@ func (r *VolumePopulatorReconciler) updatePVCConditionsIfPopulateNotReleased(req
 func (r *VolumePopulatorReconciler) buildPostReadyRestore(reqCtx intctrlutil.RequestCtx,
 	pvc *corev1.PersistentVolumeClaim,
 	restoreMgr *dprestore.RestoreManager,
-	comp *appsv1.Component) (*dpv1alpha1.Restore, error) {
+	comp *appsv1.Component,
+	targetComponentName string) (*dpv1alpha1.Restore, error) {
 	clusterName := pvc.Labels[constant.AppInstanceLabelKey]
-	componentName := restoreComponentName(pvc)
+	componentName := targetComponentName
+	if componentName == "" {
+		componentName = restoreComponentName(pvc)
+	}
 	backupNamespace, err := backupNamespaceFromPVC(pvc)
 	if err != nil {
 		return nil, intctrlutil.NewFatalError(err.Error())
@@ -1303,6 +1347,16 @@ func (r *VolumePopulatorReconciler) buildPostReadyRestore(reqCtx intctrlutil.Req
 	}
 	if sourceTarget != nil {
 		restore.Spec.Backup.SourceTargetName = sourceTarget.Name
+	} else if targetComponentName != "" && targetComponentName != restoreComponentName(pvc) {
+		// postReady-only redirect: PVC doesn't match backup target, but we need the
+		// target name for the Restore CR. Read it from the backup status.
+		backup := &dpv1alpha1.Backup{}
+		if err = r.Client.Get(reqCtx.Ctx, types.NamespacedName{Namespace: backupNamespace, Name: pvc.Spec.DataSourceRef.Name}, backup); err != nil {
+			return nil, err
+		}
+		if backup.Status.Target != nil {
+			restore.Spec.Backup.SourceTargetName = backup.Status.Target.Name
+		}
 	}
 	if err = controllerutil.SetOwnerReference(comp, restore, r.Scheme); err != nil {
 		return nil, err

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -1211,6 +1211,12 @@ func (r *VolumePopulatorReconciler) ensurePostReadyRestoreCompleted(reqCtx intct
 		Namespace: pvc.Namespace,
 		Name:      constant.GenerateClusterComponentName(clusterName, componentName),
 	}, comp); err != nil {
+		if restoreCtx.skipPostReady && apierrors.IsNotFound(err) {
+			if err = r.updatePVCConditionsIfPopulateNotReleased(reqCtx, pvc, "Waiting for backup target component to be created"); err != nil {
+				return false, err
+			}
+			return false, nil
+		}
 		return false, err
 	}
 	if comp.Status.Phase != appsv1.RunningComponentPhase || componentPostProvisionRunning(comp) {

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -1723,7 +1723,7 @@ func (r *VolumePopulatorReconciler) getProvisionOnlyPVC(reqCtx intctrlutil.Reque
 
 func (r *VolumePopulatorReconciler) rebindPVCAndPV(reqCtx intctrlutil.RequestCtx, populatePVC, pvc *corev1.PersistentVolumeClaim) (bool, error) {
 	if populatePVC == nil {
-		return false, nil
+		return false, intctrlutil.NewFatalError(fmt.Sprintf("populate PVC is nil for target PVC %s/%s; restoreData path entered without prepareData backup set", pvc.Namespace, pvc.Name))
 	}
 	if populatePVC.Spec.VolumeName == "" {
 		return false, nil

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -1722,6 +1722,9 @@ func (r *VolumePopulatorReconciler) getProvisionOnlyPVC(reqCtx intctrlutil.Reque
 }
 
 func (r *VolumePopulatorReconciler) rebindPVCAndPV(reqCtx intctrlutil.RequestCtx, populatePVC, pvc *corev1.PersistentVolumeClaim) (bool, error) {
+	if populatePVC == nil {
+		return false, nil
+	}
 	if populatePVC.Spec.VolumeName == "" {
 		return false, nil
 	}

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -2399,9 +2399,8 @@ func TestRebindPVCAndPV_NilPopulatePVC_ReturnsFatalError(t *testing.T) {
 
 func TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_TargetComponentNotYetCreated(t *testing.T) {
 	// When the backup target component (tidb) hasn't been created yet (multi-component
-	// sequential creation: PD→TiKV→TiDB), the redirect path should requeue gracefully
-	// instead of returning an error. PVC provision-only already succeeded; this is the
-	// postReady restore step which can wait.
+	// sequential creation: PD→TiKV→TiDB), the redirect path should return (false,nil)
+	// for standard requeue — no Reconciler error, no Restore CR created.
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 	require.NoError(t, kbappsv1.AddToScheme(scheme))

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -2175,12 +2175,14 @@ func TestDecidePVCRestore_MultiComponent_PostReadyOnly_SkipsNonMatchingPVC(t *te
 	backup := newBackupForRestoreDecision(nil, nil) // no targetVolumes (logical backup)
 	backup.Status.BackupMethod.TargetVolumes = nil
 	backup.Status.Target = &dpv1alpha1.BackupStatusTarget{
-		BackupTarget: dpv1alpha1.BackupTarget{Name: "tidb"},
-		PodSelector: &dpv1alpha1.PodSelector{
-			LabelSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					constant.AppInstanceLabelKey:    "cluster",
-					constant.KBAppComponentLabelKey: "tidb",
+		BackupTarget: dpv1alpha1.BackupTarget{
+			Name: "tidb",
+			PodSelector: &dpv1alpha1.PodSelector{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						constant.AppInstanceLabelKey:    "cluster",
+						constant.KBAppComponentLabelKey: "tidb",
+					},
 				},
 			},
 		},
@@ -2205,9 +2207,10 @@ func TestDecidePVCRestore_MultiComponent_PostReadyOnly_SkipsNonMatchingPVC(t *te
 }
 
 func TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_ShouldNotSilentlySkip(t *testing.T) {
-	// Desired behavior: when ActionSet has only postReady (no prepareData) and
-	// backup target component has no data PVC, at least one data PVC's component
-	// should trigger postReady restore. The result should be exactly 1 Restore CR.
+	// Desired behavior: for a TiDB-shaped multi-component logical backup restore
+	// (postReady-only ActionSet, backup target scoped to "tidb", data PVCs in pd/tikv),
+	// the full production decision→postReady path should produce exactly 1 Restore CR
+	// anchored to the backup target component context (tidb), not silently skip all.
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 	require.NoError(t, kbappsv1.AddToScheme(scheme))
@@ -2217,12 +2220,14 @@ func TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_ShouldNotSilentlySk
 	backup := newBackupForRestoreDecision(nil, nil)
 	backup.Status.BackupMethod.TargetVolumes = nil
 	backup.Status.Target = &dpv1alpha1.BackupStatusTarget{
-		BackupTarget: dpv1alpha1.BackupTarget{Name: "tidb"},
-		PodSelector: &dpv1alpha1.PodSelector{
-			LabelSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					constant.AppInstanceLabelKey:    "cluster",
-					constant.KBAppComponentLabelKey: "tidb",
+		BackupTarget: dpv1alpha1.BackupTarget{
+			Name: "tidb",
+			PodSelector: &dpv1alpha1.PodSelector{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						constant.AppInstanceLabelKey:    "cluster",
+						constant.KBAppComponentLabelKey: "tidb",
+					},
 				},
 			},
 		},
@@ -2252,6 +2257,7 @@ func TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_ShouldNotSilentlySk
 	tikvPVC.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
 	tikvPVC.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
 
+	// All three components: pd, tikv, tidb (backup target)
 	pdComp := &kbappsv1.Component{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
@@ -2268,11 +2274,19 @@ func TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_ShouldNotSilentlySk
 		},
 		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
 	}
+	tidbComp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "tidb"),
+			UID:       "tidb-component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
+	}
 
 	reconciler := &VolumePopulatorReconciler{
 		Client: fake.NewClientBuilder().WithScheme(scheme).
 			WithStatusSubresource(pdPVC, tikvPVC).
-			WithObjects(backup, pdPVC, tikvPVC, pdComp, tikvComp).
+			WithObjects(backup, pdPVC, tikvPVC, pdComp, tikvComp, tidbComp).
 			Build(),
 		Scheme:   scheme,
 		Recorder: record.NewFakeRecorder(10),
@@ -2281,24 +2295,28 @@ func TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_ShouldNotSilentlySk
 	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{
 		Spec: dpv1alpha1.RestoreSpec{Backup: dpv1alpha1.BackupRef{Name: backup.Name, Namespace: backup.Namespace}},
 	}, nil, scheme, reconciler.Client)
-	// PostReady-only ActionSet: PostReadyBackupSets non-empty, PrepareDataBackupSets empty
 	restoreMgr.PostReadyBackupSets = []dprestore.BackupActionSet{{Backup: backup}}
-	// PrepareDataBackupSets stays nil/empty (no prepareData in ActionSet)
 
-	// Simulate the VolumePopulator flow for both PVCs with skipPostReady=true
-	// (as decidePVCRestore currently sets it for non-matching PVCs)
+	// Step 1: derive context from the production decision path (not hardcoded)
+	pdDecision, err := reconciler.decidePVCRestore(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pdPVC, backup, nil)
+	require.NoError(t, err)
+	tikvDecision, err := reconciler.decidePVCRestore(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, tikvPVC, backup, nil)
+	require.NoError(t, err)
+
 	pdCtx := &pvcRestoreContext{
 		restoreMgr:    restoreMgr,
-		mode:          pvcRestoreModeProvisionOnly,
-		skipPostReady: true, // current decidePVCRestore result for non-matching PVC
+		mode:          pdDecision.mode,
+		skipPostReady: pdDecision.skipPostReady,
 	}
 	tikvCtx := &pvcRestoreContext{
 		restoreMgr:    restoreMgr,
-		mode:          pvcRestoreModeProvisionOnly,
-		skipPostReady: true,
+		mode:          tikvDecision.mode,
+		skipPostReady: tikvDecision.skipPostReady,
 	}
 
-	// Process both PVCs through ensurePostReadyRestoreCompleted
+	// Step 2: process both PVCs through ensurePostReadyRestoreCompleted
 	completed1, err := reconciler.ensurePostReadyRestoreCompleted(
 		intctrlutil.RequestCtx{Ctx: context.Background()}, pdPVC, pdCtx)
 	require.NoError(t, err)
@@ -2306,24 +2324,50 @@ func TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_ShouldNotSilentlySk
 		intctrlutil.RequestCtx{Ctx: context.Background()}, tikvPVC, tikvCtx)
 	require.NoError(t, err)
 
-	// DESIRED: at least one PVC should have triggered postReady restore creation
+	// Step 3: assert exactly 1 Restore CR
 	restoreList := &dpv1alpha1.RestoreList{}
 	require.NoError(t, reconciler.Client.List(context.Background(), restoreList, client.InNamespace("default")))
-
-	// BUG: currently both return completed=true (silent skip) and 0 Restore CRs
-	// After fix: exactly 1 Restore CR should be created, not 0 and not 2
 	require.Len(t, restoreList.Items, 1,
 		"postReady-only ActionSet with multi-component backup should create exactly 1 Restore CR, "+
-			"not silently skip all non-matching PVCs")
+			"not silently skip all non-matching PVCs (got %d)", len(restoreList.Items))
 
-	// Both PVCs should not both report completed=true when no restore was created
+	// Step 4: assert the Restore CR is anchored to the backup target component (tidb)
+	restore := restoreList.Items[0]
+
+	// Owner must be the tidb component (backup target), not pd or tikv
+	require.Len(t, restore.OwnerReferences, 1, "Restore CR should have exactly 1 owner reference")
+	require.Equal(t, tidbComp.UID, restore.OwnerReferences[0].UID,
+		"Restore CR owner should be the backup target component (tidb), not a random data component")
+	require.Equal(t, tidbComp.Name, restore.OwnerReferences[0].Name)
+
+	// ReadyConfig pod selectors must target tidb component pods
+	require.NotNil(t, restore.Spec.ReadyConfig)
+	require.NotNil(t, restore.Spec.ReadyConfig.ExecAction)
+	require.Equal(t, "tidb",
+		restore.Spec.ReadyConfig.ExecAction.Target.PodSelector.MatchLabels[constant.KBAppComponentLabelKey],
+		"ExecAction should target tidb component pods (where BR tool + PD_ADDRESS env are)")
+	require.NotNil(t, restore.Spec.ReadyConfig.JobAction)
+	require.Equal(t, "tidb",
+		restore.Spec.ReadyConfig.JobAction.Target.PodSelector.LabelSelector.MatchLabels[constant.KBAppComponentLabelKey],
+		"JobAction should target tidb component pods")
+
+	// Dedup: Restore name should be deterministic (per tidb component UID, not per data PVC)
+	require.Equal(t, postReadyRestoreName(tidbComp.UID), restore.Name,
+		"Restore CR name should be keyed on backup target component UID for deterministic dedup")
+
+	// Backup source target should reference the backup target
+	require.Equal(t, "tidb", restore.Spec.Backup.SourceTargetName,
+		"Restore CR should reference backup target name")
+
+	// Both PVCs should not both report completed=true when postReady is in-progress
 	require.False(t, completed1 && completed2,
-		"at least one PVC should trigger postReady restore, not all silently skip")
+		"at least one PVC should wait for postReady restore, not all silently skip")
 }
 
-func TestRebindPVCAndPV_NilPopulatePVC_ShouldNotPanic(t *testing.T) {
-	// Guard: rebindPVCAndPV(nil, pvc) should not nil-pointer panic.
-	// This can happen when entering restoreData path without prepareData backup set.
+func TestRebindPVCAndPV_NilPopulatePVC_ReturnsFatalError(t *testing.T) {
+	// When rebindPVCAndPV is called with nil populatePVC (restoreData path entered
+	// without prepareData backup set), it must return a fatal error — not panic,
+	// and not silently return (false, nil) which would cause infinite requeue.
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 	pvc := &corev1.PersistentVolumeClaim{
@@ -2342,8 +2386,11 @@ func TestRebindPVCAndPV_NilPopulatePVC_ShouldNotPanic(t *testing.T) {
 	}
 	reqCtx := intctrlutil.RequestCtx{Ctx: context.Background()}
 
-	// Should not panic; should return gracefully
 	require.NotPanics(t, func() {
-		_, _ = reconciler.rebindPVCAndPV(reqCtx, nil, pvc)
+		rebound, err := reconciler.rebindPVCAndPV(reqCtx, nil, pvc)
+		require.Error(t, err, "nil populatePVC should return error, not silently succeed")
+		require.True(t, intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal),
+			"nil populatePVC is an invalid contract state, should be fatal error: %v", err)
+		require.False(t, rebound)
 	}, "rebindPVCAndPV should not panic when populatePVC is nil")
 }

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -2163,3 +2163,187 @@ func TestRestoreSystemAccountSecretsReturnsFatalForInvalidAccountsPayload(t *tes
 	require.Error(t, err)
 	require.True(t, intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal))
 }
+
+// TiDB-shaped multi-component test: backup target (tidb) has no data PVC,
+// data PVCs belong to other components (pd, tikv).
+// ActionSet has only postReady (no prepareData) — logical backup pattern.
+
+func TestDecidePVCRestore_MultiComponent_PostReadyOnly_SkipsNonMatchingPVC(t *testing.T) {
+	// Documents current behavior (the bug): when backup target is scoped to
+	// component "tidb" and a PVC belongs to component "pd", skipPostReady=true.
+	reconciler := &VolumePopulatorReconciler{}
+	backup := newBackupForRestoreDecision(nil, nil) // no targetVolumes (logical backup)
+	backup.Status.BackupMethod.TargetVolumes = nil
+	backup.Status.Target = &dpv1alpha1.BackupStatusTarget{
+		BackupTarget: dpv1alpha1.BackupTarget{Name: "tidb"},
+		PodSelector: &dpv1alpha1.PodSelector{
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					constant.AppInstanceLabelKey:    "cluster",
+					constant.KBAppComponentLabelKey: "tidb",
+				},
+			},
+		},
+	}
+
+	// PD data PVC — belongs to "pd" component, not "tidb"
+	pdPVC := newPVCForRestoreDecision("data", "pd", "")
+	decision, err := reconciler.decidePVCRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pdPVC, backup, nil)
+	require.NoError(t, err)
+	require.Equal(t, pvcRestoreModeProvisionOnly, decision.mode)
+	// Current behavior: skipPostReady=true for non-matching component
+	require.True(t, decision.skipPostReady, "current behavior: non-matching PVC gets skipPostReady=true")
+	require.Nil(t, decision.sourceTarget)
+
+	// TiKV data PVC — also not "tidb"
+	tikvPVC := newPVCForRestoreDecision("data", "tikv", "")
+	decision, err = reconciler.decidePVCRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, tikvPVC, backup, nil)
+	require.NoError(t, err)
+	require.Equal(t, pvcRestoreModeProvisionOnly, decision.mode)
+	require.True(t, decision.skipPostReady, "current behavior: non-matching PVC gets skipPostReady=true")
+	require.Nil(t, decision.sourceTarget)
+}
+
+func TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_ShouldNotSilentlySkip(t *testing.T) {
+	// Desired behavior: when ActionSet has only postReady (no prepareData) and
+	// backup target component has no data PVC, at least one data PVC's component
+	// should trigger postReady restore. The result should be exactly 1 Restore CR.
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, kbappsv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	apiGroup := dptypes.DataprotectionAPIGroup
+
+	backup := newBackupForRestoreDecision(nil, nil)
+	backup.Status.BackupMethod.TargetVolumes = nil
+	backup.Status.Target = &dpv1alpha1.BackupStatusTarget{
+		BackupTarget: dpv1alpha1.BackupTarget{Name: "tidb"},
+		PodSelector: &dpv1alpha1.PodSelector{
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					constant.AppInstanceLabelKey:    "cluster",
+					constant.KBAppComponentLabelKey: "tidb",
+				},
+			},
+		},
+	}
+
+	// PD data PVC
+	pdPVC := newPVCForRestoreDecision("data", "pd", "")
+	pdPVC.UID = types.UID("pd-pvc-uid")
+	pdPVC.Spec.VolumeName = "pd-data-pv"
+	pdPVC.Spec.DataSourceRef = &corev1.TypedObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     dptypes.BackupKind,
+		Name:     backup.Name,
+	}
+	pdPVC.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
+	pdPVC.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+
+	// TiKV data PVC
+	tikvPVC := newPVCForRestoreDecision("data", "tikv", "")
+	tikvPVC.UID = types.UID("tikv-pvc-uid")
+	tikvPVC.Spec.VolumeName = "tikv-data-pv"
+	tikvPVC.Spec.DataSourceRef = &corev1.TypedObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     dptypes.BackupKind,
+		Name:     backup.Name,
+	}
+	tikvPVC.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
+	tikvPVC.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+
+	pdComp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "pd"),
+			UID:       "pd-component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
+	}
+	tikvComp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "tikv"),
+			UID:       "tikv-component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
+	}
+
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).
+			WithStatusSubresource(pdPVC, tikvPVC).
+			WithObjects(backup, pdPVC, tikvPVC, pdComp, tikvComp).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{
+		Spec: dpv1alpha1.RestoreSpec{Backup: dpv1alpha1.BackupRef{Name: backup.Name, Namespace: backup.Namespace}},
+	}, nil, scheme, reconciler.Client)
+	// PostReady-only ActionSet: PostReadyBackupSets non-empty, PrepareDataBackupSets empty
+	restoreMgr.PostReadyBackupSets = []dprestore.BackupActionSet{{Backup: backup}}
+	// PrepareDataBackupSets stays nil/empty (no prepareData in ActionSet)
+
+	// Simulate the VolumePopulator flow for both PVCs with skipPostReady=true
+	// (as decidePVCRestore currently sets it for non-matching PVCs)
+	pdCtx := &pvcRestoreContext{
+		restoreMgr:    restoreMgr,
+		mode:          pvcRestoreModeProvisionOnly,
+		skipPostReady: true, // current decidePVCRestore result for non-matching PVC
+	}
+	tikvCtx := &pvcRestoreContext{
+		restoreMgr:    restoreMgr,
+		mode:          pvcRestoreModeProvisionOnly,
+		skipPostReady: true,
+	}
+
+	// Process both PVCs through ensurePostReadyRestoreCompleted
+	completed1, err := reconciler.ensurePostReadyRestoreCompleted(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pdPVC, pdCtx)
+	require.NoError(t, err)
+	completed2, err := reconciler.ensurePostReadyRestoreCompleted(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, tikvPVC, tikvCtx)
+	require.NoError(t, err)
+
+	// DESIRED: at least one PVC should have triggered postReady restore creation
+	restoreList := &dpv1alpha1.RestoreList{}
+	require.NoError(t, reconciler.Client.List(context.Background(), restoreList, client.InNamespace("default")))
+
+	// BUG: currently both return completed=true (silent skip) and 0 Restore CRs
+	// After fix: exactly 1 Restore CR should be created, not 0 and not 2
+	require.Len(t, restoreList.Items, 1,
+		"postReady-only ActionSet with multi-component backup should create exactly 1 Restore CR, "+
+			"not silently skip all non-matching PVCs")
+
+	// Both PVCs should not both report completed=true when no restore was created
+	require.False(t, completed1 && completed2,
+		"at least one PVC should trigger postReady restore, not all silently skip")
+}
+
+func TestRebindPVCAndPV_NilPopulatePVC_ShouldNotPanic(t *testing.T) {
+	// Guard: rebindPVCAndPV(nil, pvc) should not nil-pointer panic.
+	// This can happen when entering restoreData path without prepareData backup set.
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "default",
+			Name:            "data-target-0",
+			UID:             "target-pvc-uid",
+			ResourceVersion: "1",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			DataSourceRef: &corev1.TypedObjectReference{Name: "backup"},
+		},
+	}
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc).Build(),
+	}
+	reqCtx := intctrlutil.RequestCtx{Ctx: context.Background()}
+
+	// Should not panic; should return gracefully
+	require.NotPanics(t, func() {
+		_, _ = reconciler.rebindPVCAndPV(reqCtx, nil, pvc)
+	}, "rebindPVCAndPV should not panic when populatePVC is nil")
+}

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -2397,6 +2397,99 @@ func TestRebindPVCAndPV_NilPopulatePVC_ReturnsFatalError(t *testing.T) {
 	}, "rebindPVCAndPV should not panic when populatePVC is nil")
 }
 
+func TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_TargetComponentNotYetCreated(t *testing.T) {
+	// When the backup target component (tidb) hasn't been created yet (multi-component
+	// sequential creation: PD→TiKV→TiDB), the redirect path should requeue gracefully
+	// instead of returning an error. PVC provision-only already succeeded; this is the
+	// postReady restore step which can wait.
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, kbappsv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	apiGroup := dptypes.DataprotectionAPIGroup
+
+	backup := newBackupForRestoreDecision(nil, nil)
+	backup.Status.BackupMethod.TargetVolumes = nil
+	backup.Status.Target = &dpv1alpha1.BackupStatusTarget{
+		BackupTarget: dpv1alpha1.BackupTarget{
+			Name: "tidb",
+			PodSelector: &dpv1alpha1.PodSelector{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						constant.AppInstanceLabelKey:    "cluster",
+						constant.KBAppComponentLabelKey: "tidb",
+					},
+				},
+			},
+		},
+	}
+
+	pdPVC := newPVCForRestoreDecision("data", "pd", "")
+	pdPVC.UID = types.UID("pd-pvc-uid")
+	pdPVC.Spec.VolumeName = "pd-data-pv"
+	pdPVC.Spec.DataSourceRef = &corev1.TypedObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     dptypes.BackupKind,
+		Name:     backup.Name,
+	}
+	pdPVC.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
+	pdPVC.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+
+	// Only PD and TiKV components exist — tidb NOT yet created (sequential creation)
+	pdComp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "pd"),
+			UID:       "pd-component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
+	}
+	tikvComp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "tikv"),
+			UID:       "tikv-component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
+	}
+	// NOTE: no tidb Component — simulates sequential creation where tidb doesn't exist yet
+
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).
+			WithStatusSubresource(pdPVC).
+			WithObjects(backup, pdPVC, pdComp, tikvComp).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{
+		Spec: dpv1alpha1.RestoreSpec{Backup: dpv1alpha1.BackupRef{Name: backup.Name, Namespace: backup.Namespace}},
+	}, nil, scheme, reconciler.Client)
+	restoreMgr.PostReadyBackupSets = []dprestore.BackupActionSet{{Backup: backup}}
+
+	pdDecision, err := reconciler.decidePVCRestore(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pdPVC, backup, nil)
+	require.NoError(t, err)
+	require.True(t, pdDecision.skipPostReady, "PD PVC should have skipPostReady=true")
+
+	pdCtx := &pvcRestoreContext{
+		restoreMgr:    restoreMgr,
+		mode:          pdDecision.mode,
+		skipPostReady: pdDecision.skipPostReady,
+	}
+
+	completed, err := reconciler.ensurePostReadyRestoreCompleted(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pdPVC, pdCtx)
+	require.NoError(t, err, "target Component not yet created should requeue without error, not spam Reconciler error")
+	require.False(t, completed, "should not be completed when target component doesn't exist")
+
+	// No Restore CR should be created
+	restoreList := &dpv1alpha1.RestoreList{}
+	require.NoError(t, reconciler.Client.List(context.Background(), restoreList, client.InNamespace("default")))
+	require.Len(t, restoreList.Items, 0, "no Restore CR should be created while target component doesn't exist")
+}
+
 func TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_TargetsSlice(t *testing.T) {
 	// Regression: backup target in Status.Targets[0] (not Status.Target) must also
 	// trigger the postReady-only redirect. This mirrors resolveSourceTargetFromBackup

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -2489,6 +2489,117 @@ func TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_TargetComponentNotY
 	require.Len(t, restoreList.Items, 0, "no Restore CR should be created while target component doesn't exist")
 }
 
+func TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_WaitsForAllComponentPVCs(t *testing.T) {
+	// When PD PVCs are bound but TiKV PVCs are NOT yet bound, the redirect path must
+	// wait (return false, nil) instead of creating the postReady Restore CR early.
+	// This prevents the logical restore job from running before the cluster is ready.
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, kbappsv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	apiGroup := dptypes.DataprotectionAPIGroup
+
+	backup := newBackupForRestoreDecision(nil, nil)
+	backup.Status.BackupMethod.TargetVolumes = nil
+	backup.Status.Target = &dpv1alpha1.BackupStatusTarget{
+		BackupTarget: dpv1alpha1.BackupTarget{
+			Name: "tidb",
+			PodSelector: &dpv1alpha1.PodSelector{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						constant.AppInstanceLabelKey:    "cluster",
+						constant.KBAppComponentLabelKey: "tidb",
+					},
+				},
+			},
+		},
+	}
+
+	// PD data PVC — bound (has VolumeName)
+	pdPVC := newPVCForRestoreDecision("data", "pd", "")
+	pdPVC.UID = types.UID("pd-pvc-uid")
+	pdPVC.Spec.VolumeName = "pd-data-pv"
+	pdPVC.Spec.DataSourceRef = &corev1.TypedObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     dptypes.BackupKind,
+		Name:     backup.Name,
+	}
+	pdPVC.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
+	pdPVC.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+
+	// TiKV data PVC — NOT bound (no VolumeName)
+	tikvPVC := newPVCForRestoreDecision("data", "tikv", "")
+	tikvPVC.UID = types.UID("tikv-pvc-uid")
+	tikvPVC.Spec.DataSourceRef = &corev1.TypedObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     dptypes.BackupKind,
+		Name:     backup.Name,
+	}
+	tikvPVC.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
+	tikvPVC.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+
+	pdComp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "pd"),
+			UID:       "pd-component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
+	}
+	tikvComp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "tikv"),
+			UID:       "tikv-component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.CreatingComponentPhase},
+	}
+	tidbComp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "tidb"),
+			UID:       "tidb-component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
+	}
+
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).
+			WithStatusSubresource(pdPVC, tikvPVC).
+			WithObjects(backup, pdPVC, tikvPVC, pdComp, tikvComp, tidbComp).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{
+		Spec: dpv1alpha1.RestoreSpec{Backup: dpv1alpha1.BackupRef{Name: backup.Name, Namespace: backup.Namespace}},
+	}, nil, scheme, reconciler.Client)
+	restoreMgr.PostReadyBackupSets = []dprestore.BackupActionSet{{Backup: backup}}
+
+	pdDecision, err := reconciler.decidePVCRestore(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pdPVC, backup, nil)
+	require.NoError(t, err)
+	require.True(t, pdDecision.skipPostReady, "PD PVC should have skipPostReady=true")
+
+	pdCtx := &pvcRestoreContext{
+		restoreMgr:    restoreMgr,
+		mode:          pdDecision.mode,
+		skipPostReady: pdDecision.skipPostReady,
+	}
+
+	// PD PVC triggers redirect, but TiKV PVC is not bound yet — should wait
+	completed, err := reconciler.ensurePostReadyRestoreCompleted(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pdPVC, pdCtx)
+	require.NoError(t, err, "should requeue without error while TiKV PVCs are still pending")
+	require.False(t, completed, "should not be completed while TiKV PVCs are unbound")
+
+	restoreList := &dpv1alpha1.RestoreList{}
+	require.NoError(t, reconciler.Client.List(context.Background(), restoreList, client.InNamespace("default")))
+	require.Len(t, restoreList.Items, 0,
+		"no Restore CR should be created while other component PVCs are still unbound")
+}
+
 func TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_TargetsSlice(t *testing.T) {
 	// Regression: backup target in Status.Targets[0] (not Status.Target) must also
 	// trigger the postReady-only redirect. This mirrors resolveSourceTargetFromBackup

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -1287,7 +1287,7 @@ func TestBuildPostReadyRestoreSelectsHighestPriorityRole(t *testing.T) {
 	}
 	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{}, nil, scheme, reconciler.Client)
 
-	restore, err := reconciler.buildPostReadyRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp)
+	restore, err := reconciler.buildPostReadyRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp, "")
 
 	require.NoError(t, err)
 	require.Equal(t, "leader", restore.Spec.ReadyConfig.JobAction.Target.PodSelector.LabelSelector.MatchLabels[instanceset.RoleLabelKey])
@@ -1325,7 +1325,7 @@ func TestBuildPostReadyRestoreUsesInitAccountFromComponentDefinition(t *testing.
 	}
 	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{}, nil, scheme, reconciler.Client)
 
-	restore, err := reconciler.buildPostReadyRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp)
+	restore, err := reconciler.buildPostReadyRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp, "")
 
 	require.NoError(t, err)
 	require.NotNil(t, restore.Spec.ReadyConfig.ConnectionCredential)
@@ -1675,6 +1675,7 @@ func TestCompleteBoundPVCMarksRestoreSucceededAfterPostReadyCompleted(t *testing
 		pvc,
 		restoreMgr,
 		comp,
+		"",
 	)
 	require.NoError(t, err)
 	postReadyRestore.Status.Phase = dpv1alpha1.RestorePhaseCompleted

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -1287,7 +1287,7 @@ func TestBuildPostReadyRestoreSelectsHighestPriorityRole(t *testing.T) {
 	}
 	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{}, nil, scheme, reconciler.Client)
 
-	restore, err := reconciler.buildPostReadyRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp, "")
+	restore, err := reconciler.buildPostReadyRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp, "", nil)
 
 	require.NoError(t, err)
 	require.Equal(t, "leader", restore.Spec.ReadyConfig.JobAction.Target.PodSelector.LabelSelector.MatchLabels[instanceset.RoleLabelKey])
@@ -1325,7 +1325,7 @@ func TestBuildPostReadyRestoreUsesInitAccountFromComponentDefinition(t *testing.
 	}
 	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{}, nil, scheme, reconciler.Client)
 
-	restore, err := reconciler.buildPostReadyRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp, "")
+	restore, err := reconciler.buildPostReadyRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp, "", nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, restore.Spec.ReadyConfig.ConnectionCredential)
@@ -1676,6 +1676,7 @@ func TestCompleteBoundPVCMarksRestoreSucceededAfterPostReadyCompleted(t *testing
 		restoreMgr,
 		comp,
 		"",
+		nil,
 	)
 	require.NoError(t, err)
 	postReadyRestore.Status.Phase = dpv1alpha1.RestorePhaseCompleted
@@ -2394,4 +2395,99 @@ func TestRebindPVCAndPV_NilPopulatePVC_ReturnsFatalError(t *testing.T) {
 			"nil populatePVC is an invalid contract state, should be fatal error: %v", err)
 		require.False(t, rebound)
 	}, "rebindPVCAndPV should not panic when populatePVC is nil")
+}
+
+func TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_TargetsSlice(t *testing.T) {
+	// Regression: backup target in Status.Targets[0] (not Status.Target) must also
+	// trigger the postReady-only redirect. This mirrors resolveSourceTargetFromBackup
+	// which handles both Status.Target and len(Status.Targets)==1.
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, kbappsv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	apiGroup := dptypes.DataprotectionAPIGroup
+
+	backup := newBackupForRestoreDecision(nil, nil)
+	backup.Status.BackupMethod.TargetVolumes = nil
+	backup.Status.Target = nil
+	backup.Status.Targets = []dpv1alpha1.BackupStatusTarget{{
+		BackupTarget: dpv1alpha1.BackupTarget{
+			Name: "tidb",
+			PodSelector: &dpv1alpha1.PodSelector{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						constant.AppInstanceLabelKey:    "cluster",
+						constant.KBAppComponentLabelKey: "tidb",
+					},
+				},
+			},
+		},
+	}}
+
+	pdPVC := newPVCForRestoreDecision("data", "pd", "")
+	pdPVC.UID = types.UID("pd-pvc-uid")
+	pdPVC.Spec.VolumeName = "pd-data-pv"
+	pdPVC.Spec.DataSourceRef = &corev1.TypedObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     dptypes.BackupKind,
+		Name:     backup.Name,
+	}
+	pdPVC.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
+	pdPVC.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+
+	pdComp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "pd"),
+			UID:       "pd-component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
+	}
+	tidbComp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "tidb"),
+			UID:       "tidb-component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
+	}
+
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).
+			WithStatusSubresource(pdPVC).
+			WithObjects(backup, pdPVC, pdComp, tidbComp).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{
+		Spec: dpv1alpha1.RestoreSpec{Backup: dpv1alpha1.BackupRef{Name: backup.Name, Namespace: backup.Namespace}},
+	}, nil, scheme, reconciler.Client)
+	restoreMgr.PostReadyBackupSets = []dprestore.BackupActionSet{{Backup: backup}}
+
+	pdDecision, err := reconciler.decidePVCRestore(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pdPVC, backup, nil)
+	require.NoError(t, err)
+
+	pdCtx := &pvcRestoreContext{
+		restoreMgr:    restoreMgr,
+		mode:          pdDecision.mode,
+		skipPostReady: pdDecision.skipPostReady,
+	}
+
+	_, err = reconciler.ensurePostReadyRestoreCompleted(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pdPVC, pdCtx)
+	require.NoError(t, err)
+
+	restoreList := &dpv1alpha1.RestoreList{}
+	require.NoError(t, reconciler.Client.List(context.Background(), restoreList, client.InNamespace("default")))
+	require.Len(t, restoreList.Items, 1,
+		"postReady-only with Status.Targets[0] should create exactly 1 Restore CR")
+
+	restore := restoreList.Items[0]
+	require.Equal(t, tidbComp.UID, restore.OwnerReferences[0].UID,
+		"Restore CR owner should be the backup target component (tidb) even when target is in Status.Targets[0]")
+	require.Equal(t, "tidb", restore.Spec.Backup.SourceTargetName)
+	require.Equal(t, postReadyRestoreName(tidbComp.UID), restore.Name)
 }


### PR DESCRIPTION
## Summary

Fixes #10418: VolumePopulator silently skips postReady restore for PVCs from non-backup-target components, blocking logical backup restore in multi-component addons.

## Problem

When restoring from a logical backup (e.g., TiDB BR), the ActionSet has only `restore.postReady` (no `prepareData`). The backup target is scoped to one component (e.g., TiDB SQL frontend), but data PVCs belong to other components (PD, TiKV). `resolveSingleSourceTargetForPVC` sets `skipPostReady=true` for all non-matching PVCs, and `ensurePostReadyRestoreCompleted` returns early at line 1133 — no Restore CR is ever created.

## Fix

For postReady-only ActionSets (`PrepareDataBackupSets` empty, `PostReadyBackupSets` non-empty), non-matching PVCs now redirect to the backup target component context instead of silently skipping:

1. **`ensurePostReadyRestoreCompleted`**: When `skipPostReady=true` and `PrepareDataBackupSets` is empty, do NOT early-return. Instead resolve the backup target component name and use it for the Restore CR context.

2. **`backupTargetComponentName` (new helper)**: Extracts the component name from `backup.Status.Target.PodSelector.MatchLabels[KBAppComponentLabelKey]`.

3. **`buildPostReadyRestore`**: Accepts explicit `targetComponentName` parameter to override PVC-derived component name. Sets `SourceTargetName` from backup status when source target is nil but component was redirected.

This ensures:
- **Exactly 1** postReady Restore CR (deduped by backup target component UID)
- Runs in the **correct component context** (backup target pods with required env vars like `PD_ADDRESS`)
- **Deterministic** trigger (same component UID regardless of PVC processing order)
- **No regression** for prepareData+postReady ActionSets (early-return preserved when PrepareDataBackupSets is non-empty)

4. **`rebindPVCAndPV` nil-guard**: Returns fatal error instead of `(false, nil)` for nil `populatePVC`, preventing infinite requeue.

## Tests

1. **`TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_ShouldNotSilentlySkip`**: Full production path test — derives context from `decidePVCRestore()`, asserts exactly 1 Restore CR owned by backup target component (tidb), with correct ReadyConfig selectors, deterministic name, and SourceTargetName.

2. **`TestDecidePVCRestore_MultiComponent_PostReadyOnly_SkipsNonMatchingPVC`**: Documents current `decidePVCRestore` behavior for non-matching PVCs.

3. **`TestRebindPVCAndPV_NilPopulatePVC_ReturnsFatalError`**: Asserts fatal error (not panic, not silent success) for nil populatePVC.

## Evidence

- Runtime evidence: Kate's test run at SHA `87661e0` — 0 Restore CRs, 0 jobs, PVCs provision-only
- Source code analysis: `volumepopulator_controller.go:464-469` (skipPostReady) → line 1133 (early return)
- Cross-addon comparison: Qdrant (single-component, same ActionSet pattern) works correctly
- Full analysis: addon-docs troubleshoot guide (merged as PR #776 in kubeblocks-addon-docs)
