### PR TITLE
fix(operations): match live flat ordinal instance names

### DIFF
--- a/pkg/operations/ops_runtime.go
+++ b/pkg/operations/ops_runtime.go
@@ -225,7 +225,7 @@ func toWorkloadInstanceTemplates(instances []appsv1.InstanceTemplate) []workload
 		templates[i] = workloads.InstanceTemplate{
 			Name:     instances[i].Name,
 			Replicas: instances[i].Replicas,
-			Ordinals: workloads.Ordinals(instances[i].Ordinals),
+			Ordinals: instances[i].Ordinals,
 		}
 	}
 	return templates

--- a/pkg/operations/ops_runtime.go
+++ b/pkg/operations/ops_runtime.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -198,13 +199,9 @@ func (r *opsRuntime) GenerateInstanceNameSet(clusterName, compName string, compR
 	if !matchInstanceSetSpec(its, compReplicas, instances, offlineInstances) {
 		return generateInstanceNameSetFromSpec(clusterName, compName, compReplicas, instances, offlineInstances)
 	}
-	names, err := generateAllInstanceNamesFromInstanceSet(its)
+	instanceSet, err := generateInstanceNameSetFromInstanceSet(its)
 	if err != nil {
 		return nil, err
-	}
-	instanceSet := map[string]string{}
-	for _, name := range names {
-		instanceSet[name] = appsv1.GetInstanceTemplateName(clusterName, compName, name)
 	}
 	return instanceSet, nil
 }
@@ -216,22 +213,33 @@ func matchInstanceSetSpec(its *workloads.InstanceSet, compReplicas int32, instan
 	if !reflect.DeepEqual(its.Spec.OfflineInstances, offlineInstances) {
 		return false
 	}
-	return reflect.DeepEqual(its.Spec.Instances, toWorkloadInstanceTemplates(instances))
+	return instanceTemplatesHaveSameNamingSpec(its.Spec.Instances, instances)
 }
 
