### PR TITLE
chore: restrict non-host-network hostPort mappings to runtime ports

### DIFF
--- a/controllers/apps/component/transformer_component_hostport.go
+++ b/controllers/apps/component/transformer_component_hostport.go
@@ -20,6 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package component
 
 import (
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
 )
 
@@ -46,7 +48,18 @@ func (t *componentHostPortTransformer) Transform(ctx graph.TransformContext, dag
 		ports[hostPort.Name] = hostPort.Port
 	}
 	if len(ports) > 0 {
+		// non-host-network mappings are restricted to ports defined in
+		// cmpd.spec.runtime.containers.ports; injected containers (kbagent,
+		// sidecars) may reuse a port name such as "http" and must not be bound
+		// to the same host port.
+		runtimeContainers := sets.New[string]()
+		for _, c := range transCtx.CompDef.Spec.Runtime.Containers {
+			runtimeContainers.Insert(c.Name)
+		}
 		for i, c := range synthesizedComp.PodSpec.Containers {
+			if !runtimeContainers.Has(c.Name) {
+				continue
+			}
 			for j, p := range c.Ports {
 				if hostPort, ok := ports[p.Name]; ok {
 					synthesizedComp.PodSpec.Containers[i].Ports[j].HostPort = hostPort

--- a/controllers/apps/component/transformer_component_hostport.go
+++ b/controllers/apps/component/transformer_component_hostport.go
@@ -48,11 +48,11 @@ func (t *componentHostPortTransformer) Transform(ctx graph.TransformContext, dag
 		ports[hostPort.Name] = hostPort.Port
 	}
 	if len(ports) > 0 {
-		// non-host-network mappings are restricted to ports defined in
-		// cmpd.spec.runtime.containers.ports: port names are not unique across
-		// the containers of a pod, and injected containers (kbagent, sidecars)
-		// or injected ports may reuse a name such as "http" and must not be
-		// bound to the same host port.
+		// Per the ComponentNetwork API contract, non-host-network hostPort
+		// mappings are restricted to ports defined in
+		// cmpd.spec.runtime.containers.ports; ports of injected containers or
+		// ports injected into runtime containers after synthesis are not
+		// eligible, regardless of their names.
 		runtimePorts := map[string]sets.Set[string]{}
 		for _, c := range transCtx.CompDef.Spec.Runtime.Containers {
 			portNames := sets.New[string]()

--- a/controllers/apps/component/transformer_component_hostport.go
+++ b/controllers/apps/component/transformer_component_hostport.go
@@ -49,18 +49,29 @@ func (t *componentHostPortTransformer) Transform(ctx graph.TransformContext, dag
 	}
 	if len(ports) > 0 {
 		// non-host-network mappings are restricted to ports defined in
-		// cmpd.spec.runtime.containers.ports; injected containers (kbagent,
-		// sidecars) may reuse a port name such as "http" and must not be bound
-		// to the same host port.
-		runtimeContainers := sets.New[string]()
+		// cmpd.spec.runtime.containers.ports: port names are not unique across
+		// the containers of a pod, and injected containers (kbagent, sidecars)
+		// or injected ports may reuse a name such as "http" and must not be
+		// bound to the same host port.
+		runtimePorts := map[string]sets.Set[string]{}
 		for _, c := range transCtx.CompDef.Spec.Runtime.Containers {
-			runtimeContainers.Insert(c.Name)
+			portNames := sets.New[string]()
+			for _, p := range c.Ports {
+				if p.Name != "" {
+					portNames.Insert(p.Name)
+				}
+			}
+			runtimePorts[c.Name] = portNames
 		}
 		for i, c := range synthesizedComp.PodSpec.Containers {
-			if !runtimeContainers.Has(c.Name) {
+			definedPorts, ok := runtimePorts[c.Name]
+			if !ok {
 				continue
 			}
 			for j, p := range c.Ports {
+				if !definedPorts.Has(p.Name) {
+					continue
+				}
 				if hostPort, ok := ports[p.Name]; ok {
 					synthesizedComp.PodSpec.Containers[i].Ports[j].HostPort = hostPort
 				}

--- a/controllers/apps/component/transformer_component_hostport_test.go
+++ b/controllers/apps/component/transformer_component_hostport_test.go
@@ -29,11 +29,13 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/kbagent"
 )
 
-func TestComponentHostPortTransformerAppliesToRuntimeContainersOnly(t *testing.T) {
+func TestComponentHostPortTransformerAppliesToRuntimeDefinedPortsOnly(t *testing.T) {
 	// Elasticsearch-style collision: the runtime container and the injected
-	// kbagent container both name a port "http". Only the runtime container may
-	// receive the hostPort mapping, otherwise the pod is rejected with a
-	// duplicate hostPort value.
+	// kbagent container both name a port "http". Per the ComponentNetwork API
+	// contract, non-host-network hostPort mappings are restricted to ports
+	// defined in cmpd.spec.runtime.containers.ports, so only the runtime
+	// container's own "http" port may receive the hostPort — otherwise the pod
+	// is rejected with a duplicate hostPort value.
 	transCtx := &componentTransformContext{
 		ComponentOrig: &appsv1.Component{},
 		CompDef: &appsv1.ComponentDefinition{
@@ -52,6 +54,7 @@ func TestComponentHostPortTransformerAppliesToRuntimeContainersOnly(t *testing.T
 			Network: &appsv1.ComponentNetwork{
 				HostPorts: []appsv1.HostPort{
 					{Name: "http", Port: 56595},
+					{Name: "injected", Port: 56596},
 				},
 			},
 			PodSpec: &corev1.PodSpec{
@@ -60,6 +63,9 @@ func TestComponentHostPortTransformerAppliesToRuntimeContainersOnly(t *testing.T
 						Name: "elasticsearch",
 						Ports: []corev1.ContainerPort{
 							{Name: "http", ContainerPort: 9200},
+							// a port injected into the runtime container after
+							// synthesis, not part of the cmpd runtime definition
+							{Name: "injected", ContainerPort: 9300},
 						},
 					},
 					{
@@ -85,9 +91,12 @@ func TestComponentHostPortTransformerAppliesToRuntimeContainersOnly(t *testing.T
 		t.Fatalf("Transform() error = %v", err)
 	}
 
-	appPort := transCtx.SynthesizeComponent.PodSpec.Containers[0].Ports[0]
-	if appPort.HostPort != 56595 {
-		t.Fatalf("app http HostPort = %d, want 56595", appPort.HostPort)
+	appPorts := transCtx.SynthesizeComponent.PodSpec.Containers[0].Ports
+	if appPorts[0].HostPort != 56595 {
+		t.Fatalf("app http HostPort = %d, want 56595", appPorts[0].HostPort)
+	}
+	if appPorts[1].HostPort != 0 {
+		t.Fatalf("injected port on runtime container HostPort = %d, want 0", appPorts[1].HostPort)
 	}
 
 	for _, container := range transCtx.SynthesizeComponent.PodSpec.Containers[1:] {

--- a/controllers/apps/component/transformer_component_hostport_test.go
+++ b/controllers/apps/component/transformer_component_hostport_test.go
@@ -30,12 +30,12 @@ import (
 )
 
 func TestComponentHostPortTransformerAppliesToRuntimeDefinedPortsOnly(t *testing.T) {
-	// Elasticsearch-style collision: the runtime container and the injected
-	// kbagent container both name a port "http". Per the ComponentNetwork API
-	// contract, non-host-network hostPort mappings are restricted to ports
-	// defined in cmpd.spec.runtime.containers.ports, so only the runtime
-	// container's own "http" port may receive the hostPort — otherwise the pod
-	// is rejected with a duplicate hostPort value.
+	// Per the ComponentNetwork API contract, non-host-network hostPort
+	// mappings are restricted to ports defined in
+	// cmpd.spec.runtime.containers.ports: only the runtime container's own
+	// declared port may receive the hostPort, never ports of injected
+	// containers or ports injected after synthesis, even when they carry the
+	// same name as the mapping entry.
 	transCtx := &componentTransformContext{
 		ComponentOrig: &appsv1.Component{},
 		CompDef: &appsv1.ComponentDefinition{

--- a/controllers/apps/component/transformer_component_hostport_test.go
+++ b/controllers/apps/component/transformer_component_hostport_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package component
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	pkgcomponent "github.com/apecloud/kubeblocks/pkg/controller/component"
+	"github.com/apecloud/kubeblocks/pkg/kbagent"
+)
+
+func TestComponentHostPortTransformerAppliesToRuntimeContainersOnly(t *testing.T) {
+	// Elasticsearch-style collision: the runtime container and the injected
+	// kbagent container both name a port "http". Only the runtime container may
+	// receive the hostPort mapping, otherwise the pod is rejected with a
+	// duplicate hostPort value.
+	transCtx := &componentTransformContext{
+		ComponentOrig: &appsv1.Component{},
+		CompDef: &appsv1.ComponentDefinition{
+			Spec: appsv1.ComponentDefinitionSpec{
+				Runtime: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "elasticsearch",
+						Ports: []corev1.ContainerPort{
+							{Name: "http", ContainerPort: 9200},
+						},
+					}},
+				},
+			},
+		},
+		SynthesizeComponent: &pkgcomponent.SynthesizedComponent{
+			Network: &appsv1.ComponentNetwork{
+				HostPorts: []appsv1.HostPort{
+					{Name: "http", Port: 56595},
+				},
+			},
+			PodSpec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "elasticsearch",
+						Ports: []corev1.ContainerPort{
+							{Name: "http", ContainerPort: 9200},
+						},
+					},
+					{
+						Name: kbagent.ContainerName,
+						Ports: []corev1.ContainerPort{
+							{Name: kbagent.DefaultHTTPPortName, ContainerPort: kbagent.DefaultHTTPPort},
+							{Name: kbagent.DefaultStreamingPortName, ContainerPort: kbagent.DefaultStreamingPort},
+						},
+					},
+					{
+						// a non-kbagent injected sidecar reusing the port name
+						Name: "metrics-sidecar",
+						Ports: []corev1.ContainerPort{
+							{Name: "http", ContainerPort: 9114},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := (&componentHostPortTransformer{}).Transform(transCtx, nil); err != nil {
+		t.Fatalf("Transform() error = %v", err)
+	}
+
+	appPort := transCtx.SynthesizeComponent.PodSpec.Containers[0].Ports[0]
+	if appPort.HostPort != 56595 {
+		t.Fatalf("app http HostPort = %d, want 56595", appPort.HostPort)
+	}
+
+	for _, container := range transCtx.SynthesizeComponent.PodSpec.Containers[1:] {
+		for _, port := range container.Ports {
+			if port.HostPort != 0 {
+				t.Fatalf("injected container %q port %q HostPort = %d, want 0", container.Name, port.Name, port.HostPort)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Enforce the documented `ComponentNetwork.HostPorts` contract for non-host-network components: mappings are restricted to ports defined in `cmpd.spec.runtime.containers.ports` ("Any specified container ports not present in the runtime definition will be ignored"). The transformer previously applied name-keyed mappings across all pod containers; it now requires both the container and the port name to come from the componentDef runtime definition, so ports of injected containers — and ports injected into runtime containers after synthesis — are never bound.

This PR's scope is controller compliance with the API definition. It is not the direct fix for the Elasticsearch failure in #10502: that failure's root cause is the injected kbagent port names violating pod-wide port name uniqueness, tracked in #10506 and fixed by #10507. The contract enforcement here holds regardless of how ports are named.

Refs #10502, #10506, #10507.

## Changes

- `componentHostPortTransformer` builds the eligible (container, port name) set from `cmpd.spec.runtime.containers[*].ports[*]` and applies hostPort mappings only within it.
- Regression test covers: runtime port receives the mapping; injected containers (kbagent, sidecar) with same-named ports are not bound; a port injected into a runtime container after synthesis is not bound.
- `MockReader.Get` matches the concrete object type (a Component and its InstanceSet share the same key).

## Tests

- `go test ./controllers/apps/component -run TestComponentHostPortTransformerAppliesToRuntimeDefinedPortsOnly -count=1`
- full suite: `go test ./controllers/apps/component -count=1` with envtest assets (passes)
