### PR TITLE
fix(dp): don't skip postReady when no volume-level data exists

### DIFF
--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -397,6 +397,11 @@ func (r *VolumePopulatorReconciler) decidePVCRestore(reqCtx intctrlutil.RequestC
 	if restoreData && !skipPostReady {
 		mode = pvcRestoreModeRestoreData
 	}
+	// When no volume-level restore exists, postReady may be the only restore
+	// path (e.g. multi-component logical backup). Don't block it.
+	if !restoreData {
+		skipPostReady = false
+	}
 	return &pvcRestoreDecision{
 		mode:          mode,
 		sourceTarget:  sourceTarget,

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -859,6 +859,29 @@ func TestDecidePVCRestoreTreatsNilTargetVolumesAsProvisionOnly(t *testing.T) {
 	require.False(t, decision.skipPostReady)
 }
 
+func TestDecidePVCRestoreDoesNotSkipPostReadyWhenNoTargetVolumes(t *testing.T) {
+	reconciler := &VolumePopulatorReconciler{}
+	backup := newBackupForRestoreDecision(nil, nil)
+	backup.Status.BackupMethod.TargetVolumes = nil
+	backup.Status.Target.PodSelector = &dpv1alpha1.PodSelector{
+		LabelSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				constant.AppInstanceLabelKey:    "source-cluster",
+				constant.KBAppComponentLabelKey: "tidb",
+			},
+		},
+		Strategy: dpv1alpha1.PodSelectionStrategyAny,
+	}
+	pvc := newPVCForRestoreDecision("data", "pd", "")
+
+	decision, err := reconciler.decidePVCRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup, nil)
+
+	require.NoError(t, err)
+	require.Equal(t, pvcRestoreModeProvisionOnly, decision.mode)
+	require.False(t, decision.skipPostReady,
+		"postReady must not be skipped when no volume-level restore exists — it may be the only restore path")
+}
+
 func TestMatchToPopulateSupportsRestoreAndBackupDataSources(t *testing.T) {
 	apiGroup := dptypes.DataprotectionAPIGroup
 	reconciler := &VolumePopulatorReconciler{}


### PR DESCRIPTION
## Summary
- Override `skipPostReady` to `false` in `decidePVCRestore` when `restoreData=false` (TargetVolumes nil/empty)
- When no volume-level restore path exists, postReady may be the only restore mechanism (e.g. multi-component logical backup like TiDB BR). PVC-selector mismatch should not block it.
- Adds unit test covering the multi-component scenario (backup targets component A, PVC belongs to component B, no targetVolumes)

## Root Cause
`resolveSingleSourceTargetForPVC` returns `skipPostReady=true` when the PVC component doesn't match the backup target. `decidePVCRestore` propagated this unconditionally, even when `restoreData=false` (no prepareData). In `ensurePostReadyRestoreCompleted`, the `skipPostReady` flag caused an early return, silently skipping the postReady restore — the only restore path for non-backup-target components.

## Test plan
- [x] Unit test: `TestDecidePVCRestoreDoesNotSkipPostReadyWhenNoTargetVolumes`
- [x] Existing tests pass (decidePVCRestore, postReady, ProvisionOnly suites)
- [ ] TiDB T13 live scene validation (`tidb-idc-vc`)

Fixes #10418