### PR TITLE
chore(kbagent): rename injected container ports to keep pod port names unique

### DIFF
--- a/apis/apps/v1/componentdefinition_types.go
+++ b/apis/apps/v1/componentdefinition_types.go
@@ -213,6 +213,9 @@ type ComponentDefinitionSpec struct {
 	//
 	// This field is immutable and cannot be updated once set.
 	//
+	// The container port names "kba-http" and "kba-streaming" are reserved by KubeBlocks for the
+	// kbagent container that it injects when lifecycle or reconfiguration actions are defined.
+	//
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:validation:Required
 	Runtime corev1.PodSpec `json:"runtime"`

--- a/apis/apps/v1/componentdefinition_types.go
+++ b/apis/apps/v1/componentdefinition_types.go
@@ -555,6 +555,14 @@ type ComponentDefinitionStatus struct {
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
+	// LegacyKBAgentPortNames records that this definition was already accepted
+	// before kba-http and kba-streaming became reserved names. The controller
+	// uses the durable status bit to preserve a compatible injected port name
+	// across later phase transitions without allowing new definitions to opt in.
+	//
+	// +optional
+	LegacyKBAgentPortNames bool `json:"legacyKBAgentPortNames,omitempty"`
+
 	// Represents the current status of the ComponentDefinition. Valid values include ``, `Available`, and `Unavailable`.
 	// When the status is `Available`, the ComponentDefinition is ready and can be utilized by related objects.
 	//

--- a/apis/apps/v1/componentdefinition_types.go
+++ b/apis/apps/v1/componentdefinition_types.go
@@ -213,8 +213,9 @@ type ComponentDefinitionSpec struct {
 	//
 	// This field is immutable and cannot be updated once set.
 	//
-	// The container port names "kba-http" and "kba-streaming" are reserved by KubeBlocks for the
-	// kbagent container that it injects when lifecycle or reconfiguration actions are defined.
+	// The container port names "kba-http" and "kba-streaming" are reserved by KubeBlocks for kbagent
+	// and must not be used by user-defined containers, regardless of whether this definition currently
+	// declares lifecycle or reconfiguration actions.
 	//
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +kubebuilder:validation:Required

--- a/apis/apps/v1/types.go
+++ b/apis/apps/v1/types.go
@@ -265,8 +265,9 @@ type ComponentNetwork struct {
 	//    - If this field is empty: All ports are automatically allocated by the host-port manager.
 	//    - If this field is specified:
 	//      a) Mappings for all ports defined in `cmpd.spec.hostNetwork` are MANDATORY.
-	//      b) Mappings for kbagent ports ("http", "streaming") are OPTIONAL.
+	//      b) Mappings for kbagent ports ("kba-http", "kba-streaming") are OPTIONAL.
 	//         You can explicitly map them here, or leave them omitted to be allocated by the host-port manager.
+	//         The legacy names "http" and "streaming" are still accepted as aliases for the kbagent ports.
 	//
 	// 2. When HostNetwork is disabled:
 	//    It allows optional mapping for container ports to host ports.

--- a/apis/apps/v1/types.go
+++ b/apis/apps/v1/types.go
@@ -267,7 +267,9 @@ type ComponentNetwork struct {
 	//      a) Mappings for all ports defined in `cmpd.spec.hostNetwork` are MANDATORY.
 	//      b) Mappings for kbagent ports ("kba-http", "kba-streaming") are OPTIONAL.
 	//         You can explicitly map them here, or leave them omitted to be allocated by the host-port manager.
-	//         The legacy names "http" and "streaming" are still accepted as aliases for the kbagent ports.
+	//         The legacy names "http" and "streaming" are accepted as aliases only when no non-kbagent
+	//         container declares the same port name. When a component owns that name, its mapping takes
+	//         precedence; use the "kba-*" name to map kbagent explicitly, or omit it for automatic allocation.
 	//
 	// 2. When HostNetwork is disabled:
 	//    It allows optional mapping for container ports to host ports.

--- a/config/crd/bases/apps.kubeblocks.io_clusters.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusters.yaml
@@ -2747,8 +2747,9 @@ spec:
                                - If this field is empty: All ports are automatically allocated by the host-port manager.
                                - If this field is specified:
                                  a) Mappings for all ports defined in `cmpd.spec.hostNetwork` are MANDATORY.
-                                 b) Mappings for kbagent ports ("http", "streaming") are OPTIONAL.
+                                 b) Mappings for kbagent ports ("kba-http", "kba-streaming") are OPTIONAL.
                                     You can explicitly map them here, or leave them omitted to be allocated by the host-port manager.
+                                    The legacy names "http" and "streaming" are still accepted as aliases for the kbagent ports.
 
                             2. When HostNetwork is disabled:
                                It allows optional mapping for container ports to host ports.
@@ -13994,8 +13995,9 @@ spec:
                                    - If this field is empty: All ports are automatically allocated by the host-port manager.
                                    - If this field is specified:
                                      a) Mappings for all ports defined in `cmpd.spec.hostNetwork` are MANDATORY.
-                                     b) Mappings for kbagent ports ("http", "streaming") are OPTIONAL.
+                                     b) Mappings for kbagent ports ("kba-http", "kba-streaming") are OPTIONAL.
                                         You can explicitly map them here, or leave them omitted to be allocated by the host-port manager.
+                                        The legacy names "http" and "streaming" are still accepted as aliases for the kbagent ports.
 
                                 2. When HostNetwork is disabled:
                                    It allows optional mapping for container ports to host ports.

--- a/config/crd/bases/apps.kubeblocks.io_clusters.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusters.yaml
@@ -2749,7 +2749,9 @@ spec:
                                  a) Mappings for all ports defined in `cmpd.spec.hostNetwork` are MANDATORY.
                                  b) Mappings for kbagent ports ("kba-http", "kba-streaming") are OPTIONAL.
                                     You can explicitly map them here, or leave them omitted to be allocated by the host-port manager.
-                                    The legacy names "http" and "streaming" are still accepted as aliases for the kbagent ports.
+                                    The legacy names "http" and "streaming" are accepted as aliases only when no non-kbagent
+                                    container declares the same port name. When a component owns that name, its mapping takes
+                                    precedence; use the "kba-*" name to map kbagent explicitly, or omit it for automatic allocation.
 
                             2. When HostNetwork is disabled:
                                It allows optional mapping for container ports to host ports.
@@ -13997,7 +13999,9 @@ spec:
                                      a) Mappings for all ports defined in `cmpd.spec.hostNetwork` are MANDATORY.
                                      b) Mappings for kbagent ports ("kba-http", "kba-streaming") are OPTIONAL.
                                         You can explicitly map them here, or leave them omitted to be allocated by the host-port manager.
-                                        The legacy names "http" and "streaming" are still accepted as aliases for the kbagent ports.
+                                        The legacy names "http" and "streaming" are accepted as aliases only when no non-kbagent
+                                        container declares the same port name. When a component owns that name, its mapping takes
+                                        precedence; use the "kba-*" name to map kbagent explicitly, or omit it for automatic allocation.
 
                                 2. When HostNetwork is disabled:
                                    It allows optional mapping for container ports to host ports.

--- a/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
@@ -19732,6 +19732,13 @@ spec:
           status:
             description: ComponentDefinitionStatus defines the observed state of ComponentDefinition.
             properties:
+              legacyKBAgentPortNames:
+                description: |-
+                  LegacyKBAgentPortNames records that this definition was already accepted
+                  before kba-http and kba-streaming became reserved names. The controller
+                  uses the durable status bit to preserve a compatible injected port name
+                  across later phase transitions without allowing new definitions to opt in.
+                type: boolean
               message:
                 description: Provides additional information about the current phase.
                 type: string

--- a/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
@@ -10155,6 +10155,9 @@ spec:
                   These instance-specific overrides can be specified in `cluster.spec.componentSpecs[*].instances`.
 
                   This field is immutable and cannot be updated once set.
+
+                  The container port names "kba-http" and "kba-streaming" are reserved by KubeBlocks for the
+                  kbagent container that it injects when lifecycle or reconfiguration actions are defined.
                 properties:
                   activeDeadlineSeconds:
                     description: |-

--- a/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
@@ -10156,8 +10156,9 @@ spec:
 
                   This field is immutable and cannot be updated once set.
 
-                  The container port names "kba-http" and "kba-streaming" are reserved by KubeBlocks for the
-                  kbagent container that it injects when lifecycle or reconfiguration actions are defined.
+                  The container port names "kba-http" and "kba-streaming" are reserved by KubeBlocks for kbagent
+                  and must not be used by user-defined containers, regardless of whether this definition currently
+                  declares lifecycle or reconfiguration actions.
                 properties:
                   activeDeadlineSeconds:
                     description: |-

--- a/config/crd/bases/apps.kubeblocks.io_components.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_components.yaml
@@ -2964,8 +2964,9 @@ spec:
                          - If this field is empty: All ports are automatically allocated by the host-port manager.
                          - If this field is specified:
                            a) Mappings for all ports defined in `cmpd.spec.hostNetwork` are MANDATORY.
-                           b) Mappings for kbagent ports ("http", "streaming") are OPTIONAL.
+                           b) Mappings for kbagent ports ("kba-http", "kba-streaming") are OPTIONAL.
                               You can explicitly map them here, or leave them omitted to be allocated by the host-port manager.
+                              The legacy names "http" and "streaming" are still accepted as aliases for the kbagent ports.
 
                       2. When HostNetwork is disabled:
                          It allows optional mapping for container ports to host ports.

--- a/config/crd/bases/apps.kubeblocks.io_components.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_components.yaml
@@ -2966,7 +2966,9 @@ spec:
                            a) Mappings for all ports defined in `cmpd.spec.hostNetwork` are MANDATORY.
                            b) Mappings for kbagent ports ("kba-http", "kba-streaming") are OPTIONAL.
                               You can explicitly map them here, or leave them omitted to be allocated by the host-port manager.
-                              The legacy names "http" and "streaming" are still accepted as aliases for the kbagent ports.
+                              The legacy names "http" and "streaming" are accepted as aliases only when no non-kbagent
+                              container declares the same port name. When a component owns that name, its mapping takes
+                              precedence; use the "kba-*" name to map kbagent explicitly, or omit it for automatic allocation.
 
                       2. When HostNetwork is disabled:
                          It allows optional mapping for container ports to host ports.

--- a/controllers/apps/component/transformer_component_deletion.go
+++ b/controllers/apps/component/transformer_component_deletion.go
@@ -147,7 +147,7 @@ func (t *componentDeletionTransformer) deleteCompResources(transCtx *componentTr
 	}
 
 	// release the allocated host-network ports for the component
-	pm := intctrlutil.GetPortManager(comp.Spec.Network)
+	pm := intctrlutil.GetPortManager(comp.Spec.Network, nil)
 	if err = pm.ReleaseByPrefix(comp.Name); err != nil {
 		return intctrlutil.NewRequeueError(time.Second*1, fmt.Sprintf("release host ports for component %s error: %s", comp.Name, err.Error()))
 	}

--- a/controllers/apps/component/transformer_component_hostnetwork.go
+++ b/controllers/apps/component/transformer_component_hostnetwork.go
@@ -65,7 +65,7 @@ func (t *componentHostNetworkTransformer) allocateHostPorts(synthesizedComp *com
 		}
 	}
 
