### PR TITLE
docs: fix broken Releases badge URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/7544/badge)](https://bestpractices.coreinfrastructure.org/projects/7544)
 [![CICD Push](https://github.com/apecloud/kubeblocks/actions/workflows/cicd-push.yml/badge.svg)](https://github.com/apecloud/kubeblocks/actions/workflows/cicd-push.yml)
 [![CodeQL](https://github.com/apecloud/kubeblocks/actions/workflows/codeql.yml/badge.svg)](https://github.com/apecloud/kubeblocks/actions/workflows/codeql.yml)
-[![Releases](https://github.com/apecloud/kubeblocks/workflows/RELEASE-VERSION/badge.svg)](https://github.com/apecloud/kubeblocks/actions/workflows/release-version.yml)
+[![Releases](https://github.com/apecloud/kubeblocks/actions/workflows/release-version.yml/badge.svg)](https://github.com/apecloud/kubeblocks/actions/workflows/release-version.yml)
 [![Release](https://img.shields.io/github/v/release/apecloud/kubeblocks)](https://github.com/apecloud/kubeblocks/releases/latest)
 [![LICENSE](https://img.shields.io/github/license/apecloud/kubeblocks.svg?style=flat-square)](/LICENSE)
 [![Go Report Card](https://goreportcard.com/badge/github.com/apecloud/kubeblocks)](https://goreportcard.com/report/github.com/apecloud/kubeblocks)


### PR DESCRIPTION
### Ⅰ. Describe what this PR does

Fix the broken "Releases" badge in `README.md`. The badge image URL used the deprecated legacy GitHub Actions badge format (`/workflows/RELEASE-VERSION/badge.svg`) which no longer renders. Updated to the current `/actions/workflows/release-version.yml/badge.svg` format, consistent with the `CICD Push` and `CodeQL` badges in the same file.

### Ⅱ. Does this pull request fix one issue?

NONE

### Ⅲ. Describe how to verify it

Open `README.md` and confirm the "Releases" badge renders correctly. The image URL should resolve to a valid shields/badge SVG:

- Before: `https://github.com/apecloud/kubeblocks/workflows/RELEASE-VERSION/badge.svg` (broken)
- After: `https://github.com/apecloud/kubeblocks/actions/workflows/release-version.yml/badge.svg` (valid)

### Ⅳ. Special notes for reviews

Only the badge image URL on line 6 is changed; the link target was already correct.