### PR TITLE
fix(dataprotection): requeue active populate restore job

### DIFF
--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -979,7 +979,7 @@ func (r *VolumePopulatorReconciler) Populate(reqCtx intctrlutil.RequestCtx, pvc 
 			if err = r.patchInternalRestoreStatus(reqCtx, restoreMgr); err != nil {
 				return err
 			}
-			return nil
+			return intctrlutil.NewRequeueError(reconcileInterval, "waiting for restore prepareData job")
 		}
 		if actionFailed {
 			dprestore.SetRestoreStageCondition(restoreMgr.Restore, dpv1alpha1.PrepareData, dprestore.ReasonFailed, "restore prepareData job failed")

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -1354,6 +1354,89 @@ func TestDispatchUnboundPVCFailsWhenNoRestoreActionsExist(t *testing.T) {
 		"expected fatal error when neither prepareData nor postReady exists, got: %v", err)
 }
 
+func TestPopulateRequeuesWhilePrepareDataJobIsStillActive(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	apiGroup := dptypes.DataprotectionAPIGroup
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "data-etcd-restore-0",
+			UID:       "data-etcd-restore-0-uid",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+			},
+			DataSourceRef: &corev1.TypedObjectReference{
+				APIGroup: &apiGroup,
+				Kind:     dptypes.BackupKind,
+				Name:     "backup",
+			},
+		},
+	}
+	restore := &dpv1alpha1.Restore{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "restore",
+		},
+		Spec: dpv1alpha1.RestoreSpec{
+			Backup: dpv1alpha1.BackupRef{Name: "backup", Namespace: "default"},
+			PrepareDataConfig: &dpv1alpha1.PrepareDataConfig{
+				DataSourceRef: &dpv1alpha1.VolumeConfig{
+					VolumeSource: "data",
+					MountPath:    "/var/run/etcd/backup",
+				},
+			},
+		},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(pvc, restore).
+		WithObjects(pvc, restore).
+		Build()
+	reconciler := &VolumePopulatorReconciler{
+		Client:   cli,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+	backup := newBackupForRestoreDecision([]string{"data"}, nil)
+	backup.Status.Target.PodSelector = &dpv1alpha1.PodSelector{Strategy: dpv1alpha1.PodSelectionStrategyAny}
+	actionSet := &dpv1alpha1.ActionSet{
+		Spec: dpv1alpha1.ActionSetSpec{
+			Restore: &dpv1alpha1.RestoreActionSpec{
+				PrepareData: &dpv1alpha1.JobActionSpec{
+					BaseJobActionSpec: dpv1alpha1.BaseJobActionSpec{
+						Image:   "restore-image",
+						Command: []string{"sh", "-c", "restore"},
+					},
+				},
+			},
+		},
+	}
+	restoreMgr := dprestore.NewRestoreManager(restore, record.NewFakeRecorder(10), scheme, reconciler.Client)
+	restoreMgr.PrepareDataBackupSets = []dprestore.BackupActionSet{{
+		Backup:    backup,
+		ActionSet: actionSet,
+	}}
+	restoreCtx := &pvcRestoreContext{
+		mode:       pvcRestoreModeRestoreData,
+		restoreMgr: restoreMgr,
+	}
+
+	err := reconciler.Populate(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreCtx)
+
+	require.Error(t, err)
+	require.True(t, intctrlutil.IsRequeueError(err), "expected requeue while prepareData job is still active, got: %v", err)
+	jobs := &batchv1.JobList{}
+	require.NoError(t, reconciler.Client.List(context.Background(), jobs))
+	require.Len(t, jobs.Items, 1)
+	require.Empty(t, jobs.Items[0].Status.Conditions)
+}
+
 func TestBuildPostReadyRestoreSelectsHighestPriorityRole(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))


### PR DESCRIPTION
## Problem

When VolumePopulator creates an internal prepareData Job, the Job can stay `active=1` after the main `restore` container exits successfully because the `restore-manager` sidecar is still running. The controller currently patches the internal Restore status to `Processing` and then returns without scheduling another reconcile while `actionFinished=false`.

If no later reconcile observes the terminated `restore` container, the controller never sets `dataprotection.kubeblocks.io/stop-restore-manager=true`, so the sidecar keeps running and the Job/Restore remain stuck.

Fixes #10476

## Solution

Return a bounded requeue while the prepareData Job is still active. This keeps the VolumePopulator reconcile loop observing the Job/Pod state until it can stop the restore-manager sidecar and let the Job complete.

## Validation

- `go test ./controllers/dataprotection -run 'TestPopulateRequeuesWhilePrepareDataJobIsStillActive|TestDecidePVCRestoreIgnoresRoleLabelInPVCMatch|TestDecidePVCRestoreUsesTargetVolumes|TestValidateAndInitRestoreMGRFullBackup|TestEnsurePostReadyRestore_MultiComponent_PrepareDataAndPostReady_RedirectsPostReady' -count=1`
- `KUBEBUILDER_ASSETS="/Users/wei/Library/Application Support/io.kubebuilder.envtest/k8s/1.26.1-darwin-arm64" go test ./controllers/dataprotection -count=1`
- `git diff --check -- controllers/dataprotection/volumepopulator_controller.go controllers/dataprotection/volumepopulator_controller_test.go`

## Scope

This PR fixes the controller progress gap after prepareData Job creation. It does not claim etcd restore product acceptance or release readiness; runtime validation still needs a patched DataProtection image in the target environment.
