### PR TITLE
fix: keep sharding reconfigure intent per component

### DIFF
--- a/controllers/apps/cluster/restore_intent_test.go
+++ b/controllers/apps/cluster/restore_intent_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/yaml"
 
@@ -72,6 +73,84 @@ func TestInjectRestoreIntentRemovesStaleOptionalAnnotations(t *testing.T) {
 	require.Equal(t, "backup", vct.Spec.DataSourceRef.Name)
 	require.NotNil(t, vct.Spec.DataSourceRef.Namespace)
 	require.Equal(t, "backup-ns", *vct.Spec.DataSourceRef.Namespace)
+}
+
+func TestCopyAndMergeComponentPreservesShardingReconfigureIntent(t *testing.T) {
+	hash := "target-hash"
+	oldCompObj := &appsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				constant.KBAppShardingNameLabelKey: "shard",
+			},
+		},
+		Spec: appsv1.ComponentSpec{
+			Configs: []appsv1.ClusterComponentConfig{{
+				Name:       ptr.To("mongodb.conf"),
+				ConfigHash: ptr.To(hash),
+				Restart:    ptr.To(true),
+			}},
+		},
+	}
+	newCompObj := oldCompObj.DeepCopy()
+	newCompObj.Spec.Configs = []appsv1.ClusterComponentConfig{{
+		Name: ptr.To("mongodb.conf"),
+	}}
+
+	require.Nil(t, copyAndMergeComponent(oldCompObj, newCompObj))
+}
+
+func TestCopyAndMergeComponentUsesNewShardingReconfigureIntent(t *testing.T) {
+	oldHash := "old-hash"
+	newHash := "new-hash"
+	oldCompObj := &appsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				constant.KBAppShardingNameLabelKey: "shard",
+			},
+		},
+		Spec: appsv1.ComponentSpec{
+			Configs: []appsv1.ClusterComponentConfig{{
+				Name:       ptr.To("mongodb.conf"),
+				ConfigHash: ptr.To(oldHash),
+				Restart:    ptr.To(true),
+			}},
+		},
+	}
+	newCompObj := oldCompObj.DeepCopy()
+	newCompObj.Spec.Configs = []appsv1.ClusterComponentConfig{{
+		Name:       ptr.To("mongodb.conf"),
+		ConfigHash: ptr.To(newHash),
+		Restart:    ptr.To(true),
+	}}
+
+	result := copyAndMergeComponent(oldCompObj, newCompObj)
+	require.NotNil(t, result)
+	require.Len(t, result.Spec.Configs, 1)
+	require.NotNil(t, result.Spec.Configs[0].ConfigHash)
+	require.Equal(t, newHash, *result.Spec.Configs[0].ConfigHash)
+}
+
+func TestCopyAndMergeComponentClearsNonShardingReconfigureIntent(t *testing.T) {
+	hash := "target-hash"
+	oldCompObj := &appsv1.Component{
+		Spec: appsv1.ComponentSpec{
+			Configs: []appsv1.ClusterComponentConfig{{
+				Name:       ptr.To("mongodb.conf"),
+				ConfigHash: ptr.To(hash),
+				Restart:    ptr.To(true),
+			}},
+		},
+	}
+	newCompObj := oldCompObj.DeepCopy()
+	newCompObj.Spec.Configs = []appsv1.ClusterComponentConfig{{
+		Name: ptr.To("mongodb.conf"),
+	}}
+
+	result := copyAndMergeComponent(oldCompObj, newCompObj)
+	require.NotNil(t, result)
+	require.Len(t, result.Spec.Configs, 1)
+	require.Nil(t, result.Spec.Configs[0].ConfigHash)
+	require.Nil(t, result.Spec.Configs[0].Restart)
 }
 
 func TestInjectRestoreIntentOmitsDataSourceRefNamespaceForSameNamespaceSource(t *testing.T) {

--- a/controllers/apps/cluster/restore_intent_test.go
+++ b/controllers/apps/cluster/restore_intent_test.go
@@ -88,6 +88,9 @@ func TestCopyAndMergeComponentPreservesShardingReconfigureIntent(t *testing.T) {
 				Name:       ptr.To("mongodb.conf"),
 				ConfigHash: ptr.To(hash),
 				Restart:    ptr.To(true),
+				Variables: map[string]string{
+					"KB_CONFIG_FILES_UPDATED": "checksum",
+				},
 			}},
 		},
 	}
