### PR TITLE
fix(dataprotection): unblock ordered restore after PVC initial step

### DIFF
--- a/controllers/apps/cluster/suite_test.go
+++ b/controllers/apps/cluster/suite_test.go
@@ -44,6 +44,7 @@ import (
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
 	appsv1beta1 "github.com/apecloud/kubeblocks/apis/apps/v1beta1"
+	workloadsv1 "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	"github.com/apecloud/kubeblocks/controllers/apps"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
@@ -122,6 +123,10 @@ var _ = BeforeSuite(func() {
 	err = snapshotv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 	model.AddScheme(snapshotv1.AddToScheme)
+
+	err = workloadsv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+	model.AddScheme(workloadsv1.AddToScheme)
 
 	// +kubebuilder:scaffold:rscheme
 

--- a/controllers/apps/cluster/transformer_cluster_component.go
+++ b/controllers/apps/cluster/transformer_cluster_component.go
@@ -32,6 +32,7 @@ import (
 	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -365,6 +366,7 @@ func newOrderedHandler(topology appsv1.ClusterTopology, orders []string, op int)
 				topology:       topology,
 				orders:         orders,
 				ignoreNotExist: op == updateOp,
+				op:             op,
 			},
 			clusterCompNShardingHandler: clusterCompNShardingHandler{op: op},
 		}
@@ -534,6 +536,7 @@ type phasePrecondition struct {
 	topology       appsv1.ClusterTopology
 	orders         []string
 	ignoreNotExist bool
+	op             int
 }
 
 func (c *phasePrecondition) match(transCtx *clusterTransformContext, dag *graph.DAG, name string) (bool, error) {
@@ -585,7 +588,11 @@ func (c *phasePrecondition) compMatch(transCtx *clusterTransformContext, dag *gr
 	if err := transCtx.Client.Get(transCtx.Context, compKey, comp); err != nil {
 		return c.ignoreNotExist, client.IgnoreNotFound(err)
 	}
-	if !c.expected(comp) {
+	expected, err := c.expected(transCtx, comp)
+	if err != nil {
+		return false, err
+	}
+	if !expected {
 		transCtx.Logger.Info("waiting for predecessor component in expected phase",
 			"component", comp.Name, "predecessor", name)
 		return false, nil
@@ -626,7 +633,11 @@ func (c *phasePrecondition) shardingMatch(transCtx *clusterTransformContext, dag
 		return false, nil
 	}
 	for _, comp := range comps {
-		if !c.expected(&comp) {
+		expected, err := c.expected(transCtx, &comp)
+		if err != nil {
+			return false, err
+		}
+		if !expected {
 			transCtx.Logger.Info("waiting for predecessor sharding in expected phase",
 				"shard", comp.Name, "predecessor sharding", name)
 			return false, nil
@@ -641,13 +652,79 @@ func (c *phasePrecondition) shardingMatch(transCtx *clusterTransformContext, dag
 	return true, nil
 }
 
-func (c *phasePrecondition) expected(comp *appsv1.Component) bool {
-	if comp.Generation == comp.Status.ObservedGeneration {
-		expect := appsv1.RunningComponentPhase
-		if comp.Spec.Stop != nil && *comp.Spec.Stop {
-			expect = appsv1.StoppedComponentPhase
+func (c *phasePrecondition) expected(transCtx *clusterTransformContext, comp *appsv1.Component) (bool, error) {
+	if comp.Generation != comp.Status.ObservedGeneration {
+		return false, nil
+	}
+	expect := appsv1.RunningComponentPhase
+	if comp.Spec.Stop != nil && *comp.Spec.Stop {
+		expect = appsv1.StoppedComponentPhase
+	}
+	if comp.Status.Phase == expect {
+		return true, nil
+	}
+	if c.op != createOp {
+		return false, nil
+	}
+	return restorePVCInitialStepCompletedForComponent(transCtx, comp)
+}
+
+func restorePVCInitialStepCompletedForComponent(transCtx *clusterTransformContext, comp *appsv1.Component) (bool, error) {
+	cond := meta.FindStatusCondition(comp.Status.Conditions, appsv1.ConditionTypeRestore)
+	if cond == nil || cond.Status != metav1.ConditionUnknown || cond.Reason != ReasonRestoreRunning {
+		return false, nil
+	}
+	expected := expectedRestorePVCCountForComponentSpec(comp.Spec.Replicas, comp.Spec.VolumeClaimTemplates, comp.Spec.Instances)
+	if expected == 0 {
+		return false, nil
+	}
+	componentName := comp.Labels[constant.KBAppComponentLabelKey]
+	if componentName == "" {
+		var err error
+		componentName, err = component.ShortName(transCtx.Cluster.Name, comp.Name)
+		if err != nil {
+			return false, err
 		}
-		return comp.Status.Phase == expect
+	}
+	pvcList := &corev1.PersistentVolumeClaimList{}
+	if err := transCtx.Client.List(transCtx.Context, pvcList,
+		client.InNamespace(comp.Namespace),
+		client.MatchingLabels(constant.GetCompLabels(transCtx.Cluster.Name, componentName))); err != nil {
+		return false, err
+	}
+	completed := 0
+	for i := range pvcList.Items {
+		pvc := &pvcList.Items[i]
+		if !pvc.DeletionTimestamp.IsZero() ||
+			pvc.Annotations[constant.RestoreSourceKindAnnotationKey] == "" {
+			continue
+		}
+		if !restorePVCInitialStepCompleted(pvc) {
+			return false, nil
+		}
+		completed++
+	}
+	return completed >= expected, nil
+}
+
+func restorePVCInitialStepCompleted(pvc *corev1.PersistentVolumeClaim) bool {
+	for i := range pvc.Status.Conditions {
+		condition := pvc.Status.Conditions[i]
+		if string(condition.Type) != appsv1.ConditionTypeRestore {
+			continue
+		}
+		if condition.Status == corev1.ConditionFalse {
+			return false
+		}
+	}
+	for i := range pvc.Status.Conditions {
+		condition := pvc.Status.Conditions[i]
+		if string(condition.Type) != constant.DataProtectionPVCConditionPopulating {
+			continue
+		}
+		return condition.Status == corev1.ConditionTrue &&
+			(condition.Reason == constant.DataProtectionPVCConditionReasonPopulatingSucceed ||
+				condition.Reason == constant.DataProtectionPVCConditionReasonPopulatingProvision)
 	}
 	return false
 }

--- a/controllers/apps/cluster/transformer_cluster_component.go
+++ b/controllers/apps/cluster/transformer_cluster_component.go
@@ -41,9 +41,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
+	"github.com/apecloud/kubeblocks/pkg/controller/instancetemplate"
+	"github.com/apecloud/kubeblocks/pkg/controller/kubebuilderx"
 	"github.com/apecloud/kubeblocks/pkg/controller/lifecycle"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
 	"github.com/apecloud/kubeblocks/pkg/controller/sharding"
@@ -678,33 +681,63 @@ func restorePVCInitialStepCompletedForComponent(transCtx *clusterTransformContex
 	if expected == 0 {
 		return false, nil
 	}
-	componentName := comp.Labels[constant.KBAppComponentLabelKey]
-	if componentName == "" {
-		var err error
-		componentName, err = component.ShortName(transCtx.Cluster.Name, comp.Name)
-		if err != nil {
-			return false, err
-		}
-	}
-	pvcList := &corev1.PersistentVolumeClaimList{}
-	if err := transCtx.Client.List(transCtx.Context, pvcList,
-		client.InNamespace(comp.Namespace),
-		client.MatchingLabels(constant.GetCompLabels(transCtx.Cluster.Name, componentName))); err != nil {
+	pvcNames, err := expectedRestorePVCNamesForComponent(transCtx, comp)
+	if err != nil {
 		return false, err
 	}
-	completed := 0
-	for i := range pvcList.Items {
-		pvc := &pvcList.Items[i]
-		if !pvc.DeletionTimestamp.IsZero() ||
-			pvc.Annotations[constant.RestoreSourceKindAnnotationKey] == "" {
-			continue
+	// The ITS spec may not have converged to the component spec yet; keep the
+	// strict phase gate until both agree on the restore PVC set, so that stale
+	// or leftover PVCs cannot substitute for expected ones.
+	if len(pvcNames) != expected {
+		return false, nil
+	}
+	for _, pvcName := range pvcNames {
+		pvc := &corev1.PersistentVolumeClaim{}
+		pvcKey := types.NamespacedName{Namespace: comp.Namespace, Name: pvcName}
+		if err := transCtx.Client.Get(transCtx.Context, pvcKey, pvc); err != nil {
+			return false, client.IgnoreNotFound(err)
 		}
-		if !restorePVCInitialStepCompleted(pvc) {
+		if !pvc.DeletionTimestamp.IsZero() || !restorePVCInitialStepCompleted(pvc) {
 			return false, nil
 		}
-		completed++
 	}
-	return completed >= expected, nil
+	return true, nil
+}
+
+func expectedRestorePVCNamesForComponent(transCtx *clusterTransformContext, comp *appsv1.Component) ([]string, error) {
+	its := &workloads.InstanceSet{}
+	if err := transCtx.Client.Get(transCtx.Context, client.ObjectKeyFromObject(comp), its); err != nil {
+		return nil, client.IgnoreNotFound(err)
+	}
+	if its.Spec.Replicas == nil {
+		return nil, nil
+	}
+	// The empty tree makes compressed instance templates unresolvable; name
+	// generation then comes up short and the caller falls back to the strict
+	// phase gate.
+	itsExt, err := instancetemplate.BuildInstanceSetExt(its, kubebuilderx.NewObjectTree())
+	if err != nil {
+		return nil, err
+	}
+	nameBuilder, err := instancetemplate.NewPodNameBuilder(itsExt, nil)
+	if err != nil {
+		return nil, err
+	}
+	name2TemplateMap, err := nameBuilder.BuildInstanceName2TemplateMap()
+	if err != nil {
+		return nil, err
+	}
+	var pvcNames []string
+	for podName, template := range name2TemplateMap {
+		for i := range template.VolumeClaimTemplates {
+			claimTemplate := template.VolumeClaimTemplates[i]
+			if claimTemplate.Annotations[constant.RestoreSourceKindAnnotationKey] == "" {
+				continue
+			}
+			pvcNames = append(pvcNames, ictrlutil.ComposePVCName(claimTemplate, its.Name, podName))
+		}
+	}
+	return pvcNames, nil
 }
 
 func restorePVCInitialStepCompleted(pvc *corev1.PersistentVolumeClaim) bool {
@@ -713,7 +746,10 @@ func restorePVCInitialStepCompleted(pvc *corev1.PersistentVolumeClaim) bool {
 		if string(condition.Type) != appsv1.ConditionTypeRestore {
 			continue
 		}
-		if condition.Status == corev1.ConditionFalse {
+		// A terminal Restore condition means the PVC is out of the initial-step
+		// window: False is a failed restore, True means the full restore has
+		// already completed and ordering reverts to the regular phase gate.
+		if condition.Status != corev1.ConditionUnknown {
 			return false
 		}
 	}

--- a/controllers/apps/cluster/transformer_cluster_component_test.go
+++ b/controllers/apps/cluster/transformer_cluster_component_test.go
@@ -562,6 +562,98 @@ var _ = Describe("cluster component transformer test", func() {
 			Expect(len(objs)).Should(Equal(0))
 		})
 
+		It("w/ orders provision - predecessor restore PVC initial step completed", func() {
+			transformer, transCtx, dag := newTransformerNCtx(clusterTopologyProvisionNUpdateOOD)
+			restoreVCT := appsv1.PersistentVolumeClaimTemplate{
+				Name: "data",
+				Annotations: map[string]string{
+					constant.RestoreSourceKindAnnotationKey: "Backup",
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					Resources: corev1.VolumeResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceStorage: resource.MustParse("1Gi"),
+						},
+					},
+				},
+			}
+			for i := range transCtx.components {
+				if transCtx.components[i].Name == comp1aName {
+					transCtx.components[i].Replicas = 1
+					transCtx.components[i].VolumeClaimTemplates = []appsv1.PersistentVolumeClaimTemplate{restoreVCT}
+					break
+				}
+			}
+			predecessor := mockCompObj(transCtx, comp1aName, func(comp *appsv1.Component) {
+				comp.Status.ObservedGeneration = comp.Generation
+				comp.Status.Phase = appsv1.CreatingComponentPhase
+				comp.Status.Conditions = []metav1.Condition{{
+					Type:   appsv1.ConditionTypeRestore,
+					Status: metav1.ConditionUnknown,
+					Reason: ReasonRestoreRunning,
+				}}
+			})
+			peerPredecessor := mockCompObj(transCtx, comp1bName, func(comp *appsv1.Component) {
+				comp.Status.Phase = appsv1.RunningComponentPhase
+			})
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: transCtx.Cluster.Namespace,
+					Name:      "data-" + predecessor.Name + "-0",
+					Labels:    constant.GetCompLabels(transCtx.Cluster.Name, comp1aName),
+					Annotations: map[string]string{
+						constant.RestoreSourceKindAnnotationKey: "Backup",
+					},
+				},
+				Status: corev1.PersistentVolumeClaimStatus{
+					Conditions: []corev1.PersistentVolumeClaimCondition{{
+						Type:   corev1.PersistentVolumeClaimConditionType(constant.DataProtectionPVCConditionPopulating),
+						Status: corev1.ConditionTrue,
+						Reason: constant.DataProtectionPVCConditionReasonPopulatingProvision,
+					}},
+				},
+			}
+			restoreOnlyPVC := pvc.DeepCopy()
+			restoreOnlyPVC.Status.Conditions = []corev1.PersistentVolumeClaimCondition{{
+				Type:   corev1.PersistentVolumeClaimConditionType(appsv1.ConditionTypeRestore),
+				Status: corev1.ConditionTrue,
+				Reason: constant.DataProtectionPVCConditionReasonPopulatingProvision,
+			}}
+			transCtx.Client = model.NewGraphClient(&appsutil.MockReader{
+				Objects: []client.Object{predecessor, peerPredecessor, restoreOnlyPVC},
+			})
+			completed, err := restorePVCInitialStepCompletedForComponent(transCtx, predecessor)
+			Expect(err).Should(BeNil())
+			Expect(completed).Should(BeFalse())
+
+			reader := &appsutil.MockReader{
+				Objects: []client.Object{predecessor, peerPredecessor, pvc},
+			}
+			transCtx.Client = model.NewGraphClient(reader)
+			completed, err = restorePVCInitialStepCompletedForComponent(transCtx, predecessor)
+			Expect(err).Should(BeNil())
+			Expect(completed).Should(BeTrue())
+
+			err = transformer.Transform(transCtx, dag)
+
+			Expect(err).Should(BeNil())
+			graphCli := transCtx.Client.(model.GraphClient)
+			objs := graphCli.FindAll(dag, &appsv1.Component{})
+			Expect(objs).Should(HaveLen(2))
+			created := map[string]struct{}{}
+			for _, obj := range objs {
+				comp := obj.(*appsv1.Component)
+				shortName, err := component.ShortName(transCtx.Cluster.Name, comp.Name)
+				Expect(err).Should(BeNil())
+				created[shortName] = struct{}{}
+				Expect(graphCli.IsAction(dag, comp, model.ActionCreatePtr())).Should(BeTrue())
+			}
+			Expect(created).Should(Equal(map[string]struct{}{
+				comp2aName: {},
+				comp2bName: {},
+			}))
+		})
+
 		It("w/ orders provision - has a predecessor in DAG", func() {
 			transformer, transCtx, dag := newTransformerNCtx(clusterTopologyDefault)
 

--- a/controllers/apps/cluster/transformer_cluster_component_test.go
+++ b/controllers/apps/cluster/transformer_cluster_component_test.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	appsutil "github.com/apecloud/kubeblocks/controllers/apps/util"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
@@ -613,6 +614,23 @@ var _ = Describe("cluster component transformer test", func() {
 					}},
 				},
 			}
+			its := &workloads.InstanceSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: predecessor.Namespace,
+					Name:      predecessor.Name,
+				},
+				Spec: workloads.InstanceSetSpec{
+					Replicas: ptr.To[int32](1),
+					VolumeClaimTemplates: []corev1.PersistentVolumeClaim{{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "data",
+							Annotations: map[string]string{
+								constant.RestoreSourceKindAnnotationKey: "Backup",
+							},
+						},
+					}},
+				},
+			}
 			restoreOnlyPVC := pvc.DeepCopy()
 			restoreOnlyPVC.Status.Conditions = []corev1.PersistentVolumeClaimCondition{{
 				Type:   corev1.PersistentVolumeClaimConditionType(appsv1.ConditionTypeRestore),
@@ -620,14 +638,48 @@ var _ = Describe("cluster component transformer test", func() {
 				Reason: constant.DataProtectionPVCConditionReasonPopulatingProvision,
 			}}
 			transCtx.Client = model.NewGraphClient(&appsutil.MockReader{
-				Objects: []client.Object{predecessor, peerPredecessor, restoreOnlyPVC},
+				Objects: []client.Object{predecessor, peerPredecessor, its, restoreOnlyPVC},
 			})
 			completed, err := restorePVCInitialStepCompletedForComponent(transCtx, predecessor)
 			Expect(err).Should(BeNil())
 			Expect(completed).Should(BeFalse())
 
-			reader := &appsutil.MockReader{
+			// the full restore has already completed for this PVC: the initial-step
+			// bypass must not apply anymore
+			terminalPVC := pvc.DeepCopy()
+			terminalPVC.Status.Conditions = append(terminalPVC.Status.Conditions, corev1.PersistentVolumeClaimCondition{
+				Type:   corev1.PersistentVolumeClaimConditionType(appsv1.ConditionTypeRestore),
+				Status: corev1.ConditionTrue,
+				Reason: constant.DataProtectionPVCConditionReasonPopulatingProvision,
+			})
+			transCtx.Client = model.NewGraphClient(&appsutil.MockReader{
+				Objects: []client.Object{predecessor, peerPredecessor, its, terminalPVC},
+			})
+			completed, err = restorePVCInitialStepCompletedForComponent(transCtx, predecessor)
+			Expect(err).Should(BeNil())
+			Expect(completed).Should(BeFalse())
+
+			// a leftover PVC with a name outside the expected set cannot substitute
+			// for the expected one
+			stalePVC := pvc.DeepCopy()
+			stalePVC.Name = "data-" + predecessor.Name + "-1"
+			transCtx.Client = model.NewGraphClient(&appsutil.MockReader{
+				Objects: []client.Object{predecessor, peerPredecessor, its, stalePVC},
+			})
+			completed, err = restorePVCInitialStepCompletedForComponent(transCtx, predecessor)
+			Expect(err).Should(BeNil())
+			Expect(completed).Should(BeFalse())
+
+			// without the ITS the expected PVC names cannot be resolved: stay strict
+			transCtx.Client = model.NewGraphClient(&appsutil.MockReader{
 				Objects: []client.Object{predecessor, peerPredecessor, pvc},
+			})
+			completed, err = restorePVCInitialStepCompletedForComponent(transCtx, predecessor)
+			Expect(err).Should(BeNil())
+			Expect(completed).Should(BeFalse())
+
+			reader := &appsutil.MockReader{
+				Objects: []client.Object{predecessor, peerPredecessor, its, pvc},
 			}
 			transCtx.Client = model.NewGraphClient(reader)
 			completed, err = restorePVCInitialStepCompletedForComponent(transCtx, predecessor)

--- a/controllers/apps/util/mock_reader.go
+++ b/controllers/apps/util/mock_reader.go
@@ -36,8 +36,9 @@ type MockReader struct {
 
 func (r *MockReader) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
 	for _, o := range r.Objects {
-		// ignore the GVK check
-		if client.ObjectKeyFromObject(o) == key {
+		// objects of different kinds may share the same key (e.g. a Component
+		// and its InstanceSet), so match the concrete type as well
+		if client.ObjectKeyFromObject(o) == key && reflect.TypeOf(o) == reflect.TypeOf(obj) {
 			reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(o).Elem())
 			return nil
 		}

--- a/controllers/dataprotection/types.go
+++ b/controllers/dataprotection/types.go
@@ -23,6 +23,8 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/apecloud/kubeblocks/pkg/constant"
 )
 
 const (
@@ -87,12 +89,12 @@ const (
 	ReasonVolumePopulateFailed  = "VolumePopulateFailed"
 
 	// pvc condition type and reason
-	ReasonPopulatingFailed      = "Failed"
+	ReasonPopulatingFailed      = constant.DataProtectionPVCConditionReasonPopulatingFailed
 	ReasonPopulatingProcessing  = "Processing"
-	ReasonPopulatingSucceed     = "Succeed"
-	ReasonPopulatingProvisioned = "Provisioned"
+	ReasonPopulatingSucceed     = constant.DataProtectionPVCConditionReasonPopulatingSucceed
+	ReasonPopulatingProvisioned = constant.DataProtectionPVCConditionReasonPopulatingProvision
 
-	PersistentVolumeClaimPopulating corev1.PersistentVolumeClaimConditionType = "Populating"
+	PersistentVolumeClaimPopulating corev1.PersistentVolumeClaimConditionType = constant.DataProtectionPVCConditionPopulating
 )
 
 var reconcileInterval = time.Second

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -1653,7 +1653,7 @@ func TestCompleteBoundPVCReleasesPopulatePVCBeforeWaitingForPostReady(t *testing
 	require.NotNil(t, populatingCondition)
 	require.Equal(t, ReasonPopulatingSucceed, populatingCondition.Reason)
 	restoreCondition := findPVCConditionByType(currentPVC, kbappsv1.ConditionTypeRestore)
-	require.Nil(t, restoreCondition)
+	require.Nil(t, restoreCondition, "Restore=True must wait for postReady completion")
 	currentPopulatePVC := &corev1.PersistentVolumeClaim{}
 	require.Error(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(populatePVC), currentPopulatePVC))
 }
@@ -3013,6 +3013,122 @@ func TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_WaitsForAllComponen
 	require.NoError(t, reconciler.Client.List(context.Background(), restoreList, client.InNamespace("default")))
 	require.Len(t, restoreList.Items, 0,
 		"no Restore CR should be created while other component PVCs are still unbound")
+}
+
+func TestCompleteBoundPVCIfNeeded_PostReadyOnlyProvisionedPVCKeepsRestoreUnknownBeforePostReady(t *testing.T) {
+	// TiDB-shaped logical backups have no targetVolumes; PD/TiKV data PVCs are
+	// provision-only and the postReady action redirects to the TiDB component.
+	// While postReady waits for other component PVCs, the current PVC may publish
+	// Populating=Provisioned as an initial-step signal, but Restore=True is still
+	// reserved for postReady completion.
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+	require.NoError(t, kbappsv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	apiGroup := dptypes.DataprotectionAPIGroup
+
+	backup := newBackupForRestoreDecision(nil, nil)
+	backup.Status.BackupMethod.TargetVolumes = nil
+	backup.Status.Target = &dpv1alpha1.BackupStatusTarget{
+		BackupTarget: dpv1alpha1.BackupTarget{
+			Name: "tidb",
+			PodSelector: &dpv1alpha1.PodSelector{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						constant.AppInstanceLabelKey:    "cluster",
+						constant.KBAppComponentLabelKey: "tidb",
+					},
+				},
+			},
+		},
+	}
+
+	pdPVC := newPVCForRestoreDecision("data", "pd", "")
+	pdPVC.UID = types.UID("pd-pvc-uid")
+	pdPVC.Spec.VolumeName = "pd-data-pv"
+	pdPVC.Spec.DataSourceRef = &corev1.TypedObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     dptypes.BackupKind,
+		Name:     backup.Name,
+	}
+	pdPVC.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
+	pdPVC.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+
+	tikvPVC := newPVCForRestoreDecision("data", "tikv", "")
+	tikvPVC.UID = types.UID("tikv-pvc-uid")
+	tikvPVC.Spec.DataSourceRef = &corev1.TypedObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     dptypes.BackupKind,
+		Name:     backup.Name,
+	}
+	tikvPVC.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
+	tikvPVC.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+
+	pdComp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "pd"),
+			UID:       "pd-component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
+	}
+	tikvComp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "tikv"),
+			UID:       "tikv-component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.CreatingComponentPhase},
+	}
+	tidbComp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "tidb"),
+			UID:       "tidb-component-uid",
+		},
+		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
+	}
+
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).
+			WithStatusSubresource(pdPVC, tikvPVC).
+			WithObjects(backup, pdPVC, tikvPVC, pdComp, tikvComp, tidbComp).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{
+		Spec: dpv1alpha1.RestoreSpec{Backup: dpv1alpha1.BackupRef{Name: backup.Name, Namespace: backup.Namespace}},
+	}, nil, scheme, reconciler.Client)
+	restoreMgr.PostReadyBackupSets = []dprestore.BackupActionSet{{Backup: backup}}
+
+	decision, err := reconciler.decidePVCRestore(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pdPVC, backup, nil)
+	require.NoError(t, err)
+	require.Equal(t, pvcRestoreModeProvisionOnly, decision.mode)
+	require.True(t, decision.skipPostReady)
+
+	err = reconciler.completeBoundPVCIfNeeded(intctrlutil.RequestCtx{Ctx: context.Background()}, pdPVC, &pvcRestoreContext{
+		restoreMgr:    restoreMgr,
+		mode:          decision.mode,
+		skipPostReady: decision.skipPostReady,
+	})
+
+	require.Error(t, err)
+	require.True(t, intctrlutil.IsRequeueError(err), "expected postReady wait requeue, got: %v", err)
+	currentPVC := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pdPVC), currentPVC))
+	populatingCondition := findPVCConditionByType(currentPVC, string(PersistentVolumeClaimPopulating))
+	require.NotNil(t, populatingCondition)
+	require.Equal(t, corev1.ConditionTrue, populatingCondition.Status)
+	require.Equal(t, ReasonPopulatingProvisioned, populatingCondition.Reason)
+	restoreCondition := findPVCConditionByType(currentPVC, kbappsv1.ConditionTypeRestore)
+	require.Nil(t, restoreCondition, "Restore=True must not be written before postReady completes")
+
+	restoreList := &dpv1alpha1.RestoreList{}
+	require.NoError(t, reconciler.Client.List(context.Background(), restoreList, client.InNamespace("default")))
+	require.Empty(t, restoreList.Items, "postReady Restore must still wait for other component PVCs")
 }
 
 func TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_TargetsSlice(t *testing.T) {

--- a/pkg/constant/annotations.go
+++ b/pkg/constant/annotations.go
@@ -71,6 +71,8 @@ const (
 	RestoreComponentAnnotationKey       = "apps.kubeblocks.io/restore-component"
 	RestoreVolumeTemplateAnnotationKey  = "apps.kubeblocks.io/restore-volume-template"
 
+	RestorePVCInitialStepCompletedAnnotationKey = "apps.kubeblocks.io/restore-pvc-initial-step-completed"
+
 	// These annoations serve in a transition period when existing clusters can adopt
 	// new serviceaccount naming rules.
 	// They will be removed in the future.

--- a/pkg/constant/dataprotection.go
+++ b/pkg/constant/dataprotection.go
@@ -1,0 +1,27 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package constant
+
+const (
+	DataProtectionPVCConditionPopulating                = "Populating"
+	DataProtectionPVCConditionReasonPopulatingFailed    = "Failed"
+	DataProtectionPVCConditionReasonPopulatingSucceed   = "Succeed"
+	DataProtectionPVCConditionReasonPopulatingProvision = "Provisioned"
+)

--- a/pkg/controller/instance/reconciler_status.go
+++ b/pkg/controller/instance/reconciler_status.go
@@ -112,6 +112,8 @@ func (r *statusReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 	}
 	inst.Status.Configs = configs
 
+	r.reconcileRestorePVCAnnotation(tree, inst)
+
 	if inst.Spec.MinReadySeconds > 0 && !available {
 		return kubebuilderx.RetryAfter(time.Second), nil
 	}
@@ -210,6 +212,69 @@ func (r *statusReconciler) hasRunningVolumeExpansion(tree *kubebuilderx.ObjectTr
 				return true
 			}
 		}
+	}
+	return false
+}
+
+func (r *statusReconciler) reconcileRestorePVCAnnotation(tree *kubebuilderx.ObjectTree, inst *workloads.Instance) {
+	var expected int
+	for _, vct := range inst.Spec.VolumeClaimTemplates {
+		if vct.Annotations[constant.RestoreSourceKindAnnotationKey] != "" {
+			expected++
+		}
+	}
+	if expected == 0 {
+		delete(inst.Annotations, constant.RestorePVCInitialStepCompletedAnnotationKey)
+		return
+	}
+
+	pvcMap := map[string]*corev1.PersistentVolumeClaim{}
+	for _, obj := range tree.List(&corev1.PersistentVolumeClaim{}) {
+		pvc, _ := obj.(*corev1.PersistentVolumeClaim)
+		pvcMap[pvc.Name] = pvc
+	}
+
+	completed := 0
+	for _, vct := range inst.Spec.VolumeClaimTemplates {
+		if vct.Annotations[constant.RestoreSourceKindAnnotationKey] == "" {
+			continue
+		}
+		pvcName := intctrlutil.ComposePVCName(corev1.PersistentVolumeClaim{ObjectMeta: vct.ObjectMeta}, inst.Spec.InstanceSetName, inst.Name)
+		pvc, ok := pvcMap[pvcName]
+		if !ok || !pvc.DeletionTimestamp.IsZero() || !restorePVCInitialStepCompleted(pvc) {
+			continue
+		}
+		completed++
+	}
+
+	if completed == expected {
+		if inst.Annotations == nil {
+			inst.Annotations = make(map[string]string)
+		}
+		inst.Annotations[constant.RestorePVCInitialStepCompletedAnnotationKey] = "true"
+	} else {
+		delete(inst.Annotations, constant.RestorePVCInitialStepCompletedAnnotationKey)
+	}
+}
+
+func restorePVCInitialStepCompleted(pvc *corev1.PersistentVolumeClaim) bool {
+	for i := range pvc.Status.Conditions {
+		condition := pvc.Status.Conditions[i]
+		if string(condition.Type) != string(workloads.InstanceRestore) {
+			continue
+		}
+		if condition.Status != corev1.ConditionUnknown {
+			return false
+		}
+	}
+	for i := range pvc.Status.Conditions {
+		condition := pvc.Status.Conditions[i]
+		if string(condition.Type) != constant.DataProtectionPVCConditionPopulating {
+			continue
+		}
+		return condition.Status == corev1.ConditionTrue &&
+			(condition.Reason == constant.DataProtectionPVCConditionReasonPopulatingSucceed ||
+				condition.Reason == constant.DataProtectionPVCConditionReasonPopulatingProvision)
 	}
 	return false
 }

