### PR TITLE
fix: its revision tracking

### DIFF
--- a/pkg/controller/instanceset2/instance_util.go
+++ b/pkg/controller/instanceset2/instance_util.go
@@ -146,6 +146,7 @@ func buildInstanceByTemplate(tree *kubebuilderx.ObjectTree,
 	}
 
 	inst := b.GetObject()
+	stampInstanceRevision(inst)
 	if !shouldCloneInstanceAssistantObjects(its) {
 		if err := controllerutil.SetControllerReference(its, inst, model.GetScheme()); err != nil {
 			return nil, err
@@ -325,6 +326,39 @@ func getHeadlessSvcName(itsName string) string {
 	return strings.Join([]string{itsName, "headless"}, "-")
 }
 
+func buildDesiredInstancesByName(tree *kubebuilderx.ObjectTree, its *workloads.InstanceSet) (map[string]*workloads.Instance, []string, error) {
+	itsExt, err := instancetemplate.BuildInstanceSetExt(its, tree)
+	if err != nil {
+		return nil, nil, err
+	}
+	nameBuilder, err := instancetemplate.NewPodNameBuilder(itsExt, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	nameToTemplateMap, err := nameBuilder.BuildInstanceName2TemplateMap()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	names := make([]string, 0, len(nameToTemplateMap))
+	for name := range nameToTemplateMap {
+		names = append(names, name)
+	}
+	baseSort(names, func(i int) (string, int) {
+		return parseParentNameAndOrdinal(names[i])
+	}, nil, true)
+
+	instances := make(map[string]*workloads.Instance, len(names))
+	for _, name := range names {
+		inst, err := buildInstanceByTemplate(tree, name, nameToTemplateMap[name], its)
+		if err != nil {
+			return nil, nil, err
+		}
+		instances[name] = inst
+	}
+	return instances, names, nil
+}
+
 // func mergeInPlaceFields(src, dst *corev1.PodTemplateSpec) {
 //	mergeMap(&src.Annotations, &dst.Annotations)
 //	mergeMap(&src.Labels, &dst.Labels)
@@ -394,9 +428,13 @@ func getHeadlessSvcName(itsName string) string {
 // }
 
 func isInstanceUpdated(its *workloads.InstanceSet, inst *workloads.Instance) bool {
-	generation, ok := inst.Annotations[constant.KubeBlocksGenerationKey]
-	if !ok {
+	return isInstanceUpdatedWithRevisions(inst, getInstanceRevision(inst), its.Status.UpdateRevisions)
+}
+
+func isInstanceUpdatedWithRevisions(inst *workloads.Instance, currentRevision string, updateRevisions map[string]string) bool {
+	updateRevision, ok := updateRevisions[inst.Name]
+	if !ok || currentRevision != updateRevision {
 		return false
 	}
-	return strconv.FormatInt(its.Generation, 10) == generation
+	return inst.Generation == inst.Status.ObservedGeneration && inst.Status.UpToDate
 }

--- a/pkg/controller/instanceset2/reconciler_revision_update.go
+++ b/pkg/controller/instanceset2/reconciler_revision_update.go
@@ -45,6 +45,20 @@ func (r *revisionUpdateReconciler) PreCondition(tree *kubebuilderx.ObjectTree) *
 func (r *revisionUpdateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilderx.Result, error) {
 	its, _ := tree.GetRoot().(*workloads.InstanceSet)
 
+	desiredInstances, names, err := buildDesiredInstancesByName(tree, its)
+	if err != nil {
+		return kubebuilderx.Continue, err
+	}
+
+	updateRevisions := make(map[string]string, len(names))
+	for _, name := range names {
+		updateRevisions[name] = getInstanceRevision(desiredInstances[name])
+	}
+	its.Status.UpdateRevisions = updateRevisions
+	if len(names) > 0 {
+		its.Status.UpdateRevision = updateRevisions[names[len(names)-1]]
+	}
+
 	updatedReplicas := r.calculateUpdatedReplicas(its, tree.List(&workloads.Instance{}))
 	its.Status.UpdatedReplicas = updatedReplicas
 

--- a/pkg/controller/instanceset2/reconciler_status.go
+++ b/pkg/controller/instanceset2/reconciler_status.go
@@ -65,7 +65,7 @@ func (r *statusReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 	readyReplicas, availableReplicas := int32(0), int32(0)
 	notReadyNames := sets.New[string]()
 	notAvailableNames := sets.New[string]()
-	// currentRevisions := map[string]string{}
+	currentRevisions := map[string]string{}
 
 	template2TemplatesStatus := map[string]*workloads.InstanceTemplateStatus{}
 	template2TotalReplicas := map[string]int32{}
@@ -100,8 +100,9 @@ func (r *statusReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 				notAvailableNames.Insert(inst.Name)
 			}
 		}
+		currentRevisions[inst.Name] = getInstanceRevision(inst)
 		if !intctrlutil.IsInstanceTerminating(inst) {
-			if isInstanceUpdated(its, inst) {
+			if isInstanceUpdatedWithRevisions(inst, currentRevisions[inst.Name], its.Status.UpdateRevisions) {
 				updatedReplicas++
 				template2TemplatesStatus[templateName].UpdatedReplicas++
 			} else {
@@ -115,7 +116,7 @@ func (r *statusReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 	its.Status.AvailableReplicas = availableReplicas
 	its.Status.CurrentReplicas = currentReplicas
 	its.Status.UpdatedReplicas = updatedReplicas
-	// its.Status.CurrentRevisions, _ = buildRevisions(currentRevisions)
+	its.Status.CurrentRevisions = currentRevisions
 	its.Status.TemplatesStatus = buildTemplatesStatus(template2TemplatesStatus)
 	// all pods have been updated
 	totalReplicas := int32(1)
@@ -123,7 +124,7 @@ func (r *statusReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 		totalReplicas = *its.Spec.Replicas
 	}
 	if its.Status.Replicas == totalReplicas && its.Status.UpdatedReplicas == totalReplicas {
-		// its.Status.CurrentRevision = its.Status.UpdateRevision
+		its.Status.CurrentRevision = its.Status.UpdateRevision
 		its.Status.CurrentReplicas = totalReplicas
 	}
 	for idx, templateStatus := range its.Status.TemplatesStatus {

--- a/pkg/controller/instanceset2/reconciler_status_test.go
+++ b/pkg/controller/instanceset2/reconciler_status_test.go
@@ -1,0 +1,300 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package instanceset2
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/instancetemplate"
+	"github.com/apecloud/kubeblocks/pkg/controller/kubebuilderx"
+)
+
+func TestIsInstanceUpdated(t *testing.T) {
+	latestInst := newRevisionTestInstance("test-its-0")
+	latestRevision := stampInstanceRevision(latestInst)
+	its := &workloads.InstanceSet{
+		Status: workloads.InstanceSetStatus{
+			UpdateRevisions: map[string]string{
+				latestInst.Name: latestRevision,
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		inst *workloads.Instance
+		want bool
+	}{
+		{
+			name: "true when instance revision annotation matches",
+			inst: func() *workloads.Instance {
+				inst := newRevisionTestInstance("test-its-0")
+				inst.Annotations[instanceSetRevisionAnnotationKey] = latestRevision
+				return inst
+			}(),
+			want: true,
+		},
+		{
+			name: "false when instance status is not up to date",
+			inst: func() *workloads.Instance {
+				inst := newRevisionTestInstance("test-its-0")
+				inst.Annotations[instanceSetRevisionAnnotationKey] = latestRevision
+				inst.Status.UpToDate = false
+				return inst
+			}(),
+			want: false,
+		},
+		{
+			name: "false when revision annotation differs",
+			inst: func() *workloads.Instance {
+				inst := newRevisionTestInstance("test-its-0")
+				inst.Annotations[instanceSetRevisionAnnotationKey] = "stale"
+				return inst
+			}(),
+			want: false,
+		},
+		{
+			name: "false when revision annotation is missing",
+			inst: func() *workloads.Instance {
+				inst := newRevisionTestInstance("test-its-0")
+				delete(inst.Annotations, instanceSetRevisionAnnotationKey)
+				return inst
+			}(),
+			want: false,
+		},
+		{
+			name: "false when instance status has not observed latest generation",
+			inst: func() *workloads.Instance {
+				inst := newRevisionTestInstance("test-its-0")
+				inst.Annotations[instanceSetRevisionAnnotationKey] = latestRevision
+				inst.Status.ObservedGeneration = 1
+				return inst
+			}(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isInstanceUpdated(its, tt.inst); got != tt.want {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestBuildInstanceRevisionIgnoresNonIntentState(t *testing.T) {
+	inst := newRevisionTestInstance("test-its-0")
+	inst.Labels = map[string]string{"managed-label": "desired"}
+	inst.Annotations[constant.KubeBlocksGenerationKey] = "1"
+	inst.Annotations[instanceSetRevisionAnnotationKey] = "revision-1"
+	inst.Annotations["managed-annotation"] = "desired"
+	inst.Spec.InstanceAssistantObjects = []workloads.InstanceAssistantObject{
+		{
+			Service: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-its-headless",
+					Namespace:         "default",
+					CreationTimestamp: metav1.Now(),
+				},
+				Spec: corev1.ServiceSpec{
+					ClusterIP:  "10.0.0.1",
+					ClusterIPs: []string{"10.0.0.1"},
+				},
+			},
+		},
+	}
+	inst.Spec.LifecycleActions = &workloads.LifecycleActions{
+		TemplateVars: map[string]string{"instance": "test-its-0"},
+	}
+	revision := buildInstanceRevision(inst)
+
+	inst.Labels["managed-label"] = "changed"
+	inst.Annotations[constant.KubeBlocksGenerationKey] = "2"
+	inst.Annotations[instanceSetRevisionAnnotationKey] = "revision-2"
+	inst.Annotations["managed-annotation"] = "changed"
+	inst.Spec.InstanceAssistantObjects[0].Service.Spec.ClusterIP = "10.0.0.2"
+	inst.Spec.InstanceAssistantObjects[0].Service.Spec.ClusterIPs = []string{"10.0.0.2"}
+	inst.Spec.InstanceAssistantObjects[0].Service.ResourceVersion = "2"
+	inst.Spec.LifecycleActions.TemplateVars["instance"] = "test-its-1"
+	inst.Spec.Template.CreationTimestamp = metav1.Now()
+	inst.Spec.Template.ResourceVersion = "2"
+	inst.Spec.Template.Generation = 2
+	inst.Spec.VolumeClaimTemplates[0].CreationTimestamp = metav1.Now()
+	inst.Spec.VolumeClaimTemplates[0].ResourceVersion = "2"
+	inst.Spec.VolumeClaimTemplates[0].Generation = 2
+	if got := buildInstanceRevision(inst); got != revision {
+		t.Fatalf("expected non-intent state to be ignored, got %s want %s", got, revision)
+	}
+
+	inst.Spec.Template.Labels["pod-label"] = "changed"
+	if got := buildInstanceRevision(inst); got == revision {
+		t.Fatalf("expected pod template label change to alter revision")
+	}
+}
+
+func TestBuildInstanceByTemplateStampsRevisionAnnotation(t *testing.T) {
+	its := &workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-its",
+			Namespace:  "default",
+			Generation: 3,
+		},
+		Spec: workloads.InstanceSetSpec{
+			Replicas: ptr.To[int32](1),
+		},
+	}
+	template := &instancetemplate.InstanceTemplateExt{
+		Name: "tpl",
+		PodTemplateSpec: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"pod-label": "desired"},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "postgres", Image: "postgres:16"}},
+			},
+		},
+	}
+
+	inst, err := buildInstanceByTemplate(kubebuilderx.NewObjectTree(), "test-its-0", template, its)
+	if err != nil {
+		t.Fatalf("buildInstanceByTemplate() error = %v", err)
+	}
+	if got := getInstanceRevision(inst); got == "" {
+		t.Fatalf("expected desired instance to carry revision annotation")
+	} else if want := buildInstanceRevision(inst); got != want {
+		t.Fatalf("expected revision annotation %s, got %s", want, got)
+	}
+}
+
+func TestStatusReconcilerReadsCurrentRevisionFromInstanceAnnotation(t *testing.T) {
+	its := &workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-its",
+			Namespace: "default",
+		},
+		Spec: workloads.InstanceSetSpec{
+			Replicas: ptr.To[int32](1),
+		},
+	}
+	inst := newRevisionTestInstance("test-its-0")
+	revision := stampInstanceRevision(inst)
+	its.Status.UpdateRevisions = map[string]string{inst.Name: revision}
+	its.Status.UpdateRevision = revision
+
+	tree := kubebuilderx.NewObjectTree()
+	tree.SetRoot(its)
+	if err := tree.Add(inst); err != nil {
+		t.Fatalf("add instance: %v", err)
+	}
+	if _, err := NewStatusReconciler().Reconcile(tree); err != nil {
+		t.Fatalf("status reconcile: %v", err)
+	}
+	if got := its.Status.CurrentRevisions[inst.Name]; got != revision {
+		t.Fatalf("expected current revision %s, got %s", revision, got)
+	}
+	if got := its.Status.UpdatedReplicas; got != 1 {
+		t.Fatalf("expected updated replicas 1, got %d", got)
+	}
+	if got := its.Status.CurrentRevision; got != revision {
+		t.Fatalf("expected current revision summary %s, got %s", revision, got)
+	}
+}
+
+func TestStatusReconcilerDoesNotFallbackToLiveHashWhenRevisionAnnotationMissing(t *testing.T) {
+	its := &workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-its",
+			Namespace: "default",
+		},
+		Spec: workloads.InstanceSetSpec{
+			Replicas: ptr.To[int32](1),
+		},
+	}
+	desired := newRevisionTestInstance("test-its-0")
+	revision := stampInstanceRevision(desired)
+	its.Status.UpdateRevisions = map[string]string{desired.Name: revision}
+	its.Status.UpdateRevision = revision
+
+	inst := desired.DeepCopy()
+	delete(inst.Annotations, instanceSetRevisionAnnotationKey)
+
+	tree := kubebuilderx.NewObjectTree()
+	tree.SetRoot(its)
+	if err := tree.Add(inst); err != nil {
+		t.Fatalf("add instance: %v", err)
+	}
+	if _, err := NewStatusReconciler().Reconcile(tree); err != nil {
+		t.Fatalf("status reconcile: %v", err)
+	}
+	if got := its.Status.CurrentRevisions[inst.Name]; got != "" {
+		t.Fatalf("expected empty current revision, got %s", got)
+	}
+	if got := its.Status.UpdatedReplicas; got != 0 {
+		t.Fatalf("expected missing revision annotation to keep updated replicas at 0, got %d", got)
+	}
+}
+
+func newRevisionTestInstance(name string) *workloads.Instance {
+	return &workloads.Instance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Generation: 2,
+			Labels: map[string]string{
+				instancetemplate.TemplateNameLabelKey: "tpl",
+			},
+			Annotations: map[string]string{},
+		},
+		Spec: workloads.InstanceSpec{
+			MinReadySeconds: 1,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      map[string]string{"pod-label": "desired"},
+					Annotations: map[string]string{"pod-annotation": "desired"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "postgres", Image: "postgres:16"}},
+				},
+			},
+			VolumeClaimTemplates: []corev1.PersistentVolumeClaimTemplate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "data",
+						Labels:      map[string]string{"pvc-label": "desired"},
+						Annotations: map[string]string{"pvc-annotation": "desired"},
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+					},
+				},
+			},
+		},
+		Status: workloads.InstanceStatus2{
+			ObservedGeneration: 2,
+			UpToDate:           true,
+		},
+	}
+}

