### PR TITLE
fix(operations): wait for member join before completing scale-out progress

### DIFF
--- a/pkg/operations/ops_progress_util.go
+++ b/pkg/operations/ops_progress_util.go
@@ -459,6 +459,7 @@ func handleScaleOutProgressWithWorkload(
 	notReadyPodSet := workload.GetNotReadyInstanceNameSet()
 	notAvailablePodSet := workload.GetNotAvailableInstanceNameSet()
 	failurePodSet := workload.GetFailedInstanceNameSet()
+	notJoinedPodSet := workload.GetNotJoinedInstanceNameSet()
 	pgRes.opsMessageKey = "Create"
 	memberStatusMap := workload.GetInstanceNameSet()
 	for podName := range pgRes.createdPodSet {
@@ -477,6 +478,12 @@ func handleScaleOutProgressWithWorkload(
 			continue
 		}
 		if _, ok := notAvailablePodSet[podName]; ok {
+			continue
+		}
+		if notJoinedPodSet.Has(podName) {
+			// the pod is running but its dataLoad/memberJoin lifecycle action has not
+			// completed, so the scale-out of this replica is not done yet.
+			updateProgressDetailForHScale(opsRes, pgRes, compStatus, objectKey, opsv1alpha1.ProcessingProgressStatus)
 			continue
 		}
 		if !memberStatusMap.Has(podName) && needToCheckRole(pgRes) {

--- a/pkg/operations/ops_runtime.go
+++ b/pkg/operations/ops_runtime.go
@@ -109,6 +109,7 @@ func (r *opsRuntime) GetWorkload(namespace, clusterName, compName string) (Workl
 		notAvailableSet:    sets.New[string](),
 		failedSet:          sets.New[string](),
 		instanceNames:      sets.New[string](),
+		notJoinedSet:       sets.New[string](),
 	}
 	if its.Name != "" {
 		currRevisionMap, _ := instanceset.GetRevisions(its.Status.CurrentRevisions)
@@ -118,6 +119,16 @@ func (r *opsRuntime) GetWorkload(namespace, clusterName, compName string) (Workl
 		workload.notReadySet = instanceset.GetPodNameSetFromInstanceSetCondition(its, workloads.InstanceReady)
 		workload.notAvailableSet = instanceset.GetPodNameSetFromInstanceSetCondition(its, workloads.InstanceAvailable)
 		workload.failedSet = instanceset.GetPodNameSetFromInstanceSetCondition(its, workloads.InstanceFailure)
+		// replicas whose dataLoad/memberJoin lifecycle actions have not completed are
+		// still being provisioned, even if their pods are ready; same predicate as the
+		// component controller's hasScaleOutRunning.
+		notJoined, err := component.GetReplicasStatusFunc(its, func(s component.ReplicaStatus) bool {
+			return s.DataLoaded != nil && !*s.DataLoaded || s.MemberJoined != nil && !*s.MemberJoined
+		})
+		if err != nil {
+			return nil, err
+		}
+		workload.notJoinedSet = sets.New(notJoined...)
 		return workload, nil
 	}
 	pods, err := component.ListOwnedPods(r.dataContext(), r.cli, namespace, clusterName, compName, r.dataListOpts...)
@@ -339,6 +350,7 @@ type defaultWorkload struct {
 	notAvailableSet    sets.Set[string]
 	failedSet          sets.Set[string]
 	instanceNames      sets.Set[string]
+	notJoinedSet       sets.Set[string]
 }
 
 func (w *defaultWorkload) GetMinReadySeconds() int32 { return w.minReadySeconds }
@@ -357,6 +369,10 @@ func (w *defaultWorkload) GetFailedInstanceNameSet() sets.Set[string] { return w
 
 func (w *defaultWorkload) GetInstanceNameSet() sets.Set[string] {
 	return w.instanceNames.Clone()
+}
+
+func (w *defaultWorkload) GetNotJoinedInstanceNameSet() sets.Set[string] {
+	return w.notJoinedSet.Clone()
 }
 
 type defaultInstance struct {

--- a/pkg/operations/ops_scale_out_membership_test.go
+++ b/pkg/operations/ops_scale_out_membership_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package operations
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	opsv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+)
+
+func TestGetWorkloadBuildsNotJoinedSetFromReplicasStatus(t *testing.T) {
+	scheme := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{corev1.AddToScheme, appsv1.AddToScheme, workloads.AddToScheme} {
+		if err := add(scheme); err != nil {
+			t.Fatalf("add scheme: %v", err)
+		}
+	}
+
+	const (
+		namespace   = "default"
+		clusterName = "test-cluster"
+		compName    = "kafka"
+	)
+	pod0 := clusterName + "-" + compName + "-0"
+	pod1 := clusterName + "-" + compName + "-1"
+	its := &workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      constant.GenerateClusterComponentName(clusterName, compName),
+			Annotations: map[string]string{
+				"apps.kubeblocks.io/replicas-status": `{"replicas":2,"status":[` +
+					`{"name":"` + pod0 + `","generation":"2","creationTimestamp":"0001-01-01T00:00:00Z","provisioned":true,"memberJoined":true},` +
+					`{"name":"` + pod1 + `","generation":"3","creationTimestamp":"2026-07-03T02:04:32Z","memberJoined":false}]}`,
+			},
+		},
+		Status: workloads.InstanceSetStatus{
+			CurrentRevisions: map[string]string{pod0: "rev-a", pod1: "rev-a"},
+		},
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(its).Build()
+	rt := newOpsRuntime(context.Background(), cli, "")
+	workload, err := rt.GetWorkload(namespace, clusterName, compName)
+	if err != nil {
+		t.Fatalf("get workload: %v", err)
+	}
+	notJoined := workload.GetNotJoinedInstanceNameSet()
+	if !notJoined.Has(pod1) {
+		t.Fatalf("expected %s in not-joined set, got %v", pod1, notJoined.UnsortedList())
+	}
+	if notJoined.Has(pod0) {
+		t.Fatalf("did not expect %s in not-joined set, got %v", pod0, notJoined.UnsortedList())
+	}
+}
+
+func TestHandleScaleOutProgressWaitsForMemberJoin(t *testing.T) {
+	const (
+		compName = "kafka"
+		podName  = "test-cluster-kafka-1"
+	)
+
+	newFixtures := func(notJoined sets.Set[string]) (*OpsResource, *progressResource, Workload, *opsv1alpha1.OpsRequestComponentStatus) {
+		workload := &defaultWorkload{
+			currentRevisionMap: map[string]string{podName: "rev-a"},
+			notReadySet:        sets.New[string](),
+			notAvailableSet:    sets.New[string](),
+			failedSet:          sets.New[string](),
+			instanceNames:      sets.New(podName),
+			notJoinedSet:       notJoined,
+		}
+		opsRes := &OpsResource{
+			Recorder: record.NewFakeRecorder(16),
+			OpsRequest: &opsv1alpha1.OpsRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-scale-out", Namespace: "default"},
+			},
+		}
+		pgRes := &progressResource{
+			clusterComponent:  &appsv1.ClusterComponentSpec{Name: compName},
+			componentDef:      &appsv1.ComponentDefinition{},
+			fullComponentName: compName,
+			createdPodSet:     map[string]string{podName: ""},
+			compOps:           opsv1alpha1.ComponentOps{ComponentName: compName},
+		}
+		return opsRes, pgRes, workload, &opsv1alpha1.OpsRequestComponentStatus{}
+	}
+
+	// a created and ready pod whose memberJoin/dataLoad has not completed must not
+	// be counted as completed; it stays in Processing.
+	opsRes, pgRes, workload, compStatus := newFixtures(sets.New(podName))
+	completed, err := handleScaleOutProgressWithWorkload(opsRes, pgRes, workload, compStatus)
+	if err != nil {
+		t.Fatalf("handle scale-out progress: %v", err)
+	}
+	if completed != 0 {
+		t.Fatalf("expected 0 completed while member join is pending, got %d", completed)
+	}
+	if len(compStatus.ProgressDetails) != 1 {
+		t.Fatalf("expected 1 progress detail, got %d", len(compStatus.ProgressDetails))
+	}
+	if compStatus.ProgressDetails[0].Status != opsv1alpha1.ProcessingProgressStatus {
+		t.Fatalf("expected Processing progress while member join is pending, got %s", compStatus.ProgressDetails[0].Status)
+	}
+
+	// control: once the replica has joined, the same pod counts as completed.
+	opsRes, pgRes, workload, compStatus = newFixtures(sets.New[string]())
+	completed, err = handleScaleOutProgressWithWorkload(opsRes, pgRes, workload, compStatus)
+	if err != nil {
+		t.Fatalf("handle scale-out progress: %v", err)
+	}
+	if completed != 1 {
+		t.Fatalf("expected 1 completed after member join, got %d", completed)
+	}
+	if len(compStatus.ProgressDetails) != 1 || compStatus.ProgressDetails[0].Status != opsv1alpha1.SucceedProgressStatus {
+		t.Fatalf("expected Succeed progress after member join, got %+v", compStatus.ProgressDetails)
+	}
+}

--- a/pkg/operations/type.go
+++ b/pkg/operations/type.go
@@ -139,6 +139,9 @@ type Workload interface {
 	GetNotReadyInstanceNameSet() sets.Set[string]
 	GetNotAvailableInstanceNameSet() sets.Set[string]
 	GetFailedInstanceNameSet() sets.Set[string]
+	// GetNotJoinedInstanceNameSet returns the instances whose scale-out provisioning
+	// (dataLoad/memberJoin lifecycle actions) has not completed yet.
+	GetNotJoinedInstanceNameSet() sets.Set[string]
 }
 
 type Instance interface {


### PR DESCRIPTION
## What this PR does

Fixes #10522.

A `HorizontalScaling` scale-out could report `Succeed 1/1` while the component's `memberJoin` lifecycle action kept failing (exit code 1) on the new replica. Field case: Kafka combined-KRaft mode, where the addon guard intentionally rejects the join — the OpsRequest still succeeded, while the InstanceSet `replicas-status` showed the new replica `memberJoined: false` and the component controller retried the join every second, never letting the component reach `Running`.

Root cause: `handleScaleOutProgressWithWorkload` counted a created pod as `Succeed` based only on ITS current-revision membership + Ready/Available/Failure conditions, and `noWaitComponentCompleted = true` for horizontal scaling bypasses the component terminal-phase gate — so a memberJoin failure had **no** path to influence the OpsRequest phase, contradicting the component controller's own view (`hasScaleOutRunning` blocks `Running` on `memberJoined=false`).

## Change

- Expose the not-yet-provisioned replicas through the ops `Workload` view: `GetNotJoinedInstanceNameSet()`, built from the ITS `apps.kubeblocks.io/replicas-status` annotation with the same predicate the component controller uses (`dataLoaded`/`memberJoined` recorded explicitly `false`).
- In the scale-out progress loop, keep such pods in `Processing` instead of counting them as completed. The ops then completes only after the join converges, or fails via the user's `timeoutSeconds` instead of falsely succeeding.

No behavior change for components without `dataLoad`/`memberJoin` actions (fields stay `nil`, annotation may be absent — both short-circuit to the previous behavior). The pod-list fallback path (no ITS) is unchanged.

## Testing

- New unit tests (TDD, verified red before the fix):
  - `TestGetWorkloadBuildsNotJoinedSetFromReplicasStatus` — the workload view extracts the not-joined replica from the replicas-status annotation.
  - `TestHandleScaleOutProgressWaitsForMemberJoin` — a created+ready pod with a pending member join stays `Processing` with 0 completed; the same pod counts as completed once joined.
- `go test -short ./pkg/operations` (envtest): 110/112 specs pass; the 2 failing `CustomOps` specs fail identically on unmodified `main` (pre-existing, unrelated).

## Follow-up (not in this PR)

Visibility of the failure itself: the memberJoin error currently surfaces only in controller logs (non-delayed requeue error skips the status transformer and warning events), and `hasFailedScaleOut` is a hard-coded TODO, so persistent failures can never terminalize the component as `Failed`. Tracked in #10522.
