### PR TITLE
fix(dataprotection): observe populate restore pod updates

### DIFF
--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -42,7 +42,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
@@ -137,7 +139,44 @@ func (r *VolumePopulatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return intctrlutil.NewControllerManagedBy(mgr).
 		For(&corev1.PersistentVolumeClaim{}).
 		Owns(&batchv1.Job{}).
+		Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(r.parsePopulatePod)).
 		Complete(r)
+}
+
+func (r *VolumePopulatorReconciler) parsePopulatePod(ctx context.Context, object client.Object) []reconcile.Request {
+	labels := object.GetLabels()
+	if labels[dprestore.DataProtectionRestoreLabelKey] == "" ||
+		labels[dprestore.DataProtectionPopulatePVCLabelKey] == "" {
+		return nil
+	}
+	owner := metav1.GetControllerOf(object)
+	if owner == nil || owner.Kind != constant.JobKind {
+		return nil
+	}
+	job := &batchv1.Job{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: object.GetNamespace(), Name: owner.Name}, job); err != nil {
+		if !apierrors.IsNotFound(err) {
+			log.FromContext(ctx).V(1).Info("failed to map volume populate pod to job",
+				"pod", client.ObjectKeyFromObject(object),
+				"job", types.NamespacedName{Namespace: object.GetNamespace(), Name: owner.Name},
+				"error", err)
+		}
+		return nil
+	}
+	if job.Labels[dprestore.DataProtectionRestoreLabelKey] == "" ||
+		job.Labels[dprestore.DataProtectionPopulatePVCLabelKey] == "" {
+		return nil
+	}
+	pvcOwner := metav1.GetControllerOf(job)
+	if pvcOwner == nil || pvcOwner.Kind != constant.PersistentVolumeClaimKind {
+		return nil
+	}
+	return []reconcile.Request{{
+		NamespacedName: types.NamespacedName{
+			Namespace: job.Namespace,
+			Name:      pvcOwner.Name,
+		},
+	}}
 }
 
 func (r *VolumePopulatorReconciler) MatchToPopulate(pvc *corev1.PersistentVolumeClaim) (bool, error) {

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
@@ -1352,6 +1353,166 @@ func TestDispatchUnboundPVCFailsWhenNoRestoreActionsExist(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal),
 		"expected fatal error when neither prepareData nor postReady exists, got: %v", err)
