### PR TITLE
fix(component): skip precheck for externalManaged configs with empty template

### DIFF
--- a/controllers/apps/component/transformer_component_template.go
+++ b/controllers/apps/component/transformer_component_template.go
@@ -112,7 +112,7 @@ func (t *componentFileTemplateTransformer) instanceAssistantObject(transCtx *com
 
 func (t *componentFileTemplateTransformer) precheck(transCtx *componentTransformContext) error {
 	for _, tpl := range transCtx.SynthesizeComponent.FileTemplates {
-		if len(tpl.Template) == 0 {
+		if len(tpl.Template) == 0 && !isExternalManaged(tpl) {
 			return fmt.Errorf("config/script template has no template specified: %s", tpl.Name)
 		}
 	}
@@ -149,7 +149,9 @@ func (t *componentFileTemplateTransformer) buildPodVolumes(transCtx *componentTr
 		objName := fileTemplateObjectName(transCtx.SynthesizeComponent, tpl.Name)
 		// If the file template is managed by external, the volume mount object should be the external object.
 		if isExternalManaged(tpl) {
-			objName = tpl.Template
+			if len(tpl.Template) > 0 {
+				objName = tpl.Template
+			}
 		}
 		createFn := func(_ string) corev1.Volume {
 			return t.newVolume(tpl, objName)

--- a/controllers/apps/component/transformer_component_template_test.go
+++ b/controllers/apps/component/transformer_component_template_test.go
@@ -362,8 +362,11 @@ var _ = Describe("file templates transformer test", func() {
 
 			transformer := &componentFileTemplateTransformer{}
 			err := transformer.Transform(transCtx, dag)
-			Expect(err).ShouldNot(BeNil())
-			Expect(err.Error()).Should(ContainSubstring("config/script template has no template specified"))
+			Expect(err).Should(BeNil())
+
+			checkVolumes([]string{"logConf"})
+			checkTemplateObjects([]string{"logConf"})
+			Expect(transCtx.SynthesizeComponent.PodSpec.Volumes).Should(ContainElement(newVolume("serverConf")))
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- `componentFileTemplateTransformer.precheck()` unconditionally rejects configs with empty `Template`, but `externalManaged: true` configs intentionally have their Template cleared by `synthesizeFileTemplate` (the parameters controller chain provisions the ConfigMap)
- This blocks Component from reaching Running for all addons using `externalManaged: true` + ParametersDefinition (FalkorDB, Valkey both confirmed on KB main commit b51e227)
- Fix: precheck skips externalManaged configs; `buildPodVolumes` uses the deterministic runtime ConfigMap name (`fileTemplateObjectName`) instead of the (empty) external template name, so the pod waits for the parameters controller to create the ConfigMap

## Runtime repro scope

| Engine   | KB Branch | KB commit | Addon Branch | CmpD config pattern        | Result |
|----------|-----------|-----------|--------------|----------------------------|--------|
| FalkorDB | main      | b51e227   | main         | externalManaged: true + PD | FAIL   |
| Valkey   | main      | b51e227   | main         | externalManaged: true + PD | FAIL   |

Error: `config/script template has no template specified: <name>`
Component stuck; no ComponentParameter created.

## Source hypothesis (pinned to KB main commit b51e227)

1. `synthesize_component.go:synthesizeFileTemplate` clears Template for externalManaged configs (correct behavior)
2. `transformer_component_template.go:precheck()` line 115 unconditionally requires Template non-empty → ERROR
3. `buildPodVolumes()` never reached; no pod created
4. Parameters controller chain never triggered (Component never reaches the state where it would)

## Design question for controller owner

When `externalManaged=true` and Template is empty, this fix mounts a ConfigMap volume referencing the deterministic runtime CM name (`fileTemplateObjectName` = `GetComponentCfgName`). The pod stays in `ContainerCreating` until the parameters controller creates the ConfigMap.

Questions:
1. Is waiting on a not-yet-existent ConfigMap acceptable, or should the component reconciler requeue?
2. If no PD matches (no provision source), the pod will be permanently stuck in `ContainerCreating` — acceptable error signal?

## Patch validation plan

1. Unit test: "external managed - w/o template" updated to expect success with deterministic ConfigMap volume
2. CI: standard `make test`
3. Runtime (post-merge or sideload): create FalkorDB/Valkey cluster → verify ComponentParameter + runtime CM + Component spec.configs + Pod Running + no precheck error
4. Sideload per `local-build-sideload-test-image` skill (no ACR push for temp images)

🤖 Generated with [Claude Code](https://claude.com/claude-code)