### PR TITLE
fix(component): Persist member join status on conflict

### DIFF
--- a/controllers/apps/component/transformer_component_workload_ops.go
+++ b/controllers/apps/component/transformer_component_workload_ops.go
@@ -27,6 +27,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -353,6 +354,9 @@ func (r *componentWorkloadOps) joinMember4ScaleOut() error {
 			if err := r.joinMemberForPod(pod, pods); err != nil {
 				joinErrors = append(joinErrors, fmt.Errorf("pod %s: %w", pod.Name, err))
 			} else {
+				if err := r.persistMemberJoined(pod.Name); err != nil {
+					return err
+				}
 				replicas.Status[i].MemberJoined = ptr.To(true)
 			}
 		}
@@ -375,6 +379,30 @@ func (r *componentWorkloadOps) joinMember4ScaleOut() error {
 		return intctrlutil.NewRequeueError(time.Second, fmt.Sprintf("%v", joinErrors))
 	}
 	return nil
+}
+
+func (r *componentWorkloadOps) persistMemberJoined(podName string) error {
+	if r.runningITS == nil {
+		return nil
+	}
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		its := &workloads.InstanceSet{}
+		if err := r.cli.Get(r.transCtx.Context, client.ObjectKeyFromObject(r.runningITS), its); err != nil {
+			return err
+		}
+		if err := component.UpdateReplicasStatusFunc(its, func(replicas *component.ReplicasStatus) error {
+			for i := range replicas.Status {
+				if replicas.Status[i].Name == podName {
+					replicas.Status[i].MemberJoined = ptr.To(true)
+					return nil
+				}
+			}
+			return fmt.Errorf("replica %s not found", podName)
+		}); err != nil {
+			return err
+		}
+		return r.cli.Update(r.transCtx.Context, its)
+	})
 }
 
 func (r *componentWorkloadOps) joinMemberForPod(pod *corev1.Pod, pods []*corev1.Pod) error {

--- a/controllers/apps/component/transformer_component_workload_ops.go
+++ b/controllers/apps/component/transformer_component_workload_ops.go
@@ -355,7 +355,8 @@ func (r *componentWorkloadOps) joinMember4ScaleOut() error {
 				joinErrors = append(joinErrors, fmt.Errorf("pod %s: %w", pod.Name, err))
 			} else {
 				if err := r.persistMemberJoined(pod.Name); err != nil {
-					return err
+					joinErrors = append(joinErrors, fmt.Errorf("pod %s: persist member joined: %w", pod.Name, err))
+					continue
 				}
 				replicas.Status[i].MemberJoined = ptr.To(true)
 			}
@@ -385,7 +386,8 @@ func (r *componentWorkloadOps) persistMemberJoined(podName string) error {
 	if r.runningITS == nil {
 		return nil
 	}
-	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+	var updatedITS *workloads.InstanceSet
+	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		its := &workloads.InstanceSet{}
 		if err := r.cli.Get(r.transCtx.Context, client.ObjectKeyFromObject(r.runningITS), its); err != nil {
 			return err
@@ -401,8 +403,18 @@ func (r *componentWorkloadOps) persistMemberJoined(podName string) error {
 		}); err != nil {
 			return err
 		}
-		return r.cli.Update(r.transCtx.Context, its)
-	})
+		if err := r.cli.Update(r.transCtx.Context, its); err != nil {
+			return err
+		}
+		updatedITS = its
+		return nil
+	}); err != nil {
+		return err
+	}
+	if updatedITS != nil {
+		r.runningITS.SetResourceVersion(updatedITS.GetResourceVersion())
+	}
+	return nil
 }
 
 func (r *componentWorkloadOps) joinMemberForPod(pod *corev1.Pod, pods []*corev1.Pod) error {

--- a/controllers/apps/component/transformer_component_workload_test.go
+++ b/controllers/apps/component/transformer_component_workload_test.go
@@ -17,14 +17,18 @@ package component
 
 import (
 	"context"
+	"fmt"
+	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/golang/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
@@ -37,6 +41,9 @@ import (
 	kbacli "github.com/apecloud/kubeblocks/pkg/kbagent/client"
 	kbagentproto "github.com/apecloud/kubeblocks/pkg/kbagent/proto"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 var _ = Describe("Component Workload Operations Test", func() {
@@ -1207,3 +1214,69 @@ var _ = Describe("Component Workload Operations Test", func() {
 		})
 	})
 })
+
+func TestPersistMemberJoinedRetriesUpdateConflict(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := workloads.AddToScheme(scheme); err != nil {
+		t.Fatalf("add workloads scheme: %v", err)
+	}
+
+	replicas := int32(2)
+	its := &workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-its",
+		},
+		Spec: workloads.InstanceSetSpec{
+			Replicas: &replicas,
+		},
+	}
+	const podName = "test-pod-1"
+	if err := component.NewReplicasStatus(its, []string{podName}, true, false); err != nil {
+		t.Fatalf("new replicas status: %v", err)
+	}
+
+	updateCount := 0
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(its).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				updateCount++
+				if updateCount == 1 {
+					return apierrors.NewConflict(workloads.Resource("instancesets"), obj.GetName(),
+						fmt.Errorf("simulated conflict"))
+				}
+				return c.Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	ops := &componentWorkloadOps{
+		transCtx: &componentTransformContext{
+			Context: context.Background(),
+		},
+		cli:        cli,
+		runningITS: its,
+	}
+
+	if err := ops.persistMemberJoined(podName); err != nil {
+		t.Fatalf("persist member joined: %v", err)
+	}
+
+	current := &workloads.InstanceSet{}
+	if err := cli.Get(context.Background(), client.ObjectKeyFromObject(its), current); err != nil {
+		t.Fatalf("get current instanceset: %v", err)
+	}
+	joined, err := component.GetReplicasStatusFunc(current, func(s component.ReplicaStatus) bool {
+		return s.Name == podName && s.MemberJoined != nil && *s.MemberJoined
+	})
+	if err != nil {
+		t.Fatalf("get replicas status: %v", err)
+	}
+	if len(joined) != 1 || joined[0] != podName {
+		t.Fatalf("expected %s joined, got %v", podName, joined)
+	}
+	if updateCount != 2 {
+		t.Fatalf("expected one conflict retry, got %d updates", updateCount)
+	}
+}

