### PR TITLE
fix: exclude assistant objects from instance revision (multi-cluster #10500 residual)

### DIFF
--- a/pkg/constant/annotations.go
+++ b/pkg/constant/annotations.go
@@ -57,6 +57,9 @@ const (
 	// NodeSelectorOnceAnnotationKey adds nodeSelector in podSpec for one pod exactly once
 	NodeSelectorOnceAnnotationKey = "workloads.kubeblocks.io/node-selector-once"
 
+	// InstanceSetRevisionAnnotationKey records the InstanceSet-managed revision carried by an Instance.
+	InstanceSetRevisionAnnotationKey = "workloads.kubeblocks.io/instance-revision"
+
 	PVCNamePrefixAnnotationKey = "apps.kubeblocks.io/pvc-name-prefix"
 
 	RestoreSourceAPIGroupAnnotationKey  = "apps.kubeblocks.io/restore-source-api-group"

--- a/pkg/controller/instanceset2/instance_util.go
+++ b/pkg/controller/instanceset2/instance_util.go
@@ -147,6 +147,7 @@ func buildInstanceByTemplate(tree *kubebuilderx.ObjectTree,
 	}
 
 	inst := b.GetObject()
+	stampInstanceRevision(inst)
 	if !shouldCloneInstanceAssistantObjects(its) {
 		if err := controllerutil.SetControllerReference(its, inst, model.GetScheme()); err != nil {
 			return nil, err
@@ -425,12 +426,12 @@ func buildDesiredInstancesByName(tree *kubebuilderx.ObjectTree, its *workloads.I
 //	return requests, limits
 // }
 
-func isInstanceUpdated(its *workloads.InstanceSet, inst, desired *workloads.Instance) bool {
+func isInstanceUpdated(its *workloads.InstanceSet, inst *workloads.Instance) bool {
 	updateRevisions, err := revisionmap.Decode(its.Status.UpdateRevisions)
 	if err != nil {
 		return false
 	}
-	return isInstanceUpdatedWithRevisions(inst, buildCurrentInstanceRevision(inst, desired), updateRevisions)
+	return isInstanceUpdatedWithRevisions(inst, getInstanceRevision(inst), updateRevisions)
 }
 
 func isInstanceUpdatedWithRevisions(inst *workloads.Instance, currentRevision string, updateRevisions map[string]string) bool {

--- a/pkg/controller/instanceset2/reconciler_revision_update.go
+++ b/pkg/controller/instanceset2/reconciler_revision_update.go
@@ -53,7 +53,7 @@ func (r *revisionUpdateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kub
 
 	updateRevisions := make(map[string]string, len(names))
 	for _, name := range names {
-		updateRevisions[name] = buildInstanceRevision(desiredInstances[name])
+		updateRevisions[name] = getInstanceRevision(desiredInstances[name])
 	}
 	revisions, err := revisionmap.Encode(updateRevisions)
 	if err != nil {
@@ -64,7 +64,7 @@ func (r *revisionUpdateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kub
 		its.Status.UpdateRevision = updateRevisions[names[len(names)-1]]
 	}
 
-	updatedReplicas := r.calculateUpdatedReplicas(its, tree.List(&workloads.Instance{}), desiredInstances)
+	updatedReplicas := r.calculateUpdatedReplicas(its, tree.List(&workloads.Instance{}))
 	its.Status.UpdatedReplicas = updatedReplicas
 
 	its.Status.ObservedGeneration = its.Generation
@@ -72,11 +72,11 @@ func (r *revisionUpdateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kub
 	return kubebuilderx.Continue, nil
 }
 
-func (r *revisionUpdateReconciler) calculateUpdatedReplicas(its *workloads.InstanceSet, instances []client.Object, desiredInstances map[string]*workloads.Instance) int32 {
+func (r *revisionUpdateReconciler) calculateUpdatedReplicas(its *workloads.InstanceSet, instances []client.Object) int32 {
 	updatedReplicas := int32(0)
 	for i := range instances {
 		inst, _ := instances[i].(*workloads.Instance)
-		if isInstanceUpdated(its, inst, desiredInstances[inst.Name]) {
+		if isInstanceUpdated(its, inst) {
 			updatedReplicas++
 		}
 	}

--- a/pkg/controller/instanceset2/reconciler_status.go
+++ b/pkg/controller/instanceset2/reconciler_status.go
@@ -55,11 +55,6 @@ func (r *statusReconciler) PreCondition(tree *kubebuilderx.ObjectTree) *kubebuil
 func (r *statusReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilderx.Result, error) {
 	its, _ := tree.GetRoot().(*workloads.InstanceSet)
 
-	desiredInstances, _, err := buildDesiredInstancesByName(tree, its)
-	if err != nil {
-		return kubebuilderx.Continue, err
-	}
-
 	instances := tree.List(&workloads.Instance{})
 	var instanceList []*workloads.Instance
 	for _, object := range instances {
@@ -111,7 +106,7 @@ func (r *statusReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 				notAvailableNames.Insert(inst.Name)
 			}
 		}
-		currentRevisions[inst.Name] = buildCurrentInstanceRevision(inst, desiredInstances[inst.Name])
+		currentRevisions[inst.Name] = getInstanceRevision(inst)
 		if !intctrlutil.IsInstanceTerminating(inst) {
 			if isInstanceUpdatedWithRevisions(inst, currentRevisions[inst.Name], updateRevisions) {
 				updatedReplicas++

--- a/pkg/controller/instanceset2/reconciler_status_test.go
+++ b/pkg/controller/instanceset2/reconciler_status_test.go
@@ -116,8 +116,9 @@ func TestIsInstanceUpdated(t *testing.T) {
 		}
 	}
 	latestInst := newInstance("2", true)
+	latestRevision := stampInstanceRevision(latestInst)
 	updateRevisions, err := revisionmap.Encode(map[string]string{
-		latestInst.Name: buildInstanceRevision(latestInst),
+		latestInst.Name: latestRevision,
 	})
 	if err != nil {
 		t.Fatalf("build revisions: %v", err)
@@ -138,19 +139,46 @@ func TestIsInstanceUpdated(t *testing.T) {
 	}{
 		{
 			name: "true when instance revision matches even if parent generation changed",
-			inst: newInstance("1", true),
+			inst: func() *workloads.Instance {
+				inst := newInstance("1", true)
+				inst.Annotations[constant.InstanceSetRevisionAnnotationKey] = latestRevision
+				return inst
+			}(),
 			want: true,
 		},
 		{
 			name: "false when instance spec is latest but pod status is not up to date",
-			inst: newInstance("3", false),
+			inst: func() *workloads.Instance {
+				inst := newInstance("3", false)
+				inst.Annotations[constant.InstanceSetRevisionAnnotationKey] = latestRevision
+				return inst
+			}(),
 			want: false,
 		},
 		{
-			name: "false when instance intent revision differs",
+			name: "false when instance revision annotation differs",
 			inst: func() *workloads.Instance {
 				inst := newInstance("3", true)
-				inst.Spec.MinReadySeconds = 2
+				inst.Annotations[constant.InstanceSetRevisionAnnotationKey] = "stale"
+				return inst
+			}(),
+			want: false,
+		},
+		{
+			name: "false when instance revision annotation is missing",
+			inst: func() *workloads.Instance {
+				inst := newInstance("3", true)
+				delete(inst.Annotations, constant.InstanceSetRevisionAnnotationKey)
+				return inst
+			}(),
+			want: false,
+		},
+		{
+			name: "false when instance status has not observed latest generation",
+			inst: func() *workloads.Instance {
+				inst := newInstance("3", true)
+				inst.Annotations[constant.InstanceSetRevisionAnnotationKey] = latestRevision
+				inst.Status.ObservedGeneration = 1
 				return inst
 			}(),
 			want: false,
@@ -159,19 +187,20 @@ func TestIsInstanceUpdated(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isInstanceUpdated(its, tt.inst, nil); got != tt.want {
+			if got := isInstanceUpdated(its, tt.inst); got != tt.want {
 				t.Fatalf("expected %v, got %v", tt.want, got)
 			}
 		})
 	}
 }
 
-func TestBuildInstanceRevisionIgnoresParentGenerationAnnotation(t *testing.T) {
+func TestBuildInstanceRevisionIgnoresControllerOwnedAnnotations(t *testing.T) {
 	inst := &workloads.Instance{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-its-0",
 			Annotations: map[string]string{
-				constant.KubeBlocksGenerationKey: "1",
+				constant.KubeBlocksGenerationKey:          "1",
+				constant.InstanceSetRevisionAnnotationKey: "revision-1",
 			},
 		},
 		Spec: workloads.InstanceSpec{
@@ -181,8 +210,9 @@ func TestBuildInstanceRevisionIgnoresParentGenerationAnnotation(t *testing.T) {
 	revision := buildInstanceRevision(inst)
 
 	inst.Annotations[constant.KubeBlocksGenerationKey] = "2"
+	inst.Annotations[constant.InstanceSetRevisionAnnotationKey] = "revision-2"
 	if got := buildInstanceRevision(inst); got != revision {
-		t.Fatalf("expected generation annotation to be ignored, got %s want %s", got, revision)
+		t.Fatalf("expected controller-owned annotations to be ignored, got %s want %s", got, revision)
 	}
 
 	inst.Spec.MinReadySeconds = 2
@@ -191,7 +221,7 @@ func TestBuildInstanceRevisionIgnoresParentGenerationAnnotation(t *testing.T) {
 	}
 }
 
-func TestBuildInstanceRevisionUsesDesiredMetadataKeys(t *testing.T) {
+func TestStampInstanceRevisionCarriesDesiredRevision(t *testing.T) {
 	desired := &workloads.Instance{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-its-0",
@@ -208,30 +238,68 @@ func TestBuildInstanceRevisionUsesDesiredMetadataKeys(t *testing.T) {
 			MinReadySeconds: 1,
 		},
 	}
-	revision := buildInstanceRevision(desired)
-
-	actual := desired.DeepCopy()
-	actual.Annotations[constant.KubeBlocksGenerationKey] = "1"
-	actual.Annotations["external-annotation"] = "ignored"
-	actual.Labels["external-label"] = "ignored"
-	if got := buildCurrentInstanceRevision(actual, desired); got != revision {
-		t.Fatalf("expected unmanaged metadata to be ignored, got %s want %s", got, revision)
+	revision := stampInstanceRevision(desired)
+	if revision == "" {
+		t.Fatalf("expected revision to be stamped")
+	}
+	if got := desired.Annotations[constant.InstanceSetRevisionAnnotationKey]; got != revision {
+		t.Fatalf("expected revision annotation %s, got %s", revision, got)
+	}
+	if got := buildInstanceRevision(desired); got != revision {
+		t.Fatalf("expected stamped annotation to be ignored by revision hash, got %s want %s", got, revision)
 	}
 
-	actual = desired.DeepCopy()
-	actual.Annotations["managed-annotation"] = "changed"
-	if got := buildCurrentInstanceRevision(actual, desired); got == revision {
+	desired.Annotations[constant.InstanceSetRevisionAnnotationKey] = "changed"
+	if got := buildInstanceRevision(desired); got != revision {
+		t.Fatalf("expected revision annotation changes to be ignored, got %s want %s", got, revision)
+	}
+
+	desired.Annotations["managed-annotation"] = "changed"
+	if got := buildInstanceRevision(desired); got == revision {
 		t.Fatalf("expected managed annotation change to alter revision")
 	}
 
-	actual = desired.DeepCopy()
-	actual.Labels["managed-label"] = "changed"
-	if got := buildCurrentInstanceRevision(actual, desired); got == revision {
+	desired.Annotations["managed-annotation"] = "desired"
+	desired.Labels["managed-label"] = "changed"
+	if got := buildInstanceRevision(desired); got == revision {
 		t.Fatalf("expected managed label change to alter revision")
 	}
 }
 
-func TestStatusReconcilerKeepsScaleOutInstancesUpdatedAfterParentGenerationBump(t *testing.T) {
+func TestBuildInstanceByTemplateStampsRevisionAnnotation(t *testing.T) {
+	its := &workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-its",
+			Namespace:  "default",
+			Generation: 3,
+		},
+		Spec: workloads.InstanceSetSpec{
+			Replicas:            ptr.To[int32](1),
+			FlatInstanceOrdinal: true,
+			Instances: []workloads.InstanceTemplate{
+				{Name: "tpl", Replicas: ptr.To[int32](1)},
+			},
+		},
+	}
+	tree := kubebuilderx.NewObjectTree()
+	tree.SetRoot(its)
+
+	desiredInstances, _, err := buildDesiredInstancesByName(tree, its)
+	if err != nil {
+		t.Fatalf("build desired instances: %v", err)
+	}
+	inst := desiredInstances["test-its-0"]
+	if inst == nil {
+		t.Fatalf("expected desired instance test-its-0, got %#v", desiredInstances)
+	}
+	if got := getInstanceRevision(inst); got == "" {
+		t.Fatalf("expected desired instance to carry revision annotation")
+	} else if want := buildInstanceRevision(inst); got != want {
+		t.Fatalf("expected carried revision to match desired revision, got %s want %s", got, want)
+	}
+}
+
+func TestStatusReconcilerReadsCurrentRevisionFromInstanceAnnotation(t *testing.T) {
 	its := &workloads.InstanceSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "test-its",
@@ -269,7 +337,7 @@ func TestStatusReconcilerKeepsScaleOutInstancesUpdatedAfterParentGenerationBump(
 	if desired == nil {
 		t.Fatalf("expected desired instance test-its-0, got %#v", desiredInstances)
 	}
-	desiredRevision := buildInstanceRevision(desired)
+	desiredRevision := getInstanceRevision(desired)
 	updateRevisions, err := revisionmap.Encode(map[string]string{
 		desired.Name: desiredRevision,
 	})
@@ -281,6 +349,7 @@ func TestStatusReconcilerKeepsScaleOutInstancesUpdatedAfterParentGenerationBump(
 
 	inst := desired.DeepCopy()
 	inst.Annotations[constant.KubeBlocksGenerationKey] = "1"
+	inst.Annotations[constant.InstanceSetRevisionAnnotationKey] = desiredRevision
 	inst.Annotations["external-annotation"] = "ignored"
 	inst.Labels["external-label"] = "ignored"
 	inst.Generation = 2
@@ -305,9 +374,6 @@ func TestStatusReconcilerKeepsScaleOutInstancesUpdatedAfterParentGenerationBump(
 	if err != nil {
 		t.Fatalf("get current revisions: %v", err)
 	}
-	if currentRevisions[inst.Name] != buildCurrentInstanceRevision(inst, desired) {
-		t.Fatalf("unexpected current revision: %#v", currentRevisions)
-	}
 	if currentRevisions[inst.Name] != desiredRevision {
 		t.Fatalf("expected current revision to match desired update revision, got %s want %s", currentRevisions[inst.Name], desiredRevision)
 	}
@@ -323,5 +389,78 @@ func TestStatusReconcilerKeepsScaleOutInstancesUpdatedAfterParentGenerationBump(
 	}
 	if got.Status.CurrentRevision != got.Status.UpdateRevision {
 		t.Fatalf("expected current revision to advance to update revision")
+	}
+}
+
+func TestStatusReconcilerDoesNotFallbackToLiveHashWhenRevisionAnnotationMissing(t *testing.T) {
+	its := &workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-its",
+			Namespace:  "default",
+			Generation: 3,
+		},
+		Spec: workloads.InstanceSetSpec{
+			Replicas:            ptr.To[int32](1),
+			FlatInstanceOrdinal: true,
+			Instances: []workloads.InstanceTemplate{
+				{Name: "tpl", Replicas: ptr.To[int32](1)},
+			},
+		},
+		Status: workloads.InstanceSetStatus{
+			ObservedGeneration: 3,
+		},
+	}
+
+	tree := kubebuilderx.NewObjectTree()
+	tree.SetRoot(its)
+	desiredInstances, _, err := buildDesiredInstancesByName(tree, its)
+	if err != nil {
+		t.Fatalf("build desired instances: %v", err)
+	}
+	desired := desiredInstances["test-its-0"]
+	desiredRevision := getInstanceRevision(desired)
+	updateRevisions, err := revisionmap.Encode(map[string]string{
+		desired.Name: desiredRevision,
+	})
+	if err != nil {
+		t.Fatalf("build revisions: %v", err)
+	}
+	its.Status.UpdateRevision = "update-revision"
+	its.Status.UpdateRevisions = updateRevisions
+
+	inst := desired.DeepCopy()
+	delete(inst.Annotations, constant.InstanceSetRevisionAnnotationKey)
+	inst.Generation = 2
+	inst.Status = workloads.InstanceStatus2{
+		ObservedGeneration: 2,
+		UpToDate:           true,
+		Conditions: []metav1.Condition{
+			{Type: string(workloads.InstanceReady), Status: metav1.ConditionTrue},
+			{Type: string(workloads.InstanceAvailable), Status: metav1.ConditionTrue},
+		},
+	}
+
+	if err := tree.Add(inst); err != nil {
+		t.Fatalf("add instance: %v", err)
+	}
+	if _, err := NewStatusReconciler().Reconcile(tree); err != nil {
+		t.Fatalf("reconcile status: %v", err)
+	}
+
+	got := tree.GetRoot().(*workloads.InstanceSet)
+	currentRevisions, err := revisionmap.Decode(got.Status.CurrentRevisions)
+	if err != nil {
+		t.Fatalf("get current revisions: %v", err)
+	}
+	if currentRevisions[inst.Name] != "" {
+		t.Fatalf("expected empty current revision for missing annotation, got %#v", currentRevisions)
+	}
+	if got.Status.UpdatedReplicas != 0 {
+		t.Fatalf("expected missing revision annotation to keep updated replicas at 0, got %d", got.Status.UpdatedReplicas)
+	}
+	if len(got.Status.TemplatesStatus) != 1 ||
+		got.Status.TemplatesStatus[0].UpdatedReplicas != 0 ||
+		got.Status.TemplatesStatus[0].CurrentReplicas != 1 {
+		t.Fatalf("unexpected template status: %#v", got.Status.TemplatesStatus)
 	}
 }

--- a/pkg/controller/instanceset2/reconciler_status_test.go
+++ b/pkg/controller/instanceset2/reconciler_status_test.go
@@ -23,11 +23,13 @@ import (
 	"reflect"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/builder"
 	"github.com/apecloud/kubeblocks/pkg/controller/kubebuilderx"
 	"github.com/apecloud/kubeblocks/pkg/controller/revisionmap"
 )
@@ -296,6 +298,63 @@ func TestBuildInstanceByTemplateStampsRevisionAnnotation(t *testing.T) {
 		t.Fatalf("expected desired instance to carry revision annotation")
 	} else if want := buildInstanceRevision(inst); got != want {
 		t.Fatalf("expected carried revision to match desired revision, got %s want %s", got, want)
+	}
+}
+
+func TestBuildInstanceRevisionIgnoresAssistantObjectLiveState(t *testing.T) {
+	// In multi-cluster, desired instances carry InstanceAssistantObjects cloned
+	// from live tree objects. Server-assigned fields (e.g. a headless Service's
+	// clusterIP that only appears after creation) must not change the pod
+	// revision, otherwise updatedReplicas can never converge.
+	its := &workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-its",
+			Namespace: "default",
+			Annotations: map[string]string{
+				constant.KBAppMultiClusterPlacementKey: "c1,c2,c3",
+			},
+			Generation: 1,
+		},
+		Spec: workloads.InstanceSetSpec{
+			Replicas:            ptr.To[int32](1),
+			FlatInstanceOrdinal: true,
+			Instances:           []workloads.InstanceTemplate{{Name: "tpl", Replicas: ptr.To[int32](1)}},
+			InstanceAssistantObjects: []corev1.ObjectReference{
+				{Kind: "Service", Namespace: "default", Name: "test-its-headless"},
+			},
+		},
+	}
+
+	revisionWithService := func(svc *corev1.Service) string {
+		tree := kubebuilderx.NewObjectTree()
+		tree.SetRoot(its)
+		if err := tree.Add(svc); err != nil {
+			t.Fatalf("add service: %v", err)
+		}
+		desired, _, err := buildDesiredInstancesByName(tree, its)
+		if err != nil {
+			t.Fatalf("build desired instances: %v", err)
+		}
+		inst := desired["test-its-0"]
+		if inst == nil {
+			t.Fatalf("expected desired instance test-its-0, got %#v", desired)
+		}
+		if len(inst.Spec.InstanceAssistantObjects) == 0 {
+			t.Fatalf("expected desired instance to carry the assistant object")
+		}
+		return getInstanceRevision(inst)
+	}
+
+	svcAtCreate := builder.NewServiceBuilder("default", "test-its-headless").GetObject()
+	revAtCreate := revisionWithService(svcAtCreate)
+
+	svcLive := svcAtCreate.DeepCopy()
+	svcLive.Spec.ClusterIP = "10.0.0.5"
+	svcLive.Spec.ClusterIPs = []string{"10.0.0.5"}
+	revLive := revisionWithService(svcLive)
+
+	if revAtCreate != revLive {
+		t.Fatalf("assistant-object live state must not change the revision, got %s then %s", revAtCreate, revLive)
 	}
 }
 

--- a/pkg/controller/instanceset2/reconciler_update.go
+++ b/pkg/controller/instanceset2/reconciler_update.go
@@ -110,15 +110,7 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 	// if it's a roleful InstanceSet, we use updateCount to represent Pods can be updated according to the spec.memberUpdateStrategy.
 	updateCount := len(oldInstanceList)
 	if len(its.Spec.Roles) > 0 {
-		desiredInstances := make(map[string]*workloads.Instance, len(nameToTemplateMap))
-		for name, template := range nameToTemplateMap {
-			inst, err := buildInstanceByTemplate(tree, name, template, its)
-			if err != nil {
-				return kubebuilderx.Continue, err
-			}
-			desiredInstances[name] = inst
-		}
-		plan := newUpdatePlan(*its, oldInstanceList, desiredInstances)
+		plan := newUpdatePlan(*its, oldInstanceList)
 		instancesToBeUpdated, err := plan.Execute()
 		if err != nil {
 			return kubebuilderx.Continue, err

--- a/pkg/controller/instanceset2/revision_util.go
+++ b/pkg/controller/instanceset2/revision_util.go
@@ -37,7 +37,14 @@ type instanceRevisionIntent struct {
 }
 
 func buildInstanceRevision(inst *workloads.Instance) string {
-	return buildRevisionIntentHash(copyRevisionLabels(inst.Labels), copyRevisionAnnotations(inst.Annotations), *inst.Spec.DeepCopy())
+	spec := *inst.Spec.DeepCopy()
+	// InstanceAssistantObjects are cloned from live cluster objects (e.g. the
+	// headless Service) and carry server-assigned fields such as clusterIP that
+	// only appear after creation. They are synced state, not pod-template
+	// intent, so hashing them makes the revision diverge on every reconcile in
+	// multi-cluster and keeps updatedReplicas at zero. Exclude them.
+	spec.InstanceAssistantObjects = nil
+	return buildRevisionIntentHash(copyRevisionLabels(inst.Labels), copyRevisionAnnotations(inst.Annotations), spec)
 }
 
 func stampInstanceRevision(inst *workloads.Instance) string {

--- a/pkg/controller/instanceset2/revision_util.go
+++ b/pkg/controller/instanceset2/revision_util.go
@@ -40,14 +40,20 @@ func buildInstanceRevision(inst *workloads.Instance) string {
 	return buildRevisionIntentHash(copyRevisionLabels(inst.Labels), copyRevisionAnnotations(inst.Annotations), *inst.Spec.DeepCopy())
 }
 
-func buildCurrentInstanceRevision(inst, desired *workloads.Instance) string {
-	if desired == nil {
-		return buildInstanceRevision(inst)
+func stampInstanceRevision(inst *workloads.Instance) string {
+	revision := buildInstanceRevision(inst)
+	if inst.Annotations == nil {
+		inst.Annotations = make(map[string]string)
 	}
-	return buildRevisionIntentHash(
-		copyRevisionLabelsByKeys(inst.Labels, desired.Labels),
-		copyRevisionAnnotationsByKeys(inst.Annotations, desired.Annotations),
-		*inst.Spec.DeepCopy())
+	inst.Annotations[constant.InstanceSetRevisionAnnotationKey] = revision
+	return revision
+}
+
+func getInstanceRevision(inst *workloads.Instance) string {
+	if inst.Annotations == nil {
+		return ""
+	}
+	return inst.Annotations[constant.InstanceSetRevisionAnnotationKey]
 }
 
 func buildRevisionIntentHash(labels, annotations map[string]string, spec workloads.InstanceSpec) string {
@@ -126,7 +132,7 @@ func copyRevisionAnnotationsByKeys(annotations, keys map[string]string) map[stri
 
 func isNonRevisionAnnotation(key string) bool {
 	switch key {
-	case constant.KubeBlocksGenerationKey:
+	case constant.KubeBlocksGenerationKey, constant.InstanceSetRevisionAnnotationKey:
 		return true
 	default:
 		return false

--- a/pkg/controller/instanceset2/update_plan.go
+++ b/pkg/controller/instanceset2/update_plan.go
@@ -29,16 +29,15 @@ import (
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 )
 
-func newUpdatePlan(its workloads.InstanceSet, instances []*workloads.Instance, desiredInstances map[string]*workloads.Instance) updatePlan {
+func newUpdatePlan(its workloads.InstanceSet, instances []*workloads.Instance) updatePlan {
 	var instanceList []workloads.Instance
 	for _, inst := range instances {
 		instanceList = append(instanceList, *inst)
 	}
 	return &realUpdatePlan{
-		its:              its,
-		instances:        instanceList,
-		desiredInstances: desiredInstances,
-		dag:              graph.NewDAG(),
+		its:       its,
+		instances: instanceList,
+		dag:       graph.NewDAG(),
 	}
 }
 
@@ -59,7 +58,6 @@ var (
 type realUpdatePlan struct {
 	its                  workloads.InstanceSet
 	instances            []workloads.Instance
-	desiredInstances     map[string]*workloads.Instance
 	dag                  *graph.DAG
 	instancesToBeUpdated []*workloads.Instance
 }
@@ -82,7 +80,7 @@ func (p *realUpdatePlan) planWalkFunc(vertex graph.Vertex) error {
 	}
 
 	// if instance is the latest version, we do nothing
-	if isInstanceUpdated(&p.its, inst, p.desiredInstances[inst.Name]) {
+	if isInstanceUpdated(&p.its, inst) {
 		if !intctrlutil.IsInstanceReady(inst) {
 			return ErrWait
 		}


### PR DESCRIPTION
Stacked on #10513. Addresses the residual reported by @jinuxstyle: a fresh multi-cluster PostgreSQL cluster with `enableInstanceAPI: true` still stays in `Creating` after #10513, with all pods Ready/Available but `updatedReplicas=0` and `WorkloadNotUpdated`.

## Root cause (reproduced)

#10513 stamps an Instance-carried revision so revisions are no longer recomputed from live object state. But in multi-cluster the desired instance carries `InstanceAssistantObjects` cloned from live tree objects (e.g. the headless Service), and `buildInstanceRevision` hashes the whole `InstanceSpec` — including those assistant objects. A member-cluster Service gets its `clusterIP` assigned *after* creation, so the freshly-built desired revision changes on the next reconcile:

```
revAtCreate=5d9fc7ffdd  (Service without clusterIP)
revLive=76b67c6559      (same Service after clusterIP assigned)
```

The live instance's stamped annotation never matches the recomputed update revision → `updatedReplicas` stays 0 → Component `WorkloadNotUpdated` → cluster stuck. This is the same "desired intent mixed with live state" class #10513 fixes for the parent generation annotation, reintroduced through the assistant-object clone path — and it is multi-cluster-only, which is why the single-cluster tests pass.

## Fix

Assistant objects are synced live state, not pod-template intent, so exclude them from the revision hash (same principle #10513 applies to the generation annotation). Assistant-object content is reconciled through its own path and is unaffected.

## Tests

- `TestBuildInstanceRevisionIgnoresAssistantObjectLiveState` reproduces the divergence and pins the fix.
- `go test ./pkg/controller/instanceset2 ./pkg/controller/instance -count=1` with envtest assets — pass.