### PR TITLE
fix(component): unblock externally managed configs whose ConfigMap is not provisioned yet

### DIFF
--- a/controllers/apps/component/transformer_component_template.go
+++ b/controllers/apps/component/transformer_component_template.go
@@ -113,6 +113,18 @@ func (t *componentFileTemplateTransformer) instanceAssistantObject(transCtx *com
 func (t *componentFileTemplateTransformer) precheck(transCtx *componentTransformContext) error {
 	for _, tpl := range transCtx.SynthesizeComponent.FileTemplates {
 		if len(tpl.Template) == 0 {
+			if tpl.Config && isExternalManaged(tpl) {
+				// The template of an externally managed config is reset when no ConfigMap
+				// source has been provided (see synthesizeFileTemplates): the parameters
+				// controllers will provision the runtime ConfigMap and back-fill
+				// spec.configs[].configMap with it later. Provision the workload with the
+				// deterministic runtime ConfigMap name (see buildPodVolumes) and let the
+				// pod wait for it, instead of failing the transformation.
+				continue
+			}
+			// Externally managed scripts are NOT covered by the bypass above: only configs
+			// have a producer (the parameters controllers) for the ConfigMap, so an empty
+			// template is a definition error for scripts as well as for ordinary templates.
 			return fmt.Errorf("config/script template has no template specified: %s", tpl.Name)
 		}
 	}
@@ -148,7 +160,12 @@ func (t *componentFileTemplateTransformer) buildPodVolumes(transCtx *componentTr
 	for _, tpl := range synthesizedComp.FileTemplates {
 		objName := fileTemplateObjectName(transCtx.SynthesizeComponent, tpl.Name)
 		// If the file template is managed by external, the volume mount object should be the external object.
-		if isExternalManaged(tpl) {
+		// An externally managed config whose ConfigMap has not been provisioned yet (empty
+		// template, configs only, see precheck) keeps the default objName: the parameters
+		// controllers create the runtime ConfigMap with exactly this deterministic name
+		// (GetComponentCfgName == fileTemplateObjectName), so the pod waits on the volume
+		// mount until it is provisioned.
+		if isExternalManaged(tpl) && len(tpl.Template) > 0 {
 			objName = tpl.Template
 		}
 		createFn := func(_ string) corev1.Volume {

--- a/controllers/apps/component/transformer_component_template_test.go
+++ b/controllers/apps/component/transformer_component_template_test.go
@@ -250,6 +250,15 @@ var _ = Describe("file templates transformer test", func() {
 			checkTemplateObjects([]string{"logConf", "serverConf"})
 		})
 
+		It("template not specified and not externally managed - error", func() {
+			transCtx.SynthesizeComponent.FileTemplates[0].Template = ""
+
+			transformer := &componentFileTemplateTransformer{}
+			err := transformer.Transform(transCtx, dag)
+			Expect(err).ShouldNot(BeNil())
+			Expect(err.Error()).Should(ContainSubstring("has no template specified"))
+		})
+
 		It("variables - w/o", func() {
 			logConfCM.Data["level"] = "{{- if (index $ \"LOG_LEVEL\") }}\n\t{{- .LOG_LEVEL }}\n{{- else }}\n\t{{- \"info\" }}\n{{- end }}"
 
@@ -354,16 +363,34 @@ var _ = Describe("file templates transformer test", func() {
 			// checkEnvWithAction(component.UDFReconfigureActionName(transCtx.SynthesizeComponent.FileTemplates[1]))
 		})
 
-		It("external managed - w/o template", func() {
+		It("external managed config - w/o template", func() {
 			transCtx.SynthesizeComponent.FileTemplates[1].Template = ""
 			transCtx.SynthesizeComponent.FileTemplates[1].Namespace = ""
 			transCtx.SynthesizeComponent.FileTemplates[1].Reconfigure = nil
 			transCtx.SynthesizeComponent.FileTemplates[1].ExternalManaged = ptr.To(true)
+			transCtx.SynthesizeComponent.FileTemplates[1].Config = true
 
+			// the ConfigMap of an externally managed config is not provisioned yet: the
+			// transformation should succeed and mount the deterministic runtime ConfigMap
+			// name, so that the pod waits for the parameters controllers to provision it.
+			transformer := &componentFileTemplateTransformer{}
+			err := transformer.Transform(transCtx, dag)
+			Expect(err).Should(BeNil())
+			Expect(transCtx.SynthesizeComponent.PodSpec.Volumes).Should(ContainElement(newVolume("serverConf")))
+		})
+
+		It("external managed script - w/o template", func() {
+			transCtx.SynthesizeComponent.FileTemplates[1].Template = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].Namespace = ""
+			transCtx.SynthesizeComponent.FileTemplates[1].Reconfigure = nil
+			transCtx.SynthesizeComponent.FileTemplates[1].ExternalManaged = ptr.To(true)
+			transCtx.SynthesizeComponent.FileTemplates[1].Config = false
+
+			// scripts have no producer for the ConfigMap, the bypass must not apply to them.
 			transformer := &componentFileTemplateTransformer{}
 			err := transformer.Transform(transCtx, dag)
 			Expect(err).ShouldNot(BeNil())
-			Expect(err.Error()).Should(ContainSubstring("config/script template has no template specified"))
+			Expect(err.Error()).Should(ContainSubstring("has no template specified"))
 		})
 	})
 })


### PR DESCRIPTION
## Problem

Fixes #10316
Fixes #10436

When a `ComponentDefinition` config has `externalManaged: true` and the user creates a Cluster without a ConfigMap override, `synthesizeFileTemplates` intentionally resets the template (the parameters controllers render the runtime ConfigMap and `ParameterTemplateExtensionReconciler` back-fills `spec.configs[].configMap` later). But the file template transformer's precheck unconditionally rejects the empty template:

```
config/script template has no template specified: <config-name>
```

which blocks the component behind an error indistinguishable from a broken definition (reported for MongoDB in #10316, FalkorDB/Valkey in #10428).

## Fix (per the review direction on the earlier attempt #10427)

This continues closed PR #10427 and implements the P1 review feedback recorded in #10436:

1. **precheck**: skip the empty-template check only for `tpl.Config && isExternalManaged(tpl)`.
2. **buildPodVolumes**: for such templates, mount the deterministic runtime ConfigMap name (`fileTemplateObjectName`, which equals the parameters controllers' `GetComponentCfgName`: `{cluster}-{component}-{tplName}`), so the workload is provisioned immediately and the pod waits on the volume mount (`ContainerCreating`) until the ConfigMap appears. When `ParameterTemplateExtensionReconciler` later back-fills `spec.configs[].configMap`, the volume keeps the same object name — no pod restart.
3. **scripts are NOT bypassed** (the P1 from #10427): `SynthesizedFileTemplate` covers both configs and scripts, and only configs have a producer (the parameters controllers). An externally managed script with an empty template remains a definition error with the original message, instead of leaving the workload silently stuck in ContainerCreating.

Other consumers are already safe for the empty-template external state: `instanceAssistantObject` skips it, `buildFileTemplateObjects`/`buildConfigTemplates` skip externally managed templates entirely.

## Testing

- `external managed config - w/o template`: transformation succeeds and the pod volume references the deterministic runtime ConfigMap name.
- `external managed script - w/o template`: keeps the validation error (P1 case).
- `template not specified and not externally managed`: keeps the original error.
- `controllers/apps/component` suite passes locally (136/136).

/nopick