-	pm := intctrlutil.GetPortManager(synthesizedComp.Network)
+	pm := intctrlutil.GetPortManager(synthesizedComp.Network, component.NonKBAgentPortNames(synthesizedComp))
 	needAllocate := func(c string, p string) bool {
 		containerPorts, ok := ports[c]
 		if !ok {

--- a/controllers/apps/component/transformer_component_hostnetwork_test.go
+++ b/controllers/apps/component/transformer_component_hostnetwork_test.go
@@ -20,11 +20,15 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package component
 
 import (
+	"strconv"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	appsutil "github.com/apecloud/kubeblocks/controllers/apps/util"
@@ -32,6 +36,10 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	"github.com/apecloud/kubeblocks/pkg/kbagent"
+	testutil "github.com/apecloud/kubeblocks/pkg/testutil/k8s"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
 
 var _ = Describe("component hostnetwork transformer test", func() {
@@ -165,6 +173,63 @@ var _ = Describe("component hostnetwork transformer test", func() {
 			Expect(transCtx.SynthesizeComponent.PodSpec.Containers[0].Ports[0].ContainerPort).ShouldNot(Equal(int32(3306)))
 			Expect(transCtx.SynthesizeComponent.PodSpec.Containers[1].Ports[0].ContainerPort).ShouldNot(Equal(int32(3501)))
 			Expect(transCtx.SynthesizeComponent.PodSpec.Containers[1].Ports[1].ContainerPort).ShouldNot(Equal(int32(3502)))
+		})
+
+		It("dynamically allocates legacy kbagent ports and rewrites args and probe", func() {
+			dataCM := map[string]string{}
+			oldPortRange := viper.GetString(constant.CfgHostPortIncludeRanges)
+			mockClient := testutil.NewK8sMockClient()
+			DeferCleanup(func() {
+				viper.Set(constant.CfgHostPortIncludeRanges, oldPortRange)
+				restoreErr := intctrlutil.InitDefaultHostPortManager(k8sClient)
+				mockClient.Finish()
+				Expect(restoreErr).Should(Succeed())
+			})
+			mockClient.MockCreateMethod(testutil.WithCreateReturned(func(obj client.Object) error {
+				dataCM = obj.(*corev1.ConfigMap).Data
+				return nil
+			}, testutil.WithAnyTimes()))
+			mockClient.MockGetMethod(testutil.WithGetReturned(testutil.WithConstructSimpleGetResult([]client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: viper.GetString(constant.CfgKeyCtrlrMgrNS),
+						Name:      viper.GetString(constant.CfgHostPortConfigMapName),
+					},
+					Data: dataCM,
+				},
+			}), testutil.WithAnyTimes()))
+			mockClient.MockUpdateMethod(testutil.WithCreateReturned(func(obj client.Object) error {
+				dataCM = obj.(*corev1.ConfigMap).Data
+				return nil
+			}, testutil.WithAnyTimes()))
+			viper.Set(constant.CfgHostPortIncludeRanges, "14000-14010")
+			Expect(intctrlutil.InitDefaultHostPortManager(mockClient.Client())).Should(Succeed())
+
+			transCtx.SynthesizeComponent.Annotations = map[string]string{
+				constant.HostNetworkAnnotationKey: compName,
+			}
+			transCtx.SynthesizeComponent.Network.HostPorts = []appsv1.HostPort{{Name: "mysql", Port: 13306}}
+			agent := &transCtx.SynthesizeComponent.PodSpec.Containers[1]
+			agent.Args = []string{"--port", "3501", "--streaming-port", "3502"}
+			agent.StartupProbe = &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					TCPSocket: &corev1.TCPSocketAction{Port: intstr.FromInt(3501)},
+				},
+			}
+
+			transformer := &componentHostNetworkTransformer{}
+			Expect(transformer.Transform(transCtx, dag)).Should(Succeed())
+
+			agent = &transCtx.SynthesizeComponent.PodSpec.Containers[1]
+			Expect(agent.Ports[0].Name).Should(Equal(kbagent.LegacyHTTPPortName))
+			Expect(agent.Ports[1].Name).Should(Equal(kbagent.LegacyStreamingPortName))
+			httpPort, streamingPort := agent.Ports[0].ContainerPort, agent.Ports[1].ContainerPort
+			Expect(httpPort).Should(BeNumerically(">=", 14000))
+			Expect(streamingPort).Should(BeNumerically(">=", 14000))
+			Expect(streamingPort).ShouldNot(Equal(httpPort))
+			Expect(agent.Args).Should(ContainElements("--port", strconv.Itoa(int(httpPort)),
+				"--streaming-port", strconv.Itoa(int(streamingPort))))
+			Expect(agent.StartupProbe.TCPSocket.Port.IntValue()).Should(Equal(int(httpPort)))
 		})
 
 		It("skips allocation when the original component is deleting", func() {

--- a/controllers/apps/component/transformer_component_workload.go
+++ b/controllers/apps/component/transformer_component_workload.go
@@ -36,7 +36,6 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
-	"github.com/apecloud/kubeblocks/pkg/controller/instanceset"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	"github.com/apecloud/kubeblocks/pkg/kbagent"
@@ -295,13 +294,13 @@ func copyAndMergeITS(oldITS, newITS *workloads.InstanceSet, legacyConfigManagerP
 }
 
 // deferKBAgentPortRename keeps the legacy kbagent port names on an existing
-// workload whose live template still carries them, unless the accompanying
-// template change is going to recreate the pods anyway. Port names are pure
+// workload whose live template still carries them. Port names are pure
 // identifiers inside the template (kbagent probes and args reference numeric
-// ports) but they are not in-place updatable, so letting the rename ride on an
-// in-place or metadata-only change would turn it into a full rollout (or block
-// it under StrictInPlace); only a change that the configured update policy will
-// actually recreate carries the rename along.
+// ports) but they are not in-place updatable. The apps controller must not
+// predict whether InstanceSet will roll a concrete Pod: that decision also
+// depends on InstanceSet-owned state and feature gates. Existing workloads
+// therefore retain the legacy aliases until InstanceSet owns an explicit
+// migration contract.
 func deferKBAgentPortRename(oldITS, mergedITS *workloads.InstanceSet) {
 	if oldITS == nil || mergedITS == nil {
 		return
@@ -323,26 +322,12 @@ func deferKBAgentPortRename(oldITS, mergedITS *workloads.InstanceSet) {
 		kbagent.DefaultStreamingPortName: kbagent.LegacyStreamingPortName,
 	}
 	ports := mergedITS.Spec.Template.Spec.Containers[idx].Ports
-	renamed := map[int]string{}
 	for i, p := range ports {
 		legacy, ok := legacyNames[p.Name]
 		if !ok || oldNames.Has(p.Name) || !oldNames.Has(legacy) {
 			continue
 		}
-		renamed[i] = p.Name
 		ports[i].Name = legacy
-	}
-	if len(renamed) == 0 {
-		return
-	}
-	// With the legacy names restored, classify the accompanying template change
-	// with the same policy and vertical-resize boundaries used for legacy
-	// config-manager cleanup. Filtering in-place fields alone is insufficient:
-	// an application image or resource update can still be ReCreate.
-	if shouldRecreatePodsForTemplateChange(oldITS.Spec.Template, mergedITS.Spec.Template, mergedITS) {
-		for i, name := range renamed {
-			ports[i].Name = name
-		}
 	}
 }
 
@@ -439,61 +424,6 @@ func shouldCleanupLegacyConfigManager(oldITS, desiredITS *workloads.InstanceSet)
 		return desiredITS.Spec.PodUpdatePolicy == appsv1.ReCreatePodUpdatePolicyType
 	}
 	return false
-}
-
-func shouldRecreatePodsForTemplateChange(oldTemplate, newTemplate corev1.PodTemplateSpec,
-	desiredITS *workloads.InstanceSet) bool {
-	if reflect.DeepEqual(oldTemplate, newTemplate) {
-		return false
-	}
-	// A revision-changing field always selects the InstanceSet recreate path.
-	// StrictInPlace is the only policy that blocks that path. Which strictness
-	// field applies follows GetPodUpdatePolicyInSpec: container image/list
-	// upgrade-class changes use PodUpgradePolicy; command, port, resource, and
-	// other template changes use PodUpdatePolicy.
-	oldRecreateFields := podRecreateFields(oldTemplate)
-	newRecreateFields := podRecreateFields(newTemplate)
-	if !reflect.DeepEqual(oldRecreateFields, newRecreateFields) {
-		oldPod := &corev1.Pod{Spec: *oldTemplate.Spec.DeepCopy()}
-		newPod := &corev1.Pod{Spec: *newTemplate.Spec.DeepCopy()}
-		policy := instanceset.GetPodUpdatePolicyInSpec(desiredITS, oldPod, newPod)
-		return policy != appsv1.StrictInPlacePodUpdatePolicyType
-	}
-
-	initChanged, initOK := intctrlutil.OnlyKBManagedContainerImageChanged(oldTemplate.Spec.InitContainers, newTemplate.Spec.InitContainers)
-	containerChanged, containerOK := intctrlutil.OnlyKBManagedContainerImageChanged(oldTemplate.Spec.Containers, newTemplate.Spec.Containers)
-	if initOK && containerOK && (initChanged || containerChanged) {
-		return false
-	}
-	if hasPodUpgradeTemplateChanges(oldTemplate, newTemplate) {
-		return desiredITS.Spec.PodUpgradePolicy == appsv1.ReCreatePodUpdatePolicyType
-	}
-	if hasPodResourceChanges(oldTemplate.Spec, newTemplate.Spec) {
-		if !viper.GetBool(constant.FeatureGateInPlacePodVerticalScaling) {
-			return desiredITS.Spec.PodUpdatePolicy != appsv1.StrictInPlacePodUpdatePolicyType
-		}
-		return desiredITS.Spec.PodUpdatePolicy == appsv1.ReCreatePodUpdatePolicyType
-	}
-	if hasPodUpdateTemplateChanges(oldTemplate, newTemplate) {
-		return desiredITS.Spec.PodUpdatePolicy == appsv1.ReCreatePodUpdatePolicyType
-	}
-	return false
-}
-
-func podRecreateFields(template corev1.PodTemplateSpec) *corev1.PodTemplateSpec {
-	filtered := instanceset.FilterInPlaceFields(&template)
-	// FilterInPlaceFields deletes CPU/memory entries. Normalize the empty maps
-	// that deletion can leave behind so this comparison matches the serialized
-	// revision contract (nil and omitted empty maps hash the same).
-	for i := range filtered.Spec.Containers {
-		if len(filtered.Spec.Containers[i].Resources.Requests) == 0 {
-			filtered.Spec.Containers[i].Resources.Requests = nil
-		}
-		if len(filtered.Spec.Containers[i].Resources.Limits) == 0 {
-			filtered.Spec.Containers[i].Resources.Limits = nil
-		}
-	}
-	return filtered
 }
 
 func stripLegacyConfigManagerPodTemplate(template corev1.PodTemplateSpec) corev1.PodTemplateSpec {

--- a/controllers/apps/component/transformer_component_workload.go
+++ b/controllers/apps/component/transformer_component_workload.go
@@ -36,6 +36,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
+	"github.com/apecloud/kubeblocks/pkg/controller/instanceset"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	"github.com/apecloud/kubeblocks/pkg/kbagent"
@@ -294,11 +295,13 @@ func copyAndMergeITS(oldITS, newITS *workloads.InstanceSet, legacyConfigManagerP
 }
 
 // deferKBAgentPortRename keeps the legacy kbagent port names on an existing
-// workload whose live template still carries them, as long as the rename would
-// be the only pod template change. Port names are pure identifiers inside the
-// template (kbagent probes and args reference numeric ports), so preserving
-// them avoids a rename-only diff from restarting all pods; once any other
-// change rebuilds the pods, the rename is applied together with it.
+// workload whose live template still carries them, unless the accompanying
+// template change is going to recreate the pods anyway. Port names are pure
+// identifiers inside the template (kbagent probes and args reference numeric
+// ports) but they are not in-place updatable, so letting the rename ride on an
+// in-place or metadata-only change would turn it into a full rollout (or block
+// it under StrictInPlace); only a recreate-class diff — detected with the same
+// field filter the InstanceSet controller uses — carries the rename along.
 func deferKBAgentPortRename(oldITS, mergedITS *workloads.InstanceSet) {
 	if oldITS == nil || mergedITS == nil {
 		return
@@ -332,8 +335,11 @@ func deferKBAgentPortRename(oldITS, mergedITS *workloads.InstanceSet) {
 	if len(renamed) == 0 {
 		return
 	}
-	if !reflect.DeepEqual(oldITS.Spec.Template, mergedITS.Spec.Template) {
-		// other template changes exist, the pods are rebuilt anyway
+	// with the legacy names restored, any remaining difference in the
+	// recreate-relevant part of the template means the pods are rebuilt anyway
+	oldFiltered := instanceset.FilterInPlaceFields(&oldITS.Spec.Template)
+	mergedFiltered := instanceset.FilterInPlaceFields(&mergedITS.Spec.Template)
+	if !reflect.DeepEqual(oldFiltered, mergedFiltered) {
 		for i, name := range renamed {
 			ports[i].Name = name
 		}

--- a/controllers/apps/component/transformer_component_workload.go
+++ b/controllers/apps/component/transformer_component_workload.go
@@ -300,8 +300,8 @@ func copyAndMergeITS(oldITS, newITS *workloads.InstanceSet, legacyConfigManagerP
 // identifiers inside the template (kbagent probes and args reference numeric
 // ports) but they are not in-place updatable, so letting the rename ride on an
 // in-place or metadata-only change would turn it into a full rollout (or block
-// it under StrictInPlace); only a recreate-class diff — detected with the same
-// field filter the InstanceSet controller uses — carries the rename along.
+// it under StrictInPlace); only a change that the configured update policy will
+// actually recreate carries the rename along.
 func deferKBAgentPortRename(oldITS, mergedITS *workloads.InstanceSet) {
 	if oldITS == nil || mergedITS == nil {
 		return
@@ -335,11 +335,11 @@ func deferKBAgentPortRename(oldITS, mergedITS *workloads.InstanceSet) {
 	if len(renamed) == 0 {
 		return
 	}
-	// with the legacy names restored, any remaining difference in the
-	// recreate-relevant part of the template means the pods are rebuilt anyway
-	oldFiltered := instanceset.FilterInPlaceFields(&oldITS.Spec.Template)
-	mergedFiltered := instanceset.FilterInPlaceFields(&mergedITS.Spec.Template)
-	if !reflect.DeepEqual(oldFiltered, mergedFiltered) {
+	// With the legacy names restored, classify the accompanying template change
+	// with the same policy and vertical-resize boundaries used for legacy
+	// config-manager cleanup. Filtering in-place fields alone is insufficient:
+	// an application image or resource update can still be ReCreate.
+	if shouldRecreatePodsForTemplateChange(oldITS.Spec.Template, mergedITS.Spec.Template, mergedITS) {
 		for i, name := range renamed {
 			ports[i].Name = name
 		}
@@ -439,6 +439,62 @@ func shouldCleanupLegacyConfigManager(oldITS, desiredITS *workloads.InstanceSet)
 		return desiredITS.Spec.PodUpdatePolicy == appsv1.ReCreatePodUpdatePolicyType
 	}
 	return false
+}
+
+func shouldRecreatePodsForTemplateChange(oldTemplate, newTemplate corev1.PodTemplateSpec,
+	desiredITS *workloads.InstanceSet) bool {
+	if reflect.DeepEqual(oldTemplate, newTemplate) {
+		return false
+	}
+	// A revision-changing field always selects the InstanceSet recreate path.
+	// StrictInPlace is the only policy that blocks that path. Which strictness
+	// field applies follows getPodUpdatePolicyInSpec: container/init-container
+	// changes use PodUpgradePolicy; other template changes use PodUpdatePolicy.
+	oldRecreateFields := podRecreateFields(oldTemplate)
+	newRecreateFields := podRecreateFields(newTemplate)
+	if !reflect.DeepEqual(oldRecreateFields, newRecreateFields) {
+		policy := desiredITS.Spec.PodUpdatePolicy
+		if !reflect.DeepEqual(oldTemplate.Spec.InitContainers, newTemplate.Spec.InitContainers) ||
+			!reflect.DeepEqual(oldTemplate.Spec.Containers, newTemplate.Spec.Containers) {
+			policy = desiredITS.Spec.PodUpgradePolicy
+		}
+		return policy != appsv1.StrictInPlacePodUpdatePolicyType
+	}
+
+	initChanged, initOK := intctrlutil.OnlyKBManagedContainerImageChanged(oldTemplate.Spec.InitContainers, newTemplate.Spec.InitContainers)
+	containerChanged, containerOK := intctrlutil.OnlyKBManagedContainerImageChanged(oldTemplate.Spec.Containers, newTemplate.Spec.Containers)
+	if initOK && containerOK && (initChanged || containerChanged) {
+		return false
+	}
+	if hasPodUpgradeTemplateChanges(oldTemplate, newTemplate) {
+		return desiredITS.Spec.PodUpgradePolicy == appsv1.ReCreatePodUpdatePolicyType
+	}
+	if hasPodResourceChanges(oldTemplate.Spec, newTemplate.Spec) {
+		if !viper.GetBool(constant.FeatureGateInPlacePodVerticalScaling) {
+			return desiredITS.Spec.PodUpdatePolicy != appsv1.StrictInPlacePodUpdatePolicyType
+		}
+		return desiredITS.Spec.PodUpdatePolicy == appsv1.ReCreatePodUpdatePolicyType
+	}
+	if hasPodUpdateTemplateChanges(oldTemplate, newTemplate) {
+		return desiredITS.Spec.PodUpdatePolicy == appsv1.ReCreatePodUpdatePolicyType
+	}
+	return false
+}
+
+func podRecreateFields(template corev1.PodTemplateSpec) *corev1.PodTemplateSpec {
+	filtered := instanceset.FilterInPlaceFields(&template)
+	// FilterInPlaceFields deletes CPU/memory entries. Normalize the empty maps
+	// that deletion can leave behind so this comparison matches the serialized
+	// revision contract (nil and omitted empty maps hash the same).
+	for i := range filtered.Spec.Containers {
+		if len(filtered.Spec.Containers[i].Resources.Requests) == 0 {
+			filtered.Spec.Containers[i].Resources.Requests = nil
+		}
+		if len(filtered.Spec.Containers[i].Resources.Limits) == 0 {
+			filtered.Spec.Containers[i].Resources.Limits = nil
+		}
+	}
+	return filtered
 }
 
 func stripLegacyConfigManagerPodTemplate(template corev1.PodTemplateSpec) corev1.PodTemplateSpec {

--- a/controllers/apps/component/transformer_component_workload.go
+++ b/controllers/apps/component/transformer_component_workload.go
@@ -448,16 +448,15 @@ func shouldRecreatePodsForTemplateChange(oldTemplate, newTemplate corev1.PodTemp
 	}
 	// A revision-changing field always selects the InstanceSet recreate path.
 	// StrictInPlace is the only policy that blocks that path. Which strictness
-	// field applies follows getPodUpdatePolicyInSpec: container/init-container
-	// changes use PodUpgradePolicy; other template changes use PodUpdatePolicy.
+	// field applies follows GetPodUpdatePolicyInSpec: container image/list
+	// upgrade-class changes use PodUpgradePolicy; command, port, resource, and
+	// other template changes use PodUpdatePolicy.
 	oldRecreateFields := podRecreateFields(oldTemplate)
 	newRecreateFields := podRecreateFields(newTemplate)
 	if !reflect.DeepEqual(oldRecreateFields, newRecreateFields) {
-		policy := desiredITS.Spec.PodUpdatePolicy
-		if !reflect.DeepEqual(oldTemplate.Spec.InitContainers, newTemplate.Spec.InitContainers) ||
-			!reflect.DeepEqual(oldTemplate.Spec.Containers, newTemplate.Spec.Containers) {
-			policy = desiredITS.Spec.PodUpgradePolicy
-		}
+		oldPod := &corev1.Pod{Spec: *oldTemplate.Spec.DeepCopy()}
+		newPod := &corev1.Pod{Spec: *newTemplate.Spec.DeepCopy()}
+		policy := instanceset.GetPodUpdatePolicyInSpec(desiredITS, oldPod, newPod)
 		return policy != appsv1.StrictInPlacePodUpdatePolicyType
 	}
 

--- a/controllers/apps/component/transformer_component_workload.go
+++ b/controllers/apps/component/transformer_component_workload.go
@@ -38,6 +38,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	"github.com/apecloud/kubeblocks/pkg/kbagent"
 	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
 
@@ -278,6 +279,11 @@ func copyAndMergeITS(oldITS, newITS *workloads.InstanceSet, legacyConfigManagerP
 
 	intctrlutil.ResolvePodSpecDefaultFields(oldITS.Spec.Template.Spec, &itsObjCopy.Spec.Template.Spec)
 
+	// Defer the kbagent port rename on existing workloads: keep the legacy
+	// names while the rename would be the only template change, and let the
+	// rename ride along when some other change rebuilds the pods anyway.
+	deferKBAgentPortRename(oldITS, itsObjCopy)
+
 	isSpecUpdated := !reflect.DeepEqual(&oldITS.Spec, &itsObjCopy.Spec)
 	isLabelsUpdated := !reflect.DeepEqual(oldITS.Labels, itsObjCopy.Labels)
 	isAnnotationsUpdated := !reflect.DeepEqual(oldITS.Annotations, itsObjCopy.Annotations)
@@ -285,6 +291,53 @@ func copyAndMergeITS(oldITS, newITS *workloads.InstanceSet, legacyConfigManagerP
 		return nil
 	}
 	return itsObjCopy
+}
+
+// deferKBAgentPortRename keeps the legacy kbagent port names on an existing
+// workload whose live template still carries them, as long as the rename would
+// be the only pod template change. Port names are pure identifiers inside the
+// template (kbagent probes and args reference numeric ports), so preserving
+// them avoids a rename-only diff from restarting all pods; once any other
+// change rebuilds the pods, the rename is applied together with it.
+func deferKBAgentPortRename(oldITS, mergedITS *workloads.InstanceSet) {
+	if oldITS == nil || mergedITS == nil {
+		return
+	}
+	_, oldAgent := intctrlutil.GetContainerByName(oldITS.Spec.Template.Spec.Containers, kbagent.ContainerName)
+	if oldAgent == nil {
+		return
+	}
+	oldNames := sets.New[string]()
+	for _, p := range oldAgent.Ports {
+		oldNames.Insert(p.Name)
+	}
+	idx, agent := intctrlutil.GetContainerByName(mergedITS.Spec.Template.Spec.Containers, kbagent.ContainerName)
+	if agent == nil {
+		return
+	}
+	legacyNames := map[string]string{
+		kbagent.DefaultHTTPPortName:      kbagent.LegacyHTTPPortName,
+		kbagent.DefaultStreamingPortName: kbagent.LegacyStreamingPortName,
+	}
+	ports := mergedITS.Spec.Template.Spec.Containers[idx].Ports
+	renamed := map[int]string{}
+	for i, p := range ports {
+		legacy, ok := legacyNames[p.Name]
+		if !ok || oldNames.Has(p.Name) || !oldNames.Has(legacy) {
+			continue
+		}
+		renamed[i] = p.Name
+		ports[i].Name = legacy
+	}
+	if len(renamed) == 0 {
+		return
+	}
+	if !reflect.DeepEqual(oldITS.Spec.Template, mergedITS.Spec.Template) {
+		// other template changes exist, the pods are rebuilt anyway
+		for i, name := range renamed {
+			ports[i].Name = name
+		}
+	}
 }
 
 const (

--- a/controllers/apps/component/transformer_component_workload.go
+++ b/controllers/apps/component/transformer_component_workload.go
@@ -279,9 +279,9 @@ func copyAndMergeITS(oldITS, newITS *workloads.InstanceSet, legacyConfigManagerP
 
 	intctrlutil.ResolvePodSpecDefaultFields(oldITS.Spec.Template.Spec, &itsObjCopy.Spec.Template.Spec)
 
-	// Defer the kbagent port rename on existing workloads: keep the legacy
-	// names while the rename would be the only template change, and let the
-	// rename ride along when some other change rebuilds the pods anyway.
+	// Defer the kbagent port rename on existing workloads while their legacy
+	// aliases remain valid. A preferred name still wins when it repairs a
+	// collision that already makes the live template invalid.
 	deferKBAgentPortRename(oldITS, itsObjCopy)
 
 	isSpecUpdated := !reflect.DeepEqual(&oldITS.Spec, &itsObjCopy.Spec)
@@ -317,6 +317,20 @@ func deferKBAgentPortRename(oldITS, mergedITS *workloads.InstanceSet) {
 	if agent == nil {
 		return
 	}
+	occupied := sets.New[string]()
+	for _, containers := range [][]corev1.Container{
+		mergedITS.Spec.Template.Spec.InitContainers,
+		mergedITS.Spec.Template.Spec.Containers,
+	} {
+		for i := range containers {
+			if component.IsKBAgentContainer(&containers[i]) {
+				continue
+			}
+			for _, port := range containers[i].Ports {
+				occupied.Insert(port.Name)
+			}
+		}
+	}
 	legacyNames := map[string]string{
 		kbagent.DefaultHTTPPortName:      kbagent.LegacyHTTPPortName,
 		kbagent.DefaultStreamingPortName: kbagent.LegacyStreamingPortName,
@@ -324,7 +338,7 @@ func deferKBAgentPortRename(oldITS, mergedITS *workloads.InstanceSet) {
 	ports := mergedITS.Spec.Template.Spec.Containers[idx].Ports
 	for i, p := range ports {
 		legacy, ok := legacyNames[p.Name]
-		if !ok || oldNames.Has(p.Name) || !oldNames.Has(legacy) {
+		if !ok || oldNames.Has(p.Name) || !oldNames.Has(legacy) || occupied.Has(legacy) {
 			continue
 		}
 		ports[i].Name = legacy

--- a/controllers/apps/component/transformer_component_workload_test.go
+++ b/controllers/apps/component/transformer_component_workload_test.go
@@ -304,6 +304,7 @@ var _ = Describe("Component Workload Operations Test", func() {
 						{Name: kbagent.LegacyStreamingPortName, ContainerPort: 3502, Protocol: corev1.ProtocolTCP},
 					},
 				})
+			oldITS.Spec.PodUpgradePolicy = appsv1.PreferInPlacePodUpdatePolicyType
 
 			newITS := oldITS.DeepCopy()
 			newITS.Spec.Template.Spec.Containers[0].Image = "new-image"
@@ -318,6 +319,74 @@ var _ = Describe("Component Workload Operations Test", func() {
 			Expect(mergedAgent).ShouldNot(BeNil())
 			Expect(mergedAgent.Ports[0].Name).Should(Equal(kbagent.LegacyHTTPPortName))
 			Expect(mergedAgent.Ports[1].Name).Should(Equal(kbagent.LegacyStreamingPortName))
+		})
+
+		It("should apply the kbagent port rename with an application image ReCreate upgrade", func() {
+			oldITS := testapps.NewInstanceSetFactory(testCtx.DefaultNamespace,
+				"old-its-kbagent-ports-image-recreate", clusterName, compName).
+				AddContainer(corev1.Container{
+					Name:  "main",
+					Image: "test-image",
+				}).
+				GetObject()
+			oldITS.Spec.PodUpgradePolicy = appsv1.ReCreatePodUpdatePolicyType
+			oldITS.Spec.Template.Spec.Containers = append(oldITS.Spec.Template.Spec.Containers,
+				corev1.Container{
+					Name: kbagent.ContainerName,
+					Ports: []corev1.ContainerPort{
+						{Name: kbagent.LegacyHTTPPortName, ContainerPort: 3501, Protocol: corev1.ProtocolTCP},
+						{Name: kbagent.LegacyStreamingPortName, ContainerPort: 3502, Protocol: corev1.ProtocolTCP},
+					},
+				})
+
+			newITS := oldITS.DeepCopy()
+			newITS.Spec.Template.Spec.Containers[0].Image = "new-image"
+			_, agent := intctrlutil.GetContainerByName(newITS.Spec.Template.Spec.Containers, kbagent.ContainerName)
+			agent.Ports[0].Name = kbagent.DefaultHTTPPortName
+			agent.Ports[1].Name = kbagent.DefaultStreamingPortName
+
+			merged := copyAndMergeITS(oldITS, newITS, legacyConfigManagerPolicyKeep)
+			Expect(merged).ShouldNot(BeNil())
+			_, mergedAgent := intctrlutil.GetContainerByName(merged.Spec.Template.Spec.Containers, kbagent.ContainerName)
+			Expect(mergedAgent.Ports[0].Name).Should(Equal(kbagent.DefaultHTTPPortName))
+			Expect(mergedAgent.Ports[1].Name).Should(Equal(kbagent.DefaultStreamingPortName))
+		})
+
+		It("should apply the kbagent port rename when resource resize requires Pod recreation", func() {
+			oldFeatureGate := viper.GetBool(constant.FeatureGateInPlacePodVerticalScaling)
+			defer viper.Set(constant.FeatureGateInPlacePodVerticalScaling, oldFeatureGate)
+			viper.Set(constant.FeatureGateInPlacePodVerticalScaling, false)
+
+			oldITS := testapps.NewInstanceSetFactory(testCtx.DefaultNamespace,
+				"old-its-kbagent-ports-resource-recreate", clusterName, compName).
+				AddContainer(corev1.Container{
+					Name:  "main",
+					Image: "test-image",
+				}).
+				GetObject()
+			oldITS.Spec.PodUpgradePolicy = appsv1.PreferInPlacePodUpdatePolicyType
+			oldITS.Spec.Template.Spec.Containers = append(oldITS.Spec.Template.Spec.Containers,
+				corev1.Container{
+					Name: kbagent.ContainerName,
+					Ports: []corev1.ContainerPort{
+						{Name: kbagent.LegacyHTTPPortName, ContainerPort: 3501, Protocol: corev1.ProtocolTCP},
+						{Name: kbagent.LegacyStreamingPortName, ContainerPort: 3502, Protocol: corev1.ProtocolTCP},
+					},
+				})
+
+			newITS := oldITS.DeepCopy()
+			newITS.Spec.Template.Spec.Containers[0].Resources.Requests = corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("2"),
+			}
+			_, agent := intctrlutil.GetContainerByName(newITS.Spec.Template.Spec.Containers, kbagent.ContainerName)
+			agent.Ports[0].Name = kbagent.DefaultHTTPPortName
+			agent.Ports[1].Name = kbagent.DefaultStreamingPortName
+
+			merged := copyAndMergeITS(oldITS, newITS, legacyConfigManagerPolicyKeep)
+			Expect(merged).ShouldNot(BeNil())
+			_, mergedAgent := intctrlutil.GetContainerByName(merged.Spec.Template.Spec.Containers, kbagent.ContainerName)
+			Expect(mergedAgent.Ports[0].Name).Should(Equal(kbagent.DefaultHTTPPortName))
+			Expect(mergedAgent.Ports[1].Name).Should(Equal(kbagent.DefaultStreamingPortName))
 		})
 
 		It("should apply the kbagent port rename together with a pod-recreating template change", func() {
@@ -339,6 +408,7 @@ var _ = Describe("Component Workload Operations Test", func() {
 
 			newITS := oldITS.DeepCopy()
 			// a command change is not in-place updatable and recreates the pods
+			newITS.Spec.PodUpgradePolicy = appsv1.PreferInPlacePodUpdatePolicyType
 			newITS.Spec.Template.Spec.Containers[0].Command = []string{"run", "--new-flag"}
 			_, agent := intctrlutil.GetContainerByName(newITS.Spec.Template.Spec.Containers, kbagent.ContainerName)
 			agent.Ports[0].Name = kbagent.DefaultHTTPPortName
@@ -1262,7 +1332,6 @@ var _ = Describe("Component Workload Operations Test", func() {
 			oldToolsImage := viper.GetString(constant.KBToolsImage)
 			defer viper.Set(constant.KBToolsImage, oldToolsImage)
 			viper.Set(constant.KBToolsImage, "docker.io/apecloud/kubeblocks-tools:1.0.0")
-
 			baseTemplate := corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{"app": "mysql"},

--- a/controllers/apps/component/transformer_component_workload_test.go
+++ b/controllers/apps/component/transformer_component_workload_test.go
@@ -287,6 +287,40 @@ var _ = Describe("Component Workload Operations Test", func() {
 			Expect(merged).Should(BeNil())
 		})
 
+		It("should keep a preferred kbagent name that repairs a legacy collision", func() {
+			oldITS := testapps.NewInstanceSetFactory(testCtx.DefaultNamespace,
+				"old-its-kbagent-collision", clusterName, compName).
+				AddContainer(corev1.Container{
+					Name:  "main",
+					Image: "test-image",
+					Ports: []corev1.ContainerPort{{
+						Name:          kbagent.LegacyHTTPPortName,
+						ContainerPort: 9200,
+					}},
+				}).
+				GetObject()
+			oldITS.Spec.Template.Spec.Containers = append(oldITS.Spec.Template.Spec.Containers,
+				corev1.Container{
+					Name: kbagent.ContainerName,
+					Ports: []corev1.ContainerPort{
+						{Name: kbagent.LegacyHTTPPortName, ContainerPort: 3501, Protocol: corev1.ProtocolTCP},
+						{Name: kbagent.LegacyStreamingPortName, ContainerPort: 3502, Protocol: corev1.ProtocolTCP},
+					},
+				})
+
+			newITS := oldITS.DeepCopy()
+			_, agent := intctrlutil.GetContainerByName(newITS.Spec.Template.Spec.Containers, kbagent.ContainerName)
+			agent.Ports[0].Name = kbagent.DefaultHTTPPortName
+			agent.Ports[1].Name = kbagent.DefaultStreamingPortName
+
+			merged := copyAndMergeITS(oldITS, newITS, legacyConfigManagerPolicyKeep)
+			Expect(merged).ShouldNot(BeNil())
+			_, mergedAgent := intctrlutil.GetContainerByName(merged.Spec.Template.Spec.Containers, kbagent.ContainerName)
+			Expect(mergedAgent).ShouldNot(BeNil())
+			Expect(mergedAgent.Ports[0].Name).Should(Equal(kbagent.DefaultHTTPPortName))
+			Expect(mergedAgent.Ports[1].Name).Should(Equal(kbagent.LegacyStreamingPortName))
+		})
+
 		It("should keep legacy kbagent port names when only in-place fields change", func() {
 			// an image bump is applied in place by the InstanceSet controller;
 			// the rename must not turn it into a pod-recreating rollout

--- a/controllers/apps/component/transformer_component_workload_test.go
+++ b/controllers/apps/component/transformer_component_workload_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	"github.com/apecloud/kubeblocks/pkg/kbagent"
 	kbacli "github.com/apecloud/kubeblocks/pkg/kbagent/client"
 	kbagentproto "github.com/apecloud/kubeblocks/pkg/kbagent/proto"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
@@ -255,6 +256,86 @@ var _ = Describe("Component Workload Operations Test", func() {
 			newITS.Spec.Template.Spec.InitContainers = nil
 			newITS.Spec.Template.Spec.Volumes = nil
 
+			merged := copyAndMergeITS(oldITS, newITS, legacyConfigManagerPolicyKeep)
+			Expect(merged).Should(BeNil())
+		})
+
+		It("should defer the kbagent port rename when it is the only template change", func() {
+			oldITS := testapps.NewInstanceSetFactory(testCtx.DefaultNamespace,
+				"old-its-kbagent-ports", clusterName, compName).
+				AddContainer(corev1.Container{
+					Name:  "main",
+					Image: "test-image",
+				}).
+				GetObject()
+			oldITS.Spec.Template.Spec.Containers = append(oldITS.Spec.Template.Spec.Containers,
+				corev1.Container{
+					Name: kbagent.ContainerName,
+					Ports: []corev1.ContainerPort{
+						{Name: kbagent.LegacyHTTPPortName, ContainerPort: 3501, Protocol: corev1.ProtocolTCP},
+						{Name: kbagent.LegacyStreamingPortName, ContainerPort: 3502, Protocol: corev1.ProtocolTCP},
+					},
+				})
+
+			newITS := oldITS.DeepCopy()
+			_, agent := intctrlutil.GetContainerByName(newITS.Spec.Template.Spec.Containers, kbagent.ContainerName)
+			agent.Ports[0].Name = kbagent.DefaultHTTPPortName
+			agent.Ports[1].Name = kbagent.DefaultStreamingPortName
+
+			merged := copyAndMergeITS(oldITS, newITS, legacyConfigManagerPolicyKeep)
+			Expect(merged).Should(BeNil())
+		})
+
+		It("should apply the kbagent port rename together with another template change", func() {
+			oldITS := testapps.NewInstanceSetFactory(testCtx.DefaultNamespace,
+				"old-its-kbagent-ports-2", clusterName, compName).
+				AddContainer(corev1.Container{
+					Name:  "main",
+					Image: "test-image",
+				}).
+				GetObject()
+			oldITS.Spec.Template.Spec.Containers = append(oldITS.Spec.Template.Spec.Containers,
+				corev1.Container{
+					Name: kbagent.ContainerName,
+					Ports: []corev1.ContainerPort{
+						{Name: kbagent.LegacyHTTPPortName, ContainerPort: 3501, Protocol: corev1.ProtocolTCP},
+						{Name: kbagent.LegacyStreamingPortName, ContainerPort: 3502, Protocol: corev1.ProtocolTCP},
+					},
+				})
+
+			newITS := oldITS.DeepCopy()
+			newITS.Spec.Template.Spec.Containers[0].Image = "new-image"
+			_, agent := intctrlutil.GetContainerByName(newITS.Spec.Template.Spec.Containers, kbagent.ContainerName)
+			agent.Ports[0].Name = kbagent.DefaultHTTPPortName
+			agent.Ports[1].Name = kbagent.DefaultStreamingPortName
+
+			merged := copyAndMergeITS(oldITS, newITS, legacyConfigManagerPolicyKeep)
+			Expect(merged).ShouldNot(BeNil())
+			Expect(merged.Spec.Template.Spec.Containers[0].Image).Should(Equal("new-image"))
+			_, mergedAgent := intctrlutil.GetContainerByName(merged.Spec.Template.Spec.Containers, kbagent.ContainerName)
+			Expect(mergedAgent).ShouldNot(BeNil())
+			Expect(mergedAgent.Ports[0].Name).Should(Equal(kbagent.DefaultHTTPPortName))
+			Expect(mergedAgent.Ports[1].Name).Should(Equal(kbagent.DefaultStreamingPortName))
+		})
+
+		It("should keep the new kbagent port names for workloads already renamed", func() {
+			oldITS := testapps.NewInstanceSetFactory(testCtx.DefaultNamespace,
+				"old-its-kbagent-ports-3", clusterName, compName).
+				AddContainer(corev1.Container{
+					Name:  "main",
+					Image: "test-image",
+				}).
+				GetObject()
+			oldITS.Spec.Template.Spec.Containers = append(oldITS.Spec.Template.Spec.Containers,
+				corev1.Container{
+					Name: kbagent.ContainerName,
+					Ports: []corev1.ContainerPort{
+						{Name: kbagent.DefaultHTTPPortName, ContainerPort: 3501, Protocol: corev1.ProtocolTCP},
+						{Name: kbagent.DefaultStreamingPortName, ContainerPort: 3502, Protocol: corev1.ProtocolTCP},
+					},
+				})
+
+			newITS := oldITS.DeepCopy()
 			merged := copyAndMergeITS(oldITS, newITS, legacyConfigManagerPolicyKeep)
 			Expect(merged).Should(BeNil())
 		})

--- a/controllers/apps/component/transformer_component_workload_test.go
+++ b/controllers/apps/component/transformer_component_workload_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
+	"github.com/apecloud/kubeblocks/pkg/controller/instanceset"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	"github.com/apecloud/kubeblocks/pkg/kbagent"
@@ -321,7 +322,7 @@ var _ = Describe("Component Workload Operations Test", func() {
 			Expect(mergedAgent.Ports[1].Name).Should(Equal(kbagent.LegacyStreamingPortName))
 		})
 
-		It("should apply the kbagent port rename with an application image ReCreate upgrade", func() {
+		It("should not predict the InstanceSet rollout for an application image upgrade", func() {
 			oldITS := testapps.NewInstanceSetFactory(testCtx.DefaultNamespace,
 				"old-its-kbagent-ports-image-recreate", clusterName, compName).
 				AddContainer(corev1.Container{
@@ -348,14 +349,17 @@ var _ = Describe("Component Workload Operations Test", func() {
 			merged := copyAndMergeITS(oldITS, newITS, legacyConfigManagerPolicyKeep)
 			Expect(merged).ShouldNot(BeNil())
 			_, mergedAgent := intctrlutil.GetContainerByName(merged.Spec.Template.Spec.Containers, kbagent.ContainerName)
-			Expect(mergedAgent.Ports[0].Name).Should(Equal(kbagent.DefaultHTTPPortName))
-			Expect(mergedAgent.Ports[1].Name).Should(Equal(kbagent.DefaultStreamingPortName))
+			Expect(mergedAgent.Ports[0].Name).Should(Equal(kbagent.LegacyHTTPPortName))
+			Expect(mergedAgent.Ports[1].Name).Should(Equal(kbagent.LegacyStreamingPortName))
 		})
 
-		It("should apply the kbagent port rename when resource resize requires Pod recreation", func() {
+		It("should not predict a rollout when InstanceSet ignores vertical scaling", func() {
 			oldFeatureGate := viper.GetBool(constant.FeatureGateInPlacePodVerticalScaling)
 			defer viper.Set(constant.FeatureGateInPlacePodVerticalScaling, oldFeatureGate)
 			viper.Set(constant.FeatureGateInPlacePodVerticalScaling, false)
+			oldIgnoreGate := viper.GetBool(instanceset.FeatureGateIgnorePodVerticalScaling)
+			defer viper.Set(instanceset.FeatureGateIgnorePodVerticalScaling, oldIgnoreGate)
+			viper.Set(instanceset.FeatureGateIgnorePodVerticalScaling, true)
 
 			oldITS := testapps.NewInstanceSetFactory(testCtx.DefaultNamespace,
 				"old-its-kbagent-ports-resource-recreate", clusterName, compName).
@@ -385,11 +389,11 @@ var _ = Describe("Component Workload Operations Test", func() {
 			merged := copyAndMergeITS(oldITS, newITS, legacyConfigManagerPolicyKeep)
 			Expect(merged).ShouldNot(BeNil())
 			_, mergedAgent := intctrlutil.GetContainerByName(merged.Spec.Template.Spec.Containers, kbagent.ContainerName)
-			Expect(mergedAgent.Ports[0].Name).Should(Equal(kbagent.DefaultHTTPPortName))
-			Expect(mergedAgent.Ports[1].Name).Should(Equal(kbagent.DefaultStreamingPortName))
+			Expect(mergedAgent.Ports[0].Name).Should(Equal(kbagent.LegacyHTTPPortName))
+			Expect(mergedAgent.Ports[1].Name).Should(Equal(kbagent.LegacyStreamingPortName))
 		})
 
-		It("should apply the kbagent port rename together with a pod-recreating template change", func() {
+		It("should keep legacy names across a pod-recreating template change", func() {
 			oldITS := testapps.NewInstanceSetFactory(testCtx.DefaultNamespace,
 				"old-its-kbagent-ports-4", clusterName, compName).
 				AddContainer(corev1.Container{
@@ -419,11 +423,11 @@ var _ = Describe("Component Workload Operations Test", func() {
 			Expect(merged.Spec.Template.Spec.Containers[0].Command).Should(Equal([]string{"run", "--new-flag"}))
 			_, mergedAgent := intctrlutil.GetContainerByName(merged.Spec.Template.Spec.Containers, kbagent.ContainerName)
 			Expect(mergedAgent).ShouldNot(BeNil())
-			Expect(mergedAgent.Ports[0].Name).Should(Equal(kbagent.DefaultHTTPPortName))
-			Expect(mergedAgent.Ports[1].Name).Should(Equal(kbagent.DefaultStreamingPortName))
+			Expect(mergedAgent.Ports[0].Name).Should(Equal(kbagent.LegacyHTTPPortName))
+			Expect(mergedAgent.Ports[1].Name).Should(Equal(kbagent.LegacyStreamingPortName))
 		})
 
-		It("should classify command changes with PodUpdatePolicy instead of PodUpgradePolicy", func() {
+		It("should not copy InstanceSet policy classification into the apps controller", func() {
 			oldITS := testapps.NewInstanceSetFactory(testCtx.DefaultNamespace,
 				"old-its-kbagent-command-update-policy", clusterName, compName).
 				AddContainer(corev1.Container{Name: "main", Image: "test-image"}).
@@ -448,8 +452,8 @@ var _ = Describe("Component Workload Operations Test", func() {
 			merged := copyAndMergeITS(oldITS, newITS, legacyConfigManagerPolicyKeep)
 			Expect(merged).ShouldNot(BeNil())
 			_, mergedAgent := intctrlutil.GetContainerByName(merged.Spec.Template.Spec.Containers, kbagent.ContainerName)
-			Expect(mergedAgent.Ports[0].Name).Should(Equal(kbagent.DefaultHTTPPortName))
-			Expect(mergedAgent.Ports[1].Name).Should(Equal(kbagent.DefaultStreamingPortName))
+			Expect(mergedAgent.Ports[0].Name).Should(Equal(kbagent.LegacyHTTPPortName))
+			Expect(mergedAgent.Ports[1].Name).Should(Equal(kbagent.LegacyStreamingPortName))
 		})
 
 		It("should keep legacy names when PodUpdatePolicy blocks a command-change rollout", func() {

--- a/controllers/apps/component/transformer_component_workload_test.go
+++ b/controllers/apps/component/transformer_component_workload_test.go
@@ -423,6 +423,64 @@ var _ = Describe("Component Workload Operations Test", func() {
 			Expect(mergedAgent.Ports[1].Name).Should(Equal(kbagent.DefaultStreamingPortName))
 		})
 
+		It("should classify command changes with PodUpdatePolicy instead of PodUpgradePolicy", func() {
+			oldITS := testapps.NewInstanceSetFactory(testCtx.DefaultNamespace,
+				"old-its-kbagent-command-update-policy", clusterName, compName).
+				AddContainer(corev1.Container{Name: "main", Image: "test-image"}).
+				GetObject()
+			oldITS.Spec.PodUpgradePolicy = appsv1.StrictInPlacePodUpdatePolicyType
+			oldITS.Spec.PodUpdatePolicy = appsv1.ReCreatePodUpdatePolicyType
+			oldITS.Spec.Template.Spec.Containers = append(oldITS.Spec.Template.Spec.Containers,
+				corev1.Container{
+					Name: kbagent.ContainerName,
+					Ports: []corev1.ContainerPort{
+						{Name: kbagent.LegacyHTTPPortName, ContainerPort: 3501, Protocol: corev1.ProtocolTCP},
+						{Name: kbagent.LegacyStreamingPortName, ContainerPort: 3502, Protocol: corev1.ProtocolTCP},
+					},
+				})
+
+			newITS := oldITS.DeepCopy()
+			newITS.Spec.Template.Spec.Containers[0].Command = []string{"run", "--new-flag"}
+			_, agent := intctrlutil.GetContainerByName(newITS.Spec.Template.Spec.Containers, kbagent.ContainerName)
+			agent.Ports[0].Name = kbagent.DefaultHTTPPortName
+			agent.Ports[1].Name = kbagent.DefaultStreamingPortName
+
+			merged := copyAndMergeITS(oldITS, newITS, legacyConfigManagerPolicyKeep)
+			Expect(merged).ShouldNot(BeNil())
+			_, mergedAgent := intctrlutil.GetContainerByName(merged.Spec.Template.Spec.Containers, kbagent.ContainerName)
+			Expect(mergedAgent.Ports[0].Name).Should(Equal(kbagent.DefaultHTTPPortName))
+			Expect(mergedAgent.Ports[1].Name).Should(Equal(kbagent.DefaultStreamingPortName))
+		})
+
+		It("should keep legacy names when PodUpdatePolicy blocks a command-change rollout", func() {
+			oldITS := testapps.NewInstanceSetFactory(testCtx.DefaultNamespace,
+				"old-its-kbagent-command-strict", clusterName, compName).
+				AddContainer(corev1.Container{Name: "main", Image: "test-image"}).
+				GetObject()
+			oldITS.Spec.PodUpgradePolicy = appsv1.ReCreatePodUpdatePolicyType
+			oldITS.Spec.PodUpdatePolicy = appsv1.StrictInPlacePodUpdatePolicyType
+			oldITS.Spec.Template.Spec.Containers = append(oldITS.Spec.Template.Spec.Containers,
+				corev1.Container{
+					Name: kbagent.ContainerName,
+					Ports: []corev1.ContainerPort{
+						{Name: kbagent.LegacyHTTPPortName, ContainerPort: 3501, Protocol: corev1.ProtocolTCP},
+						{Name: kbagent.LegacyStreamingPortName, ContainerPort: 3502, Protocol: corev1.ProtocolTCP},
+					},
+				})
+
+			newITS := oldITS.DeepCopy()
+			newITS.Spec.Template.Spec.Containers[0].Command = []string{"run", "--new-flag"}
+			_, agent := intctrlutil.GetContainerByName(newITS.Spec.Template.Spec.Containers, kbagent.ContainerName)
+			agent.Ports[0].Name = kbagent.DefaultHTTPPortName
+			agent.Ports[1].Name = kbagent.DefaultStreamingPortName
+
+			merged := copyAndMergeITS(oldITS, newITS, legacyConfigManagerPolicyKeep)
+			Expect(merged).ShouldNot(BeNil())
+			_, mergedAgent := intctrlutil.GetContainerByName(merged.Spec.Template.Spec.Containers, kbagent.ContainerName)
+			Expect(mergedAgent.Ports[0].Name).Should(Equal(kbagent.LegacyHTTPPortName))
+			Expect(mergedAgent.Ports[1].Name).Should(Equal(kbagent.LegacyStreamingPortName))
+		})
+
 		It("should keep the new kbagent port names for workloads already renamed", func() {
 			oldITS := testapps.NewInstanceSetFactory(testCtx.DefaultNamespace,
 				"old-its-kbagent-ports-3", clusterName, compName).

--- a/controllers/apps/component/transformer_component_workload_test.go
+++ b/controllers/apps/component/transformer_component_workload_test.go
@@ -286,7 +286,9 @@ var _ = Describe("Component Workload Operations Test", func() {
 			Expect(merged).Should(BeNil())
 		})
 
-		It("should apply the kbagent port rename together with another template change", func() {
+		It("should keep legacy kbagent port names when only in-place fields change", func() {
+			// an image bump is applied in place by the InstanceSet controller;
+			// the rename must not turn it into a pod-recreating rollout
 			oldITS := testapps.NewInstanceSetFactory(testCtx.DefaultNamespace,
 				"old-its-kbagent-ports-2", clusterName, compName).
 				AddContainer(corev1.Container{
@@ -312,6 +314,39 @@ var _ = Describe("Component Workload Operations Test", func() {
 			merged := copyAndMergeITS(oldITS, newITS, legacyConfigManagerPolicyKeep)
 			Expect(merged).ShouldNot(BeNil())
 			Expect(merged.Spec.Template.Spec.Containers[0].Image).Should(Equal("new-image"))
+			_, mergedAgent := intctrlutil.GetContainerByName(merged.Spec.Template.Spec.Containers, kbagent.ContainerName)
+			Expect(mergedAgent).ShouldNot(BeNil())
+			Expect(mergedAgent.Ports[0].Name).Should(Equal(kbagent.LegacyHTTPPortName))
+			Expect(mergedAgent.Ports[1].Name).Should(Equal(kbagent.LegacyStreamingPortName))
+		})
+
+		It("should apply the kbagent port rename together with a pod-recreating template change", func() {
+			oldITS := testapps.NewInstanceSetFactory(testCtx.DefaultNamespace,
+				"old-its-kbagent-ports-4", clusterName, compName).
+				AddContainer(corev1.Container{
+					Name:  "main",
+					Image: "test-image",
+				}).
+				GetObject()
+			oldITS.Spec.Template.Spec.Containers = append(oldITS.Spec.Template.Spec.Containers,
+				corev1.Container{
+					Name: kbagent.ContainerName,
+					Ports: []corev1.ContainerPort{
+						{Name: kbagent.LegacyHTTPPortName, ContainerPort: 3501, Protocol: corev1.ProtocolTCP},
+						{Name: kbagent.LegacyStreamingPortName, ContainerPort: 3502, Protocol: corev1.ProtocolTCP},
+					},
+				})
+
+			newITS := oldITS.DeepCopy()
+			// a command change is not in-place updatable and recreates the pods
+			newITS.Spec.Template.Spec.Containers[0].Command = []string{"run", "--new-flag"}
+			_, agent := intctrlutil.GetContainerByName(newITS.Spec.Template.Spec.Containers, kbagent.ContainerName)
+			agent.Ports[0].Name = kbagent.DefaultHTTPPortName
+			agent.Ports[1].Name = kbagent.DefaultStreamingPortName
+
+			merged := copyAndMergeITS(oldITS, newITS, legacyConfigManagerPolicyKeep)
+			Expect(merged).ShouldNot(BeNil())
+			Expect(merged.Spec.Template.Spec.Containers[0].Command).Should(Equal([]string{"run", "--new-flag"}))
 			_, mergedAgent := intctrlutil.GetContainerByName(merged.Spec.Template.Spec.Containers, kbagent.ContainerName)
 			Expect(mergedAgent).ShouldNot(BeNil())
 			Expect(mergedAgent.Ports[0].Name).Should(Equal(kbagent.DefaultHTTPPortName))

--- a/controllers/apps/componentdefinition_controller.go
+++ b/controllers/apps/componentdefinition_controller.go
@@ -261,12 +261,32 @@ func (r *ComponentDefinitionReconciler) validateLabels(cli client.Client, rctx i
 
 func (r *ComponentDefinitionReconciler) validateRuntime(cli client.Client, rctx intctrlutil.RequestCtx,
 	cmpd *appsv1.ComponentDefinition) error {
+	if !componentDefinitionInjectsKBAgent(cmpd) {
+		return nil
+	}
 	if component.KBAgentPortNamesGrandfathered(cmpd) {
 		return nil
 	}
 	return component.ValidateKBAgentPortNames(
 		cmpd.Spec.Runtime.InitContainers,
 		cmpd.Spec.Runtime.Containers)
+}
+
+func componentDefinitionInjectsKBAgent(cmpd *appsv1.ComponentDefinition) bool {
+	if cmpd == nil {
+		return false
+	}
+	if cmpd.Spec.LifecycleActions != nil {
+		return true
+	}
+	for _, templates := range [][]appsv1.ComponentFileTemplate{cmpd.Spec.Configs, cmpd.Spec.Scripts} {
+		for i := range templates {
+			if templates[i].Reconfigure != nil {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (r *ComponentDefinitionReconciler) validateVars(cli client.Client, rctx intctrlutil.RequestCtx,

--- a/controllers/apps/componentdefinition_controller.go
+++ b/controllers/apps/componentdefinition_controller.go
@@ -262,32 +262,12 @@ func (r *ComponentDefinitionReconciler) validateLabels(cli client.Client, rctx i
 
 func (r *ComponentDefinitionReconciler) validateRuntime(cli client.Client, rctx intctrlutil.RequestCtx,
 	cmpd *appsv1.ComponentDefinition) error {
-	if !componentDefinitionInjectsKBAgent(cmpd) {
-		return nil
-	}
 	if component.KBAgentPortNamesGrandfathered(cmpd) || component.KBAgentPortNamesUpgradeEligible(cmpd) {
 		return nil
 	}
 	return component.ValidateKBAgentPortNames(
 		cmpd.Spec.Runtime.InitContainers,
 		cmpd.Spec.Runtime.Containers)
-}
-
-func componentDefinitionInjectsKBAgent(cmpd *appsv1.ComponentDefinition) bool {
-	if cmpd == nil {
-		return false
-	}
-	if cmpd.Spec.LifecycleActions != nil {
-		return true
-	}
-	for _, templates := range [][]appsv1.ComponentFileTemplate{cmpd.Spec.Configs, cmpd.Spec.Scripts} {
-		for i := range templates {
-			if templates[i].Reconfigure != nil {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 func (r *ComponentDefinitionReconciler) validateVars(cli client.Client, rctx intctrlutil.RequestCtx,

--- a/controllers/apps/componentdefinition_controller.go
+++ b/controllers/apps/componentdefinition_controller.go
@@ -161,6 +161,8 @@ func (r *ComponentDefinitionReconciler) unavailable(cli client.Client, rctx intc
 func (r *ComponentDefinitionReconciler) status(cli client.Client, rctx intctrlutil.RequestCtx,
 	cmpd *appsv1.ComponentDefinition, phase appsv1.Phase, message string) error {
 	patch := client.MergeFrom(cmpd.DeepCopy())
+	cmpd.Status.LegacyKBAgentPortNames = component.KBAgentPortNamesGrandfathered(cmpd) &&
+		component.ValidateKBAgentPortNames(cmpd.Spec.Runtime.InitContainers, cmpd.Spec.Runtime.Containers) != nil
 	cmpd.Status.ObservedGeneration = cmpd.Generation
 	cmpd.Status.Phase = phase
 	cmpd.Status.Message = message
@@ -259,6 +261,9 @@ func (r *ComponentDefinitionReconciler) validateLabels(cli client.Client, rctx i
 
 func (r *ComponentDefinitionReconciler) validateRuntime(cli client.Client, rctx intctrlutil.RequestCtx,
 	cmpd *appsv1.ComponentDefinition) error {
+	if component.KBAgentPortNamesGrandfathered(cmpd) {
+		return nil
+	}
 	return component.ValidateKBAgentPortNames(
 		cmpd.Spec.Runtime.InitContainers,
 		cmpd.Spec.Runtime.Containers)

--- a/controllers/apps/componentdefinition_controller.go
+++ b/controllers/apps/componentdefinition_controller.go
@@ -259,7 +259,9 @@ func (r *ComponentDefinitionReconciler) validateLabels(cli client.Client, rctx i
 
 func (r *ComponentDefinitionReconciler) validateRuntime(cli client.Client, rctx intctrlutil.RequestCtx,
 	cmpd *appsv1.ComponentDefinition) error {
-	return nil
+	return component.ValidateKBAgentPortNames(
+		cmpd.Spec.Runtime.InitContainers,
+		cmpd.Spec.Runtime.Containers)
 }
 
 func (r *ComponentDefinitionReconciler) validateVars(cli client.Client, rctx intctrlutil.RequestCtx,

--- a/controllers/apps/componentdefinition_controller.go
+++ b/controllers/apps/componentdefinition_controller.go
@@ -161,8 +161,9 @@ func (r *ComponentDefinitionReconciler) unavailable(cli client.Client, rctx intc
 func (r *ComponentDefinitionReconciler) status(cli client.Client, rctx intctrlutil.RequestCtx,
 	cmpd *appsv1.ComponentDefinition, phase appsv1.Phase, message string) error {
 	patch := client.MergeFrom(cmpd.DeepCopy())
-	cmpd.Status.LegacyKBAgentPortNames = component.KBAgentPortNamesGrandfathered(cmpd) &&
-		component.ValidateKBAgentPortNames(cmpd.Spec.Runtime.InitContainers, cmpd.Spec.Runtime.Containers) != nil
+	cmpd.Status.LegacyKBAgentPortNames =
+		(component.KBAgentPortNamesGrandfathered(cmpd) || component.KBAgentPortNamesUpgradeEligible(cmpd)) &&
+			component.ValidateKBAgentPortNames(cmpd.Spec.Runtime.InitContainers, cmpd.Spec.Runtime.Containers) != nil
 	cmpd.Status.ObservedGeneration = cmpd.Generation
 	cmpd.Status.Phase = phase
 	cmpd.Status.Message = message
@@ -264,7 +265,7 @@ func (r *ComponentDefinitionReconciler) validateRuntime(cli client.Client, rctx 
 	if !componentDefinitionInjectsKBAgent(cmpd) {
 		return nil
 	}
-	if component.KBAgentPortNamesGrandfathered(cmpd) {
+	if component.KBAgentPortNamesGrandfathered(cmpd) || component.KBAgentPortNamesUpgradeEligible(cmpd) {
 		return nil
 	}
 	return component.ValidateKBAgentPortNames(

--- a/controllers/apps/componentdefinition_controller_test.go
+++ b/controllers/apps/componentdefinition_controller_test.go
@@ -28,12 +28,15 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/pointer"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
+	controllerutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/generics"
 	"github.com/apecloud/kubeblocks/pkg/kbagent"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
@@ -104,8 +107,8 @@ var _ = Describe("ComponentDefinition Controller", func() {
 	})
 
 	Context("runtime", func() {
-		It("rejects port names reserved for the injected kbagent container", func() {
-			componentDefObj := testapps.NewComponentDefinitionFactory(componentDefName).
+		newReservedPortDefinition := func() *kbappsv1.ComponentDefinition {
+			return testapps.NewComponentDefinitionFactory(componentDefName).
 				SetRuntime(&corev1.Container{
 					Name: "database",
 					Ports: []corev1.ContainerPort{{
@@ -113,13 +116,114 @@ var _ = Describe("ComponentDefinition Controller", func() {
 						ContainerPort: 9200,
 					}},
 				}).
-				Create(&testCtx).GetObject()
+				GetObject()
+		}
+
+		newStatusClient := func(obj *kbappsv1.ComponentDefinition) (client.Client, *kbappsv1.ComponentDefinition) {
+			cli := fake.NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithStatusSubresource(&kbappsv1.ComponentDefinition{}).
+				WithObjects(obj).
+				Build()
+			current := &kbappsv1.ComponentDefinition{}
+			Expect(cli.Get(ctx, client.ObjectKeyFromObject(obj), current)).Should(Succeed())
+			return cli, current
+		}
+
+		It("rejects port names reserved for the injected kbagent container", func() {
+			componentDefObj := newReservedPortDefinition()
+			Expect(testCtx.CreateObj(testCtx.Ctx, componentDefObj)).Should(Succeed())
 
 			checkObjectStatus(componentDefObj, kbappsv1.UnavailablePhase)
 			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(componentDefObj),
 				func(g Gomega, cmpd *kbappsv1.ComponentDefinition) {
 					g.Expect(cmpd.Status.Message).Should(ContainSubstring("reserved for the injected kbagent container"))
 				})).Should(Succeed())
+		})
+
+		It("keeps a current-generation available definition valid across the reserved-name upgrade", func() {
+			componentDefObj := newReservedPortDefinition()
+			componentDefObj.Generation = 3
+			componentDefObj.Status.ObservedGeneration = 3
+			componentDefObj.Status.Phase = kbappsv1.AvailablePhase
+
+			reconciler := &ComponentDefinitionReconciler{}
+			Expect(reconciler.validateRuntime(nil, controllerutil.RequestCtx{}, componentDefObj)).Should(Succeed())
+		})
+
+		It("keeps the compatibility proof after an unrelated phase transition", func() {
+			componentDefObj := newReservedPortDefinition()
+			componentDefObj.Generation = 3
+			componentDefObj.Status.ObservedGeneration = 3
+			componentDefObj.Status.LegacyKBAgentPortNames = true
+			componentDefObj.Status.Phase = kbappsv1.UnavailablePhase
+
+			reconciler := &ComponentDefinitionReconciler{}
+			Expect(reconciler.validateRuntime(nil, controllerutil.RequestCtx{}, componentDefObj)).Should(Succeed())
+		})
+
+		It("persists the compatibility proof for an old available current-generation definition", func() {
+			componentDefObj := newReservedPortDefinition()
+			componentDefObj.Generation = 3
+			componentDefObj.Status.ObservedGeneration = 3
+			componentDefObj.Status.Phase = kbappsv1.AvailablePhase
+			cli, current := newStatusClient(componentDefObj)
+
+			reconciler := &ComponentDefinitionReconciler{}
+			Expect(reconciler.status(cli, controllerutil.RequestCtx{Ctx: ctx}, current, kbappsv1.AvailablePhase, "")).Should(Succeed())
+			Expect(cli.Get(ctx, client.ObjectKeyFromObject(componentDefObj), current)).Should(Succeed())
+			Expect(current.Status.LegacyKBAgentPortNames).Should(BeTrue())
+			Expect(current.Status.ObservedGeneration).Should(Equal(int64(3)))
+		})
+
+		It("preserves the compatibility proof across a same-generation phase change", func() {
+			componentDefObj := newReservedPortDefinition()
+			componentDefObj.Generation = 3
+			componentDefObj.Status.ObservedGeneration = 3
+			componentDefObj.Status.LegacyKBAgentPortNames = true
+			componentDefObj.Status.Phase = kbappsv1.AvailablePhase
+			cli, current := newStatusClient(componentDefObj)
+
+			reconciler := &ComponentDefinitionReconciler{}
+			Expect(reconciler.status(cli, controllerutil.RequestCtx{Ctx: ctx}, current, kbappsv1.UnavailablePhase, "unrelated")).Should(Succeed())
+			Expect(cli.Get(ctx, client.ObjectKeyFromObject(componentDefObj), current)).Should(Succeed())
+			Expect(current.Status.LegacyKBAgentPortNames).Should(BeTrue())
+			Expect(current.Status.Phase).Should(Equal(kbappsv1.UnavailablePhase))
+		})
+
+		It("rejects a generation change and clears the compatibility proof", func() {
+			componentDefObj := newReservedPortDefinition()
+			componentDefObj.Generation = 4
+			componentDefObj.Status.ObservedGeneration = 3
+			componentDefObj.Status.LegacyKBAgentPortNames = true
+			componentDefObj.Status.Phase = kbappsv1.AvailablePhase
+			cli, current := newStatusClient(componentDefObj)
+
+			reconciler := &ComponentDefinitionReconciler{}
+			err := reconciler.validateRuntime(nil, controllerutil.RequestCtx{}, current)
+			Expect(err).Should(MatchError(ContainSubstring("reserved for the injected kbagent container")))
+			Expect(reconciler.status(cli, controllerutil.RequestCtx{Ctx: ctx}, current, kbappsv1.UnavailablePhase, err.Error())).Should(Succeed())
+			Expect(cli.Get(ctx, client.ObjectKeyFromObject(componentDefObj), current)).Should(Succeed())
+			Expect(current.Status.LegacyKBAgentPortNames).Should(BeFalse())
+			Expect(current.Status.ObservedGeneration).Should(Equal(int64(4)))
+		})
+
+		It("continues rejecting after the failed generation is written to status", func() {
+			componentDefObj := newReservedPortDefinition()
+			componentDefObj.Generation = 4
+			componentDefObj.Status.ObservedGeneration = 3
+			componentDefObj.Status.LegacyKBAgentPortNames = true
+			componentDefObj.Status.Phase = kbappsv1.AvailablePhase
+			cli, current := newStatusClient(componentDefObj)
+
+			reconciler := &ComponentDefinitionReconciler{}
+			firstErr := reconciler.validateRuntime(nil, controllerutil.RequestCtx{}, current)
+			Expect(firstErr).Should(HaveOccurred())
+			Expect(reconciler.status(cli, controllerutil.RequestCtx{Ctx: ctx}, current, kbappsv1.UnavailablePhase, firstErr.Error())).Should(Succeed())
+			Expect(cli.Get(ctx, client.ObjectKeyFromObject(componentDefObj), current)).Should(Succeed())
+			Expect(reconciler.validateRuntime(nil, controllerutil.RequestCtx{}, current)).Should(
+				MatchError(ContainSubstring("reserved for the injected kbagent container")))
+			Expect(current.Status.LegacyKBAgentPortNames).Should(BeFalse())
 		})
 	})
 

--- a/controllers/apps/componentdefinition_controller_test.go
+++ b/controllers/apps/componentdefinition_controller_test.go
@@ -35,6 +35,7 @@ import (
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/generics"
+	"github.com/apecloud/kubeblocks/pkg/kbagent"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
 )
 
@@ -98,6 +99,26 @@ var _ = Describe("ComponentDefinition Controller", func() {
 					g.Expect(cmpd.Finalizers).ShouldNot(BeEmpty())
 					g.Expect(cmpd.Status.ObservedGeneration).Should(Equal(cmpd.GetGeneration()))
 					g.Expect(cmpd.Status.Phase).Should(Equal(kbappsv1.AvailablePhase))
+				})).Should(Succeed())
+		})
+	})
+
+	Context("runtime", func() {
+		It("rejects port names reserved for the injected kbagent container", func() {
+			componentDefObj := testapps.NewComponentDefinitionFactory(componentDefName).
+				SetRuntime(&corev1.Container{
+					Name: "database",
+					Ports: []corev1.ContainerPort{{
+						Name:          kbagent.DefaultHTTPPortName,
+						ContainerPort: 9200,
+					}},
+				}).
+				Create(&testCtx).GetObject()
+
+			checkObjectStatus(componentDefObj, kbappsv1.UnavailablePhase)
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(componentDefObj),
+				func(g Gomega, cmpd *kbappsv1.ComponentDefinition) {
+					g.Expect(cmpd.Status.Message).Should(ContainSubstring("reserved for the injected kbagent container"))
 				})).Should(Succeed())
 		})
 	})

--- a/controllers/apps/componentdefinition_controller_test.go
+++ b/controllers/apps/componentdefinition_controller_test.go
@@ -120,12 +120,13 @@ var _ = Describe("ComponentDefinition Controller", func() {
 				GetObject()
 		}
 
-		It("allows kbagent port names when the definition has no actions", func() {
+		It("reserves kbagent port names even when the definition has no actions", func() {
 			componentDefObj := newReservedPortDefinition()
 			componentDefObj.Spec.LifecycleActions = nil
 
 			reconciler := &ComponentDefinitionReconciler{}
-			Expect(reconciler.validateRuntime(nil, controllerutil.RequestCtx{}, componentDefObj)).Should(Succeed())
+			Expect(reconciler.validateRuntime(nil, controllerutil.RequestCtx{}, componentDefObj)).Should(
+				MatchError(ContainSubstring("reserved for the injected kbagent container")))
 		})
 
 		It("reserves kbagent port names when a file reconfigure action injects kbagent", func() {

--- a/controllers/apps/componentdefinition_controller_test.go
+++ b/controllers/apps/componentdefinition_controller_test.go
@@ -116,8 +116,30 @@ var _ = Describe("ComponentDefinition Controller", func() {
 						ContainerPort: 9200,
 					}},
 				}).
+				SetLifecycleAction("PostProvision", &kbappsv1.Action{}).
 				GetObject()
 		}
+
+		It("allows kbagent port names when the definition has no actions", func() {
+			componentDefObj := newReservedPortDefinition()
+			componentDefObj.Spec.LifecycleActions = nil
+
+			reconciler := &ComponentDefinitionReconciler{}
+			Expect(reconciler.validateRuntime(nil, controllerutil.RequestCtx{}, componentDefObj)).Should(Succeed())
+		})
+
+		It("reserves kbagent port names when a file reconfigure action injects kbagent", func() {
+			componentDefObj := newReservedPortDefinition()
+			componentDefObj.Spec.LifecycleActions = nil
+			componentDefObj.Spec.Configs = []kbappsv1.ComponentFileTemplate{{
+				Name:        "config",
+				Reconfigure: &kbappsv1.Action{},
+			}}
+
+			reconciler := &ComponentDefinitionReconciler{}
+			Expect(reconciler.validateRuntime(nil, controllerutil.RequestCtx{}, componentDefObj)).Should(
+				MatchError(ContainSubstring("reserved for the injected kbagent container")))
+		})
 
 		newStatusClient := func(obj *kbappsv1.ComponentDefinition) (client.Client, *kbappsv1.ComponentDefinition) {
 			cli := fake.NewClientBuilder().

--- a/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
@@ -2747,8 +2747,9 @@ spec:
                                - If this field is empty: All ports are automatically allocated by the host-port manager.
                                - If this field is specified:
                                  a) Mappings for all ports defined in `cmpd.spec.hostNetwork` are MANDATORY.
-                                 b) Mappings for kbagent ports ("http", "streaming") are OPTIONAL.
+                                 b) Mappings for kbagent ports ("kba-http", "kba-streaming") are OPTIONAL.
                                     You can explicitly map them here, or leave them omitted to be allocated by the host-port manager.
+                                    The legacy names "http" and "streaming" are still accepted as aliases for the kbagent ports.
 
                             2. When HostNetwork is disabled:
                                It allows optional mapping for container ports to host ports.
@@ -13994,8 +13995,9 @@ spec:
                                    - If this field is empty: All ports are automatically allocated by the host-port manager.
                                    - If this field is specified:
                                      a) Mappings for all ports defined in `cmpd.spec.hostNetwork` are MANDATORY.
-                                     b) Mappings for kbagent ports ("http", "streaming") are OPTIONAL.
+                                     b) Mappings for kbagent ports ("kba-http", "kba-streaming") are OPTIONAL.
                                         You can explicitly map them here, or leave them omitted to be allocated by the host-port manager.
+                                        The legacy names "http" and "streaming" are still accepted as aliases for the kbagent ports.
 
                                 2. When HostNetwork is disabled:
                                    It allows optional mapping for container ports to host ports.

--- a/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
@@ -2749,7 +2749,9 @@ spec:
                                  a) Mappings for all ports defined in `cmpd.spec.hostNetwork` are MANDATORY.
                                  b) Mappings for kbagent ports ("kba-http", "kba-streaming") are OPTIONAL.
                                     You can explicitly map them here, or leave them omitted to be allocated by the host-port manager.
-                                    The legacy names "http" and "streaming" are still accepted as aliases for the kbagent ports.
+                                    The legacy names "http" and "streaming" are accepted as aliases only when no non-kbagent
+                                    container declares the same port name. When a component owns that name, its mapping takes
+                                    precedence; use the "kba-*" name to map kbagent explicitly, or omit it for automatic allocation.
 
                             2. When HostNetwork is disabled:
                                It allows optional mapping for container ports to host ports.
@@ -13997,7 +13999,9 @@ spec:
                                      a) Mappings for all ports defined in `cmpd.spec.hostNetwork` are MANDATORY.
                                      b) Mappings for kbagent ports ("kba-http", "kba-streaming") are OPTIONAL.
                                         You can explicitly map them here, or leave them omitted to be allocated by the host-port manager.
-                                        The legacy names "http" and "streaming" are still accepted as aliases for the kbagent ports.
+                                        The legacy names "http" and "streaming" are accepted as aliases only when no non-kbagent
+                                        container declares the same port name. When a component owns that name, its mapping takes
+                                        precedence; use the "kba-*" name to map kbagent explicitly, or omit it for automatic allocation.
 
                                 2. When HostNetwork is disabled:
                                    It allows optional mapping for container ports to host ports.

--- a/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
@@ -19732,6 +19732,13 @@ spec:
           status:
             description: ComponentDefinitionStatus defines the observed state of ComponentDefinition.
             properties:
+              legacyKBAgentPortNames:
+                description: |-
+                  LegacyKBAgentPortNames records that this definition was already accepted
+                  before kba-http and kba-streaming became reserved names. The controller
+                  uses the durable status bit to preserve a compatible injected port name
+                  across later phase transitions without allowing new definitions to opt in.
+                type: boolean
               message:
                 description: Provides additional information about the current phase.
                 type: string

--- a/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
@@ -10155,6 +10155,9 @@ spec:
                   These instance-specific overrides can be specified in `cluster.spec.componentSpecs[*].instances`.
 
                   This field is immutable and cannot be updated once set.
+
+                  The container port names "kba-http" and "kba-streaming" are reserved by KubeBlocks for the
+                  kbagent container that it injects when lifecycle or reconfiguration actions are defined.
                 properties:
                   activeDeadlineSeconds:
                     description: |-

--- a/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
@@ -10156,8 +10156,9 @@ spec:
 
                   This field is immutable and cannot be updated once set.
 
-                  The container port names "kba-http" and "kba-streaming" are reserved by KubeBlocks for the
-                  kbagent container that it injects when lifecycle or reconfiguration actions are defined.
+                  The container port names "kba-http" and "kba-streaming" are reserved by KubeBlocks for kbagent
+                  and must not be used by user-defined containers, regardless of whether this definition currently
+                  declares lifecycle or reconfiguration actions.
                 properties:
                   activeDeadlineSeconds:
                     description: |-

--- a/deploy/helm/crds/apps.kubeblocks.io_components.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_components.yaml
@@ -2964,8 +2964,9 @@ spec:
                          - If this field is empty: All ports are automatically allocated by the host-port manager.
                          - If this field is specified:
                            a) Mappings for all ports defined in `cmpd.spec.hostNetwork` are MANDATORY.
-                           b) Mappings for kbagent ports ("http", "streaming") are OPTIONAL.
+                           b) Mappings for kbagent ports ("kba-http", "kba-streaming") are OPTIONAL.
                               You can explicitly map them here, or leave them omitted to be allocated by the host-port manager.
+                              The legacy names "http" and "streaming" are still accepted as aliases for the kbagent ports.
 
                       2. When HostNetwork is disabled:
                          It allows optional mapping for container ports to host ports.

--- a/deploy/helm/crds/apps.kubeblocks.io_components.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_components.yaml
@@ -2966,7 +2966,9 @@ spec:
                            a) Mappings for all ports defined in `cmpd.spec.hostNetwork` are MANDATORY.
                            b) Mappings for kbagent ports ("kba-http", "kba-streaming") are OPTIONAL.
                               You can explicitly map them here, or leave them omitted to be allocated by the host-port manager.
-                              The legacy names "http" and "streaming" are still accepted as aliases for the kbagent ports.
+                              The legacy names "http" and "streaming" are accepted as aliases only when no non-kbagent
+                              container declares the same port name. When a component owns that name, its mapping takes
+                              precedence; use the "kba-*" name to map kbagent explicitly, or omit it for automatic allocation.
 
                       2. When HostNetwork is disabled:
                          It allows optional mapping for container ports to host ports.

--- a/docs/developer_docs/api-reference/cluster.md
+++ b/docs/developer_docs/api-reference/cluster.md
@@ -6006,6 +6006,21 @@ int64
 </tr>
 <tr>
 <td>
+<code>legacyKBAgentPortNames</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>LegacyKBAgentPortNames records that this definition was already accepted
+before kba-http and kba-streaming became reserved names. The controller
+uses the durable status bit to preserve a compatible injected port name
+across later phase transitions without allowing new definitions to opt in.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>phase</code><br/>
 <em>
 <a href="#apps.kubeblocks.io/v1.Phase">

--- a/docs/developer_docs/api-reference/cluster.md
+++ b/docs/developer_docs/api-reference/cluster.md
@@ -6627,8 +6627,9 @@ The behavior varies based on the HostNetwork setting:</p>
 <li>If this field is empty: All ports are automatically allocated by the host-port manager.</li>
 <li>If this field is specified:
 a) Mappings for all ports defined in <code>cmpd.spec.hostNetwork</code> are MANDATORY.
-b) Mappings for kbagent ports (&ldquo;http&rdquo;, &ldquo;streaming&rdquo;) are OPTIONAL.
-You can explicitly map them here, or leave them omitted to be allocated by the host-port manager.</li>
+b) Mappings for kbagent ports (&ldquo;kba-http&rdquo;, &ldquo;kba-streaming&rdquo;) are OPTIONAL.
+You can explicitly map them here, or leave them omitted to be allocated by the host-port manager.
+The legacy names &ldquo;http&rdquo; and &ldquo;streaming&rdquo; are still accepted as aliases for the kbagent ports.</li>
 </ul></li>
 <li><p>When HostNetwork is disabled:
 It allows optional mapping for container ports to host ports.</p>

--- a/docs/developer_docs/api-reference/cluster.md
+++ b/docs/developer_docs/api-reference/cluster.md
@@ -1265,6 +1265,8 @@ They should be specified in the <code>cluster.spec.componentSpecs</code> (Cluste
 or modifying environment variable values.
 These instance-specific overrides can be specified in <code>cluster.spec.componentSpecs[*].instances</code>.</p>
 <p>This field is immutable and cannot be updated once set.</p>
+<p>The container port names &ldquo;kba-http&rdquo; and &ldquo;kba-streaming&rdquo; are reserved by KubeBlocks for the
+kbagent container that it injects when lifecycle or reconfiguration actions are defined.</p>
 </td>
 </tr>
 <tr>
@@ -5498,6 +5500,8 @@ They should be specified in the <code>cluster.spec.componentSpecs</code> (Cluste
 or modifying environment variable values.
 These instance-specific overrides can be specified in <code>cluster.spec.componentSpecs[*].instances</code>.</p>
 <p>This field is immutable and cannot be updated once set.</p>
+<p>The container port names &ldquo;kba-http&rdquo; and &ldquo;kba-streaming&rdquo; are reserved by KubeBlocks for the
+kbagent container that it injects when lifecycle or reconfiguration actions are defined.</p>
 </td>
 </tr>
 <tr>
@@ -6629,7 +6633,9 @@ The behavior varies based on the HostNetwork setting:</p>
 a) Mappings for all ports defined in <code>cmpd.spec.hostNetwork</code> are MANDATORY.
 b) Mappings for kbagent ports (&ldquo;kba-http&rdquo;, &ldquo;kba-streaming&rdquo;) are OPTIONAL.
 You can explicitly map them here, or leave them omitted to be allocated by the host-port manager.
-The legacy names &ldquo;http&rdquo; and &ldquo;streaming&rdquo; are still accepted as aliases for the kbagent ports.</li>
+The legacy names &ldquo;http&rdquo; and &ldquo;streaming&rdquo; are accepted as aliases only when no non-kbagent
+container declares the same port name. When a component owns that name, its mapping takes
+precedence; use the &ldquo;kba-*&rdquo; name to map kbagent explicitly, or omit it for automatic allocation.</li>
 </ul></li>
 <li><p>When HostNetwork is disabled:
 It allows optional mapping for container ports to host ports.</p>

--- a/docs/developer_docs/api-reference/cluster.md
+++ b/docs/developer_docs/api-reference/cluster.md
@@ -1265,8 +1265,9 @@ They should be specified in the <code>cluster.spec.componentSpecs</code> (Cluste
 or modifying environment variable values.
 These instance-specific overrides can be specified in <code>cluster.spec.componentSpecs[*].instances</code>.</p>
 <p>This field is immutable and cannot be updated once set.</p>
-<p>The container port names &ldquo;kba-http&rdquo; and &ldquo;kba-streaming&rdquo; are reserved by KubeBlocks for the
-kbagent container that it injects when lifecycle or reconfiguration actions are defined.</p>
+<p>The container port names &ldquo;kba-http&rdquo; and &ldquo;kba-streaming&rdquo; are reserved by KubeBlocks for kbagent
+and must not be used by user-defined containers, regardless of whether this definition currently
+declares lifecycle or reconfiguration actions.</p>
 </td>
 </tr>
 <tr>
@@ -5500,8 +5501,9 @@ They should be specified in the <code>cluster.spec.componentSpecs</code> (Cluste
 or modifying environment variable values.
 These instance-specific overrides can be specified in <code>cluster.spec.componentSpecs[*].instances</code>.</p>
 <p>This field is immutable and cannot be updated once set.</p>
-<p>The container port names &ldquo;kba-http&rdquo; and &ldquo;kba-streaming&rdquo; are reserved by KubeBlocks for the
-kbagent container that it injects when lifecycle or reconfiguration actions are defined.</p>
+<p>The container port names &ldquo;kba-http&rdquo; and &ldquo;kba-streaming&rdquo; are reserved by KubeBlocks for kbagent
+and must not be used by user-defined containers, regardless of whether this definition currently
+declares lifecycle or reconfiguration actions.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/controller/component/kbagent.go
+++ b/pkg/controller/component/kbagent.go
@@ -64,6 +64,27 @@ func IsKBAgentContainer(c *corev1.Container) bool {
 	return c.Name == kbagent.ContainerName || c.Name == kbagent.ContainerName4Worker || c.Name == kbagent.InitContainerName
 }
 
+// NonKBAgentPortNames returns the port names declared by the component's own
+// containers, excluding the injected kbagent containers.
+func NonKBAgentPortNames(synthesizedComp *SynthesizedComponent) sets.Set[string] {
+	names := sets.New[string]()
+	if synthesizedComp == nil || synthesizedComp.PodSpec == nil {
+		return names
+	}
+	for i := range synthesizedComp.PodSpec.Containers {
+		c := &synthesizedComp.PodSpec.Containers[i]
+		if IsKBAgentContainer(c) {
+			continue
+		}
+		for _, p := range c.Ports {
+			if p.Name != "" {
+				names.Insert(p.Name)
+			}
+		}
+	}
+	return names
+}
+
 func UpdateKBAgentContainer4HostNetwork(synthesizedComp *SynthesizedComponent) {
 	idx, c := intctrlutil.GetContainerByName(synthesizedComp.PodSpec.Containers, kbagent.ContainerName)
 	if c == nil {

--- a/pkg/controller/component/kbagent.go
+++ b/pkg/controller/component/kbagent.go
@@ -101,7 +101,14 @@ func UpdateKBAgentContainer4HostNetwork(synthesizedComp *SynthesizedComponent) {
 	}
 	httpPort := port(kbagent.DefaultHTTPPortName)
 	if httpPort == 0 {
+		httpPort = port(kbagent.LegacyHTTPPortName)
+	}
+	if httpPort == 0 {
 		return
+	}
+	streamingPort := port(kbagent.DefaultStreamingPortName)
+	if streamingPort == 0 {
+		streamingPort = port(kbagent.LegacyStreamingPortName)
 	}
 
 	updatePortInArgs := func(arg string, port int) {
@@ -113,7 +120,7 @@ func UpdateKBAgentContainer4HostNetwork(synthesizedComp *SynthesizedComponent) {
 		}
 	}
 	updatePortInArgs("--port", httpPort)
-	updatePortInArgs("--streaming-port", port(kbagent.DefaultStreamingPortName))
+	updatePortInArgs("--streaming-port", streamingPort)
 
 	// update startup probe
 	if c.StartupProbe != nil && c.StartupProbe.TCPSocket != nil {
@@ -150,10 +157,8 @@ func buildKBAgentContainer(synthesizedComp *SynthesizedComponent) error {
 	if !hasActionDefined(synthesizedComp) {
 		return nil
 	}
-	if err := validateKBAgentPortNames(
-		sets.New(kbagent.ContainerName),
-		synthesizedComp.PodSpec.InitContainers,
-		synthesizedComp.PodSpec.Containers); err != nil {
+	httpPortName, streamingPortName, err := kbagentContainerPortNames(synthesizedComp)
+	if err != nil {
 		return err
 	}
 
@@ -192,12 +197,12 @@ func buildKBAgentContainer(synthesizedComp *SynthesizedComponent) error {
 			AddPorts(
 				corev1.ContainerPort{
 					ContainerPort: int32(httpPort),
-					Name:          kbagent.DefaultHTTPPortName,
+					Name:          httpPortName,
 					Protocol:      corev1.ProtocolTCP,
 				},
 				corev1.ContainerPort{
 					ContainerPort: int32(streamingPort),
-					Name:          kbagent.DefaultStreamingPortName,
+					Name:          streamingPortName,
 					Protocol:      corev1.ProtocolTCP,
 				}).
 			SetStartupProbe(corev1.Probe{
@@ -236,11 +241,11 @@ func buildKBAgentContainer(synthesizedComp *SynthesizedComponent) error {
 			[]appsv1.HostNetworkContainerPort{
 				{
 					Container: container.Name,
-					Ports:     []string{kbagent.DefaultHTTPPortName},
+					Ports:     []string{httpPortName},
 				},
 				{
 					Container: container.Name,
-					Ports:     []string{kbagent.DefaultStreamingPortName},
+					Ports:     []string{streamingPortName},
 				},
 			}...)
 	}
@@ -249,6 +254,67 @@ func buildKBAgentContainer(synthesizedComp *SynthesizedComponent) error {
 	synthesizedComp.PodSpec.InitContainers = append(synthesizedComp.PodSpec.InitContainers, *workerContainer)
 
 	return nil
+}
+
+// KBAgentPortNamesGrandfathered reports whether a ComponentDefinition was
+// already accepted at its current generation before the prefixed kbagent port
+// names became reserved. Status is controller-owned, so a newly created or
+// changed definition cannot opt itself into this compatibility path.
+func KBAgentPortNamesGrandfathered(cmpd *appsv1.ComponentDefinition) bool {
+	if cmpd == nil || cmpd.Status.ObservedGeneration <= 0 || cmpd.Status.ObservedGeneration != cmpd.Generation {
+		return false
+	}
+	return cmpd.Status.LegacyKBAgentPortNames || cmpd.Status.Phase == appsv1.AvailablePhase
+}
+
+func kbagentContainerPortNames(synthesizedComp *SynthesizedComponent) (string, string, error) {
+	if !synthesizedComp.grandfatherKBAgentPortNames {
+		if err := validateKBAgentPortNames(
+			sets.New(kbagent.ContainerName),
+			synthesizedComp.PodSpec.InitContainers,
+			synthesizedComp.PodSpec.Containers); err != nil {
+			return "", "", err
+		}
+		return kbagent.DefaultHTTPPortName, kbagent.DefaultStreamingPortName, nil
+	}
+
+	occupied := sets.New[string]()
+	for _, containers := range [][]corev1.Container{
+		synthesizedComp.PodSpec.InitContainers,
+		synthesizedComp.PodSpec.Containers,
+	} {
+		for i := range containers {
+			if IsKBAgentContainer(&containers[i]) {
+				continue
+			}
+			for _, port := range containers[i].Ports {
+				if port.Name != "" {
+					occupied.Insert(port.Name)
+				}
+			}
+		}
+	}
+
+	choose := func(preferred, legacy string) (string, error) {
+		if !occupied.Has(preferred) {
+			return preferred, nil
+		}
+		if occupied.Has(legacy) {
+			return "", fmt.Errorf("container port names %q and %q are both in use; no compatible name remains for the injected kbagent container",
+				preferred, legacy)
+		}
+		return legacy, nil
+	}
+
+	httpName, err := choose(kbagent.DefaultHTTPPortName, kbagent.LegacyHTTPPortName)
+	if err != nil {
+		return "", "", err
+	}
+	streamingName, err := choose(kbagent.DefaultStreamingPortName, kbagent.LegacyStreamingPortName)
+	if err != nil {
+		return "", "", err
+	}
+	return httpName, streamingName, nil
 }
 
 // ValidateKBAgentPortNames rejects user-defined ports that would collide with

--- a/pkg/controller/component/kbagent.go
+++ b/pkg/controller/component/kbagent.go
@@ -256,15 +256,22 @@ func buildKBAgentContainer(synthesizedComp *SynthesizedComponent) error {
 	return nil
 }
 
-// KBAgentPortNamesGrandfathered reports whether a ComponentDefinition was
-// already accepted at its current generation before the prefixed kbagent port
-// names became reserved. Status is controller-owned, so a newly created or
-// changed definition cannot opt itself into this compatibility path.
+// KBAgentPortNamesGrandfathered reports whether the controller persisted a
+// compatibility proof for the ComponentDefinition's current generation.
 func KBAgentPortNamesGrandfathered(cmpd *appsv1.ComponentDefinition) bool {
-	if cmpd == nil || cmpd.Status.ObservedGeneration <= 0 || cmpd.Status.ObservedGeneration != cmpd.Generation {
-		return false
-	}
-	return cmpd.Status.LegacyKBAgentPortNames || cmpd.Status.Phase == appsv1.AvailablePhase
+	return kbagentPortNamesStatusCurrent(cmpd) && cmpd.Status.LegacyKBAgentPortNames
+}
+
+// KBAgentPortNamesUpgradeEligible reports whether an old, already available
+// current-generation definition may have its compatibility proof persisted.
+// This transitional signal is valid only during validation/status migration;
+// synthesis must rely on KBAgentPortNamesGrandfathered instead.
+func KBAgentPortNamesUpgradeEligible(cmpd *appsv1.ComponentDefinition) bool {
+	return kbagentPortNamesStatusCurrent(cmpd) && cmpd.Status.Phase == appsv1.AvailablePhase
+}
+
+func kbagentPortNamesStatusCurrent(cmpd *appsv1.ComponentDefinition) bool {
+	return cmpd != nil && cmpd.Status.ObservedGeneration > 0 && cmpd.Status.ObservedGeneration == cmpd.Generation
 }
 
 func kbagentContainerPortNames(synthesizedComp *SynthesizedComponent) (string, string, error) {

--- a/pkg/controller/component/kbagent.go
+++ b/pkg/controller/component/kbagent.go
@@ -150,6 +150,12 @@ func buildKBAgentContainer(synthesizedComp *SynthesizedComponent) error {
 	if !hasActionDefined(synthesizedComp) {
 		return nil
 	}
+	if err := validateKBAgentPortNames(
+		sets.New(kbagent.ContainerName),
+		synthesizedComp.PodSpec.InitContainers,
+		synthesizedComp.PodSpec.Containers); err != nil {
+		return err
+	}
 
 	envVars, err := buildKBAgentStartupEnvs(synthesizedComp)
 	if err != nil {
@@ -242,6 +248,36 @@ func buildKBAgentContainer(synthesizedComp *SynthesizedComponent) error {
 	synthesizedComp.PodSpec.Containers = append(synthesizedComp.PodSpec.Containers, *container)
 	synthesizedComp.PodSpec.InitContainers = append(synthesizedComp.PodSpec.InitContainers, *workerContainer)
 
+	return nil
+}
+
+// ValidateKBAgentPortNames rejects user-defined ports that would collide with
+// the fixed names of the injected kbagent container. ContainerPort.Name is
+// pod-wide, so moving from the legacy generic names to prefixed names is only a
+// complete uniqueness contract when those prefixed names are reserved.
+func ValidateKBAgentPortNames(containerGroups ...[]corev1.Container) error {
+	return validateKBAgentPortNames(nil, containerGroups...)
+}
+
+func validateKBAgentPortNames(ignoredContainerNames sets.Set[string], containerGroups ...[]corev1.Container) error {
+	reserved := sets.New(kbagent.DefaultHTTPPortName, kbagent.DefaultStreamingPortName)
+	for _, containers := range containerGroups {
+		for _, container := range containers {
+			// BuildSynthesizedComponent may be called again with a PodSpec that
+			// already contains the controller-injected kbagent container. The API
+			// validator still checks every user runtime container; only this
+			// synthesis-time defense skips the already-injected container itself.
+			if ignoredContainerNames.Has(container.Name) {
+				continue
+			}
+			for _, port := range container.Ports {
+				if reserved.Has(port.Name) {
+					return fmt.Errorf("container port name %q in container %q is reserved for the injected kbagent container",
+						port.Name, container.Name)
+				}
+			}
+		}
+	}
 	return nil
 }
 

--- a/pkg/controller/component/kbagent_test.go
+++ b/pkg/controller/component/kbagent_test.go
@@ -164,6 +164,19 @@ var _ = Describe("kb-agent", func() {
 			Expect(c.Ports[1].ContainerPort).Should(Equal(int32(kbagent.DefaultStreamingPort + 1)))
 		})
 
+		It("rejects runtime ports that use reserved kbagent port names", func() {
+			synthesizedComp.PodSpec.Containers[0].Ports = []corev1.ContainerPort{
+				{
+					Name:          kbagent.DefaultHTTPPortName,
+					ContainerPort: 9200,
+				},
+			}
+
+			err := buildKBAgentContainer(synthesizedComp)
+			Expect(err).Should(MatchError(ContainSubstring("reserved for the injected kbagent container")))
+			Expect(kbAgentContainer()).Should(BeNil())
+		})
+
 		It("startup env", func() {
 			err := buildKBAgentContainer(synthesizedComp)
 			Expect(err).Should(BeNil())

--- a/pkg/controller/component/kbagent_test.go
+++ b/pkg/controller/component/kbagent_test.go
@@ -29,6 +29,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
@@ -190,6 +191,20 @@ var _ = Describe("kb-agent", func() {
 			Expect(c).ShouldNot(BeNil())
 			Expect(c.Ports[0].Name).Should(Equal(kbagent.LegacyHTTPPortName))
 			Expect(c.Ports[1].Name).Should(Equal(kbagent.DefaultStreamingPortName))
+		})
+
+		It("requires a durable status bit before synthesis uses legacy port names", func() {
+			cmpd := &appsv1.ComponentDefinition{
+				ObjectMeta: metav1.ObjectMeta{Generation: 3},
+				Status: appsv1.ComponentDefinitionStatus{
+					ObservedGeneration: 3,
+					Phase:              appsv1.AvailablePhase,
+				},
+			}
+			Expect(KBAgentPortNamesGrandfathered(cmpd)).Should(BeFalse())
+
+			cmpd.Status.LegacyKBAgentPortNames = true
+			Expect(KBAgentPortNamesGrandfathered(cmpd)).Should(BeTrue())
 		})
 
 		It("updates host-network args and probe from an allocated legacy port", func() {

--- a/pkg/controller/component/kbagent_test.go
+++ b/pkg/controller/component/kbagent_test.go
@@ -177,6 +177,60 @@ var _ = Describe("kb-agent", func() {
 			Expect(kbAgentContainer()).Should(BeNil())
 		})
 
+		It("uses the legacy name for a reserved port on a grandfathered definition", func() {
+			synthesizedComp.grandfatherKBAgentPortNames = true
+			synthesizedComp.PodSpec.Containers[0].Ports = []corev1.ContainerPort{{
+				Name:          kbagent.DefaultHTTPPortName,
+				ContainerPort: 9200,
+			}}
+
+			err := buildKBAgentContainer(synthesizedComp)
+			Expect(err).Should(BeNil())
+			c := kbAgentContainer()
+			Expect(c).ShouldNot(BeNil())
+			Expect(c.Ports[0].Name).Should(Equal(kbagent.LegacyHTTPPortName))
+			Expect(c.Ports[1].Name).Should(Equal(kbagent.DefaultStreamingPortName))
+		})
+
+		It("updates host-network args and probe from an allocated legacy port", func() {
+			synthesizedComp.grandfatherKBAgentPortNames = true
+			synthesizedComp.PodSpec.Containers[0].Ports = []corev1.ContainerPort{{
+				Name:          kbagent.DefaultHTTPPortName,
+				ContainerPort: 9200,
+			}}
+
+			Expect(buildKBAgentContainer(synthesizedComp)).Should(Succeed())
+			idx := -1
+			for i := range synthesizedComp.PodSpec.Containers {
+				if synthesizedComp.PodSpec.Containers[i].Name == kbagent.ContainerName {
+					idx = i
+					break
+				}
+			}
+			Expect(idx).Should(BeNumerically(">=", 0))
+			agent := &synthesizedComp.PodSpec.Containers[idx]
+			Expect(agent.Ports[0].Name).Should(Equal(kbagent.LegacyHTTPPortName))
+			agent.Ports[0].ContainerPort = 13501
+			agent.Ports[1].ContainerPort = 13502
+
+			UpdateKBAgentContainer4HostNetwork(synthesizedComp)
+			agent = &synthesizedComp.PodSpec.Containers[idx]
+			Expect(agent.Args).Should(ContainElements("--port", "13501", "--streaming-port", "13502"))
+			Expect(agent.StartupProbe.TCPSocket.Port.IntValue()).Should(Equal(13501))
+		})
+
+		It("fails closed when a grandfathered definition occupies both compatible names", func() {
+			synthesizedComp.grandfatherKBAgentPortNames = true
+			synthesizedComp.PodSpec.Containers[0].Ports = []corev1.ContainerPort{
+				{Name: kbagent.DefaultHTTPPortName, ContainerPort: 9200},
+				{Name: kbagent.LegacyHTTPPortName, ContainerPort: 9201},
+			}
+
+			err := buildKBAgentContainer(synthesizedComp)
+			Expect(err).Should(MatchError(ContainSubstring("no compatible name remains")))
+			Expect(kbAgentContainer()).Should(BeNil())
+		})
+
 		It("startup env", func() {
 			err := buildKBAgentContainer(synthesizedComp)
 			Expect(err).Should(BeNil())

--- a/pkg/controller/component/replicas.go
+++ b/pkg/controller/component/replicas.go
@@ -212,6 +212,10 @@ func GetReplicasStatusFunc(its *workloads.InstanceSet, f func(ReplicaStatus) boo
 func NewReplicaTask(compName, uid string, source *corev1.Pod, replicas []string) (map[string]string, error) {
 	port, err := intctrlutil.GetPortByName(*source, kbagent.ContainerName, kbagent.DefaultStreamingPortName)
 	if err != nil {
+		// pods created before the port rename still carry the legacy name
+		port, err = intctrlutil.GetPortByName(*source, kbagent.ContainerName, kbagent.LegacyStreamingPortName)
+	}
+	if err != nil {
 		return nil, err
 	}
 	task := proto.Task{

--- a/pkg/controller/component/synthesize_component.go
+++ b/pkg/controller/component/synthesize_component.go
@@ -78,6 +78,7 @@ func BuildSynthesizedComponent(ctx context.Context, cli client.Reader,
 	}
 	compDefObj := compDef.DeepCopy()
 	synthesizeComp := &SynthesizedComponent{
+		grandfatherKBAgentPortNames:      KBAgentPortNamesGrandfathered(compDef),
 		Namespace:                        comp.Namespace,
 		ClusterName:                      clusterName,
 		ClusterUID:                       clusterUID,

--- a/pkg/controller/component/type.go
+++ b/pkg/controller/component/type.go
@@ -30,6 +30,7 @@ import (
 )
 
 type SynthesizedComponent struct {
+	grandfatherKBAgentPortNames      bool
 	Namespace                        string            `json:"namespace,omitempty"`
 	ClusterName                      string            `json:"clusterName,omitempty"`
 	ClusterUID                       string            `json:"clusterUID,omitempty"`

--- a/pkg/controller/component/utils.go
+++ b/pkg/controller/component/utils.go
@@ -194,7 +194,7 @@ func hasHostNetworkEnabled(synthesizedComp *SynthesizedComponent,
 }
 
 func getHostNetworkPort(synthesizedComp *SynthesizedComponent, clusterName, compName, cName, pName string) (int32, error) {
-	pm := intctrlutil.GetPortManager(synthesizedComp.Network)
+	pm := intctrlutil.GetPortManager(synthesizedComp.Network, NonKBAgentPortNames(synthesizedComp))
 	if pm == nil {
 		return 0, nil
 	}

--- a/pkg/controller/instanceset/in_place_update_util.go
+++ b/pkg/controller/instanceset/in_place_update_util.go
@@ -54,10 +54,10 @@ func supportPodVerticalScaling() bool {
 	return viper.GetBool(constant.FeatureGateInPlacePodVerticalScaling)
 }
 
-// FilterInPlaceFields strips the fields that the InstanceSet controller can
+// filterInPlaceFields strips the fields that the InstanceSet controller can
 // update without recreating pods, leaving only the recreate-relevant part of
 // the template for comparison.
-func FilterInPlaceFields(src *corev1.PodTemplateSpec) *corev1.PodTemplateSpec {
+func filterInPlaceFields(src *corev1.PodTemplateSpec) *corev1.PodTemplateSpec {
 	template := src.DeepCopy()
 	// filter annotations
 	var annotations map[string]string
@@ -395,7 +395,7 @@ func getPodUpdatePolicy(its *workloads.InstanceSet, pod *corev1.Pod) (podUpdateP
 		return noOpsPolicy, "", "", err
 	}
 
-	specUpdatePolicy := GetPodUpdatePolicyInSpec(its, pod, newPod)
+	specUpdatePolicy := getPodUpdatePolicyInSpec(its, pod, newPod)
 	if getPodRevision(pod) != updateRevisions[pod.Name] && getPodRevision(pod) != proposedRevisions[pod.Name] {
 		return recreatePolicy, specUpdatePolicy, "revision update", nil
 	}
@@ -422,11 +422,11 @@ func getPodUpdatePolicy(its *workloads.InstanceSet, pod *corev1.Pod) (podUpdateP
 	return noOpsPolicy, "", "", nil
 }
 
-// GetPodUpdatePolicyInSpec returns the policy selected by the InstanceSet
+// getPodUpdatePolicyInSpec returns the policy selected by the InstanceSet
 // controller for a concrete old/new Pod pair. Container image changes use the
 // upgrade policy; command, port, resource, and other template changes use the
 // regular update policy.
-func GetPodUpdatePolicyInSpec(its *workloads.InstanceSet, old, new *corev1.Pod) workloads.PodUpdatePolicyType {
+func getPodUpdatePolicyInSpec(its *workloads.InstanceSet, old, new *corev1.Pod) workloads.PodUpdatePolicyType {
 	if !equalField(old.Spec.InitContainers, new.Spec.InitContainers) || !equalField(old.Spec.Containers, new.Spec.Containers) {
 		if its.Spec.PodUpgradePolicy == kbappsv1.ReCreatePodUpdatePolicyType && safeKBManagedImageOnlyInPlaceUpdate(old, new) {
 			return kbappsv1.PreferInPlacePodUpdatePolicyType

--- a/pkg/controller/instanceset/in_place_update_util.go
+++ b/pkg/controller/instanceset/in_place_update_util.go
@@ -395,7 +395,7 @@ func getPodUpdatePolicy(its *workloads.InstanceSet, pod *corev1.Pod) (podUpdateP
 		return noOpsPolicy, "", "", err
 	}
 
-	specUpdatePolicy := getPodUpdatePolicyInSpec(its, pod, newPod)
+	specUpdatePolicy := GetPodUpdatePolicyInSpec(its, pod, newPod)
 	if getPodRevision(pod) != updateRevisions[pod.Name] && getPodRevision(pod) != proposedRevisions[pod.Name] {
 		return recreatePolicy, specUpdatePolicy, "revision update", nil
 	}
@@ -422,7 +422,11 @@ func getPodUpdatePolicy(its *workloads.InstanceSet, pod *corev1.Pod) (podUpdateP
 	return noOpsPolicy, "", "", nil
 }
 
-func getPodUpdatePolicyInSpec(its *workloads.InstanceSet, old, new *corev1.Pod) workloads.PodUpdatePolicyType {
+// GetPodUpdatePolicyInSpec returns the policy selected by the InstanceSet
+// controller for a concrete old/new Pod pair. Container image changes use the
+// upgrade policy; command, port, resource, and other template changes use the
+// regular update policy.
+func GetPodUpdatePolicyInSpec(its *workloads.InstanceSet, old, new *corev1.Pod) workloads.PodUpdatePolicyType {
 	if !equalField(old.Spec.InitContainers, new.Spec.InitContainers) || !equalField(old.Spec.Containers, new.Spec.Containers) {
 		if its.Spec.PodUpgradePolicy == kbappsv1.ReCreatePodUpdatePolicyType && safeKBManagedImageOnlyInPlaceUpdate(old, new) {
 			return kbappsv1.PreferInPlacePodUpdatePolicyType

--- a/pkg/controller/instanceset/in_place_update_util.go
+++ b/pkg/controller/instanceset/in_place_update_util.go
@@ -54,7 +54,10 @@ func supportPodVerticalScaling() bool {
 	return viper.GetBool(constant.FeatureGateInPlacePodVerticalScaling)
 }
 
-func filterInPlaceFields(src *corev1.PodTemplateSpec) *corev1.PodTemplateSpec {
+// FilterInPlaceFields strips the fields that the InstanceSet controller can
+// update without recreating pods, leaving only the recreate-relevant part of
+// the template for comparison.
+func FilterInPlaceFields(src *corev1.PodTemplateSpec) *corev1.PodTemplateSpec {
 	template := src.DeepCopy()
 	// filter annotations
 	var annotations map[string]string

--- a/pkg/controller/instanceset/in_place_update_util_test.go
+++ b/pkg/controller/instanceset/in_place_update_util_test.go
@@ -105,33 +105,33 @@ var _ = Describe("instance util test", func() {
 				GetObject()
 
 			Expect(equalBasicInPlaceFields(oldPod, newPod)).Should(BeTrue())
-			Expect(getPodUpdatePolicyInSpec(its, oldPod, newPod)).Should(Equal(kbappsv1.ReCreatePodUpdatePolicyType))
+			Expect(GetPodUpdatePolicyInSpec(its, oldPod, newPod)).Should(Equal(kbappsv1.ReCreatePodUpdatePolicyType))
 
 			By("tag mismatch")
 			tagChangedPod := newPod.DeepCopy()
 			tagChangedPod.Spec.Containers[0].Image = "192.168.173.140:6451/apecloud/redis:8.4.1"
 			Expect(equalBasicInPlaceFields(oldPod, tagChangedPod)).Should(BeFalse())
-			Expect(getPodUpdatePolicyInSpec(its, oldPod, tagChangedPod)).Should(Equal(kbappsv1.PreferInPlacePodUpdatePolicyType))
+			Expect(GetPodUpdatePolicyInSpec(its, oldPod, tagChangedPod)).Should(Equal(kbappsv1.PreferInPlacePodUpdatePolicyType))
 
 			By("init container tag mismatch")
 			initTagChangedPod := newPod.DeepCopy()
 			initTagChangedPod.Spec.InitContainers[0].Image = "192.168.173.140:6451/apecloud/kbagent:1.0.3-beta.6"
 			Expect(equalBasicInPlaceFields(oldPod, initTagChangedPod)).Should(BeFalse())
-			Expect(getPodUpdatePolicyInSpec(its, oldPod, initTagChangedPod)).Should(Equal(kbappsv1.PreferInPlacePodUpdatePolicyType))
+			Expect(GetPodUpdatePolicyInSpec(its, oldPod, initTagChangedPod)).Should(Equal(kbappsv1.PreferInPlacePodUpdatePolicyType))
 
 			By("digest mismatch")
 			digestChangedPod := newPod.DeepCopy()
 			oldPod.Spec.Containers[0].Image = "172.31.255.3:5000/apecloud/redis:8.4.0@sha256:old"
 			digestChangedPod.Spec.Containers[0].Image = "192.168.173.140:6451/apecloud/redis:8.4.0@sha256:new"
 			Expect(equalBasicInPlaceFields(oldPod, digestChangedPod)).Should(BeFalse())
-			Expect(getPodUpdatePolicyInSpec(its, oldPod, digestChangedPod)).Should(Equal(kbappsv1.PreferInPlacePodUpdatePolicyType))
+			Expect(GetPodUpdatePolicyInSpec(its, oldPod, digestChangedPod)).Should(Equal(kbappsv1.PreferInPlacePodUpdatePolicyType))
 
 			By("basename mismatch")
 			basenameChangedPod := newPod.DeepCopy()
 			oldPod.Spec.Containers[0].Image = "172.31.255.3:5000/apecloud/redis:8.4.0"
 			basenameChangedPod.Spec.Containers[0].Image = "192.168.173.140:6451/apecloud/redis-stack:8.4.0"
 			Expect(equalBasicInPlaceFields(oldPod, basenameChangedPod)).Should(BeFalse())
-			Expect(getPodUpdatePolicyInSpec(its, oldPod, basenameChangedPod)).Should(Equal(kbappsv1.PreferInPlacePodUpdatePolicyType))
+			Expect(GetPodUpdatePolicyInSpec(its, oldPod, basenameChangedPod)).Should(Equal(kbappsv1.PreferInPlacePodUpdatePolicyType))
 		})
 
 		It("uses in-place policy for KB-managed tools image changes even when pod upgrade policy is ReCreate", func() {
@@ -156,21 +156,21 @@ var _ = Describe("instance util test", func() {
 				SetPodUpgradePolicy(kbappsv1.ReCreatePodUpdatePolicyType).
 				GetObject()
 
-			Expect(getPodUpdatePolicyInSpec(its, oldPod, newPod)).Should(Equal(kbappsv1.PreferInPlacePodUpdatePolicyType))
+			Expect(GetPodUpdatePolicyInSpec(its, oldPod, newPod)).Should(Equal(kbappsv1.PreferInPlacePodUpdatePolicyType))
 
 			strictInPlaceITS := builder.NewInstanceSetBuilder(namespace, name).
 				SetPodUpdatePolicy(kbappsv1.ReCreatePodUpdatePolicyType).
 				SetPodUpgradePolicy(kbappsv1.StrictInPlacePodUpdatePolicyType).
 				GetObject()
-			Expect(getPodUpdatePolicyInSpec(strictInPlaceITS, oldPod, newPod)).Should(Equal(kbappsv1.StrictInPlacePodUpdatePolicyType))
+			Expect(GetPodUpdatePolicyInSpec(strictInPlaceITS, oldPod, newPod)).Should(Equal(kbappsv1.StrictInPlacePodUpdatePolicyType))
 
 			labelChangedPod := newPod.DeepCopy()
 			labelChangedPod.Labels["extra"] = "true"
-			Expect(getPodUpdatePolicyInSpec(its, oldPod, labelChangedPod)).Should(Equal(kbappsv1.ReCreatePodUpdatePolicyType))
+			Expect(GetPodUpdatePolicyInSpec(its, oldPod, labelChangedPod)).Should(Equal(kbappsv1.ReCreatePodUpdatePolicyType))
 
 			appChangedPod := oldPod.DeepCopy()
 			appChangedPod.Spec.Containers[0].Image = "docker.io/apecloud/redis:7.4"
-			Expect(getPodUpdatePolicyInSpec(its, oldPod, appChangedPod)).Should(Equal(kbappsv1.ReCreatePodUpdatePolicyType))
+			Expect(GetPodUpdatePolicyInSpec(its, oldPod, appChangedPod)).Should(Equal(kbappsv1.ReCreatePodUpdatePolicyType))
 		})
 	})
 

--- a/pkg/controller/instanceset/in_place_update_util_test.go
+++ b/pkg/controller/instanceset/in_place_update_util_test.go
@@ -50,7 +50,7 @@ var _ = Describe("instance util test", func() {
 				Spec:       pod.Spec,
 			}
 
-			result := filterInPlaceFields(podTemplate)
+			result := FilterInPlaceFields(podTemplate)
 			Expect(result.Annotations).Should(HaveKey(constant.RestartAnnotationKey))
 			Expect(result.Annotations[constant.RestartAnnotationKey]).Should(Equal(restartTime))
 			Expect(result.Labels).Should(BeNil())

--- a/pkg/controller/instanceset/in_place_update_util_test.go
+++ b/pkg/controller/instanceset/in_place_update_util_test.go
@@ -50,7 +50,7 @@ var _ = Describe("instance util test", func() {
 				Spec:       pod.Spec,
 			}
 
-			result := FilterInPlaceFields(podTemplate)
+			result := filterInPlaceFields(podTemplate)
 			Expect(result.Annotations).Should(HaveKey(constant.RestartAnnotationKey))
 			Expect(result.Annotations[constant.RestartAnnotationKey]).Should(Equal(restartTime))
 			Expect(result.Labels).Should(BeNil())
@@ -105,33 +105,33 @@ var _ = Describe("instance util test", func() {
 				GetObject()
 
 			Expect(equalBasicInPlaceFields(oldPod, newPod)).Should(BeTrue())
-			Expect(GetPodUpdatePolicyInSpec(its, oldPod, newPod)).Should(Equal(kbappsv1.ReCreatePodUpdatePolicyType))
+			Expect(getPodUpdatePolicyInSpec(its, oldPod, newPod)).Should(Equal(kbappsv1.ReCreatePodUpdatePolicyType))
 
 			By("tag mismatch")
 			tagChangedPod := newPod.DeepCopy()
 			tagChangedPod.Spec.Containers[0].Image = "192.168.173.140:6451/apecloud/redis:8.4.1"
 			Expect(equalBasicInPlaceFields(oldPod, tagChangedPod)).Should(BeFalse())
-			Expect(GetPodUpdatePolicyInSpec(its, oldPod, tagChangedPod)).Should(Equal(kbappsv1.PreferInPlacePodUpdatePolicyType))
+			Expect(getPodUpdatePolicyInSpec(its, oldPod, tagChangedPod)).Should(Equal(kbappsv1.PreferInPlacePodUpdatePolicyType))
 
 			By("init container tag mismatch")
 			initTagChangedPod := newPod.DeepCopy()
 			initTagChangedPod.Spec.InitContainers[0].Image = "192.168.173.140:6451/apecloud/kbagent:1.0.3-beta.6"
 			Expect(equalBasicInPlaceFields(oldPod, initTagChangedPod)).Should(BeFalse())
-			Expect(GetPodUpdatePolicyInSpec(its, oldPod, initTagChangedPod)).Should(Equal(kbappsv1.PreferInPlacePodUpdatePolicyType))
+			Expect(getPodUpdatePolicyInSpec(its, oldPod, initTagChangedPod)).Should(Equal(kbappsv1.PreferInPlacePodUpdatePolicyType))
 
 			By("digest mismatch")
 			digestChangedPod := newPod.DeepCopy()
 			oldPod.Spec.Containers[0].Image = "172.31.255.3:5000/apecloud/redis:8.4.0@sha256:old"
 			digestChangedPod.Spec.Containers[0].Image = "192.168.173.140:6451/apecloud/redis:8.4.0@sha256:new"
 			Expect(equalBasicInPlaceFields(oldPod, digestChangedPod)).Should(BeFalse())
-			Expect(GetPodUpdatePolicyInSpec(its, oldPod, digestChangedPod)).Should(Equal(kbappsv1.PreferInPlacePodUpdatePolicyType))
+			Expect(getPodUpdatePolicyInSpec(its, oldPod, digestChangedPod)).Should(Equal(kbappsv1.PreferInPlacePodUpdatePolicyType))
 
 			By("basename mismatch")
 			basenameChangedPod := newPod.DeepCopy()
 			oldPod.Spec.Containers[0].Image = "172.31.255.3:5000/apecloud/redis:8.4.0"
 			basenameChangedPod.Spec.Containers[0].Image = "192.168.173.140:6451/apecloud/redis-stack:8.4.0"
 			Expect(equalBasicInPlaceFields(oldPod, basenameChangedPod)).Should(BeFalse())
-			Expect(GetPodUpdatePolicyInSpec(its, oldPod, basenameChangedPod)).Should(Equal(kbappsv1.PreferInPlacePodUpdatePolicyType))
+			Expect(getPodUpdatePolicyInSpec(its, oldPod, basenameChangedPod)).Should(Equal(kbappsv1.PreferInPlacePodUpdatePolicyType))
 		})
 
 		It("uses in-place policy for KB-managed tools image changes even when pod upgrade policy is ReCreate", func() {
@@ -156,21 +156,21 @@ var _ = Describe("instance util test", func() {
 				SetPodUpgradePolicy(kbappsv1.ReCreatePodUpdatePolicyType).
 				GetObject()
 
-			Expect(GetPodUpdatePolicyInSpec(its, oldPod, newPod)).Should(Equal(kbappsv1.PreferInPlacePodUpdatePolicyType))
+			Expect(getPodUpdatePolicyInSpec(its, oldPod, newPod)).Should(Equal(kbappsv1.PreferInPlacePodUpdatePolicyType))
 
 			strictInPlaceITS := builder.NewInstanceSetBuilder(namespace, name).
 				SetPodUpdatePolicy(kbappsv1.ReCreatePodUpdatePolicyType).
 				SetPodUpgradePolicy(kbappsv1.StrictInPlacePodUpdatePolicyType).
 				GetObject()
-			Expect(GetPodUpdatePolicyInSpec(strictInPlaceITS, oldPod, newPod)).Should(Equal(kbappsv1.StrictInPlacePodUpdatePolicyType))
+			Expect(getPodUpdatePolicyInSpec(strictInPlaceITS, oldPod, newPod)).Should(Equal(kbappsv1.StrictInPlacePodUpdatePolicyType))
 
 			labelChangedPod := newPod.DeepCopy()
 			labelChangedPod.Labels["extra"] = "true"
-			Expect(GetPodUpdatePolicyInSpec(its, oldPod, labelChangedPod)).Should(Equal(kbappsv1.ReCreatePodUpdatePolicyType))
+			Expect(getPodUpdatePolicyInSpec(its, oldPod, labelChangedPod)).Should(Equal(kbappsv1.ReCreatePodUpdatePolicyType))
 
 			appChangedPod := oldPod.DeepCopy()
 			appChangedPod.Spec.Containers[0].Image = "docker.io/apecloud/redis:7.4"
-			Expect(GetPodUpdatePolicyInSpec(its, oldPod, appChangedPod)).Should(Equal(kbappsv1.ReCreatePodUpdatePolicyType))
+			Expect(getPodUpdatePolicyInSpec(its, oldPod, appChangedPod)).Should(Equal(kbappsv1.ReCreatePodUpdatePolicyType))
 		})
 	})
 

--- a/pkg/controller/instanceset/instance_util.go
+++ b/pkg/controller/instanceset/instance_util.go
@@ -555,7 +555,7 @@ func buildInstanceTemplateRevision(template *corev1.PodTemplateSpec, parent *wor
 	if mutateTemplateFn != nil {
 		mutateTemplateFn(templateCopy)
 	}
-	podTemplate := filterInPlaceFields(templateCopy)
+	podTemplate := FilterInPlaceFields(templateCopy)
 	its := builder.NewInstanceSetBuilder(parent.Namespace, parent.Name).
 		SetUID(parent.UID).
 		AddAnnotationsInMap(parent.Annotations).

--- a/pkg/controller/instanceset/instance_util.go
+++ b/pkg/controller/instanceset/instance_util.go
@@ -555,7 +555,7 @@ func buildInstanceTemplateRevision(template *corev1.PodTemplateSpec, parent *wor
 	if mutateTemplateFn != nil {
 		mutateTemplateFn(templateCopy)
 	}
-	podTemplate := FilterInPlaceFields(templateCopy)
+	podTemplate := filterInPlaceFields(templateCopy)
 	its := builder.NewInstanceSetBuilder(parent.Namespace, parent.Name).
 		SetUID(parent.UID).
 		AddAnnotationsInMap(parent.Annotations).

--- a/pkg/controller/lifecycle/kbagent.go
+++ b/pkg/controller/lifecycle/kbagent.go
@@ -417,6 +417,10 @@ func (a *kbagent) selectTargetPods(spec *appsv1.Action) ([]*corev1.Pod, error) {
 func (a *kbagent) serverEndpoint(pod *corev1.Pod) (string, int32, error) {
 	port, err := intctrlutil.GetPortByName(*pod, kbagt.ContainerName, kbagt.DefaultHTTPPortName)
 	if err != nil {
+		// pods created before the port rename still carry the legacy name
+		port, err = intctrlutil.GetPortByName(*pod, kbagt.ContainerName, kbagt.LegacyHTTPPortName)
+	}
+	if err != nil {
 		// has no kb-agent defined
 		return "", 0, nil
 	}

--- a/pkg/controller/lifecycle/lifecycle_test.go
+++ b/pkg/controller/lifecycle/lifecycle_test.go
@@ -36,6 +36,7 @@ import (
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
+	kbagt "github.com/apecloud/kubeblocks/pkg/kbagent"
 	kbacli "github.com/apecloud/kubeblocks/pkg/kbagent/client"
 	"github.com/apecloud/kubeblocks/pkg/kbagent/proto"
 )
@@ -866,6 +867,48 @@ var _ = Describe("lifecycle", func() {
 
 		It("timeout", func() {
 			// TODO: impl
+		})
+	})
+
+	Context("kbagent server endpoint", func() {
+		endpointPod := func(portName string, port int32) *corev1.Pod {
+			return &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "pod-endpoint-0",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: kbagt.ContainerName,
+						Ports: []corev1.ContainerPort{
+							{Name: portName, ContainerPort: port},
+						},
+					}},
+				},
+				Status: corev1.PodStatus{PodIP: "10.0.0.1"},
+			}
+		}
+
+		It("resolves the current port name", func() {
+			pod := endpointPod(kbagt.DefaultHTTPPortName, 3501)
+			_, port, err := (&kbagent{}).serverEndpoint(pod)
+			Expect(err).Should(BeNil())
+			Expect(port).Should(Equal(int32(3501)))
+		})
+
+		It("falls back to the legacy port name for pods created before the rename", func() {
+			pod := endpointPod(kbagt.LegacyHTTPPortName, 3501)
+			_, port, err := (&kbagent{}).serverEndpoint(pod)
+			Expect(err).Should(BeNil())
+			Expect(port).Should(Equal(int32(3501)))
+		})
+
+		It("treats pods without kbagent ports as agent-less", func() {
+			pod := endpointPod("other", 3501)
+			host, port, err := (&kbagent{}).serverEndpoint(pod)
+			Expect(err).Should(BeNil())
+			Expect(host).Should(BeEmpty())
+			Expect(port).Should(Equal(int32(0)))
 		})
 	})
 })

--- a/pkg/controllerutil/host_port_manager.go
+++ b/pkg/controllerutil/host_port_manager.go
@@ -30,6 +30,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
@@ -50,14 +51,18 @@ var (
 	defaultPortManager PortManager
 )
 
-func GetPortManager(network *appsv1.ComponentNetwork) PortManager {
+// GetPortManager returns the port manager for a component. componentPortNames
+// holds the port names declared by the component's own (non-kbagent)
+// containers; the legacy kbagent port-name aliases are disabled for names that
+// belong to a real component port.
+func GetPortManager(network *appsv1.ComponentNetwork, componentPortNames sets.Set[string]) PortManager {
 	if network == nil || !network.HostNetwork || len(network.HostPorts) == 0 {
 		return defaultPortManager
 	}
 	if defaultPortManager == nil {
-		return newDefinedPortManager(nil, network.HostPorts)
+		return newDefinedPortManager(nil, network.HostPorts, componentPortNames)
 	}
-	return newDefinedPortManager(defaultPortManager.(*portManager), network.HostPorts)
+	return newDefinedPortManager(defaultPortManager.(*portManager), network.HostPorts, componentPortNames)
 }
 
 func InitDefaultHostPortManager(cli client.Client) error {
@@ -383,6 +388,9 @@ func (m *portManager) ReleaseByPrefix(prefix string) error {
 type definedPortManager struct {
 	defaultPortManager *portManager
 	hostPorts          map[string]int32
+	// componentPortNames are port names owned by the component's own
+	// containers; a legacy kbagent alias must not consume their mappings.
+	componentPortNames sets.Set[string]
 }
 
 func (m *definedPortManager) PortKey(clusterName, compName, containerName, portName string) string {
@@ -459,6 +467,11 @@ func (m *definedPortManager) definedKBAgentPort(portName string) (int32, bool) {
 		return port, true
 	}
 	if legacy, ok := kbagentLegacyPortNames[portName]; ok {
+		// a mapping under the legacy name is only a kbagent alias when the
+		// name cannot refer to a real component port
+		if m.componentPortNames.Has(legacy) {
+			return 0, false
+		}
 		if port, ok := m.hostPorts[legacy]; ok {
 			return port, true
 		}
@@ -491,7 +504,7 @@ func (m *definedPortManager) isKBAgentPortNNotDefinedInKey(key string) bool {
 	return false
 }
 
-func newDefinedPortManager(defaultPortManager *portManager, hostPorts []appsv1.HostPort) *definedPortManager {
+func newDefinedPortManager(defaultPortManager *portManager, hostPorts []appsv1.HostPort, componentPortNames sets.Set[string]) *definedPortManager {
 	hostPortsMap := make(map[string]int32)
 	for _, hp := range hostPorts {
 		hostPortsMap[hp.Name] = hp.Port
@@ -499,5 +512,6 @@ func newDefinedPortManager(defaultPortManager *portManager, hostPorts []appsv1.H
 	return &definedPortManager{
 		defaultPortManager: defaultPortManager,
 		hostPorts:          hostPortsMap,
+		componentPortNames: componentPortNames,
 	}
 }

--- a/pkg/controllerutil/host_port_manager.go
+++ b/pkg/controllerutil/host_port_manager.go
@@ -449,6 +449,13 @@ var kbagentLegacyPortNames = map[string]string{
 	kbagent.DefaultStreamingPortName: kbagent.LegacyStreamingPortName,
 }
 
+var kbagentContainerPortNames = [...]string{
+	kbagent.DefaultHTTPPortName,
+	kbagent.DefaultStreamingPortName,
+	kbagent.LegacyHTTPPortName,
+	kbagent.LegacyStreamingPortName,
+}
+
 // legacyKBAgentPortKey rewrites an allocation key that refers to a kbagent
 // port by its current name into the key used before the port rename, or
 // returns "" when the key does not refer to a kbagent port.
@@ -463,7 +470,15 @@ func legacyKBAgentPortKey(key string) string {
 }
 
 func (m *definedPortManager) isKBAgentPort(containerName, portName string) bool {
-	return containerName == kbagent.ContainerName && (portName == kbagent.DefaultHTTPPortName || portName == kbagent.DefaultStreamingPortName)
+	if containerName != kbagent.ContainerName {
+		return false
+	}
+	for _, name := range kbagentContainerPortNames {
+		if portName == name {
+			return true
+		}
+	}
+	return false
 }
 
 // definedKBAgentPort resolves a user-defined host port for a kbagent port
@@ -503,7 +518,7 @@ func (m *definedPortManager) isKBAgentPortNNotDefined(containerName, portName st
 func (m *definedPortManager) isKBAgentPortNNotDefinedInKey(key string) bool {
 	// the port names contain dashes, so match the "<container>-<port>" key
 	// suffix instead of splitting the key
-	for _, portName := range []string{kbagent.DefaultHTTPPortName, kbagent.DefaultStreamingPortName} {
+	for _, portName := range kbagentContainerPortNames {
 		if strings.HasSuffix(key, fmt.Sprintf("-%s-%s", kbagent.ContainerName, portName)) {
 			return m.isKBAgentPortNNotDefined(kbagent.ContainerName, portName)
 		}

--- a/pkg/controllerutil/host_port_manager.go
+++ b/pkg/controllerutil/host_port_manager.go
@@ -429,7 +429,14 @@ func (m *definedPortManager) AllocatePort(key string) (int32, error) {
 }
 
 func (m *definedPortManager) ReleaseByPrefix(prefix string) error {
-	if m.hasKBAgentPortDefined() {
+	// Release must not depend on legacy-alias resolution: the deletion path
+	// builds this manager without the component-port context, so
+	// hasKBAgentPortDefined() can resolve aliases differently from allocation
+	// and skip entries the default manager actually allocated (leaking host
+	// ports). Dynamic allocations live only in the default manager and are
+	// keyed by the component prefix, so releasing unconditionally is safe and
+	// idempotent: fully user-defined setups simply have no entries there.
+	if m.defaultPortManager == nil {
 		return nil
 	}
 	return m.defaultPortManager.ReleaseByPrefix(prefix)

--- a/pkg/controllerutil/host_port_manager.go
+++ b/pkg/controllerutil/host_port_manager.go
@@ -327,6 +327,21 @@ func (m *portManager) AllocatePort(key string) (int32, error) {
 		return port, nil
 	}
 
+	// adopt an allocation recorded under the legacy kbagent port-name key, so
+	// that workloads created before the port rename keep their numeric ports
+	if legacyKey := legacyKBAgentPortKey(key); legacyKey != "" {
+		if value, ok := m.cm.Data[legacyKey]; ok {
+			port, err := m.parsePort(value)
+			if err != nil {
+				return 0, err
+			}
+			if err := m.update(key, port); err != nil {
+				return 0, err
+			}
+			return port, nil
+		}
+	}
+
 	if len(m.used) >= int(m.to-m.from)+1 {
 		return 0, fmt.Errorf("no available port: %s", key)
 	}
@@ -381,6 +396,9 @@ func (m *definedPortManager) GetPort(key string) (int32, error) {
 	if m.isKBAgentPortNNotDefinedInKey(key) {
 		return m.defaultPortManager.GetPort(key)
 	}
+	if port, ok := m.definedKBAgentPort(key); ok {
+		return port, nil
+	}
 	return m.hostPorts[key], nil
 }
 
@@ -392,8 +410,7 @@ func (m *definedPortManager) UsePort(key string, port int32) error {
 }
 
 func (m *definedPortManager) AllocatePort(key string) (int32, error) {
-	port, ok := m.hostPorts[key]
-	if ok {
+	if port, ok := m.definedKBAgentPort(key); ok {
 		return port, nil
 	}
 	if m.isKBAgentPortNNotDefinedInKey(key) {
@@ -410,27 +427,68 @@ func (m *definedPortManager) ReleaseByPrefix(prefix string) error {
 	return m.defaultPortManager.ReleaseByPrefix(prefix)
 }
 
+// kbagentLegacyPortNames maps the current kbagent port names to the names used
+// before the rename, which existing specs may still reference.
+var kbagentLegacyPortNames = map[string]string{
+	kbagent.DefaultHTTPPortName:      kbagent.LegacyHTTPPortName,
+	kbagent.DefaultStreamingPortName: kbagent.LegacyStreamingPortName,
+}
+
+// legacyKBAgentPortKey rewrites an allocation key that refers to a kbagent
+// port by its current name into the key used before the port rename, or
+// returns "" when the key does not refer to a kbagent port.
+func legacyKBAgentPortKey(key string) string {
+	for portName, legacy := range kbagentLegacyPortNames {
+		suffix := fmt.Sprintf("-%s-%s", kbagent.ContainerName, portName)
+		if strings.HasSuffix(key, suffix) {
+			return strings.TrimSuffix(key, suffix) + fmt.Sprintf("-%s-%s", kbagent.ContainerName, legacy)
+		}
+	}
+	return ""
+}
+
 func (m *definedPortManager) isKBAgentPort(containerName, portName string) bool {
 	return containerName == kbagent.ContainerName && (portName == kbagent.DefaultHTTPPortName || portName == kbagent.DefaultStreamingPortName)
 }
 
+// definedKBAgentPort resolves a user-defined host port for a kbagent port
+// name, accepting the legacy name as an alias for specs written before the
+// kbagent ports were renamed.
+func (m *definedPortManager) definedKBAgentPort(portName string) (int32, bool) {
+	if port, ok := m.hostPorts[portName]; ok {
+		return port, true
+	}
+	if legacy, ok := kbagentLegacyPortNames[portName]; ok {
+		if port, ok := m.hostPorts[legacy]; ok {
+			return port, true
+		}
+	}
+	return 0, false
+}
+
 func (m *definedPortManager) hasKBAgentPortDefined() bool {
-	_, http := m.hostPorts[kbagent.DefaultHTTPPortName]
-	_, stream := m.hostPorts[kbagent.DefaultStreamingPortName]
+	_, http := m.definedKBAgentPort(kbagent.DefaultHTTPPortName)
+	_, stream := m.definedKBAgentPort(kbagent.DefaultStreamingPortName)
 	return http && stream
 }
 
 func (m *definedPortManager) isKBAgentPortNNotDefined(containerName, portName string) bool {
-	_, defined := m.hostPorts[portName]
-	return m.isKBAgentPort(containerName, portName) && !defined
+	if !m.isKBAgentPort(containerName, portName) {
+		return false
+	}
+	_, defined := m.definedKBAgentPort(portName)
+	return !defined
 }
 
 func (m *definedPortManager) isKBAgentPortNNotDefinedInKey(key string) bool {
-	subs := strings.Split(key, "-")
-	if len(subs) < 4 {
-		return false
+	// the port names contain dashes, so match the "<container>-<port>" key
+	// suffix instead of splitting the key
+	for _, portName := range []string{kbagent.DefaultHTTPPortName, kbagent.DefaultStreamingPortName} {
+		if strings.HasSuffix(key, fmt.Sprintf("-%s-%s", kbagent.ContainerName, portName)) {
+			return m.isKBAgentPortNNotDefined(kbagent.ContainerName, portName)
+		}
 	}
-	return m.isKBAgentPortNNotDefined(subs[len(subs)-2], subs[len(subs)-1])
+	return false
 }
 
 func newDefinedPortManager(defaultPortManager *portManager, hostPorts []appsv1.HostPort) *definedPortManager {

--- a/pkg/controllerutil/host_port_manager_test.go
+++ b/pkg/controllerutil/host_port_manager_test.go
@@ -320,6 +320,44 @@ var _ = Describe("host port manager test", func() {
 			Expect(port).Should(Equal(int32(30001)))
 			Expect(dataCM).Should(HaveKeyWithValue(key, "30001"))
 		})
+
+		It("release - deletion-path nil context still releases default-manager allocations", func() {
+			// allocation side: the component owns real ports named "http" and
+			// "streaming", so both legacy aliases are suppressed and the two
+			// kbagent ports are dynamically allocated in the default manager.
+			// unique cluster/comp names keep this spec independent from the
+			// allocations other specs may have recorded in the shared manager
+			delCluster, delComp := "del-cluster", "del-comp"
+			aliasNetwork := &appsv1.ComponentNetwork{
+				HostNetwork: true,
+				HostPorts: []appsv1.HostPort{
+					{Name: kbagent.LegacyHTTPPortName, Port: 7001},
+					{Name: kbagent.LegacyStreamingPortName, Port: 7002},
+				},
+			}
+			alloc := GetPortManager(aliasNetwork, sets.New(kbagent.LegacyHTTPPortName, kbagent.LegacyStreamingPortName))
+			cmData := func() map[string]string {
+				return alloc.(*definedPortManager).defaultPortManager.cm.Data
+			}
+			for _, pn := range []string{kbagent.DefaultHTTPPortName, kbagent.DefaultStreamingPortName} {
+				key := alloc.PortKey(delCluster, delComp, kbagent.ContainerName, pn)
+				_, err := alloc.AllocatePort(key)
+				Expect(err).Should(BeNil())
+				Expect(cmData()).Should(HaveKey(key))
+			}
+
+			// deletion side: the component-port context is unavailable (nil),
+			// so the legacy aliases resolve and hasKBAgentPortDefined() is
+			// true — release must not consult alias resolution and still has
+			// to remove the default-manager allocations, or the host ports
+			// leak forever
+			del := GetPortManager(aliasNetwork, nil)
+			Expect(del.ReleaseByPrefix(fmt.Sprintf("%s-%s", delCluster, delComp))).Should(Succeed())
+			for _, pn := range []string{kbagent.DefaultHTTPPortName, kbagent.DefaultStreamingPortName} {
+				key := alloc.PortKey(delCluster, delComp, kbagent.ContainerName, pn)
+				Expect(cmData()).ShouldNot(HaveKey(key))
+			}
+		})
 	})
 
 	Context("defined host-port manager - legacy kbagent port names", func() {

--- a/pkg/controllerutil/host_port_manager_test.go
+++ b/pkg/controllerutil/host_port_manager_test.go
@@ -231,6 +231,19 @@ var _ = Describe("host port manager test", func() {
 			Expect(port).Should(Equal(minPort))
 		})
 
+		It("dynamically allocates an actual legacy kbagent port name", func() {
+			legacyManager := GetPortManager(network, sets.New(kbagent.DefaultHTTPPortName))
+			key := legacyManager.PortKey(clusterName, compName, kbagent.ContainerName, kbagent.LegacyHTTPPortName)
+			Expect(key).Should(Equal(fmt.Sprintf("%s-%s-%s-%s", clusterName, compName,
+				kbagent.ContainerName, kbagent.LegacyHTTPPortName)))
+
+			port, err := legacyManager.AllocatePort(key)
+			Expect(err).Should(BeNil())
+			Expect(port).Should(BeNumerically(">=", minPort))
+			Expect(port).Should(BeNumerically("<=", maxPort))
+			Expect(dataCM).Should(HaveKeyWithValue(key, fmt.Sprintf("%d", port)))
+		})
+
 		It("allocate port - not defined", func() {
 			errPortName := fmt.Sprintf("%s-not-defined", portName)
 			key := manager.PortKey(clusterName, compName, containerName, errPortName)
@@ -389,6 +402,14 @@ var _ = Describe("host port manager test", func() {
 
 		It("allocate port via legacy alias", func() {
 			key := manager.PortKey(clusterName, compName, kbagent.ContainerName, kbagent.DefaultHTTPPortName)
+			port, err := manager.AllocatePort(key)
+			Expect(err).Should(BeNil())
+			Expect(port).Should(Equal(int32(kbagent.DefaultHTTPPort)))
+		})
+
+		It("allocates an explicitly defined actual legacy port name", func() {
+			key := manager.PortKey(clusterName, compName, kbagent.ContainerName, kbagent.LegacyHTTPPortName)
+			Expect(key).Should(Equal(kbagent.LegacyHTTPPortName))
 			port, err := manager.AllocatePort(key)
 			Expect(err).Should(BeNil())
 			Expect(port).Should(Equal(int32(kbagent.DefaultHTTPPort)))

--- a/pkg/controllerutil/host_port_manager_test.go
+++ b/pkg/controllerutil/host_port_manager_test.go
@@ -27,6 +27,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
@@ -69,7 +70,7 @@ var _ = Describe("host port manager test", func() {
 
 		BeforeEach(func() {
 			defaultPortManager = nil
-			manager = GetPortManager(network)
+			manager = GetPortManager(network, nil)
 		})
 
 		AfterEach(func() {
@@ -197,7 +198,7 @@ var _ = Describe("host port manager test", func() {
 			err := InitDefaultHostPortManager(mockClient.Client())
 			Expect(err).ShouldNot(HaveOccurred())
 
-			manager = GetPortManager(network)
+			manager = GetPortManager(network, nil)
 			Expect(manager).ShouldNot(BeNil())
 			definedPortManagerInst = manager.(*definedPortManager)
 		})
@@ -340,7 +341,7 @@ var _ = Describe("host port manager test", func() {
 
 		BeforeEach(func() {
 			defaultPortManager = nil
-			manager = GetPortManager(network)
+			manager = GetPortManager(network, nil)
 		})
 
 		It("port key resolves the legacy mapping as defined", func() {
@@ -364,6 +365,24 @@ var _ = Describe("host port manager test", func() {
 
 		It("treats both kbagent ports as defined via legacy names", func() {
 			Expect(manager.(*definedPortManager).hasKBAgentPortDefined()).Should(BeTrue())
+		})
+
+		It("does not treat a real component port name as a kbagent alias", func() {
+			// an engine that declares its own "http" port owns the "http"
+			// mapping; kbagent must not consume it as a legacy alias
+			scoped := GetPortManager(network, sets.New(kbagent.LegacyHTTPPortName))
+			pm := scoped.(*definedPortManager)
+
+			_, defined := pm.definedKBAgentPort(kbagent.DefaultHTTPPortName)
+			Expect(defined).Should(BeFalse())
+
+			// streaming is not a component port, the alias still applies
+			port, defined := pm.definedKBAgentPort(kbagent.DefaultStreamingPortName)
+			Expect(defined).Should(BeTrue())
+			Expect(port).Should(Equal(int32(kbagent.DefaultStreamingPort)))
+
+			// with one alias suppressed, kbagent ports are no longer fully defined
+			Expect(pm.hasKBAgentPortDefined()).Should(BeFalse())
 		})
 	})
 })

--- a/pkg/controllerutil/host_port_manager_test.go
+++ b/pkg/controllerutil/host_port_manager_test.go
@@ -307,5 +307,63 @@ var _ = Describe("host port manager test", func() {
 			Expect(err).Should(BeNil())
 			Expect(dataCM).Should(BeEmpty())
 		})
+
+		It("allocate port - kbagent adopts allocation recorded under legacy port name", func() {
+			legacyKey := fmt.Sprintf("%s-%s-%s-%s", clusterName, compName, kbagent.ContainerName, kbagent.LegacyHTTPPortName)
+			err := definedPortManagerInst.defaultPortManager.UsePort(legacyKey, int32(30001))
+			Expect(err).Should(BeNil())
+
+			key := manager.PortKey(clusterName, compName, kbagent.ContainerName, kbagent.DefaultHTTPPortName)
+			port, err := manager.AllocatePort(key)
+			Expect(err).Should(BeNil())
+			Expect(port).Should(Equal(int32(30001)))
+			Expect(dataCM).Should(HaveKeyWithValue(key, "30001"))
+		})
+	})
+
+	Context("defined host-port manager - legacy kbagent port names", func() {
+		var (
+			network = &appsv1.ComponentNetwork{
+				HostNetwork: true,
+				HostPorts: []appsv1.HostPort{
+					{
+						Name: kbagent.LegacyHTTPPortName,
+						Port: kbagent.DefaultHTTPPort,
+					},
+					{
+						Name: kbagent.LegacyStreamingPortName,
+						Port: kbagent.DefaultStreamingPort,
+					},
+				},
+			}
+		)
+
+		BeforeEach(func() {
+			defaultPortManager = nil
+			manager = GetPortManager(network)
+		})
+
+		It("port key resolves the legacy mapping as defined", func() {
+			key := manager.PortKey(clusterName, compName, kbagent.ContainerName, kbagent.DefaultHTTPPortName)
+			Expect(key).To(Equal(kbagent.DefaultHTTPPortName))
+		})
+
+		It("allocate port via legacy alias", func() {
+			key := manager.PortKey(clusterName, compName, kbagent.ContainerName, kbagent.DefaultHTTPPortName)
+			port, err := manager.AllocatePort(key)
+			Expect(err).Should(BeNil())
+			Expect(port).Should(Equal(int32(kbagent.DefaultHTTPPort)))
+		})
+
+		It("get port via legacy alias", func() {
+			key := manager.PortKey(clusterName, compName, kbagent.ContainerName, kbagent.DefaultStreamingPortName)
+			port, err := manager.GetPort(key)
+			Expect(err).Should(BeNil())
+			Expect(port).Should(Equal(int32(kbagent.DefaultStreamingPort)))
+		})
+
+		It("treats both kbagent ports as defined via legacy names", func() {
+			Expect(manager.(*definedPortManager).hasKBAgentPortDefined()).Should(BeTrue())
+		})
 	})
 })

--- a/pkg/kbagent/setup.go
+++ b/pkg/kbagent/setup.go
@@ -40,8 +40,17 @@ const (
 	ContainerName4Worker = "kbagent-worker"
 	InitContainerName    = "init-kbagent"
 
-	DefaultHTTPPortName      = "http"
-	DefaultStreamingPortName = "streaming"
+	// Injected container port names are prefixed to keep port names unique
+	// within the pod, as required by the Kubernetes API contract for
+	// ContainerPort.Name; generic names like "http" collide with engine
+	// runtime container ports (e.g. Elasticsearch).
+	DefaultHTTPPortName      = "kba-http"
+	DefaultStreamingPortName = "kba-streaming"
+
+	// Legacy port names carried by pods created before the rename; consumers
+	// that resolve ports from live pod specs fall back to them during upgrade.
+	LegacyHTTPPortName      = "http"
+	LegacyStreamingPortName = "streaming"
 
 	DefaultHTTPPort      = 3501
 	DefaultStreamingPort = 3502


### PR DESCRIPTION
## Summary

Implements the direction from #10506 using the Kubernetes API contract: `ContainerPort.Name` must be unique within a Pod. kbagent previously injected `http` / `streaming` into every component Pod, which can collide with engine runtime ports and make named `targetPort` resolution container-order-dependent.

## Changes

- Rename injected kbagent ports to `kba-http` / `kba-streaming` for new workloads.
- Establish `kba-http` and `kba-streaming` as globally reserved names in `ComponentDefinition.spec.runtime`, independent of the definition's current action set. The controller always validates this public contract; it no longer mirrors synthesis-internal action predicates. CRD, Helm CRD, and API reference generation are updated with the same contract.
- Preserve upgrade compatibility with a controller-owned, generation-scoped status proof. An old current-generation `Available` definition may persist the proof during validation/status migration, while synthesis uses only the durable status bit.
- Keep existing workload templates on their live legacy aliases until InstanceSet owns an explicit migration contract. The apps controller does not predict rollout behavior from InstanceSet internals or feature gates.
- Repair invalid historical templates: if a non-kbagent container already occupies a legacy alias, the preferred kbagent name wins instead of preserving the collision.
- Keep the InstanceSet update classifier and recreate-relevant template filter package-private because they have no external-package callers.
- Resolve live-Pod consumers using the preferred name first and the legacy name as compatibility fallback.
- Preserve hostNetwork compatibility by adopting legacy-key allocations only when the application does not own the alias and by rewriting the allocated numeric ports into kbagent args and startup probes.

## Contract coverage

- new workload uses preferred names
- new or changed definitions reject globally reserved names even when they currently declare no actions
- existing valid legacy workload keeps legacy names across image, resource, command, and feature-gate combinations
- existing invalid legacy collision self-heals to the preferred name
- old `Available` current-generation definitions may persist a compatibility proof
- synthesis requires the durable proof; `Available` phase alone is insufficient
- generation change clears compatibility and remains rejected on the next reconcile
- preferred+legacy double occupancy fails closed
- lifecycle and streaming consumers support both preferred and legacy live-Pod names
- hostNetwork allocation covers preferred names, actual legacy names, legacy-key adoption, conditional aliases, args/probe rewrite, and cleanup isolation

## Tests

Current exact head validation with Kubernetes 1.26.1 envtest assets:

- full `go test`:
  - `./controllers/apps`
  - `./controllers/apps/component`
  - `./pkg/controller/component`
  - `./pkg/controller/instanceset`
- focused `-race` for the ComponentDefinition, Component, synthesis, and InstanceSet compatibility scopes
- targeted `go vet` for the touched packages
- `make generate`, `make manifests`, `make doc`, `make test-go-generate`
- `git diff --check`

Runtime validation is not claimed; current exact head runtime N=0.

Fixes #10506.

Related: #10502, #10505.


## Compatibility / release note

- **Spec-only GitOps replay of an old ComponentDefinition fails closed by design.** The upgrade-compatibility proof is a controller-owned, generation-scoped *status* bit. Re-applying only the spec of a pre-upgrade definition (e.g. from a GitOps repo that does not carry status) does not reproduce that proof, so a definition that declares the now-reserved `kba-http` / `kba-streaming` names is rejected instead of silently falling back to legacy aliases. Recovery is explicit: rename the conflicting ports in the definition. Existing running workloads are unaffected; they keep their live legacy aliases.
- **SidecarDefinition port-name reservation is enforced at synthesis time**, not at SidecarDefinition admission. A sidecar declaring a reserved name becomes visible as a component synthesis error on the consuming component rather than as a rejection of the SidecarDefinition object itself.
