### PR TITLE
fix(ops): fail rebuild ops for non-existent instances

### DIFF
--- a/pkg/operations/rebuild_instance.go
+++ b/pkg/operations/rebuild_instance.go
@@ -101,6 +101,11 @@ func (r rebuildInstanceOpsHandler) Action(reqCtx intctrlutil.RequestCtx, cli cli
 			}
 			targetInstance, err := runtime.GetInstance(opsRes.Cluster.Namespace, opsRes.Cluster.Name, v.ComponentName, ins.Name)
 			if err != nil {
+				if apierrors.IsNotFound(err) {
+					// neither a Pod nor a retained PVC exists for this name, so
+					// retrying the same input can never converge
+					return intctrlutil.NewFatalError(fmt.Sprintf(`instance "%s" not found`, ins.Name))
+				}
 				return err
 			}
 			synthesizedComp, err = r.buildSynthesizedComponent(reqCtx.Ctx, cli, opsRes.Cluster, targetInstance.GetComponentName())

--- a/pkg/operations/rebuild_instance_test.go
+++ b/pkg/operations/rebuild_instance_test.go
@@ -180,6 +180,29 @@ var _ = Describe("OpsUtil functions", func() {
 			return pvs
 		}
 
+		It("fails rebuild OpsRequest when the instance does not exist", func() {
+			By("init operations resources")
+			opsRes := prepareOpsRes("", true)
+			reqCtx := intctrlutil.RequestCtx{Ctx: testCtx.Ctx}
+
+			By("fake component phase to Failed so the phase gate passes")
+			Expect(testapps.ChangeObjStatus(&testCtx, opsRes.Cluster, func() {
+				compStatus := opsRes.Cluster.Status.Components[defaultCompName]
+				compStatus.Phase = appsv1.FailedComponentPhase
+				opsRes.Cluster.Status.Components[defaultCompName] = compStatus
+			})).Should(Succeed())
+
+			By("create a rebuild ops naming an instance with no pod and no retained PVC")
+			missingName := fmt.Sprintf("%s-%s-99", clusterName, defaultCompName)
+			opsRes.OpsRequest = createRebuildInstanceOps("", true, missingName)
+			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsCreatingPhase
+
+			By("expect terminal failure instead of endless retry")
+			_, _ = GetOpsManager().Do(reqCtx, k8sClient, opsRes)
+			Expect(opsRes.OpsRequest.Status.Phase).Should(Equal(opsv1alpha1.OpsFailedPhase))
+			Expect(opsRes.OpsRequest.Status.Conditions[0].Message).Should(ContainSubstring(fmt.Sprintf(`instance "%s" not found`, missingName)))
+		})
+
 		It("test rebuild instance when cluster/component are mismatched", func() {
 			By("init operations resources ")
 			opsRes := prepareOpsRes("", true)


### PR DESCRIPTION
## Problem

`rebuildInstancePreCheck` resolves each requested instance via `runtime.GetInstance` and returns the raw Kubernetes `NotFound` error. The Ops manager treats non-fatal errors as retryable, so an OpsRequest naming a nonexistent instance retries the same unresolvable input forever and stays in `Creating` — the same failure shape as #10456 (switchover), fixed by #10455.

`GetInstance` returns `NotFound` only when neither a Pod nor a retained PVC exists for the name, so retrying cannot converge.

## Changes

- Convert instance `NotFound` during rebuild precheck into a fatal Ops error, so the OpsRequest reaches terminal `Failed` with `instance "<name>" not found`.
- Progress-phase lookups are intentionally unchanged: `scaledOutInstance` absence during scale-out (rebuild_instance.go:493) is a legitimate transient and keeps retry semantics.
- Regression test: rebuild ops naming an instance with no pod and no retained PVC terminal-fails.

Fixes #10509.

## Tests

- `go test ./pkg/operations -count=1` with envtest assets (passes)