### PR TITLE
docs(api): fix serviceVersion comment in parameters group to match implementation

### DIFF
--- a/apis/parameters/v1alpha1/paramconfigrenderer_types.go
+++ b/apis/parameters/v1alpha1/paramconfigrenderer_types.go
@@ -73,7 +73,7 @@ type ParamConfigRendererSpec struct {
 
 	// ServiceVersion specifies the version of the Service expected to be provisioned by this Component.
 	// The version should follow the syntax and semantics of the "Semantic Versioning" specification (http://semver.org/).
-	// If no version is specified, the latest available version will be used.
+	// If not specified, it applies to any service version of the matched ComponentDefinition.
 	//
 	// +optional
 	ServiceVersion string `json:"serviceVersion,omitempty"`

--- a/apis/parameters/v1alpha1/parametersdefinition_types.go
+++ b/apis/parameters/v1alpha1/parametersdefinition_types.go
@@ -64,7 +64,7 @@ type ParametersDefinitionSpec struct {
 
 	// ServiceVersion specifies the version of the Service expected to be provisioned by this Component.
 	// The version should follow the syntax and semantics of the "Semantic Versioning" specification (http://semver.org/).
-	// If no version is specified, the latest available version will be used.
+	// If not specified, it applies to any service version of the matched ComponentDefinition.
 	//
 	// +optional
 	ServiceVersion string `json:"serviceVersion,omitempty"`

--- a/config/crd/bases/parameters.kubeblocks.io_paramconfigrenderers.yaml
+++ b/config/crd/bases/parameters.kubeblocks.io_paramconfigrenderers.yaml
@@ -176,7 +176,7 @@ spec:
                 description: |-
                   ServiceVersion specifies the version of the Service expected to be provisioned by this Component.
                   The version should follow the syntax and semantics of the "Semantic Versioning" specification (http://semver.org/).
-                  If no version is specified, the latest available version will be used.
+                  If not specified, it applies to any service version of the matched ComponentDefinition.
                 type: string
             required:
             - componentDef

--- a/config/crd/bases/parameters.kubeblocks.io_parametersdefinitions.yaml
+++ b/config/crd/bases/parameters.kubeblocks.io_parametersdefinitions.yaml
@@ -410,7 +410,7 @@ spec:
                 description: |-
                   ServiceVersion specifies the version of the Service expected to be provisioned by this Component.
                   The version should follow the syntax and semantics of the "Semantic Versioning" specification (http://semver.org/).
-                  If no version is specified, the latest available version will be used.
+                  If not specified, it applies to any service version of the matched ComponentDefinition.
                 type: string
               staticParameters:
                 description: |-

--- a/deploy/helm/crds/parameters.kubeblocks.io_paramconfigrenderers.yaml
+++ b/deploy/helm/crds/parameters.kubeblocks.io_paramconfigrenderers.yaml
@@ -176,7 +176,7 @@ spec:
                 description: |-
                   ServiceVersion specifies the version of the Service expected to be provisioned by this Component.
                   The version should follow the syntax and semantics of the "Semantic Versioning" specification (http://semver.org/).
-                  If no version is specified, the latest available version will be used.
+                  If not specified, it applies to any service version of the matched ComponentDefinition.
                 type: string
             required:
             - componentDef

--- a/deploy/helm/crds/parameters.kubeblocks.io_parametersdefinitions.yaml
+++ b/deploy/helm/crds/parameters.kubeblocks.io_parametersdefinitions.yaml
@@ -410,7 +410,7 @@ spec:
                 description: |-
                   ServiceVersion specifies the version of the Service expected to be provisioned by this Component.
                   The version should follow the syntax and semantics of the "Semantic Versioning" specification (http://semver.org/).
-                  If no version is specified, the latest available version will be used.
+                  If not specified, it applies to any service version of the matched ComponentDefinition.
                 type: string
               staticParameters:
                 description: |-


### PR DESCRIPTION
## Problem

The doc comment on `spec.serviceVersion` in `ParametersDefinition` and `ParamConfigRenderer` says "If no version is specified, the latest available version will be used", but the implementation treats an empty serviceVersion as matching **any** service version of the matched ComponentDefinition — no latest-version selection happens on this path:

- `pkg/parameters/config_util.go:400`: `paramsDef.Spec.ServiceVersion == "" || paramsDef.Spec.ServiceVersion == cmpd.Spec.ServiceVersion`
- `pkg/parameters/config_util.go:444`: same pattern for ParamConfigRenderer resolution

Addon authors with per-version parameter schemas can be misled into assuming the newest schema is picked automatically; in reality one PD/PCR with empty serviceVersion applies to every version, so per-version schemas must be split explicitly.

## Change

- Correct the comment in `apis/parameters/v1alpha1/parametersdefinition_types.go` and `apis/parameters/v1alpha1/paramconfigrenderer_types.go` to: "If not specified, it applies to any service version of the matched ComponentDefinition."
- Update the four generated CRD manifests (config/crd/bases + deploy/helm/crds) with the same text, matching what `make manifests` produces for this comment.

`Cluster.spec.componentSpecs[*].serviceVersion` carries the same original sentence and is intentionally left untouched — cluster normalization does select the highest semver, so the comment is correct there.

Doc-comment-only change; no behavior change.

Fixes #10515