### PR TITLE
fix(operations): validate upgrade service version and fail fast on invalid format

### DIFF
--- a/apis/operations/v1alpha1/opsrequest_types_test.go
+++ b/apis/operations/v1alpha1/opsrequest_types_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"testing"
 )
 
@@ -51,4 +52,151 @@ func TestSetStatusAndMessage(t *testing.T) {
 	if p.Status != SucceedProgressStatus && p.Message != message {
 		t.Error("set progressDetail status and message failed")
 	}
+}
+
+func TestValidateUpgradeServiceVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		upgrade *Upgrade
+		wantErr bool
+	}{
+		{
+			name:    "nil upgrade",
+			upgrade: nil,
+			wantErr: true,
+		},
+		{
+			name:    "empty components",
+			upgrade: &Upgrade{},
+			wantErr: true,
+		},
+		{
+			name: "valid service version with three parts",
+			upgrade: &Upgrade{
+				Components: []UpgradeComponent{
+					{
+						ComponentOps:   ComponentOps{ComponentName: "pg"},
+						ServiceVersion: strPtr("17.5.0"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid service version without patch",
+			upgrade: &Upgrade{
+				Components: []UpgradeComponent{
+					{
+						ComponentOps:   ComponentOps{ComponentName: "pg"},
+						ServiceVersion: strPtr("17.5"),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "nil service version skips validation",
+			upgrade: &Upgrade{
+				Components: []UpgradeComponent{
+					{
+						ComponentOps:            ComponentOps{ComponentName: "pg"},
+						ComponentDefinitionName: strPtr("new-compdef"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty service version string is valid",
+			upgrade: &Upgrade{
+				Components: []UpgradeComponent{
+					{
+						ComponentOps:   ComponentOps{ComponentName: "pg"},
+						ServiceVersion: strPtr(""),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "service version with prefix v is valid",
+			upgrade: &Upgrade{
+				Components: []UpgradeComponent{
+					{
+						ComponentOps:   ComponentOps{ComponentName: "pg"},
+						ServiceVersion: strPtr("v1.0.0"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid service version random text",
+			upgrade: &Upgrade{
+				Components: []UpgradeComponent{
+					{
+						ComponentOps:   ComponentOps{ComponentName: "pg"},
+						ServiceVersion: strPtr("not-a-version"),
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid version with pre-release",
+			upgrade: &Upgrade{
+				Components: []UpgradeComponent{
+					{
+						ComponentOps:   ComponentOps{ComponentName: "pg"},
+						ServiceVersion: strPtr("17.5.0-alpha.1"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid version with build metadata",
+			upgrade: &Upgrade{
+				Components: []UpgradeComponent{
+					{
+						ComponentOps:   ComponentOps{ComponentName: "pg"},
+						ServiceVersion: strPtr("17.5.0+build123"),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "multiple components with mixed versions",
+			upgrade: &Upgrade{
+				Components: []UpgradeComponent{
+					{
+						ComponentOps:   ComponentOps{ComponentName: "pg"},
+						ServiceVersion: strPtr("17.5.0"),
+					},
+					{
+						ComponentOps:   ComponentOps{ComponentName: "redis"},
+						ServiceVersion: strPtr("7.2"),
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &OpsRequest{}
+			if tt.upgrade != nil {
+				r.Spec.Upgrade = tt.upgrade
+			}
+			err := r.validateUpgrade(context.Background(), nil, nil)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateUpgrade() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func strPtr(s string) *string {
+	return &s
 }

--- a/apis/operations/v1alpha1/opsrequest_validation.go
+++ b/apis/operations/v1alpha1/opsrequest_validation.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
@@ -213,6 +214,13 @@ func (r *OpsRequest) validateUpgrade(ctx context.Context, k8sClient client.Clien
 	}
 	if len(r.Spec.Upgrade.Components) == 0 {
 		return notEmptyError("spec.upgrade.components")
+	}
+	for _, v := range r.Spec.Upgrade.Components {
+		if v.ServiceVersion != nil && *v.ServiceVersion != "" {
+			if _, err := version.ParseSemantic(*v.ServiceVersion); err != nil {
+				return invalidValueError(v.ComponentName, fmt.Sprintf("serviceVersion \"%s\" is not a valid semantic version: %s", *v.ServiceVersion, err.Error()))
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/operations/upgrade.go
+++ b/pkg/operations/upgrade.go
@@ -148,10 +148,10 @@ func (u upgradeOpsHandler) getComponentDefMapWithUpdatedImages(reqCtx intctrluti
 		}
 		compDef, err := component.GetCompDefByName(reqCtx.Ctx, cli, compSpec.ComponentDef)
 		if err != nil {
-			return nil, err
+			return nil, intctrlutil.NewFatalError(err.Error())
 		}
 		if err = component.UpdateCompDefinitionImages4ServiceVersion(reqCtx.Ctx, cli, compDef, compSpec.ServiceVersion); err != nil {
-			return nil, err
+			return nil, intctrlutil.NewFatalError(err.Error())
 		}
 		compDefMap[v.ComponentName] = compDef
 	}

--- a/pkg/operations/upgrade.go
+++ b/pkg/operations/upgrade.go
@@ -148,10 +148,10 @@ func (u upgradeOpsHandler) getComponentDefMapWithUpdatedImages(reqCtx intctrluti
 		}
 		compDef, err := component.GetCompDefByName(reqCtx.Ctx, cli, compSpec.ComponentDef)
 		if err != nil {
-			return nil, intctrlutil.NewFatalError(err.Error())
+			return nil, err
 		}
 		if err = component.UpdateCompDefinitionImages4ServiceVersion(reqCtx.Ctx, cli, compDef, compSpec.ServiceVersion); err != nil {
-			return nil, intctrlutil.NewFatalError(err.Error())
+			return nil, err
 		}
 		compDefMap[v.ComponentName] = compDef
 	}

--- a/pkg/operations/upgrade_test.go
+++ b/pkg/operations/upgrade_test.go
@@ -373,6 +373,27 @@ var _ = Describe("Upgrade OpsRequest", func() {
 			})).Should(Succeed())
 		})
 
+		It("Test upgrade OpsRequest with invalid service version should fail validation", func() {
+			By("init operations resources")
+			_, _, opsRes := initOpsResWithComponentDef(true)
+
+			By("create Upgrade Ops with invalid service version")
+			opsRes.OpsRequest = createUpgradeOpsRequest(opsRes.Cluster, opsv1alpha1.Upgrade{
+				Components: []opsv1alpha1.UpgradeComponent{
+					{
+						ComponentOps:   opsv1alpha1.ComponentOps{ComponentName: defaultCompName},
+						ServiceVersion: pointer.String("17.5"),
+					},
+				},
+			})
+
+			By("expect Do() fails with validation error and OpsRequest enters Failed phase")
+			reqCtx := intctrlutil.RequestCtx{Ctx: ctx}
+			_, err := GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(opsRes.OpsRequest))).Should(Equal(opsv1alpha1.OpsFailedPhase))
+		})
+
 		It("Test upgrade OpsRequest when componentDefinitionName is nil", func() {
 			By("init operations resources")
 			compDef1, _, opsRes := initOpsResWithComponentDef(true)


### PR DESCRIPTION
## Description

When OpsRequest upgrade is used with an invalid service version format (e.g., `"17.5"` instead of `"17.5.0"`), the OpsRequest gets stuck in `Running` status forever because:

1. `validateUpgrade()` does not validate the `ServiceVersion` format, so invalid versions pass initial validation
2. Later during `ReconcileAction()`, `version.ParseSemantic()` fails but returns a regular (non-fatal) error, causing infinite retry loops

## Changes

### `apis/operations/v1alpha1/opsrequest_validation.go`
- Added `ServiceVersion` semver format validation in `validateUpgrade()` using `version.ParseSemantic()`
- Empty strings and nil values are allowed (no version change or clear version)
- Invalid formats (e.g., `"17.5"`, `"not-a-version"`) now fail during validation phase

### `pkg/operations/upgrade.go`
- Wrapped errors from `GetCompDefByName()` and `UpdateCompDefinitionImages4ServiceVersion()` as fatal errors via `intctrlutil.NewFatalError()`
- Ensures that if a version resolution error does occur during reconciliation, the OpsRequest immediately transitions to `Failed` phase instead of retrying indefinitely

## Tests

- Added table-driven unit test `TestValidateUpgradeServiceVersion` (11 cases) for the validation function
- Added Ginkgo integration test verifying upgrade with invalid version format transitions to `OpsFailedPhase`

Fix #10461