### PR TITLE
fix(ops): fail invalid switchover instances

### DIFF
--- a/pkg/operations/ops_manager.go
+++ b/pkg/operations/ops_manager.go
@@ -98,7 +98,7 @@ func (opsMgr *OpsManager) Do(reqCtx intctrlutil.RequestCtx, cli client.Client, o
 			return &ctrl.Result{}, patchFatalFailErrorCondition(reqCtx.Ctx, cli, opsRes, err)
 		}
 		if intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeNeedWaiting) {
-			return intctrlutil.ResultToP(intctrlutil.Reconciled())
+			return intctrlutil.ResultToP(intctrlutil.RequeueAfter(time.Second, reqCtx.Log, err.Error()))
 		}
 		return nil, err
 	}

--- a/pkg/operations/ops_runtime.go
+++ b/pkg/operations/ops_runtime.go
@@ -235,10 +235,14 @@ func (r *opsRuntime) doSwitchover(ctx context.Context, cli client.Reader, synthe
 		return intctrlutil.NewFatalError(fmt.Sprintf(`instance "%s" not found`, switchover.InstanceName))
 	}
 	if switchover.CandidateName != "" {
-		if _, err := r.GetInstance(synthesizedComp.Namespace, synthesizedComp.ClusterName, synthesizedComp.Name, switchover.CandidateName); err != nil {
-			if !apierrors.IsNotFound(err) {
-				return err
+		candidateFound := false
+		for _, p := range pods {
+			if p.Name == switchover.CandidateName {
+				candidateFound = true
+				break
 			}
+		}
+		if !candidateFound {
 			return intctrlutil.NewFatalError(fmt.Sprintf(`candidate instance "%s" not found`, switchover.CandidateName))
 		}
 	}

--- a/pkg/operations/ops_runtime.go
+++ b/pkg/operations/ops_runtime.go
@@ -231,6 +231,9 @@ func (r *opsRuntime) doSwitchover(ctx context.Context, cli client.Reader, synthe
 			break
 		}
 	}
+	if pod.Name == "" {
+		return intctrlutil.NewFatalError(fmt.Sprintf(`instance "%s" not found`, switchover.InstanceName))
+	}
 
 	lfa, err := lifecycle.New(synthesizedComp.Namespace, synthesizedComp.ClusterName, synthesizedComp.Name,
 		synthesizedComp.LifecycleActions.ComponentLifecycleActions, synthesizedComp.TemplateVars, pod, pods)

--- a/pkg/operations/ops_runtime.go
+++ b/pkg/operations/ops_runtime.go
@@ -234,6 +234,18 @@ func (r *opsRuntime) doSwitchover(ctx context.Context, cli client.Reader, synthe
 	if pod.Name == "" {
 		return intctrlutil.NewFatalError(fmt.Sprintf(`instance "%s" not found`, switchover.InstanceName))
 	}
+	if switchover.CandidateName != "" {
+		candidateFound := false
+		for _, p := range pods {
+			if p.Name == switchover.CandidateName {
+				candidateFound = true
+				break
+			}
+		}
+		if !candidateFound {
+			return intctrlutil.NewFatalError(fmt.Sprintf(`candidate instance "%s" not found`, switchover.CandidateName))
+		}
+	}
 
 	lfa, err := lifecycle.New(synthesizedComp.Namespace, synthesizedComp.ClusterName, synthesizedComp.Name,
 		synthesizedComp.LifecycleActions.ComponentLifecycleActions, synthesizedComp.TemplateVars, pod, pods)

--- a/pkg/operations/ops_runtime.go
+++ b/pkg/operations/ops_runtime.go
@@ -235,14 +235,14 @@ func (r *opsRuntime) doSwitchover(ctx context.Context, cli client.Reader, synthe
 		return intctrlutil.NewFatalError(fmt.Sprintf(`instance "%s" not found`, switchover.InstanceName))
 	}
 	if switchover.CandidateName != "" {
-		candidateFound := false
-		for _, p := range pods {
-			if p.Name == switchover.CandidateName {
-				candidateFound = true
-				break
+		candidate, err := r.GetInstance(synthesizedComp.Namespace, synthesizedComp.ClusterName, synthesizedComp.Name, switchover.CandidateName)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return intctrlutil.NewFatalError(fmt.Sprintf(`candidate instance "%s" not found`, switchover.CandidateName))
 			}
+			return err
 		}
-		if !candidateFound {
+		if !candidate.HasPod() {
 			return intctrlutil.NewFatalError(fmt.Sprintf(`candidate instance "%s" not found`, switchover.CandidateName))
 		}
 	}
@@ -391,6 +391,10 @@ func (i *defaultInstance) GetCreationTimestamp() metav1.Time {
 		return metav1.Time{}
 	}
 	return i.pod.CreationTimestamp
+}
+
+func (i *defaultInstance) HasPod() bool {
+	return i.pod != nil
 }
 
 func (i *defaultInstance) IsDeleting() bool {

--- a/pkg/operations/ops_runtime.go
+++ b/pkg/operations/ops_runtime.go
@@ -235,14 +235,10 @@ func (r *opsRuntime) doSwitchover(ctx context.Context, cli client.Reader, synthe
 		return intctrlutil.NewFatalError(fmt.Sprintf(`instance "%s" not found`, switchover.InstanceName))
 	}
 	if switchover.CandidateName != "" {
-		candidateFound := false
-		for _, p := range pods {
-			if p.Name == switchover.CandidateName {
-				candidateFound = true
-				break
+		if _, err := r.GetInstance(synthesizedComp.Namespace, synthesizedComp.ClusterName, synthesizedComp.Name, switchover.CandidateName); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return err
 			}
-		}
-		if !candidateFound {
 			return intctrlutil.NewFatalError(fmt.Sprintf(`candidate instance "%s" not found`, switchover.CandidateName))
 		}
 	}

--- a/pkg/operations/switchover.go
+++ b/pkg/operations/switchover.go
@@ -127,6 +127,9 @@ func switchoverPreCheck(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes
 		}
 		instance, err := runtime.GetInstance(synthesizedComp.Namespace, synthesizedComp.ClusterName, synthesizedComp.Name, switchover.InstanceName)
 		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return intctrlutil.NewFatalError(fmt.Sprintf(`instance "%s" not found`, switchover.InstanceName))
+			}
 			return err
 		}
 		roleName := instance.GetRole()
@@ -135,8 +138,15 @@ func switchoverPreCheck(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes
 		}
 
 		if switchover.CandidateName != "" {
-			if _, err := runtime.GetInstance(synthesizedComp.Namespace, synthesizedComp.ClusterName, synthesizedComp.Name, switchover.CandidateName); err != nil {
+			candidate, err := runtime.GetInstance(synthesizedComp.Namespace, synthesizedComp.ClusterName, synthesizedComp.Name, switchover.CandidateName)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					return intctrlutil.NewFatalError(fmt.Sprintf(`candidate instance "%s" not found`, switchover.CandidateName))
+				}
 				return err
+			}
+			if candidate.GetRole() == "" {
+				return intctrlutil.NewFatalError(fmt.Sprintf("candidate pod %s cannot perform switchover because it does not have a role label", switchover.CandidateName))
 			}
 		}
 