@@ -95,8 +98,11 @@ func TestCopyAndMergeComponentPreservesShardingReconfigureIntent(t *testing.T) {
 	newCompObj.Spec.Configs = []appsv1.ClusterComponentConfig{{
 		Name: ptr.To("mongodb.conf"),
 	}}
+	newCompObj.Spec.Replicas = 3
 
-	require.Nil(t, copyAndMergeComponent(oldCompObj, newCompObj))
+	result := copyAndMergeComponent(oldCompObj, newCompObj)
+	require.NotNil(t, result)
+	require.Equal(t, map[string]string{"KB_CONFIG_FILES_UPDATED": "checksum"}, result.Spec.Configs[0].Variables)
 }
 
 func TestCopyAndMergeComponentUsesNewShardingReconfigureIntent(t *testing.T) {

--- a/controllers/apps/cluster/transformer_cluster_component.go
+++ b/controllers/apps/cluster/transformer_cluster_component.go
@@ -231,12 +231,23 @@ func copyAndMergeComponent(oldCompObj, newCompObj *appsv1.Component) *appsv1.Com
 		return *normalized
 	}
 
-	mergeConfigs := func(running, expected []appsv1.ClusterComponentConfig) []appsv1.ClusterComponentConfig {
+	mergeConfigs := func(running, expected []appsv1.ClusterComponentConfig, preserveReconfigure bool) []appsv1.ClusterComponentConfig {
 		var mergedConfigs []appsv1.ClusterComponentConfig
+
+		hasReconfigureIntent := func(config appsv1.ClusterComponentConfig) bool {
+			return config.ConfigHash != nil ||
+				config.Restart != nil ||
+				config.Reconfigure != nil ||
+				config.ReconfigureAction != nil ||
+				config.ReconfigureArgs != nil
+		}
 
 		mergedConfigs = append(mergedConfigs, expected...)
 		for _, config := range running {
-			if config.Name == nil || config.ConfigMap == nil {
+			if config.Name == nil {
+				continue
+			}
+			if config.ConfigMap == nil && !preserveReconfigure {
 				continue
 			}
 			matchConfig := func(c appsv1.ClusterComponentConfig) bool {
@@ -249,6 +260,13 @@ func copyAndMergeComponent(oldCompObj, newCompObj *appsv1.Component) *appsv1.Com
 			}
 			if mergedConfigs[index].ConfigMap == nil {
 				mergedConfigs[index].ConfigMap = config.ConfigMap
+			}
+			if preserveReconfigure && hasReconfigureIntent(config) && !hasReconfigureIntent(mergedConfigs[index]) {
+				mergedConfigs[index].ConfigHash = config.ConfigHash
+				mergedConfigs[index].Restart = config.Restart
+				mergedConfigs[index].Reconfigure = config.Reconfigure
+				mergedConfigs[index].ReconfigureAction = config.ReconfigureAction
+				mergedConfigs[index].ReconfigureArgs = config.ReconfigureArgs
 			}
 		}
 		return mergedConfigs
@@ -273,7 +291,7 @@ func copyAndMergeComponent(oldCompObj, newCompObj *appsv1.Component) *appsv1.Com
 	compObjCopy.Spec.Services = compProto.Spec.Services
 	compObjCopy.Spec.SystemAccounts = compProto.Spec.SystemAccounts
 	compObjCopy.Spec.Replicas = compProto.Spec.Replicas
-	compObjCopy.Spec.Configs = mergeConfigs(compObjCopy.Spec.Configs, compProto.Spec.Configs)
+	compObjCopy.Spec.Configs = mergeConfigs(compObjCopy.Spec.Configs, compProto.Spec.Configs, oldCompObj.Labels[constant.KBAppShardingNameLabelKey] != "")
 	compObjCopy.Spec.ServiceAccountName = compProto.Spec.ServiceAccountName
 	compObjCopy.Spec.ParallelPodManagementConcurrency = compProto.Spec.ParallelPodManagementConcurrency
 	compObjCopy.Spec.PodUpdatePolicy = compProto.Spec.PodUpdatePolicy

--- a/controllers/apps/cluster/transformer_cluster_component.go
+++ b/controllers/apps/cluster/transformer_cluster_component.go
@@ -239,7 +239,8 @@ func copyAndMergeComponent(oldCompObj, newCompObj *appsv1.Component) *appsv1.Com
 				config.Restart != nil ||
 				config.Reconfigure != nil ||
 				config.ReconfigureAction != nil ||
-				config.ReconfigureArgs != nil
+				config.ReconfigureArgs != nil ||
+				config.Variables != nil
 		}
 
 		mergedConfigs = append(mergedConfigs, expected...)
@@ -255,6 +256,9 @@ func copyAndMergeComponent(oldCompObj, newCompObj *appsv1.Component) *appsv1.Com
 			}
 			index := generics.FindFirstFunc(mergedConfigs, matchConfig)
 			if index < 0 {
+				if config.ConfigMap == nil {
+					continue
+				}
 				mergedConfigs = append(mergedConfigs, config)
 				continue
 			}
@@ -267,6 +271,7 @@ func copyAndMergeComponent(oldCompObj, newCompObj *appsv1.Component) *appsv1.Com
 				mergedConfigs[index].Reconfigure = config.Reconfigure
 				mergedConfigs[index].ReconfigureAction = config.ReconfigureAction
 				mergedConfigs[index].ReconfigureArgs = config.ReconfigureArgs
+				mergedConfigs[index].Variables = config.Variables
 			}
 		}
 		return mergedConfigs

