### PR TITLE
fix(api): reject multiple default topologies in ClusterDefinition via CEL

### DIFF
--- a/apis/apps/v1/clusterdefinition_types.go
+++ b/apis/apps/v1/clusterdefinition_types.go
@@ -71,6 +71,7 @@ type ClusterDefinitionSpec struct {
 	//
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=128
+	// +kubebuilder:validation:XValidation:rule="size(self.filter(t, has(t.default) && t.default)) <= 1",message="at most one topology can be marked as default"
 	// +optional
 	Topologies []ClusterTopology `json:"topologies,omitempty"`
 }

--- a/config/crd/bases/apps.kubeblocks.io_clusterdefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusterdefinitions.yaml
@@ -210,6 +210,9 @@ spec:
                 maxItems: 128
                 minItems: 1
                 type: array
+                x-kubernetes-validations:
+                - message: at most one topology can be marked as default
+                  rule: size(self.filter(t, has(t.default) && t.default)) <= 1
             type: object
           status:
             description: ClusterDefinitionStatus defines the observed state of ClusterDefinition

--- a/deploy/helm/crds/apps.kubeblocks.io_clusterdefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusterdefinitions.yaml
@@ -210,6 +210,9 @@ spec:
                 maxItems: 128
                 minItems: 1
                 type: array
+                x-kubernetes-validations:
+                - message: at most one topology can be marked as default
+                  rule: size(self.filter(t, has(t.default) && t.default)) <= 1
             type: object
           status:
             description: ClusterDefinitionStatus defines the observed state of ClusterDefinition


### PR DESCRIPTION
## Problem

A ClusterDefinition declaring two or more topologies with `default: true` is silently accepted. Topology resolution then returns the first `default: true` entry in list order (`controllers/apps/cluster/transformer_cluster_normalization.go`, `defaultClusterTopology`), so a chart refactor that accidentally introduces a second default can route new Clusters to the wrong topology with no error, event, or condition anywhere.

Reported in #10517.

## Change

Add a CEL validation rule on `spec.topologies`:

```
size(self.filter(t, has(t.default) && t.default)) <= 1
```

with message "at most one topology can be marked as default", and regenerate the CRD manifests (config/crd/bases + deploy/helm/crds).

## Notes

- `has(t.default)` guards the omitempty bool: `default: false` entries serialize as absent and are excluded before evaluation.
- Cost: single O(n) filter over a list capped at 128 items, same shape as the existing componentSpecs rule on Cluster.
- With validation ratcheting, pre-existing objects that already violate the rule only fail on a subsequent write that touches the field; new creates fail immediately.
- The "no default and none specified" half of #10517 (better error surfacing) is not addressed here — it needs a controller-side condition, left for the issue.

Fixes #10517