### PR TITLE
fix(parameters): handle uint64 schema validation at shared boundary

### DIFF
--- a/pkg/common/openapiv3schema.go
+++ b/pkg/common/openapiv3schema.go
@@ -53,7 +53,7 @@ func ValidateDataWithSchema(openAPIV3Schema *apiextensionsv1.JSONSchemaProps, da
 		// throw the head error
 		return res.Errors[0]
 	}
-	return nil
+	return validateLargeIntegerBounds(openAPIV3Schema, data)
 }
 
 func ConvertStringToInterfaceBySchemaType(openAPIV3Schema *apiextensionsv1.JSONSchemaProps, input map[string]string) (map[string]interface{}, error) {
@@ -116,9 +116,8 @@ func isUnsignedByBounds(prop apiextensionsv1.JSONSchemaProps) bool {
 // stripIntegerOverflow removes Maximum from integer properties whose Maximum
 // >= 2^63. kube-openapi internally converts float64 Maximum to int64;
 // float64(MaxInt64) rounds to 2^63 and float64(MaxUint64) rounds to 2^64,
-// both of which overflow int64. Stripping is safe because the integer range
-// is already enforced by ParseInt/ParseUint at the conversion layer.
-// User-defined maximums below 2^63 are preserved.
+// both of which overflow int64. User-declared maximums that were stripped
+// are enforced separately by validateLargeIntegerBounds.
 func stripIntegerOverflow(schema *apiextensionsv1.JSONSchemaProps) *apiextensionsv1.JSONSchemaProps {
 	if schema == nil {
 		return nil
@@ -142,4 +141,46 @@ func stripIntegerOverflow(schema *apiextensionsv1.JSONSchemaProps) *apiextension
 		}
 	}
 	return out
+}
+
+// validateLargeIntegerBounds enforces original Maximum for integer properties
+// whose Maximum was >= 2^63 (stripped by stripIntegerOverflow to prevent
+// kube-openapi int64 overflow). CUE type extrema (2^63 for int64, 2^64 for
+// uint64) are skipped because ParseInt/ParseUint already enforce type range.
+func validateLargeIntegerBounds(schema *apiextensionsv1.JSONSchemaProps, data interface{}) error {
+	dataMap, ok := data.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	for k, prop := range schema.Properties {
+		if prop.Type != "integer" || prop.Maximum == nil || *prop.Maximum < math.Exp2(63) {
+			continue
+		}
+		if *prop.Maximum == math.Exp2(63) || *prop.Maximum == math.Exp2(64) {
+			continue
+		}
+		val, exists := dataMap[k]
+		if !exists {
+			continue
+		}
+		var f float64
+		switch v := val.(type) {
+		case int64:
+			f = float64(v)
+		case uint64:
+			f = float64(v)
+		default:
+			continue
+		}
+		if prop.ExclusiveMaximum {
+			if f >= *prop.Maximum {
+				return fmt.Errorf("%s: must be less than %g", k, *prop.Maximum)
+			}
+		} else {
+			if f > *prop.Maximum {
+				return fmt.Errorf("%s: must be less than or equal to %g", k, *prop.Maximum)
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/common/openapiv3schema.go
+++ b/pkg/common/openapiv3schema.go
@@ -21,6 +21,7 @@ package common
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -37,8 +38,9 @@ func ValidateDataWithSchema(openAPIV3Schema *apiextensionsv1.JSONSchemaProps, da
 	if openAPIV3Schema == nil {
 		return fmt.Errorf("openAPIV3Schema can not be empty")
 	}
+	sanitized := stripIntegerOverflow(openAPIV3Schema)
 	out := &apiextensions.JSONSchemaProps{}
-	if err := apiextensionsv1.Convert_v1_JSONSchemaProps_To_apiextensions_JSONSchemaProps(openAPIV3Schema, out, nil); err != nil {
+	if err := apiextensionsv1.Convert_v1_JSONSchemaProps_To_apiextensions_JSONSchemaProps(sanitized, out, nil); err != nil {
 		return err
 	}
 	openapiSchema := &spec.Schema{}
@@ -68,7 +70,11 @@ func ConvertStringToInterfaceBySchemaType(openAPIV3Schema *apiextensionsv1.JSONS
 		}
 		switch p.Type {
 		case "integer":
-			out[k], err = strconv.ParseInt(v, 10, 64)
+			if IsUnsignedIntegerFormat(p.Format) || isUnsignedByBounds(p) {
+				out[k], err = strconv.ParseUint(v, 10, 64)
+			} else {
+				out[k], err = strconv.ParseInt(v, 10, 64)
+			}
 		case "number":
 			out[k], err = strconv.ParseFloat(v, 64)
 		case "boolean":
@@ -84,4 +90,56 @@ func ConvertStringToInterfaceBySchemaType(openAPIV3Schema *apiextensionsv1.JSONS
 		}
 	}
 	return out, nil
+}
+
+func IsUnsignedIntegerFormat(format string) bool {
+	switch format {
+	case "uint", "uint8", "uint16", "uint32", "uint64":
+		return true
+	}
+	return false
+}
+
+// IsUnsignedInteger returns true if the schema represents an unsigned integer,
+// detected by explicit Format or by CUE-generated bounds (Minimum >= 0, Maximum > 2^63).
+func IsUnsignedInteger(prop apiextensionsv1.JSONSchemaProps) bool {
+	return IsUnsignedIntegerFormat(prop.Format) || isUnsignedByBounds(prop)
+}
+
+// isUnsignedByBounds detects CUE-generated uint64 schemas by their bounds:
+// Minimum >= 0 and Maximum above the signed int64 range.
+func isUnsignedByBounds(prop apiextensionsv1.JSONSchemaProps) bool {
+	return prop.Minimum != nil && *prop.Minimum >= 0 &&
+		prop.Maximum != nil && *prop.Maximum > math.Exp2(63)
+}
+
+// stripIntegerOverflow removes Maximum from integer properties whose Maximum
+// >= 2^63. kube-openapi internally converts float64 Maximum to int64;
+// float64(MaxInt64) rounds to 2^63 and float64(MaxUint64) rounds to 2^64,
+// both of which overflow int64. Stripping is safe because the integer range
+// is already enforced by ParseInt/ParseUint at the conversion layer.
+// User-defined maximums below 2^63 are preserved.
+func stripIntegerOverflow(schema *apiextensionsv1.JSONSchemaProps) *apiextensionsv1.JSONSchemaProps {
+	if schema == nil {
+		return nil
+	}
+	needsCopy := false
+	for _, prop := range schema.Properties {
+		if prop.Type == "integer" && prop.Maximum != nil && *prop.Maximum >= math.Exp2(63) {
+			needsCopy = true
+			break
+		}
+	}
+	if !needsCopy {
+		return schema
+	}
+	out := schema.DeepCopy()
+	for k, prop := range out.Properties {
+		if prop.Type == "integer" && prop.Maximum != nil && *prop.Maximum >= math.Exp2(63) {
+			prop.Maximum = nil
+			prop.ExclusiveMaximum = false
+			out.Properties[k] = prop
+		}
+	}
+	return out
 }

--- a/pkg/common/openapiv3schema.go
+++ b/pkg/common/openapiv3schema.go
@@ -163,13 +163,8 @@ func validateLargeIntegerBounds(schema *apiextensionsv1.JSONSchemaProps, data in
 		if !exists {
 			continue
 		}
-		var f float64
-		switch v := val.(type) {
-		case int64:
-			f = float64(v)
-		case uint64:
-			f = float64(v)
-		default:
+		f, ok := toFloat64(val)
+		if !ok {
 			continue
 		}
 		if prop.ExclusiveMaximum {
@@ -183,4 +178,26 @@ func validateLargeIntegerBounds(schema *apiextensionsv1.JSONSchemaProps, data in
 		}
 	}
 	return nil
+}
+
+func toFloat64(val interface{}) (float64, bool) {
+	switch v := val.(type) {
+	case float64:
+		return v, true
+	case float32:
+		return float64(v), true
+	case int64:
+		return float64(v), true
+	case uint64:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	case int32:
+		return float64(v), true
+	case uint:
+		return float64(v), true
+	case uint32:
+		return float64(v), true
+	}
+	return 0, false
 }

--- a/pkg/common/openapiv3schema_test.go
+++ b/pkg/common/openapiv3schema_test.go
@@ -254,6 +254,19 @@ func TestValidateLargeIntegerBounds(t *testing.T) {
 	if err := validateLargeIntegerBounds(cueI64Schema, map[string]interface{}{"cue_i64": int64(math.MaxInt64)}); err != nil {
 		t.Fatalf("expected CUE int64 extremum to be skipped, got %v", err)
 	}
+
+	// float64 value (JSON/YAML parser output) within user max should pass
+	if err := validateLargeIntegerBounds(schema, map[string]interface{}{"custom_max": float64(9e18)}); err != nil {
+		t.Fatalf("expected float64 value within user max to pass, got %v", err)
+	}
+	// float64 value above user max should fail
+	if err := validateLargeIntegerBounds(schema, map[string]interface{}{"custom_max": float64(1.1e19)}); err == nil {
+		t.Fatalf("expected float64 value above user max to be rejected")
+	}
+	// int value (YAML parser output) within user max should pass
+	if err := validateLargeIntegerBounds(schema, map[string]interface{}{"custom_max": int(100)}); err != nil {
+		t.Fatalf("expected int value within user max to pass, got %v", err)
+	}
 }
 
 func TestValidateDataWithSchemaUserDeclaredLargeMax(t *testing.T) {
@@ -276,6 +289,29 @@ func TestValidateDataWithSchemaUserDeclaredLargeMax(t *testing.T) {
 	// Value above user max fails end-to-end
 	if err := ValidateDataWithSchema(schema, map[string]interface{}{"max_items": uint64(11e18)}); err == nil {
 		t.Fatalf("expected value above user-declared max to be rejected")
+	}
+}
+
+func TestValidateDataWithSchemaIntTypeLargeMax(t *testing.T) {
+	userMax := float64(1e19)
+	schema := &apiextensionsv1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]apiextensionsv1.JSONSchemaProps{
+			"max_items": {
+				Type:    "integer",
+				Minimum: ptrFloat64(0),
+				Maximum: &userMax,
+			},
+		},
+	}
+
+	// int value within user max passes end-to-end (YAML parser produces int)
+	if err := ValidateDataWithSchema(schema, map[string]interface{}{"max_items": int(100)}); err != nil {
+		t.Fatalf("expected int value within user max to pass, got %v", err)
+	}
+	// int32 value passes end-to-end
+	if err := ValidateDataWithSchema(schema, map[string]interface{}{"max_items": int32(100)}); err != nil {
+		t.Fatalf("expected int32 value within user max to pass, got %v", err)
 	}
 }
 

--- a/pkg/common/openapiv3schema_test.go
+++ b/pkg/common/openapiv3schema_test.go
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package common
 
 import (
+	"math"
 	"reflect"
 	"strings"
 	"testing"
@@ -84,6 +85,120 @@ func TestConvertStringToInterfaceBySchemaType(t *testing.T) {
 	_, err = ConvertStringToInterfaceBySchemaType(schema, map[string]string{"replicas": "bad"})
 	if err == nil || !strings.Contains(err.Error(), `convert "replicas" failed`) {
 		t.Fatalf("expected conversion error for replicas, got %v", err)
+	}
+}
+
+func TestConvertStringToInterfaceBySchemaTypeUint64(t *testing.T) {
+	schema := &apiextensionsv1.JSONSchemaProps{
+		Properties: map[string]apiextensionsv1.JSONSchemaProps{
+			"max_queries": {
+				Type:    "integer",
+				Minimum: ptrFloat64(0),
+				Maximum: ptrFloat64(float64(math.MaxUint64)),
+			},
+		},
+	}
+
+	got, err := ConvertStringToInterfaceBySchemaType(schema, map[string]string{"max_queries": "50"})
+	if err != nil {
+		t.Fatalf("expected uint64 parse to succeed, got %v", err)
+	}
+	if got["max_queries"] != uint64(50) {
+		t.Fatalf("expected uint64(50), got %T(%v)", got["max_queries"], got["max_queries"])
+	}
+
+	_, err = ConvertStringToInterfaceBySchemaType(schema, map[string]string{"max_queries": "-1"})
+	if err == nil {
+		t.Fatalf("expected parse error for negative value with uint64 bounds")
+	}
+
+	got, err = ConvertStringToInterfaceBySchemaType(schema, map[string]string{"max_queries": "9223372036854775808"})
+	if err != nil {
+		t.Fatalf("expected value above MaxInt64 to parse as uint64, got %v", err)
+	}
+	if got["max_queries"] != uint64(9223372036854775808) {
+		t.Fatalf("expected uint64(9223372036854775808), got %T(%v)", got["max_queries"], got["max_queries"])
+	}
+}
+
+func TestValidateDataWithSchemaUint64(t *testing.T) {
+	schema := &apiextensionsv1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]apiextensionsv1.JSONSchemaProps{
+			"max_queries": {
+				Type:    "integer",
+				Minimum: ptrFloat64(0),
+				Maximum: ptrFloat64(float64(math.MaxUint64)),
+			},
+		},
+	}
+
+	if err := ValidateDataWithSchema(schema, map[string]interface{}{"max_queries": uint64(50)}); err != nil {
+		t.Fatalf("expected uint64(50) to pass validation, got %v", err)
+	}
+	if err := ValidateDataWithSchema(schema, map[string]interface{}{"max_queries": uint64(math.MaxInt64) + 1}); err != nil {
+		t.Fatalf("expected uint64 above MaxInt64 to pass validation, got %v", err)
+	}
+}
+
+func TestValidateDataWithSchemaInt64(t *testing.T) {
+	schema := &apiextensionsv1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]apiextensionsv1.JSONSchemaProps{
+			"count": {
+				Type:    "integer",
+				Minimum: ptrFloat64(float64(-math.MaxInt64)),
+				Maximum: ptrFloat64(float64(math.MaxInt64)),
+			},
+		},
+	}
+
+	if err := ValidateDataWithSchema(schema, map[string]interface{}{"count": int64(50)}); err != nil {
+		t.Fatalf("expected int64(50) to pass validation, got %v", err)
+	}
+}
+
+func TestStripIntegerOverflow(t *testing.T) {
+	schema := &apiextensionsv1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]apiextensionsv1.JSONSchemaProps{
+			"u64_field": {
+				Type:    "integer",
+				Minimum: ptrFloat64(0),
+				Maximum: ptrFloat64(float64(math.MaxUint64)),
+			},
+			"i64_field": {
+				Type:    "integer",
+				Maximum: ptrFloat64(100),
+			},
+			"i64_cue": {
+				Type:    "integer",
+				Minimum: ptrFloat64(float64(-math.MaxInt64)),
+				Maximum: ptrFloat64(float64(math.MaxInt64)),
+			},
+			"custom_small": {
+				Type:    "integer",
+				Minimum: ptrFloat64(0),
+				Maximum: ptrFloat64(1000),
+			},
+		},
+	}
+
+	result := stripIntegerOverflow(schema)
+	if result.Properties["u64_field"].Maximum != nil {
+		t.Fatalf("expected u64_field Maximum to be stripped (overflow)")
+	}
+	if result.Properties["i64_field"].Maximum == nil || *result.Properties["i64_field"].Maximum != 100 {
+		t.Fatalf("expected i64_field Maximum to be preserved")
+	}
+	if result.Properties["i64_cue"].Maximum != nil {
+		t.Fatalf("expected i64_cue Maximum to be stripped (float64(MaxInt64) rounds to 2^63)")
+	}
+	if result.Properties["custom_small"].Maximum == nil || *result.Properties["custom_small"].Maximum != 1000 {
+		t.Fatalf("expected custom_small Maximum to be preserved (below 2^63)")
+	}
+	if schema.Properties["u64_field"].Maximum == nil {
+		t.Fatalf("expected original schema to be unchanged")
 	}
 }
 

--- a/pkg/common/openapiv3schema_test.go
+++ b/pkg/common/openapiv3schema_test.go
@@ -202,6 +202,83 @@ func TestStripIntegerOverflow(t *testing.T) {
 	}
 }
 
