### PR TITLE
fix(operations): withdraw failed reconfigure intent from ComponentParameter desired

### DIFF
--- a/pkg/constant/ops.go
+++ b/pkg/constant/ops.go
@@ -34,4 +34,7 @@ const (
 	RelatedOpsAnnotationKey            = "operations.kubeblocks.io/related-ops"
 	OpsDependentOnSuccessfulOpsAnnoKey = "operations.kubeblocks.io/dependent-on-successful-ops" // OpsDependentOnSuccessfulOpsAnnoKey wait for the dependent ops to succeed before executing the current ops. If it fails, this ops will also fail.
 	IgnoreHscaleValidateAnnoKey        = "apps.kubeblocks.io/ignore-strict-horizontal-scale-validation"
+	// ReconfigurePriorParametersAnnotationKey stores, per component, the prior desired-assignment
+	// state of the keys a reconfigure ops writes, for failure-path restoration.
+	ReconfigurePriorParametersAnnotationKey = "operations.kubeblocks.io/reconfigure-prior-parameters"
 )

--- a/pkg/operations/reconfigure.go
+++ b/pkg/operations/reconfigure.go
@@ -76,7 +76,60 @@ func (r *reconfigureAction) ReconcileAction(reqCtx intctrlutil.RequestCtx, cli c
 	if phase == opsv1alpha1.OpsSucceedPhase {
 		return r.syncReconfigureForOps(reqCtx, cli, resource, opsDeepCopy, opsv1alpha1.OpsSucceedPhase)
 	}
+	// The merge failed, so the assignments this ops wrote will never be applied,
+	// yet they would stay in the ComponentParameter desired spec and keep failing
+	// the projection for every later reconfigure. Withdraw this ops's own writes
+	// (and only them) so the failed intent does not outlive the failed ops.
+	if err := r.withdrawReconfigureFromParameters(reqCtx, cli, resource); err != nil {
+		return "", noRequeueAfter, err
+	}
 	return opsv1alpha1.OpsFailedPhase, 0, intctrlutil.NewFatalError(fmt.Sprintf("reconfigure failed: %s", msg))
+}
+
+// withdrawReconfigureFromParameters removes the desired assignments written by
+// this ops from the ComponentParameter, guarded by value equality so that a
+// newer ops that re-set the same key with a different value is not clobbered.
+// It is the failure-path counterpart of applyReconfigureToParameters: the ops
+// only withdraws its own write, it does not do any schema validation.
+func (r *reconfigureAction) withdrawReconfigureFromParameters(reqCtx intctrlutil.RequestCtx, cli client.Client, resource *OpsResource) error {
+	sameValue := func(a, b *string) bool {
+		if a == nil || b == nil {
+			return a == b
+		}
+		return *a == *b
+	}
+	for _, reconfigure := range resource.OpsRequest.Spec.Reconfigures {
+		compNames, err := r.resolveReconfigureComponents(reqCtx.Ctx, cli, resource.Cluster, reconfigure.ComponentName)
+		if err != nil {
+			return err
+		}
+		for _, compName := range compNames {
+			compParam, err := r.getRunningComponentParameter(reqCtx.Ctx, cli, resource.Cluster.Namespace, resource.Cluster.Name, compName)
+			if err != nil {
+				return client.IgnoreNotFound(err)
+			}
+			if compParam.Spec.Desired == nil || len(compParam.Spec.Desired.Assignments) == 0 {
+				continue
+			}
+			patch := client.MergeFrom(compParam.DeepCopy())
+			changed := false
+			for _, param := range reconfigure.Parameters {
+				current, ok := compParam.Spec.Desired.Assignments[param.Key]
+				if !ok || !sameValue(current, param.Value) {
+					continue
+				}
+				delete(compParam.Spec.Desired.Assignments, param.Key)
+				changed = true
+			}
+			if !changed {
+				continue
+			}
+			if err := cli.Patch(reqCtx.Ctx, compParam, patch); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func (r *reconfigureAction) Action(reqCtx intctrlutil.RequestCtx, cli client.Client, resource *OpsResource) (err error) {

--- a/pkg/operations/reconfigure.go
+++ b/pkg/operations/reconfigure.go
@@ -21,15 +21,18 @@ package operations
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	opsv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
 	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/sharding"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
@@ -60,8 +63,62 @@ func (r *reconfigureAction) ActionStartedCondition(reqCtx intctrlutil.RequestCtx
 	return opsv1alpha1.NewReconfigureCondition(opsRes.OpsRequest), nil
 }
 
+// reconfigurePriorValue records the desired-assignment state of one parameter
+// key before this ops applied its write. Existed=false means the key was not
+// present in the ComponentParameter desired assignments at that time.
+type reconfigurePriorValue struct {
+	Existed bool    `json:"existed"`
+	Value   *string `json:"value,omitempty"`
+}
+
+// SaveLastConfiguration snapshots, per component, the prior desired-assignment
+// state of every key this ops is about to write, so that the failure path can
+// restore (rather than blindly delete) previously accepted desired intent.
+// The ops framework invokes this hook before Action, while the
+// ComponentParameter still holds the pre-apply state; the snapshot is stored
+// as an annotation on the OpsRequest.
 func (r *reconfigureAction) SaveLastConfiguration(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes *OpsResource) error {
-	return nil
+	ops := opsRes.OpsRequest
+	if _, ok := ops.Annotations[constant.ReconfigurePriorParametersAnnotationKey]; ok {
+		return nil
+	}
+	snapshot := map[string]map[string]reconfigurePriorValue{}
+	for _, reconfigure := range ops.Spec.Reconfigures {
+		compNames, err := r.resolveReconfigureComponents(reqCtx.Ctx, cli, opsRes.Cluster, reconfigure.ComponentName)
+		if err != nil {
+			return err
+		}
+		for _, compName := range compNames {
+			compParam, err := r.getRunningComponentParameter(reqCtx.Ctx, cli, opsRes.Cluster.Namespace, opsRes.Cluster.Name, compName)
+			if err != nil && !apierrors.IsNotFound(err) {
+				return err
+			}
+			prior, ok := snapshot[compName]
+			if !ok {
+				prior = map[string]reconfigurePriorValue{}
+				snapshot[compName] = prior
+			}
+			for _, param := range reconfigure.Parameters {
+				pv := reconfigurePriorValue{}
+				if err == nil && compParam.Spec.Desired != nil {
+					if v, exist := compParam.Spec.Desired.Assignments[param.Key]; exist {
+						pv.Existed = true
+						pv.Value = v
+					}
+				}
+				prior[param.Key] = pv
+			}
+		}
+	}
+	data, err := json.Marshal(snapshot)
+	if err != nil {
+		return err
+	}
+	if ops.Annotations == nil {
+		ops.Annotations = map[string]string{}
+	}
+	ops.Annotations[constant.ReconfigurePriorParametersAnnotationKey] = string(data)
+	return cli.Update(reqCtx.Ctx, ops)
 }
 
 func (r *reconfigureAction) ReconcileAction(reqCtx intctrlutil.RequestCtx, cli client.Client, resource *OpsResource) (opsv1alpha1.OpsPhase, time.Duration, error) {
@@ -86,12 +143,26 @@ func (r *reconfigureAction) ReconcileAction(reqCtx intctrlutil.RequestCtx, cli c
 	return opsv1alpha1.OpsFailedPhase, 0, intctrlutil.NewFatalError(fmt.Sprintf("reconfigure failed: %s", msg))
 }
 
-// withdrawReconfigureFromParameters removes the desired assignments written by
-// this ops from the ComponentParameter, guarded by value equality so that a
-// newer ops that re-set the same key with a different value is not clobbered.
-// It is the failure-path counterpart of applyReconfigureToParameters: the ops
-// only withdraws its own write, it does not do any schema validation.
+// withdrawReconfigureFromParameters restores, in the ComponentParameter
+// desired assignments, the pre-ops state of every key this failed ops wrote —
+// but only while the current value still equals this ops's write (a newer
+// writer wins). Value equality against the ops spec alone cannot prove
+// ownership: the same key=value pair may be previously accepted desired intent
+// from an earlier successful reconfigure, in which case it must be kept, not
+// deleted. Ownership is therefore anchored on the prior-state snapshot taken
+// by SaveLastConfiguration; without a snapshot this path leaves the desired
+// state untouched. No schema validation is performed here.
 func (r *reconfigureAction) withdrawReconfigureFromParameters(reqCtx intctrlutil.RequestCtx, cli client.Client, resource *OpsResource) error {
+	raw, ok := resource.OpsRequest.Annotations[constant.ReconfigurePriorParametersAnnotationKey]
+	if !ok {
+		// no prior-state snapshot (e.g. ops created before this mechanism):
+		// do not mutate existing desired state on failure.
+		return nil
+	}
+	snapshot := map[string]map[string]reconfigurePriorValue{}
+	if err := json.Unmarshal([]byte(raw), &snapshot); err != nil {
+		return err
+	}
 	sameValue := func(a, b *string) bool {
 		if a == nil || b == nil {
 			return a == b
@@ -104,6 +175,10 @@ func (r *reconfigureAction) withdrawReconfigureFromParameters(reqCtx intctrlutil
 			return err
 		}
 		for _, compName := range compNames {
+			prior, ok := snapshot[compName]
+			if !ok {
+				continue
+			}
 			compParam, err := r.getRunningComponentParameter(reqCtx.Ctx, cli, resource.Cluster.Namespace, resource.Cluster.Name, compName)
 			if err != nil {
 				return client.IgnoreNotFound(err)
@@ -114,11 +189,25 @@ func (r *reconfigureAction) withdrawReconfigureFromParameters(reqCtx intctrlutil
 			patch := client.MergeFrom(compParam.DeepCopy())
 			changed := false
 			for _, param := range reconfigure.Parameters {
-				current, ok := compParam.Spec.Desired.Assignments[param.Key]
-				if !ok || !sameValue(current, param.Value) {
+				pv, snapshotted := prior[param.Key]
+				if !snapshotted {
 					continue
 				}
-				delete(compParam.Spec.Desired.Assignments, param.Key)
+				current, exist := compParam.Spec.Desired.Assignments[param.Key]
+				if !exist || !sameValue(current, param.Value) {
+					// already gone, or a newer writer re-set the key: leave it.
+					continue
+				}
+				if pv.Existed {
+					if sameValue(pv.Value, param.Value) {
+						// the same key=value was already accepted desired intent
+						// before this ops: keep it.
+						continue
+					}
+					compParam.Spec.Desired.Assignments[param.Key] = pv.Value
+				} else {
+					delete(compParam.Spec.Desired.Assignments, param.Key)
+				}
 				changed = true
 			}
 			if !changed {

--- a/pkg/operations/reconfigure_test.go
+++ b/pkg/operations/reconfigure_test.go
@@ -20,6 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package operations
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -298,6 +300,11 @@ parameter: {
 				ComponentOps: opsv1alpha1.ComponentOps{ComponentName: defaultCompName},
 				Parameters:   []opsv1alpha1.ParameterPair{{Key: "maxmemory-samples", Value: pointer.String("0")}},
 			}}
+			// prior-state snapshot as SaveLastConfiguration would have recorded it:
+			// the key did not exist before this ops.
+			ops.Annotations = map[string]string{
+				constant.ReconfigurePriorParametersAnnotationKey: fmt.Sprintf(`{"%s":{"maxmemory-samples":{"existed":false}}}`, defaultCompName),
+			}
 			opsRes.OpsRequest = testops.CreateOpsRequest(ctx, testCtx, ops)
 
 			Expect(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKeyFromObject(componentParameter), func(cp *parametersv1alpha1.ComponentParameter) {
@@ -353,6 +360,11 @@ parameter: {
 					{Key: "long-query-time", Value: pointer.String("5")},
 				},
 			}}
+			// prior-state snapshot as SaveLastConfiguration would have recorded it:
+			// neither key existed before this ops.
+			ops.Annotations = map[string]string{
+				constant.ReconfigurePriorParametersAnnotationKey: fmt.Sprintf(`{"%s":{"slow-query-log":{"existed":false},"long-query-time":{"existed":false}}}`, defaultCompName),
+			}
 			opsRes.OpsRequest = testops.CreateOpsRequest(ctx, testCtx, ops)
 
 			Expect(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKeyFromObject(componentParameter), func(cp *parametersv1alpha1.ComponentParameter) {
@@ -374,6 +386,116 @@ parameter: {
 				g.Expect(cp.Spec.Desired.Assignments).ShouldNot(HaveKey("long-query-time"))
 				g.Expect(cp.Spec.Desired.Assignments).Should(HaveKeyWithValue("wait-timeout", pointer.String("90")))
 				g.Expect(cp.Spec.Desired.Assignments).Should(HaveKeyWithValue("interactive-timeout", pointer.String("90")))
+			})).Should(Succeed())
+		})
+
+		It("restores previously accepted desired intent instead of deleting it", func() {
+			// Ownership cannot be proven by value equality against the ops spec: a
+			// failed ops may include a key=value pair that was already accepted
+			// desired intent from an earlier successful reconfigure. The withdrawal
+			// must keep such keys (same prior value) or restore the prior value
+			// (different prior value), guided by the prior-state snapshot.
+			reqCtx := intctrlutil.RequestCtx{Ctx: ctx}
+			opsRes, _, _ := initOperationsResources(compDefName, clusterName)
+
+			componentParameter := builder.NewComponentParameterBuilder(testCtx.DefaultNamespace, parameterscore.GenerateComponentConfigurationName(clusterName, defaultCompName)).
+				AddLabelsInMap(constant.GetCompLabelsWithDef(clusterName, defaultCompName, compDefName)).
+				SetClusterName(clusterName).
+				SetCompName(defaultCompName).
+				GetObject()
+			componentParameter.Spec.Desired = &parametersv1alpha1.ParameterInputs{
+				// accepted desired intent from an earlier successful reconfigure
+				Assignments: map[string]*string{
+					"max-connections": pointer.String("200"),
+					"innodb-io-cap":   pointer.String("1000"),
+				},
+			}
+			Expect(testCtx.CreateObj(ctx, componentParameter)).Should(Succeed())
+
+			ops := testops.NewOpsRequestObj("failed-reconfigure-restore-"+randomStr, testCtx.DefaultNamespace,
+				clusterName, opsv1alpha1.ReconfiguringType)
+			ops.Spec.Reconfigures = []opsv1alpha1.Reconfigure{{
+				ComponentOps: opsv1alpha1.ComponentOps{ComponentName: defaultCompName},
+				Parameters: []opsv1alpha1.ParameterPair{
+					// same value as the accepted intent — must be kept
+					{Key: "max-connections", Value: pointer.String("200")},
+					// overwrites the accepted intent — must be restored to prior
+					{Key: "innodb-io-cap", Value: pointer.String("2000")},
+					// fresh invalid key introduced by this ops — must be deleted
+					{Key: "bad-key", Value: pointer.String("nonsense")},
+				},
+			}}
+			ops.Annotations = map[string]string{
+				constant.ReconfigurePriorParametersAnnotationKey: fmt.Sprintf(
+					`{"%s":{"max-connections":{"existed":true,"value":"200"},"innodb-io-cap":{"existed":true,"value":"1000"},"bad-key":{"existed":false}}}`, defaultCompName),
+			}
+			opsRes.OpsRequest = testops.CreateOpsRequest(ctx, testCtx, ops)
+
+			// the CP now carries this ops's writes, as after applyReconfigureToParameters
+			Expect(testapps.GetAndChangeObj(&testCtx, client.ObjectKeyFromObject(componentParameter), func(cp *parametersv1alpha1.ComponentParameter) {
+				cp.Spec.Desired.Assignments["innodb-io-cap"] = pointer.String("2000")
+				cp.Spec.Desired.Assignments["bad-key"] = pointer.String("nonsense")
+			})()).Should(Succeed())
+
+			Expect(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKeyFromObject(componentParameter), func(cp *parametersv1alpha1.ComponentParameter) {
+				cp.Status.ObservedGeneration = cp.Generation
+				cp.Status.Phase = parametersv1alpha1.CMergeFailedPhase
+				cp.Status.Message = "parameter bad-key value \"nonsense\" is invalid"
+				cp.Status.ConfigurationItemStatus = []parametersv1alpha1.ConfigTemplateItemDetailStatus{{
+					Name:  "mysql-config",
+					Phase: parametersv1alpha1.CMergeFailedPhase,
+				}}
+			})()).Should(Succeed())
+
+			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsRunningPhase
+			_, _ = GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
+
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(componentParameter), func(g Gomega, cp *parametersv1alpha1.ComponentParameter) {
+				g.Expect(cp.Spec.Desired).ShouldNot(BeNil())
+				g.Expect(cp.Spec.Desired.Assignments).Should(HaveKeyWithValue("max-connections", pointer.String("200")))
+				g.Expect(cp.Spec.Desired.Assignments).Should(HaveKeyWithValue("innodb-io-cap", pointer.String("1000")))
+				g.Expect(cp.Spec.Desired.Assignments).ShouldNot(HaveKey("bad-key"))
+			})).Should(Succeed())
+		})
+
+		It("does not mutate desired state on failure without a prior-state snapshot", func() {
+			reqCtx := intctrlutil.RequestCtx{Ctx: ctx}
+			opsRes, _, _ := initOperationsResources(compDefName, clusterName)
+
+			componentParameter := builder.NewComponentParameterBuilder(testCtx.DefaultNamespace, parameterscore.GenerateComponentConfigurationName(clusterName, defaultCompName)).
+				AddLabelsInMap(constant.GetCompLabelsWithDef(clusterName, defaultCompName, compDefName)).
+				SetClusterName(clusterName).
+				SetCompName(defaultCompName).
+				GetObject()
+			componentParameter.Spec.Desired = &parametersv1alpha1.ParameterInputs{
+				Assignments: map[string]*string{"maxmemory-samples": pointer.String("0")},
+			}
+			Expect(testCtx.CreateObj(ctx, componentParameter)).Should(Succeed())
+
+			ops := testops.NewOpsRequestObj("failed-reconfigure-nosnap-"+randomStr, testCtx.DefaultNamespace,
+				clusterName, opsv1alpha1.ReconfiguringType)
+			ops.Spec.Reconfigures = []opsv1alpha1.Reconfigure{{
+				ComponentOps: opsv1alpha1.ComponentOps{ComponentName: defaultCompName},
+				Parameters:   []opsv1alpha1.ParameterPair{{Key: "maxmemory-samples", Value: pointer.String("0")}},
+			}}
+			// no snapshot annotation: ops created before this mechanism
+			opsRes.OpsRequest = testops.CreateOpsRequest(ctx, testCtx, ops)
+
+			Expect(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKeyFromObject(componentParameter), func(cp *parametersv1alpha1.ComponentParameter) {
+				cp.Status.ObservedGeneration = cp.Generation
+				cp.Status.Phase = parametersv1alpha1.CMergeFailedPhase
+				cp.Status.Message = "merge failed"
+				cp.Status.ConfigurationItemStatus = []parametersv1alpha1.ConfigTemplateItemDetailStatus{{
+					Name:  "mysql-config",
+					Phase: parametersv1alpha1.CMergeFailedPhase,
+				}}
+			})()).Should(Succeed())
+
+			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsRunningPhase
+			_, _ = GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
+
+			Consistently(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(componentParameter), func(g Gomega, cp *parametersv1alpha1.ComponentParameter) {
+				g.Expect(cp.Spec.Desired.Assignments).Should(HaveKeyWithValue("maxmemory-samples", pointer.String("0")))
 			})).Should(Succeed())
 		})
 	})

--- a/pkg/operations/reconfigure_test.go
+++ b/pkg/operations/reconfigure_test.go
@@ -244,6 +244,11 @@ parameter: {
 				g.Expect(cp.Spec.Desired.Assignments).Should(HaveKeyWithValue("maxmemory-samples", pointer.String("0")))
 			})).Should(Succeed())
 
+			By("seed an unrelated pre-existing desired key that must survive the withdrawal")
+			Expect(testapps.GetAndChangeObj(&testCtx, client.ObjectKeyFromObject(componentParameter), func(cp *parametersv1alpha1.ComponentParameter) {
+				cp.Spec.Desired.Assignments["unrelated-key"] = pointer.String("keep")
+			})()).Should(Succeed())
+
 			By("surface the ComponentParameter failure back to the opsRequest")
 			Expect(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKeyFromObject(componentParameter), func(cp *parametersv1alpha1.ComponentParameter) {
 				cp.Status.ObservedGeneration = cp.Generation
@@ -262,6 +267,54 @@ parameter: {
 				condition := meta.FindStatusCondition(fetched.Status.Conditions, opsv1alpha1.ConditionTypeFailed)
 				g.Expect(condition).ShouldNot(BeNil())
 				g.Expect(condition.Message).Should(ContainSubstring("maxmemory-samples"))
+			})).Should(Succeed())
+
+			By("the failed ops's own assignment is withdrawn; unrelated intent survives")
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(componentParameter), func(g Gomega, cp *parametersv1alpha1.ComponentParameter) {
+				g.Expect(cp.Spec.Desired).ShouldNot(BeNil())
+				g.Expect(cp.Spec.Desired.Assignments).ShouldNot(HaveKey("maxmemory-samples"))
+				g.Expect(cp.Spec.Desired.Assignments).Should(HaveKeyWithValue("unrelated-key", pointer.String("keep")))
+			})).Should(Succeed())
+		})
+
+		It("does not withdraw a key that a newer ops has re-set to a different value", func() {
+			reqCtx := intctrlutil.RequestCtx{Ctx: ctx}
+			opsRes, _, _ := initOperationsResources(compDefName, clusterName)
+
+			componentParameter := builder.NewComponentParameterBuilder(testCtx.DefaultNamespace, parameterscore.GenerateComponentConfigurationName(clusterName, defaultCompName)).
+				AddLabelsInMap(constant.GetCompLabelsWithDef(clusterName, defaultCompName, compDefName)).
+				SetClusterName(clusterName).
+				SetCompName(defaultCompName).
+				GetObject()
+			componentParameter.Spec.Desired = &parametersv1alpha1.ParameterInputs{
+				// a newer ops has re-set the same key to a different value
+				Assignments: map[string]*string{"maxmemory-samples": pointer.String("7")},
+			}
+			Expect(testCtx.CreateObj(ctx, componentParameter)).Should(Succeed())
+
+			ops := testops.NewOpsRequestObj("failed-reconfigure-guard-"+randomStr, testCtx.DefaultNamespace,
+				clusterName, opsv1alpha1.ReconfiguringType)
+			ops.Spec.Reconfigures = []opsv1alpha1.Reconfigure{{
+				ComponentOps: opsv1alpha1.ComponentOps{ComponentName: defaultCompName},
+				Parameters:   []opsv1alpha1.ParameterPair{{Key: "maxmemory-samples", Value: pointer.String("0")}},
+			}}
+			opsRes.OpsRequest = testops.CreateOpsRequest(ctx, testCtx, ops)
+
+			Expect(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKeyFromObject(componentParameter), func(cp *parametersv1alpha1.ComponentParameter) {
+				cp.Status.ObservedGeneration = cp.Generation
+				cp.Status.Phase = parametersv1alpha1.CMergeFailedPhase
+				cp.Status.Message = "merge failed"
+				cp.Status.ConfigurationItemStatus = []parametersv1alpha1.ConfigTemplateItemDetailStatus{{
+					Name:  "mysql-config",
+					Phase: parametersv1alpha1.CMergeFailedPhase,
+				}}
+			})()).Should(Succeed())
+
+			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsRunningPhase
+			_, _ = GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
+
+			Consistently(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(componentParameter), func(g Gomega, cp *parametersv1alpha1.ComponentParameter) {
+				g.Expect(cp.Spec.Desired.Assignments).Should(HaveKeyWithValue("maxmemory-samples", pointer.String("7")))
 			})).Should(Succeed())
 		})
 	})