@@ -233,10 +243,16 @@ func handleSwitchover(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes *
 		targetRole := progressDetail.Group
 		if switchover.CandidateName != "" {
 			candidateInstance, err := runtime.GetInstance(synthesizedComp.Namespace, synthesizedComp.ClusterName, synthesizedComp.Name, switchover.CandidateName)
-			if err != nil {
+			switch {
+			case err != nil && !apierrors.IsNotFound(err):
 				return err
-			}
-			if targetRole == candidateInstance.GetRole() {
+			case err != nil:
+				progressDetail.Message = fmt.Sprintf(`component %s candidate instance "%s" not found`, compName, switchover.CandidateName)
+				progressDetail.Status = opsv1alpha1.FailedProgressStatus
+			case candidateInstance.GetRole() == "":
+				progressDetail.Message = fmt.Sprintf("component %s candidate pod %s cannot perform switchover because it does not have a role label", compName, switchover.CandidateName)
+				progressDetail.Status = opsv1alpha1.FailedProgressStatus
+			case targetRole == candidateInstance.GetRole():
 				progressDetail.Message = "do switchover succeed"
 				progressDetail.Status = opsv1alpha1.SucceedProgressStatus
 			}

--- a/pkg/operations/switchover.go
+++ b/pkg/operations/switchover.go
@@ -134,7 +134,7 @@ func switchoverPreCheck(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes
 		}
 		roleName := instance.GetRole()
 		if roleName == "" {
-			return intctrlutil.NewFatalError(fmt.Sprintf("pod %s cannot perform switchover because it does not have a role label", switchover.InstanceName))
+			return intctrlutil.NewErrorf(intctrlutil.ErrorTypeNeedWaiting, "waiting for instance %s role label", switchover.InstanceName)
 		}
 
 		if switchover.CandidateName != "" {
@@ -246,12 +246,12 @@ func handleSwitchover(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes *
 			case err != nil:
 				progressDetail.Message = fmt.Sprintf(`component %s candidate instance "%s" not found`, compName, switchover.CandidateName)
 				progressDetail.Status = opsv1alpha1.FailedProgressStatus
-			case candidateInstance.GetRole() == "":
-				progressDetail.Message = fmt.Sprintf("component %s is waiting for candidate pod %s role label", compName, switchover.CandidateName)
 			case targetRole == candidateInstance.GetRole():
 				progressDetail.Message = "do switchover succeed"
 				progressDetail.Status = opsv1alpha1.SucceedProgressStatus
-				// default: candidate role hasn't converged to target; stay Processing
+			default:
+				progressDetail.Message = fmt.Sprintf("component %s is waiting for candidate pod %s role change, current role %q, expected role %q",
+					compName, switchover.CandidateName, candidateInstance.GetRole(), targetRole)
 			}
 		} else {
 			progressDetail.Message = "do switchover succeed"

--- a/pkg/operations/switchover.go
+++ b/pkg/operations/switchover.go
@@ -255,6 +255,7 @@ func handleSwitchover(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes *
 			case targetRole == candidateInstance.GetRole():
 				progressDetail.Message = "do switchover succeed"
 				progressDetail.Status = opsv1alpha1.SucceedProgressStatus
+			// default: candidate role hasn't converged to target; stay Processing
 			}
 		} else {
 			progressDetail.Message = "do switchover succeed"

--- a/pkg/operations/switchover.go
+++ b/pkg/operations/switchover.go
@@ -145,7 +145,7 @@ func switchoverPreCheck(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes
 				}
 				return err
 			}
-			if candidate.GetRole() == "" && isPVCOnlyInstance(candidate) {
+			if candidate.GetRole() == "" && hasRetainedPVCWithoutPod(candidate) {
 				return intctrlutil.NewFatalError(fmt.Sprintf("candidate pod %s cannot perform switchover because it does not have a role label", switchover.CandidateName))
 			}
 		}
@@ -250,7 +250,7 @@ func handleSwitchover(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes *
 				progressDetail.Message = fmt.Sprintf(`component %s candidate instance "%s" not found`, compName, switchover.CandidateName)
 				progressDetail.Status = opsv1alpha1.FailedProgressStatus
 			case candidateInstance.GetRole() == "":
-				if isPVCOnlyInstance(candidateInstance) {
+				if hasRetainedPVCWithoutPod(candidateInstance) {
 					progressDetail.Message = fmt.Sprintf("component %s candidate pod %s cannot perform switchover because it does not have a role label", compName, switchover.CandidateName)
 					progressDetail.Status = opsv1alpha1.FailedProgressStatus
 				} else {
@@ -270,7 +270,9 @@ func handleSwitchover(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes *
 	return nil
 }
 
-func isPVCOnlyInstance(instance Instance) bool {
+// GetInstance may return a defaultInstance built from retained PVCs when the named Pod is gone.
+// That is terminal for switchover, unlike a real Pod whose role label is temporarily empty.
+func hasRetainedPVCWithoutPod(instance Instance) bool {
 	podInstance, ok := instance.(*defaultInstance)
 	return ok && podInstance.pod == nil && len(podInstance.volumes) > 0
 }

--- a/pkg/operations/switchover.go
+++ b/pkg/operations/switchover.go
@@ -138,15 +138,12 @@ func switchoverPreCheck(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes
 		}
 
 		if switchover.CandidateName != "" {
-			candidate, err := runtime.GetInstance(synthesizedComp.Namespace, synthesizedComp.ClusterName, synthesizedComp.Name, switchover.CandidateName)
+			_, err := runtime.GetInstance(synthesizedComp.Namespace, synthesizedComp.ClusterName, synthesizedComp.Name, switchover.CandidateName)
 			if err != nil {
 				if apierrors.IsNotFound(err) {
 					return intctrlutil.NewFatalError(fmt.Sprintf(`candidate instance "%s" not found`, switchover.CandidateName))
 				}
 				return err
-			}
-			if candidate.GetRole() == "" && hasRetainedPVCWithoutPod(candidate) {
-				return intctrlutil.NewFatalError(fmt.Sprintf("candidate pod %s cannot perform switchover because it does not have a role label", switchover.CandidateName))
 			}
 		}
 
@@ -250,12 +247,7 @@ func handleSwitchover(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes *
 				progressDetail.Message = fmt.Sprintf(`component %s candidate instance "%s" not found`, compName, switchover.CandidateName)
 				progressDetail.Status = opsv1alpha1.FailedProgressStatus
 			case candidateInstance.GetRole() == "":
-				if hasRetainedPVCWithoutPod(candidateInstance) {
-					progressDetail.Message = fmt.Sprintf("component %s candidate pod %s cannot perform switchover because it does not have a role label", compName, switchover.CandidateName)
-					progressDetail.Status = opsv1alpha1.FailedProgressStatus
-				} else {
-					progressDetail.Message = fmt.Sprintf("component %s is waiting for candidate pod %s role label", compName, switchover.CandidateName)
-				}
+				progressDetail.Message = fmt.Sprintf("component %s is waiting for candidate pod %s role label", compName, switchover.CandidateName)
 			case targetRole == candidateInstance.GetRole():
 				progressDetail.Message = "do switchover succeed"
 				progressDetail.Status = opsv1alpha1.SucceedProgressStatus
@@ -268,13 +260,6 @@ func handleSwitchover(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes *
 	}
 	handleProgressDetail(reqCtx, opsRequest, progressDetail, compName, completedCount, failedCount)
 	return nil
-}
-
-// GetInstance may return a defaultInstance built from retained PVCs when the named Pod is gone.
-// That is terminal for switchover, unlike a real Pod whose role label is temporarily empty.
-func hasRetainedPVCWithoutPod(instance Instance) bool {
-	podInstance, ok := instance.(*defaultInstance)
-	return ok && podInstance.pod == nil && len(podInstance.volumes) > 0
 }
 
 // setComponentSwitchoverProgressDetails sets component switchover progress details.

--- a/pkg/operations/switchover.go
+++ b/pkg/operations/switchover.go
@@ -30,6 +30,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -121,20 +122,24 @@ func switchoverPreCheck(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes
 			return intctrlutil.NewFatalError(fmt.Sprintf(`the component "%s" does not have any role`, compName))
 		}
 
-		pod, err := getSwitchoverPod(reqCtx.Ctx, cli, synthesizedComp.Namespace, synthesizedComp.ClusterName, synthesizedComp.Name, switchover.InstanceName)
+		runtime, err := opsRes.GetRuntime(compName)
+		if err != nil {
+			return err
+		}
+		instance, err := getSwitchoverPodBackedInstance(runtime, synthesizedComp.Namespace, synthesizedComp.ClusterName, synthesizedComp.Name, switchover.InstanceName)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return intctrlutil.NewFatalError(fmt.Sprintf(`instance "%s" not found`, switchover.InstanceName))
 			}
 			return err
 		}
-		roleName := pod.Labels[constant.RoleLabelKey]
+		roleName := instance.GetRole()
 		if roleName == "" {
 			return intctrlutil.NewErrorf(intctrlutil.ErrorTypeNeedWaiting, "waiting for instance %s role label", switchover.InstanceName)
 		}
 
 		if switchover.CandidateName != "" {
-			_, err := getSwitchoverPod(reqCtx.Ctx, cli, synthesizedComp.Namespace, synthesizedComp.ClusterName, synthesizedComp.Name, switchover.CandidateName)
+			_, err := getSwitchoverPodBackedInstance(runtime, synthesizedComp.Namespace, synthesizedComp.ClusterName, synthesizedComp.Name, switchover.CandidateName)
 			if err != nil {
 				if apierrors.IsNotFound(err) {
 					return intctrlutil.NewFatalError(fmt.Sprintf(`candidate instance "%s" not found`, switchover.CandidateName))
@@ -235,19 +240,19 @@ func handleSwitchover(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes *
 	case opsv1alpha1.ProcessingProgressStatus:
 		targetRole := progressDetail.Group
 		if switchover.CandidateName != "" {
-			candidatePod, err := getSwitchoverPod(reqCtx.Ctx, cli, synthesizedComp.Namespace, synthesizedComp.ClusterName, synthesizedComp.Name, switchover.CandidateName)
+			candidateInstance, err := getSwitchoverPodBackedInstance(runtime, synthesizedComp.Namespace, synthesizedComp.ClusterName, synthesizedComp.Name, switchover.CandidateName)
 			switch {
 			case err != nil && !apierrors.IsNotFound(err):
 				return err
 			case err != nil:
 				progressDetail.Message = fmt.Sprintf(`component %s candidate instance "%s" not found`, compName, switchover.CandidateName)
 				progressDetail.Status = opsv1alpha1.FailedProgressStatus
-			case targetRole == candidatePod.Labels[constant.RoleLabelKey]:
+			case targetRole == candidateInstance.GetRole():
 				progressDetail.Message = "do switchover succeed"
 				progressDetail.Status = opsv1alpha1.SucceedProgressStatus
 			default:
 				progressDetail.Message = fmt.Sprintf("component %s is waiting for candidate pod %s role change, current role %q, expected role %q",
-					compName, switchover.CandidateName, candidatePod.Labels[constant.RoleLabelKey], targetRole)
+					compName, switchover.CandidateName, candidateInstance.GetRole(), targetRole)
 			}
 		} else {
 			progressDetail.Message = "do switchover succeed"
@@ -258,18 +263,15 @@ func handleSwitchover(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes *
 	return nil
 }
 
-func getSwitchoverPod(ctx context.Context, cli client.Reader, namespace, clusterName, compName, instanceName string) (*corev1.Pod, error) {
-	pod := &corev1.Pod{}
-	if err := cli.Get(ctx, client.ObjectKey{Namespace: namespace, Name: instanceName}, pod); err != nil {
+func getSwitchoverPodBackedInstance(runtime OpsRuntime, namespace, clusterName, compName, instanceName string) (Instance, error) {
+	instance, err := runtime.GetInstance(namespace, clusterName, compName, instanceName)
+	if err != nil {
 		return nil, err
 	}
-	if pod.Labels[constant.AppInstanceLabelKey] != clusterName {
-		return nil, intctrlutil.NewFatalError(fmt.Sprintf(`instance "%s" does not belong to cluster "%s"`, instanceName, clusterName))
+	if !instance.HasPod() {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, instanceName)
 	}
-	if pod.Labels[constant.KBAppComponentLabelKey] != compName {
-		return nil, intctrlutil.NewFatalError(fmt.Sprintf(`instance "%s" does not belong to component "%s"`, instanceName, compName))
-	}
-	return pod, nil
+	return instance, nil
 }
 
 // setComponentSwitchoverProgressDetails sets component switchover progress details.

--- a/pkg/operations/switchover.go
+++ b/pkg/operations/switchover.go
@@ -145,7 +145,7 @@ func switchoverPreCheck(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes
 				}
 				return err
 			}
-			if candidate.GetRole() == "" {
+			if candidate.GetRole() == "" && isPVCOnlyInstance(candidate) {
 				return intctrlutil.NewFatalError(fmt.Sprintf("candidate pod %s cannot perform switchover because it does not have a role label", switchover.CandidateName))
 			}
 		}
@@ -374,6 +374,9 @@ func buildSynthesizedComp(ctx context.Context, cli client.Client, opsRes *OpsRes
 func getShardingComponentObjectNameByInstance(ctx context.Context, cli client.Client, cluster *appsv1.Cluster, shardingName, instanceName string) (string, error) {
 	pod := &corev1.Pod{}
 	if err := cli.Get(ctx, client.ObjectKey{Namespace: cluster.Namespace, Name: instanceName}, pod); err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", intctrlutil.NewFatalError(fmt.Sprintf(`instance "%s" not found`, instanceName))
+		}
 		return "", err
 	}
 	if pod.Labels[constant.AppInstanceLabelKey] != cluster.Name {

--- a/pkg/operations/switchover.go
+++ b/pkg/operations/switchover.go
@@ -250,8 +250,12 @@ func handleSwitchover(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes *
 				progressDetail.Message = fmt.Sprintf(`component %s candidate instance "%s" not found`, compName, switchover.CandidateName)
 				progressDetail.Status = opsv1alpha1.FailedProgressStatus
 			case candidateInstance.GetRole() == "":
-				progressDetail.Message = fmt.Sprintf("component %s candidate pod %s cannot perform switchover because it does not have a role label", compName, switchover.CandidateName)
-				progressDetail.Status = opsv1alpha1.FailedProgressStatus
+				if isPVCOnlyInstance(candidateInstance) {
+					progressDetail.Message = fmt.Sprintf("component %s candidate pod %s cannot perform switchover because it does not have a role label", compName, switchover.CandidateName)
+					progressDetail.Status = opsv1alpha1.FailedProgressStatus
+				} else {
+					progressDetail.Message = fmt.Sprintf("component %s is waiting for candidate pod %s role label", compName, switchover.CandidateName)
+				}
 			case targetRole == candidateInstance.GetRole():
 				progressDetail.Message = "do switchover succeed"
 				progressDetail.Status = opsv1alpha1.SucceedProgressStatus
@@ -264,6 +268,11 @@ func handleSwitchover(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes *
 	}
 	handleProgressDetail(reqCtx, opsRequest, progressDetail, compName, completedCount, failedCount)
 	return nil
+}
+
+func isPVCOnlyInstance(instance Instance) bool {
+	podInstance, ok := instance.(*defaultInstance)
+	return ok && podInstance.pod == nil && len(podInstance.volumes) > 0
 }
 
 // setComponentSwitchoverProgressDetails sets component switchover progress details.

--- a/pkg/operations/switchover.go
+++ b/pkg/operations/switchover.go
@@ -121,24 +121,20 @@ func switchoverPreCheck(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes
 			return intctrlutil.NewFatalError(fmt.Sprintf(`the component "%s" does not have any role`, compName))
 		}
 
-		runtime, err := opsRes.GetRuntime(compName)
-		if err != nil {
-			return err
-		}
-		instance, err := runtime.GetInstance(synthesizedComp.Namespace, synthesizedComp.ClusterName, synthesizedComp.Name, switchover.InstanceName)
+		pod, err := getSwitchoverPod(reqCtx.Ctx, cli, synthesizedComp.Namespace, synthesizedComp.ClusterName, synthesizedComp.Name, switchover.InstanceName)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return intctrlutil.NewFatalError(fmt.Sprintf(`instance "%s" not found`, switchover.InstanceName))
 			}
 			return err
 		}
-		roleName := instance.GetRole()
+		roleName := pod.Labels[constant.RoleLabelKey]
 		if roleName == "" {
 			return intctrlutil.NewErrorf(intctrlutil.ErrorTypeNeedWaiting, "waiting for instance %s role label", switchover.InstanceName)
 		}
 
 		if switchover.CandidateName != "" {
-			_, err := runtime.GetInstance(synthesizedComp.Namespace, synthesizedComp.ClusterName, synthesizedComp.Name, switchover.CandidateName)
+			_, err := getSwitchoverPod(reqCtx.Ctx, cli, synthesizedComp.Namespace, synthesizedComp.ClusterName, synthesizedComp.Name, switchover.CandidateName)
 			if err != nil {
 				if apierrors.IsNotFound(err) {
 					return intctrlutil.NewFatalError(fmt.Sprintf(`candidate instance "%s" not found`, switchover.CandidateName))
@@ -239,19 +235,19 @@ func handleSwitchover(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes *
 	case opsv1alpha1.ProcessingProgressStatus:
 		targetRole := progressDetail.Group
 		if switchover.CandidateName != "" {
-			candidateInstance, err := runtime.GetInstance(synthesizedComp.Namespace, synthesizedComp.ClusterName, synthesizedComp.Name, switchover.CandidateName)
+			candidatePod, err := getSwitchoverPod(reqCtx.Ctx, cli, synthesizedComp.Namespace, synthesizedComp.ClusterName, synthesizedComp.Name, switchover.CandidateName)
 			switch {
 			case err != nil && !apierrors.IsNotFound(err):
 				return err
 			case err != nil:
 				progressDetail.Message = fmt.Sprintf(`component %s candidate instance "%s" not found`, compName, switchover.CandidateName)
 				progressDetail.Status = opsv1alpha1.FailedProgressStatus
-			case targetRole == candidateInstance.GetRole():
+			case targetRole == candidatePod.Labels[constant.RoleLabelKey]:
 				progressDetail.Message = "do switchover succeed"
 				progressDetail.Status = opsv1alpha1.SucceedProgressStatus
 			default:
 				progressDetail.Message = fmt.Sprintf("component %s is waiting for candidate pod %s role change, current role %q, expected role %q",
-					compName, switchover.CandidateName, candidateInstance.GetRole(), targetRole)
+					compName, switchover.CandidateName, candidatePod.Labels[constant.RoleLabelKey], targetRole)
 			}
 		} else {
 			progressDetail.Message = "do switchover succeed"
@@ -260,6 +256,20 @@ func handleSwitchover(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes *
 	}
 	handleProgressDetail(reqCtx, opsRequest, progressDetail, compName, completedCount, failedCount)
 	return nil
+}
+
+func getSwitchoverPod(ctx context.Context, cli client.Reader, namespace, clusterName, compName, instanceName string) (*corev1.Pod, error) {
+	pod := &corev1.Pod{}
+	if err := cli.Get(ctx, client.ObjectKey{Namespace: namespace, Name: instanceName}, pod); err != nil {
+		return nil, err
+	}
+	if pod.Labels[constant.AppInstanceLabelKey] != clusterName {
+		return nil, intctrlutil.NewFatalError(fmt.Sprintf(`instance "%s" does not belong to cluster "%s"`, instanceName, clusterName))
+	}
+	if pod.Labels[constant.KBAppComponentLabelKey] != compName {
+		return nil, intctrlutil.NewFatalError(fmt.Sprintf(`instance "%s" does not belong to component "%s"`, instanceName, compName))
+	}
+	return pod, nil
 }
 
 // setComponentSwitchoverProgressDetails sets component switchover progress details.

--- a/pkg/operations/switchover.go
+++ b/pkg/operations/switchover.go
@@ -255,7 +255,7 @@ func handleSwitchover(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes *
 			case targetRole == candidateInstance.GetRole():
 				progressDetail.Message = "do switchover succeed"
 				progressDetail.Status = opsv1alpha1.SucceedProgressStatus
-			// default: candidate role hasn't converged to target; stay Processing
+				// default: candidate role hasn't converged to target; stay Processing
 			}
 		} else {
 			progressDetail.Message = "do switchover succeed"

--- a/pkg/operations/switchover_test.go
+++ b/pkg/operations/switchover_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -74,6 +75,7 @@ var _ = Describe("", func() {
 		// namespaced
 		testapps.ClearResources(&testCtx, generics.OpsRequestSignature, inNS, ml)
 		testapps.ClearResources(&testCtx, generics.ComponentSignature, inNS, ml)
+		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.PersistentVolumeClaimSignature, true, inNS, ml)
 	}
 
 	BeforeEach(cleanEnv)
@@ -245,6 +247,185 @@ var _ = Describe("", func() {
 
 		It("Test switchover OpsRequest with candidate and specified a component object name", func() {
 			testSwitchoverWithCandidate(true)
+		})
+
+		It("fails switchover OpsRequest when source instance does not exist", func() {
+			By("create switchover opsRequest with a missing source instance")
+			ops := testops.NewOpsRequestObj("ops-switchover-"+testCtx.GetRandomStr(), testCtx.DefaultNamespace,
+				clusterObj.Name, opsv1alpha1.SwitchoverType)
+			instanceName := fmt.Sprintf("%s-%s-%d", clusterObj.Name, defaultCompName, 99)
+			ops.Spec.SwitchoverList = []opsv1alpha1.Switchover{
+				{
+					ComponentName: defaultCompName,
+					InstanceName:  instanceName,
+				},
+			}
+			opsRes.OpsRequest = testops.CreateOpsRequest(ctx, testCtx, ops)
+			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsPendingPhase
+
+			By("mock switchover OpsRequest phase is Creating")
+			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsCreatingPhase))
+
+			By("do switchover action and expect terminal failure")
+			_, err = GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsFailedPhase))
+		})
+
+		It("fails switchover OpsRequest when candidate instance does not exist", func() {
+			By("create switchover opsRequest with a missing candidate")
+			ops := testops.NewOpsRequestObj("ops-switchover-"+testCtx.GetRandomStr(), testCtx.DefaultNamespace,
+				clusterObj.Name, opsv1alpha1.SwitchoverType)
+			instanceName := fmt.Sprintf("%s-%s-%d", clusterObj.Name, defaultCompName, 1)
+			candidateName := fmt.Sprintf("%s-%s-%d", clusterObj.Name, defaultCompName, 99)
+			ops.Spec.SwitchoverList = []opsv1alpha1.Switchover{
+				{
+					ComponentName: defaultCompName,
+					InstanceName:  instanceName,
+					CandidateName: candidateName,
+				},
+			}
+			opsRes.OpsRequest = testops.CreateOpsRequest(ctx, testCtx, ops)
+			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsPendingPhase
+
+			By("mock switchover OpsRequest phase is Creating")
+			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsCreatingPhase))
+
+			By("do switchover action and expect terminal failure")
+			_, err = GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsFailedPhase))
+		})
+
+		It("fails switchover OpsRequest when candidate only has retained PVC", func() {
+			By("create a retained candidate PVC without a candidate Pod")
+			ops := testops.NewOpsRequestObj("ops-switchover-"+testCtx.GetRandomStr(), testCtx.DefaultNamespace,
+				clusterObj.Name, opsv1alpha1.SwitchoverType)
+			instanceName := fmt.Sprintf("%s-%s-%d", clusterObj.Name, defaultCompName, 1)
+			candidateName := fmt.Sprintf("%s-%s-%d", clusterObj.Name, defaultCompName, 99)
+			testapps.NewPersistentVolumeClaimFactory(testCtx.DefaultNamespace, "data-"+candidateName,
+				clusterObj.Name, defaultCompName, testapps.DataVolumeName).
+				SetStorage("1Gi").
+				Create(&testCtx)
+			ops.Spec.SwitchoverList = []opsv1alpha1.Switchover{
+				{
+					ComponentName: defaultCompName,
+					InstanceName:  instanceName,
+					CandidateName: candidateName,
+				},
+			}
+			opsRes.OpsRequest = testops.CreateOpsRequest(ctx, testCtx, ops)
+			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsPendingPhase
+
+			By("mock switchover OpsRequest phase is Creating")
+			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsCreatingPhase))
+
+			By("do switchover action and expect terminal failure")
+			_, err = GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsFailedPhase))
+		})
+
+		startProcessingSwitchoverWithCandidate := func() (client.ObjectKey, string) {
+			By("create a valid switchover OpsRequest with a candidate")
+			ops := testops.NewOpsRequestObj("ops-switchover-"+testCtx.GetRandomStr(), testCtx.DefaultNamespace,
+				clusterObj.Name, opsv1alpha1.SwitchoverType)
+			instanceName := fmt.Sprintf("%s-%s-%d", clusterObj.Name, defaultCompName, 1)
+			candidateName := fmt.Sprintf("%s-%s-%d", clusterObj.Name, defaultCompName, 0)
+			ops.Spec.SwitchoverList = []opsv1alpha1.Switchover{
+				{
+					ComponentName: defaultCompName,
+					InstanceName:  instanceName,
+					CandidateName: candidateName,
+				},
+			}
+			opsRes.OpsRequest = testops.CreateOpsRequest(ctx, testCtx, ops)
+			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsPendingPhase
+			key := client.ObjectKeyFromObject(opsRes.OpsRequest)
+
+			By("run precheck and start the switchover action")
+			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testops.GetOpsRequestPhase(&testCtx, key)).Should(Equal(opsv1alpha1.OpsCreatingPhase))
+			_, err = GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			testapps.MockKBAgentClient(func(recorder *kbacli.MockClientMockRecorder) {
+				recorder.Action(gomock.Any(), gomock.Any()).Times(1).DoAndReturn(func(ctx context.Context, req kbagentproto.ActionRequest) (kbagentproto.ActionResponse, error) {
+					Expect(req.Parameters["KB_SWITCHOVER_CURRENT_NAME"]).Should(Equal(instanceName))
+					Expect(req.Parameters["KB_SWITCHOVER_CANDIDATE_NAME"]).Should(Equal(candidateName))
+					return kbagentproto.ActionResponse{Message: "mock success"}, nil
+				})
+			})
+			_, err = GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(func(g Gomega) {
+				fetched := &opsv1alpha1.OpsRequest{}
+				g.Expect(k8sClient.Get(ctx, key, fetched)).Should(Succeed())
+				progressDetail := findStatusProgressDetail(fetched.Status.Components[defaultCompName].ProgressDetails, getProgressObjectKey(KBSwitchoverKey, defaultCompName))
+				g.Expect(progressDetail).ShouldNot(BeNil())
+				g.Expect(progressDetail.Status).Should(Equal(opsv1alpha1.ProcessingProgressStatus))
+			}).Should(Succeed())
+			return key, candidateName
+		}
+
+		expectProcessingCandidateFailure := func(key client.ObjectKey, expectedMessage string) {
+			By("reconcile Processing status and expect terminal failure")
+			_, err := GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(func(g Gomega) {
+				fetched := &opsv1alpha1.OpsRequest{}
+				g.Expect(k8sClient.Get(ctx, key, fetched)).Should(Succeed())
+				g.Expect(fetched.Status.Phase).Should(Equal(opsv1alpha1.OpsFailedPhase))
+				progressDetail := findStatusProgressDetail(fetched.Status.Components[defaultCompName].ProgressDetails, getProgressObjectKey(KBSwitchoverKey, defaultCompName))
+				g.Expect(progressDetail).ShouldNot(BeNil())
+				g.Expect(progressDetail.Status).Should(Equal(opsv1alpha1.FailedProgressStatus))
+				g.Expect(progressDetail.Message).Should(ContainSubstring(expectedMessage))
+			}).Should(Succeed())
+		}
+
+		waitForCandidatePodGone := func(candidateName string) {
+			candidatePod := &corev1.Pod{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: testCtx.DefaultNamespace, Name: candidateName}, candidatePod)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, candidatePod)).Should(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{Namespace: testCtx.DefaultNamespace, Name: candidateName}, &corev1.Pod{})
+				return apierrors.IsNotFound(err)
+			}).Should(BeTrue())
+		}
+
+		It("fails Processing switchover when candidate instance disappears", func() {
+			key, candidateName := startProcessingSwitchoverWithCandidate()
+			By("delete the candidate Pod after the switchover action starts")
+			waitForCandidatePodGone(candidateName)
+			expectProcessingCandidateFailure(key, fmt.Sprintf(`candidate instance "%s" not found`, candidateName))
+		})
+
+		It("fails Processing switchover when candidate only has retained PVC", func() {
+			key, candidateName := startProcessingSwitchoverWithCandidate()
+			By("leave only a retained candidate PVC after the switchover action starts")
+			waitForCandidatePodGone(candidateName)
+			testapps.NewPersistentVolumeClaimFactory(testCtx.DefaultNamespace, "data-"+candidateName,
+				clusterObj.Name, defaultCompName, testapps.DataVolumeName).
+				SetStorage("1Gi").
+				Create(&testCtx)
+			expectProcessingCandidateFailure(key, fmt.Sprintf("candidate pod %s cannot perform switchover because it does not have a role label", candidateName))
+		})
+
+		It("fails Processing switchover when candidate loses role label", func() {
+			key, candidateName := startProcessingSwitchoverWithCandidate()
+			By("remove the candidate role label after the switchover action starts")
+			candidatePod := &corev1.Pod{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: testCtx.DefaultNamespace, Name: candidateName}, candidatePod)).Should(Succeed())
+			delete(candidatePod.Labels, constant.RoleLabelKey)
+			Expect(k8sClient.Update(ctx, candidatePod)).Should(Succeed())
+			expectProcessingCandidateFailure(key, fmt.Sprintf("candidate pod %s cannot perform switchover because it does not have a role label", candidateName))
 		})
 
 		It("Test switchover OpsRequest with sharding component name", func() {

--- a/pkg/operations/switchover_test.go
+++ b/pkg/operations/switchover_test.go
@@ -274,6 +274,45 @@ var _ = Describe("", func() {
 			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsFailedPhase))
 		})
 
