### PR TITLE
fix(parameters): Clear completed reconfigure intent

### DIFF
--- a/controllers/parameters/reconfigure/sync.go
+++ b/controllers/parameters/reconfigure/sync.go
@@ -323,7 +323,26 @@ func syncReconfigureStatus(ctx Context) Status {
 		}
 	}
 	if updated == replicas {
+		clearCompletedConfigIntent(ctx)
 		return makeStatus(StatusNone, withReason("reconfigure completed"), withExpected(replicas), withSucceed(updated))
 	}
 	return makeStatus(StatusRetry, withReason("reconfiguring"), withExpected(replicas), withSucceed(updated))
+}
+
+func clearCompletedConfigIntent(ctx Context) {
+	if ctx.ClusterComponent == nil {
+		return
+	}
+	for i := range ctx.ClusterComponent.Configs {
+		config := &ctx.ClusterComponent.Configs[i]
+		if ptr.Deref(config.Name, "") != ctx.ConfigTemplate.Name {
+			continue
+		}
+		config.Restart = nil
+		config.Reconfigure = nil
+		config.ReconfigureAction = nil
+		config.ReconfigureArgs = nil
+		config.Variables = clearReconfigureSystemParameters(config.Variables)
+		return
+	}
 }

--- a/controllers/parameters/reconfigure/sync_test.go
+++ b/controllers/parameters/reconfigure/sync_test.go
@@ -849,6 +849,131 @@ func TestApplyChangesToClusterTemplateReconfigureWithRestartSemantics(t *testing
 	})
 }
 