-func toWorkloadInstanceTemplates(instances []appsv1.InstanceTemplate) []workloads.InstanceTemplate {
-	templates := make([]workloads.InstanceTemplate, len(instances))
-	for i := range instances {
-		templates[i] = workloads.InstanceTemplate{
-			Name:     instances[i].Name,
-			Replicas: instances[i].Replicas,
-			Ordinals: instances[i].Ordinals,
+func instanceTemplatesHaveSameNamingSpec(current []workloads.InstanceTemplate, expected []appsv1.InstanceTemplate) bool {
+	if len(current) != len(expected) {
+		return false
+	}
+	expectedByName := make(map[string]appsv1.InstanceTemplate, len(expected))
+	for i := range expected {
+		expectedByName[expected[i].Name] = expected[i]
+	}
+	for i := range current {
+		expectedTemplate, ok := expectedByName[current[i].Name]
+		if !ok {
+			return false
+		}
+		if current[i].GetReplicas() != expectedTemplate.GetReplicas() {
+			return false
+		}
+		if !reflect.DeepEqual(current[i].Ordinals, expectedTemplate.Ordinals) {
+			return false
 		}
 	}
-	return templates
+	return true
 }
 
-func generateAllInstanceNamesFromInstanceSet(its *workloads.InstanceSet) ([]string, error) {
+func generateInstanceNameSetFromInstanceSet(its *workloads.InstanceSet) (map[string]string, error) {
 	itsExt, err := instancetemplate.BuildInstanceSetExt(its, nil)
 	if err != nil {
 		return nil, err
@@ -240,7 +248,15 @@ func generateAllInstanceNamesFromInstanceSet(its *workloads.InstanceSet) ([]stri
 	if err != nil {
 		return nil, err
 	}
-	return nameBuilder.GenerateAllInstanceNames()
+	name2Template, err := nameBuilder.BuildInstanceName2TemplateMap()
+	if err != nil {
+		return nil, err
+	}
+	instanceSet := make(map[string]string, len(name2Template))
+	for name, template := range name2Template {
+		instanceSet[name] = template.Name
+	}
+	return instanceSet, nil
 }
 
 func generateInstanceNameSetFromSpec(clusterName, compName string, compReplicas int32, instances []appsv1.InstanceTemplate, offlineInstances []string) (map[string]string, error) {
@@ -248,12 +264,62 @@ func generateInstanceNameSetFromSpec(clusterName, compName string, compReplicas 
 }
 
 func (r *opsRuntime) GenerateTemplateInstanceNames(clusterName, compName, templateName string, replicas int32, offlineInstances []string, ordinals appsv1.Ordinals) ([]string, error) {
+	if r.namespace != "" {
+		itsName := constant.GenerateClusterComponentName(clusterName, compName)
+		its := &workloads.InstanceSet{}
+		if err := r.cli.Get(r.ctx, client.ObjectKey{Name: itsName, Namespace: r.namespace}, its); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return nil, err
+			}
+		} else if names, ok, err := generateTemplateInstanceNamesFromInstanceSet(its, templateName, replicas, offlineInstances, ordinals); ok || err != nil {
+			return names, err
+		}
+	}
 	workloadName := constant.GenerateWorkloadNamePattern(clusterName, compName)
 	ordinalList, err := instanceset.ConvertOrdinalsToSortedList(ordinals)
 	if err != nil {
 		return nil, err
 	}
 	return instanceset.GenerateInstanceNamesFromTemplate(workloadName, templateName, replicas, offlineInstances, ordinalList)
+}
+
+func generateTemplateInstanceNamesFromInstanceSet(its *workloads.InstanceSet, templateName string, replicas int32, offlineInstances []string, ordinals appsv1.Ordinals) ([]string, bool, error) {
+	if !instanceSetHasTemplateSpec(its, templateName, replicas, offlineInstances, ordinals) {
+		return nil, false, nil
+	}
+	itsExt, err := instancetemplate.BuildInstanceSetExt(its, nil)
+	if err != nil {
+		return nil, true, err
+	}
+	nameBuilder, err := instancetemplate.NewPodNameBuilder(itsExt, nil)
+	if err != nil {
+		return nil, true, err
+	}
+	name2Template, err := nameBuilder.BuildInstanceName2TemplateMap()
+	if err != nil {
+		return nil, true, err
+	}
+	names := make([]string, 0, replicas)
+	for name, tpl := range name2Template {
+		if tpl.Name == templateName {
+			names = append(names, name)
+		}
+	}
+	slices.Sort(names)
+	return names, true, nil
+}
+
+func instanceSetHasTemplateSpec(its *workloads.InstanceSet, templateName string, replicas int32, offlineInstances []string, ordinals appsv1.Ordinals) bool {
+	if !reflect.DeepEqual(its.Spec.OfflineInstances, offlineInstances) {
+		return false
+	}
+	for _, template := range its.Spec.Instances {
+		if template.Name != templateName {
+			continue
+		}
+		return template.GetReplicas() == replicas && reflect.DeepEqual(template.Ordinals, ordinals)
+	}
+	return false
 }
 
 func (r *opsRuntime) Switchover(ctx context.Context, namespace, clusterName, compName, instanceName, candidateName string) error {

--- a/pkg/operations/ops_runtime.go
+++ b/pkg/operations/ops_runtime.go
@@ -22,6 +22,7 @@ package operations
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -38,6 +39,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/instanceset"
+	"github.com/apecloud/kubeblocks/pkg/controller/instancetemplate"
 	"github.com/apecloud/kubeblocks/pkg/controller/lifecycle"
 	"github.com/apecloud/kubeblocks/pkg/controller/multicluster"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
@@ -46,6 +48,7 @@ import (
 type opsRuntime struct {
 	ctx          context.Context
 	cli          client.Client
+	namespace    string
 	multiCluster bool
 	dataCtx      context.Context
 	dataGetOpts  []client.GetOption
@@ -64,6 +67,7 @@ func buildOpsRuntimes(ctx context.Context, cli client.Client, opsRes *OpsResourc
 		} else {
 			runtimes[comp.Name] = newOpsRuntime(ctx, cli, "")
 		}
+		runtimes[comp.Name].(*opsRuntime).namespace = opsRes.Cluster.Namespace
 	}
 	for _, sharding := range opsRes.Cluster.Spec.Shardings {
 		if enabledMultiCluster(opsRes.Cluster) {
@@ -71,6 +75,7 @@ func buildOpsRuntimes(ctx context.Context, cli client.Client, opsRes *OpsResourc
 		} else {
 			runtimes[sharding.Name] = newOpsRuntime(ctx, cli, "")
 		}
+		runtimes[sharding.Name].(*opsRuntime).namespace = opsRes.Cluster.Namespace
 	}
 	return runtimes, nil
 }
@@ -179,6 +184,66 @@ func (r *opsRuntime) ListInstances(namespace, clusterName, compName string) ([]I
 }
 
 func (r *opsRuntime) GenerateInstanceNameSet(clusterName, compName string, compReplicas int32, instances []appsv1.InstanceTemplate, offlineInstances []string) (map[string]string, error) {
+	if r.namespace == "" {
+		return generateInstanceNameSetFromSpec(clusterName, compName, compReplicas, instances, offlineInstances)
+	}
+	itsName := constant.GenerateClusterComponentName(clusterName, compName)
+	its := &workloads.InstanceSet{}
+	if err := r.cli.Get(r.ctx, client.ObjectKey{Name: itsName, Namespace: r.namespace}, its); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, err
+		}
+		return generateInstanceNameSetFromSpec(clusterName, compName, compReplicas, instances, offlineInstances)
+	}
+	if !matchInstanceSetSpec(its, compReplicas, instances, offlineInstances) {
+		return generateInstanceNameSetFromSpec(clusterName, compName, compReplicas, instances, offlineInstances)
+	}
+	names, err := generateAllInstanceNamesFromInstanceSet(its)
+	if err != nil {
+		return nil, err
+	}
+	instanceSet := map[string]string{}
+	for _, name := range names {
+		instanceSet[name] = appsv1.GetInstanceTemplateName(clusterName, compName, name)
+	}
+	return instanceSet, nil
+}
+
+func matchInstanceSetSpec(its *workloads.InstanceSet, compReplicas int32, instances []appsv1.InstanceTemplate, offlineInstances []string) bool {
+	if its.Spec.Replicas == nil || *its.Spec.Replicas != compReplicas {
+		return false
+	}
+	if !reflect.DeepEqual(its.Spec.OfflineInstances, offlineInstances) {
+		return false
+	}
+	return reflect.DeepEqual(its.Spec.Instances, toWorkloadInstanceTemplates(instances))
+}
+
+func toWorkloadInstanceTemplates(instances []appsv1.InstanceTemplate) []workloads.InstanceTemplate {
+	templates := make([]workloads.InstanceTemplate, len(instances))
+	for i := range instances {
+		templates[i] = workloads.InstanceTemplate{
+			Name:     instances[i].Name,
+			Replicas: instances[i].Replicas,
+			Ordinals: workloads.Ordinals(instances[i].Ordinals),
+		}
+	}
+	return templates
+}
+
+func generateAllInstanceNamesFromInstanceSet(its *workloads.InstanceSet) ([]string, error) {
+	itsExt, err := instancetemplate.BuildInstanceSetExt(its, nil)
+	if err != nil {
+		return nil, err
+	}
+	nameBuilder, err := instancetemplate.NewPodNameBuilder(itsExt, nil)
+	if err != nil {
+		return nil, err
+	}
+	return nameBuilder.GenerateAllInstanceNames()
+}
+
+func generateInstanceNameSetFromSpec(clusterName, compName string, compReplicas int32, instances []appsv1.InstanceTemplate, offlineInstances []string) (map[string]string, error) {
 	return generateAllPodNamesToSet(compReplicas, instances, offlineInstances, clusterName, compName)
 }
 

--- a/pkg/operations/ops_runtime_test.go
+++ b/pkg/operations/ops_runtime_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
@@ -275,6 +276,88 @@ func TestOpsRuntimeBuildsInstanceAPIView(t *testing.T) {
 	}
 	if volume.IsExpanding() {
 		t.Fatalf("did not expect volume to be expanding")
+	}
+}
+
+func TestOpsRuntimeGenerateInstanceNameSetUsesLiveFlatOrdinalInstanceSet(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add apps scheme: %v", err)
+	}
+	if err := workloads.AddToScheme(scheme); err != nil {
+		t.Fatalf("add workloads scheme: %v", err)
+	}
+
+	const (
+		namespace    = "default"
+		clusterName  = "mysql-qpferu"
+		component    = "mysql"
+		templateName = "32a9e872"
+	)
+	its := &workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      constant.GenerateClusterComponentName(clusterName, component),
+			Labels:    constant.GetCompLabels(clusterName, component),
+		},
+		Spec: workloads.InstanceSetSpec{
+			Replicas:            ptr.To[int32](2),
+			FlatInstanceOrdinal: true,
+			OfflineInstances:    []string{constant.GenerateClusterComponentName(clusterName, component) + "-1"},
+			Instances: []workloads.InstanceTemplate{{
+				Name:     templateName,
+				Replicas: ptr.To[int32](1),
+			}},
+		},
+	}
+	cluster := &appsv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      clusterName,
+		},
+		Spec: appsv1.ClusterSpec{
+			ComponentSpecs: []appsv1.ClusterComponentSpec{{
+				Name:                component,
+				Replicas:            2,
+				FlatInstanceOrdinal: true,
+				OfflineInstances:    []string{constant.GenerateClusterComponentName(clusterName, component) + "-1"},
+				Instances: []appsv1.InstanceTemplate{{
+					Name:     templateName,
+					Replicas: ptr.To[int32](1),
+				}},
+			}},
+		},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(its).
+		Build()
+	opsRes := &OpsResource{Cluster: cluster}
+	runtimes, err := buildOpsRuntimes(context.Background(), cli, opsRes)
+	if err != nil {
+		t.Fatalf("build runtime: %v", err)
+	}
+
+	names, err := runtimes[component].GenerateInstanceNameSet(clusterName, component, 2, cluster.Spec.ComponentSpecs[0].Instances, cluster.Spec.ComponentSpecs[0].OfflineInstances)
+	if err != nil {
+		t.Fatalf("generate instance names: %v", err)
+	}
+	if _, ok := names["mysql-qpferu-mysql-0"]; !ok {
+		t.Fatalf("expected default flat ordinal pod name, got %v", names)
+	}
+	if _, ok := names["mysql-qpferu-mysql-2"]; !ok {
+		t.Fatalf("expected canary flat ordinal pod name, got %v", names)
+	}
+	if _, ok := names["mysql-qpferu-mysql-32a9e872-0"]; ok {
+		t.Fatalf("did not expect deprecated template-based pod name, got %v", names)
+	}
+
+	oldSpecNames, err := runtimes[component].GenerateInstanceNameSet(clusterName, component, 1, cluster.Spec.ComponentSpecs[0].Instances, cluster.Spec.ComponentSpecs[0].OfflineInstances)
+	if err != nil {
+		t.Fatalf("generate instance names from non-current spec: %v", err)
+	}
+	if _, ok := oldSpecNames["mysql-qpferu-mysql-32a9e872-0"]; !ok {
+		t.Fatalf("expected non-current spec to use spec-based template pod name, got %v", oldSpecNames)
 	}
 }
 