--- a/controllers/parameters/reconfigure_controller.go
+++ b/controllers/parameters/reconfigure_controller.go
@@ -431,6 +431,9 @@ func (r *ReconfigureReconciler) performUpgrade(rctx *reconcileContext, tasks []r
 }
 
 func (r *ReconfigureReconciler) submit(rctx *reconcileContext) error {
+	if rctx.ComponentObj != nil && rctx.ClusterObj != nil && rctx.ClusterObj.Spec.GetComponentByName(rctx.ComponentName) == nil {
+		return r.submitComponentConfigs(rctx)
+	}
 	if rctx.ClusterObj == nil || rctx.ClusterObjCopy == nil {
 		return fmt.Errorf("the cluster object is nil")
 	}
@@ -438,6 +441,18 @@ func (r *ReconfigureReconciler) submit(rctx *reconcileContext) error {
 		return nil
 	}
 	return rctx.Client.Update(rctx.RequestCtx.Ctx, rctx.ClusterObj)
+}
+
+func (r *ReconfigureReconciler) submitComponentConfigs(rctx *reconcileContext) error {
+	if rctx.ComponentObj == nil || rctx.ClusterComObj == nil {
+		return fmt.Errorf("the component object is nil")
+	}
+	if reflect.DeepEqual(rctx.ComponentObj.Spec.Configs, rctx.ClusterComObj.Configs) {
+		return nil
+	}
+	patch := client.MergeFrom(rctx.ComponentObj.DeepCopy())
+	rctx.ComponentObj.Spec.Configs = rctx.ClusterComObj.Configs
+	return rctx.Client.Patch(rctx.RequestCtx.Ctx, rctx.ComponentObj, patch)
 }
 
 func (r *ReconfigureReconciler) status(rctx *reconcileContext, policy string, status reconfigure.Status, err error) (ctrl.Result, error) {

--- a/controllers/parameters/reconfigure_controller.go
+++ b/controllers/parameters/reconfigure_controller.go
@@ -66,6 +66,7 @@ const (
 	reasonReconfigureFailed                 = "ReconfigureFailed"
 	reasonReconfigureRunning                = "ReconfigureRunning"
 	reasonReconfigureSucceed                = "ReconfigureSucceed"
+	configFilesUpdated                      = "KB_CONFIG_FILES_UPDATED"
 )
 
 var reconfigureRequiredLabels = []string{
@@ -443,9 +444,30 @@ func (r *ReconfigureReconciler) submit(rctx *reconcileContext) error {
 	return rctx.Client.Update(rctx.RequestCtx.Ctx, rctx.ClusterObj)
 }
 
+func clearConfigReconfigureIntent(config *appsv1.ClusterComponentConfig) {
+	config.ConfigHash = nil
+	config.Restart = nil
+	config.Reconfigure = nil
+	config.ReconfigureAction = nil
+	config.ReconfigureArgs = nil
+	if config.Variables != nil {
+		delete(config.Variables, configFilesUpdated)
+	}
+}
+
 func (r *ReconfigureReconciler) submitComponentConfigs(rctx *reconcileContext) error {
 	if rctx.ComponentObj == nil || rctx.ClusterComObj == nil {
 		return fmt.Errorf("the component object is nil")
+	}
+	for i := range rctx.ClusterObj.Spec.Shardings {
+		for j := range rctx.ClusterObj.Spec.Shardings[i].Template.Configs {
+			clearConfigReconfigureIntent(&rctx.ClusterObj.Spec.Shardings[i].Template.Configs[j])
+		}
+	}
+	if !reflect.DeepEqual(rctx.ClusterObj.Spec, rctx.ClusterObjCopy.Spec) {
+		if err := rctx.Client.Update(rctx.RequestCtx.Ctx, rctx.ClusterObj); err != nil {
+			return err
+		}
 	}
 	if reflect.DeepEqual(rctx.ComponentObj.Spec.Configs, rctx.ClusterComObj.Configs) {
 		return nil

--- a/controllers/parameters/reconfigure_controller_test.go
+++ b/controllers/parameters/reconfigure_controller_test.go
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package parameters
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -28,9 +29,12 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
@@ -612,6 +616,99 @@ func TestValidateLegacyReloadActionSupportWithClusterAnnotation(t *testing.T) {
 				t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
 			}
 		})
+	}
+}
+
+func TestSubmitShardingReconfigureConfigsToConcreteComponent(t *testing.T) {
+	hash := "target-hash"
+	configName := configSpecName
+	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add apps scheme: %v", err)
+	}
+	cluster := &appsv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      clusterName,
+		},
+		Spec: appsv1.ClusterSpec{
+			Shardings: []appsv1.ClusterSharding{{
+				Name: "shard",
+				Template: appsv1.ClusterComponentSpec{
+					Replicas: 3,
+					Configs: []appsv1.ClusterComponentConfig{{
+						Name: ptr.To(configName),
+					}},
+				},
+			}},
+		},
+	}
+	comp := &appsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName(clusterName, "shard-abc"),
+			Labels: map[string]string{
+				constant.AppInstanceLabelKey:       clusterName,
+				constant.KBAppComponentLabelKey:    "shard-abc",
+				constant.KBAppShardingNameLabelKey: "shard",
+			},
+		},
+		Spec: appsv1.ComponentSpec{
+			Replicas: 3,
+			Configs: []appsv1.ClusterComponentConfig{{
+				Name: ptr.To(configName),
+			}},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster, comp).Build()
+	rctx := &reconcileContext{
+		ResourceFetcher: parameters.ResourceFetcher[reconcileContext]{
+			ResourceCtx: &render.ResourceCtx{
+				Context:       context.Background(),
+				Client:        cli,
+				Namespace:     "default",
+				ClusterName:   clusterName,
+				ComponentName: "shard-abc",
+			},
+			ClusterObj:     cluster,
+			ClusterObjCopy: cluster.DeepCopy(),
+			ComponentObj:   comp,
+			ClusterComObj: &appsv1.ClusterComponentSpec{
+				Name:     "shard-abc",
+				Replicas: 3,
+				Configs: []appsv1.ClusterComponentConfig{{
+					Name:       ptr.To(configName),
+					ConfigHash: ptr.To(hash),
+					Restart:    ptr.To(true),
+				}},
+			},
+		},
+	}
+
+	if err := (&ReconfigureReconciler{Client: cli}).submit(rctx); err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+
+	updatedComp := &appsv1.Component{}
+	if err := cli.Get(context.Background(), client.ObjectKeyFromObject(comp), updatedComp); err != nil {
+		t.Fatalf("get component: %v", err)
+	}
+	if len(updatedComp.Spec.Configs) != 1 {
+		t.Fatalf("expected one component config, got %d", len(updatedComp.Spec.Configs))
+	}
+	if updatedComp.Spec.Configs[0].ConfigHash == nil || *updatedComp.Spec.Configs[0].ConfigHash != hash {
+		t.Fatalf("expected component config hash %q, got %v", hash, updatedComp.Spec.Configs[0].ConfigHash)
+	}
+	if updatedComp.Spec.Configs[0].Restart == nil || !*updatedComp.Spec.Configs[0].Restart {
+		t.Fatalf("expected component restart intent, got %v", updatedComp.Spec.Configs[0].Restart)
+	}
+
+	updatedCluster := &appsv1.Cluster{}
+	if err := cli.Get(context.Background(), client.ObjectKeyFromObject(cluster), updatedCluster); err != nil {
+		t.Fatalf("get cluster: %v", err)
+	}
+	if updatedCluster.Spec.Shardings[0].Template.Configs[0].ConfigHash != nil {
+		t.Fatalf("expected sharding template config hash to remain nil")
 	}
 }
 

