### PR TITLE
fix(component): Skip kbagent for runtime host ports

### DIFF
--- a/controllers/apps/component/transformer_component_hostport.go
+++ b/controllers/apps/component/transformer_component_hostport.go
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package component
 
 import (
+	pkgcomponent "github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
 )
 
@@ -47,6 +48,9 @@ func (t *componentHostPortTransformer) Transform(ctx graph.TransformContext, dag
 	}
 	if len(ports) > 0 {
 		for i, c := range synthesizedComp.PodSpec.Containers {
+			if pkgcomponent.IsKBAgentContainer(&c) {
+				continue
+			}
 			for j, p := range c.Ports {
 				if hostPort, ok := ports[p.Name]; ok {
 					synthesizedComp.PodSpec.Containers[i].Ports[j].HostPort = hostPort

--- a/controllers/apps/component/transformer_component_hostport_test.go
+++ b/controllers/apps/component/transformer_component_hostport_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package component
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	pkgcomponent "github.com/apecloud/kubeblocks/pkg/controller/component"
+	"github.com/apecloud/kubeblocks/pkg/kbagent"
+)
+
+func TestComponentHostPortTransformerSkipsInjectedKBAgentPorts(t *testing.T) {
+	transCtx := &componentTransformContext{
+		ComponentOrig: &appsv1.Component{},
+		SynthesizeComponent: &pkgcomponent.SynthesizedComponent{
+			Network: &appsv1.ComponentNetwork{
+				HostPorts: []appsv1.HostPort{
+					{Name: "http", Port: 56595},
+				},
+			},
+			PodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "elasticsearch",
+						Ports: []corev1.ContainerPort{
+							{Name: "http", ContainerPort: 9200},
+						},
+					},
+					{
+						Name: kbagent.ContainerName,
+						Ports: []corev1.ContainerPort{
+							{Name: kbagent.DefaultHTTPPortName, ContainerPort: kbagent.DefaultHTTPPort},
+							{Name: kbagent.DefaultStreamingPortName, ContainerPort: kbagent.DefaultStreamingPort},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := (&componentHostPortTransformer{}).Transform(transCtx, nil); err != nil {
+		t.Fatalf("Transform() error = %v", err)
+	}
+
+	appPort := transCtx.SynthesizeComponent.PodSpec.Containers[0].Ports[0]
+	if appPort.HostPort != 56595 {
+		t.Fatalf("app http HostPort = %d, want 56595", appPort.HostPort)
+	}
+
+	for _, port := range transCtx.SynthesizeComponent.PodSpec.Containers[1].Ports {
+		if port.HostPort != 0 {
+			t.Fatalf("kbagent port %q HostPort = %d, want 0", port.Name, port.HostPort)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Prevent non-host-network `network.hostPorts` mappings from applying to injected kbagent containers when port names collide with runtime containers.
- Add a regression test for an Elasticsearch-style `http` port collision so the application container gets the hostPort and kbagent remains unbound.

Fixes #10502

## Tests
- `GOCACHE=/tmp/go-cache go generate ./pkg/testutil/k8s/mocks/...`
- `GOCACHE=/tmp/go-cache go test ./controllers/apps/component -run TestComponentHostPortTransformerSkipsInjectedKBAgentPorts -count=1`
- `GOCACHE=/tmp/go-cache go test ./controllers/apps/component -run '^$' -count=1`\n\nNote: the envtest-backed Ginkgo package run is blocked in this sandbox by controller-runtime trying to remove `/Users/bytedance/Library/Caches/kubebuilder-envtest/port-54668` with operation-not-permitted.