### PR TITLE
fix(operations): two-pass reconfigure validation to prevent partial CP pollution

### DIFF
--- a/pkg/operations/reconfigure.go
+++ b/pkg/operations/reconfigure.go
@@ -33,6 +33,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/sharding"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	pkgparameters "github.com/apecloud/kubeblocks/pkg/parameters"
 	parameterscore "github.com/apecloud/kubeblocks/pkg/parameters/core"
 )
 
@@ -87,10 +88,19 @@ func (r *reconfigureAction) Action(reqCtx intctrlutil.RequestCtx, cli client.Cli
 	if len(resource.OpsRequest.Spec.Reconfigures) == 0 {
 		return intctrlutil.NewErrorf(intctrlutil.ErrorTypeFatal, `invalid reconfigure request: %s`, resource.OpsRequest.GetName())
 	}
+
+	// Pass 1: validate all reconfigure entries before patching any CP desired.
 	for _, reconfigure := range resource.OpsRequest.Spec.Reconfigures {
 		if len(reconfigure.Parameters) == 0 {
 			return intctrlutil.NewErrorf(intctrlutil.ErrorTypeFatal, "invalid reconfigure request for component %s: no parameters", reconfigure.ComponentName)
 		}
+		if err := r.validateReconfigureParameters(reqCtx, cli, resource.Cluster, reconfigure); err != nil {
+			return err
+		}
+	}
+
+	// Pass 2: apply all patches.
+	for _, reconfigure := range resource.OpsRequest.Spec.Reconfigures {
 		compNames, err := r.resolveReconfigureComponents(reqCtx.Ctx, cli, resource.Cluster, reconfigure.ComponentName)
 		if err != nil {
 			return err
@@ -180,6 +190,58 @@ func (r *reconfigureAction) resolveReconfigureComponents(ctx context.Context, re
 		compNames = append(compNames, shortName)
 	}
 	return compNames, nil
+}
+
+func (r *reconfigureAction) validateReconfigureParameters(reqCtx intctrlutil.RequestCtx, cli client.Client,
+	cluster *appsv1.Cluster, reconfigure opsv1alpha1.Reconfigure) error {
+	compDefNames, err := r.resolveCompDefNames(reqCtx.Ctx, cli, cluster, reconfigure.ComponentName)
+	if err != nil {
+		return err
+	}
+	assignments := make(parametersv1alpha1.ComponentParameters, len(reconfigure.Parameters))
+	for _, param := range reconfigure.Parameters {
+		assignments[param.Key] = param.Value
+	}
+	for _, compDefName := range compDefNames {
+		cmpd := &appsv1.ComponentDefinition{}
+		if err := cli.Get(reqCtx.Ctx, client.ObjectKey{Name: compDefName}, cmpd); err != nil {
+			return err
+		}
+		_, paramsDefs, err := pkgparameters.ResolveCmpdParametersDefs(reqCtx.Ctx, cli, cmpd)
+		if err != nil {
+			return err
+		}
+		if err := pkgparameters.ValidateComponentParameterAssignments(assignments, paramsDefs); err != nil {
+			return intctrlutil.NewFatalError(err.Error())
+		}
+	}
+	return nil
+}
+
+func (r *reconfigureAction) resolveCompDefNames(ctx context.Context, cli client.Reader, cluster *appsv1.Cluster, compName string) ([]string, error) {
+	if compSpec := cluster.Spec.GetComponentByName(compName); compSpec != nil {
+		if compSpec.ComponentDef == "" {
+			return nil, nil
+		}
+		return []string{compSpec.ComponentDef}, nil
+	}
+	shardingSpec := cluster.Spec.GetShardingByName(compName)
+	if shardingSpec == nil {
+		return nil, intctrlutil.NewErrorf(intctrlutil.ErrorTypeFatal, "component not found: %s", compName)
+	}
+	comps, err := sharding.ListShardingComponents(ctx, cli, cluster, compName)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]struct{})
+	var compDefNames []string
+	for _, comp := range comps {
+		if _, ok := seen[comp.Spec.CompDef]; !ok {
+			seen[comp.Spec.CompDef] = struct{}{}
+			compDefNames = append(compDefNames, comp.Spec.CompDef)
+		}
+	}
+	return compDefNames, nil
 }
 
 func (r *reconfigureAction) getRunningComponentParameter(ctx context.Context, cli client.Client, namespace, clusterName, compName string) (*parametersv1alpha1.ComponentParameter, error) {

--- a/pkg/operations/reconfigure_test.go
+++ b/pkg/operations/reconfigure_test.go
@@ -450,43 +450,25 @@ parameter: {
 			})).Should(Succeed())
 		})
 
