### PR TITLE
fix(component): surface member join failures during scale-out

### DIFF
--- a/controllers/apps/component/transformer_component_status_test.go
+++ b/controllers/apps/component/transformer_component_status_test.go
@@ -413,6 +413,10 @@ var _ = Describe("component status transformer conditions", func() {
 			Expect(err).Should(BeNil())
 			transformer.protoITS = protoITS
 
+			err = transformer.reconcileStatus(transCtx)
+			Expect(err).Should(BeNil())
+			Expect(comp.Status.Phase).Should(Equal(appsv1.UpdatingComponentPhase))
+
 			err = transformer.reconcileProgressingCondition(transCtx)
 			Expect(err).Should(BeNil())
 

--- a/controllers/apps/component/transformer_component_workload_ops.go
+++ b/controllers/apps/component/transformer_component_workload_ops.go
@@ -354,7 +354,7 @@ func (r *componentWorkloadOps) joinMember4ScaleOut() error {
 
 			if err := r.joinMemberForPod(pod, pods); err != nil {
 				joinErr := fmt.Errorf("pod %s: %w", pod.Name, err)
-				if errors.Is(err, lifecycle.ErrActionInProgress) || errors.Is(err, lifecycle.ErrActionBusy) {
+				if lifecycle.IsActionPending(err) {
 					retryErrors = append(retryErrors, joinErr)
 				} else {
 					joinErrors = append(joinErrors, joinErr)

--- a/controllers/apps/component/transformer_component_workload_ops.go
+++ b/controllers/apps/component/transformer_component_workload_ops.go
@@ -372,7 +372,11 @@ func (r *componentWorkloadOps) joinMember4ScaleOut() error {
 	}
 
 	if len(joinErrors) > 0 {
-		return intctrlutil.NewRequeueError(time.Second, fmt.Sprintf("%v", joinErrors))
+		// surface the failure on the Component object, otherwise the kbagent error is only visible in V-level logs
+		r.transCtx.EventRecorder.Eventf(r.component, corev1.EventTypeWarning, "MemberJoinFailed",
+			"member join for scale-out has not completed: %v", joinErrors)
+		// delayed requeue lets the status transformer still run so component phase/conditions stay live while the join retries
+		return intctrlutil.NewDelayedRequeueError(time.Second, fmt.Sprintf("%v", joinErrors))
 	}
 	return nil
 }

--- a/controllers/apps/component/transformer_component_workload_ops.go
+++ b/controllers/apps/component/transformer_component_workload_ops.go
@@ -334,6 +334,7 @@ func (r *componentWorkloadOps) joinMember4ScaleOut() error {
 	}
 
 	joinErrors := make([]error, 0)
+	retryErrors := make([]error, 0)
 	notJoinedReplicas := make([]string, 0)
 	if err = component.UpdateReplicasStatusFunc(r.protoITS, func(replicas *component.ReplicasStatus) error {
 		for _, pod := range pods {
@@ -352,7 +353,12 @@ func (r *componentWorkloadOps) joinMember4ScaleOut() error {
 			// TODO: should wait for the data to be loaded before joining the member?
 
 			if err := r.joinMemberForPod(pod, pods); err != nil {
-				joinErrors = append(joinErrors, fmt.Errorf("pod %s: %w", pod.Name, err))
+				joinErr := fmt.Errorf("pod %s: %w", pod.Name, err)
+				if errors.Is(err, lifecycle.ErrActionInProgress) || errors.Is(err, lifecycle.ErrActionBusy) {
+					retryErrors = append(retryErrors, joinErr)
+				} else {
+					joinErrors = append(joinErrors, joinErr)
+				}
 			} else {
 				replicas.Status[i].MemberJoined = ptr.To(true)
 			}
@@ -374,6 +380,9 @@ func (r *componentWorkloadOps) joinMember4ScaleOut() error {
 			"member join for scale-out has not completed: %v", joinErrors)
 		// delayed requeue lets the status transformer still run so component phase/conditions stay live while the join retries
 		return intctrlutil.NewDelayedRequeueError(time.Second, fmt.Sprintf("%v", joinErrors))
+	}
+	if len(retryErrors) > 0 {
+		return intctrlutil.NewDelayedRequeueError(time.Second, fmt.Sprintf("%v", retryErrors))
 	}
 	if len(notJoinedReplicas) > 0 {
 		// A replica can be pending before its Pod exists, so no lifecycle action

--- a/controllers/apps/component/transformer_component_workload_ops.go
+++ b/controllers/apps/component/transformer_component_workload_ops.go
@@ -334,6 +334,7 @@ func (r *componentWorkloadOps) joinMember4ScaleOut() error {
 	}
 
 	joinErrors := make([]error, 0)
+	notJoinedReplicas := make([]string, 0)
 	if err = component.UpdateReplicasStatusFunc(r.protoITS, func(replicas *component.ReplicasStatus) error {
 		for _, pod := range pods {
 			i := slices.IndexFunc(replicas.Status, func(r component.ReplicaStatus) bool {
@@ -357,14 +358,10 @@ func (r *componentWorkloadOps) joinMember4ScaleOut() error {
 			}
 		}
 
-		notJoinedReplicas := make([]string, 0)
 		for _, r := range replicas.Status {
 			if r.MemberJoined != nil && !*r.MemberJoined {
 				notJoinedReplicas = append(notJoinedReplicas, r.Name)
 			}
-		}
-		if len(notJoinedReplicas) > 0 {
-			joinErrors = append(joinErrors, fmt.Errorf("some replicas have not joined: %v", notJoinedReplicas))
 		}
 		return nil
 	}); err != nil {
@@ -377,6 +374,13 @@ func (r *componentWorkloadOps) joinMember4ScaleOut() error {
 			"member join for scale-out has not completed: %v", joinErrors)
 		// delayed requeue lets the status transformer still run so component phase/conditions stay live while the join retries
 		return intctrlutil.NewDelayedRequeueError(time.Second, fmt.Sprintf("%v", joinErrors))
+	}
+	if len(notJoinedReplicas) > 0 {
+		// A replica can be pending before its Pod exists, so no lifecycle action
+		// was invoked and there is no failure to report. Keep the ordinary
+		// delayed retry without emitting a misleading MemberJoinFailed event.
+		return intctrlutil.NewDelayedRequeueError(time.Second,
+			fmt.Sprintf("some replicas have not joined: %v", notJoinedReplicas))
 	}
 	return nil
 }

--- a/controllers/apps/component/transformer_component_workload_ops_test.go
+++ b/controllers/apps/component/transformer_component_workload_ops_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package component
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/component"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	kbacli "github.com/apecloud/kubeblocks/pkg/kbagent/client"
+)
+
+// TestJoinMember4ScaleOutFailureVisibility verifies that when the memberJoin
+// lifecycle action fails during scale-out:
+//  1. a Warning event is emitted on the Component so the failure is visible, and
+//  2. a *delayed* requeue error is returned so that the component status
+//     transformer still runs and the component phase/conditions stay live.
+func TestJoinMember4ScaleOutFailureVisibility(t *testing.T) {
+	const (
+		namespace   = "default"
+		clusterName = "test-cluster"
+		compName    = "mysql"
+	)
+	fullCompName := clusterName + "-" + compName
+	podName := fullCompName + "-1"
+
+	// the memberJoin lifecycle action fails with a kbagent error
+	kbacli.SetMockClient(nil, errors.New("memberJoin failed: rc: 1, stderr: node is not reachable"))
+	defer kbacli.UnsetMockClient()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      podName,
+			Labels:    constant.GetCompLabels(clusterName, compName),
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+
+	comp := &appsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      fullCompName,
+			Labels: map[string]string{
+				constant.AppInstanceLabelKey:    clusterName,
+				constant.KBAppComponentLabelKey: compName,
+			},
+		},
+	}
+
+	runningITS := &workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: fullCompName},
+		Spec:       workloads.InstanceSetSpec{Replicas: ptr.To[int32](2)},
+	}
+	protoITS := runningITS.DeepCopy()
+	// replicas-status: the new replica has been provisioned but has not joined yet
+	require.NoError(t, component.NewReplicasStatus(protoITS, []string{podName}, true, false))
+
+	synthesizedComp := &component.SynthesizedComponent{
+		Namespace:   namespace,
+		ClusterName: clusterName,
+		Name:        compName,
+		Replicas:    2,
+		LifecycleActions: component.SynthesizedLifecycleActions{
+			ComponentLifecycleActions: &appsv1.ComponentLifecycleActions{
+				MemberJoin: &appsv1.Action{
+					Exec: &appsv1.ExecAction{Command: []string{"/scripts/member-join.sh"}},
+				},
+			},
+		},
+	}
+
+	recorder := record.NewFakeRecorder(8)
+	transCtx := &componentTransformContext{
+		Context:             context.Background(),
+		Client:              cli,
+		EventRecorder:       recorder,
+		Logger:              logr.Discard(),
+		Component:           comp,
+		SynthesizeComponent: synthesizedComp,
+		RunningWorkload:     runningITS,
+		ProtoWorkload:       protoITS,
+	}
+	ops := &componentWorkloadOps{
+		transCtx:       transCtx,
+		cli:            cli,
+		component:      comp,
+		synthesizeComp: synthesizedComp,
+		runningITS:     runningITS,
+		protoITS:       protoITS,
+	}
+
+	err := ops.joinMember4ScaleOut()
+	require.Error(t, err)
+	require.True(t, intctrlutil.IsDelayedRequeueError(err),
+		"member join failure should return a delayed requeue error so the status transformer still runs, got: %v", err)
+
+	select {
+	case event := <-recorder.Events:
+		require.Contains(t, event, corev1.EventTypeWarning)
+		require.Contains(t, event, "MemberJoinFailed")
+		require.True(t, strings.Contains(event, "member join"), "event should describe the member join failure: %s", event)
+	default:
+		t.Fatalf("expected a Warning event to be emitted on the component for the member join failure")
+	}
+}

--- a/controllers/apps/component/transformer_component_workload_ops_test.go
+++ b/controllers/apps/component/transformer_component_workload_ops_test.go
@@ -140,3 +140,53 @@ func TestJoinMember4ScaleOutFailureVisibility(t *testing.T) {
 		t.Fatalf("expected a Warning event to be emitted on the component for the member join failure")
 	}
 }
+
+func TestJoinMember4ScaleOutPendingReplicaDoesNotReportFailure(t *testing.T) {
+	const (
+		namespace   = "default"
+		clusterName = "test-cluster"
+		compName    = "mysql"
+	)
+	fullCompName := clusterName + "-" + compName
+	podName := fullCompName + "-1"
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	comp := &appsv1.Component{ObjectMeta: metav1.ObjectMeta{
+		Namespace: namespace,
+		Name:      fullCompName,
+		Labels: map[string]string{
+			constant.AppInstanceLabelKey:    clusterName,
+			constant.KBAppComponentLabelKey: compName,
+		},
+	}}
+	runningITS := &workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: fullCompName},
+		Spec:       workloads.InstanceSetSpec{Replicas: ptr.To[int32](2)},
+	}
+	protoITS := runningITS.DeepCopy()
+	require.NoError(t, component.NewReplicasStatus(protoITS, []string{podName}, true, false))
+	recorder := record.NewFakeRecorder(8)
+	synthesizedComp := &component.SynthesizedComponent{
+		Namespace: namespace, ClusterName: clusterName, Name: compName, Replicas: 2,
+	}
+	transCtx := &componentTransformContext{
+		Context: context.Background(), Client: cli, EventRecorder: recorder, Logger: logr.Discard(),
+		Component: comp, SynthesizeComponent: synthesizedComp,
+		RunningWorkload: runningITS, ProtoWorkload: protoITS,
+	}
+	ops := &componentWorkloadOps{
+		transCtx: transCtx, cli: cli, component: comp, synthesizeComp: synthesizedComp,
+		runningITS: runningITS, protoITS: protoITS,
+	}
+
+	err := ops.joinMember4ScaleOut()
+	require.Error(t, err)
+	require.Truef(t, intctrlutil.IsDelayedRequeueError(err), "expected delayed requeue, got %T: %v", err, err)
+	select {
+	case event := <-recorder.Events:
+		t.Fatalf("pending replica without a lifecycle invocation must not emit a failure event: %s", event)
+	default:
+	}
+}

--- a/controllers/apps/component/transformer_component_workload_ops_test.go
+++ b/controllers/apps/component/transformer_component_workload_ops_test.go
@@ -39,6 +39,7 @@ import (
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
+	"github.com/apecloud/kubeblocks/pkg/controller/lifecycle"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	kbacli "github.com/apecloud/kubeblocks/pkg/kbagent/client"
 )
@@ -188,5 +189,77 @@ func TestJoinMember4ScaleOutPendingReplicaDoesNotReportFailure(t *testing.T) {
 	case event := <-recorder.Events:
 		t.Fatalf("pending replica without a lifecycle invocation must not emit a failure event: %s", event)
 	default:
+	}
+}
+
+func TestJoinMember4ScaleOutRetryableActionDoesNotReportFailure(t *testing.T) {
+	for name, actionErr := range map[string]error{
+		"in progress": lifecycle.ErrActionInProgress,
+		"busy":        lifecycle.ErrActionBusy,
+	} {
+		t.Run(name, func(t *testing.T) {
+			const (
+				namespace   = "default"
+				clusterName = "test-cluster"
+				compName    = "mysql"
+			)
+			fullCompName := clusterName + "-" + compName
+			podName := fullCompName + "-1"
+
+			kbacli.SetMockClient(nil, actionErr)
+			defer kbacli.UnsetMockClient()
+
+			scheme := runtime.NewScheme()
+			require.NoError(t, clientgoscheme.AddToScheme(scheme))
+			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      podName,
+				Labels:    constant.GetCompLabels(clusterName, compName),
+			}}
+			cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+			comp := &appsv1.Component{ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+				Name:      fullCompName,
+				Labels: map[string]string{
+					constant.AppInstanceLabelKey:    clusterName,
+					constant.KBAppComponentLabelKey: compName,
+				},
+			}}
+			runningITS := &workloads.InstanceSet{
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: fullCompName},
+				Spec:       workloads.InstanceSetSpec{Replicas: ptr.To[int32](2)},
+			}
+			protoITS := runningITS.DeepCopy()
+			require.NoError(t, component.NewReplicasStatus(protoITS, []string{podName}, true, false))
+			recorder := record.NewFakeRecorder(8)
+			synthesizedComp := &component.SynthesizedComponent{
+				Namespace: namespace, ClusterName: clusterName, Name: compName, Replicas: 2,
+				LifecycleActions: component.SynthesizedLifecycleActions{
+					ComponentLifecycleActions: &appsv1.ComponentLifecycleActions{
+						MemberJoin: &appsv1.Action{
+							Exec: &appsv1.ExecAction{Command: []string{"/scripts/member-join.sh"}},
+						},
+					},
+				},
+			}
+			transCtx := &componentTransformContext{
+				Context: context.Background(), Client: cli, EventRecorder: recorder, Logger: logr.Discard(),
+				Component: comp, SynthesizeComponent: synthesizedComp,
+				RunningWorkload: runningITS, ProtoWorkload: protoITS,
+			}
+			ops := &componentWorkloadOps{
+				transCtx: transCtx, cli: cli, component: comp, synthesizeComp: synthesizedComp,
+				runningITS: runningITS, protoITS: protoITS,
+			}
+
+			err := ops.joinMember4ScaleOut()
+			require.Error(t, err)
+			require.Truef(t, intctrlutil.IsDelayedRequeueError(err), "expected delayed requeue, got %T: %v", err, err)
+			select {
+			case event := <-recorder.Events:
+				t.Fatalf("retryable lifecycle state must not emit a failure event: %s", event)
+			default:
+			}
+		})
 	}
 }