--- a/pkg/operations/ops_runtime_test.go
+++ b/pkg/operations/ops_runtime_test.go
@@ -305,8 +305,11 @@ func TestOpsRuntimeGenerateInstanceNameSetUsesLiveFlatOrdinalInstanceSet(t *test
 			FlatInstanceOrdinal: true,
 			OfflineInstances:    []string{constant.GenerateClusterComponentName(clusterName, component) + "-1"},
 			Instances: []workloads.InstanceTemplate{{
-				Name:     templateName,
-				Replicas: ptr.To[int32](1),
+				Name:        templateName,
+				Replicas:    ptr.To[int32](1),
+				Labels:      map[string]string{constant.KBAppReleasePhaseKey: constant.ReleasePhaseCanary},
+				Annotations: map[string]string{"rollout.kubeblocks.io/canary": "true"},
+				Images:      map[string]string{"mysql": "mysql:canary"},
 			}},
 		},
 	}
@@ -348,6 +351,9 @@ func TestOpsRuntimeGenerateInstanceNameSetUsesLiveFlatOrdinalInstanceSet(t *test
 	if _, ok := names["mysql-qpferu-mysql-2"]; !ok {
 		t.Fatalf("expected canary flat ordinal pod name, got %v", names)
 	}
+	if got := names["mysql-qpferu-mysql-2"]; got != templateName {
+		t.Fatalf("expected canary pod to map to live template %q, got %q in %v", templateName, got, names)
+	}
 	if _, ok := names["mysql-qpferu-mysql-32a9e872-0"]; ok {
 		t.Fatalf("did not expect deprecated template-based pod name, got %v", names)
 	}
@@ -358,6 +364,22 @@ func TestOpsRuntimeGenerateInstanceNameSetUsesLiveFlatOrdinalInstanceSet(t *test
 	}
 	if _, ok := oldSpecNames["mysql-qpferu-mysql-32a9e872-0"]; !ok {
 		t.Fatalf("expected non-current spec to use spec-based template pod name, got %v", oldSpecNames)
+	}
+
+	templateNames, err := runtimes[component].GenerateTemplateInstanceNames(clusterName, component, templateName, 1, cluster.Spec.ComponentSpecs[0].OfflineInstances, appsv1.Ordinals{})
+	if err != nil {
+		t.Fatalf("generate template instance names: %v", err)
+	}
+	if len(templateNames) != 1 || templateNames[0] != "mysql-qpferu-mysql-2" {
+		t.Fatalf("expected flat ordinal template pod name, got %v", templateNames)
+	}
+
+	oldTemplateNames, err := runtimes[component].GenerateTemplateInstanceNames(clusterName, component, templateName, 2, cluster.Spec.ComponentSpecs[0].OfflineInstances, appsv1.Ordinals{})
+	if err != nil {
+		t.Fatalf("generate non-current template instance names: %v", err)
+	}
+	if len(oldTemplateNames) == 0 || oldTemplateNames[0] != "mysql-qpferu-mysql-32a9e872-0" {
+		t.Fatalf("expected non-current template spec to use spec-based pod name, got %v", oldTemplateNames)
 	}
 }
 


