### PR TITLE
fix(api): validate instance template labels in webhook

### DIFF
--- a/apis/apps/v1/cluster_webhook.go
+++ b/apis/apps/v1/cluster_webhook.go
@@ -20,7 +20,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package v1
 
 import (
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // log is for logging in this package.
@@ -32,4 +39,57 @@ func (r *Cluster) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-// TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
+func (r *Cluster) ValidateCreate() (admission.Warnings, error) {
+	return nil, r.validateInstanceTemplateLabels()
+}
+
+func (r *Cluster) ValidateUpdate(_ runtime.Object) (admission.Warnings, error) {
+	return nil, r.validateInstanceTemplateLabels()
+}
+
+func (r *Cluster) ValidateDelete() (admission.Warnings, error) {
+	return nil, nil
+}
+
+func (r *Cluster) validateInstanceTemplateLabels() error {
+	var allErrs field.ErrorList
+	specPath := field.NewPath("spec")
+	for i := range r.Spec.ComponentSpecs {
+		allErrs = append(allErrs, validateInstanceTemplatesLabels(r.Spec.ComponentSpecs[i].Instances,
+			specPath.Child("componentSpecs").Index(i).Child("instances"))...)
+	}
+	for i := range r.Spec.Shardings {
+		shardingPath := specPath.Child("shardings").Index(i)
+		allErrs = append(allErrs, validateInstanceTemplatesLabels(r.Spec.Shardings[i].Template.Instances,
+			shardingPath.Child("template").Child("instances"))...)
+		for j := range r.Spec.Shardings[i].ShardTemplates {
+			allErrs = append(allErrs, validateInstanceTemplatesLabels(r.Spec.Shardings[i].ShardTemplates[j].Instances,
+				shardingPath.Child("shardTemplates").Index(j).Child("instances"))...)
+		}
+	}
+	if len(allErrs) == 0 {
+		return nil
+	}
+	return apierrors.NewInvalid(GroupVersion.WithKind("Cluster").GroupKind(), r.Name, allErrs)
+}
+
+func validateInstanceTemplatesLabels(instances []InstanceTemplate, path *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	for i := range instances {
+		allErrs = append(allErrs, validateLabels(instances[i].Labels, path.Index(i).Child("labels"))...)
+	}
+	return allErrs
+}
+
+func validateLabels(labels map[string]string, path *field.Path) field.ErrorList {
+	var allErrs field.ErrorList
+	for k, v := range labels {
+		for _, msg := range validation.IsQualifiedName(k) {
+			allErrs = append(allErrs, field.Invalid(path.Key(k), k, fmt.Sprintf("invalid label key: %s", msg)))
+		}
+		for _, msg := range validation.IsValidLabelValue(v) {
+			allErrs = append(allErrs, field.Invalid(path.Key(k), v, fmt.Sprintf("invalid label value: %s", msg)))
+		}
+	}
+	return allErrs
+}

--- a/apis/apps/v1/component_webhook.go
+++ b/apis/apps/v1/component_webhook.go
@@ -20,7 +20,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package v1
 
 import (
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // log is for logging in this package.
@@ -32,4 +36,22 @@ func (r *Component) SetupWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-// TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
+func (r *Component) ValidateCreate() (admission.Warnings, error) {
+	return nil, r.validateInstanceTemplateLabels()
+}
+
+func (r *Component) ValidateUpdate(_ runtime.Object) (admission.Warnings, error) {
+	return nil, r.validateInstanceTemplateLabels()
+}
+
+func (r *Component) ValidateDelete() (admission.Warnings, error) {
+	return nil, nil
+}
+
+func (r *Component) validateInstanceTemplateLabels() error {
+	allErrs := validateInstanceTemplatesLabels(r.Spec.Instances, field.NewPath("spec").Child("instances"))
+	if len(allErrs) == 0 {
+		return nil
+	}
+	return apierrors.NewInvalid(GroupVersion.WithKind("Component").GroupKind(), r.Name, allErrs)
+}

--- a/apis/apps/v1/instance_template_label_validation_test.go
+++ b/apis/apps/v1/instance_template_label_validation_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package v1
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestClusterValidatesInstanceTemplateLabelValues(t *testing.T) {
+	cluster := &Cluster{
+		Spec: ClusterSpec{
+			ComponentSpecs: []ClusterComponentSpec{{
+				Name: "mysql",
+				Instances: []InstanceTemplate{{
+					Name:   "az-a",
+					Labels: map[string]string{"test": "test-wec1, test-wec2"},
+				}},
+			}},
+		},
+	}
+
+	err := cluster.validateInstanceTemplateLabels()
+	if err == nil {
+		t.Fatal("expected invalid label value to be rejected")
+	}
+	if !strings.Contains(err.Error(), "spec.componentSpecs[0].instances[0].labels[test]") {
+		t.Fatalf("expected component instance label path in error, got %v", err)
+	}
+}
+
+func TestClusterValidatesShardingInstanceTemplateLabelValues(t *testing.T) {
+	cluster := &Cluster{
+		Spec: ClusterSpec{
+			Shardings: []ClusterSharding{{
+				Name: "shard",
+				Template: ClusterComponentSpec{
+					Instances: []InstanceTemplate{{
+						Name:   "az-a",
+						Labels: map[string]string{"test": "valid"},
+					}},
+				},
+				ShardTemplates: []ShardTemplate{{
+					Name: "shard-a",
+					Instances: []InstanceTemplate{{
+						Name:   "az-b",
+						Labels: map[string]string{"test": "test-wec1, test-wec2"},
+					}},
+				}},
+			}},
+		},
+	}
+
+	err := cluster.validateInstanceTemplateLabels()
+	if err == nil {
+		t.Fatal("expected invalid sharding label value to be rejected")
+	}
+	if !strings.Contains(err.Error(), "spec.shardings[0].shardTemplates[0].instances[0].labels[test]") {
+		t.Fatalf("expected sharding instance label path in error, got %v", err)
+	}
+}
+
+func TestComponentValidatesInstanceTemplateLabelKeys(t *testing.T) {
+	component := &Component{
+		Spec: ComponentSpec{
+			Instances: []InstanceTemplate{{
+				Name:   "az-a",
+				Labels: map[string]string{"bad/key/again": "valid"},
+			}},
+		},
+	}
+
+	err := component.validateInstanceTemplateLabels()
+	if err == nil {
+		t.Fatal("expected invalid label key to be rejected")
+	}
+	if !strings.Contains(err.Error(), "spec.instances[0].labels[bad/key/again]") {
+		t.Fatalf("expected component instance label path in error, got %v", err)
+	}
+}
+
+func TestClusterAllowsValidInstanceTemplateLabels(t *testing.T) {
+	cluster := &Cluster{
+		Spec: ClusterSpec{
+			ComponentSpecs: []ClusterComponentSpec{{
+				Name: "mysql",
+				Instances: []InstanceTemplate{{
+					Name: "az-a",
+					Labels: map[string]string{
+						"example.com/role": "primary",
+						"empty":            "",
+					},
+				}},
+			}},
+		},
+	}
+
+	if err := cluster.validateInstanceTemplateLabels(); err != nil {
+		t.Fatalf("expected valid labels to pass, got %v", err)
+	}
+}

--- a/apis/apps/v1/zz_generated.deepcopy.go
+++ b/apis/apps/v1/zz_generated.deepcopy.go
@@ -28,7 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -136,6 +136,46 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-apps-kubeblocks-io-v1-cluster
+  failurePolicy: Fail
+  name: vcluster.kb.io
+  rules:
+  - apiGroups:
+    - apps.kubeblocks.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-apps-kubeblocks-io-v1-component
+  failurePolicy: Fail
+  name: vcomponent.kb.io
+  rules:
+  - apiGroups:
+    - apps.kubeblocks.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - components
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-apps-kubeblocks-io-v1alpha1-clusterdefinition
   failurePolicy: Fail
   name: vclusterdefinition.kb.io


### PR DESCRIPTION
## Summary
- validate Cluster and Component instance template labels in app API webhooks
- reject invalid Kubernetes label keys and values, including comma-separated values like the #10539 report
- keep CRDs free of expensive CEL validation so schema installation and status ratcheting are not affected

Fixes #10539

Follow-up to closed #10553 using the webhook-layer direction from review.

## Validation
- GOPATH=/tmp/go-path GOCACHE=/tmp/go-cache GOMODCACHE=/tmp/go-mod-cache make manifests
- GOPATH=/tmp/go-path GOCACHE=/tmp/go-cache GOMODCACHE=/tmp/go-mod-cache go test ./apis/apps/v1 -run 'Test(Cluster|Component).*InstanceTemplateLabel|TestClusterAllowsValidInstanceTemplateLabels' -count=1
- GOPATH=/tmp/go-path GOCACHE=/tmp/go-cache GOMODCACHE=/tmp/go-mod-cache go test ./apis/apps/v1
- git diff --check