--- a/controllers/parameters/reconfigure_controller_test.go
+++ b/controllers/parameters/reconfigure_controller_test.go
@@ -637,7 +637,13 @@ func TestSubmitShardingReconfigureConfigsToConcreteComponent(t *testing.T) {
 				Template: appsv1.ClusterComponentSpec{
 					Replicas: 3,
 					Configs: []appsv1.ClusterComponentConfig{{
-						Name: ptr.To(configName),
+						Name:       ptr.To(configName),
+						ConfigHash: ptr.To("stale-hash"),
+						Restart:    ptr.To(true),
+						Variables: map[string]string{
+							"KB_CONFIG_FILES_UPDATED": "stale",
+							"template_var":            "kept",
+						},
 					}},
 				},
 			}},
@@ -709,6 +715,16 @@ func TestSubmitShardingReconfigureConfigsToConcreteComponent(t *testing.T) {
 	}
 	if updatedCluster.Spec.Shardings[0].Template.Configs[0].ConfigHash != nil {
 		t.Fatalf("expected sharding template config hash to remain nil")
+	}
+	if updatedCluster.Spec.Shardings[0].Template.Configs[0].Restart != nil {
+		t.Fatalf("expected sharding template restart to be cleared")
+	}
+	variables := updatedCluster.Spec.Shardings[0].Template.Configs[0].Variables
+	if variables["template_var"] != "kept" {
+		t.Fatalf("expected user template variables to be preserved, got %v", variables)
+	}
+	if _, ok := variables["KB_CONFIG_FILES_UPDATED"]; ok {
+		t.Fatalf("expected system checksum variable to be cleared, got %v", variables)
 	}
 }
 

