### PR TITLE
chore: propagate sharding labels to InstanceSet

### DIFF
--- a/pkg/controller/component/workload.go
+++ b/pkg/controller/component/workload.go
@@ -56,7 +56,7 @@ func BuildInstanceSet(synthesizedComp *SynthesizedComponent, compDef *kbappsv1.C
 		// priority: static < dynamic < built-in
 		AddLabelsInMap(synthesizedComp.StaticLabels).
 		AddLabelsInMap(synthesizedComp.DynamicLabels).
-		AddLabelsInMap(constant.GetCompLabels(clusterName, compName)).
+		AddLabelsInMap(constant.GetCompLabels(clusterName, compName, synthesizedComp.Labels)).
 		AddAnnotations(constant.KubeBlocksGenerationKey, synthesizedComp.Generation).
 		AddAnnotations(constant.CRDAPIVersionAnnotationKey, workloads.GroupVersion.String()).
 		AddAnnotationsInMap(map[string]string{

--- a/pkg/controller/component/workload_test.go
+++ b/pkg/controller/component/workload_test.go
@@ -93,7 +93,7 @@ var _ = Describe("workload InstanceSet", func() {
 			CompDefName:   "mongodb",
 			Generation:    "1",
 			Labels:        compLabels,
-			DynamicLabels: compLabels,
+			DynamicLabels: map[string]string{"dynamic-label": "true"},
 			Replicas:      1,
 			PodSpec: &corev1.PodSpec{
 				Containers: []corev1.Container{{Name: "mongodb"}},
@@ -104,6 +104,7 @@ var _ = Describe("workload InstanceSet", func() {
 
 		Expect(err).Should(Succeed())
 		Expect(its.Labels).Should(HaveKeyWithValue(constant.KBAppShardingNameLabelKey, shardingName))
+		Expect(its.Labels).Should(HaveKeyWithValue("dynamic-label", "true"))
 		Expect(its.Spec.Selector.MatchLabels).Should(HaveKeyWithValue(constant.KBAppShardingNameLabelKey, shardingName))
 		Expect(its.Spec.Template.Labels).Should(HaveKeyWithValue(constant.KBAppShardingNameLabelKey, shardingName))
 	})

--- a/pkg/controller/component/workload_test.go
+++ b/pkg/controller/component/workload_test.go
@@ -78,6 +78,37 @@ var _ = Describe("workload PVC templates", func() {
 	})
 })
 
+var _ = Describe("workload InstanceSet", func() {
+	It("propagates sharding labels to InstanceSet metadata", func() {
+		clusterName := "test-cluster"
+		compName := "shard-a"
+		shardingName := "shard"
+		compLabels := constant.GetClusterLabels(clusterName, map[string]string{
+			constant.KBAppShardingNameLabelKey: shardingName,
+		})
+		synthesizedComp := &SynthesizedComponent{
+			Namespace:     "default",
+			ClusterName:   clusterName,
+			Name:          compName,
+			CompDefName:   "mongodb",
+			Generation:    "1",
+			Labels:        compLabels,
+			DynamicLabels: compLabels,
+			Replicas:      1,
+			PodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "mongodb"}},
+			},
+		}
+
+		its, err := BuildInstanceSet(synthesizedComp, nil)
+
+		Expect(err).Should(Succeed())
+		Expect(its.Labels).Should(HaveKeyWithValue(constant.KBAppShardingNameLabelKey, shardingName))
+		Expect(its.Spec.Selector.MatchLabels).Should(HaveKeyWithValue(constant.KBAppShardingNameLabelKey, shardingName))
+		Expect(its.Spec.Template.Labels).Should(HaveKeyWithValue(constant.KBAppShardingNameLabelKey, shardingName))
+	})
+})
+
 var _ = Describe("workload resource defaults", func() {
 	AfterEach(func() {
 		viper.Set(constant.CfgKeyClusterDefaultResources, "")


### PR DESCRIPTION
## Summary
* fix: #10424 

This PR fixes a sharding lifecycle issue where `postProvision` could fail with `action precondition is not met: no runtime found`.

The root cause is that `RuntimeReady` selects shard runtimes by `apps.kubeblocks.io/sharding-name`, but generated shard `InstanceSet` metadata did not carry this label. The shard `Component` has the label, but it was only propagated to pod template labels, not the `InstanceSet` object labels.

## Changes

- Propagate recognized sharding labels from the synthesized Component metadata into generated `InstanceSet` labels via `constant.GetCompLabels(...)`.
- Add a regression test to verify sharding labels are present on:
  - `InstanceSet` metadata labels
  - `InstanceSet` selector labels
  - pod template labels

## Verification

```text
make test TEST_PACKAGES=./pkg/controller/component