--- a/controllers/apps/component/transformer_component_workload_ops_test.go
+++ b/controllers/apps/component/transformer_component_workload_ops_test.go
@@ -194,8 +194,9 @@ func TestJoinMember4ScaleOutPendingReplicaDoesNotReportFailure(t *testing.T) {
 
 func TestJoinMember4ScaleOutRetryableActionDoesNotReportFailure(t *testing.T) {
 	for name, actionErr := range map[string]error{
-		"in progress": lifecycle.ErrActionInProgress,
-		"busy":        lifecycle.ErrActionBusy,
+		"in progress":         lifecycle.ErrActionInProgress,
+		"busy":                lifecycle.ErrActionBusy,
+		"precondition failed": lifecycle.ErrPreconditionFailed,
 	} {
 		t.Run(name, func(t *testing.T) {
 			const (

--- a/pkg/controller/lifecycle/errors.go
+++ b/pkg/controller/lifecycle/errors.go
@@ -41,6 +41,31 @@ func IgnoreNotDefined(err error) error {
 	return err
 }
 
+// IsActionPending reports whether the complete lifecycle result contains
+// only states that should be retried without being surfaced as action
+// failures. Aggregated AllReplicas results are pending only when every
+// selected pod returned a pending state.
+func IsActionPending(err error) bool {
+	if err == nil {
+		return false
+	}
+	var aggregateErr *actionAggregateError
+	if errors.As(err, &aggregateErr) {
+		if len(aggregateErr.errs) == 0 {
+			return false
+		}
+		for _, childErr := range aggregateErr.errs {
+			if !IsActionPending(childErr) {
+				return false
+			}
+		}
+		return true
+	}
+	return errors.Is(err, ErrActionInProgress) ||
+		errors.Is(err, ErrActionBusy) ||
+		errors.Is(err, ErrPreconditionFailed)
+}
+
 type actionAggregateError struct {
 	errs []error
 }

--- a/pkg/controller/lifecycle/errors_test.go
+++ b/pkg/controller/lifecycle/errors_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package lifecycle
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsActionPending(t *testing.T) {
+	testCases := []struct {
+		name      string
+		err       error
+		retryable bool
+	}{
+		{name: "in progress", err: ErrActionInProgress, retryable: true},
+		{name: "busy", err: ErrActionBusy, retryable: true},
+		{name: "precondition", err: ErrPreconditionFailed, retryable: true},
+		{name: "wrapped retry", err: fmt.Errorf("pod: %w", ErrActionBusy), retryable: true},
+		{
+			name: "aggregate retry states",
+			err: newActionAggregateError([]error{
+				fmt.Errorf("pod-0: %w", ErrActionBusy),
+				fmt.Errorf("pod-1: %w", ErrPreconditionFailed),
+			}),
+			retryable: true,
+		},
+		{
+			name: "aggregate retry and failure",
+			err: newActionAggregateError([]error{
+				fmt.Errorf("pod-0: %w", ErrActionInProgress),
+				fmt.Errorf("pod-1: %w", ErrActionFailed),
+			}),
+			retryable: false,
+		},
+		{name: "failed", err: ErrActionFailed, retryable: false},
+		{name: "nil", err: nil, retryable: false},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.Equal(t, testCase.retryable, IsActionPending(testCase.err))
+		})
+	}
+}


### PR DESCRIPTION
## What this PR does

Fixes #10551 (split out from #10522, follow-up items 1+2 of the tracked design; independent of #10526).

When a component's `memberJoin` lifecycle action keeps failing during scale-out, the failure is invisible today: the kbagent exit code / stderr appear only in V-level controller logs. Two mechanisms cause this:
- `joinMember4ScaleOut` returns a plain requeue error, which aborts the transformer chain before `componentStatusTransformer` runs — the component's phase/conditions freeze at their last written values while the join retries every second;
- requeue errors return early before the controller's warning-event path, so no event is ever emitted.

Field case: the Kafka combined-KRaft validation for #10522 — operators had to grep controller logs to learn why a scale-out was stuck.

## Change

In `joinMember4ScaleOut`:
- generic member-join execution failures emit a `Warning MemberJoinFailed` event on the Component carrying the action error (recorder-side aggregation handles the 1s retry cadence);
- all incomplete joins return `NewDelayedRequeueError`, so the transformer chain continues and component phase/conditions stay live while the join retries — the same pattern already used for account-provision and post-provision lifecycle failures;
- `ErrActionInProgress`, `ErrActionBusy`, and `ErrPreconditionFailed` are pending states, not failures: they keep the delayed retry without emitting `MemberJoinFailed`;
- an `AllReplicas` aggregate is pending only when every child is pending; a mixed pending-plus-failure result still emits `MemberJoinFailed`;
- a replica whose Pod is not present has not invoked the lifecycle action and likewise retries without a failure event.

No completion-semantics change: the reconcile still requeues every second and the scale-out still does not complete until the join converges.

## Testing

The focused tests drive the real `joinMember4ScaleOut` path with a fake Kubernetes client and kbagent mock. They cover four distinct outcomes:
- generic execution error: delayed retry plus `Warning MemberJoinFailed`;
- `ErrActionInProgress`: delayed retry, no failure event;
- `ErrActionBusy`: delayed retry, no failure event;
- `ErrPreconditionFailed`: delayed retry, no failure event;
- all-pending aggregate: classified pending;
- mixed pending-plus-`ErrActionFailed` aggregate: classified as failure;
- missing Pod / action not invoked: delayed retry, no failure event.

Validation on exact head `9a0c69174796801289907a6ebb402b2d7f8e8ab1`: precondition and aggregate RED coverage preceded the fix; focused tests PASS; full `pkg/controller/lifecycle` and `controllers/apps/component` packages PASS with envtest assets; focused race PASS for both packages; package vet PASS; diff check PASS. Runtime environment coverage remains N=0.

## Integration order

Merge this lifecycle error-vs-pending contract before #10448. PR #10448 calls `joinMember4ScaleOut` from its scale-in gate and must then rebase semantically: actual invocation errors keep the `MemberJoinFailed` signal without a misleading `PendingMemberJoin` event; ordinary non-invoked or retryable state remains a delayed retry without failure; terminal failure releases the scale-in gate.
