### PR TITLE
fix: align instanceset2 revision status

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -76,6 +76,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/instanceset"
 	"github.com/apecloud/kubeblocks/pkg/controller/multicluster"
+	"github.com/apecloud/kubeblocks/pkg/controller/revisionmap"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	"github.com/apecloud/kubeblocks/pkg/metrics"
 	viper "github.com/apecloud/kubeblocks/pkg/viperx"
@@ -155,7 +156,7 @@ func init() {
 	viper.SetDefault(constant.CfgKeyClusterDefaultResources, `{"zero":true}`)
 	viper.SetDefault(constant.CfgKeyOperationZeroResourceForUnset, true)
 	viper.SetDefault(constant.KubernetesClusterDomainEnv, constant.DefaultDNSDomain)
-	viper.SetDefault(instanceset.MaxPlainRevisionCount, 1024)
+	viper.SetDefault(revisionmap.MaxPlainRevisionCount, 1024)
 	viper.SetDefault(instanceset.FeatureGateIgnorePodVerticalScaling, false)
 	viper.SetDefault(intctrlutil.FeatureGateEnableRuntimeMetrics, false)
 	viper.SetDefault(constant.FeatureGateIgnoreConfigTemplateDefaultMode, false)

--- a/pkg/controller/instanceset/instance_util.go
+++ b/pkg/controller/instanceset/instance_util.go
@@ -28,11 +28,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/klauspost/compress/zstd"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -58,19 +56,6 @@ type instanceTemplateExt struct {
 	Replicas int32
 	corev1.PodTemplateSpec
 	VolumeClaimTemplates []corev1.PersistentVolumeClaim
-}
-
-var (
-	reader *zstd.Decoder
-	writer *zstd.Encoder
-)
-
-func init() {
-	var err error
-	reader, err = zstd.NewReader(nil)
-	runtime.Must(err)
-	writer, err = zstd.NewWriter(nil)
-	runtime.Must(err)
 }
 
 // parseParentNameAndOrdinal parses parent (instance template) Name and ordinal from the give instance name.

--- a/pkg/controller/instanceset/revision_util.go
+++ b/pkg/controller/instanceset/revision_util.go
@@ -20,14 +20,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package instanceset
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"hash"
 	"hash/fnv"
 	"strconv"
 
-	jsoniter "github.com/json-iterator/go"
 	apps "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -38,8 +36,7 @@ import (
 
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
-	"github.com/apecloud/kubeblocks/pkg/lru"
-	viper "github.com/apecloud/kubeblocks/pkg/viperx"
+	"github.com/apecloud/kubeblocks/pkg/controller/revisionmap"
 )
 
 // ControllerRevisionHashLabel is the label used to indicate the hash value of a ControllerRevision's Data.
@@ -48,8 +45,6 @@ const ControllerRevisionHashLabel = "controller.kubernetes.io/hash"
 var Codecs = serializer.NewCodecFactory(model.GetScheme())
 var patchCodec = Codecs.LegacyCodec(workloads.SchemeGroupVersion)
 var controllerKind = apps.SchemeGroupVersion.WithKind("StatefulSet")
-
-var jsonIter = jsoniter.ConfigCompatibleWithStandardLibrary
 
 func NewRevision(its *workloads.InstanceSet) (*apps.ControllerRevision, error) {
 	patch, err := getPatch(its)
@@ -163,46 +158,10 @@ func DeepHashObject(hasher hash.Hash, objectToWrite interface{}) {
 	fmt.Fprintf(hasher, "%v", dump.ForHash(objectToWrite))
 }
 
-var revisionsCache = lru.New(1024)
-
 func GetRevisions(revisions map[string]string) (map[string]string, error) {
-	if revisions == nil {
-		return nil, nil
-	}
-	revisionsStr, ok := revisions[revisionsZSTDKey]
-	if !ok {
-		return revisions, nil
-	}
-	if revisionsInCache, ok := revisionsCache.Get(revisionsStr); ok {
-		return revisionsInCache.(map[string]string), nil
-	}
-	revisionsData, err := base64.StdEncoding.DecodeString(revisionsStr)
-	if err != nil {
-		return nil, err
-	}
-	revisionsJSON, err := reader.DecodeAll(revisionsData, nil)
-	if err != nil {
-		return nil, err
-	}
-	updateRevisions := make(map[string]string)
-
-	if err = jsonIter.Unmarshal(revisionsJSON, &updateRevisions); err != nil {
-		return nil, err
-	}
-	revisionsCache.Put(revisionsStr, updateRevisions)
-	return updateRevisions, nil
+	return revisionmap.Decode(revisions)
 }
 
 func buildRevisions(updateRevisions map[string]string) (map[string]string, error) {
-	maxPlainRevisionCount := viper.GetInt(MaxPlainRevisionCount)
-	if len(updateRevisions) <= maxPlainRevisionCount {
-		return updateRevisions, nil
-	}
-	revisionsJSON, err := jsonIter.Marshal(updateRevisions)
-	if err != nil {
-		return nil, err
-	}
-	revisionsData := writer.EncodeAll(revisionsJSON, nil)
-	revisionsStr := base64.StdEncoding.EncodeToString(revisionsData)
-	return map[string]string{revisionsZSTDKey: revisionsStr}, nil
+	return revisionmap.Encode(updateRevisions)
 }

--- a/pkg/controller/instanceset/suite_test.go
+++ b/pkg/controller/instanceset/suite_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
+	"github.com/klauspost/compress/zstd"
 	apps "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -168,6 +169,10 @@ func mockCompressedInstanceTemplates(ns, name string) (*corev1.ConfigMap, string
 		},
 	}
 	templateByte, err := json.Marshal(instances)