--- a/pkg/controller/instance/reconciler_status_test.go
+++ b/pkg/controller/instance/reconciler_status_test.go
@@ -1,0 +1,257 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package instance
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/kubebuilderx"
+)
+
+func TestRestorePVCInitialStepCompleted(t *testing.T) {
+	tests := []struct {
+		name     string
+		pvc      *corev1.PersistentVolumeClaim
+		expected bool
+	}{
+		{
+			name: "no conditions",
+			pvc: &corev1.PersistentVolumeClaim{
+				Status: corev1.PersistentVolumeClaimStatus{},
+			},
+			expected: false,
+		},
+		{
+			name: "populating succeed",
+			pvc: &corev1.PersistentVolumeClaim{
+				Status: corev1.PersistentVolumeClaimStatus{
+					Conditions: []corev1.PersistentVolumeClaimCondition{
+						{
+							Type:   corev1.PersistentVolumeClaimConditionType(constant.DataProtectionPVCConditionPopulating),
+							Status: corev1.ConditionTrue,
+							Reason: constant.DataProtectionPVCConditionReasonPopulatingSucceed,
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "populating provisioned",
+			pvc: &corev1.PersistentVolumeClaim{
+				Status: corev1.PersistentVolumeClaimStatus{
+					Conditions: []corev1.PersistentVolumeClaimCondition{
+						{
+							Type:   corev1.PersistentVolumeClaimConditionType(constant.DataProtectionPVCConditionPopulating),
+							Status: corev1.ConditionTrue,
+							Reason: constant.DataProtectionPVCConditionReasonPopulatingProvision,
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "restore condition terminal true blocks",
+			pvc: &corev1.PersistentVolumeClaim{
+				Status: corev1.PersistentVolumeClaimStatus{
+					Conditions: []corev1.PersistentVolumeClaimCondition{
+						{
+							Type:   corev1.PersistentVolumeClaimConditionType(workloads.InstanceRestore),
+							Status: corev1.ConditionTrue,
+						},
+						{
+							Type:   corev1.PersistentVolumeClaimConditionType(constant.DataProtectionPVCConditionPopulating),
+							Status: corev1.ConditionTrue,
+							Reason: constant.DataProtectionPVCConditionReasonPopulatingSucceed,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "populating failed",
+			pvc: &corev1.PersistentVolumeClaim{
+				Status: corev1.PersistentVolumeClaimStatus{
+					Conditions: []corev1.PersistentVolumeClaimCondition{
+						{
+							Type:   corev1.PersistentVolumeClaimConditionType(constant.DataProtectionPVCConditionPopulating),
+							Status: corev1.ConditionFalse,
+							Reason: constant.DataProtectionPVCConditionReasonPopulatingFailed,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := restorePVCInitialStepCompleted(tt.pvc)
+			if result != tt.expected {
+				t.Errorf("restorePVCInitialStepCompleted() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestReconcileRestorePVCAnnotation(t *testing.T) {
+	makeInst := func(vctAnnotations map[string]string) *workloads.Instance {
+		inst := &workloads.Instance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-0",
+				Namespace: "default",
+			},
+			Spec: workloads.InstanceSpec{
+				InstanceSetName: "test",
+			},
+		}
+		if vctAnnotations != nil {
+			inst.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaimTemplate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "data",
+						Annotations: vctAnnotations,
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+			}
+		}
+		return inst
+	}
+
+	makePVC := func(name string, conditions []corev1.PersistentVolumeClaimCondition) *corev1.PersistentVolumeClaim {
+		return &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				Labels: map[string]string{
+					constant.AppManagedByLabelKey:      constant.AppName,
+					constant.KBAppInstanceNameLabelKey: "test-0",
+				},
+			},
+			Status: corev1.PersistentVolumeClaimStatus{
+				Conditions: conditions,
+			},
+		}
+	}
+
+	t.Run("no restore VCT - no annotation", func(t *testing.T) {
+		inst := makeInst(nil)
+		tree := kubebuilderx.NewObjectTree()
+		tree.SetRoot(inst)
+
+		r := &statusReconciler{}
+		r.reconcileRestorePVCAnnotation(tree, inst)
+
+		if _, ok := inst.Annotations[constant.RestorePVCInitialStepCompletedAnnotationKey]; ok {
+			t.Error("expected no annotation when no restore VCTs")
+		}
+	})
+
+	t.Run("restore VCT but PVC not found - no annotation", func(t *testing.T) {
+		inst := makeInst(map[string]string{
+			constant.RestoreSourceKindAnnotationKey: "Backup",
+		})
+		tree := kubebuilderx.NewObjectTree()
+		tree.SetRoot(inst)
+
+		r := &statusReconciler{}
+		r.reconcileRestorePVCAnnotation(tree, inst)
+
+		if _, ok := inst.Annotations[constant.RestorePVCInitialStepCompletedAnnotationKey]; ok {
+			t.Error("expected no annotation when PVC not found")
+		}
+	})
+
+	t.Run("restore VCT with PVC populating succeed - annotation set", func(t *testing.T) {
+		inst := makeInst(map[string]string{
+			constant.RestoreSourceKindAnnotationKey: "Backup",
+		})
+		pvc := makePVC("data-test-0", []corev1.PersistentVolumeClaimCondition{
+			{
+				Type:   corev1.PersistentVolumeClaimConditionType(constant.DataProtectionPVCConditionPopulating),
+				Status: corev1.ConditionTrue,
+				Reason: constant.DataProtectionPVCConditionReasonPopulatingSucceed,
+			},
+		})
+		tree := kubebuilderx.NewObjectTree()
+		tree.SetRoot(inst)
+		if err := tree.Add(pvc); err != nil {
+			t.Fatal(err)
+		}
+
+		r := &statusReconciler{}
+		r.reconcileRestorePVCAnnotation(tree, inst)
+
+		if inst.Annotations[constant.RestorePVCInitialStepCompletedAnnotationKey] != "true" {
+			t.Error("expected annotation to be set when PVC populating succeeded")
+		}
+	})
+
+	t.Run("restore VCT with PVC no conditions - no annotation", func(t *testing.T) {
+		inst := makeInst(map[string]string{
+			constant.RestoreSourceKindAnnotationKey: "Backup",
+		})
+		pvc := makePVC("data-test-0", nil)
+		tree := kubebuilderx.NewObjectTree()
+		tree.SetRoot(inst)
+		if err := tree.Add(pvc); err != nil {
+			t.Fatal(err)
+		}
+
+		r := &statusReconciler{}
+		r.reconcileRestorePVCAnnotation(tree, inst)
+
+		if _, ok := inst.Annotations[constant.RestorePVCInitialStepCompletedAnnotationKey]; ok {
+			t.Error("expected no annotation when PVC has no populating condition")
+		}
+	})
+
+	t.Run("annotation removed when restore completes", func(t *testing.T) {
+		inst := makeInst(nil)
+		inst.Annotations = map[string]string{
+			constant.RestorePVCInitialStepCompletedAnnotationKey: "true",
+		}
+		tree := kubebuilderx.NewObjectTree()
+		tree.SetRoot(inst)
+
+		r := &statusReconciler{}
+		r.reconcileRestorePVCAnnotation(tree, inst)
+
+		if _, ok := inst.Annotations[constant.RestorePVCInitialStepCompletedAnnotationKey]; ok {
+			t.Error("expected annotation to be removed when no restore VCTs")
+		}
+	})
+}

--- a/pkg/controller/instanceset/reconciler_instance_alignment.go
+++ b/pkg/controller/instanceset/reconciler_instance_alignment.go
@@ -22,6 +22,7 @@ package instanceset
 import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
@@ -135,7 +136,8 @@ func (r *instanceAlignmentReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (
 			break
 		}
 		predecessor := getPredecessor(i)
-		if isOrderedReady && predecessor != nil && !intctrlutil.IsPodAvailable(predecessor, its.Spec.MinReadySeconds) {
+		if isOrderedReady && predecessor != nil && !intctrlutil.IsPodAvailable(predecessor, its.Spec.MinReadySeconds) &&
+			!restorePVCInitialStepCompletedForPod(tree, its, predecessor.Name, nameToTemplateMap[predecessor.Name]) {
 			break
 		}
 		newPod, err := buildInstancePodByTemplate(name, nameToTemplateMap[name], its, "")
@@ -228,3 +230,60 @@ func (r *instanceAlignmentReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (
 }
 
 var _ kubebuilderx.Reconciler = &instanceAlignmentReconciler{}
+
+func restorePVCInitialStepCompletedForPod(tree *kubebuilderx.ObjectTree,
+	its *workloads.InstanceSet,
+	podName string,
+	template *instancetemplate.InstanceTemplateExt) bool {
+	if template == nil {
+		return false
+	}
+	expected := 0
+	for _, claimTemplate := range template.VolumeClaimTemplates {
+		if claimTemplate.Annotations[constant.RestoreSourceKindAnnotationKey] == "" {
+			continue
+		}
+		expected++
+		pvcName := intctrlutil.ComposePVCName(claimTemplate, its.Name, podName)
+		pvcObj, err := tree.Get(pvcForLookup(its.Namespace, pvcName))
+		if err != nil || pvcObj == nil {
+			return false
+		}
+		pvc, ok := pvcObj.(*corev1.PersistentVolumeClaim)
+		if !ok || !restorePVCInitialStepCompleted(pvc) {
+			return false
+		}
+	}
+	return expected > 0
+}
+
+func pvcForLookup(namespace, name string) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+}
+
+func restorePVCInitialStepCompleted(pvc *corev1.PersistentVolumeClaim) bool {
+	for i := range pvc.Status.Conditions {
+		condition := pvc.Status.Conditions[i]
+		if string(condition.Type) != string(workloads.InstanceRestore) {
+			continue
+		}
+		if condition.Status == corev1.ConditionFalse {
+			return false
+		}
+	}
+	for i := range pvc.Status.Conditions {
+		condition := pvc.Status.Conditions[i]
+		if string(condition.Type) != constant.DataProtectionPVCConditionPopulating {
+			continue
+		}
+		return condition.Status == corev1.ConditionTrue &&
+			(condition.Reason == constant.DataProtectionPVCConditionReasonPopulatingSucceed ||
+				condition.Reason == constant.DataProtectionPVCConditionReasonPopulatingProvision)
+	}
+	return false
+}

--- a/pkg/controller/instanceset/reconciler_instance_alignment.go
+++ b/pkg/controller/instanceset/reconciler_instance_alignment.go
@@ -250,7 +250,7 @@ func restorePVCInitialStepCompletedForPod(tree *kubebuilderx.ObjectTree,
 			return false
 		}
 		pvc, ok := pvcObj.(*corev1.PersistentVolumeClaim)
-		if !ok || !restorePVCInitialStepCompleted(pvc) {
+		if !ok || !pvc.DeletionTimestamp.IsZero() || !restorePVCInitialStepCompleted(pvc) {
 			return false
 		}
 	}

--- a/pkg/controller/instanceset/reconciler_instance_alignment.go
+++ b/pkg/controller/instanceset/reconciler_instance_alignment.go
@@ -272,7 +272,10 @@ func restorePVCInitialStepCompleted(pvc *corev1.PersistentVolumeClaim) bool {
 		if string(condition.Type) != string(workloads.InstanceRestore) {
 			continue
 		}
-		if condition.Status == corev1.ConditionFalse {
+		// A terminal Restore condition means the PVC is out of the initial-step
+		// window: False is a failed restore, True means the full restore has
+		// already completed and ordering reverts to the regular readiness gate.
+		if condition.Status != corev1.ConditionUnknown {
 			return false
 		}
 	}

--- a/pkg/controller/instanceset/reconciler_instance_alignment_test.go
+++ b/pkg/controller/instanceset/reconciler_instance_alignment_test.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/builder"
 	"github.com/apecloud/kubeblocks/pkg/controller/kubebuilderx"
 )
@@ -159,6 +160,67 @@ var _ = Describe("replicas alignment reconciler test", func() {
 					return expectedPVCName == item.GetName()
 				})).Should(BeNumerically(">=", 0))
 			}
+		})
+
+		It("should create next ordered pod after predecessor restore PVC initial step completes", func() {
+			its.Generation = 1
+			restoreVCTs := []corev1.PersistentVolumeClaim{*volumeClaimTemplates[0].DeepCopy()}
+			restoreVCTs[0].Annotations = map[string]string{
+				constant.RestoreSourceKindAnnotationKey: "Backup",
+			}
+			its.Spec.VolumeClaimTemplates = restoreVCTs
+			tree := kubebuilderx.NewObjectTree()
+			tree.SetRoot(its)
+			reconciler = NewReplicasAlignmentReconciler()
+			pod0 := builder.NewPodBuilder(namespace, name+"-0").GetObject()
+			pvc0 := builder.NewPVCBuilder(namespace, volumeClaimTemplates[0].Name+"-"+pod0.Name).GetObject()
+			pvc0.Status.Conditions = []corev1.PersistentVolumeClaimCondition{{
+				Type:   corev1.PersistentVolumeClaimConditionType(constant.DataProtectionPVCConditionPopulating),
+				Status: corev1.ConditionTrue,
+				Reason: constant.DataProtectionPVCConditionReasonPopulatingProvision,
+			}}
+			Expect(tree.Add(pod0, pvc0)).Should(Succeed())
+
+			res, err := reconciler.Reconcile(tree)
+
+			Expect(err).Should(BeNil())
+			Expect(res).Should(Equal(kubebuilderx.Continue))
+			pods := tree.List(&corev1.Pod{})
+			Expect(pods).Should(HaveLen(2))
+			Expect(slices.IndexFunc(pods, func(item client.Object) bool {
+				return item.GetName() == name+"-1"
+			})).Should(BeNumerically(">=", 0))
+			Expect(slices.IndexFunc(pods, func(item client.Object) bool {
+				return item.GetName() == name+"-2"
+			})).Should(Equal(-1))
+		})
+
+		It("should not use terminal Restore condition as ordered restore initial step", func() {
+			its.Generation = 1
+			restoreVCTs := []corev1.PersistentVolumeClaim{*volumeClaimTemplates[0].DeepCopy()}
+			restoreVCTs[0].Annotations = map[string]string{
+				constant.RestoreSourceKindAnnotationKey: "Backup",
+			}
+			its.Spec.VolumeClaimTemplates = restoreVCTs
+			tree := kubebuilderx.NewObjectTree()
+			tree.SetRoot(its)
+			reconciler = NewReplicasAlignmentReconciler()
+			pod0 := builder.NewPodBuilder(namespace, name+"-0").GetObject()
+			pvc0 := builder.NewPVCBuilder(namespace, volumeClaimTemplates[0].Name+"-"+pod0.Name).GetObject()
+			pvc0.Status.Conditions = []corev1.PersistentVolumeClaimCondition{{
+				Type:   corev1.PersistentVolumeClaimConditionType(workloads.InstanceRestore),
+				Status: corev1.ConditionTrue,
+				Reason: constant.DataProtectionPVCConditionReasonPopulatingProvision,
+			}}
+			Expect(tree.Add(pod0, pvc0)).Should(Succeed())
+
+			res, err := reconciler.Reconcile(tree)
+
+			Expect(err).Should(BeNil())
+			Expect(res).Should(Equal(kubebuilderx.Continue))
+			pods := tree.List(&corev1.Pod{})
+			Expect(pods).Should(HaveLen(1))
+			Expect(pods[0].GetName()).Should(Equal(name + "-0"))
 		})
 
 		It("handles nodeSelectorOnce Annotation", func() {

--- a/pkg/controller/instanceset/reconciler_instance_alignment_test.go
+++ b/pkg/controller/instanceset/reconciler_instance_alignment_test.go
@@ -28,6 +28,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -193,6 +194,36 @@ var _ = Describe("replicas alignment reconciler test", func() {
 			Expect(slices.IndexFunc(pods, func(item client.Object) bool {
 				return item.GetName() == name+"-2"
 			})).Should(Equal(-1))
+		})
+
+		It("should not create next ordered pod from terminating predecessor restore PVC", func() {
+			its.Generation = 1
+			restoreVCTs := []corev1.PersistentVolumeClaim{*volumeClaimTemplates[0].DeepCopy()}
+			restoreVCTs[0].Annotations = map[string]string{
+				constant.RestoreSourceKindAnnotationKey: "Backup",
+			}
+			its.Spec.VolumeClaimTemplates = restoreVCTs
+			tree := kubebuilderx.NewObjectTree()
+			tree.SetRoot(its)
+			reconciler = NewReplicasAlignmentReconciler()
+			pod0 := builder.NewPodBuilder(namespace, name+"-0").GetObject()
+			pvc0 := builder.NewPVCBuilder(namespace, volumeClaimTemplates[0].Name+"-"+pod0.Name).GetObject()
+			now := metav1.Now()
+			pvc0.DeletionTimestamp = &now
+			pvc0.Status.Conditions = []corev1.PersistentVolumeClaimCondition{{
+				Type:   corev1.PersistentVolumeClaimConditionType(constant.DataProtectionPVCConditionPopulating),
+				Status: corev1.ConditionTrue,
+				Reason: constant.DataProtectionPVCConditionReasonPopulatingProvision,
+			}}
+			Expect(tree.Add(pod0, pvc0)).Should(Succeed())
+
+			res, err := reconciler.Reconcile(tree)
+
+			Expect(err).Should(BeNil())
+			Expect(res).Should(Equal(kubebuilderx.Continue))
+			pods := tree.List(&corev1.Pod{})
+			Expect(pods).Should(HaveLen(1))
+			Expect(pods[0].GetName()).Should(Equal(name + "-0"))
 		})
 
 		It("should not use terminal Restore condition as ordered restore initial step", func() {

--- a/pkg/controller/instanceset/reconciler_instance_alignment_test.go
+++ b/pkg/controller/instanceset/reconciler_instance_alignment_test.go
@@ -223,6 +223,40 @@ var _ = Describe("replicas alignment reconciler test", func() {
 			Expect(pods[0].GetName()).Should(Equal(name + "-0"))
 		})
 
+		It("should stop using the initial-step signal once the full restore completes", func() {
+			its.Generation = 1
+			restoreVCTs := []corev1.PersistentVolumeClaim{*volumeClaimTemplates[0].DeepCopy()}
+			restoreVCTs[0].Annotations = map[string]string{
+				constant.RestoreSourceKindAnnotationKey: "Backup",
+			}
+			its.Spec.VolumeClaimTemplates = restoreVCTs
+			tree := kubebuilderx.NewObjectTree()
+			tree.SetRoot(its)
+			reconciler = NewReplicasAlignmentReconciler()
+			pod0 := builder.NewPodBuilder(namespace, name+"-0").GetObject()
+			pvc0 := builder.NewPVCBuilder(namespace, volumeClaimTemplates[0].Name+"-"+pod0.Name).GetObject()
+			// after postReady the PVC keeps Populating=True and gains a terminal
+			// Restore=True: ordering must revert to the regular readiness gate
+			pvc0.Status.Conditions = []corev1.PersistentVolumeClaimCondition{{
+				Type:   corev1.PersistentVolumeClaimConditionType(constant.DataProtectionPVCConditionPopulating),
+				Status: corev1.ConditionTrue,
+				Reason: constant.DataProtectionPVCConditionReasonPopulatingProvision,
+			}, {
+				Type:   corev1.PersistentVolumeClaimConditionType(workloads.InstanceRestore),
+				Status: corev1.ConditionTrue,
+				Reason: constant.DataProtectionPVCConditionReasonPopulatingProvision,
+			}}
+			Expect(tree.Add(pod0, pvc0)).Should(Succeed())
+
+			res, err := reconciler.Reconcile(tree)
+
+			Expect(err).Should(BeNil())
+			Expect(res).Should(Equal(kubebuilderx.Continue))
+			pods := tree.List(&corev1.Pod{})
+			Expect(pods).Should(HaveLen(1))
+			Expect(pods[0].GetName()).Should(Equal(name + "-0"))
+		})
+
 		It("handles nodeSelectorOnce Annotation", func() {
 			tree := kubebuilderx.NewObjectTree()
 			tree.SetRoot(its)

--- a/pkg/controller/instanceset2/reconciler_alignment.go
+++ b/pkg/controller/instanceset2/reconciler_alignment.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/utils/ptr"
 
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/instancetemplate"
 	"github.com/apecloud/kubeblocks/pkg/controller/kubebuilderx"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
@@ -125,7 +126,8 @@ func (r *alignmentReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuil
 			break
 		}
 		predecessor := getPredecessor(i)
-		if isOrderedReady && predecessor != nil && !intctrlutil.IsInstanceAvailable(predecessor) {
+		if isOrderedReady && predecessor != nil && !intctrlutil.IsInstanceAvailable(predecessor) &&
+			!restorePVCInitialStepCompletedForInstance(predecessor, nameToTemplateMap[predecessor.Name]) {
 			break
 		}
 		newInst, err := buildInstanceByTemplate(tree, name, nameToTemplateMap[name], its)
@@ -177,4 +179,21 @@ func (r *alignmentReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuil
 	}
 
 	return kubebuilderx.Continue, nil
+}
+
+func restorePVCInitialStepCompletedForInstance(inst *workloads.Instance, template *instancetemplate.InstanceTemplateExt) bool {
+	if template == nil {
+		return false
+	}
+	hasRestoreVCT := false
+	for _, vct := range template.VolumeClaimTemplates {
+		if vct.Annotations[constant.RestoreSourceKindAnnotationKey] != "" {
+			hasRestoreVCT = true
+			break
+		}
+	}
+	if !hasRestoreVCT {
+		return false
+	}
+	return inst.Annotations[constant.RestorePVCInitialStepCompletedAnnotationKey] == "true"
 }

--- a/pkg/controller/instanceset2/reconciler_alignment_test.go
+++ b/pkg/controller/instanceset2/reconciler_alignment_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package instanceset2
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/instancetemplate"
+)
+
+func TestRestorePVCInitialStepCompletedForInstance(t *testing.T) {
+	makeTemplate := func(restoreAnnot bool) *instancetemplate.InstanceTemplateExt {
+		vct := corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "data",
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				},
+			},
+		}
+		if restoreAnnot {
+			vct.Annotations = map[string]string{
+				constant.RestoreSourceKindAnnotationKey: "Backup",
+			}
+		}
+		return &instancetemplate.InstanceTemplateExt{
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaim{vct},
+		}
+	}
+
+	makeInst := func(annotations map[string]string) *workloads.Instance {
+		return &workloads.Instance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "test-0",
+				Namespace:   "default",
+				Annotations: annotations,
+			},
+		}
+	}
+
+	t.Run("nil template returns false", func(t *testing.T) {
+		inst := makeInst(nil)
+		if restorePVCInitialStepCompletedForInstance(inst, nil) {
+			t.Error("expected false for nil template")
+		}
+	})
+
+	t.Run("no restore VCT returns false", func(t *testing.T) {
+		inst := makeInst(map[string]string{
+			constant.RestorePVCInitialStepCompletedAnnotationKey: "true",
+		})
+		template := makeTemplate(false)
+		if restorePVCInitialStepCompletedForInstance(inst, template) {
+			t.Error("expected false when no restore VCT")
+		}
+	})
+
+	t.Run("restore VCT without annotation returns false", func(t *testing.T) {
+		inst := makeInst(nil)
+		template := makeTemplate(true)
+		if restorePVCInitialStepCompletedForInstance(inst, template) {
+			t.Error("expected false without annotation")
+		}
+	})
+
+	t.Run("restore VCT with annotation returns true", func(t *testing.T) {
+		inst := makeInst(map[string]string{
+			constant.RestorePVCInitialStepCompletedAnnotationKey: "true",
+		})
+		template := makeTemplate(true)
+		if !restorePVCInitialStepCompletedForInstance(inst, template) {
+			t.Error("expected true with annotation and restore VCT")
+		}
+	})
+
+	t.Run("wrong annotation value returns false", func(t *testing.T) {
+		inst := makeInst(map[string]string{
+			constant.RestorePVCInitialStepCompletedAnnotationKey: "false",
+		})
+		template := makeTemplate(true)
+		if restorePVCInitialStepCompletedForInstance(inst, template) {
+			t.Error("expected false with wrong annotation value")
+		}
+	})
+}


### PR DESCRIPTION
## What changed

This keeps PVC `Restore=True` reserved for full restore completion after postReady finishes. When VolumePopulator has already finished the PVC prepare/provision step but postReady still needs later component PVCs, the PVC exposes the existing non-terminal `Populating=True` signal with reason `Succeed` or `Provisioned`.

Ordered workload creation now consumes that initial-step signal for restore PVCs:

- InstanceSet ordered pod creation can create the next ordinal after the predecessor restore PVC initial step is complete.
- Cluster ordered component creation can create the next component group while a predecessor component is still `Restore=Unknown/RestoreRunning`, as long as all expected restore PVCs for that predecessor have the initial-step signal.

## Scope

This PR touches three ordered-creation layers. Each layer has a v1 and v2 code path:

| Layer | v1 path | v2 path | Signal consumed |
|---|---|---|---|
| **InstanceSet** ordered pod creation | `pkg/controller/instanceset/reconciler_instance_alignment.go` — `restorePVCInitialStepCompletedForPod` reads PVC conditions directly | `pkg/controller/instanceset2/reconciler_alignment.go` — `restorePVCInitialStepCompletedForInstance` reads Instance annotation | PVC `Populating=True` (Succeed/Provisioned) |
| **Instance controller** (v2 signal propagation) | N/A (v1 InstanceSet tree has PVCs) | `pkg/controller/instance/reconciler_status.go` — `reconcileRestorePVCAnnotation` checks PVCs, sets `RestorePVCInitialStepCompletedAnnotationKey` on Instance | PVC `Populating=True` -> Instance annotation |
| **Cluster** ordered component creation | `controllers/apps/cluster/transformer_cluster_component.go` — `restorePVCInitialStepCompleted` reads PVC conditions via MockReader | Same file, same function | PVC `Populating=True` (Succeed/Provisioned) |

### v2 architecture note

v2 InstanceSet tree only contains Instance + Service objects (no PVCs). PVCs belong to the Instance subtree. Therefore the v2 bypass uses a two-layer annotation propagation: Instance controller checks its PVCs and sets annotation -> InstanceSet v2 alignment reads the annotation on predecessor Instance.

### Bypass condition (all layers)

```
predecessor NOT Available AND restorePVCInitialStepCompleted(predecessor)
```

The bypass is disqualified when a terminal PVC `Restore` condition (True or False) exists — this scopes it to in-progress restores only.

## Why

A TiDB PITR restore can use a logical Backup whose target selector points at the `tidb` component while data PVCs belong to `tidb-pd` / other components. Those PVCs may be provision-only until postReady redirects to the TiDB component. If ordered creation waits for terminal component/pod readiness, DP waits for later component PVCs while those later pods/components are not created yet.

The earlier version of this PR used early `Restore=True/Provisioned`, but review correctly pointed out that this made Cluster/Component/InstanceSet restore state terminally successful before the postReady Restore finished. This version separates the contracts: `Populating=True` is the PVC initial-step/unblock signal; `Restore=True` remains the terminal restore-complete signal.

Fixes #10478.
Related to #10393 and #10466.

## Tests

- `go test ./pkg/controller/instanceset -count=1`
- `go test ./pkg/controller/instance/... -count=1`
- `go test ./pkg/controller/instanceset2/... -count=1`
- `KUBEBUILDER_ASSETS="..." go test ./controllers/dataprotection -count=1`
- `KUBEBUILDER_ASSETS="..." go test ./controllers/apps/cluster -count=1`
- `git diff --check`
- CI: all green

### Test coverage

| Package | Function | Cases |
|---|---|---|
| `pkg/controller/instance` | `restorePVCInitialStepCompleted` | 5 (no conditions / succeed / provisioned / terminal blocks / failed) |
| `pkg/controller/instance` | `reconcileRestorePVCAnnotation` | 5 (no restore VCT / PVC not found / succeed sets annotation / no conditions / annotation removed) |
| `pkg/controller/instanceset2` | `restorePVCInitialStepCompletedForInstance` | 5 (nil template / no restore VCT / without annotation / with annotation / wrong value) |

## Follow-up hardening (commit 9c3294b)

- Scope the initial-step bypass to in-progress restores: a terminal PVC `Restore` condition (True or False) now disqualifies the bypass in both the InstanceSet and Cluster consumers. Previously `Populating=True` persisted after postReady completion, keeping the bypass active until the VCT restore annotations were cleaned up asynchronously.
- Cluster ordered creation resolves the exact expected restore PVC names from the predecessor's InstanceSet spec (shared pod-name builder + `ComposePVCName`) instead of counting label-matched PVCs, so leftover PVCs from a previous incarnation cannot substitute for expected ones. The component-spec count cross-check makes a stale InstanceSet spec fall back to the strict phase gate.
- `MockReader.Get` now matches the concrete object type, since a Component and its InstanceSet share the same key.

## Remaining gate

- TiDB exact-head runtime validation (blocked on L1 vcluster PVC sync environment issue)
