### PR TITLE
fix: map renamed template fields for natively-v1 ComponentDefinitions

### DIFF
--- a/apis/apps/v1alpha1/componentdefinition_conversion.go
+++ b/apis/apps/v1alpha1/componentdefinition_conversion.go
@@ -62,6 +62,17 @@ func (r *ComponentDefinition) ConvertFrom(srcRaw conversion.Hub) error {
 	if err := copier.Copy(&r.Spec, &src.Spec); err != nil {
 		return err
 	}
+	// The field was renamed between versions (v1 `template` vs v1alpha1
+	// `templateRef`), so the name-based copy above cannot map it. For objects
+	// created natively as v1 there is no increment-converter annotation to
+	// restore it from, so map it from the source here; the annotation path
+	// below still takes precedence for round-tripped v1alpha1 objects.
+	for i := range src.Spec.Configs {
+		r.Spec.Configs[i].TemplateRef = src.Spec.Configs[i].Template
+	}
+	for i := range src.Spec.Scripts {
+		r.Spec.Scripts[i].TemplateRef = src.Spec.Scripts[i].Template
+	}
 	if err := incrementConvertFrom(r, src, &componentDefinitionConverter{}); err != nil {
 		return err
 	}

--- a/apis/apps/v1alpha1/componentdefinition_conversion.go
+++ b/apis/apps/v1alpha1/componentdefinition_conversion.go
@@ -67,10 +67,10 @@ func (r *ComponentDefinition) ConvertFrom(srcRaw conversion.Hub) error {
 	// created natively as v1 there is no increment-converter annotation to
 	// restore it from, so map it from the source here; the annotation path
 	// below still takes precedence for round-tripped v1alpha1 objects.
-	for i := range src.Spec.Configs {
+	for i := 0; i < len(src.Spec.Configs) && i < len(r.Spec.Configs); i++ {
 		r.Spec.Configs[i].TemplateRef = src.Spec.Configs[i].Template
 	}
-	for i := range src.Spec.Scripts {
+	for i := 0; i < len(src.Spec.Scripts) && i < len(r.Spec.Scripts); i++ {
 		r.Spec.Scripts[i].TemplateRef = src.Spec.Scripts[i].Template
 	}
 	if err := incrementConvertFrom(r, src, &componentDefinitionConverter{}); err != nil {
@@ -117,10 +117,10 @@ func (r *ComponentDefinition) incrementConvertTo(dstRaw metav1.Object) (incremen
 			}
 		}
 	}
-	for i := range r.Spec.Scripts {
+	for i := 0; i < len(r.Spec.Scripts) && i < len(dstObj.Spec.Scripts); i++ {
 		dstObj.Spec.Scripts[i].Template = r.Spec.Scripts[i].TemplateRef
 	}
-	for i := range r.Spec.Configs {
+	for i := 0; i < len(r.Spec.Configs) && i < len(dstObj.Spec.Configs); i++ {
 		dstObj.Spec.Configs[i].Template = r.Spec.Configs[i].TemplateRef
 	}
 	// changed

--- a/apis/apps/v1alpha1/componentdefinition_conversion_test.go
+++ b/apis/apps/v1alpha1/componentdefinition_conversion_test.go
@@ -1,0 +1,101 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+)
+
+func TestComponentDefinitionConvertFromMapsNativeV1Templates(t *testing.T) {
+	// a ComponentDefinition created natively as v1 carries no
+	// increment-converter annotation, so the renamed template fields must be
+	// mapped from the v1 source directly
+	src := &appsv1.ComponentDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "postgresql",
+		},
+		Spec: appsv1.ComponentDefinitionSpec{
+			Configs: []appsv1.ComponentFileTemplate{{
+				Name:     "postgresql-configuration",
+				Template: "postgresql-configuration-tpl",
+			}},
+			Scripts: []appsv1.ComponentFileTemplate{{
+				Name:     "postgresql-scripts",
+				Template: "postgresql-scripts-tpl",
+			}},
+		},
+	}
+
+	dst := &ComponentDefinition{}
+	if err := dst.ConvertFrom(src); err != nil {
+		t.Fatalf("ConvertFrom: %v", err)
+	}
+	if len(dst.Spec.Configs) != 1 || dst.Spec.Configs[0].TemplateRef != "postgresql-configuration-tpl" {
+		t.Fatalf("config templateRef not mapped from v1 template: %+v", dst.Spec.Configs)
+	}
+	if len(dst.Spec.Scripts) != 1 || dst.Spec.Scripts[0].TemplateRef != "postgresql-scripts-tpl" {
+		t.Fatalf("script templateRef not mapped from v1 template: %+v", dst.Spec.Scripts)
+	}
+}
+
+func TestComponentDefinitionConvertRoundTripKeepsTemplates(t *testing.T) {
+	// an object created as v1alpha1 must survive the v1 round trip through the
+	// increment-converter annotation with its templateRef intact
+	orig := &ComponentDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "postgresql",
+		},
+		Spec: ComponentDefinitionSpec{
+			Configs: []ComponentConfigSpec{{
+				ComponentTemplateSpec: ComponentTemplateSpec{
+					Name:        "postgresql-configuration",
+					TemplateRef: "postgresql-configuration-tpl",
+				},
+			}},
+			Scripts: []ComponentTemplateSpec{{
+				Name:        "postgresql-scripts",
+				TemplateRef: "postgresql-scripts-tpl",
+			}},
+		},
+	}
+
+	hub := &appsv1.ComponentDefinition{}
+	if err := orig.ConvertTo(hub); err != nil {
+		t.Fatalf("ConvertTo: %v", err)
+	}
+	if hub.Spec.Configs[0].Template != "postgresql-configuration-tpl" {
+		t.Fatalf("v1 config template not set: %+v", hub.Spec.Configs)
+	}
+
+	back := &ComponentDefinition{}
+	if err := back.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom: %v", err)
+	}
+	if back.Spec.Configs[0].TemplateRef != "postgresql-configuration-tpl" {
+		t.Fatalf("round-trip config templateRef lost: %+v", back.Spec.Configs)
+	}
+	if back.Spec.Scripts[0].TemplateRef != "postgresql-scripts-tpl" {
+		t.Fatalf("round-trip script templateRef lost: %+v", back.Spec.Scripts)
+	}
+}