+	if err != nil {
+		return nil, "", err
+	}
+	writer, err := zstd.NewWriter(nil)
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/controller/instanceset/types.go
+++ b/pkg/controller/instanceset/types.go
@@ -32,13 +32,8 @@ const (
 )
 
 const (
-	// MaxPlainRevisionCount specified max number of plain revision stored in status.updateRevisions.
-	// All revisions will be compressed if exceeding this value.
-	MaxPlainRevisionCount = "MAX_PLAIN_REVISION_COUNT"
-
 	templateRefAnnotationKey = "kubeblocks.io/template-ref"
 	templateRefDataKey       = "instances"
-	revisionsZSTDKey         = "zstd"
 
 	FeatureGateIgnorePodVerticalScaling = "IGNORE_POD_VERTICAL_SCALING"
 

--- a/pkg/controller/instanceset2/instance_util.go
+++ b/pkg/controller/instanceset2/instance_util.go
@@ -38,6 +38,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/instancetemplate"
 	"github.com/apecloud/kubeblocks/pkg/controller/kubebuilderx"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
+	"github.com/apecloud/kubeblocks/pkg/controller/revisionmap"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 )
 
@@ -325,6 +326,37 @@ func getHeadlessSvcName(itsName string) string {
 	return strings.Join([]string{itsName, "headless"}, "-")
 }
 
