### PR TITLE
fix(dataprotection): redirect postReady for multi-component restores

### DIFF
--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -452,11 +452,11 @@ func (r *VolumePopulatorReconciler) resolveSourceTargetFromBackup(reqCtx intctrl
 	if len(backup.Status.Targets) == 0 {
 		return backup.Status.Target, false, nil
 	}
-	if len(backup.Status.Targets) == 1 {
-		return resolveSingleSourceTargetForPVC(&backup.Status.Targets[0], pvc)
-	}
 	if pvc.Labels[constant.KBAppShardingNameLabelKey] != "" {
 		return r.resolveShardingSourceTarget(reqCtx, pvc, backup)
+	}
+	if len(backup.Status.Targets) == 1 {
+		return resolveSingleSourceTargetForPVC(&backup.Status.Targets[0], pvc)
 	}
 	var matched []*dpv1alpha1.BackupStatusTarget
 	for i := range backup.Status.Targets {
@@ -483,6 +483,59 @@ func resolveSingleSourceTargetForPVC(target *dpv1alpha1.BackupStatusTarget, pvc 
 		return nil, true, nil
 	}
 	return target, false, nil
+}
+
+func (r *VolumePopulatorReconciler) postReadyRedirectTarget(reqCtx intctrlutil.RequestCtx,
+	pvc *corev1.PersistentVolumeClaim) (string, *dpv1alpha1.BackupStatusTarget, bool, error) {
+	backupNamespace, err := backupNamespaceFromPVC(pvc)
+	if err != nil {
+		return "", nil, false, intctrlutil.NewFatalError(err.Error())
+	}
+	backup := &dpv1alpha1.Backup{}
+	if err = r.Client.Get(reqCtx.Ctx, types.NamespacedName{
+		Namespace: backupNamespace,
+		Name:      pvc.Spec.DataSourceRef.Name,
+	}, backup); err != nil {
+		return "", nil, false, err
+	}
+	if backup.Status.Target == nil && len(backup.Status.Targets) > 0 && pvc.Labels[constant.KBAppShardingNameLabelKey] != "" {
+		target, skipPostReady, err := r.resolveShardingSourceTarget(reqCtx, pvc, backup)
+		if err != nil {
+			return "", nil, false, err
+		}
+		if skipPostReady {
+			return "", nil, false, nil
+		}
+		if target != nil {
+			return postReadyRedirectComponentName(target, pvc)
+		}
+	}
+	var target *dpv1alpha1.BackupStatusTarget
+	if backup.Status.Target != nil {
+		target = backup.Status.Target
+	} else if len(backup.Status.Targets) == 1 {
+		target = &backup.Status.Targets[0]
+	}
+	if target == nil {
+		return "", nil, false, nil
+	}
+	return postReadyRedirectComponentName(target, pvc)
+}
+
+func postReadyRedirectComponentName(target *dpv1alpha1.BackupStatusTarget,
+	pvc *corev1.PersistentVolumeClaim) (string, *dpv1alpha1.BackupStatusTarget, bool, error) {
+	if target.PodSelector == nil || target.PodSelector.LabelSelector == nil {
+		return "", nil, false, intctrlutil.NewFatalError(fmt.Sprintf(
+			"postReady redirect: backup target %q has no PodSelector for PVC %s/%s",
+			target.Name, pvc.Namespace, pvc.Name))
+	}
+	compName := target.PodSelector.MatchLabels[constant.KBAppComponentLabelKey]
+	if compName == "" {
+		return "", nil, false, intctrlutil.NewFatalError(fmt.Sprintf(
+			"postReady redirect: backup target %q PodSelector has no %s label for PVC %s/%s",
+			target.Name, constant.KBAppComponentLabelKey, pvc.Namespace, pvc.Name))
+	}
+	return compName, target, true, nil
 }
 
 func (r *VolumePopulatorReconciler) resolveShardingSourceTarget(reqCtx intctrlutil.RequestCtx,
@@ -1151,29 +1204,48 @@ func (r *VolumePopulatorReconciler) ensurePostReadyRestoreCompleted(reqCtx intct
 	if len(restoreMgr.PostReadyBackupSets) == 0 {
 		return true, nil
 	}
-	if restoreCtx.skipPostReady {
-		return true, nil
-	}
 	if pvc.Annotations[constant.RestoreSourceKindAnnotationKey] == "" {
 		return true, nil
-	}
-	allBound, err := r.allRestorePVCsForComponentBound(reqCtx, pvc)
-	if err != nil || !allBound {
-		if err == nil {
-			err = r.updatePVCConditionsIfPopulateNotReleased(reqCtx, pvc, "Waiting for all restore PVCs to finish prepareData")
-		}
-		return false, err
 	}
 	clusterName := pvc.Labels[constant.AppInstanceLabelKey]
 	componentName := restoreComponentName(pvc)
 	if clusterName == "" || componentName == "" {
 		return false, intctrlutil.NewFatalError(fmt.Sprintf("missing cluster/component labels for PVC %s/%s postReady restore", pvc.Namespace, pvc.Name))
 	}
+	var backupTarget *dpv1alpha1.BackupStatusTarget
+	var err error
+	redirectPostReady := false
+	if restoreCtx.skipPostReady {
+		var targetCompName string
+		targetCompName, backupTarget, redirectPostReady, err = r.postReadyRedirectTarget(reqCtx, pvc)
+		if err != nil {
+			return false, err
+		}
+		if !redirectPostReady {
+			return true, nil
+		}
+		componentName = targetCompName
+	}
+	var allBound bool
+	if redirectPostReady {
+		allBound, err = r.allRestorePVCsForClusterBound(reqCtx, pvc)
+	} else {
+		allBound, err = r.allRestorePVCsForComponentBound(reqCtx, pvc)
+	}
+	if err != nil || !allBound {
+		if err == nil {
+			err = r.updatePVCConditionsIfPopulateNotReleased(reqCtx, pvc, "Waiting for all restore PVCs to finish prepareData")
+		}
+		return false, err
+	}
 	comp := &appsv1.Component{}
 	if err = r.Client.Get(reqCtx.Ctx, types.NamespacedName{
 		Namespace: pvc.Namespace,
 		Name:      constant.GenerateClusterComponentName(clusterName, componentName),
 	}, comp); err != nil {
+		if redirectPostReady && apierrors.IsNotFound(err) {
+			return false, nil
+		}
 		return false, err
 	}
 	if comp.Status.Phase != appsv1.RunningComponentPhase || componentPostProvisionRunning(comp) {
@@ -1198,7 +1270,7 @@ func (r *VolumePopulatorReconciler) ensurePostReadyRestoreCompleted(reqCtx intct
 			return false, nil
 		}
 	}
-	postReadyRestore, err := r.buildPostReadyRestore(reqCtx, pvc, restoreMgr, comp)
+	postReadyRestore, err := r.buildPostReadyRestore(reqCtx, pvc, restoreMgr, comp, componentName, backupTarget)
 	if err != nil {
 		return false, err
 	}
@@ -1243,9 +1315,14 @@ func (r *VolumePopulatorReconciler) updatePVCConditionsIfPopulateNotReleased(req
 func (r *VolumePopulatorReconciler) buildPostReadyRestore(reqCtx intctrlutil.RequestCtx,
 	pvc *corev1.PersistentVolumeClaim,
 	restoreMgr *dprestore.RestoreManager,
-	comp *appsv1.Component) (*dpv1alpha1.Restore, error) {
+	comp *appsv1.Component,
+	targetComponentName string,
+	redirectTarget *dpv1alpha1.BackupStatusTarget) (*dpv1alpha1.Restore, error) {
 	clusterName := pvc.Labels[constant.AppInstanceLabelKey]
-	componentName := restoreComponentName(pvc)
+	componentName := targetComponentName
+	if componentName == "" {
+		componentName = restoreComponentName(pvc)
+	}
 	backupNamespace, err := backupNamespaceFromPVC(pvc)
 	if err != nil {
 		return nil, intctrlutil.NewFatalError(err.Error())
@@ -1260,6 +1337,10 @@ func (r *VolumePopulatorReconciler) buildPostReadyRestore(reqCtx intctrlutil.Req
 	sourceTarget, err := r.resolveSourceTarget(reqCtx, pvc, backupNamespace)
 	if err != nil {
 		return nil, err
+	}
+	effectiveTarget := sourceTarget
+	if effectiveTarget == nil {
+		effectiveTarget = redirectTarget
 	}
 	connectionCredential, err := r.postReadyConnectionCredential(reqCtx, pvc, backupNamespace, clusterName, componentName, comp)
 	if err != nil {
@@ -1292,11 +1373,11 @@ func (r *VolumePopulatorReconciler) buildPostReadyRestore(reqCtx intctrlutil.Req
 		},
 		ConnectionCredential: connectionCredential,
 	}
-	if sourceTarget != nil {
-		if sourceTarget.PodSelector != nil {
-			readyConfig.JobAction.Target.PodSelector.Strategy = sourceTarget.PodSelector.Strategy
+	if effectiveTarget != nil {
+		if effectiveTarget.PodSelector != nil {
+			readyConfig.JobAction.Target.PodSelector.Strategy = effectiveTarget.PodSelector.Strategy
 		}
-		readyConfig.JobAction.RequiredPolicyForAllPodSelection = postReadyRequiredPolicy(sourceTarget)
+		readyConfig.JobAction.RequiredPolicyForAllPodSelection = postReadyRequiredPolicy(effectiveTarget)
 		backup := &dpv1alpha1.Backup{}
 		if err = r.Client.Get(reqCtx.Ctx, types.NamespacedName{Namespace: backupNamespace, Name: pvc.Spec.DataSourceRef.Name}, backup); err != nil {
 			return nil, err
@@ -1322,8 +1403,8 @@ func (r *VolumePopulatorReconciler) buildPostReadyRestore(reqCtx intctrlutil.Req
 			ReadyConfig: readyConfig,
 		},
 	}
-	if sourceTarget != nil {
-		restore.Spec.Backup.SourceTargetName = sourceTarget.Name
+	if effectiveTarget != nil {
+		restore.Spec.Backup.SourceTargetName = effectiveTarget.Name
 	}
 	if err = controllerutil.SetOwnerReference(comp, restore, r.Scheme); err != nil {
 		return nil, err
@@ -1388,6 +1469,59 @@ func (r *VolumePopulatorReconciler) allRestorePVCsForComponentBound(reqCtx intct
 		}
 	}
 	return true, nil
+}
+
+func (r *VolumePopulatorReconciler) allRestorePVCsForClusterBound(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim) (bool, error) {
+	pvcs, err := r.listRestorePVCsForCluster(reqCtx, pvc)
+	if err != nil {
+		return false, err
+	}
+	for i := range pvcs {
+		item := &pvcs[i]
+		cond := findPVCConditionByType(item, appsv1.ConditionTypeRestore)
+		if cond != nil && cond.Status == corev1.ConditionFalse {
+			return false, intctrlutil.NewFatalError(fmt.Sprintf("restore PVC %s/%s failed: %s", item.Namespace, item.Name, cond.Message))
+		}
+		if item.Spec.VolumeName == "" {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func (r *VolumePopulatorReconciler) listRestorePVCsForCluster(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim) ([]corev1.PersistentVolumeClaim, error) {
+	clusterName := pvc.Labels[constant.AppInstanceLabelKey]
+	if clusterName == "" || pvc.Spec.DataSourceRef == nil {
+		return []corev1.PersistentVolumeClaim{*pvc}, nil
+	}
+	pvcList := &corev1.PersistentVolumeClaimList{}
+	if err := r.Client.List(reqCtx.Ctx, pvcList, client.InNamespace(pvc.Namespace),
+		client.MatchingLabels(constant.GetClusterLabels(clusterName))); err != nil {
+		return nil, err
+	}
+	var result []corev1.PersistentVolumeClaim
+	sourceNamespace, err := r.authorizedBackupNamespaceFromPVC(reqCtx, pvc)
+	if err != nil {
+		return nil, intctrlutil.NewFatalError(err.Error())
+	}
+	for i := range pvcList.Items {
+		item := pvcList.Items[i]
+		if item.Spec.DataSourceRef == nil || item.Spec.DataSourceRef.Name != pvc.Spec.DataSourceRef.Name {
+			continue
+		}
+		if item.Annotations[constant.RestoreSourceKindAnnotationKey] == "" {
+			continue
+		}
+		itemSourceNamespace, err := r.authorizedBackupNamespaceFromPVC(reqCtx, &item)
+		if err != nil {
+			return nil, intctrlutil.NewFatalError(err.Error())
+		}
+		if itemSourceNamespace != sourceNamespace {
+			continue
+		}
+		result = append(result, item)
+	}
+	return result, nil
 }
 
 func findPVCConditionByType(pvc *corev1.PersistentVolumeClaim, conditionType string) *corev1.PersistentVolumeClaimCondition {
@@ -1743,6 +1877,9 @@ func (r *VolumePopulatorReconciler) getProvisionOnlyPVC(reqCtx intctrlutil.Reque
 }
 
 func (r *VolumePopulatorReconciler) rebindPVCAndPV(reqCtx intctrlutil.RequestCtx, populatePVC, pvc *corev1.PersistentVolumeClaim) (bool, error) {
+	if populatePVC == nil {
+		return false, intctrlutil.NewFatalError(fmt.Sprintf("populate PVC is nil for target PVC %s/%s; restoreData path entered without prepareData backup set", pvc.Namespace, pvc.Name))
+	}
 	if populatePVC.Spec.VolumeName == "" {
 		return false, nil
 	}

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -1385,7 +1385,7 @@ func TestBuildPostReadyRestoreSelectsHighestPriorityRole(t *testing.T) {
 	}
 	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{}, nil, scheme, reconciler.Client)
 
-	restore, err := reconciler.buildPostReadyRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp)
+	restore, err := reconciler.buildPostReadyRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp, "", nil)
 
 	require.NoError(t, err)
 	require.Equal(t, "leader", restore.Spec.ReadyConfig.JobAction.Target.PodSelector.LabelSelector.MatchLabels[instanceset.RoleLabelKey])
@@ -1423,7 +1423,7 @@ func TestBuildPostReadyRestoreUsesInitAccountFromComponentDefinition(t *testing.
 	}
 	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{}, nil, scheme, reconciler.Client)
 
-	restore, err := reconciler.buildPostReadyRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp)
+	restore, err := reconciler.buildPostReadyRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp, "", nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, restore.Spec.ReadyConfig.ConnectionCredential)
@@ -1773,6 +1773,8 @@ func TestCompleteBoundPVCMarksRestoreSucceededAfterPostReadyCompleted(t *testing
 		pvc,
 		restoreMgr,
 		comp,
+		"",
+		nil,
 	)
 	require.NoError(t, err)
 	postReadyRestore.Status.Phase = dpv1alpha1.RestorePhaseCompleted
@@ -2260,4 +2262,850 @@ func TestRestoreSystemAccountSecretsReturnsFatalForInvalidAccountsPayload(t *tes
 	err := reconciler.restoreSystemAccountSecrets(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup.Namespace)
 	require.Error(t, err)
 	require.True(t, intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal))
+}
+
+// TiDB-shaped multi-component test: backup target (tidb) has no data PVC,
+// data PVCs belong to other components (pd, tikv).
+// ActionSet has only postReady (no prepareData) — logical backup pattern.
+
+func TestDecidePVCRestore_MultiComponent_PostReadyOnly_SkipsNonMatchingPVC(t *testing.T) {
+	// Documents current behavior (the bug): when backup target is scoped to
+	// component "tidb" and a PVC belongs to component "pd", skipPostReady=true.
+	reconciler := &VolumePopulatorReconciler{}
+	backup := newBackupForRestoreDecision(nil, nil) // no targetVolumes (logical backup)
+	backup.Status.BackupMethod.TargetVolumes = nil
+	backup.Status.Target = &dpv1alpha1.BackupStatusTarget{
+		BackupTarget: dpv1alpha1.BackupTarget{
+			Name: "tidb",
+			PodSelector: &dpv1alpha1.PodSelector{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						constant.AppInstanceLabelKey:    "cluster",
+						constant.KBAppComponentLabelKey: "tidb",
+					},
+				},
+			},
+		},
+	}
+
+	// PD data PVC — belongs to "pd" component, not "tidb"
+	pdPVC := newPVCForRestoreDecision("data", "pd", "")
+	decision, err := reconciler.decidePVCRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pdPVC, backup, nil)
+	require.NoError(t, err)
+	require.Equal(t, pvcRestoreModeProvisionOnly, decision.mode)
+	// Current behavior: skipPostReady=true for non-matching component
+	require.True(t, decision.skipPostReady, "current behavior: non-matching PVC gets skipPostReady=true")
+	require.Nil(t, decision.sourceTarget)
+
+	// TiKV data PVC — also not "tidb"
+	tikvPVC := newPVCForRestoreDecision("data", "tikv", "")
+	decision, err = reconciler.decidePVCRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, tikvPVC, backup, nil)
+	require.NoError(t, err)
+	require.Equal(t, pvcRestoreModeProvisionOnly, decision.mode)
+	require.True(t, decision.skipPostReady, "current behavior: non-matching PVC gets skipPostReady=true")
+	require.Nil(t, decision.sourceTarget)
+}
+
+func TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_ShouldNotSilentlySkip(t *testing.T) {
+	// Desired behavior: for a TiDB-shaped multi-component logical backup restore
+	// (postReady-only ActionSet, backup target scoped to "tidb", data PVCs in pd/tikv),
+	// the full production decision→postReady path should produce exactly 1 Restore CR
+	// anchored to the backup target component context (tidb), not silently skip all.
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, kbappsv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	apiGroup := dptypes.DataprotectionAPIGroup
+
+	backup := newBackupForRestoreDecision(nil, nil)
+	backup.Status.BackupMethod.TargetVolumes = nil
+	backup.Status.Target = &dpv1alpha1.BackupStatusTarget{
+		BackupTarget: dpv1alpha1.BackupTarget{
+			Name: "tidb",
+			PodSelector: &dpv1alpha1.PodSelector{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						constant.AppInstanceLabelKey:    "cluster",
+						constant.KBAppComponentLabelKey: "tidb",
+					},
+				},
+			},
+		},
+	}
+
+	// PD data PVC
+	pdPVC := newPVCForRestoreDecision("data", "pd", "")
+	pdPVC.UID = types.UID("pd-pvc-uid")
+	pdPVC.Spec.VolumeName = "pd-data-pv"
+	pdPVC.Spec.DataSourceRef = &corev1.TypedObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     dptypes.BackupKind,
+		Name:     backup.Name,
+	}
+	pdPVC.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
+	pdPVC.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+
+	// TiKV data PVC
+	tikvPVC := newPVCForRestoreDecision("data", "tikv", "")
+	tikvPVC.UID = types.UID("tikv-pvc-uid")
+	tikvPVC.Spec.VolumeName = "tikv-data-pv"
+	tikvPVC.Spec.DataSourceRef = &corev1.TypedObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     dptypes.BackupKind,
+		Name:     backup.Name,
+	}
+	tikvPVC.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
+	tikvPVC.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+
+	// All three components: pd, tikv, tidb (backup target)
+	pdComp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "pd"),
+			UID:       "pd-component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
+	}
+	tikvComp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "tikv"),
+			UID:       "tikv-component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
+	}
+	tidbComp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "tidb"),
+			UID:       "tidb-component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
+	}
+
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).
+			WithStatusSubresource(pdPVC, tikvPVC).
+			WithObjects(backup, pdPVC, tikvPVC, pdComp, tikvComp, tidbComp).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{
+		Spec: dpv1alpha1.RestoreSpec{Backup: dpv1alpha1.BackupRef{Name: backup.Name, Namespace: backup.Namespace}},
+	}, nil, scheme, reconciler.Client)
+	restoreMgr.PostReadyBackupSets = []dprestore.BackupActionSet{{Backup: backup}}
+
+	// Step 1: derive context from the production decision path (not hardcoded)
+	pdDecision, err := reconciler.decidePVCRestore(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pdPVC, backup, nil)
+	require.NoError(t, err)
+	tikvDecision, err := reconciler.decidePVCRestore(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, tikvPVC, backup, nil)
+	require.NoError(t, err)
+
+	pdCtx := &pvcRestoreContext{
+		restoreMgr:    restoreMgr,
+		mode:          pdDecision.mode,
+		skipPostReady: pdDecision.skipPostReady,
+	}
+	tikvCtx := &pvcRestoreContext{
+		restoreMgr:    restoreMgr,
+		mode:          tikvDecision.mode,
+		skipPostReady: tikvDecision.skipPostReady,
+	}
+
+	// Step 2: process both PVCs through ensurePostReadyRestoreCompleted
+	completed1, err := reconciler.ensurePostReadyRestoreCompleted(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pdPVC, pdCtx)
+	require.NoError(t, err)
+	completed2, err := reconciler.ensurePostReadyRestoreCompleted(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, tikvPVC, tikvCtx)
+	require.NoError(t, err)
+
+	// Step 3: assert exactly 1 Restore CR
+	restoreList := &dpv1alpha1.RestoreList{}
+	require.NoError(t, reconciler.Client.List(context.Background(), restoreList, client.InNamespace("default")))
+	require.Len(t, restoreList.Items, 1,
+		"postReady-only ActionSet with multi-component backup should create exactly 1 Restore CR, "+
+			"not silently skip all non-matching PVCs (got %d)", len(restoreList.Items))
+
+	// Step 4: assert the Restore CR is anchored to the backup target component (tidb)
+	restore := restoreList.Items[0]
+
+	// Owner must be the tidb component (backup target), not pd or tikv
+	require.Len(t, restore.OwnerReferences, 1, "Restore CR should have exactly 1 owner reference")
+	require.Equal(t, tidbComp.UID, restore.OwnerReferences[0].UID,
+		"Restore CR owner should be the backup target component (tidb), not a random data component")
+	require.Equal(t, tidbComp.Name, restore.OwnerReferences[0].Name)
+
+	// ReadyConfig pod selectors must target tidb component pods
+	require.NotNil(t, restore.Spec.ReadyConfig)
+	require.NotNil(t, restore.Spec.ReadyConfig.ExecAction)
+	require.Equal(t, "tidb",
+		restore.Spec.ReadyConfig.ExecAction.Target.PodSelector.MatchLabels[constant.KBAppComponentLabelKey],
+		"ExecAction should target tidb component pods (where BR tool + PD_ADDRESS env are)")
+	require.NotNil(t, restore.Spec.ReadyConfig.JobAction)
+	require.Equal(t, "tidb",
+		restore.Spec.ReadyConfig.JobAction.Target.PodSelector.LabelSelector.MatchLabels[constant.KBAppComponentLabelKey],
+		"JobAction should target tidb component pods")
+
+	// Dedup: Restore name should be deterministic (per tidb component UID, not per data PVC)
+	require.Equal(t, postReadyRestoreName(tidbComp.UID), restore.Name,
+		"Restore CR name should be keyed on backup target component UID for deterministic dedup")
+
+	// Backup source target should reference the backup target
+	require.Equal(t, "tidb", restore.Spec.Backup.SourceTargetName,
+		"Restore CR should reference backup target name")
+
+	// Both PVCs should not both report completed=true when postReady is in-progress
+	require.False(t, completed1 && completed2,
+		"at least one PVC should wait for postReady restore, not all silently skip")
+}
+
+func TestEnsurePostReadyRestore_MultiComponent_PrepareDataAndPostReady_RedirectsPostReady(t *testing.T) {
+	// TiDB PITR shape: data PVCs belong to non-target components, while the
+	// backup target component owns the postReady replay action. The presence of
+	// prepareData must not make skipPostReady treat postReady as already done.
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, kbappsv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	apiGroup := dptypes.DataprotectionAPIGroup
+
+	backup := newBackupForRestoreDecision([]string{"data"}, nil)
+	backup.Status.Target = &dpv1alpha1.BackupStatusTarget{
+		BackupTarget: dpv1alpha1.BackupTarget{
+			Name: "tidb",
+			PodSelector: &dpv1alpha1.PodSelector{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						constant.AppInstanceLabelKey:    "cluster",
+						constant.KBAppComponentLabelKey: "tidb",
+					},
+				},
+			},
+		},
+	}
+
+	pdPVC := newPVCForRestoreDecision("data", "pd", "")
+	pdPVC.UID = types.UID("pd-pvc-uid")
+	pdPVC.Spec.VolumeName = "pd-data-pv"
+	pdPVC.Spec.DataSourceRef = &corev1.TypedObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     dptypes.BackupKind,
+		Name:     backup.Name,
+	}
+	pdPVC.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
+	pdPVC.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+
+	pdComp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "pd"),
+			UID:       "pd-component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
+	}
+	tidbComp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "tidb"),
+			UID:       "tidb-component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
+	}
+
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).
+			WithStatusSubresource(pdPVC).
+			WithObjects(backup, pdPVC, pdComp, tidbComp).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{
+		Spec: dpv1alpha1.RestoreSpec{Backup: dpv1alpha1.BackupRef{Name: backup.Name, Namespace: backup.Namespace}},
+	}, nil, scheme, reconciler.Client)
+	restoreMgr.PrepareDataBackupSets = []dprestore.BackupActionSet{{Backup: backup}}
+	restoreMgr.PostReadyBackupSets = []dprestore.BackupActionSet{{Backup: backup}}
+
+	pdDecision, err := reconciler.decidePVCRestore(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pdPVC, backup, nil)
+	require.NoError(t, err)
+	require.True(t, pdDecision.skipPostReady)
+
+	completed, err := reconciler.ensurePostReadyRestoreCompleted(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pdPVC, &pvcRestoreContext{
+			restoreMgr:    restoreMgr,
+			mode:          pdDecision.mode,
+			skipPostReady: pdDecision.skipPostReady,
+		})
+	require.NoError(t, err)
+	require.False(t, completed, "postReady restore should be in progress, not silently completed")
+
+	restoreList := &dpv1alpha1.RestoreList{}
+	require.NoError(t, reconciler.Client.List(context.Background(), restoreList, client.InNamespace("default")))
+	require.Len(t, restoreList.Items, 1,
+		"prepareData+postReady with non-matching PVC must still create target-component postReady Restore CR")
+
+	restore := restoreList.Items[0]
+	require.Equal(t, tidbComp.UID, restore.OwnerReferences[0].UID)
+	require.Equal(t, "tidb", restore.Spec.Backup.SourceTargetName)
+	require.Equal(t, postReadyRestoreName(tidbComp.UID), restore.Name)
+}
+
+func TestEnsurePostReadyRestore_ShardingMissingTargetSkip_DoesNotRedirect(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, kbappsv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	apiGroup := dptypes.DataprotectionAPIGroup
+
+	cluster := newClusterForShardingDecision(3)
+	components := []client.Object{
+		newComponentForShardingDecision("shard-c"),
+		newComponentForShardingDecision("shard-a"),
+		newComponentForShardingDecision("shard-b"),
+	}
+	backup := newBackupForRestoreDecision(nil, []string{"target-a", "target-b"})
+	backup.Status.BackupMethod.TargetVolumes = nil
+
+	pvc := newPVCForRestoreDecision("data", "shard-c", "shard")
+	pvc.UID = types.UID("shard-c-pvc-uid")
+	pvc.Spec.VolumeName = "shard-c-data-pv"
+	pvc.Spec.DataSourceRef = &corev1.TypedObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     dptypes.BackupKind,
+		Name:     backup.Name,
+	}
+	pvc.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
+	pvc.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+
+	objects := append([]client.Object{cluster, backup, pvc}, components...)
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).
+			WithStatusSubresource(pvc).
+			WithObjects(objects...).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	decision, err := reconciler.decidePVCRestore(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup, nil)
+	require.NoError(t, err)
+	require.Equal(t, pvcRestoreModeProvisionOnly, decision.mode)
+	require.True(t, decision.skipPostReady)
+	require.Nil(t, decision.sourceTarget)
+
+	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{
+		Spec: dpv1alpha1.RestoreSpec{Backup: dpv1alpha1.BackupRef{Name: backup.Name, Namespace: backup.Namespace}},
+	}, nil, scheme, reconciler.Client)
+	restoreMgr.PostReadyBackupSets = []dprestore.BackupActionSet{{Backup: backup}}
+
+	completed, err := reconciler.ensurePostReadyRestoreCompleted(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, &pvcRestoreContext{
+			restoreMgr:    restoreMgr,
+			mode:          decision.mode,
+			skipPostReady: decision.skipPostReady,
+		})
+	require.NoError(t, err)
+	require.True(t, completed, "sharding PVC without source target should preserve skip-only behavior")
+
+	restoreList := &dpv1alpha1.RestoreList{}
+	require.NoError(t, reconciler.Client.List(context.Background(), restoreList, client.InNamespace("default")))
+	require.Len(t, restoreList.Items, 0,
+		"sharding missing-target skip must not create redirected postReady Restore CR")
+}
+
+func TestEnsurePostReadyRestore_ShardingSingleTargetMissingTargetSkip_DoesNotRedirect(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, kbappsv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	apiGroup := dptypes.DataprotectionAPIGroup
+
+	cluster := newClusterForShardingDecision(3)
+	components := []client.Object{
+		newComponentForShardingDecision("shard-c"),
+		newComponentForShardingDecision("shard-a"),
+		newComponentForShardingDecision("shard-b"),
+	}
+	backup := newBackupForRestoreDecision(nil, []string{"target-a"})
+	backup.Status.BackupMethod.TargetVolumes = nil
+
+	pvc := newPVCForRestoreDecision("data", "shard-b", "shard")
+	pvc.UID = types.UID("shard-b-pvc-uid")
+	pvc.Spec.VolumeName = "shard-b-data-pv"
+	pvc.Spec.DataSourceRef = &corev1.TypedObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     dptypes.BackupKind,
+		Name:     backup.Name,
+	}
+	pvc.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
+	pvc.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+
+	objects := append([]client.Object{cluster, backup, pvc}, components...)
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).
+			WithStatusSubresource(pvc).
+			WithObjects(objects...).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	decision, err := reconciler.decidePVCRestore(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup, nil)
+	require.NoError(t, err)
+	require.Equal(t, pvcRestoreModeProvisionOnly, decision.mode)
+	require.True(t, decision.skipPostReady)
+	require.Nil(t, decision.sourceTarget)
+
+	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{
+		Spec: dpv1alpha1.RestoreSpec{Backup: dpv1alpha1.BackupRef{Name: backup.Name, Namespace: backup.Namespace}},
+	}, nil, scheme, reconciler.Client)
+	restoreMgr.PostReadyBackupSets = []dprestore.BackupActionSet{{Backup: backup}}
+
+	completed, err := reconciler.ensurePostReadyRestoreCompleted(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, &pvcRestoreContext{
+			restoreMgr:    restoreMgr,
+			mode:          decision.mode,
+			skipPostReady: decision.skipPostReady,
+		})
+	require.NoError(t, err)
+	require.True(t, completed, "single-target sharding PVC without source target should preserve skip-only behavior")
+
+	restoreList := &dpv1alpha1.RestoreList{}
+	require.NoError(t, reconciler.Client.List(context.Background(), restoreList, client.InNamespace("default")))
+	require.Len(t, restoreList.Items, 0,
+		"single-target sharding missing-target skip must not create redirected postReady Restore CR")
+}
+
+func TestEnsurePostReadyRestore_MultiComponent_PostReadyRedirectPreservesTargetExecutionFields(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, kbappsv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	apiGroup := dptypes.DataprotectionAPIGroup
+	targetMounts := []corev1.VolumeMount{{Name: "data", MountPath: "/data"}}
+
+	backup := newBackupForRestoreDecision(nil, nil)
+	backup.Status.BackupMethod.TargetVolumes = &dpv1alpha1.TargetVolumeInfo{VolumeMounts: targetMounts}
+	backup.Status.Target = &dpv1alpha1.BackupStatusTarget{
+		BackupTarget: dpv1alpha1.BackupTarget{
+			Name: "tidb",
+			PodSelector: &dpv1alpha1.PodSelector{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						constant.AppInstanceLabelKey:    "cluster",
+						constant.KBAppComponentLabelKey: "tidb",
+					},
+				},
+				Strategy: dpv1alpha1.PodSelectionStrategyAll,
+			},
+		},
+	}
+
+	pdPVC := newPVCForRestoreDecision("data", "pd", "")
+	pdPVC.UID = types.UID("pd-pvc-uid")
+	pdPVC.Spec.VolumeName = "pd-data-pv"
+	pdPVC.Spec.DataSourceRef = &corev1.TypedObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     dptypes.BackupKind,
+		Name:     backup.Name,
+	}
+	pdPVC.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
+	pdPVC.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+
+	pdComp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "pd"),
+			UID:       "pd-component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
+	}
+	tidbComp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "tidb"),
+			UID:       "tidb-component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
+	}
+
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).
+			WithStatusSubresource(pdPVC).
+			WithObjects(backup, pdPVC, pdComp, tidbComp).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{
+		Spec: dpv1alpha1.RestoreSpec{Backup: dpv1alpha1.BackupRef{Name: backup.Name, Namespace: backup.Namespace}},
+	}, nil, scheme, reconciler.Client)
+	restoreMgr.PostReadyBackupSets = []dprestore.BackupActionSet{{Backup: backup}}
+
+	decision, err := reconciler.decidePVCRestore(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pdPVC, backup, nil)
+	require.NoError(t, err)
+	require.True(t, decision.skipPostReady)
+
+	_, err = reconciler.ensurePostReadyRestoreCompleted(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pdPVC, &pvcRestoreContext{
+			restoreMgr:    restoreMgr,
+			mode:          decision.mode,
+			skipPostReady: decision.skipPostReady,
+		})
+	require.NoError(t, err)
+
+	restoreList := &dpv1alpha1.RestoreList{}
+	require.NoError(t, reconciler.Client.List(context.Background(), restoreList, client.InNamespace("default")))
+	require.Len(t, restoreList.Items, 1)
+
+	restore := restoreList.Items[0]
+	require.Equal(t, tidbComp.UID, restore.OwnerReferences[0].UID)
+	require.Equal(t, "tidb", restore.Spec.Backup.SourceTargetName)
+	require.NotNil(t, restore.Spec.ReadyConfig.JobAction)
+	require.Equal(t, dpv1alpha1.PodSelectionStrategyAll,
+		restore.Spec.ReadyConfig.JobAction.Target.PodSelector.Strategy)
+	require.Equal(t, targetMounts, restore.Spec.ReadyConfig.JobAction.Target.VolumeMounts)
+	require.Equal(t, &dpv1alpha1.RequiredPolicyForAllPodSelection{
+		DataRestorePolicy: dpv1alpha1.OneToOneRestorePolicy,
+	}, restore.Spec.ReadyConfig.JobAction.RequiredPolicyForAllPodSelection)
+}
+
+func TestRebindPVCAndPV_NilPopulatePVC_ReturnsFatalError(t *testing.T) {
+	// When rebindPVCAndPV is called with nil populatePVC (restoreData path entered
+	// without prepareData backup set), it must return a fatal error — not panic,
+	// and not silently return (false, nil) which would cause infinite requeue.
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       "default",
+			Name:            "data-target-0",
+			UID:             "target-pvc-uid",
+			ResourceVersion: "1",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			DataSourceRef: &corev1.TypedObjectReference{Name: "backup"},
+		},
+	}
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc).Build(),
+	}
+	reqCtx := intctrlutil.RequestCtx{Ctx: context.Background()}
+
+	require.NotPanics(t, func() {
+		rebound, err := reconciler.rebindPVCAndPV(reqCtx, nil, pvc)
+		require.Error(t, err, "nil populatePVC should return error, not silently succeed")
+		require.True(t, intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal),
+			"nil populatePVC is an invalid contract state, should be fatal error: %v", err)
+		require.False(t, rebound)
+	}, "rebindPVCAndPV should not panic when populatePVC is nil")
+}
+
+func TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_TargetComponentNotYetCreated(t *testing.T) {
+	// When the backup target component (tidb) hasn't been created yet (multi-component
+	// sequential creation: PD→TiKV→TiDB), the redirect path should return (false,nil)
+	// for standard requeue — no Reconciler error, no Restore CR created.
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, kbappsv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	apiGroup := dptypes.DataprotectionAPIGroup
+
+	backup := newBackupForRestoreDecision(nil, nil)
+	backup.Status.BackupMethod.TargetVolumes = nil
+	backup.Status.Target = &dpv1alpha1.BackupStatusTarget{
+		BackupTarget: dpv1alpha1.BackupTarget{
+			Name: "tidb",
+			PodSelector: &dpv1alpha1.PodSelector{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						constant.AppInstanceLabelKey:    "cluster",
+						constant.KBAppComponentLabelKey: "tidb",
+					},
+				},
+			},
+		},
+	}
+
+	pdPVC := newPVCForRestoreDecision("data", "pd", "")
+	pdPVC.UID = types.UID("pd-pvc-uid")
+	pdPVC.Spec.VolumeName = "pd-data-pv"
+	pdPVC.Spec.DataSourceRef = &corev1.TypedObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     dptypes.BackupKind,
+		Name:     backup.Name,
+	}
+	pdPVC.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
+	pdPVC.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+
+	// Only PD and TiKV components exist — tidb NOT yet created (sequential creation)
+	pdComp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "pd"),
+			UID:       "pd-component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
+	}
+	tikvComp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "tikv"),
+			UID:       "tikv-component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
+	}
+	// NOTE: no tidb Component — simulates sequential creation where tidb doesn't exist yet
+
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).
+			WithStatusSubresource(pdPVC).
+			WithObjects(backup, pdPVC, pdComp, tikvComp).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{
+		Spec: dpv1alpha1.RestoreSpec{Backup: dpv1alpha1.BackupRef{Name: backup.Name, Namespace: backup.Namespace}},
+	}, nil, scheme, reconciler.Client)
+	restoreMgr.PostReadyBackupSets = []dprestore.BackupActionSet{{Backup: backup}}
+
+	pdDecision, err := reconciler.decidePVCRestore(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pdPVC, backup, nil)
+	require.NoError(t, err)
+	require.True(t, pdDecision.skipPostReady, "PD PVC should have skipPostReady=true")
+
+	pdCtx := &pvcRestoreContext{
+		restoreMgr:    restoreMgr,
+		mode:          pdDecision.mode,
+		skipPostReady: pdDecision.skipPostReady,
+	}
+
+	completed, err := reconciler.ensurePostReadyRestoreCompleted(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pdPVC, pdCtx)
+	require.NoError(t, err, "target Component not yet created should requeue without error, not spam Reconciler error")
+	require.False(t, completed, "should not be completed when target component doesn't exist")
+
+	// No Restore CR should be created
+	restoreList := &dpv1alpha1.RestoreList{}
+	require.NoError(t, reconciler.Client.List(context.Background(), restoreList, client.InNamespace("default")))
+	require.Len(t, restoreList.Items, 0, "no Restore CR should be created while target component doesn't exist")
+}
+
+func TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_WaitsForAllComponentPVCs(t *testing.T) {
+	// When PD PVCs are bound but TiKV PVCs are NOT yet bound, the redirect path must
+	// wait (return false, nil) instead of creating the postReady Restore CR early.
+	// This prevents the logical restore job from running before the cluster is ready.
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, kbappsv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	apiGroup := dptypes.DataprotectionAPIGroup
+
+	backup := newBackupForRestoreDecision(nil, nil)
+	backup.Status.BackupMethod.TargetVolumes = nil
+	backup.Status.Target = &dpv1alpha1.BackupStatusTarget{
+		BackupTarget: dpv1alpha1.BackupTarget{
+			Name: "tidb",
+			PodSelector: &dpv1alpha1.PodSelector{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						constant.AppInstanceLabelKey:    "cluster",
+						constant.KBAppComponentLabelKey: "tidb",
+					},
+				},
+			},
+		},
+	}
+
+	// PD data PVC — bound (has VolumeName)
+	pdPVC := newPVCForRestoreDecision("data", "pd", "")
+	pdPVC.UID = types.UID("pd-pvc-uid")
+	pdPVC.Spec.VolumeName = "pd-data-pv"
+	pdPVC.Spec.DataSourceRef = &corev1.TypedObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     dptypes.BackupKind,
+		Name:     backup.Name,
+	}
+	pdPVC.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
+	pdPVC.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+
+	// TiKV data PVC — NOT bound (no VolumeName)
+	tikvPVC := newPVCForRestoreDecision("data", "tikv", "")
+	tikvPVC.UID = types.UID("tikv-pvc-uid")
+	tikvPVC.Spec.DataSourceRef = &corev1.TypedObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     dptypes.BackupKind,
+		Name:     backup.Name,
+	}
+	tikvPVC.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
+	tikvPVC.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+
+	pdComp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "pd"),
+			UID:       "pd-component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
+	}
+	tikvComp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "tikv"),
+			UID:       "tikv-component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.CreatingComponentPhase},
+	}
+	tidbComp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "tidb"),
+			UID:       "tidb-component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
+	}
+
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).
+			WithStatusSubresource(pdPVC, tikvPVC).
+			WithObjects(backup, pdPVC, tikvPVC, pdComp, tikvComp, tidbComp).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{
+		Spec: dpv1alpha1.RestoreSpec{Backup: dpv1alpha1.BackupRef{Name: backup.Name, Namespace: backup.Namespace}},
+	}, nil, scheme, reconciler.Client)
+	restoreMgr.PostReadyBackupSets = []dprestore.BackupActionSet{{Backup: backup}}
+
+	pdDecision, err := reconciler.decidePVCRestore(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pdPVC, backup, nil)
+	require.NoError(t, err)
+	require.True(t, pdDecision.skipPostReady, "PD PVC should have skipPostReady=true")
+
+	pdCtx := &pvcRestoreContext{
+		restoreMgr:    restoreMgr,
+		mode:          pdDecision.mode,
+		skipPostReady: pdDecision.skipPostReady,
+	}
+
+	// PD PVC triggers redirect, but TiKV PVC is not bound yet — should wait
+	completed, err := reconciler.ensurePostReadyRestoreCompleted(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pdPVC, pdCtx)
+	require.NoError(t, err, "should requeue without error while TiKV PVCs are still pending")
+	require.False(t, completed, "should not be completed while TiKV PVCs are unbound")
+
+	restoreList := &dpv1alpha1.RestoreList{}
+	require.NoError(t, reconciler.Client.List(context.Background(), restoreList, client.InNamespace("default")))
+	require.Len(t, restoreList.Items, 0,
+		"no Restore CR should be created while other component PVCs are still unbound")
+}
+
+func TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_TargetsSlice(t *testing.T) {
+	// Regression: backup target in Status.Targets[0] (not Status.Target) must also
+	// trigger the postReady-only redirect. This mirrors resolveSourceTargetFromBackup
+	// which handles both Status.Target and len(Status.Targets)==1.
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, kbappsv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	apiGroup := dptypes.DataprotectionAPIGroup
+
+	backup := newBackupForRestoreDecision(nil, nil)
+	backup.Status.BackupMethod.TargetVolumes = nil
+	backup.Status.Target = nil
+	backup.Status.Targets = []dpv1alpha1.BackupStatusTarget{{
+		BackupTarget: dpv1alpha1.BackupTarget{
+			Name: "tidb",
+			PodSelector: &dpv1alpha1.PodSelector{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						constant.AppInstanceLabelKey:    "cluster",
+						constant.KBAppComponentLabelKey: "tidb",
+					},
+				},
+			},
+		},
+	}}
+
+	pdPVC := newPVCForRestoreDecision("data", "pd", "")
+	pdPVC.UID = types.UID("pd-pvc-uid")
+	pdPVC.Spec.VolumeName = "pd-data-pv"
+	pdPVC.Spec.DataSourceRef = &corev1.TypedObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     dptypes.BackupKind,
+		Name:     backup.Name,
+	}
+	pdPVC.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
+	pdPVC.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+
+	pdComp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "pd"),
+			UID:       "pd-component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
+	}
+	tidbComp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "tidb"),
+			UID:       "tidb-component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
+	}
+
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).
+			WithStatusSubresource(pdPVC).
+			WithObjects(backup, pdPVC, pdComp, tidbComp).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{
+		Spec: dpv1alpha1.RestoreSpec{Backup: dpv1alpha1.BackupRef{Name: backup.Name, Namespace: backup.Namespace}},
+	}, nil, scheme, reconciler.Client)
+	restoreMgr.PostReadyBackupSets = []dprestore.BackupActionSet{{Backup: backup}}
+
+	pdDecision, err := reconciler.decidePVCRestore(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pdPVC, backup, nil)
+	require.NoError(t, err)
+
+	pdCtx := &pvcRestoreContext{
+		restoreMgr:    restoreMgr,
+		mode:          pdDecision.mode,
+		skipPostReady: pdDecision.skipPostReady,
+	}
+
+	_, err = reconciler.ensurePostReadyRestoreCompleted(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pdPVC, pdCtx)
+	require.NoError(t, err)
+
+	restoreList := &dpv1alpha1.RestoreList{}
+	require.NoError(t, reconciler.Client.List(context.Background(), restoreList, client.InNamespace("default")))
+	require.Len(t, restoreList.Items, 1,
+		"postReady-only with Status.Targets[0] should create exactly 1 Restore CR")
+
+	restore := restoreList.Items[0]
+	require.Equal(t, tidbComp.UID, restore.OwnerReferences[0].UID,
+		"Restore CR owner should be the backup target component (tidb) even when target is in Status.Targets[0]")
+	require.Equal(t, "tidb", restore.Spec.Backup.SourceTargetName)
+	require.Equal(t, postReadyRestoreName(tidbComp.UID), restore.Name)
 }