--- a/pkg/controller/instanceset2/revision_util.go
+++ b/pkg/controller/instanceset2/revision_util.go
@@ -1,0 +1,165 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package instanceset2
+
+import (
+	"fmt"
+	"hash/fnv"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/dump"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+)
+
+const instanceSetRevisionAnnotationKey = "workloads.kubeblocks.io/instance-revision-hash"
+
+type instanceRevisionIntent struct {
+	Template                   podTemplateRevisionIntent
+	MinReadySeconds            int32
+	VolumeClaimTemplates       []pvcTemplateRevisionIntent
+	InstanceSetName            string
+	InstanceTemplateName       string
+	InstanceUpdateStrategyType *kbappsv1.InstanceUpdateStrategyType
+	PodUpdatePolicy            workloads.PodUpdatePolicyType
+	PodUpgradePolicy           workloads.PodUpdatePolicyType
+	Roles                      []workloads.ReplicaRole
+	Configs                    []workloads.ConfigTemplate
+}
+
+type podTemplateRevisionIntent struct {
+	Labels      map[string]string
+	Annotations map[string]string
+	Spec        corev1.PodSpec
+}
+
+type pvcTemplateRevisionIntent struct {
+	Name        string
+	Labels      map[string]string
+	Annotations map[string]string
+	Spec        corev1.PersistentVolumeClaimSpec
+}
+
+func buildInstanceRevision(inst *workloads.Instance) string {
+	return buildRevisionIntentHash(buildInstanceRevisionIntent(inst))
+}
+
+func stampInstanceRevision(inst *workloads.Instance) string {
+	revision := buildInstanceRevision(inst)
+	if inst.Annotations == nil {
+		inst.Annotations = make(map[string]string)
+	}
+	inst.Annotations[instanceSetRevisionAnnotationKey] = revision
+	return revision
+}
+
+func getInstanceRevision(inst *workloads.Instance) string {
+	if inst.Annotations == nil {
+		return ""
+	}
+	return inst.Annotations[instanceSetRevisionAnnotationKey]
+}
+
+func buildInstanceRevisionIntent(inst *workloads.Instance) instanceRevisionIntent {
+	spec := inst.Spec.DeepCopy()
+	return instanceRevisionIntent{
+		Template:                   buildPodTemplateRevisionIntent(spec.Template),
+		MinReadySeconds:            spec.MinReadySeconds,
+		VolumeClaimTemplates:       buildPVCTemplateRevisionIntents(spec.VolumeClaimTemplates),
+		InstanceSetName:            spec.InstanceSetName,
+		InstanceTemplateName:       spec.InstanceTemplateName,
+		InstanceUpdateStrategyType: copyInstanceUpdateStrategyType(spec.InstanceUpdateStrategyType),
+		PodUpdatePolicy:            spec.PodUpdatePolicy,
+		PodUpgradePolicy:           spec.PodUpgradePolicy,
+		Roles:                      copyReplicaRoles(spec.Roles),
+		Configs:                    copyConfigTemplates(spec.Configs),
+	}
+}
+
+func buildRevisionIntentHash(intent instanceRevisionIntent) string {
+	hasher := fnv.New32()
+	fmt.Fprintf(hasher, "%v", dump.ForHash(intent))
+	return rand.SafeEncodeString(fmt.Sprint(hasher.Sum32()))
+}
+
+func buildPodTemplateRevisionIntent(template corev1.PodTemplateSpec) podTemplateRevisionIntent {
+	return podTemplateRevisionIntent{
+		Labels:      copyStringMap(template.Labels),
+		Annotations: copyStringMap(template.Annotations),
+		Spec:        *template.Spec.DeepCopy(),
+	}
+}
+
+func buildPVCTemplateRevisionIntents(templates []corev1.PersistentVolumeClaimTemplate) []pvcTemplateRevisionIntent {
+	if len(templates) == 0 {
+		return nil
+	}
+	intents := make([]pvcTemplateRevisionIntent, len(templates))
+	for i := range templates {
+		intents[i] = pvcTemplateRevisionIntent{
+			Name:        templates[i].Name,
+			Labels:      copyStringMap(templates[i].Labels),
+			Annotations: copyStringMap(templates[i].Annotations),
+			Spec:        *templates[i].Spec.DeepCopy(),
+		}
+	}
+	return intents
+}
+
+func copyInstanceUpdateStrategyType(strategy *kbappsv1.InstanceUpdateStrategyType) *kbappsv1.InstanceUpdateStrategyType {
+	if strategy == nil {
+		return nil
+	}
+	copied := *strategy
+	return &copied
+}
+
+func copyStringMap(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	copied := make(map[string]string, len(m))
+	for k, v := range m {
+		copied[k] = v
+	}
+	return copied
+}
+
+func copyReplicaRoles(roles []workloads.ReplicaRole) []workloads.ReplicaRole {
+	if len(roles) == 0 {
+		return nil
+	}
+	copied := make([]workloads.ReplicaRole, len(roles))
+	copy(copied, roles)
+	return copied
+}
+
+func copyConfigTemplates(configs []workloads.ConfigTemplate) []workloads.ConfigTemplate {
+	if len(configs) == 0 {
+		return nil
+	}
+	copied := make([]workloads.ConfigTemplate, len(configs))
+	for i := range configs {
+		configs[i].DeepCopyInto(&copied[i])
+	}
+	return copied
+}


### PR DESCRIPTION
## Summary
- Backport InstanceSet2 per-Instance revision hash tracking to release-1.1.
- Stamp desired Instance objects with workloads.kubeblocks.io/instance-revision-hash.
- Populate UpdateRevisions from desired Instance intent and CurrentRevisions from live Instance annotations.
- Count updated replicas only when revision matches, the Instance observed its generation, and UpToDate is true.

## Tests
- go test ./pkg/controller/instanceset2 -count=1
- go test ./pkg/controller/instance -count=1
- go test ./controllers/apps/component -count=1
- make lint