+func TestSyncReconfigureStatusClearsCompletedConfigIntent(t *testing.T) {
+	configHash := "test-config-hash"
+	ctx := Context{
+		ConfigTemplate: appsv1.ComponentFileTemplate{
+			Name: "my.cnf",
+		},
+		ConfigHash: &configHash,
+		ClusterComponent: &appsv1.ClusterComponentSpec{
+			Replicas: 1,
+			Configs: []appsv1.ClusterComponentConfig{{
+				Name:              ptr.To("my.cnf"),
+				ConfigHash:        ptr.To(configHash),
+				Restart:           ptr.To(true),
+				Reconfigure:       ptr.To(true),
+				ReconfigureAction: &appsv1.Action{Exec: &appsv1.ExecAction{Command: []string{"bash", "-c", "reload"}}},
+				ReconfigureArgs:   [][]string{{"http-idle-timeout", "200000000000"}},
+				Variables: map[string]string{
+					configFilesUpdated: "stale-checksum",
+					"user-var":         "keep",
+				},
+			}},
+		},
+		ITS: &workloads.InstanceSet{
+			Status: workloads.InstanceSetStatus{
+				InstanceStatus: []workloads.InstanceStatus{{
+					Configs: []workloads.InstanceConfigStatus{{
+						Name:       "my.cnf",
+						ConfigHash: ptr.To(configHash),
+					}},
+				}},
+			},
+		},
+	}
+
+	status := syncReconfigureStatus(ctx)
+
+	if status.Status != StatusNone {
+		t.Fatalf("expected status %q, got %q", StatusNone, status.Status)
+	}
+	config := ctx.ClusterComponent.Configs[0]
+	if config.ConfigHash == nil || *config.ConfigHash != configHash {
+		t.Fatalf("expected config hash to be preserved, got %v", config.ConfigHash)
+	}
+	if config.Restart != nil {
+		t.Fatalf("expected completed restart intent to be cleared, got %v", config.Restart)
+	}
+	if config.Reconfigure != nil {
+		t.Fatalf("expected completed reconfigure intent to be cleared, got %v", config.Reconfigure)
+	}
+	if config.ReconfigureAction != nil {
+		t.Fatalf("expected completed reconfigure action to be cleared")
+	}
+	if config.ReconfigureArgs != nil {
+		t.Fatalf("expected completed reconfigure args to be cleared, got %v", config.ReconfigureArgs)
+	}
+	if _, ok := config.Variables[configFilesUpdated]; ok {
+		t.Fatalf("expected completed system variable %q to be cleared, got %v", configFilesUpdated, config.Variables)
+	}
+	if got := config.Variables["user-var"]; got != "keep" {
+		t.Fatalf("expected user variable to be preserved, got %v", config.Variables)
+	}
+}
+
+func TestSyncReconfigureStatusKeepsInProgressConfigIntent(t *testing.T) {
+	configHash := "test-config-hash"
+	oldHash := "old-config-hash"
+	ctx := Context{
+		ConfigTemplate: appsv1.ComponentFileTemplate{
+			Name: "my.cnf",
+		},
+		ConfigHash: &configHash,
+		ClusterComponent: &appsv1.ClusterComponentSpec{
+			Replicas: 2,
+			Configs: []appsv1.ClusterComponentConfig{{
+				Name:              ptr.To("my.cnf"),
+				ConfigHash:        ptr.To(configHash),
+				Restart:           ptr.To(true),
+				Reconfigure:       ptr.To(true),
+				ReconfigureAction: &appsv1.Action{Exec: &appsv1.ExecAction{Command: []string{"bash", "-c", "reload"}}},
+				ReconfigureArgs:   [][]string{{"http-idle-timeout", "200000000000"}},
+				Variables: map[string]string{
+					configFilesUpdated: "pending-checksum",
+				},
+			}},
+		},
+		ITS: &workloads.InstanceSet{
+			Status: workloads.InstanceSetStatus{
+				InstanceStatus: []workloads.InstanceStatus{{
+					Configs: []workloads.InstanceConfigStatus{{
+						Name:       "my.cnf",
+						ConfigHash: ptr.To(configHash),
+					}},
+				}, {
+					Configs: []workloads.InstanceConfigStatus{{
+						Name:       "my.cnf",
+						ConfigHash: ptr.To(oldHash),
+					}},
+				}},
+			},
+		},
+	}
+
+	status := syncReconfigureStatus(ctx)
+
+	if status.Status != StatusRetry {
+		t.Fatalf("expected status %q, got %q", StatusRetry, status.Status)
+	}
+	config := ctx.ClusterComponent.Configs[0]
+	if config.Restart == nil || !*config.Restart {
+		t.Fatalf("expected in-progress restart intent to be preserved, got %v", config.Restart)
+	}
+	if config.Reconfigure == nil || !*config.Reconfigure {
+		t.Fatalf("expected in-progress reconfigure intent to be preserved, got %v", config.Reconfigure)
+	}
+	if config.ReconfigureAction == nil {
+		t.Fatalf("expected in-progress reconfigure action to be preserved")
+	}
+	if !reflect.DeepEqual(config.ReconfigureArgs, [][]string{{"http-idle-timeout", "200000000000"}}) {
+		t.Fatalf("expected in-progress reconfigure args to be preserved, got %v", config.ReconfigureArgs)
+	}
+	if got := config.Variables[configFilesUpdated]; got != "pending-checksum" {
+		t.Fatalf("expected in-progress system variable to be preserved, got %v", config.Variables)
+	}
+}
+
 func TestApplyChangesToClusterTemplateReconfigureWithNonExecAction(t *testing.T) {
 	newContext := func() Context {
 		return Context{


### PR DESCRIPTION
Mitigates https://github.com/apecloud/kubeblocks/issues/10370.

## Summary
- Clear transient config reconfigure fields from cluster component configs after all instances report the target config hash.
- Preserve stable config state, including user-facing `Variables`, while removing only controller-owned reconfigure system variables such as `KB_CONFIG_FILES_UPDATED`.
- Keep in-progress restart/reconfigure intent untouched until every replica reports the completed config hash.

## Root Cause
Completed reconfigure operations left transient controller intent in `cluster.spec.componentSpecs[].configs[]`. That stale intent confused older clients and could keep completed operations looking active even after InstanceSet config status had converged.

This mitigates the compatibility symptom after successful completion. It does not claim to fully fix the old-kbcli schema mismatch during the active operation window or failed-and-paused terminal state.

## Tests
```text
GOCACHE=/tmp/go-cache go test ./controllers/parameters/reconfigure -run 'TestSyncReconfigureStatus(ClearsCompletedConfigIntent|KeepsInProgressConfigIntent)|TestApplyChangesToClusterTemplateReconfigure|TestApplyChangesToClusterTemplateReconfigureWithRestartSemantics|TestShouldBuildLegacyReconfigureAction' -count=1
git diff --check
```