+func buildDesiredInstancesByName(tree *kubebuilderx.ObjectTree, its *workloads.InstanceSet) (map[string]*workloads.Instance, []string, error) {
+	itsExt, err := instancetemplate.BuildInstanceSetExt(its, tree)
+	if err != nil {
+		return nil, nil, err
+	}
+	nameBuilder, err := instancetemplate.NewPodNameBuilder(itsExt, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	nameMap, err := nameBuilder.BuildInstanceName2TemplateMap()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	names := make([]string, 0, len(nameMap))
+	for name := range nameMap {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	desired := make(map[string]*workloads.Instance, len(names))
+	for _, name := range names {
+		inst, err := buildInstanceByTemplate(tree, name, nameMap[name], its)
+		if err != nil {
+			return nil, nil, err
+		}
+		desired[name] = inst
+	}
+	return desired, names, nil
+}
+
 // func mergeInPlaceFields(src, dst *corev1.PodTemplateSpec) {
 //	mergeMap(&src.Annotations, &dst.Annotations)
 //	mergeMap(&src.Labels, &dst.Labels)
@@ -393,10 +425,18 @@ func getHeadlessSvcName(itsName string) string {
 //	return requests, limits
 // }
 
-func isInstanceUpdated(its *workloads.InstanceSet, inst *workloads.Instance) bool {
-	generation, ok := inst.Annotations[constant.KubeBlocksGenerationKey]
-	if !ok {
+func isInstanceUpdated(its *workloads.InstanceSet, inst, desired *workloads.Instance) bool {
+	updateRevisions, err := revisionmap.Decode(its.Status.UpdateRevisions)
+	if err != nil {
 		return false
 	}
-	return strconv.FormatInt(its.Generation, 10) == generation
+	return isInstanceUpdatedWithRevisions(inst, buildCurrentInstanceRevision(inst, desired), updateRevisions)
+}
+
+func isInstanceUpdatedWithRevisions(inst *workloads.Instance, currentRevision string, updateRevisions map[string]string) bool {
+	updateRevision, ok := updateRevisions[inst.Name]
+	if !ok || currentRevision != updateRevision {
+		return false
+	}
+	return inst.Generation == inst.Status.ObservedGeneration && inst.Status.UpToDate
 }

--- a/pkg/controller/instanceset2/reconciler_revision_update.go
+++ b/pkg/controller/instanceset2/reconciler_revision_update.go
@@ -25,6 +25,7 @@ import (
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	"github.com/apecloud/kubeblocks/pkg/controller/kubebuilderx"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
+	"github.com/apecloud/kubeblocks/pkg/controller/revisionmap"
 )
 
 func NewRevisionUpdateReconciler() kubebuilderx.Reconciler {
@@ -45,7 +46,25 @@ func (r *revisionUpdateReconciler) PreCondition(tree *kubebuilderx.ObjectTree) *
 func (r *revisionUpdateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilderx.Result, error) {
 	its, _ := tree.GetRoot().(*workloads.InstanceSet)
 
-	updatedReplicas := r.calculateUpdatedReplicas(its, tree.List(&workloads.Instance{}))
+	desiredInstances, names, err := buildDesiredInstancesByName(tree, its)
+	if err != nil {
+		return kubebuilderx.Continue, err
+	}
+
+	updateRevisions := make(map[string]string, len(names))
+	for _, name := range names {
+		updateRevisions[name] = buildInstanceRevision(desiredInstances[name])
+	}
+	revisions, err := revisionmap.Encode(updateRevisions)
+	if err != nil {
+		return kubebuilderx.Continue, err
+	}
+	its.Status.UpdateRevisions = revisions
+	if len(names) > 0 {
+		its.Status.UpdateRevision = updateRevisions[names[len(names)-1]]
+	}
+
+	updatedReplicas := r.calculateUpdatedReplicas(its, tree.List(&workloads.Instance{}), desiredInstances)
 	its.Status.UpdatedReplicas = updatedReplicas
 
 	its.Status.ObservedGeneration = its.Generation
@@ -53,11 +72,11 @@ func (r *revisionUpdateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kub
 	return kubebuilderx.Continue, nil
 }
 
-func (r *revisionUpdateReconciler) calculateUpdatedReplicas(its *workloads.InstanceSet, instances []client.Object) int32 {
+func (r *revisionUpdateReconciler) calculateUpdatedReplicas(its *workloads.InstanceSet, instances []client.Object, desiredInstances map[string]*workloads.Instance) int32 {
 	updatedReplicas := int32(0)
 	for i := range instances {
 		inst, _ := instances[i].(*workloads.Instance)
-		if isInstanceUpdated(its, inst) {
+		if isInstanceUpdated(its, inst, desiredInstances[inst.Name]) {
 			updatedReplicas++
 		}
 	}

--- a/pkg/controller/instanceset2/reconciler_status.go
+++ b/pkg/controller/instanceset2/reconciler_status.go
@@ -29,9 +29,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/instancetemplate"
 	"github.com/apecloud/kubeblocks/pkg/controller/kubebuilderx"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
+	"github.com/apecloud/kubeblocks/pkg/controller/revisionmap"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 )
 
@@ -53,6 +55,11 @@ func (r *statusReconciler) PreCondition(tree *kubebuilderx.ObjectTree) *kubebuil
 func (r *statusReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilderx.Result, error) {
 	its, _ := tree.GetRoot().(*workloads.InstanceSet)
 
+	desiredInstances, _, err := buildDesiredInstancesByName(tree, its)
+	if err != nil {
+		return kubebuilderx.Continue, err
+	}
+
 	instances := tree.List(&workloads.Instance{})
 	var instanceList []*workloads.Instance
 	for _, object := range instances {
@@ -65,7 +72,11 @@ func (r *statusReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 	readyReplicas, availableReplicas := int32(0), int32(0)
 	notReadyNames := sets.New[string]()
 	notAvailableNames := sets.New[string]()
-	// currentRevisions := map[string]string{}
+	currentRevisions := map[string]string{}
+	updateRevisions, err := revisionmap.Decode(its.Status.UpdateRevisions)
+	if err != nil {
+		return kubebuilderx.Continue, err
+	}
 
 	template2TemplatesStatus := map[string]*workloads.InstanceTemplateStatus{}
 	template2TotalReplicas := map[string]int32{}
@@ -78,7 +89,7 @@ func (r *statusReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 	}
 
 	for _, inst := range instanceList {
-		templateName := inst.Labels[instancetemplate.TemplateNameLabelKey]
+		templateName := getInstanceTemplateName(inst)
 		if template2TemplatesStatus[templateName] == nil {
 			template2TemplatesStatus[templateName] = &workloads.InstanceTemplateStatus{
 				Name: templateName,
@@ -100,8 +111,9 @@ func (r *statusReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 				notAvailableNames.Insert(inst.Name)
 			}
 		}
+		currentRevisions[inst.Name] = buildCurrentInstanceRevision(inst, desiredInstances[inst.Name])
 		if !intctrlutil.IsInstanceTerminating(inst) {
-			if isInstanceUpdated(its, inst) {
+			if isInstanceUpdatedWithRevisions(inst, currentRevisions[inst.Name], updateRevisions) {
 				updatedReplicas++
 				template2TemplatesStatus[templateName].UpdatedReplicas++
 			} else {
@@ -115,7 +127,7 @@ func (r *statusReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 	its.Status.AvailableReplicas = availableReplicas
 	its.Status.CurrentReplicas = currentReplicas
 	its.Status.UpdatedReplicas = updatedReplicas
-	// its.Status.CurrentRevisions, _ = buildRevisions(currentRevisions)
+	its.Status.CurrentRevisions, _ = revisionmap.Encode(currentRevisions)
 	its.Status.TemplatesStatus = buildTemplatesStatus(template2TemplatesStatus)
 	// all pods have been updated
 	totalReplicas := int32(1)
@@ -123,7 +135,7 @@ func (r *statusReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 		totalReplicas = *its.Spec.Replicas
 	}
 	if its.Status.Replicas == totalReplicas && its.Status.UpdatedReplicas == totalReplicas {
-		// its.Status.CurrentRevision = its.Status.UpdateRevision
+		its.Status.CurrentRevision = its.Status.UpdateRevision
 		its.Status.CurrentReplicas = totalReplicas
 	}
 	for idx, templateStatus := range its.Status.TemplatesStatus {
@@ -163,6 +175,16 @@ func (r *statusReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 		return kubebuilderx.RetryAfter(time.Second), nil
 	}
 	return kubebuilderx.Continue, nil
+}
+
+func getInstanceTemplateName(inst *workloads.Instance) string {
+	if inst.Labels == nil {
+		return ""
+	}
+	if templateName := inst.Labels[instancetemplate.TemplateNameLabelKey]; templateName != "" {
+		return templateName
+	}
+	return inst.Labels[constant.KBAppInstanceTemplateLabelKey]
 }
 
 func buildConditionMessageWithNames(instanceNames []string) ([]byte, error) {

--- a/pkg/controller/instanceset2/reconciler_status_test.go
+++ b/pkg/controller/instanceset2/reconciler_status_test.go
@@ -1,0 +1,340 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package instanceset2
+
+import (
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/kubebuilderx"
+	"github.com/apecloud/kubeblocks/pkg/controller/revisionmap"
+)
+
+func TestSyncInstanceConfigStatus(t *testing.T) {
+	its := &workloads.InstanceSet{
+		Spec: workloads.InstanceSetSpec{
+			Configs: []workloads.ConfigTemplate{
+				{Name: "log"},
+				{Name: "server"},
+			},
+		},
+	}
+	instanceStatus := []workloads.InstanceStatus{
+		{PodName: "test-its-0"},
+		{PodName: "test-its-1"},
+	}
+	instances := []*workloads.Instance{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-its-0"},
+			Status: workloads.InstanceStatus2{
+				Configs: []workloads.InstanceConfigStatus{
+					{Name: "log", Generation: 1},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-its-1"},
+			Status: workloads.InstanceStatus2{
+				Configs: []workloads.InstanceConfigStatus{
+					{Name: "log", Generation: 2},
+					{Name: "server", Generation: 3},
+				},
+			},
+		},
+	}
+
+	syncInstanceConfigStatus(its, instanceStatus, instances)
+
+	expected := []workloads.InstanceStatus{
+		{
+			PodName: "test-its-0",
+			Configs: []workloads.InstanceConfigStatus{
+				{Name: "log", Generation: 1},
+			},
+		},
+		{
+			PodName: "test-its-1",
+			Configs: []workloads.InstanceConfigStatus{
+				{Name: "log", Generation: 2},
+				{Name: "server", Generation: 3},
+			},
+		},
+	}
+	if !reflect.DeepEqual(expected, instanceStatus) {
+		t.Fatalf("unexpected instance status: %#v", instanceStatus)
+	}
+}
+
+func TestSyncInstanceConfigStatusKeepsEmptyWhenInstanceHasNotReported(t *testing.T) {
+	its := &workloads.InstanceSet{
+		Spec: workloads.InstanceSetSpec{
+			Configs: []workloads.ConfigTemplate{{Name: "log"}},
+		},
+	}
+	instanceStatus := []workloads.InstanceStatus{
+		{PodName: "test-its-0"},
+	}
+	instances := []*workloads.Instance{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-its-0"},
+		},
+	}
+
+	syncInstanceConfigStatus(its, instanceStatus, instances)
+
+	if instanceStatus[0].Configs != nil {
+		t.Fatalf("expected empty configs, got %#v", instanceStatus[0].Configs)
+	}
+}
+
+func TestIsInstanceUpdated(t *testing.T) {
+	newInstance := func(generationAnnotation string, upToDate bool) *workloads.Instance {
+		return &workloads.Instance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-its-0",
+				Generation: 2,
+				Annotations: map[string]string{
+					constant.KubeBlocksGenerationKey: generationAnnotation,
+				},
+			},
+			Spec: workloads.InstanceSpec{
+				MinReadySeconds: 1,
+			},
+			Status: workloads.InstanceStatus2{
+				ObservedGeneration: 2,
+				UpToDate:           upToDate,
+			},
+		}
+	}
+	latestInst := newInstance("2", true)
+	updateRevisions, err := revisionmap.Encode(map[string]string{
+		latestInst.Name: buildInstanceRevision(latestInst),
+	})
+	if err != nil {
+		t.Fatalf("build revisions: %v", err)
+	}
+	its := &workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Generation: 3,
+		},
+		Status: workloads.InstanceSetStatus{
+			UpdateRevisions: updateRevisions,
+		},
+	}
+
+	tests := []struct {
+		name string
+		inst *workloads.Instance
+		want bool
+	}{
+		{
+			name: "true when instance revision matches even if parent generation changed",
+			inst: newInstance("1", true),
+			want: true,
+		},
+		{
+			name: "false when instance spec is latest but pod status is not up to date",
+			inst: newInstance("3", false),
+			want: false,
+		},
+		{
+			name: "false when instance intent revision differs",
+			inst: func() *workloads.Instance {
+				inst := newInstance("3", true)
+				inst.Spec.MinReadySeconds = 2
+				return inst
+			}(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isInstanceUpdated(its, tt.inst, nil); got != tt.want {
+				t.Fatalf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestBuildInstanceRevisionIgnoresParentGenerationAnnotation(t *testing.T) {
+	inst := &workloads.Instance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-its-0",
+			Annotations: map[string]string{
+				constant.KubeBlocksGenerationKey: "1",
+			},
+		},
+		Spec: workloads.InstanceSpec{
+			MinReadySeconds: 1,
+		},
+	}
+	revision := buildInstanceRevision(inst)
+
+	inst.Annotations[constant.KubeBlocksGenerationKey] = "2"
+	if got := buildInstanceRevision(inst); got != revision {
+		t.Fatalf("expected generation annotation to be ignored, got %s want %s", got, revision)
+	}
+
+	inst.Spec.MinReadySeconds = 2
+	if got := buildInstanceRevision(inst); got == revision {
+		t.Fatalf("expected spec change to alter revision")
+	}
+}
+
+func TestBuildInstanceRevisionUsesDesiredMetadataKeys(t *testing.T) {
+	desired := &workloads.Instance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-its-0",
+			Labels: map[string]string{
+				constant.KBAppInstanceTemplateLabelKey: "tpl",
+				"managed-label":                        "desired",
+			},
+			Annotations: map[string]string{
+				constant.KubeBlocksGenerationKey: "3",
+				"managed-annotation":             "desired",
+			},
+		},
+		Spec: workloads.InstanceSpec{
+			MinReadySeconds: 1,
+		},
+	}
+	revision := buildInstanceRevision(desired)
+
+	actual := desired.DeepCopy()
+	actual.Annotations[constant.KubeBlocksGenerationKey] = "1"
+	actual.Annotations["external-annotation"] = "ignored"
+	actual.Labels["external-label"] = "ignored"
+	if got := buildCurrentInstanceRevision(actual, desired); got != revision {
+		t.Fatalf("expected unmanaged metadata to be ignored, got %s want %s", got, revision)
+	}
+
+	actual = desired.DeepCopy()
+	actual.Annotations["managed-annotation"] = "changed"
+	if got := buildCurrentInstanceRevision(actual, desired); got == revision {
+		t.Fatalf("expected managed annotation change to alter revision")
+	}
+
+	actual = desired.DeepCopy()
+	actual.Labels["managed-label"] = "changed"
+	if got := buildCurrentInstanceRevision(actual, desired); got == revision {
+		t.Fatalf("expected managed label change to alter revision")
+	}
+}
+
+func TestStatusReconcilerKeepsScaleOutInstancesUpdatedAfterParentGenerationBump(t *testing.T) {
+	its := &workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-its",
+			Namespace:  "default",
+			Generation: 3,
+		},
+		Spec: workloads.InstanceSetSpec{
+			Replicas:            ptr.To[int32](1),
+			FlatInstanceOrdinal: true,
+			Instances: []workloads.InstanceTemplate{
+				{
+					Name:     "tpl",
+					Replicas: ptr.To[int32](1),
+					Labels: map[string]string{
+						"managed-label": "desired",
+					},
+					Annotations: map[string]string{
+						"managed-annotation": "desired",
+					},
+				},
+			},
+		},
+		Status: workloads.InstanceSetStatus{
+			ObservedGeneration: 3,
+		},
+	}
+
+	tree := kubebuilderx.NewObjectTree()
+	tree.SetRoot(its)
+	desiredInstances, _, err := buildDesiredInstancesByName(tree, its)
+	if err != nil {
+		t.Fatalf("build desired instances: %v", err)
+	}
+	desired := desiredInstances["test-its-0"]
+	if desired == nil {
+		t.Fatalf("expected desired instance test-its-0, got %#v", desiredInstances)
+	}
+	desiredRevision := buildInstanceRevision(desired)
+	updateRevisions, err := revisionmap.Encode(map[string]string{
+		desired.Name: desiredRevision,
+	})
+	if err != nil {
+		t.Fatalf("build revisions: %v", err)
+	}
+	its.Status.UpdateRevision = "update-revision"
+	its.Status.UpdateRevisions = updateRevisions
+
+	inst := desired.DeepCopy()
+	inst.Annotations[constant.KubeBlocksGenerationKey] = "1"
+	inst.Annotations["external-annotation"] = "ignored"
+	inst.Labels["external-label"] = "ignored"
+	inst.Generation = 2
+	inst.Status = workloads.InstanceStatus2{
+		ObservedGeneration: 2,
+		UpToDate:           true,
+		Conditions: []metav1.Condition{
+			{Type: string(workloads.InstanceReady), Status: metav1.ConditionTrue},
+			{Type: string(workloads.InstanceAvailable), Status: metav1.ConditionTrue},
+		},
+	}
+
+	if err := tree.Add(inst); err != nil {
+		t.Fatalf("add instance: %v", err)
+	}
+	if _, err := NewStatusReconciler().Reconcile(tree); err != nil {
+		t.Fatalf("reconcile status: %v", err)
+	}
+
+	got := tree.GetRoot().(*workloads.InstanceSet)
+	currentRevisions, err := revisionmap.Decode(got.Status.CurrentRevisions)
+	if err != nil {
+		t.Fatalf("get current revisions: %v", err)
+	}
+	if currentRevisions[inst.Name] != buildCurrentInstanceRevision(inst, desired) {
+		t.Fatalf("unexpected current revision: %#v", currentRevisions)
+	}
+	if currentRevisions[inst.Name] != desiredRevision {
+		t.Fatalf("expected current revision to match desired update revision, got %s want %s", currentRevisions[inst.Name], desiredRevision)
+	}
+	if got.Status.UpdatedReplicas != 1 {
+		t.Fatalf("expected updated replicas to stay at 1, got %d", got.Status.UpdatedReplicas)
+	}
+	if len(got.Status.TemplatesStatus) != 1 ||
+		got.Status.TemplatesStatus[0].Name != "tpl" ||
+		got.Status.TemplatesStatus[0].Replicas != 1 ||
+		got.Status.TemplatesStatus[0].UpdatedReplicas != 1 ||
+		got.Status.TemplatesStatus[0].CurrentReplicas != 1 {
+		t.Fatalf("unexpected template status: %#v", got.Status.TemplatesStatus)
+	}
+	if got.Status.CurrentRevision != got.Status.UpdateRevision {
+		t.Fatalf("expected current revision to advance to update revision")
+	}
+}

--- a/pkg/controller/instanceset2/reconciler_update.go
+++ b/pkg/controller/instanceset2/reconciler_update.go
@@ -110,7 +110,15 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 	// if it's a roleful InstanceSet, we use updateCount to represent Pods can be updated according to the spec.memberUpdateStrategy.
 	updateCount := len(oldInstanceList)
 	if len(its.Spec.Roles) > 0 {
-		plan := newUpdatePlan(*its, oldInstanceList, isInstanceUpdated)
+		desiredInstances := make(map[string]*workloads.Instance, len(nameToTemplateMap))
+		for name, template := range nameToTemplateMap {
+			inst, err := buildInstanceByTemplate(tree, name, template, its)
+			if err != nil {
+				return kubebuilderx.Continue, err
+			}
+			desiredInstances[name] = inst
+		}
+		plan := newUpdatePlan(*its, oldInstanceList, desiredInstances)
 		instancesToBeUpdated, err := plan.Execute()
 		if err != nil {
 			return kubebuilderx.Continue, err

--- a/pkg/controller/instanceset2/revision_util.go
+++ b/pkg/controller/instanceset2/revision_util.go
@@ -1,0 +1,134 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package instanceset2
+
+import (
+	"fmt"
+	"hash/fnv"
+
+	"k8s.io/apimachinery/pkg/util/dump"
+	"k8s.io/apimachinery/pkg/util/rand"
+
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+)
+
+type instanceRevisionIntent struct {
+	Labels      map[string]string
+	Annotations map[string]string
+	Spec        workloads.InstanceSpec
+}
+
+func buildInstanceRevision(inst *workloads.Instance) string {
+	return buildRevisionIntentHash(copyRevisionLabels(inst.Labels), copyRevisionAnnotations(inst.Annotations), *inst.Spec.DeepCopy())
+}
+
+func buildCurrentInstanceRevision(inst, desired *workloads.Instance) string {
+	if desired == nil {
+		return buildInstanceRevision(inst)
+	}
+	return buildRevisionIntentHash(
+		copyRevisionLabelsByKeys(inst.Labels, desired.Labels),
+		copyRevisionAnnotationsByKeys(inst.Annotations, desired.Annotations),
+		*inst.Spec.DeepCopy())
+}
+
+func buildRevisionIntentHash(labels, annotations map[string]string, spec workloads.InstanceSpec) string {
+	intent := instanceRevisionIntent{
+		Labels:      labels,
+		Annotations: annotations,
+		Spec:        spec,
+	}
+	hasher := fnv.New32()
+	fmt.Fprintf(hasher, "%v", dump.ForHash(intent))
+	return rand.SafeEncodeString(fmt.Sprint(hasher.Sum32()))
+}
+
+func copyRevisionLabels(labels map[string]string) map[string]string {
+	if len(labels) == 0 {
+		return nil
+	}
+	copied := make(map[string]string, len(labels))
+	for k, v := range labels {
+		copied[k] = v
+	}
+	return copied
+}
+
+func copyRevisionLabelsByKeys(labels, keys map[string]string) map[string]string {
+	if len(labels) == 0 || len(keys) == 0 {
+		return nil
+	}
+	copied := make(map[string]string, len(keys))
+	for k := range keys {
+		if v, ok := labels[k]; ok {
+			copied[k] = v
+		}
+	}
+	if len(copied) == 0 {
+		return nil
+	}
+	return copied
+}
+
+func copyRevisionAnnotations(annotations map[string]string) map[string]string {
+	if len(annotations) == 0 {
+		return nil
+	}
+	copied := make(map[string]string, len(annotations))
+	for k, v := range annotations {
+		if isNonRevisionAnnotation(k) {
+			continue
+		}
+		copied[k] = v
+	}
+	if len(copied) == 0 {
+		return nil
+	}
+	return copied
+}
+
+func copyRevisionAnnotationsByKeys(annotations, keys map[string]string) map[string]string {
+	if len(annotations) == 0 || len(keys) == 0 {
+		return nil
+	}
+	copied := make(map[string]string, len(keys))
+	for k := range keys {
+		if isNonRevisionAnnotation(k) {
+			continue
+		}
+		if v, ok := annotations[k]; ok {
+			copied[k] = v
+		}
+	}
+	if len(copied) == 0 {
+		return nil
+	}
+	return copied
+}
+
+func isNonRevisionAnnotation(key string) bool {
+	switch key {
+	case constant.KubeBlocksGenerationKey:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/controller/instanceset2/update_plan.go
+++ b/pkg/controller/instanceset2/update_plan.go
@@ -29,16 +29,16 @@ import (
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 )
 
-func newUpdatePlan(its workloads.InstanceSet, instances []*workloads.Instance, updated func(*workloads.InstanceSet, *workloads.Instance) bool) updatePlan {
+func newUpdatePlan(its workloads.InstanceSet, instances []*workloads.Instance, desiredInstances map[string]*workloads.Instance) updatePlan {
 	var instanceList []workloads.Instance
 	for _, inst := range instances {
 		instanceList = append(instanceList, *inst)
 	}
 	return &realUpdatePlan{
-		its:               its,
-		instances:         instanceList,
-		dag:               graph.NewDAG(),
-		isInstanceUpdated: updated,
+		its:              its,
+		instances:        instanceList,
+		desiredInstances: desiredInstances,
+		dag:              graph.NewDAG(),
 	}
 }
 
@@ -59,9 +59,9 @@ var (
 type realUpdatePlan struct {
 	its                  workloads.InstanceSet
 	instances            []workloads.Instance
+	desiredInstances     map[string]*workloads.Instance
 	dag                  *graph.DAG
 	instancesToBeUpdated []*workloads.Instance
-	isInstanceUpdated    func(*workloads.InstanceSet, *workloads.Instance) bool
 }
 
 var _ updatePlan = &realUpdatePlan{}
@@ -82,7 +82,7 @@ func (p *realUpdatePlan) planWalkFunc(vertex graph.Vertex) error {
 	}
 
 	// if instance is the latest version, we do nothing
-	if p.isInstanceUpdated(&p.its, inst) {
+	if isInstanceUpdated(&p.its, inst, p.desiredInstances[inst.Name]) {
 		if !intctrlutil.IsInstanceReady(inst) {
 			return ErrWait
 		}

--- a/pkg/controller/revisionmap/revision_map.go
+++ b/pkg/controller/revisionmap/revision_map.go
@@ -1,0 +1,98 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package revisionmap
+
+import (
+	"encoding/base64"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/klauspost/compress/zstd"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	"github.com/apecloud/kubeblocks/pkg/lru"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
+)
+
+const (
+	// MaxPlainRevisionCount specifies max number of plain revisions stored in status revision maps.
+	MaxPlainRevisionCount = "MAX_PLAIN_REVISION_COUNT"
+
+	revisionsZSTDKey = "zstd"
+)
+
+var (
+	jsonIter = jsoniter.ConfigCompatibleWithStandardLibrary
+
+	reader *zstd.Decoder
+	writer *zstd.Encoder
+
+	revisionsCache = lru.New(1024)
+)
+
+func init() {
+	var err error
+	reader, err = zstd.NewReader(nil)
+	utilruntime.Must(err)
+	writer, err = zstd.NewWriter(nil)
+	utilruntime.Must(err)
+}
+
+// Decode returns the plain revision map from a status-safe revision map.
+func Decode(revisions map[string]string) (map[string]string, error) {
+	if revisions == nil {
+		return nil, nil
+	}
+	revisionsStr, ok := revisions[revisionsZSTDKey]
+	if !ok {
+		return revisions, nil
+	}
+	if revisionsInCache, ok := revisionsCache.Get(revisionsStr); ok {
+		return revisionsInCache.(map[string]string), nil
+	}
+	revisionsData, err := base64.StdEncoding.DecodeString(revisionsStr)
+	if err != nil {
+		return nil, err
+	}
+	revisionsJSON, err := reader.DecodeAll(revisionsData, nil)
+	if err != nil {
+		return nil, err
+	}
+	updateRevisions := make(map[string]string)
+	if err = jsonIter.Unmarshal(revisionsJSON, &updateRevisions); err != nil {
+		return nil, err
+	}
+	revisionsCache.Put(revisionsStr, updateRevisions)
+	return updateRevisions, nil
+}
+
+// Encode returns a status-safe revision map, compressing it when it exceeds the plain-entry limit.
+func Encode(revisions map[string]string) (map[string]string, error) {
+	maxPlainRevisionCount := viper.GetInt(MaxPlainRevisionCount)
+	if len(revisions) <= maxPlainRevisionCount {
+		return revisions, nil
+	}
+	revisionsJSON, err := jsonIter.Marshal(revisions)
+	if err != nil {
+		return nil, err
+	}
+	revisionsData := writer.EncodeAll(revisionsJSON, nil)
+	revisionsStr := base64.StdEncoding.EncodeToString(revisionsData)
+	return map[string]string{revisionsZSTDKey: revisionsStr}, nil
+}


### PR DESCRIPTION
## Summary
- Cherry-pick #10488 to release-1.1: align InstanceSet2 revision status handling.
- Add shared revision map encoding/decoding helper.
- Add InstanceSet2 revision status tests adapted to release-1.1 config status API.

## Notes
- Resolved release-1.1 conflicts by preserving release branch exported InstanceSet revision helpers while using the shared revisionmap helper from #10488.

## Tests
- go test ./pkg/controller/instanceset2 -count=1
- go test ./pkg/controller/instanceset -count=1
- go test ./controllers/apps/component -count=1
- make lint