+}
+
+func TestPopulateDoesNotPollWhilePrepareDataJobIsStillActive(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	apiGroup := dptypes.DataprotectionAPIGroup
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "data-etcd-restore-0",
+			UID:       "data-etcd-restore-0-uid",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+			},
+			DataSourceRef: &corev1.TypedObjectReference{
+				APIGroup: &apiGroup,
+				Kind:     dptypes.BackupKind,
+				Name:     "backup",
+			},
+		},
+	}
+	restore := &dpv1alpha1.Restore{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "restore",
+		},
+		Spec: dpv1alpha1.RestoreSpec{
+			Backup: dpv1alpha1.BackupRef{Name: "backup", Namespace: "default"},
+			PrepareDataConfig: &dpv1alpha1.PrepareDataConfig{
+				DataSourceRef: &dpv1alpha1.VolumeConfig{
+					VolumeSource: "data",
+					MountPath:    "/var/run/etcd/backup",
+				},
+			},
+		},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(pvc, restore).
+		WithObjects(pvc, restore).
+		Build()
+	reconciler := &VolumePopulatorReconciler{
+		Client:   cli,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+	backup := newBackupForRestoreDecision([]string{"data"}, nil)
+	backup.Status.Target.PodSelector = &dpv1alpha1.PodSelector{Strategy: dpv1alpha1.PodSelectionStrategyAny}
+	actionSet := &dpv1alpha1.ActionSet{
+		Spec: dpv1alpha1.ActionSetSpec{
+			Restore: &dpv1alpha1.RestoreActionSpec{
+				PrepareData: &dpv1alpha1.JobActionSpec{
+					BaseJobActionSpec: dpv1alpha1.BaseJobActionSpec{
+						Image:   "restore-image",
+						Command: []string{"sh", "-c", "restore"},
+					},
+				},
+			},
+		},
+	}
+	restoreMgr := dprestore.NewRestoreManager(restore, record.NewFakeRecorder(10), scheme, reconciler.Client)
+	restoreMgr.PrepareDataBackupSets = []dprestore.BackupActionSet{{
+		Backup:    backup,
+		ActionSet: actionSet,
+	}}
+	restoreCtx := &pvcRestoreContext{
+		mode:       pvcRestoreModeRestoreData,
+		restoreMgr: restoreMgr,
+	}
+
+	err := reconciler.Populate(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreCtx)
+
+	require.NoError(t, err)
+	jobs := &batchv1.JobList{}
+	require.NoError(t, reconciler.Client.List(context.Background(), jobs))
+	require.Len(t, jobs.Items, 1)
+	require.Empty(t, jobs.Items[0].Status.Conditions)
+}
+
+func TestParsePopulatePodMapsJobPodToTargetPVC(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "data-etcd-restore-0",
+			UID:       "data-etcd-restore-0-uid",
+		},
+	}
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "populate-job",
+			UID:       "populate-job-uid",
+			Labels: map[string]string{
+				dprestore.DataProtectionRestoreLabelKey:     "restore",
+				dprestore.DataProtectionPopulatePVCLabelKey: "populate-pvc",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion:         "v1",
+				Kind:               constant.PersistentVolumeClaimKind,
+				Name:               pvc.Name,
+				UID:                pvc.UID,
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
+			}},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "populate-job-pod",
+			Labels: map[string]string{
+				dprestore.DataProtectionRestoreLabelKey:     "restore",
+				dprestore.DataProtectionPopulatePVCLabelKey: "populate-pvc",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion:         "batch/v1",
+				Kind:               constant.JobKind,
+				Name:               job.Name,
+				UID:                job.UID,
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
+			}},
+		},
+	}
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc, job).Build(),
+		Scheme: scheme,
+	}
+
+	requests := reconciler.parsePopulatePod(context.Background(), pod)
+
+	require.Equal(t, []reconcile.Request{{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: pvc.Name},
+	}}, requests)
+}
+
+func TestParsePopulatePodIgnoresUnrelatedPods(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+		Scheme: scheme,
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "unrelated",
+		},
+	}
+
+	require.Empty(t, reconciler.parsePopulatePod(context.Background(), pod))
 }
 
 func TestBuildPostReadyRestoreSelectsHighestPriorityRole(t *testing.T) {


### PR DESCRIPTION
## Current status

Draft while the root-cause evidence is being closed.

This PR supersedes #10477, which was closed. The first #10481 head also carried the same bounded polling direction as #10477, but that direction is not the accepted final fix. The current head removes the polling approach and is now only a candidate event-driven fix.

Current head: `16b26ba9e2acaf2dd2e42550a369a3dee534d404`

Related to #10476.

## Problem being validated

The observed stuck path is:

1. The `restore` container exits successfully.
2. The prepareData Job can still be `Active` because the restore-manager sidecar is waiting for the `dataprotection.kubeblocks.io/stop-restore-manager=true` annotation.
3. If VolumePopulator does not reconcile again after the container-status transition, `CheckJobsDone()` does not get another chance to patch the stop annotation.
4. The sidecar keeps waiting, and the Job / Restore / PVC can remain stuck.

The rejected polling approach made VolumePopulator periodically recheck active prepareData Jobs. The current candidate instead observes the missing signal directly.

## Candidate fix

VolumePopulator now watches Pods and maps a relevant prepareData pod back to the target PVC:

`Pod -> owning Job -> owning target PVC`

The mapper requires restore/populate-PVC labels on both Pod and Job, and skips unrelated pods/jobs. Active prepareData Jobs no longer return a fixed `reconcileInterval` requeue.

## Validation completed so far

Local checks passed:

- `go test ./controllers/dataprotection -run 'TestPopulateDoesNotPollWhilePrepareDataJobIsStillActive|TestParsePopulatePod' -count=1`
- `KUBEBUILDER_ASSETS="/Users/wei/Library/Application Support/io.kubebuilder.envtest/k8s/1.26.1-darwin-arm64" go test ./controllers/dataprotection -count=1`
- `git diff --check HEAD~1..HEAD`

GitHub CI on the current head is pass or expected-skip, including `push-pre-check (test)` and `make-test`.

## Evidence still required before ready-for-review

The previous Route 1 runtime evidence was for head `473ff99cd5bd5ec4143c49c35d7348b662742adf`, so it is historical positive evidence only and is not exact-head validation for `16b26ba9e2acaf2dd2e42550a369a3dee534d404`.

Before this PR is marked ready for review, the remaining evidence needs to close:

- exact-head live DP image identity for `16b26ba9e2acaf2dd2e42550a369a3dee534d404`;
- live runtime evidence that the Pod status transition enqueues the target PVC;
- proof that `CheckJobsDone()` patches the stop annotation after that enqueue;
- proof that Job, Restore, PVC, cluster, and data readback close out;
- the A/B/C chain discussed in the controller thread: Job resourceVersion/status behavior, ownerRef/predicate mapping, and whether a reconcile happened but failed to patch annotation.