### PR DESCRIPTION
## Summary

- make ops runtime instance-name generation prefer the live InstanceSet naming rules when the requested spec matches the current workload
- preserve the existing spec-based fallback for historical/prospective specs used by hscale comparisons
- add regression coverage for flat ordinal canary pods after rollout create, where ops progress must wait for `mysql-...-2` instead of the deprecated template-style `mysql-...-<template>-0`
- make template-specific ops paths, such as VolumeExpansion after rollout replace, use the live InstanceSet instance-to-template map so they find flat ordinal pods like `redis-...-2` and `redis-...-3`

Fixes #10529
Fixes #10531

## Tests

- GOCACHE=/tmp/go-cache go test ./pkg/operations -run TestOpsRuntimeGenerateInstanceNameSetUsesLiveFlatOrdinalInstanceSet -count=1
- GOCACHE=/tmp/go-cache go test ./pkg/operations -run 'TestOpsRuntime(GenerateInstanceNameSetUsesLiveFlatOrdinalInstanceSet|BuildsInstanceAPIView)' -count=1

Note: `GOCACHE=/tmp/go-cache go test ./pkg/operations -count=1` could not run the full package suite in this sandbox because envtest failed before running specs while trying to remove `~/Library/Caches/kubebuilder-envtest/port-*` with `operation not permitted`.
