### PR TITLE
fix(operations): Delete rebuild pods through runtime

### DIFF
--- a/pkg/operations/ops_runtime.go
+++ b/pkg/operations/ops_runtime.go
@@ -170,6 +170,14 @@ func (r *opsRuntime) GetInstance(namespace, clusterName, compName, instanceName 
 	return r.newPodInstance(compName, pod)
 }
 
+func (r *opsRuntime) DeleteInstance(ctx context.Context, namespace, instanceName string, opts ...client.DeleteOption) error {
+	pod := &corev1.Pod{}
+	if err := r.cli.Get(r.dataContext(), client.ObjectKey{Name: instanceName, Namespace: namespace}, pod, r.dataGetOpts...); err != nil {
+		return err
+	}
+	return intctrlutil.BackgroundDeleteObject(r.cli, r.dataContext(), pod, opts...)
+}
+
 func (r *opsRuntime) ListInstances(namespace, clusterName, compName string) ([]Instance, error) {
 	pods, err := component.ListOwnedPods(r.dataContext(), r.cli, namespace, clusterName, compName, r.dataListOpts...)
 	if err != nil {

--- a/pkg/operations/ops_runtime.go
+++ b/pkg/operations/ops_runtime.go
@@ -50,6 +50,7 @@ type opsRuntime struct {
 	dataCtx      context.Context
 	dataGetOpts  []client.GetOption
 	dataListOpts []client.ListOption
+	dataDelOpts  []client.DeleteOption
 }
 
 func buildOpsRuntimes(ctx context.Context, cli client.Client, opsRes *OpsResource) (map[string]OpsRuntime, error) {
@@ -90,6 +91,7 @@ func newOpsRuntime(ctx context.Context, cli client.Client, placement string) *op
 	r.dataCtx = multicluster.IntoContext(ctx, placement)
 	r.dataGetOpts = []client.GetOption{multicluster.InDataContext()}
 	r.dataListOpts = []client.ListOption{multicluster.InDataContext()}
+	r.dataDelOpts = []client.DeleteOption{multicluster.InDataContext()}
 	return r
 }
 
@@ -175,6 +177,7 @@ func (r *opsRuntime) DeleteInstance(ctx context.Context, namespace, instanceName
 	if err := r.cli.Get(r.dataContext(), client.ObjectKey{Name: instanceName, Namespace: namespace}, pod, r.dataGetOpts...); err != nil {
 		return err
 	}
+	opts = append(opts, r.dataDelOpts...)
 	return intctrlutil.BackgroundDeleteObject(r.cli, r.dataContext(), pod, opts...)
 }
 

--- a/pkg/operations/ops_runtime_test.go
+++ b/pkg/operations/ops_runtime_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
@@ -275,6 +276,43 @@ func TestOpsRuntimeBuildsInstanceAPIView(t *testing.T) {
 	}
 	if volume.IsExpanding() {
 		t.Fatalf("did not expect volume to be expanding")
+	}
+}
+
+func TestOpsRuntimeDeleteInstanceUsesRuntimeContext(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+
+	const (
+		namespace    = "default"
+		clusterName  = "test-cluster"
+		component    = "mysql"
+		instanceName = "test-cluster-mysql-0"
+	)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      instanceName,
+			Labels: map[string]string{
+				constant.AppInstanceLabelKey:    clusterName,
+				constant.KBAppComponentLabelKey: component,
+			},
+		},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pod).
+		Build()
+	rt := newOpsRuntime(context.Background(), cli, "data-ctx-a")
+
+	if err := rt.DeleteInstance(context.Background(), namespace, instanceName, client.GracePeriodSeconds(0)); err != nil {
+		t.Fatalf("delete instance: %v", err)
+	}
+	current := &corev1.Pod{}
+	if err := cli.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: instanceName}, current); err == nil {
+		t.Fatalf("expected pod to be deleted")
 	}
 }
 

--- a/pkg/operations/ops_runtime_test.go
+++ b/pkg/operations/ops_runtime_test.go
@@ -33,6 +33,7 @@ import (
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/multicluster"
 )
 
 func TestOpsRuntimeBuildsInstanceAPIView(t *testing.T) {
@@ -290,6 +291,7 @@ func TestOpsRuntimeDeleteInstanceUsesRuntimeContext(t *testing.T) {
 		clusterName  = "test-cluster"
 		component    = "mysql"
 		instanceName = "test-cluster-mysql-0"
+		placement    = "data-ctx-a"
 	)
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -299,20 +301,30 @@ func TestOpsRuntimeDeleteInstanceUsesRuntimeContext(t *testing.T) {
 				constant.AppInstanceLabelKey:    clusterName,
 				constant.KBAppComponentLabelKey: component,
 			},
+			Annotations: map[string]string{
+				constant.KBAppMultiClusterPlacementKey: placement,
+			},
 		},
 	}