-		It("sharding: validates against actual shard ComponentDefinition", func() {
-			By("create a cluster with a sharding spec")
+		It("sharding: validates against actual shard ComponentDefinition, not template default", func() {
 			reqCtx := intctrlutil.RequestCtx{Ctx: ctx}
-			compDef := testapps.NewComponentDefinitionFactory(compDefName).
-				SetDefaultSpec().
-				Create(&testCtx).
-				GetObject()
-			clusterObject := testapps.NewClusterFactory(testCtx.DefaultNamespace, clusterName, "").
-				AddSharding(defaultCompName, "", compDef.GetName()).
-				Create(&testCtx).
-				GetObject()
-			Expect(testapps.ChangeObjStatus(&testCtx, clusterObject, func() {
-				clusterObject.Status.Phase = appsv1.RunningClusterPhase
-			})).Should(Succeed())
-			opsRes := &OpsResource{
-				Cluster:  clusterObject,
-				Recorder: k8sManager.GetEventRecorderFor("opsrequest-controller"),
-			}
 
-			By("create a shard Component with the actual CompDef")
-			shardShortName := fmt.Sprintf("%s-%s", defaultCompName, rand.String(sharding.ShardIDLength))
-			shardFullName := fmt.Sprintf("%s-%s", clusterName, shardShortName)
-			testapps.NewComponentFactory(testCtx.DefaultNamespace, shardFullName, compDef.GetName()).
-				AddLabels(constant.AppManagedByLabelKey, constant.AppName).
-				AddLabels(constant.AppInstanceLabelKey, clusterName).
-				AddLabels(constant.KBAppClusterUIDKey, string(clusterObject.UID)).
-				AddLabels(constant.KBAppShardingNameLabelKey, defaultCompName).
-				AddLabels(constant.KBAppComponentLabelKey, shardShortName).
-				SetReplicas(1).
+			By("create template CompDef (no schema — validation would pass if code only checks this)")
+			templateCompDefName := "template-compdef-" + randomStr
+			testapps.NewComponentDefinitionFactory(templateCompDefName).
+				SetDefaultSpec().
 				Create(&testCtx)
 
-			By("prepare ParametersDefinition with schema")
+			By("create actual shard CompDef with strict schema that rejects unknown_param")
+			actualShardCompDefName := "shard-compdef-" + randomStr
+			testapps.NewComponentDefinitionFactory(actualShardCompDefName).
+				SetDefaultSpec().
+				Create(&testCtx)
 			template := testparameters.NewComponentTemplateFactory("mysql-config", testCtx.DefaultNamespace).
 				Create(&testCtx).
 				GetObject()
 			paramsDef := testparameters.NewParametersDefinitionFactory("mysql-params-shard-" + randomStr).
-				SetComponentDefinition(compDefName).
+				SetComponentDefinition(actualShardCompDefName).
 				SetTemplateName("mysql-config").
 				Schema(`
 parameter: {
@@ -498,7 +480,7 @@ parameter: {
 			Expect(testapps.ChangeObjStatus(&testCtx, paramsDef, func() {
 				paramsDef.Status.Phase = parametersv1alpha1.PDAvailablePhase
 			})).Should(Succeed())
-			Expect(testapps.GetAndChangeObj(&testCtx, client.ObjectKey{Name: compDefName}, func(cd *appsv1.ComponentDefinition) {
+			Expect(testapps.GetAndChangeObj(&testCtx, client.ObjectKey{Name: actualShardCompDefName}, func(cd *appsv1.ComponentDefinition) {
 				cd.Spec.ServiceVersion = "8.0.30"
 				cd.Spec.Configs = []appsv1.ComponentFileTemplate{
 					{
@@ -511,8 +493,33 @@ parameter: {
 				}
 			})()).Should(Succeed())
 
+			By("create cluster with sharding template pointing to templateCompDef")
+			clusterObject := testapps.NewClusterFactory(testCtx.DefaultNamespace, clusterName, "").
+				AddSharding(defaultCompName, "", templateCompDefName).
+				Create(&testCtx).
+				GetObject()
+			Expect(testapps.ChangeObjStatus(&testCtx, clusterObject, func() {
+				clusterObject.Status.Phase = appsv1.RunningClusterPhase
+			})).Should(Succeed())
+			opsRes := &OpsResource{
+				Cluster:  clusterObject,
+				Recorder: k8sManager.GetEventRecorderFor("opsrequest-controller"),
+			}
+
+			By("create actual shard Component with actualShardCompDef (differs from template)")
+			shardShortName := fmt.Sprintf("%s-%s", defaultCompName, rand.String(sharding.ShardIDLength))
+			shardFullName := fmt.Sprintf("%s-%s", clusterName, shardShortName)
+			testapps.NewComponentFactory(testCtx.DefaultNamespace, shardFullName, actualShardCompDefName).
+				AddLabels(constant.AppManagedByLabelKey, constant.AppName).
+				AddLabels(constant.AppInstanceLabelKey, clusterName).
+				AddLabels(constant.KBAppClusterUIDKey, string(clusterObject.UID)).
+				AddLabels(constant.KBAppShardingNameLabelKey, defaultCompName).
+				AddLabels(constant.KBAppComponentLabelKey, shardShortName).
+				SetReplicas(1).
+				Create(&testCtx)
+
 			cpShard := builder.NewComponentParameterBuilder(testCtx.DefaultNamespace, parameterscore.GenerateComponentConfigurationName(clusterName, shardShortName)).
-				AddLabelsInMap(constant.GetCompLabelsWithDef(clusterName, shardShortName, compDefName)).
+				AddLabelsInMap(constant.GetCompLabelsWithDef(clusterName, shardShortName, actualShardCompDefName)).
 				SetClusterName(clusterName).
 				SetCompName(shardShortName).
 				GetObject()
@@ -532,7 +539,7 @@ parameter: {
 				}}
 			})()).Should(Succeed())
 
-			By("reconfigure the sharding name with an unknown parameter")
+			By("reconfigure the sharding name with unknown_param")
 			ops := testops.NewOpsRequestObj("shard-validate-"+randomStr, testCtx.DefaultNamespace,
 				clusterName, opsv1alpha1.ReconfiguringType)
 			ops.Spec.Reconfigures = []opsv1alpha1.Reconfigure{
@@ -549,7 +556,7 @@ parameter: {
 			Expect(err).ShouldNot(HaveOccurred())
 			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsCreatingPhase))
 
-			By("Action should reject via shard's actual CompDef schema")
+			By("Action should reject via actual shard CompDef schema, not template default")
 			_, err = GetOpsManager().Do(reqCtx, k8sClient, opsRes)
 			Expect(err).ShouldNot(HaveOccurred())
 			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest), func(g Gomega, fetched *opsv1alpha1.OpsRequest) {
@@ -557,6 +564,13 @@ parameter: {
 				condition := meta.FindStatusCondition(fetched.Status.Conditions, opsv1alpha1.ConditionTypeFailed)
 				g.Expect(condition).ShouldNot(BeNil())
 				g.Expect(condition.Message).Should(ContainSubstring("unknown_param"))
+			})).Should(Succeed())
+
+			By("CP desired must NOT contain unknown_param")
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(cpShard), func(g Gomega, cp *parametersv1alpha1.ComponentParameter) {
+				if cp.Spec.Desired != nil && cp.Spec.Desired.Assignments != nil {
+					g.Expect(cp.Spec.Desired.Assignments).ShouldNot(HaveKey("unknown_param"))
+				}
 			})).Should(Succeed())
 		})
 

--- a/pkg/operations/reconfigure_test.go
+++ b/pkg/operations/reconfigure_test.go
@@ -20,11 +20,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package operations
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -33,6 +36,7 @@ import (
 	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/builder"
+	"github.com/apecloud/kubeblocks/pkg/controller/sharding"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	"github.com/apecloud/kubeblocks/pkg/generics"
 	opsutil "github.com/apecloud/kubeblocks/pkg/operations/util"
@@ -302,6 +306,257 @@ parameter: {
 				if cp.Spec.Desired != nil && cp.Spec.Desired.Assignments != nil {
 					g.Expect(cp.Spec.Desired.Assignments).ShouldNot(HaveKey("http_port"))
 				}
+			})).Should(Succeed())
+		})
+
+		It("multi-entry: invalid second entry blocks valid first entry from patching CP", func() {
+			By("create cluster with two components sharing the same compDef")
+			reqCtx := intctrlutil.RequestCtx{Ctx: ctx}
+			compDef := testapps.NewComponentDefinitionFactory(compDefName).
+				SetDefaultSpec().
+				Create(&testCtx).
+				GetObject()
+			pvcSpec := testapps.NewPVCSpec("1Gi")
+			clusterObject := testapps.NewClusterFactory(testCtx.DefaultNamespace, clusterName, "").
+				AddComponent(defaultCompName, compDef.GetName()).
+				SetReplicas(1).
+				AddVolumeClaimTemplate(testapps.DataVolumeName, pvcSpec).
+				AddComponent(secondaryCompName, compDef.GetName()).
+				SetReplicas(1).
+				Create(&testCtx).
+				GetObject()
+			Expect(testapps.ChangeObjStatus(&testCtx, clusterObject, func() {
+				clusterObject.Status.Phase = appsv1.RunningClusterPhase
+				clusterObject.Status.Components = map[string]appsv1.ClusterComponentStatus{
+					defaultCompName:   {Phase: appsv1.RunningComponentPhase},
+					secondaryCompName: {Phase: appsv1.RunningComponentPhase},
+				}
+			})).Should(Succeed())
+			opsRes := &OpsResource{
+				Cluster:  clusterObject,
+				Recorder: k8sManager.GetEventRecorderFor("opsrequest-controller"),
+			}
+			testapps.MockInstanceSetComponent(&testCtx, clusterName, defaultCompName)
+			testapps.MockInstanceSetComponent(&testCtx, clusterName, secondaryCompName)
+
+			By("prepare ParametersDefinition and ComponentParameters for both components")
+			template := testparameters.NewComponentTemplateFactory("mysql-config", testCtx.DefaultNamespace).
+				Create(&testCtx).
+				GetObject()
+			paramsDef := testparameters.NewParametersDefinitionFactory("mysql-params-multi-" + randomStr).
+				SetComponentDefinition(compDefName).
+				SetTemplateName("mysql-config").
+				Schema(`
+parameter: {
+  max_connections?: string
+  gtid_mode?: string
+}`).
+				Create(&testCtx).
+				GetObject()
+			Expect(testapps.ChangeObjStatus(&testCtx, paramsDef, func() {
+				paramsDef.Status.Phase = parametersv1alpha1.PDAvailablePhase
+			})).Should(Succeed())
+			Expect(testapps.GetAndChangeObj(&testCtx, client.ObjectKey{Name: compDefName}, func(cd *appsv1.ComponentDefinition) {
+				cd.Spec.ServiceVersion = "8.0.30"
+				cd.Spec.Configs = []appsv1.ComponentFileTemplate{
+					{
+						Name:            "mysql-config",
+						Template:        template.Name,
+						Namespace:       template.Namespace,
+						VolumeName:      "mysql-config",
+						ExternalManaged: pointer.Bool(true),
+					},
+				}
+			})()).Should(Succeed())
+
+			cpDefault := builder.NewComponentParameterBuilder(testCtx.DefaultNamespace, parameterscore.GenerateComponentConfigurationName(clusterName, defaultCompName)).
+				AddLabelsInMap(constant.GetCompLabelsWithDef(clusterName, defaultCompName, compDefName)).
+				SetClusterName(clusterName).
+				SetCompName(defaultCompName).
+				GetObject()
+			cpDefault.Spec.ConfigItemDetails = []parametersv1alpha1.ConfigTemplateItemDetail{{
+				Name: "mysql-config",
+				ConfigSpec: &appsv1.ComponentFileTemplate{
+					Name: "mysql-config", Template: template.Name, Namespace: template.Namespace,
+					VolumeName: "mysql-config", ExternalManaged: pointer.Bool(true),
+				},
+			}}
+			Expect(testCtx.CreateObj(ctx, cpDefault)).Should(Succeed())
+			Expect(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKeyFromObject(cpDefault), func(cp *parametersv1alpha1.ComponentParameter) {
+				cp.Status.ObservedGeneration = cp.Generation
+				cp.Status.Phase = parametersv1alpha1.CFinishedPhase
+				cp.Status.ConfigurationItemStatus = []parametersv1alpha1.ConfigTemplateItemDetailStatus{{
+					Name: "mysql-config", Phase: parametersv1alpha1.CFinishedPhase,
+				}}
+			})()).Should(Succeed())
+
+			cpSecondary := builder.NewComponentParameterBuilder(testCtx.DefaultNamespace, parameterscore.GenerateComponentConfigurationName(clusterName, secondaryCompName)).
+				AddLabelsInMap(constant.GetCompLabelsWithDef(clusterName, secondaryCompName, compDefName)).
+				SetClusterName(clusterName).
+				SetCompName(secondaryCompName).
+				GetObject()
+			cpSecondary.Spec.ConfigItemDetails = []parametersv1alpha1.ConfigTemplateItemDetail{{
+				Name: "mysql-config",
+				ConfigSpec: &appsv1.ComponentFileTemplate{
+					Name: "mysql-config", Template: template.Name, Namespace: template.Namespace,
+					VolumeName: "mysql-config", ExternalManaged: pointer.Bool(true),
+				},
+			}}
+			Expect(testCtx.CreateObj(ctx, cpSecondary)).Should(Succeed())
+			Expect(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKeyFromObject(cpSecondary), func(cp *parametersv1alpha1.ComponentParameter) {
+				cp.Status.ObservedGeneration = cp.Generation
+				cp.Status.Phase = parametersv1alpha1.CFinishedPhase
+				cp.Status.ConfigurationItemStatus = []parametersv1alpha1.ConfigTemplateItemDetailStatus{{
+					Name: "mysql-config", Phase: parametersv1alpha1.CFinishedPhase,
+				}}
+			})()).Should(Succeed())
+
+			By("create OpsRequest: entry[0] valid for default, entry[1] invalid for secondary")
+			ops := testops.NewOpsRequestObj("multi-entry-"+randomStr, testCtx.DefaultNamespace,
+				clusterName, opsv1alpha1.ReconfiguringType)
+			ops.Spec.Reconfigures = []opsv1alpha1.Reconfigure{
+				{
+					ComponentOps: opsv1alpha1.ComponentOps{ComponentName: defaultCompName},
+					Parameters:   []opsv1alpha1.ParameterPair{{Key: "max_connections", Value: pointer.String("200")}},
+				},
+				{
+					ComponentOps: opsv1alpha1.ComponentOps{ComponentName: secondaryCompName},
+					Parameters:   []opsv1alpha1.ParameterPair{{Key: "http_port", Value: pointer.String("9999")}},
+				},
+			}
+			opsRes.OpsRequest = testops.CreateOpsRequest(ctx, testCtx, ops)
+			Expect(opsutil.UpdateClusterOpsAnnotations(ctx, k8sClient, opsRes.Cluster, nil)).Should(Succeed())
+
+			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsPendingPhase
+			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsCreatingPhase))
+
+			By("Action should fail on the invalid second entry")
+			_, err = GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest), func(g Gomega, fetched *opsv1alpha1.OpsRequest) {
+				g.Expect(fetched.Status.Phase).Should(Equal(opsv1alpha1.OpsFailedPhase))
+				condition := meta.FindStatusCondition(fetched.Status.Conditions, opsv1alpha1.ConditionTypeFailed)
+				g.Expect(condition).ShouldNot(BeNil())
+				g.Expect(condition.Message).Should(ContainSubstring("http_port"))
+			})).Should(Succeed())
+
+			By("first entry CP desired must NOT be patched either")
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(cpDefault), func(g Gomega, cp *parametersv1alpha1.ComponentParameter) {
+				if cp.Spec.Desired != nil && cp.Spec.Desired.Assignments != nil {
+					g.Expect(cp.Spec.Desired.Assignments).ShouldNot(HaveKey("max_connections"))
+				}
+			})).Should(Succeed())
+		})
+
+		It("sharding: validates against actual shard ComponentDefinition", func() {
+			By("create a cluster with a sharding spec")
+			reqCtx := intctrlutil.RequestCtx{Ctx: ctx}
+			compDef := testapps.NewComponentDefinitionFactory(compDefName).
+				SetDefaultSpec().
+				Create(&testCtx).
+				GetObject()
+			clusterObject := testapps.NewClusterFactory(testCtx.DefaultNamespace, clusterName, "").
+				AddSharding(defaultCompName, "", compDef.GetName()).
+				Create(&testCtx).
+				GetObject()
+			Expect(testapps.ChangeObjStatus(&testCtx, clusterObject, func() {
+				clusterObject.Status.Phase = appsv1.RunningClusterPhase
+			})).Should(Succeed())
+			opsRes := &OpsResource{
+				Cluster:  clusterObject,
+				Recorder: k8sManager.GetEventRecorderFor("opsrequest-controller"),
+			}
+
+			By("create a shard Component with the actual CompDef")
+			shardShortName := fmt.Sprintf("%s-%s", defaultCompName, rand.String(sharding.ShardIDLength))
+			shardFullName := fmt.Sprintf("%s-%s", clusterName, shardShortName)
+			testapps.NewComponentFactory(testCtx.DefaultNamespace, shardFullName, compDef.GetName()).
+				AddLabels(constant.AppManagedByLabelKey, constant.AppName).
+				AddLabels(constant.AppInstanceLabelKey, clusterName).
+				AddLabels(constant.KBAppClusterUIDKey, string(clusterObject.UID)).
+				AddLabels(constant.KBAppShardingNameLabelKey, defaultCompName).
+				AddLabels(constant.KBAppComponentLabelKey, shardShortName).
+				SetReplicas(1).
+				Create(&testCtx)
+
+			By("prepare ParametersDefinition with schema")
+			template := testparameters.NewComponentTemplateFactory("mysql-config", testCtx.DefaultNamespace).
+				Create(&testCtx).
+				GetObject()
+			paramsDef := testparameters.NewParametersDefinitionFactory("mysql-params-shard-" + randomStr).
+				SetComponentDefinition(compDefName).
+				SetTemplateName("mysql-config").
+				Schema(`
+parameter: {
+  max_connections?: string
+  gtid_mode?: string
+}`).
+				Create(&testCtx).
+				GetObject()
+			Expect(testapps.ChangeObjStatus(&testCtx, paramsDef, func() {
+				paramsDef.Status.Phase = parametersv1alpha1.PDAvailablePhase
+			})).Should(Succeed())
+			Expect(testapps.GetAndChangeObj(&testCtx, client.ObjectKey{Name: compDefName}, func(cd *appsv1.ComponentDefinition) {
+				cd.Spec.ServiceVersion = "8.0.30"
+				cd.Spec.Configs = []appsv1.ComponentFileTemplate{
+					{
+						Name:            "mysql-config",
+						Template:        template.Name,
+						Namespace:       template.Namespace,
+						VolumeName:      "mysql-config",
+						ExternalManaged: pointer.Bool(true),
+					},
+				}
+			})()).Should(Succeed())
+
+			cpShard := builder.NewComponentParameterBuilder(testCtx.DefaultNamespace, parameterscore.GenerateComponentConfigurationName(clusterName, shardShortName)).
+				AddLabelsInMap(constant.GetCompLabelsWithDef(clusterName, shardShortName, compDefName)).
+				SetClusterName(clusterName).
+				SetCompName(shardShortName).
+				GetObject()
+			cpShard.Spec.ConfigItemDetails = []parametersv1alpha1.ConfigTemplateItemDetail{{
+				Name: "mysql-config",
+				ConfigSpec: &appsv1.ComponentFileTemplate{
+					Name: "mysql-config", Template: template.Name, Namespace: template.Namespace,
+					VolumeName: "mysql-config", ExternalManaged: pointer.Bool(true),
+				},
+			}}
+			Expect(testCtx.CreateObj(ctx, cpShard)).Should(Succeed())
+			Expect(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKeyFromObject(cpShard), func(cp *parametersv1alpha1.ComponentParameter) {
+				cp.Status.ObservedGeneration = cp.Generation
+				cp.Status.Phase = parametersv1alpha1.CFinishedPhase
+				cp.Status.ConfigurationItemStatus = []parametersv1alpha1.ConfigTemplateItemDetailStatus{{
+					Name: "mysql-config", Phase: parametersv1alpha1.CFinishedPhase,
+				}}
+			})()).Should(Succeed())
+
+			By("reconfigure the sharding name with an unknown parameter")
+			ops := testops.NewOpsRequestObj("shard-validate-"+randomStr, testCtx.DefaultNamespace,
+				clusterName, opsv1alpha1.ReconfiguringType)
+			ops.Spec.Reconfigures = []opsv1alpha1.Reconfigure{
+				{
+					ComponentOps: opsv1alpha1.ComponentOps{ComponentName: defaultCompName},
+					Parameters:   []opsv1alpha1.ParameterPair{{Key: "unknown_param", Value: pointer.String("1")}},
+				},
+			}
+			opsRes.OpsRequest = testops.CreateOpsRequest(ctx, testCtx, ops)
+			Expect(opsutil.UpdateClusterOpsAnnotations(ctx, k8sClient, opsRes.Cluster, nil)).Should(Succeed())
+
+			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsPendingPhase
+			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsCreatingPhase))
+
+			By("Action should reject via shard's actual CompDef schema")
+			_, err = GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest), func(g Gomega, fetched *opsv1alpha1.OpsRequest) {
+				g.Expect(fetched.Status.Phase).Should(Equal(opsv1alpha1.OpsFailedPhase))
+				condition := meta.FindStatusCondition(fetched.Status.Conditions, opsv1alpha1.ConditionTypeFailed)
+				g.Expect(condition).ShouldNot(BeNil())
+				g.Expect(condition.Message).Should(ContainSubstring("unknown_param"))
 			})).Should(Succeed())
 		})
 

--- a/pkg/operations/reconfigure_test.go
+++ b/pkg/operations/reconfigure_test.go
@@ -202,6 +202,109 @@ parameter: {
 			Expect(err).Should(BeNil())
 		})
 
+		It("rejects unknown parameter before patching CP desired", func() {
+			By("init operations resources ")
+			reqCtx := intctrlutil.RequestCtx{Ctx: ctx}
+			opsRes, _, _ := initOperationsResources(compDefName, clusterName)
+			testapps.MockInstanceSetComponent(&testCtx, clusterName, defaultCompName)
+
+			By("prepare configuration metadata and component parameter")
+			template := testparameters.NewComponentTemplateFactory("mysql-config", testCtx.DefaultNamespace).
+				Create(&testCtx).
+				GetObject()
+			paramsDef := testparameters.NewParametersDefinitionFactory("mysql-params-prevalidate-" + randomStr).
+				SetComponentDefinition(compDefName).
+				SetTemplateName("mysql-config").
+				Schema(`
+parameter: {
+  max_connections?: string
+  gtid_mode?: string
+}`).
+				Create(&testCtx).
+				GetObject()
+			Expect(testapps.ChangeObjStatus(&testCtx, paramsDef, func() {
+				paramsDef.Status.Phase = parametersv1alpha1.PDAvailablePhase
+			})).Should(Succeed())
+			Expect(testapps.GetAndChangeObj(&testCtx, client.ObjectKey{Name: compDefName}, func(compDef *appsv1.ComponentDefinition) {
+				compDef.Spec.ServiceVersion = "8.0.30"
+				compDef.Spec.Configs = []appsv1.ComponentFileTemplate{
+					{
+						Name:            "mysql-config",
+						Template:        template.Name,
+						Namespace:       template.Namespace,
+						VolumeName:      "mysql-config",
+						ExternalManaged: pointer.Bool(true),
+					},
+				}
+			})()).Should(Succeed())
+
+			componentParameter := builder.NewComponentParameterBuilder(testCtx.DefaultNamespace, parameterscore.GenerateComponentConfigurationName(clusterName, defaultCompName)).
+				AddLabelsInMap(constant.GetCompLabelsWithDef(clusterName, defaultCompName, compDefName)).
+				SetClusterName(clusterName).
+				SetCompName(defaultCompName).
+				GetObject()
+			componentParameter.Spec.ConfigItemDetails = []parametersv1alpha1.ConfigTemplateItemDetail{{
+				Name: "mysql-config",
+				ConfigSpec: &appsv1.ComponentFileTemplate{
+					Name:            "mysql-config",
+					Template:        template.Name,
+					Namespace:       template.Namespace,
+					VolumeName:      "mysql-config",
+					ExternalManaged: pointer.Bool(true),
+				},
+			}}
+			Expect(testCtx.CreateObj(ctx, componentParameter)).Should(Succeed())
+
+			Expect(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKeyFromObject(componentParameter), func(cp *parametersv1alpha1.ComponentParameter) {
+				cp.Status.ObservedGeneration = cp.Generation
+				cp.Status.Phase = parametersv1alpha1.CFinishedPhase
+				cp.Status.ConfigurationItemStatus = []parametersv1alpha1.ConfigTemplateItemDetailStatus{{
+					Name:  cp.Spec.ConfigItemDetails[0].Name,
+					Phase: parametersv1alpha1.CFinishedPhase,
+				}}
+			})()).Should(Succeed())
+
+			By("create reconfigure with unknown parameter http_port")
+			ops := testops.NewOpsRequestObj("reject-unknown-"+randomStr, testCtx.DefaultNamespace,
+				clusterName, opsv1alpha1.ReconfiguringType)
+			ops.Spec.Reconfigures = []opsv1alpha1.Reconfigure{
+				{
+					ComponentOps: opsv1alpha1.ComponentOps{ComponentName: defaultCompName},
+					Parameters: []opsv1alpha1.ParameterPair{
+						{
+							Key:   "http_port",
+							Value: pointer.String("9999"),
+						},
+					},
+				},
+			}
+			opsRes.OpsRequest = testops.CreateOpsRequest(ctx, testCtx, ops)
+			Expect(opsutil.UpdateClusterOpsAnnotations(ctx, k8sClient, opsRes.Cluster, nil)).Should(Succeed())
+
+			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsPendingPhase
+			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsCreatingPhase))
+
+			By("Action should reject the unknown parameter with a fatal error")
+			_, err = GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest), func(g Gomega, fetched *opsv1alpha1.OpsRequest) {
+				g.Expect(fetched.Status.Phase).Should(Equal(opsv1alpha1.OpsFailedPhase))
+				condition := meta.FindStatusCondition(fetched.Status.Conditions, opsv1alpha1.ConditionTypeFailed)
+				g.Expect(condition).ShouldNot(BeNil())
+				g.Expect(condition.Message).Should(ContainSubstring("http_port"))
+			})).Should(Succeed())
+
+			By("CP desired must NOT contain http_port")
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(componentParameter), func(g Gomega, cp *parametersv1alpha1.ComponentParameter) {
+				if cp.Spec.Desired != nil && cp.Spec.Desired.Assignments != nil {
+					g.Expect(cp.Spec.Desired.Assignments).ShouldNot(HaveKey("http_port"))
+				}
+			})).Should(Succeed())
+		})
+
 		It("propagates ComponentParameter merge failure", func() {
 			By("init operations resources ")
 			reqCtx := intctrlutil.RequestCtx{Ctx: ctx}


### PR DESCRIPTION
## Summary

- Separate `Action()` into validate-all then apply-all (two-pass) so that an invalid parameter in a later Reconfigure entry cannot leave dirty `ComponentParameter.spec.desired` from an earlier entry.
- For sharding, resolve each shard's actual `ComponentDefinition` via `ListShardingComponents` for schema validation, instead of using only the sharding template default.
- Add three new test cases covering: single invalid parameter rejection, multi-entry first-valid/second-invalid no-dirty-CP invariant, and sharding with distinct template vs actual CompDef regression guard.

## Problem

The original PR #10415 had two P1 issues identified by @leon-ape:
1. Validation and patching were interleaved in a single loop — if entry[0] patched CP desired and entry[1] failed validation, entry[0]'s dirty write remained.
2. Sharding validation only checked the template default ComponentDefinition, missing heterogeneous shard CompDefs.

## Solution

**Pass 1** iterates all `Reconfigure` entries and calls `validateReconfigureParameters()` which resolves the actual ComponentDefinition(s), loads their `ParametersDefinition` JSON schema, and validates parameter assignments. Any failure returns a fatal error immediately — no CP is touched.

**Pass 2** only runs after all validations pass, applying patches via `applyReconfigureToParameters()`.

For sharding, `resolveCompDefNames()` calls `sharding.ListShardingComponents()` to get the real `Component` objects and their `Spec.CompDef`, collecting unique CompDef names for validation.

## Test plan

- [x] `rejects unknown parameter before patching CP desired` — single invalid param rejected, CP desired clean
- [x] `multi-entry: invalid second entry blocks valid first entry from patching CP` — two components, first valid + second invalid, neither CP patched
- [x] `sharding: validates against actual shard ComponentDefinition, not template default` — template CompDef has no schema, actual shard CompDef has strict schema; only the ListShardingComponents path rejects unknown_param
- [x] Existing `Test Reconfigure OpsRequest` and `propagates ComponentParameter merge failure` still pass
- [x] `go build`, `go vet`, `git diff --check` clean
- [x] Jade peer review: no design-contract blocker

Supersedes #10415 (addresses P1 review comments).