### PR TITLE
fix(component): restrict precheck bypass to externalManaged configs only

### DIFF
--- a/controllers/apps/component/transformer_component_template.go
+++ b/controllers/apps/component/transformer_component_template.go
@@ -112,7 +112,7 @@ func (t *componentFileTemplateTransformer) instanceAssistantObject(transCtx *com
 
 func (t *componentFileTemplateTransformer) precheck(transCtx *componentTransformContext) error {
 	for _, tpl := range transCtx.SynthesizeComponent.FileTemplates {
-		if len(tpl.Template) == 0 {
+		if len(tpl.Template) == 0 && !(tpl.Config && isExternalManaged(tpl)) {
 			return fmt.Errorf("config/script template has no template specified: %s", tpl.Name)
 		}
 	}
@@ -147,8 +147,10 @@ func (t *componentFileTemplateTransformer) buildPodVolumes(transCtx *componentTr
 	}
 	for _, tpl := range synthesizedComp.FileTemplates {
 		objName := fileTemplateObjectName(transCtx.SynthesizeComponent, tpl.Name)
-		// If the file template is managed by external, the volume mount object should be the external object.
-		if isExternalManaged(tpl) {
+		// If the file template is managed by external and has a template specified, use the external object.
+		// When externalManaged config has empty template, the parameters controller will provision
+		// a ConfigMap using the deterministic name (fileTemplateObjectName).
+		if isExternalManaged(tpl) && len(tpl.Template) > 0 {
 			objName = tpl.Template
 		}
 		createFn := func(_ string) corev1.Volume {

--- a/controllers/apps/component/transformer_component_template_test.go
+++ b/controllers/apps/component/transformer_component_template_test.go
@@ -354,7 +354,7 @@ var _ = Describe("file templates transformer test", func() {
 			// checkEnvWithAction(component.UDFReconfigureActionName(transCtx.SynthesizeComponent.FileTemplates[1]))
 		})
 
-		It("external managed - w/o template", func() {
+		It("external managed script - w/o template", func() {
 			transCtx.SynthesizeComponent.FileTemplates[1].Template = ""
 			transCtx.SynthesizeComponent.FileTemplates[1].Namespace = ""
 			transCtx.SynthesizeComponent.FileTemplates[1].Reconfigure = nil
@@ -364,6 +364,34 @@ var _ = Describe("file templates transformer test", func() {
 			err := transformer.Transform(transCtx, dag)
 			Expect(err).ShouldNot(BeNil())
 			Expect(err.Error()).Should(ContainSubstring("config/script template has no template specified"))
+		})
+
+		It("external managed config - w/o template", func() {
+			transCtx.SynthesizeComponent.FileTemplates[1].Template = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].Namespace = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].Reconfigure = nil
+			transCtx.SynthesizeComponent.FileTemplates[1].ExternalManaged = ptr.To(true)
+			transCtx.SynthesizeComponent.FileTemplates[1].Config = true
+
+			transformer := &componentFileTemplateTransformer{}
+			err := transformer.Transform(transCtx, dag)
+			Expect(err).Should(BeNil())
+
+			checkVolumes([]string{"logConf"})
+			checkTemplateObjects([]string{"logConf"})
+			podSpec := transCtx.SynthesizeComponent.PodSpec
+			expectedObjName := fileTemplateObjectName(transCtx.SynthesizeComponent, "serverConf")
+			Expect(podSpec.Volumes).Should(ContainElement(corev1.Volume{
+				Name: "serverConf",
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: expectedObjName,
+						},
+						DefaultMode: ptr.To[int32](0444),
+					},
+				},
+			}))
 		})
 	})
 })


### PR DESCRIPTION
Closes #10436

## Summary

- Restrict the empty-template precheck bypass to config-type externalManaged templates only (`tpl.Config && isExternalManaged(tpl)`)
- Scripts with externalManaged + empty Template still fail with a clear validation error (no parameters controller producer exists for scripts)
- `buildPodVolumes` only falls back to deterministic ConfigMap name when the external template name is non-empty
- Supersedes PR #10427, addressing Leon11 P1 review: scripts must not bypass precheck

## Code evidence

| Location | Behavior |
|----------|----------|
| `synthesize_component.go:507-512` | Intentionally clears Template for externalManaged configs (comment: reset the template and wait the external system to provision it) |
| `synthesize_component.go:461` | Upstream validation allows externalManaged + empty Template |
| `transformer_component_template.go:115` (before fix) | Precheck unconditionally rejects empty Template -- inconsistent with above |
| `GetComponentCfgName` / `fileTemplateObjectName` | Both produce `clusterName-compName-tplName` -- deterministic name matches |

## Test plan

- [x] Existing test renamed: external managed script - w/o template (Config=false, ExternalManaged=true, Template empty) -- still errors
- [x] New test: external managed config - w/o template (Config=true, ExternalManaged=true, Template empty) -- succeeds, volume references deterministic ConfigMap name
- [x] go build / go vet pass
- [x] gofmt clean
- [x] Edward peer review: LGTM
- [ ] CI unit tests