--- a/pkg/parameters/resource_wrapper.go
+++ b/pkg/parameters/resource_wrapper.go
@@ -21,6 +21,7 @@ package parameters
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -128,9 +129,20 @@ func (r *ResourceFetcher[T]) getComponentSpecByName() (*appsv1.ClusterComponentS
 	shardingName := strings.Join(tokens[0:len(tokens)-1], "-")
 	sharding := r.ClusterObj.Spec.GetShardingByName(shardingName)
 	if sharding != nil {
-		return &sharding.Template, nil
+		return clusterComponentSpecFromComponent(r.ComponentName, r.ComponentObj), nil
 	}
 	return nil, nil
+}
+
+func clusterComponentSpecFromComponent(componentName string, comp *appsv1.Component) *appsv1.ClusterComponentSpec {
+	if comp == nil {
+		return nil
+	}
+	return &appsv1.ClusterComponentSpec{
+		Name:     componentName,
+		Replicas: comp.Spec.Replicas,
+		Configs:  slices.Clone(comp.Spec.Configs),
+	}
 }
 
 func (r *ResourceFetcher[T]) ConfigMap(configSpec string) *T {

--- a/pkg/parameters/resource_wrapper.go
+++ b/pkg/parameters/resource_wrapper.go
@@ -21,7 +21,6 @@ package parameters
 
 import (
 	"fmt"
-	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -141,7 +140,7 @@ func clusterComponentSpecFromComponent(componentName string, comp *appsv1.Compon
 	return &appsv1.ClusterComponentSpec{
 		Name:     componentName,
 		Replicas: comp.Spec.Replicas,
-		Configs:  slices.Clone(comp.Spec.Configs),
+		Configs:  comp.Spec.DeepCopy().Configs,
 	}
 }
 

--- a/pkg/parameters/resource_wrapper_test.go
+++ b/pkg/parameters/resource_wrapper_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
@@ -80,6 +81,24 @@ var _ = Describe("resource Fetcher", func() {
 				ComponentParameter().
 				Complete()
 			Expect(err).Should(Succeed())
+		})
+
+		It("should deep-copy configs when deriving sharding component spec from Component", func() {
+			comp := &appsv1.Component{
+				Spec: appsv1.ComponentSpec{
+					Configs: []appsv1.ClusterComponentConfig{{
+						Name: ptr.To(mysqlConfigName),
+						Variables: map[string]string{
+							"checksum": "old",
+						},
+					}},
+				},
+			}
+
+			spec := clusterComponentSpecFromComponent(mysqlCompName, comp)
+			spec.Configs[0].Variables["checksum"] = "new"
+
+			Expect(comp.Spec.Configs[0].Variables).Should(HaveKeyWithValue("checksum", "old"))
 		})
 	})
 


### PR DESCRIPTION
Closes #10459

Summary:
- keep sharding reconfigure config intent on the concrete Component instead of the shared Cluster sharding template
- preserve live sharding reconfigure intent during Component reconciliation until rollout consumes it
- add focused regressions for sharding submit and config intent preservation

Tests:
- go test ./controllers/apps/cluster -run 'TestCopyAndMergeComponent(PreservesShardingReconfigureIntent|UsesNewShardingReconfigureIntent|ClearsNonShardingReconfigureIntent)' -count=1
- go test ./controllers/parameters -run 'Test(SubmitShardingReconfigureConfigsToConcreteComponent|ValidateLegacyReloadActionSupport|NeedRestartAllowsTemplateReconfigure|ResolveReconfigurePolicy)' -count=1
- go test ./pkg/parameters -run 'TestValidateComponentParameterAssignments|TestLegacyConfigManagerRequiredForCluster' -count=1