### PR TITLE
fix(component): restrict non-host-network hostPort mappings to runtime containers

### DIFF
--- a/controllers/apps/component/transformer_component_hostport.go
+++ b/controllers/apps/component/transformer_component_hostport.go
@@ -20,6 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package component
 
 import (
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
 )
 
@@ -46,7 +48,18 @@ func (t *componentHostPortTransformer) Transform(ctx graph.TransformContext, dag
 		ports[hostPort.Name] = hostPort.Port
 	}
 	if len(ports) > 0 {
+		// non-host-network mappings are restricted to ports defined in
+		// cmpd.spec.runtime.containers.ports; injected containers (kbagent,
+		// sidecars) may reuse a port name such as "http" and must not be bound
+		// to the same host port.
+		runtimeContainers := sets.New[string]()
+		for _, c := range transCtx.CompDef.Spec.Runtime.Containers {
+			runtimeContainers.Insert(c.Name)
+		}
 		for i, c := range synthesizedComp.PodSpec.Containers {
+			if !runtimeContainers.Has(c.Name) {
+				continue
+			}
 			for j, p := range c.Ports {
 				if hostPort, ok := ports[p.Name]; ok {
 					synthesizedComp.PodSpec.Containers[i].Ports[j].HostPort = hostPort

--- a/controllers/apps/component/transformer_component_hostport_test.go
+++ b/controllers/apps/component/transformer_component_hostport_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package component
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	pkgcomponent "github.com/apecloud/kubeblocks/pkg/controller/component"
+	"github.com/apecloud/kubeblocks/pkg/kbagent"
+)
+
+func TestComponentHostPortTransformerAppliesToRuntimeContainersOnly(t *testing.T) {
+	// Elasticsearch-style collision: the runtime container and the injected
+	// kbagent container both name a port "http". Only the runtime container may
+	// receive the hostPort mapping, otherwise the pod is rejected with a
+	// duplicate hostPort value.
+	transCtx := &componentTransformContext{
+		ComponentOrig: &appsv1.Component{},
+		CompDef: &appsv1.ComponentDefinition{
+			Spec: appsv1.ComponentDefinitionSpec{
+				Runtime: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "elasticsearch",
+						Ports: []corev1.ContainerPort{
+							{Name: "http", ContainerPort: 9200},
+						},
+					}},
+				},
+			},
+		},
+		SynthesizeComponent: &pkgcomponent.SynthesizedComponent{
+			Network: &appsv1.ComponentNetwork{
+				HostPorts: []appsv1.HostPort{
+					{Name: "http", Port: 56595},
+				},
+			},
+			PodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "elasticsearch",
+						Ports: []corev1.ContainerPort{
+							{Name: "http", ContainerPort: 9200},
+						},
+					},
+					{
+						Name: kbagent.ContainerName,
+						Ports: []corev1.ContainerPort{
+							{Name: kbagent.DefaultHTTPPortName, ContainerPort: kbagent.DefaultHTTPPort},
+							{Name: kbagent.DefaultStreamingPortName, ContainerPort: kbagent.DefaultStreamingPort},
+						},
+					},
+					{
+						// a non-kbagent injected sidecar reusing the port name
+						Name: "metrics-sidecar",
+						Ports: []corev1.ContainerPort{
+							{Name: "http", ContainerPort: 9114},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := (&componentHostPortTransformer{}).Transform(transCtx, nil); err != nil {
+		t.Fatalf("Transform() error = %v", err)
+	}
+
+	appPort := transCtx.SynthesizeComponent.PodSpec.Containers[0].Ports[0]
+	if appPort.HostPort != 56595 {
+		t.Fatalf("app http HostPort = %d, want 56595", appPort.HostPort)
+	}
+
+	for _, container := range transCtx.SynthesizeComponent.PodSpec.Containers[1:] {
+		for _, port := range container.Ports {
+			if port.HostPort != 0 {
+				t.Fatalf("injected container %q port %q HostPort = %d, want 0", container.Name, port.Name, port.HostPort)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Enforce the documented `ComponentNetwork.HostPorts` contract for non-host-network components: mappings are restricted to ports defined in `cmpd.spec.runtime.containers.ports`. The transformer now skips any container not present in the componentDef runtime.
- This fixes the Elasticsearch pod rejection `spec.containers[3].ports[0].hostPort: Duplicate value`: the injected kbagent container's HTTP port is literally named `http`, colliding with the runtime container's `http` port, so both received the same host port.
- Add a regression test covering both an injected kbagent container and a non-kbagent injected sidecar reusing the `http` port name.

Fixes #10502.

Supersedes #10503: that fix skipped only `IsKBAgentContainer` containers, while the API contract restricts mappings to runtime containers, which also covers other injected sidecars (e.g. exporter containers added by the monitor transformer).

## Tests

- `go test ./controllers/apps/component -run TestComponentHostPortTransformerAppliesToRuntimeContainersOnly -count=1`
- full suite: `go test ./controllers/apps/component -count=1` with envtest assets (passes)


## Update (commit 28164da)

Tightened matching to port granularity per the contract wording ("ports defined in `cmpd.spec.runtime.containers.ports`", cross-checked with the addon-docs API reference: "Container port name (from runtime.containers[*].ports[*].name)"): a mapping now requires both the container name and the port name to come from the runtime definition, so a port injected into a runtime container after synthesis can no longer be bound. Regression test extended accordingly.
