### PR TITLE
chore(dataprotection): cover postReady restore redirect cases

### DIFF
--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -884,6 +884,125 @@ func TestDecidePVCRestoreTreatsNilTargetVolumesAsProvisionOnly(t *testing.T) {
 	require.False(t, decision.skipPostReady)
 }
 
+func TestDecidePVCRestoreNoTargetVolumesTargetComponent(t *testing.T) {
+	reconciler := &VolumePopulatorReconciler{}
+	backup := newBackupForRestoreDecision(nil, nil)
+	backup.Status.BackupMethod.TargetVolumes = nil
+	backup.Status.Target.PodSelector = &dpv1alpha1.PodSelector{
+		LabelSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				constant.AppInstanceLabelKey:    "source-cluster",
+				constant.KBAppComponentLabelKey: "tidb",
+				constant.RoleLabelKey:           "leader",
+			},
+		},
+		Strategy: dpv1alpha1.PodSelectionStrategyAny,
+	}
+
+	// PVC from the backup target component: postReady must not be skipped
+	pvc := newPVCForRestoreDecision("data", "tidb", "")
+	decision, err := reconciler.decidePVCRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup, nil)
+	require.NoError(t, err)
+	require.Equal(t, pvcRestoreModeProvisionOnly, decision.mode)
+	require.False(t, decision.skipPostReady,
+		"target component PVC must not skip postReady when no volume-level restore exists")
+	require.NotNil(t, decision.sourceTarget,
+		"sourceTarget must be recovered for the target component")
+
+	// PVC from a different component: postReady must be skipped
+	pvc = newPVCForRestoreDecision("data", "pd", "")
+	decision, err = reconciler.decidePVCRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup, nil)
+	require.NoError(t, err)
+	require.Equal(t, pvcRestoreModeProvisionOnly, decision.mode)
+	require.True(t, decision.skipPostReady,
+		"non-target component PVC must skip postReady to avoid running restore on wrong component")
+	require.Nil(t, decision.sourceTarget)
+}
+
+func TestDecidePVCRestoreNoTargetVolumesTargetComponentMatchExpression(t *testing.T) {
+	reconciler := &VolumePopulatorReconciler{}
+	backup := newBackupForRestoreDecision(nil, nil)
+	backup.Status.BackupMethod.TargetVolumes = nil
+	backup.Status.Target.PodSelector = &dpv1alpha1.PodSelector{
+		LabelSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				constant.AppInstanceLabelKey: "source-cluster",
+				constant.RoleLabelKey:        "leader",
+			},
+			MatchExpressions: []metav1.LabelSelectorRequirement{{
+				Key:      constant.KBAppComponentLabelKey,
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"tidb"},
+			}},
+		},
+		Strategy: dpv1alpha1.PodSelectionStrategyAny,
+	}
+
+	pvc := newPVCForRestoreDecision("data", "tidb", "")
+	decision, err := reconciler.decidePVCRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup, nil)
+	require.NoError(t, err)
+	require.Equal(t, pvcRestoreModeProvisionOnly, decision.mode)
+	require.False(t, decision.skipPostReady,
+		"target component selected by MatchExpressions must not skip postReady")
+	require.NotNil(t, decision.sourceTarget)
+
+	pvc = newPVCForRestoreDecision("data", "pd", "")
+	decision, err = reconciler.decidePVCRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup, nil)
+	require.NoError(t, err)
+	require.Equal(t, pvcRestoreModeProvisionOnly, decision.mode)
+	require.True(t, decision.skipPostReady,
+		"non-target component must still skip postReady when component expression does not match")
+	require.Nil(t, decision.sourceTarget)
+}
+
+func TestDecidePVCRestoreNoTargetVolumesMultiComponentTargets(t *testing.T) {
+	reconciler := &VolumePopulatorReconciler{}
+	backup := newBackupForRestoreDecision(nil, []string{"etcd"})
+	backup.Status.BackupMethod.TargetVolumes = nil
+	backup.Status.Targets[0].PodSelector = &dpv1alpha1.PodSelector{
+		LabelSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				constant.AppInstanceLabelKey:    "source-cluster",
+				constant.KBAppComponentLabelKey: "etcd",
+				constant.RoleLabelKey:           "leader",
+			},
+		},
+		Strategy: dpv1alpha1.PodSelectionStrategyAny,
+	}
+
+	// Etcd PVC matches target component — postReady enabled
+	pvc := newPVCForRestoreDecision("data", "etcd", "")
+	decision, err := reconciler.decidePVCRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup, nil)
+	require.NoError(t, err)
+	require.Equal(t, pvcRestoreModeProvisionOnly, decision.mode)
+	require.False(t, decision.skipPostReady)
+	require.NotNil(t, decision.sourceTarget)
+	require.Equal(t, "etcd", decision.sourceTarget.Name)
+}
+
+func TestDecidePVCRestoreNoTargetVolumesPodOnlySelectorUsesTarget(t *testing.T) {
+	reconciler := &VolumePopulatorReconciler{}
+	backup := newBackupForRestoreDecision(nil, nil)
+	backup.Status.BackupMethod.TargetVolumes = nil
+	backup.Status.Target.PodSelector = &dpv1alpha1.PodSelector{
+		LabelSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				constant.AppInstanceLabelKey: "source-cluster",
+				constant.RoleLabelKey:        "leader",
+			},
+		},
+		Strategy: dpv1alpha1.PodSelectionStrategyAny,
+	}
+
+	pvc := newPVCForRestoreDecision("data", "mysql", "")
+	decision, err := reconciler.decidePVCRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup, nil)
+	require.NoError(t, err)
+	require.Equal(t, pvcRestoreModeProvisionOnly, decision.mode)
+	require.False(t, decision.skipPostReady,
+		"pod-only selectors have no effective PVC selector, so the target applies to the PVC")
+	require.NotNil(t, decision.sourceTarget)
+}
+
 func TestMatchToPopulateSupportsRestoreAndBackupDataSources(t *testing.T) {
 	apiGroup := dptypes.DataprotectionAPIGroup
 	reconciler := &VolumePopulatorReconciler{}


### PR DESCRIPTION
## Summary
- Rebased this branch onto current `main` after PR #10466 merged the controller behavior.
- This PR now keeps regression coverage for the multi-component postReady redirect and skip-only boundaries.
- No controller behavior delta remains versus current `main`.

## Issue
- Issue: #10418
- #10418 now includes the PR-specific policy alignment note for #10447: problem covered, constructed test scene, reproducibility, and focused reproduction command.

## Validation
- `go test ./controllers/dataprotection -run 'TestDecidePVCRestore|TestEnsurePostReadyRestore|TestDispatchUnboundPVCFallsBackToProvisionOnlyWhenOnlyPostReadyExists|TestMatchToPopulateSupportsRestoreAndBackupDataSources' -count=1`

## Boundary
- This is regression coverage only.
- Runtime validation stays with the #10466 exact-head TiDB PITR scoped evidence.