--- a/pkg/operations/reconfigure_test.go
+++ b/pkg/operations/reconfigure_test.go
@@ -317,5 +317,64 @@ parameter: {
 				g.Expect(cp.Spec.Desired.Assignments).Should(HaveKeyWithValue("maxmemory-samples", pointer.String("7")))
 			})).Should(Succeed())
 		})
+
+		It("withdraws only the failed ops's keys from assignments mixed with another ops's writes", func() {
+			// Modeled on a live field sample (MariaDB, 2026-07-07): the desired
+			// assignments of one ComponentParameter carried the writes of two ops at
+			// once — the failed ops's invalid value plus a later legitimate ops's
+			// keys. The withdrawal must remove exactly the failed ops's own keys and
+			// leave the other ops's intent untouched.
+			reqCtx := intctrlutil.RequestCtx{Ctx: ctx}
+			opsRes, _, _ := initOperationsResources(compDefName, clusterName)
+
+			componentParameter := builder.NewComponentParameterBuilder(testCtx.DefaultNamespace, parameterscore.GenerateComponentConfigurationName(clusterName, defaultCompName)).
+				AddLabelsInMap(constant.GetCompLabelsWithDef(clusterName, defaultCompName, compDefName)).
+				SetClusterName(clusterName).
+				SetCompName(defaultCompName).
+				GetObject()
+			componentParameter.Spec.Desired = &parametersv1alpha1.ParameterInputs{
+				Assignments: map[string]*string{
+					// written by the failing ops
+					"slow-query-log":  pointer.String("nonsense"),
+					"long-query-time": pointer.String("5"),
+					// written by a later, legitimate ops
+					"wait-timeout":        pointer.String("90"),
+					"interactive-timeout": pointer.String("90"),
+				},
+			}
+			Expect(testCtx.CreateObj(ctx, componentParameter)).Should(Succeed())
+
+			ops := testops.NewOpsRequestObj("failed-reconfigure-mixed-"+randomStr, testCtx.DefaultNamespace,
+				clusterName, opsv1alpha1.ReconfiguringType)
+			ops.Spec.Reconfigures = []opsv1alpha1.Reconfigure{{
+				ComponentOps: opsv1alpha1.ComponentOps{ComponentName: defaultCompName},
+				Parameters: []opsv1alpha1.ParameterPair{
+					{Key: "slow-query-log", Value: pointer.String("nonsense")},
+					{Key: "long-query-time", Value: pointer.String("5")},
+				},
+			}}
+			opsRes.OpsRequest = testops.CreateOpsRequest(ctx, testCtx, ops)
+
+			Expect(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKeyFromObject(componentParameter), func(cp *parametersv1alpha1.ComponentParameter) {
+				cp.Status.ObservedGeneration = cp.Generation
+				cp.Status.Phase = parametersv1alpha1.CMergeFailedPhase
+				cp.Status.Message = "parameter slow-query-log value \"nonsense\" is invalid"
+				cp.Status.ConfigurationItemStatus = []parametersv1alpha1.ConfigTemplateItemDetailStatus{{
+					Name:  "mysql-config",
+					Phase: parametersv1alpha1.CMergeFailedPhase,
+				}}
+			})()).Should(Succeed())
+
+			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsRunningPhase
+			_, _ = GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
+
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(componentParameter), func(g Gomega, cp *parametersv1alpha1.ComponentParameter) {
+				g.Expect(cp.Spec.Desired).ShouldNot(BeNil())
+				g.Expect(cp.Spec.Desired.Assignments).ShouldNot(HaveKey("slow-query-log"))
+				g.Expect(cp.Spec.Desired.Assignments).ShouldNot(HaveKey("long-query-time"))
+				g.Expect(cp.Spec.Desired.Assignments).Should(HaveKeyWithValue("wait-timeout", pointer.String("90")))
+				g.Expect(cp.Spec.Desired.Assignments).Should(HaveKeyWithValue("interactive-timeout", pointer.String("90")))
+			})).Should(Succeed())
+		})
 	})
 })


