### PR TITLE
fix(parameters): backfill external-managed config details

### DIFF
--- a/controllers/parameters/componentdrivenparameter_controller.go
+++ b/controllers/parameters/componentdrivenparameter_controller.go
@@ -477,15 +477,3 @@ func validateCustomTemplate(ctx context.Context, cli client.Reader, templates ma
 	}
 	return nil
 }
-
-func resolveComponentTemplate(ctx context.Context, reader client.Reader, cmpd *appsv1.ComponentDefinition) (map[string]*corev1.ConfigMap, error) {
-	tpls := make(map[string]*corev1.ConfigMap, len(cmpd.Spec.Configs))
-	for _, config := range cmpd.Spec.Configs {
-		cm := &corev1.ConfigMap{}
-		if err := reader.Get(ctx, client.ObjectKey{Name: config.Template, Namespace: config.Namespace}, cm); err != nil {
-			return nil, err
-		}
-		tpls[config.Name] = cm
-	}
-	return tpls, nil
-}

--- a/controllers/parameters/componentparameter_controller_utils.go
+++ b/controllers/parameters/componentparameter_controller_utils.go
@@ -52,7 +52,7 @@ func reconcileConfigItemDetailsIntoSpec(ctx context.Context, cli client.Client, 
 	if !parameters.HasValidParameterTemplate(configDescs) {
 		return false, nil
 	}
-	templates, err := resolveComponentTemplate(ctx, cli, fetchTask.ComponentDefObj)
+	templates, err := resolveComponentTemplateForConfigItemDetails(ctx, cli, fetchTask.ComponentDefObj)
 	if err != nil {
 		return false, err
 	}
@@ -76,6 +76,23 @@ func reconcileConfigItemDetailsIntoSpec(ctx context.Context, cli client.Client, 
 	patch := client.MergeFrom(compParam.DeepCopy())
 	compParam.Spec.ConfigItemDetails = merged.Spec.ConfigItemDetails
 	return true, cli.Patch(ctx, compParam, patch)
+}
+
+func resolveComponentTemplateForConfigItemDetails(ctx context.Context, reader client.Reader, cmpd *appsv1.ComponentDefinition) (map[string]*corev1.ConfigMap, error) {
+	tpls := make(map[string]*corev1.ConfigMap, len(cmpd.Spec.Configs))
+	for _, config := range cmpd.Spec.Configs {
+		// ConfigItemDetails can be generated for this delegated config without
+		// reading a runtime template that intentionally does not exist yet.
+		if config.Template == "" && pointer.BoolDeref(config.ExternalManaged, false) {
+			continue
+		}
+		cm := &corev1.ConfigMap{}
+		if err := reader.Get(ctx, client.ObjectKey{Name: config.Template, Namespace: config.Namespace}, cm); err != nil {
+			return nil, err
+		}
+		tpls[config.Name] = cm
+	}
+	return tpls, nil
 }
 
 func mergeMissingConfigFileParams(dest, expected *parametersv1alpha1.ConfigTemplateItemDetail) {

--- a/controllers/parameters/componentparameter_controller_utils.go
+++ b/controllers/parameters/componentparameter_controller_utils.go
@@ -52,7 +52,7 @@ func reconcileConfigItemDetailsIntoSpec(ctx context.Context, cli client.Client, 
 	if !parameters.HasValidParameterTemplate(configDescs) {
 		return false, nil
 	}
-	templates, err := resolveComponentTemplateForConfigItemDetails(ctx, cli, fetchTask.ComponentDefObj)
+	templates, err := resolveComponentTemplatesToleratingDelegated(ctx, cli, fetchTask.ComponentDefObj)
 	if err != nil {
 		return false, err
 	}
@@ -78,7 +78,7 @@ func reconcileConfigItemDetailsIntoSpec(ctx context.Context, cli client.Client, 
 	return true, cli.Patch(ctx, compParam, patch)
 }
 
-func resolveComponentTemplateForConfigItemDetails(ctx context.Context, reader client.Reader, cmpd *appsv1.ComponentDefinition) (map[string]*corev1.ConfigMap, error) {
+func resolveComponentTemplatesToleratingDelegated(ctx context.Context, reader client.Reader, cmpd *appsv1.ComponentDefinition) (map[string]*corev1.ConfigMap, error) {
 	tpls := make(map[string]*corev1.ConfigMap, len(cmpd.Spec.Configs))
 	for _, config := range cmpd.Spec.Configs {
 		// ConfigItemDetails can be generated for this delegated config without
@@ -466,6 +466,10 @@ func newTask(item parametersv1alpha1.ConfigTemplateItemDetail,
 	return Task{
 		Name: item.Name,
 		Do: func(resource *Task, taskCtx *taskContext, revision string) error {
+			if isExternalManagedWithoutTemplate(item) {
+				completeExternalManagedStatus(status, revision)
+				return nil
+			}
 			if item.ConfigSpec == nil {
 				return core.MakeError("not found config spec: %s", item.Name)
 			}
@@ -498,6 +502,10 @@ func syncImpl(taskCtx *taskContext,
 	status *parametersv1alpha1.ConfigTemplateItemDetailStatus,
 	revision string,
 	configMap *corev1.ConfigMap) (err error) {
+	if isExternalManagedWithoutTemplate(item) {
+		completeExternalManagedStatus(status, revision)
+		return nil
+	}
 	if parameters.IsApplyUpdatedParameters(configMap, item, fetcher.ComponentObj.Generation) {
 		return syncStatus(configMap, status)
 	}
@@ -539,6 +547,9 @@ func syncImpl(taskCtx *taskContext,
 
 func mergeAndApplyConfig(resourceCtx *render.ResourceCtx, expected, running *corev1.ConfigMap, owner client.Object,
 	item parametersv1alpha1.ConfigTemplateItemDetail, compGeneration int64, revision string) error {
+	if isExternalManagedWithoutTemplate(item) {
+		return nil
+	}
 	fn := updateReconcileObject(item, owner, compGeneration, revision)
 	switch {
 	case expected == nil: // not update
@@ -548,6 +559,23 @@ func mergeAndApplyConfig(resourceCtx *render.ResourceCtx, expected, running *cor
 	default:
 		return update(resourceCtx.Context, resourceCtx.Client, running, running, mergedConfigmap(expected, fn))
 	}
+}
+
+func isExternalManaged(item parametersv1alpha1.ConfigTemplateItemDetail) bool {
+	return item.ConfigSpec != nil && pointer.BoolDeref(item.ConfigSpec.ExternalManaged, false)
+}
+
+func isExternalManagedWithoutTemplate(item parametersv1alpha1.ConfigTemplateItemDetail) bool {
+	return isExternalManaged(item) && item.ConfigSpec.Template == ""
+}
+
+func completeExternalManagedStatus(status *parametersv1alpha1.ConfigTemplateItemDetailStatus, revision string) {
+	// The external producer owns both rendering and application, so there is no
+	// reconfigure phase that can advance this item after the controller no-op.
+	status.Message = nil
+	status.Phase = parametersv1alpha1.CFinishedPhase
+	status.UpdateRevision = revision
+	status.LastDoneRevision = revision
 }
 
 func mergedConfigmap(expected *corev1.ConfigMap, setter func(*corev1.ConfigMap) error) func(*corev1.ConfigMap) error {

--- a/controllers/parameters/componentparameter_controller_utils_test.go
+++ b/controllers/parameters/componentparameter_controller_utils_test.go
@@ -20,10 +20,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package parameters
 
 import (
+	"context"
+	"strings"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
 	parampkg "github.com/apecloud/kubeblocks/pkg/parameters"
 )
@@ -146,6 +153,123 @@ func TestMergeMissingConfigFileParams(t *testing.T) {
 	*expected.ConfigFileParams["log.conf"].Parameters["slow_query_log"] = "0"
 	if got := dest.ConfigFileParams["log.conf"].Parameters["slow_query_log"]; got == nil || *got != "1" {
 		t.Fatalf("expected merged params to be deep-copied, got %#v", got)
+	}
+}
+
+func TestReconcileConfigItemDetailsExternalManagedEmptyTemplate(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(core) error = %v", err)
+	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(apps) error = %v", err)
+	}
+	if err := parametersv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(parameters) error = %v", err)
+	}
+
+	compDef := &appsv1.ComponentDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "obce"},
+		Spec: appsv1.ComponentDefinitionSpec{
+			Configs: []appsv1.ComponentFileTemplate{{
+				Name:            "oceanbase-sysvars",
+				Template:        "",
+				ExternalManaged: ptr.To(true),
+			}},
+		},
+	}
+	paramsDef := &parametersv1alpha1.ParametersDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "obce-sysvars"},
+		Spec: parametersv1alpha1.ParametersDefinitionSpec{
+			ComponentDef: compDef.Name,
+			TemplateName: "oceanbase-sysvars",
+			FileName:     "sysvars.conf",
+			FileFormatConfig: &parametersv1alpha1.FileFormatConfig{
+				Format: parametersv1alpha1.Properties,
+			},
+		},
+		Status: parametersv1alpha1.ParametersDefinitionStatus{
+			Phase: parametersv1alpha1.PDAvailablePhase,
+		},
+	}
+	compParam := &parametersv1alpha1.ComponentParameter{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "obce-oceanbase",
+		},
+		Spec: parametersv1alpha1.ComponentParameterSpec{
+			ClusterName:   "obce",
+			ComponentName: "oceanbase",
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(compDef, paramsDef, compParam).Build()
+
+	updated, err := reconcileConfigItemDetailsIntoSpec(context.Background(), cli, compParam, &Task{
+		ResourceFetcher: parampkg.ResourceFetcher[Task]{ComponentDefObj: compDef},
+	})
+	if err != nil {
+		t.Fatalf("reconcileConfigItemDetailsIntoSpec() error = %v", err)
+	}
+	if !updated {
+		t.Fatalf("expected ConfigItemDetails update for externalManaged config with empty template")
+	}
+	if got := compParam.Spec.ConfigItemDetails; len(got) != 1 || got[0].Name != "oceanbase-sysvars" {
+		t.Fatalf("unexpected ConfigItemDetails: %#v", got)
+	}
+	if compParam.Spec.ConfigItemDetails[0].ConfigSpec == nil || compParam.Spec.ConfigItemDetails[0].ConfigSpec.Template != "" {
+		t.Fatalf("expected empty-template config spec to be preserved, got %#v", compParam.Spec.ConfigItemDetails[0].ConfigSpec)
+	}
+}
+
+func TestReconcileConfigItemDetailsRequiresOrdinaryTemplateConfigMap(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(core) error = %v", err)
+	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(apps) error = %v", err)
+	}
+	if err := parametersv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(parameters) error = %v", err)
+	}
+
+	compDef := &appsv1.ComponentDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "mysql"},
+		Spec: appsv1.ComponentDefinitionSpec{
+			Configs: []appsv1.ComponentFileTemplate{{
+				Name:      "mysql-config",
+				Namespace: "default",
+				Template:  "runtime-template",
+			}},
+		},
+	}
+	paramsDef := &parametersv1alpha1.ParametersDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "mysql-config"},
+		Spec: parametersv1alpha1.ParametersDefinitionSpec{
+			ComponentDef: compDef.Name,
+			TemplateName: "mysql-config",
+			FileName:     "my.cnf",
+			FileFormatConfig: &parametersv1alpha1.FileFormatConfig{
+				Format: parametersv1alpha1.Properties,
+			},
+		},
+		Status: parametersv1alpha1.ParametersDefinitionStatus{
+			Phase: parametersv1alpha1.PDAvailablePhase,
+		},
+	}
+	compParam := &parametersv1alpha1.ComponentParameter{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "mysql",
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(compDef, paramsDef, compParam).Build()
+
+	_, err := reconcileConfigItemDetailsIntoSpec(context.Background(), cli, compParam, &Task{
+		ResourceFetcher: parampkg.ResourceFetcher[Task]{ComponentDefObj: compDef},
+	})
+	if err == nil || !strings.Contains(err.Error(), `configmaps "runtime-template" not found`) {
+		t.Fatalf("expected ordinary template ConfigMap lookup error, got %v", err)
 	}
 }
 

--- a/controllers/parameters/componentparameter_controller_utils_test.go
+++ b/controllers/parameters/componentparameter_controller_utils_test.go
@@ -21,19 +21,35 @@ package parameters
 
 import (
 	"context"
+	"errors"
+	"reflect"
 	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/controller/render"
 	parampkg "github.com/apecloud/kubeblocks/pkg/parameters"
 )
+
+type countingGetClient struct {
+	client.Client
+	err      error
+	getCount int
+}
+
+func (c *countingGetClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	c.getCount++
+	return c.err
+}
 
 func TestNormalizeManagedParameterInputs(t *testing.T) {
 	t.Run("updates override assignments and remove is explicit", func(t *testing.T) {
@@ -219,6 +235,194 @@ func TestReconcileConfigItemDetailsExternalManagedEmptyTemplate(t *testing.T) {
 	if compParam.Spec.ConfigItemDetails[0].ConfigSpec == nil || compParam.Spec.ConfigItemDetails[0].ConfigSpec.Template != "" {
 		t.Fatalf("expected empty-template config spec to be preserved, got %#v", compParam.Spec.ConfigItemDetails[0].ConfigSpec)
 	}
+}
+
+func TestExternalManagedEmptyTemplateOnlyUpdatesStatus(t *testing.T) {
+	item := parametersv1alpha1.ConfigTemplateItemDetail{
+		Name: "oceanbase-sysvars",
+		ConfigSpec: &appsv1.ComponentFileTemplate{
+			Name:            "oceanbase-sysvars",
+			ExternalManaged: ptr.To(true),
+		},
+	}
+	status := &parametersv1alpha1.ConfigTemplateItemDetailStatus{
+		Name:  item.Name,
+		Phase: parametersv1alpha1.CInitPhase,
+	}
+
+	t.Run("task does not read the runtime ConfigMap", func(t *testing.T) {
+		taskStatus := status.DeepCopy()
+		task := newTask(item, taskStatus, 7)
+		if err := task.Do(&Task{}, nil, "revision-1"); err != nil {
+			t.Fatalf("Task.Do() error = %v", err)
+		}
+		if taskStatus.Phase != parametersv1alpha1.CFinishedPhase || taskStatus.UpdateRevision != "revision-1" ||
+			taskStatus.LastDoneRevision != "revision-1" || taskStatus.Message != nil {
+			t.Fatalf("expected status-only merge for delegated config, got %#v", taskStatus)
+		}
+		beforeReplay := taskStatus.DeepCopy()
+		if err := task.Do(&Task{}, nil, "revision-1"); err != nil {
+			t.Fatalf("Task.Do() replay error = %v", err)
+		}
+		if !reflect.DeepEqual(taskStatus, beforeReplay) {
+			t.Fatalf("expected exact status replay, before = %#v, after = %#v", beforeReplay, taskStatus)
+		}
+	})
+
+	t.Run("sync implementation keeps the same defensive contract", func(t *testing.T) {
+		syncStatus := status.DeepCopy()
+		fetcher := &Task{ResourceFetcher: parampkg.ResourceFetcher[Task]{
+			ComponentObj: &appsv1.Component{ObjectMeta: metav1.ObjectMeta{Generation: 7}},
+		}}
+		if err := syncImpl(&taskContext{}, fetcher, item, syncStatus, "revision-1", nil); err != nil {
+			t.Fatalf("syncImpl() error = %v", err)
+		}
+		if syncStatus.Phase != parametersv1alpha1.CFinishedPhase || syncStatus.UpdateRevision != "revision-1" ||
+			syncStatus.LastDoneRevision != "revision-1" || syncStatus.Message != nil {
+			t.Fatalf("expected status-only merge for delegated config, got %#v", syncStatus)
+		}
+	})
+
+	t.Run("adding a template re-enters the normal task path", func(t *testing.T) {
+		withTemplate := item
+		withTemplate.ConfigSpec = item.ConfigSpec.DeepCopy()
+		withTemplate.ConfigSpec.Template = "default-template"
+		evolvedStatus := &parametersv1alpha1.ConfigTemplateItemDetailStatus{
+			Name:             item.Name,
+			Phase:            parametersv1alpha1.CFinishedPhase,
+			UpdateRevision:   "revision-1",
+			LastDoneRevision: "revision-1",
+		}
+		before := evolvedStatus.DeepCopy()
+		lookupErr := errors.New("runtime ConfigMap lookup reached")
+		spy := &countingGetClient{err: lookupErr}
+		resource := &Task{}
+		resource.Init(&render.ResourceCtx{
+			Context:       context.Background(),
+			Client:        spy,
+			Namespace:     "default",
+			ClusterName:   "obce",
+			ComponentName: "oceanbase",
+		}, resource)
+
+		task := newTask(withTemplate, evolvedStatus, 7)
+		if err := task.Do(resource, nil, "revision-2"); !errors.Is(err, lookupErr) {
+			t.Fatalf("expected normal runtime ConfigMap lookup error, got %v", err)
+		}
+		if spy.getCount != 1 {
+			t.Fatalf("expected one runtime ConfigMap lookup, got %d", spy.getCount)
+		}
+		if !reflect.DeepEqual(evolvedStatus, before) {
+			t.Fatalf("failed normal lookup must not fake a new terminal revision: before = %#v, after = %#v", before, evolvedStatus)
+		}
+	})
+}
+
+func TestMergeAndApplyConfigDoesNotWriteExternalManagedEmptyTemplate(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme(core) error = %v", err)
+	}
+	item := parametersv1alpha1.ConfigTemplateItemDetail{
+		Name: "external-config",
+		ConfigSpec: &appsv1.ComponentFileTemplate{
+			Name:            "external-config",
+			ExternalManaged: ptr.To(true),
+		},
+	}
+	owner := &parametersv1alpha1.ComponentParameter{
+		ObjectMeta: metav1.ObjectMeta{Name: "params", Namespace: "default", UID: "owner-uid"},
+	}
+
+	t.Run("does not update an existing user ConfigMap", func(t *testing.T) {
+		running := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "user-config", Namespace: "default"},
+			Data:       map[string]string{"sysvars.conf": "user-value"},
+		}
+		expected := running.DeepCopy()
+		expected.Data["sysvars.conf"] = "controller-value"
+		cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(running).Build()
+		resourceCtx := &render.ResourceCtx{Context: context.Background(), Client: cli}
+
+		if err := mergeAndApplyConfig(resourceCtx, expected, running, owner, item, 7, "revision-1"); err != nil {
+			t.Fatalf("mergeAndApplyConfig() error = %v", err)
+		}
+		got := &corev1.ConfigMap{}
+		if err := cli.Get(context.Background(), client.ObjectKeyFromObject(running), got); err != nil {
+			t.Fatalf("get ConfigMap error = %v", err)
+		}
+		if got.Data["sysvars.conf"] != "user-value" || len(got.OwnerReferences) != 0 || len(got.Finalizers) != 0 {
+			t.Fatalf("external ConfigMap was mutated: %#v", got)
+		}
+	})
+
+	t.Run("does not create a user-owned ConfigMap", func(t *testing.T) {
+		expected := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "user-config", Namespace: "default"},
+			Data:       map[string]string{"sysvars.conf": "controller-value"},
+		}
+		cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+		resourceCtx := &render.ResourceCtx{Context: context.Background(), Client: cli}
+
+		if err := mergeAndApplyConfig(resourceCtx, expected, nil, owner, item, 7, "revision-1"); err != nil {
+			t.Fatalf("mergeAndApplyConfig() error = %v", err)
+		}
+		got := &corev1.ConfigMap{}
+		err := cli.Get(context.Background(), client.ObjectKeyFromObject(expected), got)
+		if !apierrors.IsNotFound(err) {
+			t.Fatalf("expected external ConfigMap to remain absent, got %#v, error = %v", got, err)
+		}
+	})
+
+	t.Run("keeps the ordinary managed update path", func(t *testing.T) {
+		managedItem := item
+		managedItem.ConfigSpec = item.ConfigSpec.DeepCopy()
+		managedItem.ConfigSpec.ExternalManaged = nil
+		running := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "managed-config", Namespace: "default"},
+			Data:       map[string]string{"my.cnf": "old-value"},
+		}
+		expected := running.DeepCopy()
+		expected.Data["my.cnf"] = "new-value"
+		cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(running).Build()
+		resourceCtx := &render.ResourceCtx{Context: context.Background(), Client: cli}
+
+		if err := mergeAndApplyConfig(resourceCtx, expected, running, owner, managedItem, 7, "revision-1"); err != nil {
+			t.Fatalf("mergeAndApplyConfig() error = %v", err)
+		}
+		got := &corev1.ConfigMap{}
+		if err := cli.Get(context.Background(), client.ObjectKeyFromObject(running), got); err != nil {
+			t.Fatalf("get ConfigMap error = %v", err)
+		}
+		if got.Data["my.cnf"] != "new-value" {
+			t.Fatalf("expected managed ConfigMap update, got %#v", got.Data)
+		}
+	})
+
+	t.Run("keeps the parameter-managed path when an external template exists", func(t *testing.T) {
+		withTemplate := item
+		withTemplate.ConfigSpec = item.ConfigSpec.DeepCopy()
+		withTemplate.ConfigSpec.Template = "default-template"
+		running := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "parameter-managed-config", Namespace: "default"},
+			Data:       map[string]string{"my.cnf": "old-value"},
+		}
+		expected := running.DeepCopy()
+		expected.Data["my.cnf"] = "new-value"
+		cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(running).Build()
+		resourceCtx := &render.ResourceCtx{Context: context.Background(), Client: cli}
+
+		if err := mergeAndApplyConfig(resourceCtx, expected, running, owner, withTemplate, 7, "revision-1"); err != nil {
+			t.Fatalf("mergeAndApplyConfig() error = %v", err)
+		}
+		got := &corev1.ConfigMap{}
+		if err := cli.Get(context.Background(), client.ObjectKeyFromObject(running), got); err != nil {
+			t.Fatalf("get ConfigMap error = %v", err)
+		}
+		if got.Data["my.cnf"] != "new-value" {
+			t.Fatalf("expected parameter-managed ConfigMap update, got %#v", got.Data)
+		}
+	})
 }
 
 func TestReconcileConfigItemDetailsRequiresOrdinaryTemplateConfigMap(t *testing.T) {

--- a/controllers/parameters/parameterview_controller.go
+++ b/controllers/parameters/parameterview_controller.go
@@ -764,7 +764,7 @@ func (r *ParameterViewReconciler) resolveContent(ctx context.Context, compParam 
 	if err != nil {
 		return "", err
 	}
-	templates, err := resolveComponentTemplate(ctx, r.Client, fetchTask.ComponentDefObj)
+	templates, err := resolveComponentTemplatesToleratingDelegated(ctx, r.Client, fetchTask.ComponentDefObj)
 	if err != nil {
 		return "", err
 	}
@@ -793,7 +793,7 @@ func (r *ParameterViewReconciler) resolveConfigContext(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	templates, err := resolveComponentTemplate(ctx, r.Client, fetchTask.ComponentDefObj)
+	templates, err := resolveComponentTemplatesToleratingDelegated(ctx, r.Client, fetchTask.ComponentDefObj)
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/parameters/parameterview_controller_test.go
+++ b/controllers/parameters/parameterview_controller_test.go
@@ -1566,6 +1566,59 @@ func TestCompactSubmissionsKeepsNewestEntriesWithinCap(t *testing.T) {
 	}
 }
 
+func TestParameterViewToleratesExternalManagedEmptyTemplate(t *testing.T) {
+	objects := newParameterViewTestObjects("", &parametersv1alpha1.ParameterView{
+		ObjectMeta: metav1.ObjectMeta{Name: parameterViewName, Namespace: parameterViewNamespace},
+		Spec: parametersv1alpha1.ParameterViewSpec{
+			ParameterRef: corev1.LocalObjectReference{Name: componentParameterName},
+			TemplateName: templateName,
+			FileName:     fileName,
+		},
+	}, func(compParam *parametersv1alpha1.ComponentParameter) {
+		compParam.Spec.ConfigItemDetails[0].ConfigSpec.Template = ""
+		compParam.Spec.ConfigItemDetails[0].ConfigSpec.ExternalManaged = ptr.To(true)
+		compParam.Spec.ConfigItemDetails[0].ConfigFileParams = nil
+	})
+	var compParam *parametersv1alpha1.ComponentParameter
+	for _, obj := range objects {
+		switch typed := obj.(type) {
+		case *appsv1.ComponentDefinition:
+			typed.Spec.Configs[0].Template = ""
+		case *parametersv1alpha1.ComponentParameter:
+			compParam = typed
+		}
+	}
+	if compParam == nil {
+		t.Fatal("ComponentParameter fixture not found")
+	}
+	reconciler, cli := newParameterViewTestReconciler(t, objects...)
+	for _, key := range []client.ObjectKey{
+		{Namespace: parameterViewNamespace, Name: templateConfigMapName},
+		{Namespace: parameterViewNamespace, Name: parameterscore.GetComponentCfgName(pvClusterName, pvComponentName, templateName)},
+	} {
+		cm := &corev1.ConfigMap{}
+		if err := cli.Get(context.Background(), key, cm); err != nil {
+			t.Fatalf("get ConfigMap fixture %s error = %v", key, err)
+		}
+		if err := cli.Delete(context.Background(), cm); err != nil {
+			t.Fatalf("delete ConfigMap fixture %s error = %v", key, err)
+		}
+	}
+
+	_, err := reconciler.resolveContent(context.Background(), compParam, &compParam.Spec.ConfigItemDetails[0], fileName)
+	if err == nil || !strings.Contains(err.Error(), "template source not found") {
+		t.Fatalf("expected explicit missing external template source, got %v", err)
+	}
+	if strings.Contains(err.Error(), `configmaps "" not found`) {
+		t.Fatalf("empty template must not trigger a ConfigMap lookup: %v", err)
+	}
+
+	view := objects[0].(*parametersv1alpha1.ParameterView)
+	if _, err := reconciler.resolveConfigContext(context.Background(), compParam, view); err != nil {
+		t.Fatalf("resolveConfigContext() should tolerate delegated empty template: %v", err)
+	}
+}
+
 const (
 	parameterViewNamespace       = "default"
 	pvClusterName                = "test-cluster"


### PR DESCRIPTION
Fixes #10557

## What happened

An external-managed config can intentionally have an empty runtime template name while the parameters controller is expected to populate `ComponentParameter.spec.configItemDetails` from `ParametersDefinition`.

The skeleton path previously resolved every ComponentDefinition config template before writing the item. For an external-managed config with `template: ""`, that read failed with `configmaps "" not found`, so the item was never written.

After the skeleton was backfilled, the downstream task path had the same empty-template assumption. It attempted to render the empty template, moved the item to `MergeFailed`, and retried indefinitely. ParameterView also used the strict resolver and failed on the same ComponentDefinition shape.

## What changed

- Use a tolerant template resolver for ConfigItemDetails and ParameterView. It skips only external-managed configs whose template is empty.
- Finish those empty-template items as a status-only no-op before reading or rendering a runtime ConfigMap.
- Protect the final apply point from creating or updating a ConfigMap for that same delegated empty-template shape.
- Preserve the existing parameter-managed path for external-managed configs that still have a non-empty template.
- Cover the empty-to-non-empty evolution: adding a template and a new revision leaves the no-op path and resumes the normal runtime ConfigMap lookup.
- Remove the obsolete strict resolver after all callers use the shared resolver.

## What this does not change

- The Component file-template precheck remains fail-loud.
- Non-empty external-managed templates still use the normal parameters render/apply flow.
- This PR does not claim full OceanBase CE cluster creation or soak validation.

## Tests

- `go test ./controllers/parameters -run 'TestExternalManagedEmptyTemplateOnlyUpdatesStatus|TestMergeAndApplyConfigDoesNotWriteExternalManagedEmptyTemplate|TestParameterViewToleratesExternalManagedEmptyTemplate|TestReconcileConfigItemDetails' -count=10`
- `KUBEBUILDER_ASSETS=/tmp/kubebuilder-envtest-bin/k8s/1.26.1-darwin-arm64 go test ./controllers/parameters -count=1`
- `go vet ./controllers/parameters`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.8.0 run ./controllers/parameters/...`
- `git diff --check`

Runtime validation must still run against the exact controller build for commit `c0460ed7b0b6c4169a88446371c88f3c52a39c39`.