+func TestValidateLargeIntegerBounds(t *testing.T) {
+	// User-declared maximum 1e19 (not a CUE extremum) must be enforced
+	userMax := float64(1e19)
+	schema := &apiextensionsv1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]apiextensionsv1.JSONSchemaProps{
+			"custom_max": {
+				Type:    "integer",
+				Minimum: ptrFloat64(0),
+				Maximum: &userMax,
+			},
+		},
+	}
+
+	// Value within user-declared max should pass
+	if err := validateLargeIntegerBounds(schema, map[string]interface{}{"custom_max": uint64(9e18)}); err != nil {
+		t.Fatalf("expected value within user max to pass, got %v", err)
+	}
+	// Value above user-declared max should fail
+	if err := validateLargeIntegerBounds(schema, map[string]interface{}{"custom_max": uint64(11e18)}); err == nil {
+		t.Fatalf("expected value above user max to be rejected")
+	}
+
+	// CUE uint64 extremum (2^64) should be skipped (not enforced manually)
+	cueSchema := &apiextensionsv1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]apiextensionsv1.JSONSchemaProps{
+			"cue_u64": {
+				Type:    "integer",
+				Minimum: ptrFloat64(0),
+				Maximum: ptrFloat64(math.Exp2(64)),
+			},
+		},
+	}
+	if err := validateLargeIntegerBounds(cueSchema, map[string]interface{}{"cue_u64": uint64(math.MaxUint64)}); err != nil {
+		t.Fatalf("expected CUE uint64 extremum to be skipped, got %v", err)
+	}
+
+	// CUE int64 extremum (2^63) should be skipped
+	cueI64Schema := &apiextensionsv1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]apiextensionsv1.JSONSchemaProps{
+			"cue_i64": {
+				Type:    "integer",
+				Minimum: ptrFloat64(-math.Exp2(63)),
+				Maximum: ptrFloat64(math.Exp2(63)),
+			},
+		},
+	}
+	if err := validateLargeIntegerBounds(cueI64Schema, map[string]interface{}{"cue_i64": int64(math.MaxInt64)}); err != nil {
+		t.Fatalf("expected CUE int64 extremum to be skipped, got %v", err)
+	}
+}
+
+func TestValidateDataWithSchemaUserDeclaredLargeMax(t *testing.T) {
+	userMax := float64(1e19)
+	schema := &apiextensionsv1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]apiextensionsv1.JSONSchemaProps{
+			"max_items": {
+				Type:    "integer",
+				Minimum: ptrFloat64(0),
+				Maximum: &userMax,
+			},
+		},
+	}
+
+	// Value within user max passes end-to-end
+	if err := ValidateDataWithSchema(schema, map[string]interface{}{"max_items": uint64(9e18)}); err != nil {
+		t.Fatalf("expected value within user max to pass, got %v", err)
+	}
+	// Value above user max fails end-to-end
+	if err := ValidateDataWithSchema(schema, map[string]interface{}{"max_items": uint64(11e18)}); err == nil {
+		t.Fatalf("expected value above user-declared max to be rejected")
+	}
+}
+
 func ptrFloat64(v float64) *float64 {
 	return &v
 }