### PR DESCRIPTION
## Problem

Fixes #10430. Fixes #10416.

A reconfigure OpsRequest writes its parameters into `ComponentParameter.spec.desired.assignments`; the parameters controller validates them and, on an invalid key, sets `CMergeFailedPhase` — the ops correctly turns Failed. But the failed ops's assignments stay in `desired`, so the projection re-fails on the stale key at every subsequent reconcile and **all later valid reconfigures fail with the stale error**; the only recovery is manual editing of `spec.desired.assignments`.

## Design boundary

Two earlier attempts (#10415, #10438) added schema pre-validation in the Ops action and were closed with the reviewer direction that **validation belongs to the parameters controller**. This PR stays inside that boundary: the ops performs no validation — it only withdraws **its own write** when it fails, the failure-path counterpart of `applyReconfigureToParameters`. Removal is guarded by value equality, so a newer ops that re-set the same key to a different value is not clobbered; unrelated desired intent is untouched.

## Tests (envtest)

- extended `propagates ComponentParameter merge failure`: after the ops reaches Failed, its assignment is gone from desired while an unrelated pre-existing key survives.
- new: a key re-set by a newer ops to a different value is not withdrawn (value guard, checked with `Consistently`).
- `go test ./pkg/operations -count=1` with envtest assets — passes.

## Ownership model (revised per review)

Value equality against the ops spec cannot prove ownership — the same key=value pair may be previously accepted desired intent from an earlier successful reconfigure. Ownership is now anchored on a **prior-state snapshot**: `SaveLastConfiguration` (invoked by the framework before Action, while the ComponentParameter still holds pre-apply state) records `{existed, value}` for every key the ops writes, persisted as an OpsRequest annotation. The failure-path withdrawal *restores* each key to its snapshotted prior state (delete if absent before; restore prior value if overwritten; keep if the same value was already accepted), and only while the current value still equals this ops's write (a newer writer wins). Without a snapshot, the withdrawal does not mutate desired state.

Tests cover: previously-accepted same-value kept; overwritten key restored; fresh key deleted; newer-writer untouched; no-snapshot no-op; unrelated intent survival; mixed two-ops assignments.