+		It("fails switchover OpsRequest when source instance disappears before action execution", func() {
+			By("create switchover opsRequest with a valid source instance")
+			ops := testops.NewOpsRequestObj("ops-switchover-"+testCtx.GetRandomStr(), testCtx.DefaultNamespace,
+				clusterObj.Name, opsv1alpha1.SwitchoverType)
+			instanceName := fmt.Sprintf("%s-%s-%d", clusterObj.Name, defaultCompName, 1)
+			ops.Spec.SwitchoverList = []opsv1alpha1.Switchover{
+				{
+					ComponentName: defaultCompName,
+					InstanceName:  instanceName,
+				},
+			}
+			opsRes.OpsRequest = testops.CreateOpsRequest(ctx, testCtx, ops)
+			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsPendingPhase
+			key := client.ObjectKeyFromObject(opsRes.OpsRequest)
+
+			By("run precheck while the source pod still exists")
+			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testops.GetOpsRequestPhase(&testCtx, key)).Should(Equal(opsv1alpha1.OpsCreatingPhase))
+
+			By("delete the source Pod before the lifecycle action is invoked")
+			sourcePod := &corev1.Pod{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: testCtx.DefaultNamespace, Name: instanceName}, sourcePod)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, sourcePod)).Should(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{Namespace: testCtx.DefaultNamespace, Name: instanceName}, &corev1.Pod{})
+				return apierrors.IsNotFound(err)
+			}).Should(BeTrue())
+
+			testapps.MockKBAgentClient(func(recorder *kbacli.MockClientMockRecorder) {
+				recorder.Action(gomock.Any(), gomock.Any()).Times(0)
+			})
+
+			By("do switchover action and expect terminal failure without calling the addon")
+			_, err = GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testops.GetOpsRequestPhase(&testCtx, key)).Should(Equal(opsv1alpha1.OpsFailedPhase))
+		})
+
 		It("fails switchover OpsRequest when candidate instance does not exist", func() {
 			By("create switchover opsRequest with a missing candidate")
 			ops := testops.NewOpsRequestObj("ops-switchover-"+testCtx.GetRandomStr(), testCtx.DefaultNamespace,
@@ -390,6 +429,21 @@ var _ = Describe("", func() {
 			}).Should(Succeed())
 		}
 
+		expectProcessingCandidateWaiting := func(key client.ObjectKey, expectedMessage string) {
+			By("reconcile Processing status and expect it to keep waiting")
+			_, err := GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(func(g Gomega) {
+				fetched := &opsv1alpha1.OpsRequest{}
+				g.Expect(k8sClient.Get(ctx, key, fetched)).Should(Succeed())
+				g.Expect(fetched.Status.Phase).ShouldNot(Equal(opsv1alpha1.OpsFailedPhase))
+				progressDetail := findStatusProgressDetail(fetched.Status.Components[defaultCompName].ProgressDetails, getProgressObjectKey(KBSwitchoverKey, defaultCompName))
+				g.Expect(progressDetail).ShouldNot(BeNil())
+				g.Expect(progressDetail.Status).Should(Equal(opsv1alpha1.ProcessingProgressStatus))
+				g.Expect(progressDetail.Message).Should(ContainSubstring(expectedMessage))
+			}).Should(Succeed())
+		}
+
 		waitForCandidatePodGone := func(candidateName string) {
 			candidatePod := &corev1.Pod{}
 			Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: testCtx.DefaultNamespace, Name: candidateName}, candidatePod)).Should(Succeed())
