### PR TITLE
fix(dp): fallback to ProvisionOnly when PrepareDataBackupSets is empty

### DIFF
--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -195,18 +195,29 @@ func (r *VolumePopulatorReconciler) syncPVC(reqCtx intctrlutil.RequestCtx, pvc *
 	}
 	// if pvc has not bound pv, populate it.
 	if pvc.Spec.VolumeName == "" {
-		if restoreCtx.mode == pvcRestoreModeRestoreData {
-			if err = r.waitForSerialPredecessors(reqCtx, pvc, restoreCtx.restoreMgr); err != nil {
-				return err
-			}
-			return r.Populate(reqCtx, pvc, restoreCtx)
-		}
-		return r.ProvisionOnly(reqCtx, pvc, restoreCtx)
+		return r.dispatchUnboundPVC(reqCtx, pvc, restoreCtx)
 	}
 	if err = r.completeBoundPVCIfNeeded(reqCtx, pvc, restoreCtx); err != nil {
 		return err
 	}
 	return r.Cleanup(reqCtx, pvc)
+}
+
+// dispatchUnboundPVC routes an unbound PVC to either Populate or ProvisionOnly.
+// When mode is RestoreData but PrepareDataBackupSets is empty (ActionSet has
+// only PostReady restore, no PrepareData), it falls back to ProvisionOnly to
+// avoid a nil-pointer panic in the Populate path.
+func (r *VolumePopulatorReconciler) dispatchUnboundPVC(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim, restoreCtx *pvcRestoreContext) error {
+	if restoreCtx.mode == pvcRestoreModeRestoreData {
+		if len(restoreCtx.restoreMgr.PrepareDataBackupSets) == 0 {
+			return r.ProvisionOnly(reqCtx, pvc, restoreCtx)
+		}
+		if err := r.waitForSerialPredecessors(reqCtx, pvc, restoreCtx.restoreMgr); err != nil {
+			return err
+		}
+		return r.Populate(reqCtx, pvc, restoreCtx)
+	}
+	return r.ProvisionOnly(reqCtx, pvc, restoreCtx)
 }
 
 func (r *VolumePopulatorReconciler) validateRestoreRefAndBuildMGR(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim) (*dprestore.RestoreManager, error) {

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -1256,6 +1256,51 @@ func TestProvisionOnlyCreatesPopulatePVCWithoutJob(t *testing.T) {
 	require.Empty(t, jobs.Items)
 }
 
+func TestDispatchUnboundPVCFallsBackToProvisionOnlyWhenPrepareDataBackupSetsEmpty(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+	apiGroup := dptypes.DataprotectionAPIGroup
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "data-restore-qdrant-0",
+			UID:       "data-restore-qdrant-0-uid",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("10Gi")},
+			},
+			DataSourceRef: &corev1.TypedObjectReference{
+				APIGroup: &apiGroup,
+				Kind:     dptypes.BackupKind,
+				Name:     "backup",
+			},
+		},
+	}
+	reconciler := &VolumePopulatorReconciler{
+		Client:   fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(pvc).WithObjects(pvc).Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{
+		Spec: dpv1alpha1.RestoreSpec{Backup: dpv1alpha1.BackupRef{Name: "backup", Namespace: "default"}},
+	}, nil, scheme, reconciler.Client)
+	restoreCtx := &pvcRestoreContext{
+		mode:       pvcRestoreModeRestoreData,
+		restoreMgr: restoreMgr,
+	}
+
+	err := reconciler.dispatchUnboundPVC(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreCtx)
+
+	require.Error(t, err)
+	require.True(t, intctrlutil.IsRequeueError(err), "expected requeue from ProvisionOnly fallback, got: %v", err)
+	populatePVC := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: getPopulatePVCName(pvc.UID)}, populatePVC))
+	require.Empty(t, populatePVC.Spec.DataSourceRef, "populate PVC must not have dataSourceRef (ProvisionOnly path)")
+}
+
 func TestBuildPostReadyRestoreSelectsHighestPriorityRole(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))


### PR DESCRIPTION
## Summary
- When an ActionSet has only PostReady restore (no PrepareData), `decidePVCRestore` picks RestoreData mode based on `targetVolumes` presence, but `SetBackupSets` leaves `PrepareDataBackupSets` empty. The `Populate` path iterates the empty slice, leaving `populatePVC` nil, causing a nil-pointer panic.
- Extract `dispatchUnboundPVC` from `syncPVC` and add an empty-slice guard that falls back to `ProvisionOnly`, letting PVC/PV bind normally so PostReady restore proceeds after pod readiness.
- Reproducer: Qdrant `qdrant-snapshot-br` ActionSet restore S19 — crash-loops DP controller.

## Test plan
- [x] `TestDispatchUnboundPVCFallsBackToProvisionOnlyWhenPrepareDataBackupSetsEmpty` — mode=RestoreData + empty PrepareDataBackupSets → ProvisionOnly path (requeue + populate PVC without dataSourceRef)
- [x] `go build ./controllers/dataprotection/` PASS
- [x] `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build ./cmd/dataprotection/main.go` PASS
- [x] All related unit tests (10/10) PASS
- [ ] Scoped S18/S19 validation with candidate controller image on frozen `qdrant-smoke-s18s19-v2` (pending post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)