--- a/pkg/parameters/parameter_assignment_test.go
+++ b/pkg/parameters/parameter_assignment_test.go
@@ -20,6 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package parameters
 
 import (
+	"fmt"
+	"math"
 	"testing"
 
 	"k8s.io/utils/pointer"
@@ -99,6 +101,56 @@ parameter: {
 				"not-a-real-parameter": nil,
 			},
 			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateComponentParameterAssignments(tt.assignments, []*parametersv1alpha1.ParametersDefinition{paramsDef})
+			if tt.wantErr && err == nil {
+				t.Fatalf("expected validation error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("expected no validation error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateComponentParameterAssignmentsUint64(t *testing.T) {
+	paramsDef := testparameters.NewParametersDefinitionFactory("clickhouse-params").
+		SetTemplateName("clickhouse-config").
+		SetConfigFile("config.xml").
+		SetFileFormatConfig(parametersv1alpha1.FileFormatConfig{Format: parametersv1alpha1.XML}).
+		Schema(`
+parameter: {
+  max_concurrent_queries?: uint64 | *0
+}`).
+		GetObject()
+
+	tests := []struct {
+		name        string
+		assignments parametersv1alpha1.ComponentParameters
+		wantErr     bool
+	}{
+		{
+			name: "valid uint64 value",
+			assignments: parametersv1alpha1.ComponentParameters{
+				"max_concurrent_queries": pointer.String("50"),
+			},
+		},
+		{
+			name: "reject negative value for uint64",
+			assignments: parametersv1alpha1.ComponentParameters{
+				"max_concurrent_queries": pointer.String("-1"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "accept value above MaxInt64",
+			assignments: parametersv1alpha1.ComponentParameters{
+				"max_concurrent_queries": pointer.String(fmt.Sprintf("%d", uint64(math.MaxInt64)+1)),
+			},
 		},
 	}
 

--- a/pkg/parameters/value_transformer.go
+++ b/pkg/parameters/value_transformer.go
@@ -25,6 +25,7 @@ import (
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/common"
 	"github.com/apecloud/kubeblocks/pkg/generics"
 	"github.com/apecloud/kubeblocks/pkg/parameters/core"
 	"github.com/apecloud/kubeblocks/pkg/parameters/openapi"
@@ -43,6 +44,9 @@ func (d *defaultValueTransformer) resolveValueWithType(value string, fieldName s
 	default:
 		return value, nil
 	case "integer":
+		if common.IsUnsignedInteger(schema) {
+			return strconv.ParseUint(value, 10, 64)
+		}
 		return strconv.ParseInt(value, 10, 64)
 	case "number":
 		return strconv.ParseFloat(value, 64)


### PR DESCRIPTION
## Summary
- Fix kube-openapi int64 overflow when validating CUE-generated uint64/int64 schemas at the shared `ValidateDataWithSchema` boundary
- Detect uint64 schemas by CUE-generated bounds (Minimum >= 0, Maximum > 2^63) since CUE does not set Format
- Strip overflowing Maximum before passing to kube-openapi; range is enforced by ParseUint/ParseInt
- All callers (ComponentParameterAssignments, OpsDefinition, DataProtection ActionSet) are protected

Addresses leon-ape P1 (preserve uint64 range, values above MaxInt64 are accepted) and P2 (fix at shared boundary, not per-caller) review comments on #10412.

Closes #10434

## Test plan
- [x] `TestConvertStringToInterfaceBySchemaTypeUint64`: ParseUint for CUE uint64 schemas, reject negative
- [x] `TestValidateDataWithSchemaUint64`: uint64 values including above MaxInt64 pass validation
- [x] `TestValidateDataWithSchemaInt64`: int64 values with CUE-generated bounds pass validation
- [x] `TestStripIntegerOverflow`: Maximum stripped for overflow, preserved for safe values
- [x] `TestValidateComponentParameterAssignmentsUint64`: end-to-end with CUE ParametersDefinition schema
- [x] Existing `TestValidateComponentParameterAssignments` still passes (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)