@@ -418,14 +472,14 @@ var _ = Describe("", func() {
 			expectProcessingCandidateFailure(key, fmt.Sprintf("candidate pod %s cannot perform switchover because it does not have a role label", candidateName))
 		})
 
-		It("fails Processing switchover when candidate loses role label", func() {
+		It("keeps Processing switchover when candidate temporarily loses role label", func() {
 			key, candidateName := startProcessingSwitchoverWithCandidate()
 			By("remove the candidate role label after the switchover action starts")
 			candidatePod := &corev1.Pod{}
 			Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: testCtx.DefaultNamespace, Name: candidateName}, candidatePod)).Should(Succeed())
 			delete(candidatePod.Labels, constant.RoleLabelKey)
 			Expect(k8sClient.Update(ctx, candidatePod)).Should(Succeed())
-			expectProcessingCandidateFailure(key, fmt.Sprintf("candidate pod %s cannot perform switchover because it does not have a role label", candidateName))
+			expectProcessingCandidateWaiting(key, fmt.Sprintf("waiting for candidate pod %s role label", candidateName))
 		})
 
 		It("Test switchover OpsRequest with sharding component name", func() {

--- a/pkg/operations/switchover_test.go
+++ b/pkg/operations/switchover_test.go
@@ -381,7 +381,7 @@ var _ = Describe("", func() {
 			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsFailedPhase))
 		})
 
