### PR TITLE
fix(parameter): resolve ref for allOf

### DIFF
--- a/apis/parameters/v1alpha1/parametersdefinition_types.go
+++ b/apis/parameters/v1alpha1/parametersdefinition_types.go
@@ -467,6 +467,7 @@ type IniConfig struct {
 type ParametersSchema struct {
 	// Specifies the top-level key in the 'configSchema.cue' that organizes the validation rules for parameters.
 	// This key must exist within the CUE script defined in 'configSchema.cue'.
+	// If not specified, the first schema found will be used.
 	//
 	// +optional
 	TopLevelKey string `json:"topLevelKey,omitempty"`

--- a/config/crd/bases/parameters.kubeblocks.io_parametersdefinitions.yaml
+++ b/config/crd/bases/parameters.kubeblocks.io_parametersdefinitions.yaml
@@ -188,6 +188,7 @@ spec:
                     description: |-
                       Specifies the top-level key in the 'configSchema.cue' that organizes the validation rules for parameters.
                       This key must exist within the CUE script defined in 'configSchema.cue'.
+                      If not specified, the first schema found will be used.
                     type: string
                 type: object
               reloadAction:

--- a/deploy/helm/crds/parameters.kubeblocks.io_parametersdefinitions.yaml
+++ b/deploy/helm/crds/parameters.kubeblocks.io_parametersdefinitions.yaml
@@ -188,6 +188,7 @@ spec:
                     description: |-
                       Specifies the top-level key in the 'configSchema.cue' that organizes the validation rules for parameters.
                       This key must exist within the CUE script defined in 'configSchema.cue'.
+                      If not specified, the first schema found will be used.
                     type: string
                 type: object
               reloadAction:

--- a/docs/developer_docs/api-reference/parameters.md
+++ b/docs/developer_docs/api-reference/parameters.md
@@ -3241,7 +3241,8 @@ string
 <td>
 <em>(Optional)</em>
 <p>Specifies the top-level key in the &lsquo;configSchema.cue&rsquo; that organizes the validation rules for parameters.
-This key must exist within the CUE script defined in &lsquo;configSchema.cue&rsquo;.</p>
+This key must exist within the CUE script defined in &lsquo;configSchema.cue&rsquo;.
+If not specified, the first schema found will be used.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/common/openapiv3schema.go
+++ b/pkg/common/openapiv3schema.go
@@ -122,39 +122,40 @@ func stripIntegerOverflow(schema *apiextensionsv1.JSONSchemaProps) *apiextension
 	if schema == nil {
 		return nil
 	}
-	if !hasIntegerOverflowMaximum(schema) {
+	if !hasIntegerOverflowMaximum(schema, false) {
 		return schema
 	}
 	out := schema.DeepCopy()
-	stripIntegerOverflowMaximum(out)
+	stripIntegerOverflowMaximum(out, false)
 	return out
 }
 
-func hasIntegerOverflowMaximum(schema *apiextensionsv1.JSONSchemaProps) bool {
-	if schema.Type == "integer" && schema.Maximum != nil && *schema.Maximum >= math.Exp2(63) {
+func hasIntegerOverflowMaximum(schema *apiextensionsv1.JSONSchemaProps, inheritedInteger bool) bool {
+	integerContext := hasEffectiveIntegerType(schema, inheritedInteger)
+	if integerContext && schema.Maximum != nil && *schema.Maximum >= math.Exp2(63) {
 		return true
 	}
 	for i := range schema.AllOf {
-		if hasIntegerOverflowMaximum(&schema.AllOf[i]) {
+		if hasIntegerOverflowMaximum(&schema.AllOf[i], integerContext) {
 			return true
 		}
 	}
 	for k := range schema.Properties {
 		prop := schema.Properties[k]
-		if hasIntegerOverflowMaximum(&prop) {
+		if hasIntegerOverflowMaximum(&prop, false) {
 			return true
 		}
 	}
 	if schema.AdditionalProperties != nil && schema.AdditionalProperties.Schema != nil &&
-		hasIntegerOverflowMaximum(schema.AdditionalProperties.Schema) {
+		hasIntegerOverflowMaximum(schema.AdditionalProperties.Schema, false) {
 		return true
 	}
 	if schema.Items != nil {
-		if schema.Items.Schema != nil && hasIntegerOverflowMaximum(schema.Items.Schema) {
+		if schema.Items.Schema != nil && hasIntegerOverflowMaximum(schema.Items.Schema, false) {
 			return true
 		}
 		for i := range schema.Items.JSONSchemas {
-			if hasIntegerOverflowMaximum(&schema.Items.JSONSchemas[i]) {
+			if hasIntegerOverflowMaximum(&schema.Items.JSONSchemas[i], false) {
 				return true
 			}
 		}
@@ -162,30 +163,73 @@ func hasIntegerOverflowMaximum(schema *apiextensionsv1.JSONSchemaProps) bool {
 	return false
 }
 
-func stripIntegerOverflowMaximum(schema *apiextensionsv1.JSONSchemaProps) {
-	if schema.Type == "integer" && schema.Maximum != nil && *schema.Maximum >= math.Exp2(63) {
+func stripIntegerOverflowMaximum(schema *apiextensionsv1.JSONSchemaProps, inheritedInteger bool) {
+	integerContext := hasEffectiveIntegerType(schema, inheritedInteger)
+	if integerContext && schema.Maximum != nil && *schema.Maximum >= math.Exp2(63) {
 		schema.Maximum = nil
 		schema.ExclusiveMaximum = false
 	}
 	for i := range schema.AllOf {
-		stripIntegerOverflowMaximum(&schema.AllOf[i])
+		stripIntegerOverflowMaximum(&schema.AllOf[i], integerContext)
 	}
 	for k := range schema.Properties {
 		prop := schema.Properties[k]
-		stripIntegerOverflowMaximum(&prop)
+		stripIntegerOverflowMaximum(&prop, false)
 		schema.Properties[k] = prop
 	}
 	if schema.AdditionalProperties != nil && schema.AdditionalProperties.Schema != nil {
-		stripIntegerOverflowMaximum(schema.AdditionalProperties.Schema)
+		stripIntegerOverflowMaximum(schema.AdditionalProperties.Schema, false)
 	}
 	if schema.Items != nil {
 		if schema.Items.Schema != nil {
-			stripIntegerOverflowMaximum(schema.Items.Schema)
+			stripIntegerOverflowMaximum(schema.Items.Schema, false)
 		}
 		for i := range schema.Items.JSONSchemas {
-			stripIntegerOverflowMaximum(&schema.Items.JSONSchemas[i])
+			stripIntegerOverflowMaximum(&schema.Items.JSONSchemas[i], false)
 		}
 	}
+}
+
+func hasEffectiveIntegerType(schema *apiextensionsv1.JSONSchemaProps, inheritedInteger bool) bool {
+	typeName, conflict := effectiveAllOfType(schema)
+	if conflict {
+		return false
+	}
+	if inheritedInteger {
+		typeName, conflict = intersectJSONSchemaType("integer", typeName)
+	}
+	return !conflict && typeName == "integer"
+}
+
+func effectiveAllOfType(schema *apiextensionsv1.JSONSchemaProps) (string, bool) {
+	if schema == nil {
+		return "", false
+	}
+	typeName := schema.Type
+	for i := range schema.AllOf {
+		branchType, conflict := effectiveAllOfType(&schema.AllOf[i])
+		if conflict {
+			return "", true
+		}
+		typeName, conflict = intersectJSONSchemaType(typeName, branchType)
+		if conflict {
+			return "", true
+		}
+	}
+	return typeName, false
+}
+
+func intersectJSONSchemaType(left, right string) (string, bool) {
+	if left == "" {
+		return right, false
+	}
+	if right == "" || left == right {
+		return left, false
+	}
+	if (left == "integer" && right == "number") || (left == "number" && right == "integer") {
+		return "integer", false
+	}
+	return "", true
 }
 
 // validateLargeIntegerBounds enforces original Maximum for integer properties
@@ -193,14 +237,15 @@ func stripIntegerOverflowMaximum(schema *apiextensionsv1.JSONSchemaProps) {
 // kube-openapi int64 overflow). CUE type extrema (2^63 for int64, 2^64 for
 // uint64) are skipped because ParseInt/ParseUint already enforce type range.
 func validateLargeIntegerBounds(schema *apiextensionsv1.JSONSchemaProps, data interface{}) error {
-	return validateLargeIntegerBoundsAt(schema, data, "")
+	return validateLargeIntegerBoundsAt(schema, data, "", false)
 }
 
-func validateLargeIntegerBoundsAt(schema *apiextensionsv1.JSONSchemaProps, data interface{}, path string) error {
+func validateLargeIntegerBoundsAt(schema *apiextensionsv1.JSONSchemaProps, data interface{}, path string, inheritedInteger bool) error {
 	if schema == nil {
 		return nil
 	}
-	if schema.Type == "integer" && schema.Maximum != nil && *schema.Maximum >= math.Exp2(63) &&
+	integerContext := hasEffectiveIntegerType(schema, inheritedInteger)
+	if integerContext && schema.Maximum != nil && *schema.Maximum >= math.Exp2(63) &&
 		*schema.Maximum != math.Exp2(63) && *schema.Maximum != math.Exp2(64) {
 		if f, ok := toFloat64(data); ok {
 			if schema.ExclusiveMaximum && f >= *schema.Maximum {
@@ -212,7 +257,7 @@ func validateLargeIntegerBoundsAt(schema *apiextensionsv1.JSONSchemaProps, data 
 		}
 	}
 	for i := range schema.AllOf {
-		if err := validateLargeIntegerBoundsAt(&schema.AllOf[i], data, path); err != nil {
+		if err := validateLargeIntegerBoundsAt(&schema.AllOf[i], data, path, integerContext); err != nil {
 			return err
 		}
 	}
@@ -224,7 +269,7 @@ func validateLargeIntegerBoundsAt(schema *apiextensionsv1.JSONSchemaProps, data 
 				continue
 			}
 			prop := schema.Properties[k]
-			if err := validateLargeIntegerBoundsAt(&prop, val, childSchemaPath(path, k)); err != nil {
+			if err := validateLargeIntegerBoundsAt(&prop, val, childSchemaPath(path, k), false); err != nil {
 				return err
 			}
 		}
@@ -233,7 +278,7 @@ func validateLargeIntegerBoundsAt(schema *apiextensionsv1.JSONSchemaProps, data 
 				if _, defined := schema.Properties[k]; defined {
 					continue
 				}
-				if err := validateLargeIntegerBoundsAt(schema.AdditionalProperties.Schema, val, childSchemaPath(path, k)); err != nil {
+				if err := validateLargeIntegerBoundsAt(schema.AdditionalProperties.Schema, val, childSchemaPath(path, k), false); err != nil {
 					return err
 				}
 			}
@@ -245,7 +290,7 @@ func validateLargeIntegerBoundsAt(schema *apiextensionsv1.JSONSchemaProps, data 
 	}
 	if schema.Items.Schema != nil {
 		for i, val := range dataSlice {
-			if err := validateLargeIntegerBoundsAt(schema.Items.Schema, val, fmt.Sprintf("%s[%d]", schemaPath(path), i)); err != nil {
+			if err := validateLargeIntegerBoundsAt(schema.Items.Schema, val, fmt.Sprintf("%s[%d]", schemaPath(path), i), false); err != nil {
 				return err
 			}
 		}
@@ -255,7 +300,7 @@ func validateLargeIntegerBoundsAt(schema *apiextensionsv1.JSONSchemaProps, data 
 		if i >= len(dataSlice) {
 			break
 		}
-		if err := validateLargeIntegerBoundsAt(&schema.Items.JSONSchemas[i], dataSlice[i], fmt.Sprintf("%s[%d]", schemaPath(path), i)); err != nil {
+		if err := validateLargeIntegerBoundsAt(&schema.Items.JSONSchemas[i], dataSlice[i], fmt.Sprintf("%s[%d]", schemaPath(path), i), false); err != nil {
 			return err
 		}
 	}

--- a/pkg/common/openapiv3schema.go
+++ b/pkg/common/openapiv3schema.go
@@ -22,6 +22,7 @@ package common
 import (
 	"fmt"
 	"math"
+	"math/big"
 	"strconv"
 	"strings"
 
@@ -234,8 +235,7 @@ func intersectJSONSchemaType(left, right string) (string, bool) {
 
 // validateLargeIntegerBounds enforces original Maximum for integer properties
 // whose Maximum was >= 2^63 (stripped by stripIntegerOverflow to prevent
-// kube-openapi int64 overflow). CUE type extrema (2^63 for int64, 2^64 for
-// uint64) are skipped because ParseInt/ParseUint already enforce type range.
+// kube-openapi int64 overflow).
 func validateLargeIntegerBounds(schema *apiextensionsv1.JSONSchemaProps, data interface{}) error {
 	return validateLargeIntegerBoundsAt(schema, data, "", false)
 }
@@ -245,13 +245,12 @@ func validateLargeIntegerBoundsAt(schema *apiextensionsv1.JSONSchemaProps, data 
 		return nil
 	}
 	integerContext := hasEffectiveIntegerType(schema, inheritedInteger)
-	if integerContext && schema.Maximum != nil && *schema.Maximum >= math.Exp2(63) &&
-		*schema.Maximum != math.Exp2(63) && *schema.Maximum != math.Exp2(64) {
-		if f, ok := toFloat64(data); ok {
-			if schema.ExclusiveMaximum && f >= *schema.Maximum {
+	if integerContext && schema.Maximum != nil && *schema.Maximum >= math.Exp2(63) {
+		if cmp, ok := compareNumericValueToFloat64(data, *schema.Maximum); ok {
+			if schema.ExclusiveMaximum && cmp >= 0 {
 				return fmt.Errorf("%s: must be less than %g", schemaPath(path), *schema.Maximum)
 			}
-			if !schema.ExclusiveMaximum && f > *schema.Maximum {
+			if !schema.ExclusiveMaximum && cmp > 0 {
 				return fmt.Errorf("%s: must be less than or equal to %g", schemaPath(path), *schema.Maximum)
 			}
 		}
@@ -321,24 +320,51 @@ func schemaPath(path string) string {
 	return path
 }
 
-func toFloat64(val interface{}) (float64, bool) {
+func compareNumericValueToFloat64(val interface{}, bound float64) (int, bool) {
 	switch v := val.(type) {
 	case float64:
-		return v, true
+		return compareFloat64(v, bound)
 	case float32:
-		return float64(v), true
+		return compareFloat64(float64(v), bound)
 	case int64:
-		return float64(v), true
+		return compareIntegerToFloat64(big.NewInt(v), bound)
 	case uint64:
-		return float64(v), true
+		return compareIntegerToFloat64(new(big.Int).SetUint64(v), bound)
 	case int:
-		return float64(v), true
+		return compareIntegerToFloat64(big.NewInt(int64(v)), bound)
 	case int32:
-		return float64(v), true
+		return compareIntegerToFloat64(big.NewInt(int64(v)), bound)
 	case uint:
-		return float64(v), true
+		return compareIntegerToFloat64(new(big.Int).SetUint64(uint64(v)), bound)
 	case uint32:
-		return float64(v), true
+		return compareIntegerToFloat64(new(big.Int).SetUint64(uint64(v)), bound)
 	}
 	return 0, false
+}
+
+func compareIntegerToFloat64(value *big.Int, bound float64) (int, bool) {
+	boundValue := new(big.Rat).SetFloat64(bound)
+	if boundValue == nil {
+		if math.IsInf(bound, 1) {
+			return -1, true
+		}
+		if math.IsInf(bound, -1) {
+			return 1, true
+		}
+		return 0, false
+	}
+	return new(big.Rat).SetInt(value).Cmp(boundValue), true
+}
+
+func compareFloat64(value, bound float64) (int, bool) {
+	if math.IsNaN(value) || math.IsNaN(bound) {
+		return 0, false
+	}
+	if value < bound {
+		return -1, true
+	}
+	if value > bound {
+		return 1, true
+	}
+	return 0, true
 }

--- a/pkg/common/openapiv3schema.go
+++ b/pkg/common/openapiv3schema.go
@@ -113,7 +113,7 @@ func isUnsignedByBounds(prop apiextensionsv1.JSONSchemaProps) bool {
 		prop.Maximum != nil && *prop.Maximum > math.Exp2(63)
 }
 
-// stripIntegerOverflow removes Maximum from integer properties whose Maximum
+// stripIntegerOverflow removes Maximum from integer schemas whose Maximum
 // >= 2^63. kube-openapi internally converts float64 Maximum to int64;
 // float64(MaxInt64) rounds to 2^63 and float64(MaxUint64) rounds to 2^64,
 // both of which overflow int64. User-declared maximums that were stripped
@@ -122,25 +122,70 @@ func stripIntegerOverflow(schema *apiextensionsv1.JSONSchemaProps) *apiextension
 	if schema == nil {
 		return nil
 	}
-	needsCopy := false
-	for _, prop := range schema.Properties {
-		if prop.Type == "integer" && prop.Maximum != nil && *prop.Maximum >= math.Exp2(63) {
-			needsCopy = true
-			break
-		}
-	}
-	if !needsCopy {
+	if !hasIntegerOverflowMaximum(schema) {
 		return schema
 	}
 	out := schema.DeepCopy()
-	for k, prop := range out.Properties {
-		if prop.Type == "integer" && prop.Maximum != nil && *prop.Maximum >= math.Exp2(63) {
-			prop.Maximum = nil
-			prop.ExclusiveMaximum = false
-			out.Properties[k] = prop
+	stripIntegerOverflowMaximum(out)
+	return out
+}
+
+func hasIntegerOverflowMaximum(schema *apiextensionsv1.JSONSchemaProps) bool {
+	if schema.Type == "integer" && schema.Maximum != nil && *schema.Maximum >= math.Exp2(63) {
+		return true
+	}
+	for i := range schema.AllOf {
+		if hasIntegerOverflowMaximum(&schema.AllOf[i]) {
+			return true
 		}
 	}
-	return out
+	for k := range schema.Properties {
+		prop := schema.Properties[k]
+		if hasIntegerOverflowMaximum(&prop) {
+			return true
+		}
+	}
+	if schema.AdditionalProperties != nil && schema.AdditionalProperties.Schema != nil &&
+		hasIntegerOverflowMaximum(schema.AdditionalProperties.Schema) {
+		return true
+	}
+	if schema.Items != nil {
+		if schema.Items.Schema != nil && hasIntegerOverflowMaximum(schema.Items.Schema) {
+			return true
+		}
+		for i := range schema.Items.JSONSchemas {
+			if hasIntegerOverflowMaximum(&schema.Items.JSONSchemas[i]) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func stripIntegerOverflowMaximum(schema *apiextensionsv1.JSONSchemaProps) {
+	if schema.Type == "integer" && schema.Maximum != nil && *schema.Maximum >= math.Exp2(63) {
+		schema.Maximum = nil
+		schema.ExclusiveMaximum = false
+	}
+	for i := range schema.AllOf {
+		stripIntegerOverflowMaximum(&schema.AllOf[i])
+	}
+	for k := range schema.Properties {
+		prop := schema.Properties[k]
+		stripIntegerOverflowMaximum(&prop)
+		schema.Properties[k] = prop
+	}
+	if schema.AdditionalProperties != nil && schema.AdditionalProperties.Schema != nil {
+		stripIntegerOverflowMaximum(schema.AdditionalProperties.Schema)
+	}
+	if schema.Items != nil {
+		if schema.Items.Schema != nil {
+			stripIntegerOverflowMaximum(schema.Items.Schema)
+		}
+		for i := range schema.Items.JSONSchemas {
+			stripIntegerOverflowMaximum(&schema.Items.JSONSchemas[i])
+		}
+	}
 }
 
 // validateLargeIntegerBounds enforces original Maximum for integer properties
@@ -148,36 +193,87 @@ func stripIntegerOverflow(schema *apiextensionsv1.JSONSchemaProps) *apiextension
 // kube-openapi int64 overflow). CUE type extrema (2^63 for int64, 2^64 for
 // uint64) are skipped because ParseInt/ParseUint already enforce type range.
 func validateLargeIntegerBounds(schema *apiextensionsv1.JSONSchemaProps, data interface{}) error {
-	dataMap, ok := data.(map[string]interface{})
-	if !ok {
+	return validateLargeIntegerBoundsAt(schema, data, "")
+}
+
+func validateLargeIntegerBoundsAt(schema *apiextensionsv1.JSONSchemaProps, data interface{}, path string) error {
+	if schema == nil {
 		return nil
 	}
-	for k, prop := range schema.Properties {
-		if prop.Type != "integer" || prop.Maximum == nil || *prop.Maximum < math.Exp2(63) {
-			continue
-		}
-		if *prop.Maximum == math.Exp2(63) || *prop.Maximum == math.Exp2(64) {
-			continue
-		}
-		val, exists := dataMap[k]
-		if !exists {
-			continue
-		}
-		f, ok := toFloat64(val)
-		if !ok {
-			continue
-		}
-		if prop.ExclusiveMaximum {
-			if f >= *prop.Maximum {
-				return fmt.Errorf("%s: must be less than %g", k, *prop.Maximum)
+	if schema.Type == "integer" && schema.Maximum != nil && *schema.Maximum >= math.Exp2(63) &&
+		*schema.Maximum != math.Exp2(63) && *schema.Maximum != math.Exp2(64) {
+		if f, ok := toFloat64(data); ok {
+			if schema.ExclusiveMaximum && f >= *schema.Maximum {
+				return fmt.Errorf("%s: must be less than %g", schemaPath(path), *schema.Maximum)
 			}
-		} else {
-			if f > *prop.Maximum {
-				return fmt.Errorf("%s: must be less than or equal to %g", k, *prop.Maximum)
+			if !schema.ExclusiveMaximum && f > *schema.Maximum {
+				return fmt.Errorf("%s: must be less than or equal to %g", schemaPath(path), *schema.Maximum)
 			}
+		}
+	}
+	for i := range schema.AllOf {
+		if err := validateLargeIntegerBoundsAt(&schema.AllOf[i], data, path); err != nil {
+			return err
+		}
+	}
+	dataMap, ok := data.(map[string]interface{})
+	if ok {
+		for k := range schema.Properties {
+			val, exists := dataMap[k]
+			if !exists {
+				continue
+			}
+			prop := schema.Properties[k]
+			if err := validateLargeIntegerBoundsAt(&prop, val, childSchemaPath(path, k)); err != nil {
+				return err
+			}
+		}
+		if schema.AdditionalProperties != nil && schema.AdditionalProperties.Schema != nil {
+			for k, val := range dataMap {
+				if _, defined := schema.Properties[k]; defined {
+					continue
+				}
+				if err := validateLargeIntegerBoundsAt(schema.AdditionalProperties.Schema, val, childSchemaPath(path, k)); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	dataSlice, ok := data.([]interface{})
+	if !ok || schema.Items == nil {
+		return nil
+	}
+	if schema.Items.Schema != nil {
+		for i, val := range dataSlice {
+			if err := validateLargeIntegerBoundsAt(schema.Items.Schema, val, fmt.Sprintf("%s[%d]", schemaPath(path), i)); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	for i := range schema.Items.JSONSchemas {
+		if i >= len(dataSlice) {
+			break
+		}
+		if err := validateLargeIntegerBoundsAt(&schema.Items.JSONSchemas[i], dataSlice[i], fmt.Sprintf("%s[%d]", schemaPath(path), i)); err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+func childSchemaPath(path, child string) string {
+	if path == "" {
+		return child
+	}
+	return path + "." + child
+}
+
+func schemaPath(path string) string {
+	if path == "" {
+		return "value"
+	}
+	return path
 }
 
 func toFloat64(val interface{}) (float64, bool) {

--- a/pkg/common/openapiv3schema_test.go
+++ b/pkg/common/openapiv3schema_test.go
@@ -158,6 +158,42 @@ func TestValidateDataWithSchemaInt64(t *testing.T) {
 	}
 }
 
+func TestValidateDataWithSchemaComposedConstraintOnlyIntegerMax(t *testing.T) {
+	maximum := math.Exp2(63)
+	tests := []struct {
+		name   string
+		schema *apiextensionsv1.JSONSchemaProps
+	}{
+		{
+			name: "parent type",
+			schema: &apiextensionsv1.JSONSchemaProps{
+				Type: "integer",
+				AllOf: []apiextensionsv1.JSONSchemaProps{{
+					Maximum:          &maximum,
+					ExclusiveMaximum: true,
+				}},
+			},
+		},
+		{
+			name: "sibling type",
+			schema: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{
+					{Type: "integer"},
+					{Maximum: &maximum, ExclusiveMaximum: true},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateDataWithSchema(tt.schema, int64(math.MaxInt64)); err != nil {
+				t.Fatalf("expected MaxInt64 to satisfy the composed integer schema, got %v", err)
+			}
+		})
+	}
+}
+
 func TestStripIntegerOverflow(t *testing.T) {
 	schema := &apiextensionsv1.JSONSchemaProps{
 		Type: "object",
@@ -237,6 +273,80 @@ func TestStripIntegerOverflow(t *testing.T) {
 	}
 	if schema.Properties["map_field"].AdditionalProperties.Schema.Maximum == nil {
 		t.Fatalf("expected original map schema to be unchanged")
+	}
+}
+
+func TestStripIntegerOverflowComposedTypeContext(t *testing.T) {
+	maximum := math.Exp2(63)
+	tests := []struct {
+		name     string
+		schema   *apiextensionsv1.JSONSchemaProps
+		stripped bool
+	}{
+		{
+			name: "parent integer",
+			schema: &apiextensionsv1.JSONSchemaProps{
+				Type:  "integer",
+				AllOf: []apiextensionsv1.JSONSchemaProps{{Maximum: &maximum}},
+			},
+			stripped: true,
+		},
+		{
+			name: "sibling integer",
+			schema: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{{Type: "integer"}, {Maximum: &maximum}},
+			},
+			stripped: true,
+		},
+		{
+			name: "numeric intersection",
+			schema: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{{Type: "number"}, {Type: "integer"}, {Maximum: &maximum}},
+			},
+			stripped: true,
+		},
+		{
+			name: "nested integer",
+			schema: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{{
+					AllOf: []apiextensionsv1.JSONSchemaProps{{Type: "integer"}},
+				}, {Maximum: &maximum}},
+			},
+			stripped: true,
+		},
+		{
+			name: "number",
+			schema: &apiextensionsv1.JSONSchemaProps{
+				Type:  "number",
+				AllOf: []apiextensionsv1.JSONSchemaProps{{Maximum: &maximum}},
+			},
+		},
+		{
+			name:   "unknown type",
+			schema: &apiextensionsv1.JSONSchemaProps{AllOf: []apiextensionsv1.JSONSchemaProps{{Maximum: &maximum}}},
+		},
+		{
+			name: "conflicting type",
+			schema: &apiextensionsv1.JSONSchemaProps{
+				AllOf: []apiextensionsv1.JSONSchemaProps{{Type: "integer"}, {Type: "string"}, {Maximum: &maximum}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := stripIntegerOverflow(tt.schema)
+			maximumAfter := result.AllOf[len(result.AllOf)-1].Maximum
+			if tt.stripped && maximumAfter != nil {
+				t.Fatalf("expected overflow maximum to be stripped")
+			}
+			if !tt.stripped && maximumAfter == nil {
+				t.Fatalf("expected maximum to be preserved without an effective integer type")
+			}
+			if tt.schema.AllOf[len(tt.schema.AllOf)-1].Maximum == nil {
+				t.Fatalf("expected original schema to be unchanged")
+			}
+		})
 	}
 }
 
@@ -369,16 +479,31 @@ func TestValidateDataWithSchemaNestedUserDeclaredLargeMax(t *testing.T) {
 		invalid interface{}
 	}{
 		{
-			name: "allOf",
+			name: "allOf parent type",
 			schema: &apiextensionsv1.JSONSchemaProps{
 				Type: "object",
 				Properties: map[string]apiextensionsv1.JSONSchemaProps{
 					"value": {
 						Type: "integer",
 						AllOf: []apiextensionsv1.JSONSchemaProps{{
-							Type:    "integer",
 							Maximum: &userMax,
 						}},
+					},
+				},
+			},
+			valid:   map[string]interface{}{"value": uint64(9e18)},
+			invalid: map[string]interface{}{"value": uint64(11e18)},
+		},
+		{
+			name: "allOf sibling type",
+			schema: &apiextensionsv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{
+					"value": {
+						AllOf: []apiextensionsv1.JSONSchemaProps{
+							{Type: "integer"},
+							{Maximum: &userMax},
+						},
 					},
 				},
 			},

--- a/pkg/common/openapiv3schema_test.go
+++ b/pkg/common/openapiv3schema_test.go
@@ -166,6 +166,12 @@ func TestStripIntegerOverflow(t *testing.T) {
 				Type:    "integer",
 				Minimum: ptrFloat64(0),
 				Maximum: ptrFloat64(float64(math.MaxUint64)),
+				AllOf: []apiextensionsv1.JSONSchemaProps{
+					{
+						Type:    "integer",
+						Maximum: ptrFloat64(math.Exp2(64)),
+					},
+				},
 			},
 			"i64_field": {
 				Type:    "integer",
@@ -181,12 +187,29 @@ func TestStripIntegerOverflow(t *testing.T) {
 				Minimum: ptrFloat64(0),
 				Maximum: ptrFloat64(1000),
 			},
+			"array_field": {
+				Type: "array",
+				Items: &apiextensionsv1.JSONSchemaPropsOrArray{Schema: &apiextensionsv1.JSONSchemaProps{
+					Type:    "integer",
+					Maximum: ptrFloat64(math.Exp2(64)),
+				}},
+			},
+			"map_field": {
+				Type: "object",
+				AdditionalProperties: &apiextensionsv1.JSONSchemaPropsOrBool{Allows: true, Schema: &apiextensionsv1.JSONSchemaProps{
+					Type:    "integer",
+					Maximum: ptrFloat64(math.Exp2(64)),
+				}},
+			},
 		},
 	}
 
 	result := stripIntegerOverflow(schema)
 	if result.Properties["u64_field"].Maximum != nil {
 		t.Fatalf("expected u64_field Maximum to be stripped (overflow)")
+	}
+	if result.Properties["u64_field"].AllOf[0].Maximum != nil {
+		t.Fatalf("expected composed u64_field Maximum to be stripped (overflow)")
 	}
 	if result.Properties["i64_field"].Maximum == nil || *result.Properties["i64_field"].Maximum != 100 {
 		t.Fatalf("expected i64_field Maximum to be preserved")
@@ -197,8 +220,23 @@ func TestStripIntegerOverflow(t *testing.T) {
 	if result.Properties["custom_small"].Maximum == nil || *result.Properties["custom_small"].Maximum != 1000 {
 		t.Fatalf("expected custom_small Maximum to be preserved (below 2^63)")
 	}
+	if result.Properties["array_field"].Items.Schema.Maximum != nil {
+		t.Fatalf("expected array item Maximum to be stripped (overflow)")
+	}
+	if result.Properties["map_field"].AdditionalProperties.Schema.Maximum != nil {
+		t.Fatalf("expected map value Maximum to be stripped (overflow)")
+	}
 	if schema.Properties["u64_field"].Maximum == nil {
 		t.Fatalf("expected original schema to be unchanged")
+	}
+	if schema.Properties["u64_field"].AllOf[0].Maximum == nil {
+		t.Fatalf("expected original composed schema to be unchanged")
+	}
+	if schema.Properties["array_field"].Items.Schema.Maximum == nil {
+		t.Fatalf("expected original array schema to be unchanged")
+	}
+	if schema.Properties["map_field"].AdditionalProperties.Schema.Maximum == nil {
+		t.Fatalf("expected original map schema to be unchanged")
 	}
 }
 
@@ -267,6 +305,36 @@ func TestValidateLargeIntegerBounds(t *testing.T) {
 	if err := validateLargeIntegerBounds(schema, map[string]interface{}{"custom_max": int(100)}); err != nil {
 		t.Fatalf("expected int value within user max to pass, got %v", err)
 	}
+
+	nestedSchema := &apiextensionsv1.JSONSchemaProps{
+		Type: "object",
+		Properties: map[string]apiextensionsv1.JSONSchemaProps{
+			"values": {
+				Type: "array",
+				Items: &apiextensionsv1.JSONSchemaPropsOrArray{Schema: &apiextensionsv1.JSONSchemaProps{
+					Type:    "integer",
+					Maximum: &userMax,
+				}},
+			},
+			"labels": {
+				Type: "object",
+				AdditionalProperties: &apiextensionsv1.JSONSchemaPropsOrBool{Schema: &apiextensionsv1.JSONSchemaProps{
+					Type:    "integer",
+					Maximum: &userMax,
+				}},
+			},
+		},
+	}
+	if err := validateLargeIntegerBounds(nestedSchema, map[string]interface{}{
+		"values": []interface{}{uint64(11e18)},
+	}); err == nil {
+		t.Fatalf("expected nested array value above user max to be rejected")
+	}
+	if err := validateLargeIntegerBounds(nestedSchema, map[string]interface{}{
+		"labels": map[string]interface{}{"entry": uint64(11e18)},
+	}); err == nil {
+		t.Fatalf("expected nested map value above user max to be rejected")
+	}
 }
 
 func TestValidateDataWithSchemaUserDeclaredLargeMax(t *testing.T) {
@@ -289,6 +357,69 @@ func TestValidateDataWithSchemaUserDeclaredLargeMax(t *testing.T) {
 	// Value above user max fails end-to-end
 	if err := ValidateDataWithSchema(schema, map[string]interface{}{"max_items": uint64(11e18)}); err == nil {
 		t.Fatalf("expected value above user-declared max to be rejected")
+	}
+}
+
+func TestValidateDataWithSchemaNestedUserDeclaredLargeMax(t *testing.T) {
+	userMax := float64(1e19)
+	tests := []struct {
+		name    string
+		schema  *apiextensionsv1.JSONSchemaProps
+		valid   interface{}
+		invalid interface{}
+	}{
+		{
+			name: "allOf",
+			schema: &apiextensionsv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{
+					"value": {
+						Type: "integer",
+						AllOf: []apiextensionsv1.JSONSchemaProps{{
+							Type:    "integer",
+							Maximum: &userMax,
+						}},
+					},
+				},
+			},
+			valid:   map[string]interface{}{"value": uint64(9e18)},
+			invalid: map[string]interface{}{"value": uint64(11e18)},
+		},
+		{
+			name: "array item",
+			schema: &apiextensionsv1.JSONSchemaProps{
+				Type: "array",
+				Items: &apiextensionsv1.JSONSchemaPropsOrArray{Schema: &apiextensionsv1.JSONSchemaProps{
+					Type:    "integer",
+					Maximum: &userMax,
+				}},
+			},
+			valid:   []interface{}{uint64(9e18)},
+			invalid: []interface{}{uint64(11e18)},
+		},
+		{
+			name: "map value",
+			schema: &apiextensionsv1.JSONSchemaProps{
+				Type: "object",
+				AdditionalProperties: &apiextensionsv1.JSONSchemaPropsOrBool{Allows: true, Schema: &apiextensionsv1.JSONSchemaProps{
+					Type:    "integer",
+					Maximum: &userMax,
+				}},
+			},
+			valid:   map[string]interface{}{"entry": uint64(9e18)},
+			invalid: map[string]interface{}{"entry": uint64(11e18)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateDataWithSchema(tt.schema, tt.valid); err != nil {
+				t.Fatalf("expected value within user max to pass, got %v", err)
+			}
+			if err := ValidateDataWithSchema(tt.schema, tt.invalid); err == nil {
+				t.Fatalf("expected value above user max to be rejected")
+			}
+		})
 	}
 }
 

--- a/pkg/common/openapiv3schema_test.go
+++ b/pkg/common/openapiv3schema_test.go
@@ -190,6 +190,9 @@ func TestValidateDataWithSchemaComposedConstraintOnlyIntegerMax(t *testing.T) {
 			if err := ValidateDataWithSchema(tt.schema, int64(math.MaxInt64)); err != nil {
 				t.Fatalf("expected MaxInt64 to satisfy the composed integer schema, got %v", err)
 			}
+			if err := ValidateDataWithSchema(tt.schema, uint64(1)<<63); err == nil {
+				t.Fatalf("expected 2^63 to violate the exclusive composed integer maximum")
+			}
 		})
 	}
 }
@@ -373,7 +376,7 @@ func TestValidateLargeIntegerBounds(t *testing.T) {
 		t.Fatalf("expected value above user max to be rejected")
 	}
 
-	// CUE uint64 extremum (2^64) should be skipped (not enforced manually)
+	// CUE uint64 extremum (2^64) should accept MaxUint64 exactly.
 	cueSchema := &apiextensionsv1.JSONSchemaProps{
 		Type: "object",
 		Properties: map[string]apiextensionsv1.JSONSchemaProps{
@@ -385,22 +388,26 @@ func TestValidateLargeIntegerBounds(t *testing.T) {
 		},
 	}
 	if err := validateLargeIntegerBounds(cueSchema, map[string]interface{}{"cue_u64": uint64(math.MaxUint64)}); err != nil {
-		t.Fatalf("expected CUE uint64 extremum to be skipped, got %v", err)
+		t.Fatalf("expected MaxUint64 below the CUE uint64 extremum to pass, got %v", err)
 	}
 
-	// CUE int64 extremum (2^63) should be skipped
+	// CUE int64 extremum (2^63 exclusive) should accept MaxInt64 and reject 2^63.
 	cueI64Schema := &apiextensionsv1.JSONSchemaProps{
 		Type: "object",
 		Properties: map[string]apiextensionsv1.JSONSchemaProps{
 			"cue_i64": {
-				Type:    "integer",
-				Minimum: ptrFloat64(-math.Exp2(63)),
-				Maximum: ptrFloat64(math.Exp2(63)),
+				Type:             "integer",
+				Minimum:          ptrFloat64(-math.Exp2(63)),
+				Maximum:          ptrFloat64(math.Exp2(63)),
+				ExclusiveMaximum: true,
 			},
 		},
 	}
 	if err := validateLargeIntegerBounds(cueI64Schema, map[string]interface{}{"cue_i64": int64(math.MaxInt64)}); err != nil {
-		t.Fatalf("expected CUE int64 extremum to be skipped, got %v", err)
+		t.Fatalf("expected MaxInt64 below the CUE int64 extremum to pass, got %v", err)
+	}
+	if err := validateLargeIntegerBounds(cueI64Schema, map[string]interface{}{"cue_i64": uint64(1) << 63}); err == nil {
+		t.Fatalf("expected 2^63 to violate the exclusive CUE int64 extremum")
 	}
 
 	// float64 value (JSON/YAML parser output) within user max should pass
@@ -449,24 +456,45 @@ func TestValidateLargeIntegerBounds(t *testing.T) {
 
 func TestValidateDataWithSchemaUserDeclaredLargeMax(t *testing.T) {
 	userMax := float64(1e19)
-	schema := &apiextensionsv1.JSONSchemaProps{
-		Type: "object",
-		Properties: map[string]apiextensionsv1.JSONSchemaProps{
-			"max_items": {
-				Type:    "integer",
-				Minimum: ptrFloat64(0),
-				Maximum: &userMax,
-			},
+	tests := []struct {
+		name            string
+		exclusive       bool
+		validBoundary   uint64
+		invalidBoundary uint64
+	}{
+		{
+			name:            "inclusive",
+			validBoundary:   uint64(1e19),
+			invalidBoundary: uint64(1e19) + 1,
+		},
+		{
+			name:            "exclusive",
+			exclusive:       true,
+			validBoundary:   uint64(1e19) - 1,
+			invalidBoundary: uint64(1e19),
 		},
 	}
 
-	// Value within user max passes end-to-end
-	if err := ValidateDataWithSchema(schema, map[string]interface{}{"max_items": uint64(9e18)}); err != nil {
-		t.Fatalf("expected value within user max to pass, got %v", err)
-	}
-	// Value above user max fails end-to-end
-	if err := ValidateDataWithSchema(schema, map[string]interface{}{"max_items": uint64(11e18)}); err == nil {
-		t.Fatalf("expected value above user-declared max to be rejected")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema := &apiextensionsv1.JSONSchemaProps{
+				Type: "object",
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{
+					"max_items": {
+						Type:             "integer",
+						Minimum:          ptrFloat64(0),
+						Maximum:          &userMax,
+						ExclusiveMaximum: tt.exclusive,
+					},
+				},
+			}
+			if err := ValidateDataWithSchema(schema, map[string]interface{}{"max_items": tt.validBoundary}); err != nil {
+				t.Fatalf("expected exact value within user max to pass, got %v", err)
+			}
+			if err := ValidateDataWithSchema(schema, map[string]interface{}{"max_items": tt.invalidBoundary}); err == nil {
+				t.Fatalf("expected exact value outside user max to be rejected")
+			}
+		})
 	}
 }
 

--- a/pkg/parameters/openapi/cue_gen_openapi.go
+++ b/pkg/parameters/openapi/cue_gen_openapi.go
@@ -164,6 +164,15 @@ func deReferenceSchema(props *apiextv1.JSONSchemaProps, resolveFn func(path stri
 			return err
 		}
 	}
+	for i := range props.AllOf {
+		schemaProps := util.ToPointer(props.AllOf[i])
+		schemaProps, err = oneProps(schemaProps)
+		if err != nil {
+			return err
+		}
+		props.AllOf[i] = *schemaProps
+	}
+	expandAllOf(props)
 	for key := range props.Properties {
 		schemaProps := util.ToPointer(props.Properties[key])
 		schemaProps, err = oneProps(schemaProps)
@@ -173,4 +182,57 @@ func deReferenceSchema(props *apiextv1.JSONSchemaProps, resolveFn func(path stri
 		props.Properties[key] = *schemaProps
 	}
 	return nil
+}
+
+func expandAllOf(props *apiextv1.JSONSchemaProps) {
+	if len(props.AllOf) == 0 {
+		return
+	}
+	allOf := props.AllOf
+	props.AllOf = nil
+	for _, schemaProps := range allOf {
+		if schemaProps.Type != "" && schemaProps.Type != SchemaStructType {
+			props.AllOf = append(props.AllOf, schemaProps)
+			continue
+		}
+		mergeSchemaProps(props, schemaProps)
+	}
+}
+
+func mergeSchemaProps(dst *apiextv1.JSONSchemaProps, src apiextv1.JSONSchemaProps) {
+	if dst.Type == "" {
+		dst.Type = src.Type
+	}
+	if len(src.Properties) > 0 {
+		if dst.Properties == nil {
+			dst.Properties = map[string]apiextv1.JSONSchemaProps{}
+		}
+		for key, value := range src.Properties {
+			if _, ok := dst.Properties[key]; !ok {
+				dst.Properties[key] = value
+			}
+		}
+	}
+	if dst.AdditionalProperties == nil {
+		dst.AdditionalProperties = src.AdditionalProperties
+	}
+	dst.Required = mergeRequired(dst.Required, src.Required)
+}
+
+func mergeRequired(dst, src []string) []string {
+	if len(src) == 0 {
+		return dst
+	}
+	required := make(map[string]struct{}, len(dst)+len(src))
+	for _, item := range dst {
+		required[item] = struct{}{}
+	}
+	for _, item := range src {
+		if _, ok := required[item]; ok {
+			continue
+		}
+		required[item] = struct{}{}
+		dst = append(dst, item)
+	}
+	return dst
 }

--- a/pkg/parameters/openapi/cue_gen_openapi.go
+++ b/pkg/parameters/openapi/cue_gen_openapi.go
@@ -172,7 +172,6 @@ func deReferenceSchema(props *apiextv1.JSONSchemaProps, resolveFn func(path stri
 		}
 		props.AllOf[i] = *schemaProps
 	}
-	expandAllOf(props)
 	for key := range props.Properties {
 		schemaProps := util.ToPointer(props.Properties[key])
 		schemaProps, err = oneProps(schemaProps)
@@ -182,57 +181,4 @@ func deReferenceSchema(props *apiextv1.JSONSchemaProps, resolveFn func(path stri
 		props.Properties[key] = *schemaProps
 	}
 	return nil
-}
-
-func expandAllOf(props *apiextv1.JSONSchemaProps) {
-	if len(props.AllOf) == 0 {
-		return
-	}
-	allOf := props.AllOf
-	props.AllOf = nil
-	for _, schemaProps := range allOf {
-		if schemaProps.Type != "" && schemaProps.Type != SchemaStructType {
-			props.AllOf = append(props.AllOf, schemaProps)
-			continue
-		}
-		mergeSchemaProps(props, schemaProps)
-	}
-}
-
-func mergeSchemaProps(dst *apiextv1.JSONSchemaProps, src apiextv1.JSONSchemaProps) {
-	if dst.Type == "" {
-		dst.Type = src.Type
-	}
-	if len(src.Properties) > 0 {
-		if dst.Properties == nil {
-			dst.Properties = map[string]apiextv1.JSONSchemaProps{}
-		}
-		for key, value := range src.Properties {
-			if _, ok := dst.Properties[key]; !ok {
-				dst.Properties[key] = value
-			}
-		}
-	}
-	if dst.AdditionalProperties == nil {
-		dst.AdditionalProperties = src.AdditionalProperties
-	}
-	dst.Required = mergeRequired(dst.Required, src.Required)
-}
-
-func mergeRequired(dst, src []string) []string {
-	if len(src) == 0 {
-		return dst
-	}
-	required := make(map[string]struct{}, len(dst)+len(src))
-	for _, item := range dst {
-		required[item] = struct{}{}
-	}
-	for _, item := range src {
-		if _, ok := required[item]; ok {
-			continue
-		}
-		required[item] = struct{}{}
-		dst = append(dst, item)
-	}
-	return dst
 }

--- a/pkg/parameters/openapi/cue_gen_openapi_test.go
+++ b/pkg/parameters/openapi/cue_gen_openapi_test.go
@@ -23,104 +23,44 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
-	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"github.com/apecloud/kubeblocks/pkg/parameters/core"
 	"github.com/apecloud/kubeblocks/test/testdata"
 )
 
 func TestGenerateOpenApiSchema(t *testing.T) {
-	type args struct {
-		cueFile    string
-		schemaType string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    string
-		wantErr bool
-	}{{
-		name: "normal_test",
-		args: args{
-			cueFile:    "test_import_type.cue",
-			schemaType: "Exemplar",
-		},
-		want:    "test_import_type.json",
-		wantErr: false,
-	}, {
-		name: "normal_test",
-		args: args{
-			cueFile:    "mysql_openapi.cue",
-			schemaType: "MysqlParameter",
-		},
-		want:    "mysql_openapi.json",
-		wantErr: false,
-	}, {
-		//	name: "normal_test",
-		//	args: args{
-		//		cueFile:    "mysql_openapi_v2.cue",
-		//		schemaType: "MysqlSchema",
-		//	},
-		//	want:    "mysql_openapi_v2.json",
-		//	wantErr: false,
-		// }, {
-		name: "normal_with_not_empty",
-		args: args{
-			cueFile:    "mysql_openapi.cue",
-			schemaType: "",
-		},
-		want:    "mysql_openapi.json",
-		wantErr: false,
-	}, {
-		name: "pg14_openapi",
-		args: args{
-			cueFile:    "pg14.cue",
-			schemaType: "PGPameter",
-		},
-		want:    "pg14_openapi.json",
-		wantErr: false,
-	}, {
-		name: "multiple_schema_arch_a",
-		args: args{
-			cueFile:    "multiple_schema.cue",
-			schemaType: "archA",
-		},
-		want:    "multiple_schema_arch_a.json",
-		wantErr: false,
-	}, {
-		name: "multiple_schema_combined",
-		args: args{
-			cueFile:    "multiple_schema.cue",
-			schemaType: "combined",
-		},
-		want:    "multiple_schema_combined.json",
-		wantErr: false,
-	}, {
-		name: "failed_test",
-		args: args{
-			cueFile:    "mysql.cue",
-			schemaType: "NotType",
-		},
-		want:    "mysql_openapi_failed_not_exist",
-		wantErr: true,
-	}}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := runOpenAPITest(tt.args.cueFile, tt.args.schemaType)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("GenerateOpenAPISchema() error = %v, wantErr %v", err, tt.wantErr)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "OpenAPI Schema Suite")
+}
+
+var _ = Describe("GenerateOpenAPISchema", func() {
+	DescribeTable("generates schema from CUE definitions",
+		func(cueFile, schemaType, want string, wantErr bool) {
+			got, err := runOpenAPITest(cueFile, schemaType)
+			GinkgoWriter.Println(string(got))
+			Expect(err != nil).To(Equal(wantErr), "GenerateOpenAPISchema() error = %v, wantErr %v", err, wantErr)
+			if wantErr {
 				return
 			}
-			wantContent := getContentFromFile(tt.want)
-			if !reflect.DeepEqual(got, wantContent) {
-				t.Errorf("GenerateOpenAPISchema() diff: %s", cmp.Diff(wantContent, got))
-			}
-		})
-	}
-}
+
+			wantContent := getContentFromFile(want)
+			Expect(got).To(Equal(wantContent), "GenerateOpenAPISchema() diff: %s", cmp.Diff(wantContent, got))
+		},
+		Entry("test_import_type", "test_import_type.cue", "Exemplar", "test_import_type.json", false),
+		Entry("normal_test with mysql", "mysql_openapi.cue", "MysqlParameter", "mysql_openapi.json", false),
+		FEntry("normal_test with mysql2", "mysql_openapi_v2.cue", "MysqlSchema", "mysql_openapi_v2.json", false),
+		Entry("normal_with_not_empty", "mysql_openapi.cue", "", "mysql_openapi.json", false),
+		Entry("pg14_openapi", "pg14.cue", "PGPameter", "pg14_openapi.json", false),
+		Entry("multiple_schema_arch_a", "multiple_schema.cue", "archA", "multiple_schema_arch_a.json", false),
+		Entry("multiple_schema_combined", "multiple_schema.cue", "combined", "multiple_schema_combined.json", false),
+		Entry("failed_test", "mysql.cue", "NotType", "mysql_openapi_failed_not_exist", true),
+	)
+})
 
 func getContentFromFile(file string) []byte {
 	content, err := os.ReadFile(testdata.SubTestDataPath("./cue_testdata/" + file))

--- a/pkg/parameters/openapi/cue_gen_openapi_test.go
+++ b/pkg/parameters/openapi/cue_gen_openapi_test.go
@@ -83,6 +83,22 @@ func TestGenerateOpenApiSchema(t *testing.T) {
 		want:    "pg14_openapi.json",
 		wantErr: false,
 	}, {
+		name: "multiple_schema_arch_a",
+		args: args{
+			cueFile:    "multiple_schema.cue",
+			schemaType: "archA",
+		},
+		want:    "multiple_schema_arch_a.json",
+		wantErr: false,
+	}, {
+		name: "multiple_schema_combined",
+		args: args{
+			cueFile:    "multiple_schema.cue",
+			schemaType: "combined",
+		},
+		want:    "multiple_schema_combined.json",
+		wantErr: false,
+	}, {
 		name: "failed_test",
 		args: args{
 			cueFile:    "mysql.cue",

--- a/pkg/parameters/openapi/cue_gen_openapi_test.go
+++ b/pkg/parameters/openapi/cue_gen_openapi_test.go
@@ -53,11 +53,12 @@ var _ = Describe("GenerateOpenAPISchema", func() {
 		},
 		Entry("test_import_type", "test_import_type.cue", "Exemplar", "test_import_type.json", false),
 		Entry("normal_test with mysql", "mysql_openapi.cue", "MysqlParameter", "mysql_openapi.json", false),
-		FEntry("normal_test with mysql2", "mysql_openapi_v2.cue", "MysqlSchema", "mysql_openapi_v2.json", false),
+		Entry("normal_test with mysql2", "mysql_openapi_v2.cue", "MysqlSchema", "mysql_openapi_v2.json", false),
 		Entry("normal_with_not_empty", "mysql_openapi.cue", "", "mysql_openapi.json", false),
 		Entry("pg14_openapi", "pg14.cue", "PGPameter", "pg14_openapi.json", false),
 		Entry("multiple_schema_arch_a", "multiple_schema.cue", "archA", "multiple_schema_arch_a.json", false),
 		Entry("multiple_schema_combined", "multiple_schema.cue", "combined", "multiple_schema_combined.json", false),
+		Entry("multiple_schema_embedded", "multiple_schema.cue", "embedded", "multiple_schema_combined.json", false),
 		Entry("failed_test", "mysql.cue", "NotType", "mysql_openapi_failed_not_exist", true),
 	)
 })

--- a/pkg/parameters/openapi/flatten.go
+++ b/pkg/parameters/openapi/flatten.go
@@ -54,9 +54,24 @@ func addFlattenedSchema(flattenProps map[string]apiextv1.JSONSchemaProps, prefix
 		flattenProps[prefix] = schema
 		return
 	}
-	// Keep the first schema's type available to value conversion while retaining every intersection.
+	intersectFlattenedSchemaType(&existing, schema)
 	existing.AllOf = append(existing.AllOf, schema)
 	flattenProps[prefix] = existing
+}
+
+func intersectFlattenedSchemaType(existing *apiextv1.JSONSchemaProps, schema apiextv1.JSONSchemaProps) {
+	switch {
+	case existing.Type == "":
+		existing.Type = schema.Type
+		existing.Format = schema.Format
+	case schema.Type == "" || existing.Type == schema.Type:
+		return
+	case existing.Type == "number" && schema.Type == "integer":
+		existing.Type = schema.Type
+		existing.Format = schema.Format
+	case existing.Type == "integer" && schema.Type == "number":
+		return
+	}
 }
 
 func flattenSchemaProps(flattenProps map[string]apiextv1.JSONSchemaProps, m apiextv1.JSONSchemaProps, prefix string, delim string) {

--- a/pkg/parameters/openapi/flatten.go
+++ b/pkg/parameters/openapi/flatten.go
@@ -55,6 +55,7 @@ func addFlattenedSchema(flattenProps map[string]apiextv1.JSONSchemaProps, prefix
 		return
 	}
 	intersectFlattenedSchemaType(&existing, schema)
+	intersectFlattenedSchemaConversionHints(&existing, schema)
 	existing.AllOf = append(existing.AllOf, schema)
 	flattenProps[prefix] = existing
 }
@@ -71,6 +72,63 @@ func intersectFlattenedSchemaType(existing *apiextv1.JSONSchemaProps, schema api
 		existing.Format = schema.Format
 	case existing.Type == "integer" && schema.Type == "number":
 		return
+	}
+}
+
+func intersectFlattenedSchemaConversionHints(existing *apiextv1.JSONSchemaProps, schema apiextv1.JSONSchemaProps) {
+	if existing.Type != "integer" {
+		return
+	}
+	intersectFlattenedSchemaFormat(existing, schema)
+	intersectFlattenedSchemaMinimum(existing, schema)
+	intersectFlattenedSchemaMaximum(existing, schema)
+}
+
+func intersectFlattenedSchemaFormat(existing *apiextv1.JSONSchemaProps, schema apiextv1.JSONSchemaProps) {
+	if isUnsignedIntegerFormat(existing.Format) {
+		return
+	}
+	if existing.Format == "" || isUnsignedIntegerFormat(schema.Format) {
+		existing.Format = schema.Format
+	}
+}
+
+func isUnsignedIntegerFormat(format string) bool {
+	switch format {
+	case "uint", "uint8", "uint16", "uint32", "uint64":
+		return true
+	default:
+		return false
+	}
+}
+
+func intersectFlattenedSchemaMinimum(existing *apiextv1.JSONSchemaProps, schema apiextv1.JSONSchemaProps) {
+	if schema.Minimum == nil {
+		return
+	}
+	if existing.Minimum == nil || *schema.Minimum > *existing.Minimum {
+		minimum := *schema.Minimum
+		existing.Minimum = &minimum
+		existing.ExclusiveMinimum = schema.ExclusiveMinimum
+		return
+	}
+	if *schema.Minimum == *existing.Minimum {
+		existing.ExclusiveMinimum = existing.ExclusiveMinimum || schema.ExclusiveMinimum
+	}
+}
+
+func intersectFlattenedSchemaMaximum(existing *apiextv1.JSONSchemaProps, schema apiextv1.JSONSchemaProps) {
+	if schema.Maximum == nil {
+		return
+	}
+	if existing.Maximum == nil || *schema.Maximum < *existing.Maximum {
+		maximum := *schema.Maximum
+		existing.Maximum = &maximum
+		existing.ExclusiveMaximum = schema.ExclusiveMaximum
+		return
+	}
+	if *schema.Maximum == *existing.Maximum {
+		existing.ExclusiveMaximum = existing.ExclusiveMaximum || schema.ExclusiveMaximum
 	}
 }
 

--- a/pkg/parameters/openapi/flatten.go
+++ b/pkg/parameters/openapi/flatten.go
@@ -20,6 +20,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package openapi
 
 import (
+	"math"
+
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
@@ -79,17 +81,71 @@ func intersectFlattenedSchemaConversionHints(existing *apiextv1.JSONSchemaProps,
 	if existing.Type != "integer" {
 		return
 	}
+	intersectFlattenedSchemaIntegerFormatBounds(existing)
+	intersectFlattenedSchemaIntegerFormatBounds(&schema)
 	intersectFlattenedSchemaFormat(existing, schema)
 	intersectFlattenedSchemaMinimum(existing, schema)
 	intersectFlattenedSchemaMaximum(existing, schema)
 }
 
+func intersectFlattenedSchemaIntegerFormatBounds(schema *apiextv1.JSONSchemaProps) {
+	var minimum, maximum float64
+	var exclusiveMaximum bool
+	switch schema.Format {
+	case "int8":
+		minimum, maximum = -128, 127
+	case "int16":
+		minimum, maximum = -32768, 32767
+	case "int32":
+		minimum, maximum = -2147483648, 2147483647
+	case "int64":
+		minimum, maximum = -math.Exp2(63), math.Exp2(63)
+		exclusiveMaximum = true
+	case "uint8":
+		minimum, maximum = 0, 255
+	case "uint16":
+		minimum, maximum = 0, 65535
+	case "uint32":
+		minimum, maximum = 0, 4294967295
+	case "uint64":
+		minimum, maximum = 0, math.Exp2(64)
+		exclusiveMaximum = true
+	case "uint":
+		minimum = 0
+		intersectFlattenedSchemaMinimum(schema, apiextv1.JSONSchemaProps{Minimum: &minimum})
+		return
+	default:
+		return
+	}
+	intersectFlattenedSchemaMinimum(schema, apiextv1.JSONSchemaProps{Minimum: &minimum})
+	intersectFlattenedSchemaMaximum(schema, apiextv1.JSONSchemaProps{
+		Maximum:          &maximum,
+		ExclusiveMaximum: exclusiveMaximum,
+	})
+}
+
 func intersectFlattenedSchemaFormat(existing *apiextv1.JSONSchemaProps, schema apiextv1.JSONSchemaProps) {
+	if isSignedIntegerFormat(existing.Format) {
+		return
+	}
+	if isSignedIntegerFormat(schema.Format) {
+		existing.Format = schema.Format
+		return
+	}
 	if isUnsignedIntegerFormat(existing.Format) {
 		return
 	}
 	if existing.Format == "" || isUnsignedIntegerFormat(schema.Format) {
 		existing.Format = schema.Format
+	}
+}
+
+func isSignedIntegerFormat(format string) bool {
+	switch format {
+	case "int", "int8", "int16", "int32", "int64":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/pkg/parameters/openapi/flatten.go
+++ b/pkg/parameters/openapi/flatten.go
@@ -48,14 +48,28 @@ func flattenSchemaAdditionalProps(flattenProps map[string]apiextv1.JSONSchemaPro
 	}
 }
 
+func addFlattenedSchema(flattenProps map[string]apiextv1.JSONSchemaProps, prefix string, schema apiextv1.JSONSchemaProps) {
+	existing, ok := flattenProps[prefix]
+	if !ok {
+		flattenProps[prefix] = schema
+		return
+	}
+	// Keep the first schema's type available to value conversion while retaining every intersection.
+	existing.AllOf = append(existing.AllOf, schema)
+	flattenProps[prefix] = existing
+}
+
 func flattenSchemaProps(flattenProps map[string]apiextv1.JSONSchemaProps, m apiextv1.JSONSchemaProps, prefix string, delim string) {
 	if m.Type != SchemaStructType && m.Type != "" {
-		flattenProps[prefix] = m
+		addFlattenedSchema(flattenProps, prefix, m)
 		return
 	}
 
 	flattenSchemaAdditionalProps(flattenProps, m, prefix, delim)
 	for k, val := range m.Properties {
 		flattenSchemaProps(flattenProps, val, genFieldPrefix(prefix, delim, k), delim)
+	}
+	for _, schema := range m.AllOf {
+		flattenSchemaProps(flattenProps, schema, prefix, delim)
 	}
 }

--- a/pkg/parameters/openapi/schema_intersection_test.go
+++ b/pkg/parameters/openapi/schema_intersection_test.go
@@ -155,6 +155,36 @@ var _ = Describe("CUE schema intersection semantics", func() {
 		Entry("integer then number", "integerThenNumber"),
 	)
 
+	DescribeTable("converts unsigned integer intersections independently of branch order",
+		func(definition string) {
+			const (
+				value        = "9223372036854775808"
+				integerValue = uint64(9223372036854775808)
+			)
+
+			cueDefinition := runtime.Underlying().LookupPath(cue.MakePath(cue.Def(definition)))
+			Expect(cueDefinition.Unify(runtime.Context().Encode(map[string]interface{}{
+				"x": integerValue,
+			})).Validate(cue.Concrete(true))).To(Succeed())
+
+			schema, err := GenerateOpenAPISchema(cueTemplate, definition)
+			Expect(err).NotTo(HaveOccurred())
+			xSchema, ok := FlattenSchema(schema.Properties[DefaultSchemaName]).Properties["x"]
+			Expect(ok).To(BeTrue())
+			leafSchema := &apiextensionsv1.JSONSchemaProps{
+				Type:       SchemaStructType,
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{"x": xSchema},
+			}
+
+			typedValue, err := common.ConvertStringToInterfaceBySchemaType(leafSchema, map[string]string{"x": value})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(typedValue["x"]).To(Equal(integerValue))
+			Expect(common.ValidateDataWithSchema(leafSchema, typedValue)).To(Succeed())
+		},
+		Entry("generic integer then uint64", "genericThenUnsigned"),
+		Entry("uint64 then generic integer", "unsignedThenGeneric"),
+	)
+
 	It("preserves conflicting leaf constraints when flattening", func() {
 		objectSchema := apiextensionsv1.JSONSchemaProps{
 			Type: SchemaStructType,

--- a/pkg/parameters/openapi/schema_intersection_test.go
+++ b/pkg/parameters/openapi/schema_intersection_test.go
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package openapi
 
 import (
+	"math"
 	"os"
 
 	"cuelang.org/go/cue"
@@ -183,6 +184,50 @@ var _ = Describe("CUE schema intersection semantics", func() {
 		},
 		Entry("generic integer then uint64", "genericThenUnsigned"),
 		Entry("uint64 then generic integer", "unsignedThenGeneric"),
+	)
+
+	DescribeTable("preserves signed integer ranges in mixed intersections",
+		func(definition string) {
+			const (
+				maxInt64      = "9223372036854775807"
+				aboveMaxInt64 = "9223372036854775808"
+			)
+
+			cueDefinition := runtime.Underlying().LookupPath(cue.MakePath(cue.Def(definition)))
+			Expect(cueDefinition.Unify(runtime.Context().Encode(map[string]interface{}{
+				"x": int64(9223372036854775807),
+			})).Validate(cue.Concrete(true))).To(Succeed())
+			Expect(cueDefinition.Unify(runtime.Context().Encode(map[string]interface{}{
+				"x": uint64(9223372036854775808),
+			})).Validate(cue.Concrete(true))).NotTo(Succeed())
+
+			schema, err := GenerateOpenAPISchema(cueTemplate, definition)
+			Expect(err).NotTo(HaveOccurred())
+			xSchema, ok := FlattenSchema(schema.Properties[DefaultSchemaName]).Properties["x"]
+			Expect(ok).To(BeTrue())
+			Expect(xSchema.Format).To(Equal("int64"))
+			Expect(xSchema.Minimum).NotTo(BeNil())
+			Expect(*xSchema.Minimum).To(Equal(float64(0)))
+			Expect(xSchema.Maximum).NotTo(BeNil())
+			Expect(*xSchema.Maximum).To(Equal(math.Exp2(63)))
+			Expect(xSchema.ExclusiveMaximum).To(BeTrue())
+			leafSchema := &apiextensionsv1.JSONSchemaProps{
+				Type:       SchemaStructType,
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{"x": xSchema},
+			}
+
+			typedValue, err := common.ConvertStringToInterfaceBySchemaType(leafSchema, map[string]string{"x": maxInt64})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(typedValue["x"]).To(Equal(int64(9223372036854775807)))
+			Expect(common.ValidateDataWithSchema(leafSchema, typedValue)).To(Succeed())
+
+			typedValue, err = common.ConvertStringToInterfaceBySchemaType(leafSchema, map[string]string{"x": aboveMaxInt64})
+			if err == nil {
+				Expect(common.ValidateDataWithSchema(leafSchema, typedValue)).NotTo(Succeed())
+			}
+		},
+		Entry("int64 then uint64", "signed64ThenUnsigned"),
+		Entry("uint64 then int64", "unsignedThenSigned64"),
 	)
 
 	It("preserves conflicting leaf constraints when flattening", func() {

--- a/pkg/parameters/openapi/schema_intersection_test.go
+++ b/pkg/parameters/openapi/schema_intersection_test.go
@@ -128,6 +128,33 @@ var _ = Describe("CUE schema intersection semantics", func() {
 		Expect(common.ValidateDataWithSchema(leafSchema, typedValue)).NotTo(Succeed())
 	})
 
+	DescribeTable("converts compatible numeric intersections independently of branch order",
+		func(definition string) {
+			const value = "9007199254740993"
+
+			cueDefinition := runtime.Underlying().LookupPath(cue.MakePath(cue.Def(definition)))
+			Expect(cueDefinition.Unify(runtime.Context().Encode(map[string]interface{}{
+				"x": int64(9007199254740993),
+			})).Validate(cue.Concrete(true))).To(Succeed())
+
+			schema, err := GenerateOpenAPISchema(cueTemplate, definition)
+			Expect(err).NotTo(HaveOccurred())
+			xSchema, ok := FlattenSchema(schema.Properties[DefaultSchemaName]).Properties["x"]
+			Expect(ok).To(BeTrue())
+			leafSchema := &apiextensionsv1.JSONSchemaProps{
+				Type:       SchemaStructType,
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{"x": xSchema},
+			}
+
+			typedValue, err := common.ConvertStringToInterfaceBySchemaType(leafSchema, map[string]string{"x": value})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(typedValue["x"]).To(Equal(int64(9007199254740993)))
+			Expect(common.ValidateDataWithSchema(leafSchema, typedValue)).To(Succeed())
+		},
+		Entry("number then integer", "numberThenInteger"),
+		Entry("integer then number", "integerThenNumber"),
+	)
+
 	It("preserves conflicting leaf constraints when flattening", func() {
 		objectSchema := apiextensionsv1.JSONSchemaProps{
 			Type: SchemaStructType,
@@ -153,6 +180,9 @@ var _ = Describe("CUE schema intersection semantics", func() {
 			Properties: map[string]apiextensionsv1.JSONSchemaProps{"x": xSchema},
 		}
 
+		typedValue, err := common.ConvertStringToInterfaceBySchemaType(leafSchema, map[string]string{"x": "5"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(common.ValidateDataWithSchema(leafSchema, typedValue)).NotTo(Succeed())
 		Expect(common.ValidateDataWithSchema(leafSchema, map[string]interface{}{"x": int64(5)})).NotTo(Succeed())
 		Expect(common.ValidateDataWithSchema(leafSchema, map[string]interface{}{"x": "value"})).NotTo(Succeed())
 	})

--- a/pkg/parameters/openapi/schema_intersection_test.go
+++ b/pkg/parameters/openapi/schema_intersection_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package openapi
+
+import (
+	"os"
+
+	"cuelang.org/go/cue"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	"github.com/apecloud/kubeblocks/pkg/common"
+	"github.com/apecloud/kubeblocks/test/testdata"
+)
+
+var _ = Describe("CUE schema intersection semantics", func() {
+	const schemaType = "combined"
+
+	var (
+		cueTemplate string
+		runtime     *Runtime
+	)
+
+	BeforeEach(func() {
+		content, err := os.ReadFile(testdata.SubTestDataPath("cue_testdata/schema_intersection.cue"))
+		Expect(err).NotTo(HaveOccurred())
+		cueTemplate = string(content)
+		runtime, err = NewRuntime(cueTemplate)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	validConfig := func() map[string]interface{} {
+		return map[string]interface{}{
+			"x":             int64(5),
+			"requiredField": "set",
+			"nested": map[string]interface{}{
+				"value": int64(5),
+			},
+			"mapField": map[string]interface{}{
+				"entry": int64(5),
+			},
+		}
+	}
+
+	validateCue := func(config map[string]interface{}) error {
+		definition := runtime.Underlying().LookupPath(cue.MakePath(cue.Def(schemaType)))
+		return definition.Unify(runtime.Context().Encode(config)).Validate(cue.Concrete(true))
+	}
+
+	validateGeneratedSchema := func(config map[string]interface{}) error {
+		schema, err := GenerateOpenAPISchema(cueTemplate, schemaType)
+		if err != nil {
+			return err
+		}
+		return common.ValidateDataWithSchema(schema, map[string]interface{}{DefaultSchemaName: config})
+	}
+
+	DescribeTable("preserves every intersected constraint",
+		func(mutate func(map[string]interface{}), wantValid bool) {
+			config := validConfig()
+			mutate(config)
+
+			cueErr := validateCue(config)
+			schemaErr := validateGeneratedSchema(config)
+			if wantValid {
+				Expect(cueErr).NotTo(HaveOccurred())
+				Expect(schemaErr).NotTo(HaveOccurred())
+				return
+			}
+			Expect(cueErr).To(HaveOccurred())
+			Expect(schemaErr).To(HaveOccurred())
+		},
+		Entry("accepts a value inside both bounds", func(map[string]interface{}) {}, true),
+		Entry("rejects a value below the lower bound", func(config map[string]interface{}) {
+			config["x"] = int64(0)
+		}, false),
+		Entry("rejects a value above the upper bound", func(config map[string]interface{}) {
+			config["x"] = int64(11)
+		}, false),
+		Entry("preserves required fields", func(config map[string]interface{}) {
+			delete(config, "requiredField")
+		}, false),
+		Entry("preserves nested reference intersections", func(config map[string]interface{}) {
+			config["nested"] = map[string]interface{}{"value": int64(11)}
+		}, false),
+		Entry("preserves additionalProperties intersections", func(config map[string]interface{}) {
+			config["mapField"] = map[string]interface{}{"entry": int64(11)}
+		}, false),
+	)
+
+	It("preserves intersected leaf constraints when flattening", func() {
+		schema, err := GenerateOpenAPISchema(cueTemplate, schemaType)
+		Expect(err).NotTo(HaveOccurred())
+		specSchema := schema.Properties[DefaultSchemaName]
+		flattened := FlattenSchema(specSchema)
+
+		xSchema, ok := flattened.Properties["x"]
+		Expect(ok).To(BeTrue())
+		leafSchema := schema.DeepCopy()
+		leafSchema.Properties = map[string]apiextensionsv1.JSONSchemaProps{"x": xSchema}
+		leafSchema.Required = nil
+
+		Expect(common.ValidateDataWithSchema(leafSchema, map[string]interface{}{"x": int64(5)})).To(Succeed())
+		Expect(common.ValidateDataWithSchema(leafSchema, map[string]interface{}{"x": int64(0)})).NotTo(Succeed())
+		Expect(common.ValidateDataWithSchema(leafSchema, map[string]interface{}{"x": int64(11)})).NotTo(Succeed())
+
+		typedValue, err := common.ConvertStringToInterfaceBySchemaType(leafSchema, map[string]string{"x": "11"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(typedValue["x"]).To(Equal(int64(11)))
+		Expect(common.ValidateDataWithSchema(leafSchema, typedValue)).NotTo(Succeed())
+	})
+
+	It("preserves conflicting leaf constraints when flattening", func() {
+		objectSchema := apiextensionsv1.JSONSchemaProps{
+			Type: SchemaStructType,
+			AllOf: []apiextensionsv1.JSONSchemaProps{
+				{
+					Type: SchemaStructType,
+					Properties: map[string]apiextensionsv1.JSONSchemaProps{
+						"x": {Type: "integer"},
+					},
+				},
+				{
+					Type: SchemaStructType,
+					Properties: map[string]apiextensionsv1.JSONSchemaProps{
+						"x": {Type: "string"},
+					},
+				},
+			},
+		}
+		xSchema, ok := FlattenSchema(objectSchema).Properties["x"]
+		Expect(ok).To(BeTrue())
+		leafSchema := &apiextensionsv1.JSONSchemaProps{
+			Type:       SchemaStructType,
+			Properties: map[string]apiextensionsv1.JSONSchemaProps{"x": xSchema},
+		}
+
+		Expect(common.ValidateDataWithSchema(leafSchema, map[string]interface{}{"x": int64(5)})).NotTo(Succeed())
+		Expect(common.ValidateDataWithSchema(leafSchema, map[string]interface{}{"x": "value"})).NotTo(Succeed())
+	})
+})

--- a/pkg/parameters/openapi/utils.go
+++ b/pkg/parameters/openapi/utils.go
@@ -96,7 +96,7 @@ func DeReference(f *ast.File, rt *Runtime) func(path string) (*apiextv1.JSONSche
 
 func fetchTypeDefine(value string, node ast.Node) ast.Node {
 	n := node
-	for _, field := range strings.Split(value, "/") {
+	for field := range strings.SplitSeq(value, "/") {
 		if field == "" {
 			continue
 		}

--- a/pkg/parameters/validate/config_validate_test.go
+++ b/pkg/parameters/validate/config_validate_test.go
@@ -21,6 +21,7 @@ package validate
 
 import (
 	"errors"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -190,4 +191,75 @@ func TestSchemaValidatorUsesSchemaInJSON(t *testing.T) {
 
 	require.NoError(t, validator.Validate("maxmemory-samples: 5"))
 	require.ErrorContains(t, validator.Validate("maxmemory-samples: 0"), "failed to schema validate for config file")
+}
+
+func TestSchemaValidatorLargeIntegerMaximumPrecision(t *testing.T) {
+	maximum := math.Exp2(63)
+	composedSchemas := []struct {
+		name   string
+		schema apiext.JSONSchemaProps
+	}{
+		{
+			name: "parent type",
+			schema: apiext.JSONSchemaProps{
+				Type: "integer",
+				AllOf: []apiext.JSONSchemaProps{{
+					Maximum:          &maximum,
+					ExclusiveMaximum: true,
+				}},
+			},
+		},
+		{
+			name: "sibling type",
+			schema: apiext.JSONSchemaProps{
+				AllOf: []apiext.JSONSchemaProps{
+					{Type: "integer"},
+					{Maximum: &maximum, ExclusiveMaximum: true},
+				},
+			},
+		},
+	}
+
+	for _, tt := range composedSchemas {
+		t.Run(tt.name, func(t *testing.T) {
+			validator := &schemaValidator{
+				cfgType: parametersv1alpha1.YAML,
+				schema: &apiext.JSONSchemaProps{
+					Type:       "object",
+					Properties: map[string]apiext.JSONSchemaProps{"x": tt.schema},
+				},
+			}
+			require.NoError(t, validator.Validate("x: 9223372036854775807"))
+			require.Error(t, validator.Validate("x: 9223372036854775808"))
+		})
+	}
+
+	userMax := float64(1e19)
+	for _, tt := range []struct {
+		name      string
+		exclusive bool
+		valid     string
+		invalid   string
+	}{
+		{name: "inclusive", valid: "10000000000000000000", invalid: "10000000000000000001"},
+		{name: "exclusive", exclusive: true, valid: "9999999999999999999", invalid: "10000000000000000000"},
+	} {
+		t.Run("custom "+tt.name, func(t *testing.T) {
+			validator := &schemaValidator{
+				cfgType: parametersv1alpha1.YAML,
+				schema: &apiext.JSONSchemaProps{
+					Type: "object",
+					Properties: map[string]apiext.JSONSchemaProps{
+						"x": {
+							Type:             "integer",
+							Maximum:          &userMax,
+							ExclusiveMaximum: tt.exclusive,
+						},
+					},
+				},
+			}
+			require.NoError(t, validator.Validate("x: "+tt.valid))
+			require.Error(t, validator.Validate("x: "+tt.invalid))
+		})
+	}
 }

--- a/test/testdata/cue_testdata/multiple_schema.cue
+++ b/test/testdata/cue_testdata/multiple_schema.cue
@@ -1,3 +1,20 @@
+// Copyright (C) 2022-2026 ApeCloud Co., Ltd
+//
+// This file is part of KubeBlocks project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 #shared: {
 	a?: string
 }

--- a/test/testdata/cue_testdata/multiple_schema.cue
+++ b/test/testdata/cue_testdata/multiple_schema.cue
@@ -1,0 +1,13 @@
+#shared: {
+	a?: string
+}
+
+#archA: #shared & {
+	b?: string
+}
+
+#archB: #shared & {
+	c?: string
+}
+
+#conbined: #archA & #archB

--- a/test/testdata/cue_testdata/multiple_schema.cue
+++ b/test/testdata/cue_testdata/multiple_schema.cue
@@ -28,3 +28,8 @@
 }
 
 #combined: #archA & #archB
+
+#embedded: {
+	#archA
+	#archB
+}

--- a/test/testdata/cue_testdata/multiple_schema.cue
+++ b/test/testdata/cue_testdata/multiple_schema.cue
@@ -10,4 +10,4 @@
 	c?: string
 }
 
-#conbined: #archA & #archB
+#combined: #archA & #archB

--- a/test/testdata/cue_testdata/multiple_schema_arch_a.json
+++ b/test/testdata/cue_testdata/multiple_schema_arch_a.json
@@ -1,0 +1,16 @@
+{
+  "type": "object",
+  "properties": {
+    "spec": {
+      "type": "object",
+      "properties": {
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/test/testdata/cue_testdata/multiple_schema_arch_a.json
+++ b/test/testdata/cue_testdata/multiple_schema_arch_a.json
@@ -3,10 +3,17 @@
   "properties": {
     "spec": {
       "type": "object",
+      "allOf": [
+        {
+          "type": "object",
+          "properties": {
+            "a": {
+              "type": "string"
+            }
+          }
+        }
+      ],
       "properties": {
-        "a": {
-          "type": "string"
-        },
         "b": {
           "type": "string"
         }

--- a/test/testdata/cue_testdata/multiple_schema_combined.json
+++ b/test/testdata/cue_testdata/multiple_schema_combined.json
@@ -1,0 +1,19 @@
+{
+  "type": "object",
+  "properties": {
+    "spec": {
+      "type": "object",
+      "properties": {
+        "a": {
+          "type": "string"
+        },
+        "b": {
+          "type": "string"
+        },
+        "c": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/test/testdata/cue_testdata/multiple_schema_combined.json
+++ b/test/testdata/cue_testdata/multiple_schema_combined.json
@@ -3,17 +3,44 @@
   "properties": {
     "spec": {
       "type": "object",
-      "properties": {
-        "a": {
-          "type": "string"
+      "allOf": [
+        {
+          "type": "object",
+          "allOf": [
+            {
+              "type": "object",
+              "properties": {
+                "a": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "properties": {
+            "b": {
+              "type": "string"
+            }
+          }
         },
-        "b": {
-          "type": "string"
-        },
-        "c": {
-          "type": "string"
+        {
+          "type": "object",
+          "allOf": [
+            {
+              "type": "object",
+              "properties": {
+                "a": {
+                  "type": "string"
+                }
+              }
+            }
+          ],
+          "properties": {
+            "c": {
+              "type": "string"
+            }
+          }
         }
-      }
+      ]
     }
   }
 }

--- a/test/testdata/cue_testdata/mysql_openapi_v2.json
+++ b/test/testdata/cue_testdata/mysql_openapi_v2.json
@@ -16,7 +16,6 @@
           }
         },
         "mysqlld": {
-          "description": "mysql config validator",
           "type": "object",
           "required": [
             "automatic_sp_privileges",
@@ -57,7 +56,9 @@
               "minimum": 4096
             },
             "caching_sha2_password_private_key_path": {
-              "$ref": "#/components/schemas/MysqlSchema.mysqlld.KeyPath"
+              "description": "custom format, reference Regular expressions",
+              "type": "string",
+              "pattern": "^[a-z][a-zA-Z0-9]+.pem$"
             },
             "flush_time": {
               "type": "integer",
@@ -67,7 +68,9 @@
             },
             "group_concat_max_len": {
               "type": "integer",
-              "default": 1024
+              "default": 1024,
+              "minimum": 4,
+              "exclusiveMinimum": true
             },
             "gtid_mode": {
               "type": "string",

--- a/test/testdata/cue_testdata/schema_intersection.cue
+++ b/test/testdata/cue_testdata/schema_intersection.cue
@@ -1,0 +1,44 @@
+// Copyright (C) 2022-2026 ApeCloud Co., Ltd
+//
+// This file is part of KubeBlocks project
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#nestedLower: {
+	value: int & >=1
+}
+
+#nestedUpper: {
+	value: int & <=10
+}
+
+#lower: {
+	x:             int & >=1
+	requiredField: string
+	nested:        #nestedLower
+	mapField: {
+		[string]: int & >=1
+	}
+}
+
+#upper: {
+	x:              int & <=10
+	requiredField?: string
+	nested:         #nestedUpper
+	mapField: {
+		[string]: int & <=10
+	}
+}
+
+#combined: #lower & #upper

--- a/test/testdata/cue_testdata/schema_intersection.cue
+++ b/test/testdata/cue_testdata/schema_intersection.cue
@@ -64,3 +64,10 @@
 
 #genericThenUnsigned: #genericInteger & #unsignedInteger
 #unsignedThenGeneric: #unsignedInteger & #genericInteger
+
+#signed64Integer: {
+	x: int64
+}
+
+#signed64ThenUnsigned: #signed64Integer & #unsignedInteger
+#unsignedThenSigned64: #unsignedInteger & #signed64Integer

--- a/test/testdata/cue_testdata/schema_intersection.cue
+++ b/test/testdata/cue_testdata/schema_intersection.cue
@@ -42,3 +42,14 @@
 }
 
 #combined: #lower & #upper
+
+#numberLower: {
+	x: >=0
+}
+
+#integerUpper: {
+	x: int & <=9223372036854775807
+}
+
+#numberThenInteger: #numberLower & #integerUpper
+#integerThenNumber: #integerUpper & #numberLower

--- a/test/testdata/cue_testdata/schema_intersection.cue
+++ b/test/testdata/cue_testdata/schema_intersection.cue
@@ -53,3 +53,14 @@
 
 #numberThenInteger: #numberLower & #integerUpper
 #integerThenNumber: #integerUpper & #numberLower
+
+#genericInteger: {
+	x: int
+}
+
+#unsignedInteger: {
+	x: uint64
+}
+
+#genericThenUnsigned: #genericInteger & #unsignedInteger
+#unsignedThenGeneric: #unsignedInteger & #genericInteger


### PR DESCRIPTION
Fixes #10710.

## Problem

CUE intersections are emitted as OpenAPI `allOf`. The previous implementation dereferenced the schemas and then flattened object branches with a first-wins property merge. When two branches constrained the same field, only the first branch survived. For example, `x >= 1` combined with `x <= 10` accepted `x = 11` in the generated schema.

## Changes

- recursively dereference schemas inside `allOf` without removing the composition
- teach `FlattenSchema` to traverse composed object schemas
- combine duplicate flattened leaf paths with `allOf`
- derive the effective conversion type from compatible intersections, including the order-independent `number & integer = integer` case
- intersect integer conversion hints (`format`, minimum, and maximum), including numeric domains implied by signed and unsigned formats
- preserve generic `int & uint64` unsigned conversion while narrowing `int64 & uint64` to the signed 64-bit range in either branch order
- infer the effective integer type across `allOf`, including parent-type and sibling-type constraint-only branches
- sanitize overflow-prone integer maxima recursively through `allOf`, object properties, array items, and map values before kube-openapi conversion
- enforce stripped large integer maxima recursively against the original schema, comparing int/uint values exactly against the schema's float64 bound without integer-to-float precision loss
- update generated-schema golden files to retain the dereferenced `allOf` shape
- add semantic coverage for bounds, required fields, nested references, map `additionalProperties`, conflicting leaves, typed assignment validation, large signed-integer precision, uint64 precision, mixed signed/unsigned boundaries, constraint-only `allOf` branches, nested large bounds, and production YAML values at `2^63` and `1e19 +/- 1`

The generated schema remains self-contained because references are resolved, while all intersected constraints are preserved. Incompatible leaf types remain represented by `allOf` and fail closed during schema validation.

## Testing

- `go test ./pkg/common ./pkg/parameters/openapi ./pkg/parameters/validate -count=1`
- `GOARCH=amd64 go test ./pkg/common ./pkg/parameters/openapi ./pkg/parameters/validate -count=1`
- `go vet ./pkg/common ./pkg/parameters/openapi ./pkg/parameters/validate`
- `go test ./pkg/parameters/... -count=1` (affected subpackages pass; top-level package is blocked by repository-missing generated `pkg/testutil/k8s/mocks`)
