### PR TITLE
fix(dp): exclude role label from PVC matching in VolumePopulator restore

### DIFF
--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -548,18 +548,22 @@ func componentLogicalName(component *appsv1.Component) string {
 	return component.Name
 }
 
+func isPodOnlyLabel(key string) bool {
+	return key == constant.AppInstanceLabelKey || key == constant.RoleLabelKey
+}
+
 func backupTargetHasEffectivePVCSelector(target *dpv1alpha1.BackupStatusTarget) bool {
 	if target == nil || target.PodSelector == nil || target.PodSelector.LabelSelector == nil {
 		return false
 	}
 	selector := target.PodSelector.LabelSelector
 	for k := range selector.MatchLabels {
-		if k != constant.AppInstanceLabelKey {
+		if !isPodOnlyLabel(k) {
 			return true
 		}
 	}
 	for _, expression := range selector.MatchExpressions {
-		if expression.Key != constant.AppInstanceLabelKey {
+		if !isPodOnlyLabel(expression.Key) {
 			return true
 		}
 	}
@@ -573,7 +577,7 @@ func backupTargetMatchesPVC(target *dpv1alpha1.BackupStatusTarget, pvc *corev1.P
 	selector := target.PodSelector.LabelSelector
 	var effective bool
 	for k, v := range selector.MatchLabels {
-		if k == constant.AppInstanceLabelKey {
+		if isPodOnlyLabel(k) {
 			continue
 		}
 		effective = true
@@ -582,7 +586,7 @@ func backupTargetMatchesPVC(target *dpv1alpha1.BackupStatusTarget, pvc *corev1.P
 		}
 	}
 	for _, expression := range selector.MatchExpressions {
-		if expression.Key == constant.AppInstanceLabelKey {
+		if isPodOnlyLabel(expression.Key) {
 			continue
 		}
 		effective = true

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -846,6 +846,31 @@ func TestDecidePVCRestoreKeepsSingleBackupTargetScopedToMatchingComponent(t *tes
 	require.Nil(t, decision.sourceTarget)
 }
 
+func TestDecidePVCRestoreIgnoresRoleLabelInPVCMatch(t *testing.T) {
+	reconciler := &VolumePopulatorReconciler{}
+	backup := newBackupForRestoreDecision([]string{"data"}, nil)
+	backup.Status.Target.PodSelector = &dpv1alpha1.PodSelector{
+		LabelSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				constant.AppInstanceLabelKey:    "source-cluster",
+				constant.AppManagedByLabelKey:   constant.AppName,
+				constant.KBAppComponentLabelKey: "falkordb",
+				constant.RoleLabelKey:           "secondary",
+			},
+		},
+		Strategy: dpv1alpha1.PodSelectionStrategyAny,
+	}
+
+	pvc := newPVCForRestoreDecision("data", "falkordb", "")
+
+	decision, err := reconciler.decidePVCRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup, nil)
+
+	require.NoError(t, err)
+	require.Equal(t, pvcRestoreModeRestoreData, decision.mode)
+	require.False(t, decision.skipPostReady)
+	require.NotNil(t, decision.sourceTarget)
+}
+
 func TestDecidePVCRestoreTreatsNilTargetVolumesAsProvisionOnly(t *testing.T) {
 	reconciler := &VolumePopulatorReconciler{}
 	backup := newBackupForRestoreDecision(nil, nil)


### PR DESCRIPTION
## Summary

- Fix `backupTargetMatchesPVC` and `backupTargetHasEffectivePVCSelector` to exclude `kubeblocks.io/role` from PVC label matching, alongside the already-excluded `app.kubernetes.io/instance`
- When a BackupPolicyTemplate configures `target.role: secondary`, the backup target PodSelector carries `kubeblocks.io/role: secondary`, but PVCs never have role labels (role is a pod-level concept), causing the match to fail and restore to incorrectly take the ProvisionOnly path — skipping PrepareData volume population
- Affects all engines that configure `target.role` in BackupPolicyTemplate (e.g. FalkorDB)

## Test plan

- [x] `TestDecidePVCRestoreIgnoresRoleLabelInPVCMatch` — verifies backup target with role label correctly matches PVC and selects RestoreData mode
- [x] All 7 `TestDecidePVCRestore*` tests PASS (no regression)
- [x] `CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build` PASS
- [ ] FalkorDB team to validate restore with patched controller (post-merge)

Closes #10444

🤖 Generated with [Claude Code](https://claude.com/claude-code)