-		It("accepts switchover candidate when GetInstance returns a retained PVC instance", func() {
+		It("fails switchover OpsRequest when candidate only has retained PVC", func() {
 			By("create a retained candidate PVC without a candidate Pod")
 			ops := testops.NewOpsRequestObj("ops-switchover-"+testCtx.GetRandomStr(), testCtx.DefaultNamespace,
 				clusterObj.Name, opsv1alpha1.SwitchoverType)
@@ -405,6 +405,11 @@ var _ = Describe("", func() {
 			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)
 			Expect(err).ShouldNot(HaveOccurred())
 			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsCreatingPhase))
+
+			By("do switchover action and expect terminal failure")
+			_, err = GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsFailedPhase))
 		})
 
 		It("accepts a real candidate pod with a temporarily empty role label in precheck", func() {
@@ -557,7 +562,7 @@ var _ = Describe("", func() {
 			expectProcessingCandidateFailure(key, fmt.Sprintf(`candidate instance "%s" not found`, candidateName))
 		})
 
-		It("keeps Processing switchover when GetInstance returns a retained PVC candidate", func() {
+		It("fails Processing switchover when candidate only has retained PVC", func() {
 			key, candidateName := startProcessingSwitchoverWithCandidate()
 			By("leave only a retained candidate PVC after the switchover action starts")
 			waitForCandidatePodGone(candidateName)
@@ -565,10 +570,7 @@ var _ = Describe("", func() {
 				clusterObj.Name, defaultCompName, testapps.DataVolumeName).
 				SetStorage("1Gi").
 				Create(&testCtx)
-			expectProcessingCandidateWaiting(key,
-				fmt.Sprintf("waiting for candidate pod %s role change", candidateName),
-				`current role ""`,
-				`expected role "`)
+			expectProcessingCandidateFailure(key, fmt.Sprintf(`candidate instance "%s" not found`, candidateName))
 		})
 
 		It("keeps Processing switchover when candidate temporarily loses role label", func() {

--- a/pkg/operations/switchover_test.go
+++ b/pkg/operations/switchover_test.go
@@ -381,7 +381,7 @@ var _ = Describe("", func() {
 			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsFailedPhase))
 		})
 
-		It("fails switchover OpsRequest when candidate only has retained PVC", func() {
+		It("accepts switchover candidate when GetInstance returns a retained PVC instance", func() {
 			By("create a retained candidate PVC without a candidate Pod")
 			ops := testops.NewOpsRequestObj("ops-switchover-"+testCtx.GetRandomStr(), testCtx.DefaultNamespace,
 				clusterObj.Name, opsv1alpha1.SwitchoverType)
@@ -405,11 +405,6 @@ var _ = Describe("", func() {
 			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)
 			Expect(err).ShouldNot(HaveOccurred())
 			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsCreatingPhase))
-
-			By("do switchover action and expect terminal failure")
-			_, err = GetOpsManager().Do(reqCtx, k8sClient, opsRes)
-			Expect(err).ShouldNot(HaveOccurred())
-			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsFailedPhase))
 		})
 
 		It("accepts a real candidate pod with a temporarily empty role label in precheck", func() {
@@ -528,7 +523,7 @@ var _ = Describe("", func() {
 			expectProcessingCandidateFailure(key, fmt.Sprintf(`candidate instance "%s" not found`, candidateName))
 		})
 
-		It("fails Processing switchover when candidate only has retained PVC", func() {
+		It("keeps Processing switchover when GetInstance returns a retained PVC candidate", func() {
 			key, candidateName := startProcessingSwitchoverWithCandidate()
 			By("leave only a retained candidate PVC after the switchover action starts")
 			waitForCandidatePodGone(candidateName)
@@ -536,7 +531,7 @@ var _ = Describe("", func() {
 				clusterObj.Name, defaultCompName, testapps.DataVolumeName).
 				SetStorage("1Gi").
 				Create(&testCtx)
-			expectProcessingCandidateFailure(key, fmt.Sprintf("candidate pod %s cannot perform switchover because it does not have a role label", candidateName))
+			expectProcessingCandidateWaiting(key, fmt.Sprintf("waiting for candidate pod %s role label", candidateName))
 		})
 
 		It("keeps Processing switchover when candidate temporarily loses role label", func() {

--- a/pkg/operations/switchover_test.go
+++ b/pkg/operations/switchover_test.go
@@ -313,6 +313,47 @@ var _ = Describe("", func() {
 			Eventually(testops.GetOpsRequestPhase(&testCtx, key)).Should(Equal(opsv1alpha1.OpsFailedPhase))
 		})
 
+		It("fails switchover OpsRequest when candidate disappears before action execution", func() {
+			By("create switchover opsRequest with a valid source and candidate")
+			ops := testops.NewOpsRequestObj("ops-switchover-"+testCtx.GetRandomStr(), testCtx.DefaultNamespace,
+				clusterObj.Name, opsv1alpha1.SwitchoverType)
+			instanceName := fmt.Sprintf("%s-%s-%d", clusterObj.Name, defaultCompName, 1)
+			candidateName := fmt.Sprintf("%s-%s-%d", clusterObj.Name, defaultCompName, 0)
+			ops.Spec.SwitchoverList = []opsv1alpha1.Switchover{
+				{
+					ComponentName: defaultCompName,
+					InstanceName:  instanceName,
+					CandidateName: candidateName,
+				},
+			}
+			opsRes.OpsRequest = testops.CreateOpsRequest(ctx, testCtx, ops)
+			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsPendingPhase
+			key := client.ObjectKeyFromObject(opsRes.OpsRequest)
+
+			By("run precheck while the candidate pod still exists")
+			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testops.GetOpsRequestPhase(&testCtx, key)).Should(Equal(opsv1alpha1.OpsCreatingPhase))
+
+			By("delete the candidate Pod before the lifecycle action is invoked")
+			candidatePod := &corev1.Pod{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: testCtx.DefaultNamespace, Name: candidateName}, candidatePod)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, candidatePod)).Should(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{Namespace: testCtx.DefaultNamespace, Name: candidateName}, &corev1.Pod{})
+				return apierrors.IsNotFound(err)
+			}).Should(BeTrue())
+
+			testapps.MockKBAgentClient(func(recorder *kbacli.MockClientMockRecorder) {
+				recorder.Action(gomock.Any(), gomock.Any()).Times(0)
+			})
+
+			By("do switchover action and expect terminal failure without calling the addon")
+			_, err = GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testops.GetOpsRequestPhase(&testCtx, key)).Should(Equal(opsv1alpha1.OpsFailedPhase))
+		})
+
 		It("fails switchover OpsRequest when candidate instance does not exist", func() {
 			By("create switchover opsRequest with a missing candidate")
 			ops := testops.NewOpsRequestObj("ops-switchover-"+testCtx.GetRandomStr(), testCtx.DefaultNamespace,
@@ -369,6 +410,32 @@ var _ = Describe("", func() {
 			_, err = GetOpsManager().Do(reqCtx, k8sClient, opsRes)
 			Expect(err).ShouldNot(HaveOccurred())
 			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsFailedPhase))
+		})
+
+		It("accepts a real candidate pod with a temporarily empty role label in precheck", func() {
+			By("create switchover opsRequest with a roleless real candidate pod")
+			ops := testops.NewOpsRequestObj("ops-switchover-"+testCtx.GetRandomStr(), testCtx.DefaultNamespace,
+				clusterObj.Name, opsv1alpha1.SwitchoverType)
+			instanceName := fmt.Sprintf("%s-%s-%d", clusterObj.Name, defaultCompName, 1)
+			candidateName := fmt.Sprintf("%s-%s-%d", clusterObj.Name, defaultCompName, 0)
+			candidatePod := &corev1.Pod{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: testCtx.DefaultNamespace, Name: candidateName}, candidatePod)).Should(Succeed())
+			delete(candidatePod.Labels, constant.RoleLabelKey)
+			Expect(k8sClient.Update(ctx, candidatePod)).Should(Succeed())
+			ops.Spec.SwitchoverList = []opsv1alpha1.Switchover{
+				{
+					ComponentName: defaultCompName,
+					InstanceName:  instanceName,
+					CandidateName: candidateName,
+				},
+			}
+			opsRes.OpsRequest = testops.CreateOpsRequest(ctx, testCtx, ops)
+			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsPendingPhase
+
+			By("mock switchover OpsRequest phase is Creating")
+			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsCreatingPhase))
 		})
 
 		startProcessingSwitchoverWithCandidate := func() (client.ObjectKey, string) {
@@ -587,6 +654,52 @@ var _ = Describe("", func() {
 			By("do reconcile switchover action")
 			_, err = GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
 			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		It("fails sharding switchover OpsRequest when source instance does not exist", func() {
+			const (
+				shardingName = "shard"
+			)
+
+			By("creating a sharding cluster")
+			shardingCluster := testapps.NewClusterFactory(testCtx.DefaultNamespace, clusterName, "").
+				WithRandomName().
+				AddSharding(shardingName, "", compDefObj.Name).
+				SetShardingReplicas(2).
+				Create(&testCtx).GetObject()
+
+			By("mocking the sharding cluster status as Running")
+			Expect(testapps.ChangeObjStatus(&testCtx, shardingCluster, func() {
+				shardingCluster.Status.Phase = appsv1.RunningClusterPhase
+				shardingCluster.Status.Shardings = map[string]appsv1.ClusterShardingStatus{
+					shardingName: {
+						Phase: appsv1.RunningComponentPhase,
+					},
+				}
+			})).Should(Succeed())
+
+			opsRes.Cluster = shardingCluster
+			ops := testops.NewOpsRequestObj("ops-switchover-"+testCtx.GetRandomStr(), testCtx.DefaultNamespace,
+				shardingCluster.Name, opsv1alpha1.SwitchoverType)
+			instanceName := fmt.Sprintf("%s-%s-%d", shardingCluster.Name, shardingName, 99)
+			ops.Spec.SwitchoverList = []opsv1alpha1.Switchover{
+				{
+					ComponentName: shardingName,
+					InstanceName:  instanceName,
+				},
+			}
+			opsRes.OpsRequest = testops.CreateOpsRequest(ctx, testCtx, ops)
+			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsPendingPhase
+
+			By("mock switchover OpsRequest phase is Creating")
+			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsCreatingPhase))
+
+			By("do switchover action and expect terminal failure")
+			_, err = GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsFailedPhase))
 		})
 	})
 })

