### PR TITLE
fix: its2 revision tracking

### DIFF
--- a/pkg/constant/annotations.go
+++ b/pkg/constant/annotations.go
@@ -57,6 +57,9 @@ const (
 	// NodeSelectorOnceAnnotationKey adds nodeSelector in podSpec for one pod exactly once
 	NodeSelectorOnceAnnotationKey = "workloads.kubeblocks.io/node-selector-once"
 
+	// InstanceSetRevisionAnnotationKey records the InstanceSet-managed revision carried by an Instance.
+	InstanceSetRevisionAnnotationKey = "workloads.kubeblocks.io/instance-revision"
+
 	PVCNamePrefixAnnotationKey = "apps.kubeblocks.io/pvc-name-prefix"
 
 	RestoreSourceAPIGroupAnnotationKey  = "apps.kubeblocks.io/restore-source-api-group"

--- a/pkg/constant/annotations.go
+++ b/pkg/constant/annotations.go
@@ -57,9 +57,6 @@ const (
 	// NodeSelectorOnceAnnotationKey adds nodeSelector in podSpec for one pod exactly once
 	NodeSelectorOnceAnnotationKey = "workloads.kubeblocks.io/node-selector-once"
 
-	// InstanceSetRevisionAnnotationKey records the InstanceSet-managed revision carried by an Instance.
-	InstanceSetRevisionAnnotationKey = "workloads.kubeblocks.io/instance-revision"
-
 	PVCNamePrefixAnnotationKey = "apps.kubeblocks.io/pvc-name-prefix"
 
 	RestoreSourceAPIGroupAnnotationKey  = "apps.kubeblocks.io/restore-source-api-group"

--- a/pkg/controller/instanceset2/instance_util.go
+++ b/pkg/controller/instanceset2/instance_util.go
@@ -147,6 +147,7 @@ func buildInstanceByTemplate(tree *kubebuilderx.ObjectTree,
 	}
 
 	inst := b.GetObject()
+	stampInstanceRevision(inst)
 	if !shouldCloneInstanceAssistantObjects(its) {
 		if err := controllerutil.SetControllerReference(its, inst, model.GetScheme()); err != nil {
 			return nil, err
@@ -425,12 +426,12 @@ func buildDesiredInstancesByName(tree *kubebuilderx.ObjectTree, its *workloads.I
 //	return requests, limits
 // }
 
-func isInstanceUpdated(its *workloads.InstanceSet, inst, desired *workloads.Instance) bool {
+func isInstanceUpdated(its *workloads.InstanceSet, inst *workloads.Instance) bool {
 	updateRevisions, err := revisionmap.Decode(its.Status.UpdateRevisions)
 	if err != nil {
 		return false
 	}
-	return isInstanceUpdatedWithRevisions(inst, buildCurrentInstanceRevision(inst, desired), updateRevisions)
+	return isInstanceUpdatedWithRevisions(inst, getInstanceRevision(inst), updateRevisions)
 }
 
 func isInstanceUpdatedWithRevisions(inst *workloads.Instance, currentRevision string, updateRevisions map[string]string) bool {

--- a/pkg/controller/instanceset2/reconciler_revision_update.go
+++ b/pkg/controller/instanceset2/reconciler_revision_update.go
@@ -53,7 +53,7 @@ func (r *revisionUpdateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kub
 
 	updateRevisions := make(map[string]string, len(names))
 	for _, name := range names {
-		updateRevisions[name] = buildInstanceRevision(desiredInstances[name])
+		updateRevisions[name] = getInstanceRevision(desiredInstances[name])
 	}
 	revisions, err := revisionmap.Encode(updateRevisions)
 	if err != nil {
@@ -64,7 +64,7 @@ func (r *revisionUpdateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kub
 		its.Status.UpdateRevision = updateRevisions[names[len(names)-1]]
 	}
 
-	updatedReplicas := r.calculateUpdatedReplicas(its, tree.List(&workloads.Instance{}), desiredInstances)
+	updatedReplicas := r.calculateUpdatedReplicas(its, tree.List(&workloads.Instance{}))
 	its.Status.UpdatedReplicas = updatedReplicas
 
 	its.Status.ObservedGeneration = its.Generation
@@ -72,11 +72,11 @@ func (r *revisionUpdateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kub
 	return kubebuilderx.Continue, nil
 }
 
-func (r *revisionUpdateReconciler) calculateUpdatedReplicas(its *workloads.InstanceSet, instances []client.Object, desiredInstances map[string]*workloads.Instance) int32 {
+func (r *revisionUpdateReconciler) calculateUpdatedReplicas(its *workloads.InstanceSet, instances []client.Object) int32 {
 	updatedReplicas := int32(0)
 	for i := range instances {
 		inst, _ := instances[i].(*workloads.Instance)
-		if isInstanceUpdated(its, inst, desiredInstances[inst.Name]) {
+		if isInstanceUpdated(its, inst) {
 			updatedReplicas++
 		}
 	}

--- a/pkg/controller/instanceset2/reconciler_status.go
+++ b/pkg/controller/instanceset2/reconciler_status.go
@@ -55,11 +55,6 @@ func (r *statusReconciler) PreCondition(tree *kubebuilderx.ObjectTree) *kubebuil
 func (r *statusReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilderx.Result, error) {
 	its, _ := tree.GetRoot().(*workloads.InstanceSet)
 
-	desiredInstances, _, err := buildDesiredInstancesByName(tree, its)
-	if err != nil {
-		return kubebuilderx.Continue, err
-	}
-
 	instances := tree.List(&workloads.Instance{})
 	var instanceList []*workloads.Instance
 	for _, object := range instances {
@@ -111,7 +106,7 @@ func (r *statusReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 				notAvailableNames.Insert(inst.Name)
 			}
 		}
-		currentRevisions[inst.Name] = buildCurrentInstanceRevision(inst, desiredInstances[inst.Name])
+		currentRevisions[inst.Name] = getInstanceRevision(inst)
 		if !intctrlutil.IsInstanceTerminating(inst) {
 			if isInstanceUpdatedWithRevisions(inst, currentRevisions[inst.Name], updateRevisions) {
 				updatedReplicas++

--- a/pkg/controller/instanceset2/reconciler_status_test.go
+++ b/pkg/controller/instanceset2/reconciler_status_test.go
@@ -142,7 +142,7 @@ func TestIsInstanceUpdated(t *testing.T) {
 			name: "true when instance revision matches even if parent generation changed",
 			inst: func() *workloads.Instance {
 				inst := newInstance("1", true)
-				inst.Annotations[constant.InstanceSetRevisionAnnotationKey] = latestRevision
+				inst.Annotations[instanceSetRevisionAnnotationKey] = latestRevision
 				return inst
 			}(),
 			want: true,
@@ -151,7 +151,7 @@ func TestIsInstanceUpdated(t *testing.T) {
 			name: "false when instance spec is latest but pod status is not up to date",
 			inst: func() *workloads.Instance {
 				inst := newInstance("3", false)
-				inst.Annotations[constant.InstanceSetRevisionAnnotationKey] = latestRevision
+				inst.Annotations[instanceSetRevisionAnnotationKey] = latestRevision
 				return inst
 			}(),
 			want: false,
@@ -160,7 +160,7 @@ func TestIsInstanceUpdated(t *testing.T) {
 			name: "false when instance revision annotation differs",
 			inst: func() *workloads.Instance {
 				inst := newInstance("3", true)
-				inst.Annotations[constant.InstanceSetRevisionAnnotationKey] = "stale"
+				inst.Annotations[instanceSetRevisionAnnotationKey] = "stale"
 				return inst
 			}(),
 			want: false,
@@ -169,7 +169,7 @@ func TestIsInstanceUpdated(t *testing.T) {
 			name: "false when instance revision annotation is missing",
 			inst: func() *workloads.Instance {
 				inst := newInstance("3", true)
-				delete(inst.Annotations, constant.InstanceSetRevisionAnnotationKey)
+				delete(inst.Annotations, instanceSetRevisionAnnotationKey)
 				return inst
 			}(),
 			want: false,
@@ -178,7 +178,7 @@ func TestIsInstanceUpdated(t *testing.T) {
 			name: "false when instance status has not observed latest generation",
 			inst: func() *workloads.Instance {
 				inst := newInstance("3", true)
-				inst.Annotations[constant.InstanceSetRevisionAnnotationKey] = latestRevision
+				inst.Annotations[instanceSetRevisionAnnotationKey] = latestRevision
 				inst.Status.ObservedGeneration = 1
 				return inst
 			}(),
@@ -203,9 +203,9 @@ func TestBuildInstanceRevisionIgnoresInstanceMetadata(t *testing.T) {
 				"managed-label": "desired",
 			},
 			Annotations: map[string]string{
-				constant.KubeBlocksGenerationKey:          "1",
-				constant.InstanceSetRevisionAnnotationKey: "revision-1",
-				"managed-annotation":                      "desired",
+				constant.KubeBlocksGenerationKey: "1",
+				instanceSetRevisionAnnotationKey: "revision-1",
+				"managed-annotation":             "desired",
 			},
 		},
 		Spec: workloads.InstanceSpec{
@@ -215,7 +215,7 @@ func TestBuildInstanceRevisionIgnoresInstanceMetadata(t *testing.T) {
 	revision := buildInstanceRevision(inst)
 
 	inst.Annotations[constant.KubeBlocksGenerationKey] = "2"
-	inst.Annotations[constant.InstanceSetRevisionAnnotationKey] = "revision-2"
+	inst.Annotations[instanceSetRevisionAnnotationKey] = "revision-2"
 	inst.Annotations["managed-annotation"] = "changed"
 	inst.Labels["managed-label"] = "changed"
 	if got := buildInstanceRevision(inst); got != revision {
@@ -370,14 +370,14 @@ func TestStampInstanceRevisionCarriesDesiredRevision(t *testing.T) {
 	if revision == "" {
 		t.Fatalf("expected revision to be stamped")
 	}
-	if got := desired.Annotations[constant.InstanceSetRevisionAnnotationKey]; got != revision {
+	if got := desired.Annotations[instanceSetRevisionAnnotationKey]; got != revision {
 		t.Fatalf("expected revision annotation %s, got %s", revision, got)
 	}
 	if got := buildInstanceRevision(desired); got != revision {
 		t.Fatalf("expected stamped annotation to be ignored by revision hash, got %s want %s", got, revision)
 	}
 
-	desired.Annotations[constant.InstanceSetRevisionAnnotationKey] = "changed"
+	desired.Annotations[instanceSetRevisionAnnotationKey] = "changed"
 	if got := buildInstanceRevision(desired); got != revision {
 		t.Fatalf("expected revision annotation changes to be ignored, got %s want %s", got, revision)
 	}
@@ -482,7 +482,7 @@ func TestStatusReconcilerReadsCurrentRevisionFromInstanceAnnotation(t *testing.T
 
 	inst := desired.DeepCopy()
 	inst.Annotations[constant.KubeBlocksGenerationKey] = "1"
-	inst.Annotations[constant.InstanceSetRevisionAnnotationKey] = desiredRevision
+	inst.Annotations[instanceSetRevisionAnnotationKey] = desiredRevision
 	inst.Annotations["external-annotation"] = "ignored"
 	inst.Labels["external-label"] = "ignored"
 	inst.Generation = 2
@@ -562,7 +562,7 @@ func TestStatusReconcilerDoesNotFallbackToLiveHashWhenRevisionAnnotationMissing(
 	its.Status.UpdateRevisions = updateRevisions
 
 	inst := desired.DeepCopy()
-	delete(inst.Annotations, constant.InstanceSetRevisionAnnotationKey)
+	delete(inst.Annotations, instanceSetRevisionAnnotationKey)
 	inst.Generation = 2
 	inst.Status = workloads.InstanceStatus2{
 		ObservedGeneration: 2,

--- a/pkg/controller/instanceset2/reconciler_status_test.go
+++ b/pkg/controller/instanceset2/reconciler_status_test.go
@@ -116,8 +116,9 @@ func TestIsInstanceUpdated(t *testing.T) {
 		}
 	}
 	latestInst := newInstance("2", true)
+	latestRevision := stampInstanceRevision(latestInst)
 	updateRevisions, err := revisionmap.Encode(map[string]string{
-		latestInst.Name: buildInstanceRevision(latestInst),
+		latestInst.Name: latestRevision,
 	})
 	if err != nil {
 		t.Fatalf("build revisions: %v", err)
@@ -138,19 +139,46 @@ func TestIsInstanceUpdated(t *testing.T) {
 	}{
 		{
 			name: "true when instance revision matches even if parent generation changed",
-			inst: newInstance("1", true),
+			inst: func() *workloads.Instance {
+				inst := newInstance("1", true)
+				inst.Annotations[constant.InstanceSetRevisionAnnotationKey] = latestRevision
+				return inst
+			}(),
 			want: true,
 		},
 		{
 			name: "false when instance spec is latest but pod status is not up to date",
-			inst: newInstance("3", false),
+			inst: func() *workloads.Instance {
+				inst := newInstance("3", false)
+				inst.Annotations[constant.InstanceSetRevisionAnnotationKey] = latestRevision
+				return inst
+			}(),
 			want: false,
 		},
 		{
-			name: "false when instance intent revision differs",
+			name: "false when instance revision annotation differs",
 			inst: func() *workloads.Instance {
 				inst := newInstance("3", true)
-				inst.Spec.MinReadySeconds = 2
+				inst.Annotations[constant.InstanceSetRevisionAnnotationKey] = "stale"
+				return inst
+			}(),
+			want: false,
+		},
+		{
+			name: "false when instance revision annotation is missing",
+			inst: func() *workloads.Instance {
+				inst := newInstance("3", true)
+				delete(inst.Annotations, constant.InstanceSetRevisionAnnotationKey)
+				return inst
+			}(),
+			want: false,
+		},
+		{
+			name: "false when instance status has not observed latest generation",
+			inst: func() *workloads.Instance {
+				inst := newInstance("3", true)
+				inst.Annotations[constant.InstanceSetRevisionAnnotationKey] = latestRevision
+				inst.Status.ObservedGeneration = 1
 				return inst
 			}(),
 			want: false,
@@ -159,19 +187,20 @@ func TestIsInstanceUpdated(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isInstanceUpdated(its, tt.inst, nil); got != tt.want {
+			if got := isInstanceUpdated(its, tt.inst); got != tt.want {
 				t.Fatalf("expected %v, got %v", tt.want, got)
 			}
 		})
 	}
 }
 
-func TestBuildInstanceRevisionIgnoresParentGenerationAnnotation(t *testing.T) {
+func TestBuildInstanceRevisionIgnoresControllerOwnedAnnotations(t *testing.T) {
 	inst := &workloads.Instance{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-its-0",
 			Annotations: map[string]string{
-				constant.KubeBlocksGenerationKey: "1",
+				constant.KubeBlocksGenerationKey:          "1",
+				constant.InstanceSetRevisionAnnotationKey: "revision-1",
 			},
 		},
 		Spec: workloads.InstanceSpec{
@@ -181,8 +210,9 @@ func TestBuildInstanceRevisionIgnoresParentGenerationAnnotation(t *testing.T) {
 	revision := buildInstanceRevision(inst)
 
 	inst.Annotations[constant.KubeBlocksGenerationKey] = "2"
+	inst.Annotations[constant.InstanceSetRevisionAnnotationKey] = "revision-2"
 	if got := buildInstanceRevision(inst); got != revision {
-		t.Fatalf("expected generation annotation to be ignored, got %s want %s", got, revision)
+		t.Fatalf("expected controller-owned annotations to be ignored, got %s want %s", got, revision)
 	}
 
 	inst.Spec.MinReadySeconds = 2
@@ -191,7 +221,7 @@ func TestBuildInstanceRevisionIgnoresParentGenerationAnnotation(t *testing.T) {
 	}
 }
 
-func TestBuildInstanceRevisionUsesDesiredMetadataKeys(t *testing.T) {
+func TestStampInstanceRevisionCarriesDesiredRevision(t *testing.T) {
 	desired := &workloads.Instance{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-its-0",
@@ -208,30 +238,68 @@ func TestBuildInstanceRevisionUsesDesiredMetadataKeys(t *testing.T) {
 			MinReadySeconds: 1,
 		},
 	}
-	revision := buildInstanceRevision(desired)
-
-	actual := desired.DeepCopy()
-	actual.Annotations[constant.KubeBlocksGenerationKey] = "1"
-	actual.Annotations["external-annotation"] = "ignored"
-	actual.Labels["external-label"] = "ignored"
-	if got := buildCurrentInstanceRevision(actual, desired); got != revision {
-		t.Fatalf("expected unmanaged metadata to be ignored, got %s want %s", got, revision)
+	revision := stampInstanceRevision(desired)
+	if revision == "" {
+		t.Fatalf("expected revision to be stamped")
+	}
+	if got := desired.Annotations[constant.InstanceSetRevisionAnnotationKey]; got != revision {
+		t.Fatalf("expected revision annotation %s, got %s", revision, got)
+	}
+	if got := buildInstanceRevision(desired); got != revision {
+		t.Fatalf("expected stamped annotation to be ignored by revision hash, got %s want %s", got, revision)
 	}
 
-	actual = desired.DeepCopy()
-	actual.Annotations["managed-annotation"] = "changed"
-	if got := buildCurrentInstanceRevision(actual, desired); got == revision {
+	desired.Annotations[constant.InstanceSetRevisionAnnotationKey] = "changed"
+	if got := buildInstanceRevision(desired); got != revision {
+		t.Fatalf("expected revision annotation changes to be ignored, got %s want %s", got, revision)
+	}
+
+	desired.Annotations["managed-annotation"] = "changed"
+	if got := buildInstanceRevision(desired); got == revision {
 		t.Fatalf("expected managed annotation change to alter revision")
 	}
 
-	actual = desired.DeepCopy()
-	actual.Labels["managed-label"] = "changed"
-	if got := buildCurrentInstanceRevision(actual, desired); got == revision {
+	desired.Annotations["managed-annotation"] = "desired"
+	desired.Labels["managed-label"] = "changed"
+	if got := buildInstanceRevision(desired); got == revision {
 		t.Fatalf("expected managed label change to alter revision")
 	}
 }
 
-func TestStatusReconcilerKeepsScaleOutInstancesUpdatedAfterParentGenerationBump(t *testing.T) {
+func TestBuildInstanceByTemplateStampsRevisionAnnotation(t *testing.T) {
+	its := &workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-its",
+			Namespace:  "default",
+			Generation: 3,
+		},
+		Spec: workloads.InstanceSetSpec{
+			Replicas:            ptr.To[int32](1),
+			FlatInstanceOrdinal: true,
+			Instances: []workloads.InstanceTemplate{
+				{Name: "tpl", Replicas: ptr.To[int32](1)},
+			},
+		},
+	}
+	tree := kubebuilderx.NewObjectTree()
+	tree.SetRoot(its)
+
+	desiredInstances, _, err := buildDesiredInstancesByName(tree, its)
+	if err != nil {
+		t.Fatalf("build desired instances: %v", err)
+	}
+	inst := desiredInstances["test-its-0"]
+	if inst == nil {
+		t.Fatalf("expected desired instance test-its-0, got %#v", desiredInstances)
+	}
+	if got := getInstanceRevision(inst); got == "" {
+		t.Fatalf("expected desired instance to carry revision annotation")
+	} else if want := buildInstanceRevision(inst); got != want {
+		t.Fatalf("expected carried revision to match desired revision, got %s want %s", got, want)
+	}
+}
+
+func TestStatusReconcilerReadsCurrentRevisionFromInstanceAnnotation(t *testing.T) {
 	its := &workloads.InstanceSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "test-its",
@@ -269,7 +337,7 @@ func TestStatusReconcilerKeepsScaleOutInstancesUpdatedAfterParentGenerationBump(
 	if desired == nil {
 		t.Fatalf("expected desired instance test-its-0, got %#v", desiredInstances)
 	}
-	desiredRevision := buildInstanceRevision(desired)
+	desiredRevision := getInstanceRevision(desired)
 	updateRevisions, err := revisionmap.Encode(map[string]string{
 		desired.Name: desiredRevision,
 	})
@@ -281,6 +349,7 @@ func TestStatusReconcilerKeepsScaleOutInstancesUpdatedAfterParentGenerationBump(
 
 	inst := desired.DeepCopy()
 	inst.Annotations[constant.KubeBlocksGenerationKey] = "1"
+	inst.Annotations[constant.InstanceSetRevisionAnnotationKey] = desiredRevision
 	inst.Annotations["external-annotation"] = "ignored"
 	inst.Labels["external-label"] = "ignored"
 	inst.Generation = 2
@@ -305,9 +374,6 @@ func TestStatusReconcilerKeepsScaleOutInstancesUpdatedAfterParentGenerationBump(
 	if err != nil {
 		t.Fatalf("get current revisions: %v", err)
 	}
-	if currentRevisions[inst.Name] != buildCurrentInstanceRevision(inst, desired) {
-		t.Fatalf("unexpected current revision: %#v", currentRevisions)
-	}
 	if currentRevisions[inst.Name] != desiredRevision {
 		t.Fatalf("expected current revision to match desired update revision, got %s want %s", currentRevisions[inst.Name], desiredRevision)
 	}
@@ -323,5 +389,78 @@ func TestStatusReconcilerKeepsScaleOutInstancesUpdatedAfterParentGenerationBump(
 	}
 	if got.Status.CurrentRevision != got.Status.UpdateRevision {
 		t.Fatalf("expected current revision to advance to update revision")
+	}
+}
+
+func TestStatusReconcilerDoesNotFallbackToLiveHashWhenRevisionAnnotationMissing(t *testing.T) {
+	its := &workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-its",
+			Namespace:  "default",
+			Generation: 3,
+		},
+		Spec: workloads.InstanceSetSpec{
+			Replicas:            ptr.To[int32](1),
+			FlatInstanceOrdinal: true,
+			Instances: []workloads.InstanceTemplate{
+				{Name: "tpl", Replicas: ptr.To[int32](1)},
+			},
+		},
+		Status: workloads.InstanceSetStatus{
+			ObservedGeneration: 3,
+		},
+	}
+
+	tree := kubebuilderx.NewObjectTree()
+	tree.SetRoot(its)
+	desiredInstances, _, err := buildDesiredInstancesByName(tree, its)
+	if err != nil {
+		t.Fatalf("build desired instances: %v", err)
+	}
+	desired := desiredInstances["test-its-0"]
+	desiredRevision := getInstanceRevision(desired)
+	updateRevisions, err := revisionmap.Encode(map[string]string{
+		desired.Name: desiredRevision,
+	})
+	if err != nil {
+		t.Fatalf("build revisions: %v", err)
+	}
+	its.Status.UpdateRevision = "update-revision"
+	its.Status.UpdateRevisions = updateRevisions
+
+	inst := desired.DeepCopy()
+	delete(inst.Annotations, constant.InstanceSetRevisionAnnotationKey)
+	inst.Generation = 2
+	inst.Status = workloads.InstanceStatus2{
+		ObservedGeneration: 2,
+		UpToDate:           true,
+		Conditions: []metav1.Condition{
+			{Type: string(workloads.InstanceReady), Status: metav1.ConditionTrue},
+			{Type: string(workloads.InstanceAvailable), Status: metav1.ConditionTrue},
+		},
+	}
+
+	if err := tree.Add(inst); err != nil {
+		t.Fatalf("add instance: %v", err)
+	}
+	if _, err := NewStatusReconciler().Reconcile(tree); err != nil {
+		t.Fatalf("reconcile status: %v", err)
+	}
+
+	got := tree.GetRoot().(*workloads.InstanceSet)
+	currentRevisions, err := revisionmap.Decode(got.Status.CurrentRevisions)
+	if err != nil {
+		t.Fatalf("get current revisions: %v", err)
+	}
+	if currentRevisions[inst.Name] != "" {
+		t.Fatalf("expected empty current revision for missing annotation, got %#v", currentRevisions)
+	}
+	if got.Status.UpdatedReplicas != 0 {
+		t.Fatalf("expected missing revision annotation to keep updated replicas at 0, got %d", got.Status.UpdatedReplicas)
+	}
+	if len(got.Status.TemplatesStatus) != 1 ||
+		got.Status.TemplatesStatus[0].UpdatedReplicas != 0 ||
+		got.Status.TemplatesStatus[0].CurrentReplicas != 1 {
+		t.Fatalf("unexpected template status: %#v", got.Status.TemplatesStatus)
 	}
 }

--- a/pkg/controller/instanceset2/reconciler_status_test.go
+++ b/pkg/controller/instanceset2/reconciler_status_test.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
@@ -194,13 +195,17 @@ func TestIsInstanceUpdated(t *testing.T) {
 	}
 }
 
-func TestBuildInstanceRevisionIgnoresControllerOwnedAnnotations(t *testing.T) {
+func TestBuildInstanceRevisionIgnoresInstanceMetadata(t *testing.T) {
 	inst := &workloads.Instance{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-its-0",
+			Labels: map[string]string{
+				"managed-label": "desired",
+			},
 			Annotations: map[string]string{
 				constant.KubeBlocksGenerationKey:          "1",
 				constant.InstanceSetRevisionAnnotationKey: "revision-1",
+				"managed-annotation":                      "desired",
 			},
 		},
 		Spec: workloads.InstanceSpec{
@@ -211,13 +216,136 @@ func TestBuildInstanceRevisionIgnoresControllerOwnedAnnotations(t *testing.T) {
 
 	inst.Annotations[constant.KubeBlocksGenerationKey] = "2"
 	inst.Annotations[constant.InstanceSetRevisionAnnotationKey] = "revision-2"
+	inst.Annotations["managed-annotation"] = "changed"
+	inst.Labels["managed-label"] = "changed"
 	if got := buildInstanceRevision(inst); got != revision {
-		t.Fatalf("expected controller-owned annotations to be ignored, got %s want %s", got, revision)
+		t.Fatalf("expected instance metadata to be ignored, got %s want %s", got, revision)
 	}
 
 	inst.Spec.MinReadySeconds = 2
 	if got := buildInstanceRevision(inst); got == revision {
 		t.Fatalf("expected spec change to alter revision")
+	}
+}
+
+func TestBuildInstanceRevisionIgnoresAssistantObjectLiveState(t *testing.T) {
+	inst := &workloads.Instance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-its-0",
+		},
+		Spec: workloads.InstanceSpec{
+			MinReadySeconds: 1,
+			InstanceAssistantObjects: []workloads.InstanceAssistantObject{
+				{
+					Service: &corev1.Service{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "test-its-headless",
+							Namespace:         "default",
+							CreationTimestamp: metav1.Now(),
+						},
+						Spec: corev1.ServiceSpec{
+							ClusterIP:  "10.0.0.1",
+							ClusterIPs: []string{"10.0.0.1"},
+						},
+					},
+				},
+			},
+		},
+	}
+	revision := buildInstanceRevision(inst)
+
+	inst.Spec.InstanceAssistantObjects[0].Service.Spec.ClusterIP = "10.0.0.2"
+	inst.Spec.InstanceAssistantObjects[0].Service.Spec.ClusterIPs = []string{"10.0.0.2"}
+	inst.Spec.InstanceAssistantObjects[0].Service.ResourceVersion = "2"
+	if got := buildInstanceRevision(inst); got != revision {
+		t.Fatalf("expected assistant object live state to be ignored, got %s want %s", got, revision)
+	}
+
+	inst.Spec.MinReadySeconds = 2
+	if got := buildInstanceRevision(inst); got == revision {
+		t.Fatalf("expected non-assistant spec change to alter revision")
+	}
+}
+
+func TestBuildInstanceRevisionIgnoresTemplateObjectMetadata(t *testing.T) {
+	inst := &workloads.Instance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-its-0",
+		},
+		Spec: workloads.InstanceSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      map[string]string{"pod-label": "desired"},
+					Annotations: map[string]string{"pod-annotation": "desired"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "postgres", Image: "postgres:16"}},
+				},
+			},
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaimTemplate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "data",
+						Labels:      map[string]string{"pvc-label": "desired"},
+						Annotations: map[string]string{"pvc-annotation": "desired"},
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+					},
+				},
+			},
+		},
+	}
+	revision := buildInstanceRevision(inst)
+
+	inst.Spec.Template.CreationTimestamp = metav1.Now()
+	inst.Spec.Template.ResourceVersion = "2"
+	inst.Spec.Template.Generation = 2
+	inst.Spec.VolumeClaimTemplates[0].CreationTimestamp = metav1.Now()
+	inst.Spec.VolumeClaimTemplates[0].ResourceVersion = "2"
+	inst.Spec.VolumeClaimTemplates[0].Generation = 2
+	if got := buildInstanceRevision(inst); got != revision {
+		t.Fatalf("expected template object metadata to be ignored, got %s want %s", got, revision)
+	}
+
+	inst.Spec.Template.Labels["pod-label"] = "changed"
+	if got := buildInstanceRevision(inst); got == revision {
+		t.Fatalf("expected pod template label change to alter revision")
+	}
+
+	inst.Spec.Template.Labels["pod-label"] = "desired"
+	inst.Spec.VolumeClaimTemplates[0].Spec.AccessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}
+	if got := buildInstanceRevision(inst); got == revision {
+		t.Fatalf("expected PVC template spec change to alter revision")
+	}
+}
+
+func TestBuildInstanceRevisionIgnoresLifecycleActions(t *testing.T) {
+	inst := &workloads.Instance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-its-0",
+		},
+		Spec: workloads.InstanceSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "postgres", Image: "postgres:16"}},
+				},
+			},
+			LifecycleActions: &workloads.LifecycleActions{
+				TemplateVars: map[string]string{"instance": "test-its-0"},
+			},
+		},
+	}
+	revision := buildInstanceRevision(inst)
+
+	inst.Spec.LifecycleActions.TemplateVars["instance"] = "test-its-1"
+	if got := buildInstanceRevision(inst); got != revision {
+		t.Fatalf("expected lifecycle action context to be ignored, got %s want %s", got, revision)
+	}
+
+	inst.Spec.Template.Spec.Containers[0].Image = "postgres:17"
+	if got := buildInstanceRevision(inst); got == revision {
+		t.Fatalf("expected pod template spec change to alter revision")
 	}
 }
 
@@ -255,14 +383,19 @@ func TestStampInstanceRevisionCarriesDesiredRevision(t *testing.T) {
 	}
 
 	desired.Annotations["managed-annotation"] = "changed"
-	if got := buildInstanceRevision(desired); got == revision {
-		t.Fatalf("expected managed annotation change to alter revision")
+	if got := buildInstanceRevision(desired); got != revision {
+		t.Fatalf("expected instance metadata annotation changes to be ignored, got %s want %s", got, revision)
 	}
 
 	desired.Annotations["managed-annotation"] = "desired"
 	desired.Labels["managed-label"] = "changed"
+	if got := buildInstanceRevision(desired); got != revision {
+		t.Fatalf("expected instance metadata label changes to be ignored, got %s want %s", got, revision)
+	}
+
+	desired.Spec.Template.Labels = map[string]string{"pod-label": "desired"}
 	if got := buildInstanceRevision(desired); got == revision {
-		t.Fatalf("expected managed label change to alter revision")
+		t.Fatalf("expected pod template label change to alter revision")
 	}
 }
 

--- a/pkg/controller/instanceset2/reconciler_update.go
+++ b/pkg/controller/instanceset2/reconciler_update.go
@@ -110,15 +110,7 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 	// if it's a roleful InstanceSet, we use updateCount to represent Pods can be updated according to the spec.memberUpdateStrategy.
 	updateCount := len(oldInstanceList)
 	if len(its.Spec.Roles) > 0 {
-		desiredInstances := make(map[string]*workloads.Instance, len(nameToTemplateMap))
-		for name, template := range nameToTemplateMap {
-			inst, err := buildInstanceByTemplate(tree, name, template, its)
-			if err != nil {
-				return kubebuilderx.Continue, err
-			}
-			desiredInstances[name] = inst
-		}
-		plan := newUpdatePlan(*its, oldInstanceList, desiredInstances)
+		plan := newUpdatePlan(*its, oldInstanceList)
 		instancesToBeUpdated, err := plan.Execute()
 		if err != nil {
 			return kubebuilderx.Continue, err

--- a/pkg/controller/instanceset2/revision_util.go
+++ b/pkg/controller/instanceset2/revision_util.go
@@ -23,21 +23,43 @@ import (
 	"fmt"
 	"hash/fnv"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/dump"
 	"k8s.io/apimachinery/pkg/util/rand"
 
+	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 )
 
 type instanceRevisionIntent struct {
+	Template                   podTemplateRevisionIntent
+	MinReadySeconds            int32
+	VolumeClaimTemplates       []pvcTemplateRevisionIntent
+	InstanceSetName            string
+	InstanceTemplateName       string
+	InstanceUpdateStrategyType *kbappsv1.InstanceUpdateStrategyType
+	PodUpdatePolicy            workloads.PodUpdatePolicyType
+	PodUpgradePolicy           workloads.PodUpdatePolicyType
+	Roles                      []workloads.ReplicaRole
+	Configs                    []workloads.ConfigTemplate
+}
+
+type podTemplateRevisionIntent struct {
 	Labels      map[string]string
 	Annotations map[string]string
-	Spec        workloads.InstanceSpec
+	Spec        corev1.PodSpec
+}
+
+type pvcTemplateRevisionIntent struct {
+	Name        string
+	Labels      map[string]string
+	Annotations map[string]string
+	Spec        corev1.PersistentVolumeClaimSpec
 }
 
 func buildInstanceRevision(inst *workloads.Instance) string {
-	return buildRevisionIntentHash(copyRevisionLabels(inst.Labels), copyRevisionAnnotations(inst.Annotations), *inst.Spec.DeepCopy())
+	return buildRevisionIntentHash(buildInstanceRevisionIntent(inst))
 }
 
 func stampInstanceRevision(inst *workloads.Instance) string {
@@ -56,50 +78,87 @@ func getInstanceRevision(inst *workloads.Instance) string {
 	return inst.Annotations[constant.InstanceSetRevisionAnnotationKey]
 }
 
-func buildRevisionIntentHash(labels, annotations map[string]string, spec workloads.InstanceSpec) string {
-	intent := instanceRevisionIntent{
-		Labels:      labels,
-		Annotations: annotations,
-		Spec:        spec,
+func buildInstanceRevisionIntent(inst *workloads.Instance) instanceRevisionIntent {
+	spec := inst.Spec.DeepCopy()
+	return instanceRevisionIntent{
+		Template:                   buildPodTemplateRevisionIntent(spec.Template),
+		MinReadySeconds:            spec.MinReadySeconds,
+		VolumeClaimTemplates:       buildPVCTemplateRevisionIntents(spec.VolumeClaimTemplates),
+		InstanceSetName:            spec.InstanceSetName,
+		InstanceTemplateName:       spec.InstanceTemplateName,
+		InstanceUpdateStrategyType: copyInstanceUpdateStrategyType(spec.InstanceUpdateStrategyType),
+		PodUpdatePolicy:            spec.PodUpdatePolicy,
+		PodUpgradePolicy:           spec.PodUpgradePolicy,
+		Roles:                      copyReplicaRoles(spec.Roles),
+		Configs:                    copyConfigTemplates(spec.Configs),
 	}
+}
+
+func buildRevisionIntentHash(intent instanceRevisionIntent) string {
 	hasher := fnv.New32()
 	fmt.Fprintf(hasher, "%v", dump.ForHash(intent))
 	return rand.SafeEncodeString(fmt.Sprint(hasher.Sum32()))
 }
 
-func copyRevisionLabels(labels map[string]string) map[string]string {
-	if len(labels) == 0 {
-		return nil
+func buildPodTemplateRevisionIntent(template corev1.PodTemplateSpec) podTemplateRevisionIntent {
+	return podTemplateRevisionIntent{
+		Labels:      copyStringMap(template.Labels),
+		Annotations: copyStringMap(template.Annotations),
+		Spec:        *template.Spec.DeepCopy(),
 	}
-	copied := make(map[string]string, len(labels))
-	for k, v := range labels {
-		copied[k] = v
-	}
-	return copied
 }
 
-func copyRevisionAnnotations(annotations map[string]string) map[string]string {
-	if len(annotations) == 0 {
+func buildPVCTemplateRevisionIntents(templates []corev1.PersistentVolumeClaimTemplate) []pvcTemplateRevisionIntent {
+	if len(templates) == 0 {
 		return nil
 	}
-	copied := make(map[string]string, len(annotations))
-	for k, v := range annotations {
-		if isNonRevisionAnnotation(k) {
-			continue
+	intents := make([]pvcTemplateRevisionIntent, len(templates))
+	for i := range templates {
+		intents[i] = pvcTemplateRevisionIntent{
+			Name:        templates[i].Name,
+			Labels:      copyStringMap(templates[i].Labels),
+			Annotations: copyStringMap(templates[i].Annotations),
+			Spec:        *templates[i].Spec.DeepCopy(),
 		}
-		copied[k] = v
 	}
-	if len(copied) == 0 {
+	return intents
+}
+
+func copyInstanceUpdateStrategyType(strategy *kbappsv1.InstanceUpdateStrategyType) *kbappsv1.InstanceUpdateStrategyType {
+	if strategy == nil {
 		return nil
+	}
+	copied := *strategy
+	return &copied
+}
+
+func copyStringMap(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	copied := make(map[string]string, len(m))
+	for k, v := range m {
+		copied[k] = v
 	}
 	return copied
 }
 
-func isNonRevisionAnnotation(key string) bool {
-	switch key {
-	case constant.KubeBlocksGenerationKey, constant.InstanceSetRevisionAnnotationKey:
-		return true
-	default:
-		return false
+func copyReplicaRoles(roles []workloads.ReplicaRole) []workloads.ReplicaRole {
+	if len(roles) == 0 {
+		return nil
 	}
+	copied := make([]workloads.ReplicaRole, len(roles))
+	copy(copied, roles)
+	return copied
+}
+
+func copyConfigTemplates(configs []workloads.ConfigTemplate) []workloads.ConfigTemplate {
+	if len(configs) == 0 {
+		return nil
+	}
+	copied := make([]workloads.ConfigTemplate, len(configs))
+	for i := range configs {
+		configs[i].DeepCopyInto(&copied[i])
+	}
+	return copied
 }

--- a/pkg/controller/instanceset2/revision_util.go
+++ b/pkg/controller/instanceset2/revision_util.go
@@ -29,8 +29,9 @@ import (
 
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
-	"github.com/apecloud/kubeblocks/pkg/constant"
 )
+
+const instanceSetRevisionAnnotationKey = "workloads.kubeblocks.io/instance-revision"
 
 type instanceRevisionIntent struct {
 	Template                   podTemplateRevisionIntent
@@ -67,7 +68,7 @@ func stampInstanceRevision(inst *workloads.Instance) string {
 	if inst.Annotations == nil {
 		inst.Annotations = make(map[string]string)
 	}
-	inst.Annotations[constant.InstanceSetRevisionAnnotationKey] = revision
+	inst.Annotations[instanceSetRevisionAnnotationKey] = revision
 	return revision
 }
 
@@ -75,7 +76,7 @@ func getInstanceRevision(inst *workloads.Instance) string {
 	if inst.Annotations == nil {
 		return ""
 	}
-	return inst.Annotations[constant.InstanceSetRevisionAnnotationKey]
+	return inst.Annotations[instanceSetRevisionAnnotationKey]
 }
 
 func buildInstanceRevisionIntent(inst *workloads.Instance) instanceRevisionIntent {

--- a/pkg/controller/instanceset2/revision_util.go
+++ b/pkg/controller/instanceset2/revision_util.go
@@ -40,14 +40,20 @@ func buildInstanceRevision(inst *workloads.Instance) string {
 	return buildRevisionIntentHash(copyRevisionLabels(inst.Labels), copyRevisionAnnotations(inst.Annotations), *inst.Spec.DeepCopy())
 }
 
-func buildCurrentInstanceRevision(inst, desired *workloads.Instance) string {
-	if desired == nil {
-		return buildInstanceRevision(inst)
+func stampInstanceRevision(inst *workloads.Instance) string {
+	revision := buildInstanceRevision(inst)
+	if inst.Annotations == nil {
+		inst.Annotations = make(map[string]string)
 	}
-	return buildRevisionIntentHash(
-		copyRevisionLabelsByKeys(inst.Labels, desired.Labels),
-		copyRevisionAnnotationsByKeys(inst.Annotations, desired.Annotations),
-		*inst.Spec.DeepCopy())
+	inst.Annotations[constant.InstanceSetRevisionAnnotationKey] = revision
+	return revision
+}
+
+func getInstanceRevision(inst *workloads.Instance) string {
+	if inst.Annotations == nil {
+		return ""
+	}
+	return inst.Annotations[constant.InstanceSetRevisionAnnotationKey]
 }
 
 func buildRevisionIntentHash(labels, annotations map[string]string, spec workloads.InstanceSpec) string {
@@ -72,22 +78,6 @@ func copyRevisionLabels(labels map[string]string) map[string]string {
 	return copied
 }
 
-func copyRevisionLabelsByKeys(labels, keys map[string]string) map[string]string {
-	if len(labels) == 0 || len(keys) == 0 {
-		return nil
-	}
-	copied := make(map[string]string, len(keys))
-	for k := range keys {
-		if v, ok := labels[k]; ok {
-			copied[k] = v
-		}
-	}
-	if len(copied) == 0 {
-		return nil
-	}
-	return copied
-}
-
 func copyRevisionAnnotations(annotations map[string]string) map[string]string {
 	if len(annotations) == 0 {
 		return nil
@@ -105,28 +95,9 @@ func copyRevisionAnnotations(annotations map[string]string) map[string]string {
 	return copied
 }
 
-func copyRevisionAnnotationsByKeys(annotations, keys map[string]string) map[string]string {
-	if len(annotations) == 0 || len(keys) == 0 {
-		return nil
-	}
-	copied := make(map[string]string, len(keys))
-	for k := range keys {
-		if isNonRevisionAnnotation(k) {
-			continue
-		}
-		if v, ok := annotations[k]; ok {
-			copied[k] = v
-		}
-	}
-	if len(copied) == 0 {
-		return nil
-	}
-	return copied
-}
-
 func isNonRevisionAnnotation(key string) bool {
 	switch key {
-	case constant.KubeBlocksGenerationKey:
+	case constant.KubeBlocksGenerationKey, constant.InstanceSetRevisionAnnotationKey:
 		return true
 	default:
 		return false

--- a/pkg/controller/instanceset2/revision_util.go
+++ b/pkg/controller/instanceset2/revision_util.go
@@ -31,7 +31,7 @@ import (
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
 )
 
-const instanceSetRevisionAnnotationKey = "workloads.kubeblocks.io/instance-revision"
+const instanceSetRevisionAnnotationKey = "workloads.kubeblocks.io/instance-revision-hash"
 
 type instanceRevisionIntent struct {
 	Template                   podTemplateRevisionIntent

--- a/pkg/controller/instanceset2/update_plan.go
+++ b/pkg/controller/instanceset2/update_plan.go
@@ -29,16 +29,15 @@ import (
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 )
 
-func newUpdatePlan(its workloads.InstanceSet, instances []*workloads.Instance, desiredInstances map[string]*workloads.Instance) updatePlan {
+func newUpdatePlan(its workloads.InstanceSet, instances []*workloads.Instance) updatePlan {
 	var instanceList []workloads.Instance
 	for _, inst := range instances {
 		instanceList = append(instanceList, *inst)
 	}
 	return &realUpdatePlan{
-		its:              its,
-		instances:        instanceList,
-		desiredInstances: desiredInstances,
-		dag:              graph.NewDAG(),
+		its:       its,
+		instances: instanceList,
+		dag:       graph.NewDAG(),
 	}
 }
 
@@ -59,7 +58,6 @@ var (
 type realUpdatePlan struct {
 	its                  workloads.InstanceSet
 	instances            []workloads.Instance
-	desiredInstances     map[string]*workloads.Instance
 	dag                  *graph.DAG
 	instancesToBeUpdated []*workloads.Instance
 }
@@ -82,7 +80,7 @@ func (p *realUpdatePlan) planWalkFunc(vertex graph.Vertex) error {
 	}
 
 	// if instance is the latest version, we do nothing
-	if isInstanceUpdated(&p.its, inst, p.desiredInstances[inst.Name]) {
+	if isInstanceUpdated(&p.its, inst) {
 		if !intctrlutil.IsInstanceReady(inst) {
 			return ErrWait
 		}


### PR DESCRIPTION
## Summary
- make InstanceSet2 stamp an Instance-carried revision annotation
- derive InstanceSet current revisions from live Instance annotations instead of live object hashes
- keep updatedReplicas gated by carried revision, observed generation, and Instance UpToDate

## Root cause
InstanceSet2 compared desired Instance revisions against hashes recomputed from live Instances. That mixed desired intent with live object state and could keep updatedReplicas at zero when live metadata/defaulting diverged from the desired builder output.

## Tests
- go test ./pkg/controller/instanceset2
- go test ./pkg/controller/instance

## Not run
- go test ./controllers/apps/component: build fails because pkg/testutil/k8s/mocks lacks generated MockClient and MockStatusWriter types in this checkout.