--- a/controllers/apps/component/transformer_component_workload_test.go
+++ b/controllers/apps/component/transformer_component_workload_test.go
@@ -1296,4 +1296,95 @@ func TestPersistMemberJoinedRetriesUpdateConflict(t *testing.T) {
 	if updateCount != 2 {
 		t.Fatalf("expected one conflict retry, got %d updates", updateCount)
 	}
+	if its.GetResourceVersion() != current.GetResourceVersion() {
+		t.Fatalf("expected running InstanceSet resourceVersion %q, got %q",
+			current.GetResourceVersion(), its.GetResourceVersion())
+	}
+}
+
+func TestJoinMemberCollectsPersistMemberJoinedError(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add apps scheme: %v", err)
+	}
+	if err := workloads.AddToScheme(scheme); err != nil {
+		t.Fatalf("add workloads scheme: %v", err)
+	}
+
+	const (
+		namespace   = "default"
+		clusterName = "test-cluster"
+		compName    = "test-comp"
+		podName     = "test-pod-1"
+	)
+	replicas := int32(1)
+	runningITS := &workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      "test-its",
+		},
+		Spec: workloads.InstanceSetSpec{
+			Replicas: &replicas,
+		},
+	}
+	protoITS := runningITS.DeepCopy()
+	if err := component.NewReplicasStatus(protoITS, []string{podName}, true, false); err != nil {
+		t.Fatalf("new proto replicas status: %v", err)
+	}
+	comp := &appsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      constant.GenerateClusterComponentName(clusterName, compName),
+			Labels:    constant.GetCompLabels(clusterName, compName),
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      podName,
+			Labels:    constant.GetCompLabels(clusterName, compName),
+		},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(runningITS, comp, pod).
+		Build()
+	ops := &componentWorkloadOps{
+		transCtx: &componentTransformContext{
+			Context: context.Background(),
+			Logger:  logger,
+		},
+		cli:       cli,
+		component: comp,
+		synthesizeComp: &component.SynthesizedComponent{
+			Namespace:   namespace,
+			ClusterName: clusterName,
+			Name:        compName,
+			LifecycleActions: component.SynthesizedLifecycleActions{
+				ComponentLifecycleActions: &appsv1.ComponentLifecycleActions{},
+			},
+		},
+		runningITS: runningITS,
+		protoITS:   protoITS,
+	}
+
+	err := ops.joinMember4ScaleOut()
+	if err == nil {
+		t.Fatal("expected requeue error")
+	}
+	if !intctrlutil.IsRequeueError(err) {
+		t.Fatalf("expected requeue error, got %T: %v", err, err)
+	}
+	joined, getErr := component.GetReplicasStatusFunc(protoITS, func(s component.ReplicaStatus) bool {
+		return s.Name == podName && s.MemberJoined != nil && *s.MemberJoined
+	})
+	if getErr != nil {
+		t.Fatalf("get proto replicas status: %v", getErr)
+	}
+	if len(joined) != 0 {
+		t.Fatalf("expected proto status to remain unjoined, got %v", joined)
+	}
 }


### PR DESCRIPTION
## Summary

- persist memberJoin success to the live InstanceSet replica-status annotation immediately after the action succeeds
- retry that live InstanceSet update on resourceVersion conflicts before relying on future scale-in status
- add a unit test that simulates an update conflict and verifies memberJoined=true is retained

Fixes #10359

## Tests

- make test-go-generate
- go test ./controllers/apps/component -run TestPersistMemberJoinedRetriesUpdateConflict -count=1

Note: the envtest-backed Ginkgo suite was not run because /usr/local/kubebuilder/bin/etcd is not installed in this environment.