### PR DESCRIPTION
## Problem

Fixes #10405.

A `ComponentDefinition` created natively with `apiVersion: apps.kubeblocks.io/v1` loses `configs[].template` / `scripts[].template` when a consumer reads it as `v1alpha1`: `ConvertFrom` uses a name-based copy (which cannot map the renamed field — v1 `template` vs v1alpha1 `templateRef`) plus the increment-converter annotation (which only exists for objects originally created as v1alpha1 and round-tripped). The v1alpha1 consumer then sees an empty `templateRef` and fails with `config/script template has no template specified`.

## Changes

- `ConvertFrom` maps `Configs[i].Template` / `Scripts[i].Template` from the v1 source into `TemplateRef` directly, before the annotation path; the annotation still takes precedence for round-tripped v1alpha1 objects (it overwrites the slices wholesale with identical values).
- Regression tests: natively-v1 object mapping, and the v1alpha1→v1→v1alpha1 round trip.

## Branch note

Targets `release-1.1` directly: main (1.2) no longer serves a v1alpha1 ComponentDefinition, so the conversion path does not exist there.

## Possible same-class follow-up

For natively-v1 objects, the annotation-gated `incrementConvertFrom` also skips the shape conversions for `Roles` (v1 `updatePriority` → v1alpha1 `writable`/`serviceable`) and `LifecycleActions`. Whether any v1alpha1 consumer depends on those fields deserves a separate check; this PR fixes the reported, evidence-backed template loss only.

## Tests

- `go test ./apis/apps/v1alpha1 -run TestComponentDefinitionConvert -count=1` (passes)