### PR DESCRIPTION
Fixes #10418.

## Summary
- supersedes the controller-code portion of #10423 with a clean controller-owned branch
- redirects non-matching restore PVC postReady handling to the backup target component instead of silently completing it
- keeps sharding missing-target `skipPostReady` as skip-only instead of treating every skip as redirectable
- keeps the cluster-wide PVC bound wait and target-component NotFound requeue behavior from #10423
- fills redirected Restore ReadyConfig from the effective backup target so Strategy, required policy, and target volume mounts match the normal source-target path
- adds regressions for the TiDB PITR prepareData+postReady shape, sharding skip-only behavior, and redirected postReady execution fields

## Validation
- PASS: `go generate ./pkg/testutil/k8s/mocks` (local compile prerequisite)
- PASS: `go test ./controllers/dataprotection -run 'TestEnsurePostReadyRestore_(ShardingMissingTargetSkip_DoesNotRedirect|MultiComponent_(PrepareDataAndPostReady_RedirectsPostReady|PostReadyOnly_ShouldNotSilentlySkip|PostReadyOnly_TargetComponentNotYetCreated|PostReadyOnly_WaitsForAllComponentPVCs|PostReadyOnly_TargetsSlice|PostReadyRedirectPreservesTargetExecutionFields))|TestDecidePVCRestore_MultiComponent_PostReadyOnly_SkipsNonMatchingPVC|TestDecidePVCRestoreAssignsShardingTargetsByStableComponentOrder|TestRebindPVCAndPV_NilPopulatePVC_ReturnsFatalError' -count=1`
- PASS: `git diff --check -- controllers/dataprotection/volumepopulator_controller.go controllers/dataprotection/volumepopulator_controller_test.go`
- BLOCKED locally: `go test ./controllers/dataprotection -count=1` cannot start envtest because `/usr/local/kubebuilder/bin/etcd` is absent; 0 envtest specs ran

## Evidence boundary
TiDB PITR on PR1/idc4 reported `13P/1F/0S`, with PITR.6 showing zero postReady Restore CRs on #10423 head `95b0723`. This PR fixes the controller path and closes the local regression gate. A TiDB PITR runtime rerun against this PR head is still required for addon acceptance.
