### PR TITLE
fix(api): validate instance template labels

### DIFF
--- a/apis/apps/v1/types.go
+++ b/apis/apps/v1/types.go
@@ -850,6 +850,9 @@ type InstanceTemplate struct {
 	// Specifies a map of key-value pairs that will be merged into the Pod's existing labels.
 	// Values for existing keys will be overwritten, and new keys will be added.
 	//
+	// +kubebuilder:validation:MaxProperties=64
+	// +kubebuilder:validation:XValidation:rule="self.all(k, size(k) <= 317 && (!k.contains('/') || k.matches('^.{1,253}/.*$')) && k.matches('^(([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)(\\\\.([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?))*\\\\/)?([A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?)$'))",message="label keys must be valid Kubernetes label keys"
+	// +kubebuilder:validation:XValidation:rule="self.all(k, size(self[k]) <= 63 && self[k].matches('^(([A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?)?)$'))",message="label values must be valid Kubernetes label values"
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
 

--- a/apis/workloads/v1/instanceset_types.go
+++ b/apis/workloads/v1/instanceset_types.go
@@ -433,6 +433,9 @@ type InstanceTemplate struct {
 	// Specifies a map of key-value pairs that will be merged into the Pod's existing labels.
 	// Values for existing keys will be overwritten, and new keys will be added.
 	//
+	// +kubebuilder:validation:MaxProperties=64
+	// +kubebuilder:validation:XValidation:rule="self.all(k, size(k) <= 317 && (!k.contains('/') || k.matches('^.{1,253}/.*$')) && k.matches('^(([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)(\\\\.([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?))*\\\\/)?([A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?)$'))",message="label keys must be valid Kubernetes label keys"
+	// +kubebuilder:validation:XValidation:rule="self.all(k, size(self[k]) <= 63 && self[k].matches('^(([A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?)?)$'))",message="label values must be valid Kubernetes label values"
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
 

--- a/config/crd/bases/apps.kubeblocks.io_clusters.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusters.yaml
@@ -1071,7 +1071,15 @@ spec:
                             description: |-
                               Specifies a map of key-value pairs that will be merged into the Pod's existing labels.
                               Values for existing keys will be overwritten, and new keys will be added.
+                            maxProperties: 64
                             type: object
+                            x-kubernetes-validations:
+                            - message: label keys must be valid Kubernetes label keys
+                              rule: self.all(k, size(k) <= 317 && (!k.contains('/')
+                                || k.matches('^.{1,253}/.*$')) && k.matches('^(([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)(\\.([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?))*\\/)?([A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?)$'))
+                            - message: label values must be valid Kubernetes label
+                                values
+                              rule: self.all(k, size(self[k]) <= 63 && self[k].matches('^(([A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?)?)$'))
                           name:
                             description: |-
                               Name specifies the unique name of the instance Pod created using this InstanceTemplate.
@@ -8272,7 +8280,16 @@ spec:
                                   description: |-
                                     Specifies a map of key-value pairs that will be merged into the Pod's existing labels.
                                     Values for existing keys will be overwritten, and new keys will be added.
+                                  maxProperties: 64
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: label keys must be valid Kubernetes label
+                                      keys
+                                    rule: self.all(k, size(k) <= 317 && (!k.contains('/')
+                                      || k.matches('^.{1,253}/.*$')) && k.matches('^(([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)(\\.([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?))*\\/)?([A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?)$'))
+                                  - message: label values must be valid Kubernetes
+                                      label values
+                                    rule: self.all(k, size(self[k]) <= 63 && self[k].matches('^(([A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?)?)$'))
                                 name:
                                   description: |-
                                     Name specifies the unique name of the instance Pod created using this InstanceTemplate.
@@ -12300,7 +12317,16 @@ spec:
                                 description: |-
                                   Specifies a map of key-value pairs that will be merged into the Pod's existing labels.
                                   Values for existing keys will be overwritten, and new keys will be added.
+                                maxProperties: 64
                                 type: object
+                                x-kubernetes-validations:
+                                - message: label keys must be valid Kubernetes label
+                                    keys
+                                  rule: self.all(k, size(k) <= 317 && (!k.contains('/')
+                                    || k.matches('^.{1,253}/.*$')) && k.matches('^(([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)(\\.([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?))*\\/)?([A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?)$'))
+                                - message: label values must be valid Kubernetes label
+                                    values
+                                  rule: self.all(k, size(self[k]) <= 63 && self[k].matches('^(([A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?)?)$'))
                               name:
                                 description: |-
                                   Name specifies the unique name of the instance Pod created using this InstanceTemplate.

--- a/config/crd/bases/apps.kubeblocks.io_components.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_components.yaml
@@ -1373,7 +1373,14 @@ spec:
                       description: |-
                         Specifies a map of key-value pairs that will be merged into the Pod's existing labels.
                         Values for existing keys will be overwritten, and new keys will be added.
+                      maxProperties: 64
                       type: object
+                      x-kubernetes-validations:
+                      - message: label keys must be valid Kubernetes label keys
+                        rule: self.all(k, size(k) <= 317 && (!k.contains('/') || k.matches('^.{1,253}/.*$'))
+                          && k.matches('^(([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)(\\.([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?))*\\/)?([A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?)$'))
+                      - message: label values must be valid Kubernetes label values
+                        rule: self.all(k, size(self[k]) <= 63 && self[k].matches('^(([A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?)?)$'))
                     name:
                       description: |-
                         Name specifies the unique name of the instance Pod created using this InstanceTemplate.

--- a/config/crd/bases/operations.kubeblocks.io_opsrequests.yaml
+++ b/config/crd/bases/operations.kubeblocks.io_opsrequests.yaml
@@ -933,7 +933,16 @@ spec:
                                 description: |-
                                   Specifies a map of key-value pairs that will be merged into the Pod's existing labels.
                                   Values for existing keys will be overwritten, and new keys will be added.
+                                maxProperties: 64
                                 type: object
+                                x-kubernetes-validations:
+                                - message: label keys must be valid Kubernetes label
+                                    keys
+                                  rule: self.all(k, size(k) <= 317 && (!k.contains('/')
+                                    || k.matches('^.{1,253}/.*$')) && k.matches('^(([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)(\\.([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?))*\\/)?([A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?)$'))
+                                - message: label values must be valid Kubernetes label
+                                    values
+                                  rule: self.all(k, size(self[k]) <= 63 && self[k].matches('^(([A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?)?)$'))
                               name:
                                 description: |-
                                   Name specifies the unique name of the instance Pod created using this InstanceTemplate.
@@ -3715,7 +3724,16 @@ spec:
                                 description: |-
                                   Specifies a map of key-value pairs that will be merged into the Pod's existing labels.
                                   Values for existing keys will be overwritten, and new keys will be added.
+                                maxProperties: 64
                                 type: object
+                                x-kubernetes-validations:
+                                - message: label keys must be valid Kubernetes label
+                                    keys
+                                  rule: self.all(k, size(k) <= 317 && (!k.contains('/')
+                                    || k.matches('^.{1,253}/.*$')) && k.matches('^(([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)(\\.([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?))*\\/)?([A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?)$'))
+                                - message: label values must be valid Kubernetes label
+                                    values
+                                  rule: self.all(k, size(self[k]) <= 63 && self[k].matches('^(([A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?)?)$'))
                               name:
                                 description: |-
                                   Name specifies the unique name of the instance Pod created using this InstanceTemplate.

--- a/config/crd/bases/workloads.kubeblocks.io_instancesets.yaml
+++ b/config/crd/bases/workloads.kubeblocks.io_instancesets.yaml
@@ -781,7 +781,14 @@ spec:
                       description: |-
                         Specifies a map of key-value pairs that will be merged into the Pod's existing labels.
                         Values for existing keys will be overwritten, and new keys will be added.
+                      maxProperties: 64
                       type: object
+                      x-kubernetes-validations:
+                      - message: label keys must be valid Kubernetes label keys
+                        rule: self.all(k, size(k) <= 317 && (!k.contains('/') || k.matches('^.{1,253}/.*$'))
+                          && k.matches('^(([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)(\\.([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?))*\\/)?([A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?)$'))
+                      - message: label values must be valid Kubernetes label values
+                        rule: self.all(k, size(self[k]) <= 63 && self[k].matches('^(([A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?)?)$'))
                     name:
                       description: |-
                         Name specifies the unique name of the instance Pod created using this InstanceTemplate.

--- a/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
@@ -1071,7 +1071,15 @@ spec:
                             description: |-
                               Specifies a map of key-value pairs that will be merged into the Pod's existing labels.
                               Values for existing keys will be overwritten, and new keys will be added.
+                            maxProperties: 64
                             type: object
+                            x-kubernetes-validations:
+                            - message: label keys must be valid Kubernetes label keys
+                              rule: self.all(k, size(k) <= 317 && (!k.contains('/')
+                                || k.matches('^.{1,253}/.*$')) && k.matches('^(([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)(\\.([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?))*\\/)?([A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?)$'))
+                            - message: label values must be valid Kubernetes label
+                                values
+                              rule: self.all(k, size(self[k]) <= 63 && self[k].matches('^(([A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?)?)$'))
                           name:
                             description: |-
                               Name specifies the unique name of the instance Pod created using this InstanceTemplate.
@@ -8272,7 +8280,16 @@ spec:
                                   description: |-
                                     Specifies a map of key-value pairs that will be merged into the Pod's existing labels.
                                     Values for existing keys will be overwritten, and new keys will be added.
+                                  maxProperties: 64
                                   type: object
+                                  x-kubernetes-validations:
+                                  - message: label keys must be valid Kubernetes label
+                                      keys
+                                    rule: self.all(k, size(k) <= 317 && (!k.contains('/')
+                                      || k.matches('^.{1,253}/.*$')) && k.matches('^(([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)(\\.([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?))*\\/)?([A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?)$'))
+                                  - message: label values must be valid Kubernetes
+                                      label values
+                                    rule: self.all(k, size(self[k]) <= 63 && self[k].matches('^(([A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?)?)$'))
                                 name:
                                   description: |-
                                     Name specifies the unique name of the instance Pod created using this InstanceTemplate.
@@ -12300,7 +12317,16 @@ spec:
                                 description: |-
                                   Specifies a map of key-value pairs that will be merged into the Pod's existing labels.
                                   Values for existing keys will be overwritten, and new keys will be added.
+                                maxProperties: 64
                                 type: object
+                                x-kubernetes-validations:
+                                - message: label keys must be valid Kubernetes label
+                                    keys
+                                  rule: self.all(k, size(k) <= 317 && (!k.contains('/')
+                                    || k.matches('^.{1,253}/.*$')) && k.matches('^(([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)(\\.([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?))*\\/)?([A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?)$'))
+                                - message: label values must be valid Kubernetes label
+                                    values
+                                  rule: self.all(k, size(self[k]) <= 63 && self[k].matches('^(([A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?)?)$'))
                               name:
                                 description: |-
                                   Name specifies the unique name of the instance Pod created using this InstanceTemplate.

--- a/deploy/helm/crds/apps.kubeblocks.io_components.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_components.yaml
@@ -1373,7 +1373,14 @@ spec:
                       description: |-
                         Specifies a map of key-value pairs that will be merged into the Pod's existing labels.
                         Values for existing keys will be overwritten, and new keys will be added.
+                      maxProperties: 64
                       type: object
+                      x-kubernetes-validations:
+                      - message: label keys must be valid Kubernetes label keys
+                        rule: self.all(k, size(k) <= 317 && (!k.contains('/') || k.matches('^.{1,253}/.*$'))
+                          && k.matches('^(([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)(\\.([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?))*\\/)?([A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?)$'))
+                      - message: label values must be valid Kubernetes label values
+                        rule: self.all(k, size(self[k]) <= 63 && self[k].matches('^(([A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?)?)$'))
                     name:
                       description: |-
                         Name specifies the unique name of the instance Pod created using this InstanceTemplate.

--- a/deploy/helm/crds/operations.kubeblocks.io_opsrequests.yaml
+++ b/deploy/helm/crds/operations.kubeblocks.io_opsrequests.yaml
@@ -933,7 +933,16 @@ spec:
                                 description: |-
                                   Specifies a map of key-value pairs that will be merged into the Pod's existing labels.
                                   Values for existing keys will be overwritten, and new keys will be added.
+                                maxProperties: 64
                                 type: object
+                                x-kubernetes-validations:
+                                - message: label keys must be valid Kubernetes label
+                                    keys
+                                  rule: self.all(k, size(k) <= 317 && (!k.contains('/')
+                                    || k.matches('^.{1,253}/.*$')) && k.matches('^(([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)(\\.([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?))*\\/)?([A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?)$'))
+                                - message: label values must be valid Kubernetes label
+                                    values
+                                  rule: self.all(k, size(self[k]) <= 63 && self[k].matches('^(([A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?)?)$'))
                               name:
                                 description: |-
                                   Name specifies the unique name of the instance Pod created using this InstanceTemplate.
@@ -3715,7 +3724,16 @@ spec:
                                 description: |-
                                   Specifies a map of key-value pairs that will be merged into the Pod's existing labels.
                                   Values for existing keys will be overwritten, and new keys will be added.
+                                maxProperties: 64
                                 type: object
+                                x-kubernetes-validations:
+                                - message: label keys must be valid Kubernetes label
+                                    keys
+                                  rule: self.all(k, size(k) <= 317 && (!k.contains('/')
+                                    || k.matches('^.{1,253}/.*$')) && k.matches('^(([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)(\\.([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?))*\\/)?([A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?)$'))
+                                - message: label values must be valid Kubernetes label
+                                    values
+                                  rule: self.all(k, size(self[k]) <= 63 && self[k].matches('^(([A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?)?)$'))
                               name:
                                 description: |-
                                   Name specifies the unique name of the instance Pod created using this InstanceTemplate.

--- a/deploy/helm/crds/workloads.kubeblocks.io_instancesets.yaml
+++ b/deploy/helm/crds/workloads.kubeblocks.io_instancesets.yaml
@@ -781,7 +781,14 @@ spec:
                       description: |-
                         Specifies a map of key-value pairs that will be merged into the Pod's existing labels.
                         Values for existing keys will be overwritten, and new keys will be added.
+                      maxProperties: 64
                       type: object
+                      x-kubernetes-validations:
+                      - message: label keys must be valid Kubernetes label keys
+                        rule: self.all(k, size(k) <= 317 && (!k.contains('/') || k.matches('^.{1,253}/.*$'))
+                          && k.matches('^(([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?)(\\.([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?))*\\/)?([A-Za-z0-9]([-A-Za-z0-9_.]{0,61}[A-Za-z0-9])?)$'))
+                      - message: label values must be valid Kubernetes label values
+                        rule: self.all(k, size(self[k]) <= 63 && self[k].matches('^(([A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?)?)$'))
                     name:
                       description: |-
                         Name specifies the unique name of the instance Pod created using this InstanceTemplate.


### PR DESCRIPTION
## Summary
- add CEL validation for InstanceTemplate label keys and values in apps/v1 and workloads/v1
- regenerate Cluster, Component, InstanceSet, and OpsRequest CRDs plus Helm CRDs so embedded instance template labels reject invalid Kubernetes label values

Fixes #10539

## Validation
- GOPATH=/tmp/go-path GOCACHE=/tmp/go-cache GOMODCACHE=/tmp/go-mod-cache make manifests
- GOPATH=/tmp/go-path GOCACHE=/tmp/go-cache GOMODCACHE=/tmp/go-mod-cache make generate
- GOPATH=/tmp/go-path GOCACHE=/tmp/go-cache GOMODCACHE=/tmp/go-mod-cache go test ./apis/apps/v1 ./apis/workloads/v1
- git diff --check