### PR TITLE
chore: keep KB-managed tools image updates in-place

### DIFF
--- a/apis/apps/v1/cluster_types.go
+++ b/apis/apps/v1/cluster_types.go
@@ -476,6 +476,8 @@ type ClusterComponentSpec struct {
 	// PodUpgradePolicy indicates how pods should be updated when the component is upgraded.
 	//
 	// If not specified, the value of PodUpdatePolicy will be used.
+	// If the referenced ComponentDefinition specifies PodUpgradePolicy or PodUpdatePolicy as "ReCreate",
+	// the definition-level "ReCreate" takes precedence over this field.
 	//
 	// +kubebuilder:validation:Enum={StrictInPlace,PreferInPlace}
 	// +optional

--- a/apis/apps/v1/component_types.go
+++ b/apis/apps/v1/component_types.go
@@ -235,6 +235,8 @@ type ComponentSpec struct {
 	// PodUpgradePolicy indicates how pods should be updated when the component is upgraded.
 	//
 	// If not specified, the value of PodUpdatePolicy will be used.
+	// If the referenced ComponentDefinition specifies PodUpgradePolicy or PodUpdatePolicy as "ReCreate",
+	// the definition-level "ReCreate" takes precedence over this field.
 	//
 	// +kubebuilder:validation:Enum={StrictInPlace,PreferInPlace}
 	// +optional

--- a/apis/apps/v1/componentdefinition_types.go
+++ b/apis/apps/v1/componentdefinition_types.go
@@ -470,6 +470,8 @@ type ComponentDefinitionSpec struct {
 	PodManagementPolicy *appsv1.PodManagementPolicyType `json:"podManagementPolicy,omitempty"`
 
 	// Specifies the default update policy for pods when the Component is updated.
+	// If PodUpgradePolicy is not specified and this field is set to "ReCreate", this definition-level
+	// policy also takes precedence over the Component or Cluster user-specified PodUpgradePolicy during upgrades.
 	//
 	// +kubebuilder:validation:Enum={PreferInPlace,ReCreate}
 	// +kubebuilder:default=PreferInPlace
@@ -477,6 +479,8 @@ type ComponentDefinitionSpec struct {
 	PodUpdatePolicy *PodUpdatePolicyType `json:"podUpdatePolicy,omitempty"`
 
 	// Specifies the default update policy for pods when the Component is upgraded (the service version changes).
+	// If set to "ReCreate", this definition-level policy takes precedence over the Component or Cluster
+	// user-specified PodUpgradePolicy.
 	//
 	// If not specified, the default behavior is the same as `podUpdatePolicy`.
 	//

--- a/config/crd/bases/apps.kubeblocks.io_clusters.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusters.yaml
@@ -2872,6 +2872,8 @@ spec:
                         PodUpgradePolicy indicates how pods should be updated when the component is upgraded.
 
                         If not specified, the value of PodUpdatePolicy will be used.
+                        If the referenced ComponentDefinition specifies PodUpgradePolicy or PodUpdatePolicy as "ReCreate",
+                        the definition-level "ReCreate" takes precedence over this field.
                       enum:
                       - StrictInPlace
                       - PreferInPlace
@@ -14117,6 +14119,8 @@ spec:
                             PodUpgradePolicy indicates how pods should be updated when the component is upgraded.
 
                             If not specified, the value of PodUpdatePolicy will be used.
+                            If the referenced ComponentDefinition specifies PodUpgradePolicy or PodUpdatePolicy as "ReCreate",
+                            the definition-level "ReCreate" takes precedence over this field.
                           enum:
                           - StrictInPlace
                           - PreferInPlace

--- a/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
@@ -9924,8 +9924,10 @@ spec:
                 type: string
               podUpdatePolicy:
                 default: PreferInPlace
-                description: Specifies the default update policy for pods when the
-                  Component is updated.
+                description: |-
+                  Specifies the default update policy for pods when the Component is updated.
+                  If PodUpgradePolicy is not specified and this field is set to "ReCreate", this definition-level
+                  policy also takes precedence over the Component or Cluster user-specified PodUpgradePolicy during upgrades.
                 enum:
                 - PreferInPlace
                 - ReCreate
@@ -9933,6 +9935,8 @@ spec:
               podUpgradePolicy:
                 description: |-
                   Specifies the default update policy for pods when the Component is upgraded (the service version changes).
+                  If set to "ReCreate", this definition-level policy takes precedence over the Component or Cluster
+                  user-specified PodUpgradePolicy.
 
                   If not specified, the default behavior is the same as `podUpdatePolicy`.
                 enum:

--- a/config/crd/bases/apps.kubeblocks.io_components.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_components.yaml
@@ -3091,6 +3091,8 @@ spec:
                   PodUpgradePolicy indicates how pods should be updated when the component is upgraded.
 
                   If not specified, the value of PodUpdatePolicy will be used.
+                  If the referenced ComponentDefinition specifies PodUpgradePolicy or PodUpdatePolicy as "ReCreate",
+                  the definition-level "ReCreate" takes precedence over this field.
                 enum:
                 - StrictInPlace
                 - PreferInPlace

--- a/controllers/apps/component/transformer_component_workload.go
+++ b/controllers/apps/component/transformer_component_workload.go
@@ -351,6 +351,20 @@ func shouldCleanupLegacyConfigManager(oldITS, desiredITS *workloads.InstanceSet)
 	if reflect.DeepEqual(oldTemplate, newTemplate) {
 		return false
 	}
+	initChanged, initOK := intctrlutil.OnlyKBManagedContainerImageChanged(oldTemplate.Spec.InitContainers, newTemplate.Spec.InitContainers)
+	containerChanged, containerOK := intctrlutil.OnlyKBManagedContainerImageChanged(oldTemplate.Spec.Containers, newTemplate.Spec.Containers)
+	if initOK && containerOK && (initChanged || containerChanged) {
+		// Container image comparison is intentionally limited to initContainers/containers.
+		// Cleanup is a full template decision, so normalize those lists and keep the legacy
+		// config-manager when the stripped templates have no other meaningful difference.
+		oldTemplateCopy := oldTemplate.DeepCopy()
+		newTemplateCopy := newTemplate.DeepCopy()
+		oldTemplateCopy.Spec.InitContainers = newTemplateCopy.Spec.InitContainers
+		oldTemplateCopy.Spec.Containers = newTemplateCopy.Spec.Containers
+		if reflect.DeepEqual(oldTemplateCopy, newTemplateCopy) {
+			return false
+		}
+	}
 	// Container list or init container changes are evaluated by InstanceSet as pod upgrade changes.
 	// Clean up only when the configured policy will recreate Pods. Otherwise we keep the live template aligned
 	// with old Pods that still carry the legacy sidecar and avoid creating an extra rollout only for cleanup.

--- a/controllers/apps/component/transformer_component_workload_test.go
+++ b/controllers/apps/component/transformer_component_workload_test.go
@@ -37,6 +37,7 @@ import (
 	kbacli "github.com/apecloud/kubeblocks/pkg/kbagent/client"
 	kbagentproto "github.com/apecloud/kubeblocks/pkg/kbagent/proto"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
 
 var _ = Describe("Component Workload Operations Test", func() {
@@ -1142,6 +1143,10 @@ var _ = Describe("Component Workload Operations Test", func() {
 		})
 
 		It("decides legacy config-manager cleanup from concrete pod template change classes", func() {
+			oldToolsImage := viper.GetString(constant.KBToolsImage)
+			defer viper.Set(constant.KBToolsImage, oldToolsImage)
+			viper.Set(constant.KBToolsImage, "docker.io/apecloud/kubeblocks-tools:1.0.0")
+
 			baseTemplate := corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{"app": "mysql"},
@@ -1168,6 +1173,18 @@ var _ = Describe("Component Workload Operations Test", func() {
 			Expect(shouldCleanupLegacyConfigManager(oldITS, upgradeITS)).Should(BeFalse())
 			upgradeITS.Spec.PodUpgradePolicy = appsv1.ReCreatePodUpdatePolicyType
 			Expect(shouldCleanupLegacyConfigManager(oldITS, upgradeITS)).Should(BeTrue())
+
+			kbManagedITS := newInstanceSet()
+			kbManagedITS.Spec.PodUpgradePolicy = appsv1.ReCreatePodUpdatePolicyType
+			kbManagedITS.Spec.Template.Spec.InitContainers = []corev1.Container{
+				{Name: "init-kbagent", Image: "docker.io/apecloud/kubeblocks-tools:1.0.0", Command: []string{"cp"}},
+			}
+			kbManagedITS.Spec.Template.Spec.Containers = append(kbManagedITS.Spec.Template.Spec.Containers,
+				corev1.Container{Name: "kbagent", Image: "docker.io/apecloud/kubeblocks-tools:1.0.0", Command: []string{"/bin/kbagent"}})
+			kbManagedUpgradeITS := kbManagedITS.DeepCopy()
+			kbManagedUpgradeITS.Spec.Template.Spec.InitContainers[0].Image = "mirror.local/apecloud/kubeblocks-tools:1.1.0"
+			kbManagedUpgradeITS.Spec.Template.Spec.Containers[1].Image = "mirror.local/apecloud/kubeblocks-tools:1.1.0"
+			Expect(shouldCleanupLegacyConfigManager(kbManagedITS, kbManagedUpgradeITS)).Should(BeFalse())
 
 			resourceITS := newInstanceSet()
 			resourceITS.Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{

--- a/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
@@ -2872,6 +2872,8 @@ spec:
                         PodUpgradePolicy indicates how pods should be updated when the component is upgraded.
 
                         If not specified, the value of PodUpdatePolicy will be used.
+                        If the referenced ComponentDefinition specifies PodUpgradePolicy or PodUpdatePolicy as "ReCreate",
+                        the definition-level "ReCreate" takes precedence over this field.
                       enum:
                       - StrictInPlace
                       - PreferInPlace
@@ -14117,6 +14119,8 @@ spec:
                             PodUpgradePolicy indicates how pods should be updated when the component is upgraded.
 
                             If not specified, the value of PodUpdatePolicy will be used.
+                            If the referenced ComponentDefinition specifies PodUpgradePolicy or PodUpdatePolicy as "ReCreate",
+                            the definition-level "ReCreate" takes precedence over this field.
                           enum:
                           - StrictInPlace
                           - PreferInPlace

--- a/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
@@ -9924,8 +9924,10 @@ spec:
                 type: string
               podUpdatePolicy:
                 default: PreferInPlace
-                description: Specifies the default update policy for pods when the
-                  Component is updated.
+                description: |-
+                  Specifies the default update policy for pods when the Component is updated.
+                  If PodUpgradePolicy is not specified and this field is set to "ReCreate", this definition-level
+                  policy also takes precedence over the Component or Cluster user-specified PodUpgradePolicy during upgrades.
                 enum:
                 - PreferInPlace
                 - ReCreate
@@ -9933,6 +9935,8 @@ spec:
               podUpgradePolicy:
                 description: |-
                   Specifies the default update policy for pods when the Component is upgraded (the service version changes).
+                  If set to "ReCreate", this definition-level policy takes precedence over the Component or Cluster
+                  user-specified PodUpgradePolicy.
 
                   If not specified, the default behavior is the same as `podUpdatePolicy`.
                 enum:

--- a/deploy/helm/crds/apps.kubeblocks.io_components.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_components.yaml
@@ -3091,6 +3091,8 @@ spec:
                   PodUpgradePolicy indicates how pods should be updated when the component is upgraded.
 
                   If not specified, the value of PodUpdatePolicy will be used.
+                  If the referenced ComponentDefinition specifies PodUpgradePolicy or PodUpdatePolicy as "ReCreate",
+                  the definition-level "ReCreate" takes precedence over this field.
                 enum:
                 - StrictInPlace
                 - PreferInPlace

--- a/docs/developer_docs/api-reference/cluster.md
+++ b/docs/developer_docs/api-reference/cluster.md
@@ -787,7 +787,9 @@ PodUpdatePolicyType
 <td>
 <em>(Optional)</em>
 <p>PodUpgradePolicy indicates how pods should be updated when the component is upgraded.</p>
-<p>If not specified, the value of PodUpdatePolicy will be used.</p>
+<p>If not specified, the value of PodUpdatePolicy will be used.
+If the referenced ComponentDefinition specifies PodUpgradePolicy or PodUpdatePolicy as &ldquo;ReCreate&rdquo;,
+the definition-level &ldquo;ReCreate&rdquo; takes precedence over this field.</p>
 </td>
 </tr>
 <tr>
@@ -1626,7 +1628,9 @@ PodUpdatePolicyType
 </td>
 <td>
 <em>(Optional)</em>
-<p>Specifies the default update policy for pods when the Component is updated.</p>
+<p>Specifies the default update policy for pods when the Component is updated.
+If PodUpgradePolicy is not specified and this field is set to &ldquo;ReCreate&rdquo;, this definition-level
+policy also takes precedence over the Component or Cluster user-specified PodUpgradePolicy during upgrades.</p>
 </td>
 </tr>
 <tr>
@@ -1640,7 +1644,9 @@ PodUpdatePolicyType
 </td>
 <td>
 <em>(Optional)</em>
-<p>Specifies the default update policy for pods when the Component is upgraded (the service version changes).</p>
+<p>Specifies the default update policy for pods when the Component is upgraded (the service version changes).
+If set to &ldquo;ReCreate&rdquo;, this definition-level policy takes precedence over the Component or Cluster
+user-specified PodUpgradePolicy.</p>
 <p>If not specified, the default behavior is the same as <code>podUpdatePolicy</code>.</p>
 </td>
 </tr>
@@ -3459,7 +3465,9 @@ PodUpdatePolicyType
 <td>
 <em>(Optional)</em>
 <p>PodUpgradePolicy indicates how pods should be updated when the component is upgraded.</p>
-<p>If not specified, the value of PodUpdatePolicy will be used.</p>
+<p>If not specified, the value of PodUpdatePolicy will be used.
+If the referenced ComponentDefinition specifies PodUpgradePolicy or PodUpdatePolicy as &ldquo;ReCreate&rdquo;,
+the definition-level &ldquo;ReCreate&rdquo; takes precedence over this field.</p>
 </td>
 </tr>
 <tr>
@@ -5853,7 +5861,9 @@ PodUpdatePolicyType
 </td>
 <td>
 <em>(Optional)</em>
-<p>Specifies the default update policy for pods when the Component is updated.</p>
+<p>Specifies the default update policy for pods when the Component is updated.
+If PodUpgradePolicy is not specified and this field is set to &ldquo;ReCreate&rdquo;, this definition-level
+policy also takes precedence over the Component or Cluster user-specified PodUpgradePolicy during upgrades.</p>
 </td>
 </tr>
 <tr>
@@ -5867,7 +5877,9 @@ PodUpdatePolicyType
 </td>
 <td>
 <em>(Optional)</em>
-<p>Specifies the default update policy for pods when the Component is upgraded (the service version changes).</p>
+<p>Specifies the default update policy for pods when the Component is upgraded (the service version changes).
+If set to &ldquo;ReCreate&rdquo;, this definition-level policy takes precedence over the Component or Cluster
+user-specified PodUpgradePolicy.</p>
 <p>If not specified, the default behavior is the same as <code>podUpdatePolicy</code>.</p>
 </td>
 </tr>
@@ -7086,7 +7098,9 @@ PodUpdatePolicyType
 <td>
 <em>(Optional)</em>
 <p>PodUpgradePolicy indicates how pods should be updated when the component is upgraded.</p>
-<p>If not specified, the value of PodUpdatePolicy will be used.</p>
+<p>If not specified, the value of PodUpdatePolicy will be used.
+If the referenced ComponentDefinition specifies PodUpgradePolicy or PodUpdatePolicy as &ldquo;ReCreate&rdquo;,
+the definition-level &ldquo;ReCreate&rdquo; takes precedence over this field.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/controller/instance/in_place_update_utils.go
+++ b/pkg/controller/instance/in_place_update_utils.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
@@ -285,6 +286,29 @@ func safeMetadataOnlyInPlaceUpdate(old, new *corev1.Pod) bool {
 	return true
 }
 
+// safeKBManagedImageOnlyInPlaceUpdate returns true when the only effective
+// difference is a KB-managed tools image update. These updates should patch the
+// Pod in place without inheriting application upgrade policy or invoking
+// database switchover. Init container image patches only converge PodSpec and
+// revision state; already-completed init containers are not re-run, so any
+// init-time copied tools refresh on the next natural Pod recreation.
+func safeKBManagedImageOnlyInPlaceUpdate(old, new *corev1.Pod) bool {
+	initChanged, ok := intctrlutil.OnlyKBManagedContainerImageChanged(old.Spec.InitContainers, new.Spec.InitContainers)
+	if !ok {
+		return false
+	}
+	containerChanged, ok := intctrlutil.OnlyKBManagedContainerImageChanged(old.Spec.Containers, new.Spec.Containers)
+	if !ok || (!initChanged && !containerChanged) {
+		return false
+	}
+
+	oldCopy := old.DeepCopy()
+	newCopy := new.DeepCopy()
+	oldCopy.Spec.InitContainers = newCopy.Spec.InitContainers
+	oldCopy.Spec.Containers = newCopy.Spec.Containers
+	return equalBasicInPlaceFields(oldCopy, newCopy) && equalResourcesInPlaceFields(oldCopy, newCopy)
+}
+
 // equalResourcesInPlaceFields checks if the desired values of pod resources are equal to their current actual values.
 // If they are equal, it returns true. Containers in 'old' that are not recognized (they may have been injected by external mutating admission webhooks)
 // will not participate in the comparison.
@@ -357,10 +381,10 @@ func getPodUpdatePolicy(inst *workloads.Instance, pod *corev1.Pod) (podUpdatePol
 }
 
 func getPodUpdatePolicyInSpec(inst *workloads.Instance, old, new *corev1.Pod) workloads.PodUpdatePolicyType {
-	if !equalField(old.Spec.InitContainers, new.Spec.InitContainers) {
-		return inst.Spec.PodUpgradePolicy
-	}
-	if !equalField(old.Spec.Containers, new.Spec.Containers) {
+	if !equalField(old.Spec.InitContainers, new.Spec.InitContainers) || !equalField(old.Spec.Containers, new.Spec.Containers) {
+		if inst.Spec.PodUpgradePolicy == kbappsv1.ReCreatePodUpdatePolicyType && safeKBManagedImageOnlyInPlaceUpdate(old, new) {
+			return kbappsv1.PreferInPlacePodUpdatePolicyType
+		}
 		return inst.Spec.PodUpgradePolicy
 	}
 	return inst.Spec.PodUpdatePolicy

--- a/pkg/controller/instance/reconciler_update.go
+++ b/pkg/controller/instance/reconciler_update.go
@@ -162,7 +162,7 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 			switch {
 			case !equalResourcesInPlaceFields(pod, newPod) && supportResizeSubResource:
 				err = tree.Update(newMergedPod, kubebuilderx.WithSubResource("resize"))
-			case safeMetadataOnlyInPlaceUpdate(pod, newPod):
+			case safeMetadataOnlyInPlaceUpdate(pod, newPod), safeKBManagedImageOnlyInPlaceUpdate(pod, newPod):
 				err = tree.Update(newMergedPod, kubebuilderx.WithPatch(true))
 			default:
 				if err = r.switchover(tree, inst, newMergedPod.(*corev1.Pod)); err != nil {

--- a/pkg/controller/instance/utils_test.go
+++ b/pkg/controller/instance/utils_test.go
@@ -29,9 +29,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 
+	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/builder"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
 
 func TestReconfigureOptions(t *testing.T) {
@@ -47,6 +49,65 @@ func TestReconfigureOptions(t *testing.T) {
 	}
 	if !reflect.DeepEqual(opts.Arguments, args) {
 		t.Fatalf("expected arguments %v, got %v", args, opts.Arguments)
+	}
+}
+
+func TestGetPodUpdatePolicyInSpecForKBManagedToolsImage(t *testing.T) {
+	oldToolsImage := viper.GetString(constant.KBToolsImage)
+	defer viper.Set(constant.KBToolsImage, oldToolsImage)
+	viper.Set(constant.KBToolsImage, "docker.io/apecloud/kubeblocks-tools:1.0.0")
+
+	oldPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "inst-0",
+			Namespace: "default",
+		},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{Name: "init-kbagent", Image: "docker.io/apecloud/kubeblocks-tools:1.0.0", Command: []string{"cp"}},
+			},
+			Containers: []corev1.Container{
+				{Name: "app", Image: "docker.io/apecloud/redis:7.2"},
+				{Name: "kbagent", Image: "docker.io/apecloud/kubeblocks-tools:1.0.0", Command: []string{"/bin/kbagent"}},
+			},
+		},
+	}
+	newPod := oldPod.DeepCopy()
+	newPod.Spec.InitContainers[0].Image = "mirror.local/apecloud/kubeblocks-tools:1.1.0"
+	newPod.Spec.Containers[1].Image = "mirror.local/apecloud/kubeblocks-tools:1.1.0"
+
+	inst := builder.NewInstanceBuilder("default", "inst-0").
+		SetPodUpdatePolicy(kbappsv1.ReCreatePodUpdatePolicyType).
+		SetPodUpgradePolicy(kbappsv1.ReCreatePodUpdatePolicyType).
+		GetObject()
+
+	if policy := getPodUpdatePolicyInSpec(inst, oldPod, newPod); policy != kbappsv1.PreferInPlacePodUpdatePolicyType {
+		t.Fatalf("expected PreferInPlace for KB-managed tools image change, got %s", policy)
+	}
+	strictInPlaceInst := builder.NewInstanceBuilder("default", "inst-0").
+		SetPodUpdatePolicy(kbappsv1.ReCreatePodUpdatePolicyType).
+		SetPodUpgradePolicy(kbappsv1.StrictInPlacePodUpdatePolicyType).
+		GetObject()
+	if policy := getPodUpdatePolicyInSpec(strictInPlaceInst, oldPod, newPod); policy != kbappsv1.StrictInPlacePodUpdatePolicyType {
+		t.Fatalf("expected StrictInPlace for KB-managed tools image change with StrictInPlace policy, got %s", policy)
+	}
+	if !safeKBManagedImageOnlyInPlaceUpdate(oldPod, newPod) {
+		t.Fatalf("expected KB-managed tools image-only change to skip switchover")
+	}
+
+	labelChangedPod := newPod.DeepCopy()
+	labelChangedPod.Labels = map[string]string{"extra": "true"}
+	if policy := getPodUpdatePolicyInSpec(inst, oldPod, labelChangedPod); policy != kbappsv1.ReCreatePodUpdatePolicyType {
+		t.Fatalf("expected ReCreate for KB-managed tools image plus label change, got %s", policy)
+	}
+	if safeKBManagedImageOnlyInPlaceUpdate(oldPod, labelChangedPod) {
+		t.Fatalf("expected KB-managed tools image plus label change not to skip switchover")
+	}
+
+	appChangedPod := oldPod.DeepCopy()
+	appChangedPod.Spec.Containers[0].Image = "docker.io/apecloud/redis:7.4"
+	if policy := getPodUpdatePolicyInSpec(inst, oldPod, appChangedPod); policy != kbappsv1.ReCreatePodUpdatePolicyType {
+		t.Fatalf("expected ReCreate for app image change, got %s", policy)
 	}
 }
 

--- a/pkg/controller/instanceset/in_place_update_util.go
+++ b/pkg/controller/instanceset/in_place_update_util.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/ptr"
 
+	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/instancetemplate"
@@ -294,6 +295,29 @@ func safeMetadataOnlyInPlaceUpdate(old, new *corev1.Pod) bool {
 	return true
 }
 
+// safeKBManagedImageOnlyInPlaceUpdate returns true when the only effective
+// difference is a KB-managed tools image update. These updates should patch the
+// Pod in place without inheriting application upgrade policy or invoking
+// database switchover. Init container image patches only converge PodSpec and
+// revision state; already-completed init containers are not re-run, so any
+// init-time copied tools refresh on the next natural Pod recreation.
+func safeKBManagedImageOnlyInPlaceUpdate(old, new *corev1.Pod) bool {
+	initChanged, ok := intctrlutil.OnlyKBManagedContainerImageChanged(old.Spec.InitContainers, new.Spec.InitContainers)
+	if !ok {
+		return false
+	}
+	containerChanged, ok := intctrlutil.OnlyKBManagedContainerImageChanged(old.Spec.Containers, new.Spec.Containers)
+	if !ok || (!initChanged && !containerChanged) {
+		return false
+	}
+
+	oldCopy := old.DeepCopy()
+	newCopy := new.DeepCopy()
+	oldCopy.Spec.InitContainers = newCopy.Spec.InitContainers
+	oldCopy.Spec.Containers = newCopy.Spec.Containers
+	return equalBasicInPlaceFields(oldCopy, newCopy) && equalResourcesInPlaceFields(oldCopy, newCopy)
+}
+
 // equalResourcesInPlaceFields checks if the desired values of pod resources are equal to their current actual values.
 // If they are equal, it returns true. Containers in 'old' that are not recognized (they may have been injected by external mutating admission webhooks)
 // will not participate in the comparison.
@@ -396,10 +420,10 @@ func getPodUpdatePolicy(its *workloads.InstanceSet, pod *corev1.Pod) (podUpdateP
 }
 
 func getPodUpdatePolicyInSpec(its *workloads.InstanceSet, old, new *corev1.Pod) workloads.PodUpdatePolicyType {
-	if !equalField(old.Spec.InitContainers, new.Spec.InitContainers) {
-		return its.Spec.PodUpgradePolicy
-	}
-	if !equalField(old.Spec.Containers, new.Spec.Containers) {
+	if !equalField(old.Spec.InitContainers, new.Spec.InitContainers) || !equalField(old.Spec.Containers, new.Spec.Containers) {
+		if its.Spec.PodUpgradePolicy == kbappsv1.ReCreatePodUpdatePolicyType && safeKBManagedImageOnlyInPlaceUpdate(old, new) {
+			return kbappsv1.PreferInPlacePodUpdatePolicyType
+		}
 		return its.Spec.PodUpgradePolicy
 	}
 	return its.Spec.PodUpdatePolicy

--- a/pkg/controller/instanceset/in_place_update_util_test.go
+++ b/pkg/controller/instanceset/in_place_update_util_test.go
@@ -133,6 +133,45 @@ var _ = Describe("instance util test", func() {
 			Expect(equalBasicInPlaceFields(oldPod, basenameChangedPod)).Should(BeFalse())
 			Expect(getPodUpdatePolicyInSpec(its, oldPod, basenameChangedPod)).Should(Equal(kbappsv1.PreferInPlacePodUpdatePolicyType))
 		})
+
+		It("uses in-place policy for KB-managed tools image changes even when pod upgrade policy is ReCreate", func() {
+			oldToolsImage := viper.GetString(constant.KBToolsImage)
+			defer viper.Set(constant.KBToolsImage, oldToolsImage)
+			viper.Set(constant.KBToolsImage, "docker.io/apecloud/kubeblocks-tools:1.0.0")
+
+			oldPod := buildRandomPod()
+			oldPod.Spec.Containers = []corev1.Container{
+				{Name: "app", Image: "docker.io/apecloud/redis:7.2"},
+				{Name: "kbagent", Image: "docker.io/apecloud/kubeblocks-tools:1.0.0", Command: []string{"/bin/kbagent"}},
+			}
+			oldPod.Spec.InitContainers = []corev1.Container{
+				{Name: "init-kbagent", Image: "docker.io/apecloud/kubeblocks-tools:1.0.0", Command: []string{"cp"}},
+			}
+			newPod := oldPod.DeepCopy()
+			newPod.Spec.Containers[1].Image = "mirror.local/apecloud/kubeblocks-tools:1.1.0"
+			newPod.Spec.InitContainers[0].Image = "mirror.local/apecloud/kubeblocks-tools:1.1.0"
+
+			its := builder.NewInstanceSetBuilder(namespace, name).
+				SetPodUpdatePolicy(kbappsv1.ReCreatePodUpdatePolicyType).
+				SetPodUpgradePolicy(kbappsv1.ReCreatePodUpdatePolicyType).
+				GetObject()
+
+			Expect(getPodUpdatePolicyInSpec(its, oldPod, newPod)).Should(Equal(kbappsv1.PreferInPlacePodUpdatePolicyType))
+
+			strictInPlaceITS := builder.NewInstanceSetBuilder(namespace, name).
+				SetPodUpdatePolicy(kbappsv1.ReCreatePodUpdatePolicyType).
+				SetPodUpgradePolicy(kbappsv1.StrictInPlacePodUpdatePolicyType).
+				GetObject()
+			Expect(getPodUpdatePolicyInSpec(strictInPlaceITS, oldPod, newPod)).Should(Equal(kbappsv1.StrictInPlacePodUpdatePolicyType))
+
+			labelChangedPod := newPod.DeepCopy()
+			labelChangedPod.Labels["extra"] = "true"
+			Expect(getPodUpdatePolicyInSpec(its, oldPod, labelChangedPod)).Should(Equal(kbappsv1.ReCreatePodUpdatePolicyType))
+
+			appChangedPod := oldPod.DeepCopy()
+			appChangedPod.Spec.Containers[0].Image = "docker.io/apecloud/redis:7.4"
+			Expect(getPodUpdatePolicyInSpec(its, oldPod, appChangedPod)).Should(Equal(kbappsv1.ReCreatePodUpdatePolicyType))
+		})
 	})
 
 	Context("getPodUpdatePolicy", func() {

--- a/pkg/controller/instanceset/reconciler_update.go
+++ b/pkg/controller/instanceset/reconciler_update.go
@@ -191,7 +191,7 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 			switch {
 			case !equalResourcesInPlaceFields(pod, newPod) && supportResizeSubResource:
 				err = tree.Update(newMergedPod, kubebuilderx.WithSubResource("resize"))
-			case safeMetadataOnlyInPlaceUpdate(pod, newPod):
+			case safeMetadataOnlyInPlaceUpdate(pod, newPod), safeKBManagedImageOnlyInPlaceUpdate(pod, newPod):
 				err = tree.Update(newMergedPod, kubebuilderx.WithPatch(true))
 			default:
 				if err = r.switchover(tree, its, newMergedPod.(*corev1.Pod)); err != nil {

--- a/pkg/controller/instanceset/reconciler_update_test.go
+++ b/pkg/controller/instanceset/reconciler_update_test.go
@@ -502,6 +502,77 @@ var _ = Describe("update reconciler test", func() {
 			Expect(spy.switchoverCalls).Should(Equal(0),
 				"switchover must not be invoked when only the config-hash annotation differs")
 		})
+
+		It("patches pod without calling switchover for KB-managed tools image-only in-place updates", func() {
+			oldToolsImage := viper.GetString(constant.KBToolsImage)
+			defer viper.Set(constant.KBToolsImage, oldToolsImage)
+			viper.Set(constant.KBToolsImage, "docker.io/apecloud/kubeblocks-tools:1.0.0")
+
+			origSupportResize := intctrlutil.SupportResizeSubResource
+			intctrlutil.SupportResizeSubResource = func() (bool, error) { return false, nil }
+			defer func() { intctrlutil.SupportResizeSubResource = origSupportResize }()
+
+			spy := &lifecycleCallSpy{}
+			origNewLifecycleAction := newLifecycleAction
+			newLifecycleAction = func(_ *workloads.InstanceSet, _ *kubebuilderx.ObjectTree, _ *corev1.Pod) (lifecycle.Lifecycle, error) {
+				return spy, nil
+			}
+			defer func() { newLifecycleAction = origNewLifecycleAction }()
+
+			its.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+			its.Spec.Replicas = ptr.To[int32](1)
+			its.Spec.PodUpdatePolicy = kbappsv1.ReCreatePodUpdatePolicyType
+			its.Spec.PodUpgradePolicy = kbappsv1.ReCreatePodUpdatePolicyType
+			its.Spec.Template.Spec.Containers = append(its.Spec.Template.Spec.Containers, corev1.Container{
+				Name:    "kbagent",
+				Image:   "docker.io/apecloud/kubeblocks-tools:1.0.0",
+				Command: []string{"/bin/kbagent"},
+			})
+			its.Spec.LifecycleActions = &workloads.LifecycleActions{
+				Switchover: &kbappsv1.Action{
+					Exec: &kbappsv1.ExecAction{Command: []string{"true"}},
+				},
+			}
+
+			tree := kubebuilderx.NewObjectTree()
+			tree.SetRoot(its)
+			prepareForUpdate(tree)
+
+			pods := tree.List(&corev1.Pod{})
+			Expect(pods).Should(HaveLen(1))
+			pod := pods[0].(*corev1.Pod)
+			pod.Status.Phase = corev1.PodRunning
+			pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
+				Type:               corev1.PodReady,
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: metav1.NewTime(time.Now().Add(-1 * minReadySeconds * time.Second)),
+			})
+
+			for i := range its.Spec.Template.Spec.Containers {
+				if its.Spec.Template.Spec.Containers[i].Name == "kbagent" {
+					its.Spec.Template.Spec.Containers[i].Image = "mirror.local/apecloud/kubeblocks-tools:1.1.0"
+				}
+			}
+
+			reconciler = NewUpdateReconciler()
+			res, err := reconciler.Reconcile(tree)
+			Expect(err).Should(BeNil())
+			Expect(res).Should(Equal(kubebuilderx.Continue))
+
+			postPods := tree.List(&corev1.Pod{})
+			Expect(postPods).Should(HaveLen(1),
+				"pod should be in-place updated, not deleted/recreated")
+			updatedPod := postPods[0].(*corev1.Pod)
+			_, updatedKBAgent := intctrlutil.GetContainerByName(updatedPod.Spec.Containers, "kbagent")
+			Expect(updatedKBAgent).ShouldNot(BeNil())
+			Expect(updatedKBAgent.Image).Should(Equal("mirror.local/apecloud/kubeblocks-tools:1.1.0"))
+			_, option, err := tree.GetWithOption(updatedPod)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(option.Patch).Should(BeTrue(),
+				"KB-managed tools image-only pod updates should use a patch")
+			Expect(spy.switchoverCalls).Should(Equal(0),
+				"switchover must not be invoked when only KB-managed tools images differ")
+		})
 	})
 })
 

--- a/pkg/controllerutil/image_util.go
+++ b/pkg/controllerutil/image_util.go
@@ -25,13 +25,16 @@ import (
 	_ "crypto/sha512"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync"
 
 	"github.com/distribution/reference"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/kbagent"
 	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
 
@@ -283,4 +286,82 @@ func imageBaseName(name string) string {
 		return name
 	}
 	return name[index+1:]
+}
+
+const (
+	legacyConfigManagerContainerName = "config-manager"
+	legacyConfigManagerToolsInitName = "install-config-manager-tool"
+)
+
+// OnlyKBManagedContainerImageChanged checks only the image fields in the given
+// container lists. It returns changed=true when at least one known KB-managed
+// container image changed, and ok=false when any list shape, non-image field, or
+// non-KB-managed image change is detected.
+func OnlyKBManagedContainerImageChanged(oldContainers, newContainers []corev1.Container) (changed bool, ok bool) {
+	toolsImage := viper.GetString(constant.KBToolsImage)
+	if toolsImage == "" {
+		return false, false
+	}
+	return onlyKBManagedContainerImageChanged(oldContainers, newContainers, toolsImage)
+}
+
+func onlyKBManagedContainerImageChanged(oldContainers, newContainers []corev1.Container, toolsImage string) (bool, bool) {
+	if len(oldContainers) != len(newContainers) {
+		return false, false
+	}
+	changed := false
+	for i := range oldContainers {
+		oldContainer := oldContainers[i]
+		newContainer := newContainers[i]
+		if oldContainer.Name != newContainer.Name {
+			return false, false
+		}
+		oldImage := oldContainer.Image
+		newImage := newContainer.Image
+		oldContainer.Image = ""
+		newContainer.Image = ""
+		if !reflect.DeepEqual(oldContainer, newContainer) {
+			return false, false
+		}
+		if oldImage == newImage {
+			continue
+		}
+		if !isKBManagedContainerName(oldContainer.Name) ||
+			!sameImageRepositoryName(oldImage, toolsImage) ||
+			!sameImageRepositoryName(newImage, toolsImage) {
+			return false, false
+		}
+		changed = true
+	}
+	return changed, true
+}
+
+func isKBManagedContainerName(name string) bool {
+	switch name {
+	case kbagent.ContainerName, kbagent.ContainerName4Worker, kbagent.InitContainerName,
+		legacyConfigManagerContainerName, legacyConfigManagerToolsInitName:
+		return true
+	default:
+		return false
+	}
+}
+
+func sameImageRepositoryName(image, target string) bool {
+	imageNamespace, imageRepository, ok := imageRepositoryName(image)
+	if !ok {
+		return false
+	}
+	targetNamespace, targetRepository, ok := imageRepositoryName(target)
+	if !ok {
+		return false
+	}
+	return imageNamespace == targetNamespace && imageRepository == targetRepository
+}
+
+func imageRepositoryName(image string) (string, string, bool) {
+	_, namespace, repository, _, err := parseImageName(image)
+	if err != nil {
+		return "", "", false
+	}
+	return namespace, repository, true
 }

--- a/pkg/controllerutil/image_util_test.go
+++ b/pkg/controllerutil/image_util_test.go
@@ -22,6 +22,11 @@ package controllerutil
 import (
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -55,6 +60,88 @@ var _ = Describe("image util test", func() {
 
 		_, _, _, _, err := parseImageName("/invalid")
 		Expect(err).To(HaveOccurred())
+	})
+
+	It("detects only KB-managed tools image updates", func() {
+		oldToolsImage := viper.GetString(constant.KBToolsImage)
+		defer viper.Set(constant.KBToolsImage, oldToolsImage)
+		viper.Set(constant.KBToolsImage, "docker.io/apecloud/kubeblocks-tools:1.0.0")
+
+		basePod := &corev1.Pod{
+			Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{
+					{
+						Name:    "init-kbagent",
+						Image:   "docker.io/apecloud/kubeblocks-tools:1.0.0",
+						Command: []string{"cp"},
+					},
+					{
+						Name:    "install-config-manager-tool",
+						Image:   "docker.io/apecloud/kubeblocks-tools:1.0.0",
+						Command: []string{"install"},
+					},
+				},
+				Containers: []corev1.Container{
+					{
+						Name:  "app",
+						Image: "docker.io/apecloud/redis:7.2",
+					},
+					{
+						Name:    "kbagent",
+						Image:   "docker.io/apecloud/kubeblocks-tools:1.0.0",
+						Command: []string{"/bin/kbagent"},
+					},
+					{
+						Name:    "kbagent-worker",
+						Image:   "docker.io/apecloud/kubeblocks-tools:1.0.0",
+						Command: []string{"/bin/kbagent"},
+						Args:    []string{"--server=false"},
+					},
+					{
+						Name:    "config-manager",
+						Image:   "docker.io/apecloud/kubeblocks-tools:1.0.0",
+						Command: []string{"/bin/config-manager"},
+					},
+				},
+			},
+		}
+
+		newPod := basePod.DeepCopy()
+		for i := range newPod.Spec.InitContainers {
+			newPod.Spec.InitContainers[i].Image = "mirror.local/apecloud/kubeblocks-tools:1.1.0"
+		}
+		for i := range newPod.Spec.Containers {
+			if newPod.Spec.Containers[i].Name != "app" {
+				newPod.Spec.Containers[i].Image = "mirror.local/apecloud/kubeblocks-tools:1.1.0"
+			}
+		}
+		changed, ok := OnlyKBManagedContainerImageChanged(basePod.Spec.InitContainers, newPod.Spec.InitContainers)
+		Expect(ok).Should(BeTrue())
+		Expect(changed).Should(BeTrue())
+		changed, ok = OnlyKBManagedContainerImageChanged(basePod.Spec.Containers, newPod.Spec.Containers)
+		Expect(ok).Should(BeTrue())
+		Expect(changed).Should(BeTrue())
+
+		appChangedPod := basePod.DeepCopy()
+		appChangedPod.Spec.Containers[0].Image = "docker.io/apecloud/redis:7.4"
+		_, ok = OnlyKBManagedContainerImageChanged(basePod.Spec.Containers, appChangedPod.Spec.Containers)
+		Expect(ok).Should(BeFalse())
+
+		customAgentPod := basePod.DeepCopy()
+		customAgentPod.Spec.Containers[1].Image = "docker.io/example/custom-agent:1.1.0"
+		_, ok = OnlyKBManagedContainerImageChanged(basePod.Spec.Containers, customAgentPod.Spec.Containers)
+		Expect(ok).Should(BeFalse())
+
+		agentEnvChangedPod := basePod.DeepCopy()
+		agentEnvChangedPod.Spec.Containers[1].Image = "mirror.local/apecloud/kubeblocks-tools:1.1.0"
+		agentEnvChangedPod.Spec.Containers[1].Env = []corev1.EnvVar{{Name: "EXTRA", Value: "true"}}
+		_, ok = OnlyKBManagedContainerImageChanged(basePod.Spec.Containers, agentEnvChangedPod.Spec.Containers)
+		Expect(ok).Should(BeFalse())
+
+		removedContainerPod := basePod.DeepCopy()
+		removedContainerPod.Spec.Containers = removedContainerPod.Spec.Containers[:len(removedContainerPod.Spec.Containers)-1]
+		_, ok = OnlyKBManagedContainerImageChanged(basePod.Spec.Containers, removedContainerPod.Spec.Containers)
+		Expect(ok).Should(BeFalse())
 	})
 
 	It("only expands image when config does not exist", func() {


### PR DESCRIPTION
## Summary
- keep KB-managed tools image-only updates in-place even when podUpgradePolicy is ReCreate
- cover kbagent, kbagent-worker, init-kbagent, and legacy config-manager tools containers by fixed container name plus KBToolsImage repo/name
- document ComponentDefinition ReCreate precedence over user Cluster/Component podUpgradePolicy and regenerate CRDs

## Root Cause
KubeBlocks-managed sidecar/tools image changes were classified as container/initContainer upgrade diffs. When the resolved podUpgradePolicy was ReCreate, the update reconciler converted an otherwise in-place image update into Pod deletion and recreation.

## Validation
- make test-go-generate
- make manifests
- go test ./pkg/controllerutil ./pkg/controller/instanceset ./pkg/controller/instance ./controllers/apps/component

Fixes #10472
