### PR TITLE
fix: initialize instanceset2 update revisions

### DIFF
--- a/pkg/controller/instanceset2/reconciler_status.go
+++ b/pkg/controller/instanceset2/reconciler_status.go
@@ -55,7 +55,7 @@ func (r *statusReconciler) PreCondition(tree *kubebuilderx.ObjectTree) *kubebuil
 func (r *statusReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilderx.Result, error) {
 	its, _ := tree.GetRoot().(*workloads.InstanceSet)
 
-	desiredInstances, _, err := buildDesiredInstancesByName(tree, its)
+	desiredInstances, desiredNames, err := buildDesiredInstancesByName(tree, its)
 	if err != nil {
 		return kubebuilderx.Continue, err
 	}
@@ -76,6 +76,19 @@ func (r *statusReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 	updateRevisions, err := revisionmap.Decode(its.Status.UpdateRevisions)
 	if err != nil {
 		return kubebuilderx.Continue, err
+	}
+	if updateRevisions == nil {
+		updateRevisions = map[string]string{}
+	}
+	for name, desired := range desiredInstances {
+		if _, ok := updateRevisions[name]; ok {
+			continue
+		}
+		updateRevisions[name] = buildInstanceRevision(desired)
+	}
+	its.Status.UpdateRevisions, _ = revisionmap.Encode(updateRevisions)
+	if len(desiredNames) > 0 {
+		its.Status.UpdateRevision = updateRevisions[desiredNames[len(desiredNames)-1]]
 	}
 
 	template2TemplatesStatus := map[string]*workloads.InstanceTemplateStatus{}

--- a/pkg/controller/instanceset2/reconciler_status_test.go
+++ b/pkg/controller/instanceset2/reconciler_status_test.go
@@ -325,3 +325,81 @@ func TestStatusReconcilerKeepsScaleOutInstancesUpdatedAfterParentGenerationBump(
 		t.Fatalf("expected current revision to advance to update revision")
 	}
 }
+
+func TestStatusReconcilerInitializesUpdateRevisionsOnFreshCreate(t *testing.T) {
+	its := &workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-its",
+			Namespace:  "default",
+			Generation: 1,
+		},
+		Spec: workloads.InstanceSetSpec{
+			Replicas:            ptr.To[int32](1),
+			FlatInstanceOrdinal: true,
+			Instances: []workloads.InstanceTemplate{
+				{
+					Name:     "tpl",
+					Replicas: ptr.To[int32](1),
+					Labels: map[string]string{
+						"managed-label": "desired",
+					},
+				},
+			},
+		},
+		Status: workloads.InstanceSetStatus{
+			ObservedGeneration: 1,
+		},
+	}
+
+	tree := kubebuilderx.NewObjectTree()
+	tree.SetRoot(its)
+	desiredInstances, _, err := buildDesiredInstancesByName(tree, its)
+	if err != nil {
+		t.Fatalf("build desired instances: %v", err)
+	}
+	desired := desiredInstances["test-its-0"]
+	if desired == nil {
+		t.Fatalf("expected desired instance test-its-0, got %#v", desiredInstances)
+	}
+
+	inst := desired.DeepCopy()
+	inst.Generation = 1
+	inst.Status = workloads.InstanceStatus2{
+		ObservedGeneration: 1,
+		UpToDate:           true,
+		Conditions: []metav1.Condition{
+			{Type: string(workloads.InstanceReady), Status: metav1.ConditionTrue},
+			{Type: string(workloads.InstanceAvailable), Status: metav1.ConditionTrue},
+		},
+	}
+	if err := tree.Add(inst); err != nil {
+		t.Fatalf("add instance: %v", err)
+	}
+
+	if _, err := NewStatusReconciler().Reconcile(tree); err != nil {
+		t.Fatalf("reconcile status: %v", err)
+	}
+
+	got := tree.GetRoot().(*workloads.InstanceSet)
+	if got.Status.UpdatedReplicas != 1 {
+		t.Fatalf("expected updated replicas to converge on fresh create, got %d", got.Status.UpdatedReplicas)
+	}
+	updateRevisions, err := revisionmap.Decode(got.Status.UpdateRevisions)
+	if err != nil {
+		t.Fatalf("decode update revisions: %v", err)
+	}
+	desiredRevision := buildInstanceRevision(desired)
+	if updateRevisions[inst.Name] != desiredRevision {
+		t.Fatalf("expected update revision to be initialized, got %#v want %s", updateRevisions, desiredRevision)
+	}
+	currentRevisions, err := revisionmap.Decode(got.Status.CurrentRevisions)
+	if err != nil {
+		t.Fatalf("decode current revisions: %v", err)
+	}
+	if currentRevisions[inst.Name] != desiredRevision {
+		t.Fatalf("expected current revision to match desired revision, got %#v want %s", currentRevisions, desiredRevision)
+	}
+	if got.Status.CurrentRevision != got.Status.UpdateRevision {
+		t.Fatalf("expected current revision to advance to update revision")
+	}
+}


### PR DESCRIPTION
## Summary

- initialize missing InstanceSet2 update revision entries from the desired Instance map before counting updated replicas
- persist the derived `UpdateRevisions` and latest `UpdateRevision` during status reconciliation
- add regression coverage for a fresh create where an observed, up-to-date Instance should converge revision status and `UpdatedReplicas`

## Root Cause

When InstanceSet2 status reconciliation ran before `status.updateRevisions` was populated, every ready Instance was counted as not updated because the updated predicate had no desired revision entry to compare against. Fresh Instance API creates could therefore remain in `Creating` even after all Instances and Pods were ready and available.

## Tests

- `go test ./pkg/controller/instanceset2 -run 'Test(StatusReconcilerInitializesUpdateRevisionsOnFreshCreate|StatusReconcilerKeepsScaleOutInstancesUpdatedAfterParentGenerationBump|IsInstanceUpdated|BuildInstanceRevision)' -count=1`
- `go test ./pkg/controller/instanceset2 -count=1`

Attempted related operations verification:

- `go test ./pkg/operations -run 'TestOpsRuntimeBuildsInstanceAPIViewFromInstanceStatusWhenCurrentRevisionsEmpty' -count=1`

The related operations package did not compile in a fresh worktree because generated `pkg/testutil/k8s/mocks` types were absent: `MockClient`, `MockStatusWriter`, and `NewMockClient`.

Fixes https://github.com/apecloud/kubeblocks/issues/10500