--- a/pkg/operations/switchover_test.go
+++ b/pkg/operations/switchover_test.go
@@ -465,8 +465,10 @@ var _ = Describe("", func() {
 			Eventually(testops.GetOpsRequestPhase(&testCtx, key)).Should(Equal(opsv1alpha1.OpsCreatingPhase))
 
 			By("run switchover precheck and expect waiting instead of terminal failure")
-			_, err = GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			result, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)
 			Expect(err).ShouldNot(HaveOccurred())
+			Expect(result).ShouldNot(BeNil())
+			Expect(result.RequeueAfter).Should(BeNumerically(">", 0))
 			Consistently(testops.GetOpsRequestPhase(&testCtx, key)).Should(Equal(opsv1alpha1.OpsCreatingPhase))
 		})
 

--- a/pkg/operations/switchover_test.go
+++ b/pkg/operations/switchover_test.go
@@ -433,6 +433,38 @@ var _ = Describe("", func() {
 			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsCreatingPhase))
 		})
 
+		It("keeps switchover OpsRequest creating when source instance temporarily has no role label", func() {
+			By("create switchover opsRequest with a roleless source instance")
+			ops := testops.NewOpsRequestObj("ops-switchover-"+testCtx.GetRandomStr(), testCtx.DefaultNamespace,
+				clusterObj.Name, opsv1alpha1.SwitchoverType)
+			instanceName := fmt.Sprintf("%s-%s-%d", clusterObj.Name, defaultCompName, 1)
+			candidateName := fmt.Sprintf("%s-%s-%d", clusterObj.Name, defaultCompName, 0)
+			sourcePod := &corev1.Pod{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: testCtx.DefaultNamespace, Name: instanceName}, sourcePod)).Should(Succeed())
+			delete(sourcePod.Labels, constant.RoleLabelKey)
+			Expect(k8sClient.Update(ctx, sourcePod)).Should(Succeed())
+			ops.Spec.SwitchoverList = []opsv1alpha1.Switchover{
+				{
+					ComponentName: defaultCompName,
+					InstanceName:  instanceName,
+					CandidateName: candidateName,
+				},
+			}
+			opsRes.OpsRequest = testops.CreateOpsRequest(ctx, testCtx, ops)
+			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsPendingPhase
+			key := client.ObjectKeyFromObject(opsRes.OpsRequest)
+
+			By("move the OpsRequest to Creating")
+			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testops.GetOpsRequestPhase(&testCtx, key)).Should(Equal(opsv1alpha1.OpsCreatingPhase))
+
+			By("run switchover precheck and expect waiting instead of terminal failure")
+			_, err = GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Consistently(testops.GetOpsRequestPhase(&testCtx, key)).Should(Equal(opsv1alpha1.OpsCreatingPhase))
+		})
+
 		startProcessingSwitchoverWithCandidate := func() (client.ObjectKey, string) {
 			By("create a valid switchover OpsRequest with a candidate")
 			ops := testops.NewOpsRequestObj("ops-switchover-"+testCtx.GetRandomStr(), testCtx.DefaultNamespace,
@@ -491,7 +523,7 @@ var _ = Describe("", func() {
 			}).Should(Succeed())
 		}
 
-		expectProcessingCandidateWaiting := func(key client.ObjectKey, expectedMessage string) {
+		expectProcessingCandidateWaiting := func(key client.ObjectKey, expectedMessages ...string) {
 			By("reconcile Processing status and expect it to keep waiting")
 			_, err := GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
 			Expect(err).ShouldNot(HaveOccurred())
@@ -502,7 +534,9 @@ var _ = Describe("", func() {
 				progressDetail := findStatusProgressDetail(fetched.Status.Components[defaultCompName].ProgressDetails, getProgressObjectKey(KBSwitchoverKey, defaultCompName))
 				g.Expect(progressDetail).ShouldNot(BeNil())
 				g.Expect(progressDetail.Status).Should(Equal(opsv1alpha1.ProcessingProgressStatus))
-				g.Expect(progressDetail.Message).Should(ContainSubstring(expectedMessage))
+				for _, expectedMessage := range expectedMessages {
+					g.Expect(progressDetail.Message).Should(ContainSubstring(expectedMessage))
+				}
 			}).Should(Succeed())
 		}
 
@@ -531,7 +565,10 @@ var _ = Describe("", func() {
 				clusterObj.Name, defaultCompName, testapps.DataVolumeName).
 				SetStorage("1Gi").
 				Create(&testCtx)
-			expectProcessingCandidateWaiting(key, fmt.Sprintf("waiting for candidate pod %s role label", candidateName))
+			expectProcessingCandidateWaiting(key,
+				fmt.Sprintf("waiting for candidate pod %s role change", candidateName),
+				`current role ""`,
+				`expected role "`)
 		})
 
 		It("keeps Processing switchover when candidate temporarily loses role label", func() {
@@ -541,7 +578,10 @@ var _ = Describe("", func() {
 			Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: testCtx.DefaultNamespace, Name: candidateName}, candidatePod)).Should(Succeed())
 			delete(candidatePod.Labels, constant.RoleLabelKey)
 			Expect(k8sClient.Update(ctx, candidatePod)).Should(Succeed())
-			expectProcessingCandidateWaiting(key, fmt.Sprintf("waiting for candidate pod %s role label", candidateName))
+			expectProcessingCandidateWaiting(key,
+				fmt.Sprintf("waiting for candidate pod %s role change", candidateName),
+				`current role ""`,
+				`expected role "`)
 		})
 
 		It("Test switchover OpsRequest with sharding component name", func() {

--- a/pkg/operations/type.go
+++ b/pkg/operations/type.go
@@ -145,6 +145,7 @@ type Instance interface {
 	GetName() string
 	GetComponentName() string
 	GetCreationTimestamp() metav1.Time
+	HasPod() bool
 	IsDeleting() bool
 	GetRole() string
 	IsAvailable(minReadySeconds int32, roleAware bool) bool


### PR DESCRIPTION
Fixes #10456

## Problem

FalkorDB negative case N04 created a Switchover OpsRequest with an invalid candidate name. The OpsRequest passed API validation, entered `Creating`, emitted `DoActionFailed`, and stayed non-terminal during a 24-minute observation window.

For Switchover, `instanceName` and `candidateName` are Pod-based operation inputs according to the OpsRequest API and ComponentDefinition lifecycle variables. If the named source/candidate does not correspond to an instance that currently has a Pod in the target component, retrying the same input cannot converge. The OpsRequest should terminal-fail instead of remaining in `Creating` or retrying in `Processing`.

## Root Cause

`switchoverPreCheck` called `runtime.GetInstance` for source/candidate and returned raw Kubernetes `NotFound` errors. The generic Ops manager treats non-fatal action errors as retryable, so the OpsRequest stayed in `Creating`.

`OpsRuntime.GetInstance` can also synthesize a retained-PVC-only instance when the Pod is gone but retained PVCs still exist. That fallback is useful for other Ops paths, but switchover still needs a Pod-backed instance because the API/lifecycle contract names source/candidate Pods. Retained-PVC-only instances must not be accepted as switchover source/candidate inputs.

A second review gap was that source role absence returned `NeedWaiting`, but `OpsManager.Do` converted `NeedWaiting` to `Reconciled()` with no `RequeueAfter`. That could leave the OpsRequest stuck in `Creating` until an unrelated Cluster/InstanceSet/Ops event happened to enqueue it.

## Contract

This PR keeps the Ops runtime abstraction as the boundary:

- source/candidate validation goes through `OpsRuntime.GetInstance`; it does not directly `Get` Pods from the Kubernetes client, so runtime data-context handling is preserved.
- the returned `Instance` must be Pod-backed for switchover. Retained-PVC-only fallback is treated as invalid switchover input.
- no Pod-backed source/candidate: invalid switchover input, terminal failure.
- Pod-backed instance exists but role label is empty/non-target: not input-invalid. Source role absence waits in precheck with explicit requeue. During `Processing`, candidate role is only an observation signal; current role equals expected role means success, otherwise the progress message reports both current and expected roles and keeps waiting.

## Changes

- Add `Instance.HasPod()` to the Ops runtime abstraction and implement it for `defaultInstance`.
- Use `OpsRuntime.GetInstance` plus `Instance.HasPod()` for switchover source/candidate validation and Processing observation instead of direct Pod reads.
- Convert source/candidate no-Pod state during switchover precheck into fatal Ops errors, so the Ops manager patches the OpsRequest to `Failed`.
- Revalidate a specified candidate through the runtime abstraction immediately before invoking the lifecycle action, so a candidate that lost its Pod fails terminally before the action is attempted.
- Convert sharding source-instance Pod `NotFound` into the same fatal invalid-input path instead of returning raw Kubernetes `NotFound`.
- Convert Processing-phase candidate no-Pod state into failed progress, so the OpsRequest reaches terminal `Failed` instead of retrying or waiting for timeout.
- Change `OpsManager.Do` handling of `NeedWaiting` from `Reconciled()` to `RequeueAfter(1s)`, so precheck waits can make progress without relying on unrelated events.
- Keep source/candidate role label absence/non-target role as waiting/observation state, not input-invalid state.
- Add regression coverage for:
  - missing source instance
  - missing candidate instance
  - source disappears before action execution
  - candidate disappears before action execution
  - sharding source instance does not exist
  - Processing-phase candidate disappears
  - source/candidate role label temporarily empty
  - source role-label wait returns explicit requeue
  - Processing message includes current and expected candidate roles when waiting
  - retained-PVC-only candidate has no Pod and therefore fails by the switchover API contract
- Add PVC finalizer-aware cleanup to the switchover test suite because the regression creates a PVC fixture.

## Verification

```bash
KUBEBUILDER_ASSETS="/Users/wei/Library/Application Support/io.kubebuilder.envtest/k8s/1.26.1-darwin-arm64" go test ./pkg/operations -run TestAPIs -ginkgo.focus 'switchover' -count=1
KUBEBUILDER_ASSETS="/Users/wei/Library/Application Support/io.kubebuilder.envtest/k8s/1.26.1-darwin-arm64" go test ./pkg/operations -count=1
git diff --check
```

All passed locally on head `e5e66fc469308e66edf2ddecf78f70f3ebdf4ada`.

## Boundary

This fixes the control-plane status path for switchover inputs that do not correspond to Pod-backed component instances. It does not redefine retained-PVC instance semantics globally, does not claim FalkorDB addon release readiness, and does not validate engine-level switchover behavior.