-	cli := fake.NewClientBuilder().
+	control := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+	worker := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithObjects(pod).
 		Build()
-	rt := newOpsRuntime(context.Background(), cli, "data-ctx-a")
+	cli := multicluster.NewClient(control, map[string]client.Client{placement: worker})
+	rt := newOpsRuntime(context.Background(), cli, placement)
 
 	if err := rt.DeleteInstance(context.Background(), namespace, instanceName, client.GracePeriodSeconds(0)); err != nil {
 		t.Fatalf("delete instance: %v", err)
 	}
 	current := &corev1.Pod{}
-	if err := cli.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: instanceName}, current); err == nil {
-		t.Fatalf("expected pod to be deleted")
+	if err := worker.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: instanceName}, current); err == nil {
+		t.Fatalf("expected worker pod to be deleted")
+	}
+	if err := control.Get(context.Background(), client.ObjectKey{Namespace: namespace, Name: instanceName}, current); err == nil {
+		t.Fatalf("did not expect pod in control plane")
 	}
 }
 

--- a/pkg/operations/rebuild_instance.go
+++ b/pkg/operations/rebuild_instance.go
@@ -525,10 +525,7 @@ func (r rebuildInstanceOpsHandler) checkProgressForScalingOutPods(reqCtx intctrl
 				progressDetail.SetStatusAndMessage(opsv1alpha1.ProcessingProgressStatus,
 					r.buildScalingOutPodMessage(scalingOutPodName, string(opsv1alpha1.AvailablePhase)))
 				if oldInstance.IsDeleting() && opsRes.OpsRequest.Force() {
-					pod := &corev1.Pod{}
-					if getErr := cli.Get(reqCtx.Ctx, client.ObjectKey{Name: instance.Name, Namespace: opsRes.Cluster.Namespace}, pod); getErr == nil {
-						_ = intctrlutil.BackgroundDeleteObject(cli, reqCtx.Ctx, pod, client.GracePeriodSeconds(0))
-					}
+					_ = runtime.DeleteInstance(reqCtx.Ctx, opsRes.Cluster.Namespace, instance.Name, client.GracePeriodSeconds(0))
 				}
 			}
 			setComponentStatusProgressDetail(opsRes.Recorder, opsRes.OpsRequest, &compStatus.ProgressDetails, progressDetail)

--- a/pkg/operations/type.go
+++ b/pkg/operations/type.go
@@ -126,6 +126,7 @@ type progressResource struct {
 type OpsRuntime interface {
 	GetWorkload(namespace, clusterName, compName string) (Workload, error)
 	GetInstance(namespace, clusterName, compName, instanceName string) (Instance, error)
+	DeleteInstance(ctx context.Context, namespace, instanceName string, opts ...client.DeleteOption) error
 	ListInstances(namespace, clusterName, compName string) ([]Instance, error)
 	GenerateInstanceNameSet(clusterName, compName string, compReplicas int32, instances []appsv1.InstanceTemplate, offlineInstances []string) (map[string]string, error)
 	GenerateTemplateInstanceNames(clusterName, compName, templateName string, replicas int32, offlineInstances []string, ordinals appsv1.Ordinals) ([]string, error)


### PR DESCRIPTION
## Summary

- add an OpsRuntime DeleteInstance action for force cleanup of rebuild replacement pods
- route runtime Get/Delete operations through the data-plane context in multi-cluster deployments
- use the runtime delete path for RebuildInstance force cleanup after replacement pods become available
- add multicluster client coverage that deletes the worker-cluster pod instead of silently no-oping on the control plane

Refs #10487

## Tests

- GOCACHE=/tmp/go-cache go test ./pkg/operations -run TestOpsRuntimeDeleteInstanceUsesRuntimeContext -count=1

Note: this PR fixes the force pod delete routing path called out in #10487. The broader Instance-finalizer deletion behavior should be tracked separately because the reported stuck state can occur before this force pod delete branch is reached.
