### PR TITLE
fix: delegate restored account secrets to apps owners

### DIFF
--- a/controllers/apps/cluster/transformer_cluster_sharding_account.go
+++ b/controllers/apps/cluster/transformer_cluster_sharding_account.go
@@ -34,6 +34,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/builder"
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
+	"github.com/apecloud/kubeblocks/pkg/controller/systemaccount"
 )
 
 // clusterShardingAccountTransformer handles shared system accounts for sharding.
@@ -47,12 +48,20 @@ func (t *clusterShardingAccountTransformer) Transform(ctx graph.TransformContext
 		return nil
 	}
 
+	graphCli, _ := transCtx.Client.(model.GraphClient)
+	handled, err := systemaccount.ReconcileRestoreRequests(transCtx.Context, graphCli, dag,
+		transCtx.Cluster, constant.DBClusterFinalizerName)
+	if err != nil {
+		return err
+	}
+	if handled {
+		return nil
+	}
+
 	if common.IsCompactMode(transCtx.Cluster.Annotations) {
 		transCtx.V(1).Info("Cluster is in compact mode, no need to create account related objects", "cluster", client.ObjectKeyFromObject(transCtx.Cluster))
 		return nil
 	}
-
-	graphCli, _ := transCtx.Client.(model.GraphClient)
 	return t.reconcileShardingAccounts(transCtx, graphCli, dag)
 }
 

--- a/controllers/apps/component/transformer_component_account.go
+++ b/controllers/apps/component/transformer_component_account.go
@@ -38,6 +38,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
+	"github.com/apecloud/kubeblocks/pkg/controller/systemaccount"
 	ctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 )
 
@@ -61,13 +62,22 @@ func (t *componentAccountTransformer) Transform(ctx graph.TransformContext, dag 
 	if isCompDeleting(transCtx.ComponentOrig) {
 		return nil
 	}
+	graphCli, _ := transCtx.Client.(model.GraphClient)
+	handled, err := systemaccount.ReconcileRestoreRequests(transCtx.Context, graphCli, dag,
+		transCtx.Component, constant.DBComponentFinalizerName)
+	if err != nil {
+		return err
+	}
+	if handled {
+		return nil
+	}
+
 	if common.IsCompactMode(transCtx.ComponentOrig.Annotations) {
 		transCtx.V(1).Info("Component is in compact mode, no need to create account related objects", "component", client.ObjectKeyFromObject(transCtx.ComponentOrig))
 		return nil
 	}
 
 	synthesizedComp := transCtx.SynthesizeComponent
-	graphCli, _ := transCtx.Client.(model.GraphClient)
 
 	// exist account objects
 	secrets, err := listSystemAccountObjects(ctx, synthesizedComp)

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -2312,31 +2312,18 @@ func (r *VolumePopulatorReconciler) upsertSystemAccountSecret(reqCtx intctrlutil
 		return r.Client.Create(reqCtx.Ctx, secret)
 	}
 	if secret.Immutable != nil && *secret.Immutable && !systemAccountSecretMatches(secret, accountName, password) {
+		if controllerutil.RemoveFinalizer(secret, constant.DBClusterFinalizerName) {
+			if err := r.Client.Update(reqCtx.Ctx, secret); err != nil && !apierrors.IsNotFound(err) {
+				return err
+			}
+		}
+		if !secret.DeletionTimestamp.IsZero() {
+			return intctrlutil.NewRequeueError(reconcileInterval, fmt.Sprintf("waiting for immutable system account secret %s/%s to be deleted", secret.Namespace, secret.Name))
+		}
 		if err := r.Client.Delete(reqCtx.Ctx, secret); err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
-		secret = &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      secretName,
-				Namespace: pvc.Namespace,
-				Labels:    labels,
-				Annotations: map[string]string{
-					constant.SystemAccountProvisionedAnnotationKey: "true",
-				},
-			},
-			Type: corev1.SecretTypeOpaque,
-			Data: map[string][]byte{
-				constant.AccountNameForSecret:   []byte(accountName),
-				constant.AccountPasswdForSecret: password,
-			},
-		}
-		if err := r.setSystemAccountSecretOwner(reqCtx, pvc.Namespace, secret, scope, clusterName, ownerName); err != nil {
-			return err
-		}
-		if err := r.Client.Create(reqCtx.Ctx, secret); err != nil {
-			return err
-		}
-		return nil
+		return intctrlutil.NewRequeueError(reconcileInterval, fmt.Sprintf("waiting for immutable system account secret %s/%s to be recreated", secret.Namespace, secret.Name))
 	}
 	patch := client.MergeFrom(secret.DeepCopy())
 	if secret.Labels == nil {

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -49,6 +49,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/instanceset"
 	"github.com/apecloud/kubeblocks/pkg/controller/instancetemplate"
+	"github.com/apecloud/kubeblocks/pkg/controller/systemaccount"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	dprestore "github.com/apecloud/kubeblocks/pkg/dataprotection/restore"
 	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
@@ -2285,91 +2286,132 @@ func (r *VolumePopulatorReconciler) upsertSystemAccountSecret(reqCtx intctrlutil
 	password []byte,
 	labels map[string]string) error {
 	secretName := systemAccountSecretName(scope, clusterName, ownerName, accountName)
-	secret := &corev1.Secret{}
 	key := types.NamespacedName{Namespace: pvc.Namespace, Name: secretName}
-	if err := r.Client.Get(reqCtx.Ctx, key, secret); err != nil {
+	request, err := r.newSystemAccountRestoreRequest(reqCtx, pvc.Namespace, secretName, scope,
+		clusterName, ownerName, accountName, password, labels)
+	if err != nil {
+		return newSystemAccountSecretRequeueError("build restore request for", key, err)
+	}
+
+	secret := &corev1.Secret{}
+	if err := r.Client.Get(reqCtx.Ctx, key, secret); err == nil {
+		if systemaccount.RestoreConverged(secret, request, systemAccountSecretFinalizer(scope)) {
+			return nil
+		}
+	} else {
 		if !apierrors.IsNotFound(err) {
-			return err
+			return newSystemAccountSecretRequeueError("get", key, err)
 		}
-		secret = &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      secretName,
-				Namespace: pvc.Namespace,
-				Labels:    labels,
-				Annotations: map[string]string{
-					constant.SystemAccountProvisionedAnnotationKey: "true",
-				},
-			},
-			Type: corev1.SecretTypeOpaque,
-			Data: map[string][]byte{
-				constant.AccountNameForSecret:   []byte(accountName),
-				constant.AccountPasswdForSecret: password,
-			},
+	}
+
+	existing := &corev1.Secret{}
+	requestKey := client.ObjectKeyFromObject(request)
+	if err := r.Client.Get(reqCtx.Ctx, requestKey, existing); err == nil {
+		if validationErr := validateSystemAccountRestoreRequest(existing, request); validationErr != nil {
+			return validationErr
 		}
-		if err := r.setSystemAccountSecretOwner(reqCtx, pvc.Namespace, secret, scope, clusterName, ownerName); err != nil {
-			return err
-		}
-		return r.Client.Create(reqCtx.Ctx, secret)
+		return intctrlutil.NewRequeueError(reconcileInterval,
+			fmt.Sprintf("waiting for system account restore request %s to converge target %s", requestKey, key))
+	} else if !apierrors.IsNotFound(err) {
+		return newSystemAccountSecretRequeueError("get restore request for", key, err)
 	}
-	if secret.Immutable != nil && *secret.Immutable && !systemAccountSecretMatches(secret, accountName, password) {
-		if controllerutil.RemoveFinalizer(secret, constant.DBClusterFinalizerName) {
-			if err := r.Client.Update(reqCtx.Ctx, secret); err != nil && !apierrors.IsNotFound(err) {
-				return err
-			}
-		}
-		if !secret.DeletionTimestamp.IsZero() {
-			return intctrlutil.NewRequeueError(reconcileInterval, fmt.Sprintf("waiting for immutable system account secret %s/%s to be deleted", secret.Namespace, secret.Name))
-		}
-		uid := secret.UID
-		if err := r.Client.Delete(reqCtx.Ctx, secret, client.Preconditions{UID: &uid}); err != nil && !apierrors.IsNotFound(err) {
-			return err
-		}
-		return intctrlutil.NewRequeueError(reconcileInterval, fmt.Sprintf("waiting for immutable system account secret %s/%s to be recreated", secret.Namespace, secret.Name))
+	if err := r.Client.Create(reqCtx.Ctx, request); err != nil {
+		return newSystemAccountSecretRequeueError("create", requestKey, err)
 	}
-	patch := client.MergeFrom(secret.DeepCopy())
-	if secret.Labels == nil {
-		secret.Labels = map[string]string{}
-	}
-	for k, v := range labels {
-		secret.Labels[k] = v
-	}
-	if secret.Annotations == nil {
-		secret.Annotations = map[string]string{}
-	}
-	secret.Annotations[constant.SystemAccountProvisionedAnnotationKey] = "true"
-	if secret.Data == nil {
-		secret.Data = map[string][]byte{}
-	}
-	secret.Data[constant.AccountNameForSecret] = []byte(accountName)
-	secret.Data[constant.AccountPasswdForSecret] = password
-	if err := r.setSystemAccountSecretOwner(reqCtx, pvc.Namespace, secret, scope, clusterName, ownerName); err != nil {
-		return err
-	}
-	return r.Client.Patch(reqCtx.Ctx, secret, patch)
+	return intctrlutil.NewRequeueError(reconcileInterval,
+		fmt.Sprintf("waiting for the Apps owner to converge system account Secret %s", key))
 }
 
-func (r *VolumePopulatorReconciler) setSystemAccountSecretOwner(reqCtx intctrlutil.RequestCtx,
+func (r *VolumePopulatorReconciler) newSystemAccountRestoreRequest(reqCtx intctrlutil.RequestCtx,
+	namespace, targetName string,
+	scope systemAccountSecretScope,
+	clusterName, ownerName, accountName string,
+	password []byte,
+	labels map[string]string) (*corev1.Secret, error) {
+	requestLabels := mapsClone(labels)
+	requestLabels[constant.SystemAccountRestoreRequestLabelKey] = "true"
+	request := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      systemaccount.RestoreRequestName(namespace, targetName),
+			Labels:    requestLabels,
+			Annotations: map[string]string{
+				constant.SystemAccountRestoreTargetAnnotationKey: targetName,
+				constant.SystemAccountProvisionedAnnotationKey:   "true",
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			constant.AccountNameForSecret:   []byte(accountName),
+			constant.AccountPasswdForSecret: slices.Clone(password),
+		},
+	}
+	if scope == systemAccountSecretScopeSharding {
+		immutable := true
+		request.Immutable = &immutable
+	}
+	if err := r.setSystemAccountRestoreRequestOwner(reqCtx, namespace, request, scope, clusterName, ownerName); err != nil {
+		return nil, err
+	}
+	if err := systemaccount.SetRestoreRevision(request); err != nil {
+		return nil, err
+	}
+	return request, nil
+}
+
+func (r *VolumePopulatorReconciler) setSystemAccountRestoreRequestOwner(reqCtx intctrlutil.RequestCtx,
 	namespace string,
-	secret *corev1.Secret,
+	request *corev1.Secret,
 	scope systemAccountSecretScope,
 	clusterName, ownerName string) error {
-	switch scope {
-	case systemAccountSecretScopeSharding:
-		cluster := &appsv1.Cluster{}
-		if err := r.Client.Get(reqCtx.Ctx, types.NamespacedName{Namespace: namespace, Name: clusterName}, cluster); err != nil {
+	var owner client.Object
+	if scope == systemAccountSecretScopeSharding {
+		owner = &appsv1.Cluster{}
+		if err := r.Client.Get(reqCtx.Ctx, types.NamespacedName{Namespace: namespace, Name: clusterName}, owner); err != nil {
 			return err
 		}
-		return controllerutil.SetOwnerReference(cluster, secret, r.Scheme)
-	default:
-		component := &appsv1.Component{}
+	} else {
+		owner = &appsv1.Component{}
 		if err := r.Client.Get(reqCtx.Ctx, types.NamespacedName{
 			Namespace: namespace,
 			Name:      constant.GenerateClusterComponentName(clusterName, ownerName),
-		}, component); err != nil {
+		}, owner); err != nil {
 			return err
 		}
-		return controllerutil.SetOwnerReference(component, secret, r.Scheme)
 	}
+	return controllerutil.SetControllerReference(owner, request, r.Scheme)
+}
+
+func newSystemAccountSecretRequeueError(action string, key client.ObjectKey, err error) error {
+	return intctrlutil.NewRequeueError(reconcileInterval,
+		fmt.Sprintf("failed to %s system account Secret %s: %v", action, key, err))
+}
+
+func validateSystemAccountRestoreRequest(existing, desired *corev1.Secret) error {
+	if err := systemaccount.ValidateRestoreRequest(existing); err != nil {
+		return intctrlutil.NewFatalError(fmt.Sprintf("invalid system account restore request %s: %v",
+			client.ObjectKeyFromObject(existing), err))
+	}
+	existingOwner := metav1.GetControllerOf(existing)
+	desiredOwner := metav1.GetControllerOf(desired)
+	if existing.Annotations[constant.SystemAccountRestoreTargetAnnotationKey] !=
+		desired.Annotations[constant.SystemAccountRestoreTargetAnnotationKey] ||
+		existingOwner == nil || desiredOwner == nil ||
+		existingOwner.APIVersion != desiredOwner.APIVersion ||
+		existingOwner.Kind != desiredOwner.Kind ||
+		existingOwner.Name != desiredOwner.Name {
+		return intctrlutil.NewFatalError(fmt.Sprintf(
+			"system account restore request %s conflicts with desired request owner or target",
+			client.ObjectKeyFromObject(existing)))
+	}
+	return nil
+}
+
+func systemAccountSecretFinalizer(scope systemAccountSecretScope) string {
+	if scope == systemAccountSecretScopeSharding {
+		return constant.DBClusterFinalizerName
+	}
+	return constant.DBComponentFinalizerName
 }
 
 func systemAccountSecretName(scope systemAccountSecretScope, clusterName, ownerName, accountName string) string {
@@ -2377,11 +2419,6 @@ func systemAccountSecretName(scope systemAccountSecretScope, clusterName, ownerN
 		return fmt.Sprintf("%s-%s-%s", clusterName, ownerName, accountName)
 	}
 	return constant.GenerateAccountSecretName(clusterName, ownerName, accountName)
-}
-
-func systemAccountSecretMatches(secret *corev1.Secret, accountName string, password []byte) bool {
-	return string(secret.Data[constant.AccountNameForSecret]) == accountName &&
-		string(secret.Data[constant.AccountPasswdForSecret]) == string(password)
 }
 
 func upsertPVCCondition(conditions *[]corev1.PersistentVolumeClaimCondition, condition corev1.PersistentVolumeClaimCondition) {

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -2320,7 +2320,8 @@ func (r *VolumePopulatorReconciler) upsertSystemAccountSecret(reqCtx intctrlutil
 		if !secret.DeletionTimestamp.IsZero() {
 			return intctrlutil.NewRequeueError(reconcileInterval, fmt.Sprintf("waiting for immutable system account secret %s/%s to be deleted", secret.Namespace, secret.Name))
 		}
-		if err := r.Client.Delete(reqCtx.Ctx, secret); err != nil && !apierrors.IsNotFound(err) {
+		uid := secret.UID
+		if err := r.Client.Delete(reqCtx.Ctx, secret, client.Preconditions{UID: &uid}); err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 		return intctrlutil.NewRequeueError(reconcileInterval, fmt.Sprintf("waiting for immutable system account secret %s/%s to be recreated", secret.Namespace, secret.Name))

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -47,6 +48,7 @@ import (
 	workloadsv1 "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/instanceset"
+	"github.com/apecloud/kubeblocks/pkg/controller/systemaccount"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	dprestore "github.com/apecloud/kubeblocks/pkg/dataprotection/restore"
 	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
@@ -189,7 +191,7 @@ var _ = Describe("Volume Populator Controller test", func() {
 	})
 
 	Context("system account secret helpers", func() {
-		It("patches existing mutable secrets and waits before recreating changed immutable secrets", func() {
+		It("hands all target mutations to the Apps owner", func() {
 			scheme := runtime.NewScheme()
 			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
 			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
@@ -211,8 +213,9 @@ var _ = Describe("Volume Populator Controller test", func() {
 			immutable := true
 			immutableSecret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      constant.GenerateAccountSecretName("cluster", "mysql", "root"),
+					Namespace:  "default",
+					Name:       constant.GenerateAccountSecretName("cluster", "mysql", "root"),
+					Finalizers: []string{constant.DBComponentFinalizerName},
 				},
 				Immutable: &immutable,
 				Data: map[string][]byte{
@@ -235,48 +238,160 @@ var _ = Describe("Volume Populator Controller test", func() {
 			}
 			reqCtx := intctrlutil.RequestCtx{Ctx: context.Background()}
 
-			Expect(reconciler.upsertSystemAccountSecret(reqCtx, pvc, systemAccountSecretScopeComponent,
-				"cluster", "mysql", "admin", []byte("new-password"), map[string]string{"role": "admin"})).Should(Succeed())
-			patched := &corev1.Secret{}
+			err := reconciler.upsertSystemAccountSecret(reqCtx, pvc, systemAccountSecretScopeComponent,
+				"cluster", "mysql", "admin", []byte("new-password"), map[string]string{"role": "admin"})
+			Expect(err).To(HaveOccurred())
+			Expect(intctrlutil.IsRequeueError(err)).To(BeTrue(), err.Error())
+			currentMutable := &corev1.Secret{}
 			Expect(reconciler.Client.Get(context.Background(), client.ObjectKey{
 				Namespace: "default",
 				Name:      mutableSecret.Name,
-			}, patched)).Should(Succeed())
-			Expect(patched.Labels["role"]).To(Equal("admin"))
-			Expect(patched.Annotations[constant.SystemAccountProvisionedAnnotationKey]).To(Equal("true"))
-			Expect(patched.Data[constant.AccountNameForSecret]).To(Equal([]byte("admin")))
-			Expect(patched.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("new-password")))
-			Expect(patched.OwnerReferences).To(HaveLen(1))
-			Expect(patched.OwnerReferences[0].Kind).To(Equal("Component"))
+			}, currentMutable)).Should(Succeed())
+			Expect(currentMutable.Labels).To(BeEmpty())
+			Expect(currentMutable.Annotations).To(BeEmpty())
+			Expect(currentMutable.Data).To(BeEmpty())
+			Expect(currentMutable.OwnerReferences).To(BeEmpty())
 
-			err := reconciler.upsertSystemAccountSecret(reqCtx, pvc, systemAccountSecretScopeComponent,
+			err = reconciler.upsertSystemAccountSecret(reqCtx, pvc, systemAccountSecretScopeComponent,
 				"cluster", "mysql", "root", []byte("new-root-password"), map[string]string{"role": "root"})
 			Expect(err).To(HaveOccurred())
 			Expect(intctrlutil.IsRequeueError(err)).To(BeTrue(), err.Error())
+			currentImmutable := &corev1.Secret{}
 			Expect(reconciler.Client.Get(context.Background(), client.ObjectKey{
 				Namespace: "default",
 				Name:      immutableSecret.Name,
-			}, &corev1.Secret{})).To(MatchError(ContainSubstring("not found")))
+			}, currentImmutable)).Should(Succeed())
+			Expect(currentImmutable.DeletionTimestamp.IsZero()).To(BeTrue())
+			Expect(currentImmutable.Finalizers).To(ConsistOf(constant.DBComponentFinalizerName))
+			Expect(currentImmutable.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("old-password")))
 
-			Expect(reconciler.upsertSystemAccountSecret(reqCtx, pvc, systemAccountSecretScopeComponent,
-				"cluster", "mysql", "root", []byte("new-root-password"), map[string]string{"role": "root"})).Should(Succeed())
-			recreated := &corev1.Secret{}
-			Expect(reconciler.Client.Get(context.Background(), client.ObjectKey{
-				Namespace: "default",
-				Name:      immutableSecret.Name,
-			}, recreated)).Should(Succeed())
-			Expect(recreated.Immutable).To(BeNil())
-			Expect(recreated.Labels["role"]).To(Equal("root"))
-			Expect(recreated.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("new-root-password")))
-			Expect(systemAccountSecretMatches(recreated, "root", []byte("new-root-password"))).To(BeTrue())
-			Expect(systemAccountSecretMatches(recreated, "root", []byte("old-password"))).To(BeFalse())
+			requests := &corev1.SecretList{}
+			Expect(reconciler.Client.List(context.Background(), requests, client.InNamespace("default"))).Should(Succeed())
+			var mutableRequest, immutableRequest *corev1.Secret
+			for i := range requests.Items {
+				switch requests.Items[i].Annotations[constant.SystemAccountRestoreTargetAnnotationKey] {
+				case mutableSecret.Name:
+					mutableRequest = &requests.Items[i]
+				case immutableSecret.Name:
+					immutableRequest = &requests.Items[i]
+				}
+			}
+			Expect(mutableRequest).NotTo(BeNil())
+			Expect(mutableRequest.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("new-password")))
+			Expect(immutableRequest).NotTo(BeNil())
+			Expect(immutableRequest.Data[constant.AccountNameForSecret]).To(Equal([]byte("root")))
+			Expect(immutableRequest.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("new-root-password")))
+			Expect(immutableRequest.OwnerReferences).To(HaveLen(1))
+			Expect(immutableRequest.OwnerReferences[0].Kind).To(Equal("Component"))
+			Expect(immutableRequest.OwnerReferences[0].Controller).NotTo(BeNil())
+			Expect(*immutableRequest.OwnerReferences[0].Controller).To(BeTrue())
+			Expect(immutableRequest.Labels[constant.SystemAccountRestoreRequestLabelKey]).To(Equal("true"))
+			Expect(immutableRequest.Annotations[constant.SystemAccountRestoreRevisionAnnotationKey]).NotTo(BeEmpty())
 		})
 
-		It("does not delete a recreated immutable system account secret", func() {
+		It("accepts only the Apps-committed restore revision as converged", func() {
 			scheme := runtime.NewScheme()
 			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
 			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
+			component := &kbappsv1.Component{ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      constant.GenerateClusterComponentName("cluster", "mysql"),
+				UID:       types.UID("component-uid"),
+			}}
+			pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "data-target-0",
+			}}
+			reconciler := &VolumePopulatorReconciler{
+				Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(component).Build(),
+				Scheme: scheme,
+			}
+			request, err := reconciler.newSystemAccountRestoreRequest(
+				intctrlutil.RequestCtx{Ctx: context.Background()}, "default",
+				constant.GenerateAccountSecretName("cluster", "mysql", "admin"),
+				systemAccountSecretScopeComponent, "cluster", "mysql", "admin", []byte("restored-password"),
+				map[string]string{"role": "admin"})
+			Expect(err).ShouldNot(HaveOccurred())
+			target := request.DeepCopy()
+			target.Name = request.Annotations[constant.SystemAccountRestoreTargetAnnotationKey]
+			delete(target.Labels, constant.SystemAccountRestoreRequestLabelKey)
+			delete(target.Annotations, constant.SystemAccountRestoreTargetAnnotationKey)
+			target.Finalizers = []string{constant.DBComponentFinalizerName}
+			Expect(reconciler.Client.Create(context.Background(), target)).Should(Succeed())
 
+			err = reconciler.upsertSystemAccountSecret(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc,
+				systemAccountSecretScopeComponent, "cluster", "mysql", "admin", []byte("restored-password"),
+				map[string]string{"role": "admin"})
+
+			Expect(err).ShouldNot(HaveOccurred())
+			requests := &corev1.SecretList{}
+			Expect(reconciler.Client.List(context.Background(), requests,
+				client.MatchingLabels{constant.SystemAccountRestoreRequestLabelKey: "true"})).Should(Succeed())
+			Expect(requests.Items).To(BeEmpty())
+		})
+
+		It("serializes a new restore behind an older valid request", func() {
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
+			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
+			component := &kbappsv1.Component{ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      constant.GenerateClusterComponentName("cluster", "mysql"),
+				UID:       types.UID("component-uid"),
+			}}
+			pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "data-target-0",
+			}}
+			reconciler := &VolumePopulatorReconciler{
+				Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(component).Build(),
+				Scheme: scheme,
+			}
+			oldRequest, err := reconciler.newSystemAccountRestoreRequest(
+				intctrlutil.RequestCtx{Ctx: context.Background()}, "default",
+				constant.GenerateAccountSecretName("cluster", "mysql", "admin"),
+				systemAccountSecretScopeComponent, "cluster", "mysql", "admin", []byte("old-password"),
+				map[string]string{"role": "admin"})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(reconciler.Client.Create(context.Background(), oldRequest)).Should(Succeed())
+
+			err = reconciler.upsertSystemAccountSecret(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc,
+				systemAccountSecretScopeComponent, "cluster", "mysql", "admin", []byte("new-password"),
+				map[string]string{"role": "admin"})
+
+			Expect(intctrlutil.IsRequeueError(err)).To(BeTrue(), err)
+			persisted := &corev1.Secret{}
+			Expect(reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(oldRequest), persisted)).Should(Succeed())
+			Expect(persisted.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("old-password")))
+		})
+
+		It("requeues a restore request create race through the full reconciler", func() {
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
+			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
+			Expect(dpv1alpha1.AddToScheme(scheme)).Should(Succeed())
+
+			apiGroup := dptypes.DataprotectionAPIGroup
+			backup := newBackupForRestoreDecision(nil, nil)
+			encryptor := intctrlutil.NewEncryptor(viper.GetString(constant.CfgKeyDPEncryptionKey))
+			encryptedPassword, err := encryptor.Encrypt([]byte("restored-password"))
+			Expect(err).ShouldNot(HaveOccurred())
+			backup.Annotations = map[string]string{
+				constant.EncryptedSystemAccountsAnnotationKey: fmt.Sprintf(`{"mysql":{"admin":"%s"}}`, encryptedPassword),
+			}
+			pvc := newPVCForRestoreDecision("data", "mysql", "")
+			pvc.UID = types.UID("target-pvc-uid")
+			pvc.Spec.DataSourceRef = &corev1.TypedObjectReference{
+				APIGroup: &apiGroup,
+				Kind:     dptypes.BackupKind,
+				Name:     backup.Name,
+			}
+			pvc.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
+			pvc.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+			pvc.Status.Conditions = []corev1.PersistentVolumeClaimCondition{{
+				Type:   PersistentVolumeClaimPopulating,
+				Status: corev1.ConditionTrue,
+			}}
 			component := &kbappsv1.Component{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
@@ -284,72 +399,38 @@ var _ = Describe("Volume Populator Controller test", func() {
 					UID:       types.UID("component-uid"),
 				},
 			}
-			immutable := true
-			oldSecret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      constant.GenerateAccountSecretName("cluster", "mysql", "root"),
-					UID:       types.UID("old-secret-uid"),
-				},
-				Immutable: &immutable,
-				Data: map[string][]byte{
-					constant.AccountNameForSecret:   []byte("root"),
-					constant.AccountPasswdForSecret: []byte("old-password"),
-				},
-			}
-			pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "data-target-0",
-			}}
 			baseClient := fake.NewClientBuilder().
 				WithScheme(scheme).
-				WithObjects(component, oldSecret).
+				WithStatusSubresource(pvc, backup).
+				WithObjects(component, backup, pvc).
 				Build()
-			replacementUID := types.UID("replacement-secret-uid")
-			deleteIntercepted := false
+			requestCreateAttempts := 0
 			interceptedClient := interceptor.NewClient(baseClient, interceptor.Funcs{
-				Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
-					if deleteIntercepted {
-						return c.Delete(ctx, obj, opts...)
+				Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+					if secret, ok := obj.(*corev1.Secret); ok &&
+						secret.Labels[constant.SystemAccountRestoreRequestLabelKey] == "true" {
+						requestCreateAttempts++
+						return apierrors.NewAlreadyExists(corev1.Resource("secrets"), secret.Name)
 					}
-					deleteIntercepted = true
-					Expect(c.Delete(ctx, obj)).Should(Succeed())
-					replacement := &corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: obj.GetNamespace(),
-							Name:      obj.GetName(),
-							UID:       replacementUID,
-						},
-						Data: map[string][]byte{constant.AccountPasswdForSecret: []byte("replacement-password")},
-					}
-					Expect(c.Create(ctx, replacement)).Should(Succeed())
-
-					deleteOptions := &client.DeleteOptions{}
-					deleteOptions.ApplyOptions(opts)
-					if deleteOptions.Preconditions != nil && deleteOptions.Preconditions.UID != nil {
-						current := &corev1.Secret{}
-						Expect(c.Get(ctx, client.ObjectKeyFromObject(replacement), current)).Should(Succeed())
-						if current.UID != *deleteOptions.Preconditions.UID {
-							return apierrors.NewConflict(corev1.Resource("secrets"), current.Name,
-								fmt.Errorf("UID precondition does not match"))
-						}
-					}
-					return c.Delete(ctx, obj, opts...)
+					return c.Create(ctx, obj, opts...)
 				},
 			})
-			reconciler := &VolumePopulatorReconciler{Client: interceptedClient, Scheme: scheme}
+			reconciler := &VolumePopulatorReconciler{
+				Client:   interceptedClient,
+				Scheme:   scheme,
+				Recorder: record.NewFakeRecorder(10),
+			}
 
-			err := reconciler.upsertSystemAccountSecret(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc,
-				systemAccountSecretScopeComponent, "cluster", "mysql", "root", []byte("new-password"), nil)
-			Expect(err).To(HaveOccurred())
-			Expect(apierrors.IsConflict(err)).To(BeTrue(), "expected a UID-precondition conflict, got %v", err)
-			current := &corev1.Secret{}
-			Expect(baseClient.Get(context.Background(), client.ObjectKeyFromObject(oldSecret), current)).Should(Succeed())
-			Expect(current.UID).To(Equal(replacementUID))
-			Expect(current.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("replacement-password")))
+			result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: client.ObjectKeyFromObject(pvc),
+			})
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(reconcileInterval))
+			Expect(requestCreateAttempts).To(Equal(1))
 		})
 
-		It("removes the cluster finalizer before replacing immutable sharding account secrets", func() {
+		It("asks the Cluster owner to replace immutable sharding account secrets", func() {
 			scheme := runtime.NewScheme()
 			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
 			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
@@ -394,26 +475,32 @@ var _ = Describe("Volume Populator Controller test", func() {
 				map[string]string{constant.KBAppShardingNameLabelKey: "shard"})
 			Expect(err).To(HaveOccurred())
 			Expect(intctrlutil.IsRequeueError(err)).To(BeTrue(), err.Error())
+			current := &corev1.Secret{}
 			Expect(reconciler.Client.Get(context.Background(), client.ObjectKey{
 				Namespace: "default",
 				Name:      secret.Name,
-			}, &corev1.Secret{})).To(MatchError(ContainSubstring("not found")))
+			}, current)).Should(Succeed())
+			Expect(current.DeletionTimestamp.IsZero()).To(BeTrue())
+			Expect(current.Finalizers).To(ConsistOf(constant.DBClusterFinalizerName))
 
-			Expect(reconciler.upsertSystemAccountSecret(reqCtx, pvc, systemAccountSecretScopeSharding,
-				"cluster", "shard", "root", []byte("new-password"),
-				map[string]string{constant.KBAppShardingNameLabelKey: "shard"})).Should(Succeed())
-			recreated := &corev1.Secret{}
-			Expect(reconciler.Client.Get(context.Background(), client.ObjectKey{
-				Namespace: "default",
-				Name:      secret.Name,
-			}, recreated)).Should(Succeed())
-			Expect(recreated.Finalizers).To(BeEmpty())
-			Expect(recreated.OwnerReferences).To(HaveLen(1))
-			Expect(recreated.OwnerReferences[0].Kind).To(Equal("Cluster"))
-			Expect(recreated.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("new-password")))
+			requests := &corev1.SecretList{}
+			Expect(reconciler.Client.List(context.Background(), requests, client.InNamespace("default"))).Should(Succeed())
+			var request *corev1.Secret
+			for i := range requests.Items {
+				if requests.Items[i].Annotations[constant.SystemAccountRestoreTargetAnnotationKey] == secret.Name {
+					request = &requests.Items[i]
+					break
+				}
+			}
+			Expect(request).NotTo(BeNil())
+			Expect(request.OwnerReferences).To(HaveLen(1))
+			Expect(request.OwnerReferences[0].Kind).To(Equal("Cluster"))
+			Expect(request.OwnerReferences[0].Controller).NotTo(BeNil())
+			Expect(*request.OwnerReferences[0].Controller).To(BeTrue())
+			Expect(request.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("new-password")))
 		})
 
-		It("removes the cluster finalizer from deletion-stamped immutable sharding account secrets", func() {
+		It("does not remove the Cluster finalizer from deletion-stamped account secrets", func() {
 			scheme := runtime.NewScheme()
 			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
 			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
@@ -439,10 +526,15 @@ var _ = Describe("Volume Populator Controller test", func() {
 					Name:      "data-target-0",
 				},
 			}
+			cluster := &kbappsv1.Cluster{ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "cluster",
+				UID:       types.UID("cluster-uid"),
+			}}
 			reconciler := &VolumePopulatorReconciler{
 				Client: fake.NewClientBuilder().
 					WithScheme(scheme).
-					WithObjects(secret).
+					WithObjects(cluster, secret).
 					Build(),
 				Scheme: scheme,
 			}
@@ -458,12 +550,15 @@ var _ = Describe("Volume Populator Controller test", func() {
 				Namespace: "default",
 				Name:      secret.Name,
 			}, patched)
-			if apierrors.IsNotFound(err) {
-				return
-			}
 			Expect(err).Should(Succeed())
-			Expect(patched.Finalizers).To(BeEmpty())
+			Expect(patched.Finalizers).To(ConsistOf(constant.DBClusterFinalizerName))
 			Expect(patched.DeletionTimestamp).NotTo(BeNil())
+
+			requests := &corev1.SecretList{}
+			Expect(reconciler.Client.List(context.Background(), requests, client.InNamespace("default"))).Should(Succeed())
+			Expect(requests.Items).To(ContainElement(WithTransform(func(item corev1.Secret) string {
+				return item.Annotations[constant.SystemAccountRestoreTargetAnnotationKey]
+			}, Equal(secret.Name))))
 		})
 
 		It("validates PVC names against instance volume templates", func() {
@@ -919,6 +1014,38 @@ var _ = Describe("Volume Populator Controller test", func() {
 					Namespace: testCtx.DefaultNamespace,
 					Name:      constant.GenerateAccountSecretName(testdp.ClusterName, testdp.ComponentName, "admin"),
 				}
+				requestKey := types.NamespacedName{
+					Namespace: testCtx.DefaultNamespace,
+					Name:      systemaccount.RestoreRequestName(testCtx.DefaultNamespace, secretKey.Name),
+				}
+				request := &corev1.Secret{}
+				Eventually(func(g Gomega) {
+					g.Expect(testCtx.Cli.Get(testCtx.Ctx, requestKey, request)).Should(Succeed())
+					g.Expect(request.Data).Should(HaveKeyWithValue(constant.AccountNameForSecret, []byte("admin")))
+					g.Expect(request.Data).Should(HaveKeyWithValue(constant.AccountPasswdForSecret, []byte("restored-password")))
+					g.Expect(request.Labels).Should(HaveKeyWithValue(constant.SystemAccountRestoreRequestLabelKey, "true"))
+					g.Expect(request.Annotations[constant.SystemAccountRestoreRevisionAnnotationKey]).ShouldNot(BeEmpty())
+				}).Should(Succeed())
+				Expect(testCtx.Cli.Get(testCtx.Ctx, secretKey, &corev1.Secret{})).Should(Satisfy(apierrors.IsNotFound))
+				Expect(testCtx.Cli.Get(testCtx.Ctx, types.NamespacedName{
+					Namespace: testCtx.DefaultNamespace,
+					Name:      getPopulatePVCName(pvc.UID),
+				}, &dpv1alpha1.Restore{})).Should(Satisfy(apierrors.IsNotFound))
+
+				// The Apps controller is not installed in this focused DP envtest. Commit
+				// its side of the public request contract before letting DP continue.
+				target := request.DeepCopy()
+				target.Name = secretKey.Name
+				target.ResourceVersion = ""
+				target.UID = ""
+				target.CreationTimestamp = metav1.Time{}
+				target.ManagedFields = nil
+				target.Finalizers = []string{constant.DBComponentFinalizerName}
+				delete(target.Labels, constant.SystemAccountRestoreRequestLabelKey)
+				delete(target.Annotations, constant.SystemAccountRestoreTargetAnnotationKey)
+				Expect(testCtx.Cli.Create(testCtx.Ctx, target)).Should(Succeed())
+				Expect(testCtx.Cli.Delete(testCtx.Ctx, request)).Should(Succeed())
+
 				Eventually(testapps.CheckObj(&testCtx, secretKey, func(g Gomega, secret *corev1.Secret) {
 					g.Expect(secret.Data).Should(HaveKeyWithValue(constant.AccountNameForSecret, []byte("admin")))
 					g.Expect(secret.Data).Should(HaveKeyWithValue(constant.AccountPasswdForSecret, []byte("restored-password")))
@@ -2763,6 +2890,19 @@ func TestRestoreSystemAccountSecretsRestoresComponentAndShardingSecrets(t *testi
 	}
 
 	err = reconciler.restoreSystemAccountSecrets(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup.Namespace)
+	require.True(t, intctrlutil.IsRequeueError(err), err)
+	componentRequest := getSystemAccountRestoreRequest(t, reconciler.Client,
+		constant.GenerateAccountSecretName("cluster", "mysql", "admin"))
+	require.Equal(t, []byte("component-password"), componentRequest.Data[constant.AccountPasswdForSecret])
+	commitSystemAccountRestoreRequest(t, reconciler.Client, componentRequest, constant.DBComponentFinalizerName)
+
+	err = reconciler.restoreSystemAccountSecrets(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup.Namespace)
+	require.True(t, intctrlutil.IsRequeueError(err), err)
+	shardingRequest := getSystemAccountRestoreRequest(t, reconciler.Client, "cluster-shard-root")
+	require.Equal(t, []byte("sharding-password"), shardingRequest.Data[constant.AccountPasswdForSecret])
+	commitSystemAccountRestoreRequest(t, reconciler.Client, shardingRequest, constant.DBClusterFinalizerName)
+
+	err = reconciler.restoreSystemAccountSecrets(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup.Namespace)
 	require.NoError(t, err)
 
 	componentSecret := &corev1.Secret{}
@@ -2784,6 +2924,36 @@ func TestRestoreSystemAccountSecretsRestoresComponentAndShardingSecrets(t *testi
 	require.Len(t, shardingSecret.OwnerReferences, 1)
 	require.Equal(t, "Cluster", shardingSecret.OwnerReferences[0].Kind)
 	require.Equal(t, cluster.Name, shardingSecret.OwnerReferences[0].Name)
+}
+
+func getSystemAccountRestoreRequest(t *testing.T, cli client.Client, targetName string) *corev1.Secret {
+	t.Helper()
+	requests := &corev1.SecretList{}
+	require.NoError(t, cli.List(context.Background(), requests,
+		client.MatchingLabels{constant.SystemAccountRestoreRequestLabelKey: "true"}))
+	for i := range requests.Items {
+		request := &requests.Items[i]
+		if request.Annotations[constant.SystemAccountRestoreTargetAnnotationKey] == targetName {
+			return request.DeepCopy()
+		}
+	}
+	require.FailNow(t, "restore request not found", targetName)
+	return nil
+}
+
+func commitSystemAccountRestoreRequest(t *testing.T, cli client.Client, request *corev1.Secret, finalizer string) {
+	t.Helper()
+	target := request.DeepCopy()
+	target.Name = request.Annotations[constant.SystemAccountRestoreTargetAnnotationKey]
+	target.ResourceVersion = ""
+	target.UID = ""
+	target.CreationTimestamp = metav1.Time{}
+	target.ManagedFields = nil
+	target.Finalizers = []string{finalizer}
+	delete(target.Labels, constant.SystemAccountRestoreRequestLabelKey)
+	delete(target.Annotations, constant.SystemAccountRestoreTargetAnnotationKey)
+	require.NoError(t, cli.Create(context.Background(), target))
+	require.NoError(t, cli.Delete(context.Background(), request))
 }
 
 func TestRestoreSystemAccountSecretsReturnsFatalForInvalidAccountsPayload(t *testing.T) {

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
@@ -269,6 +270,83 @@ var _ = Describe("Volume Populator Controller test", func() {
 			Expect(recreated.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("new-root-password")))
 			Expect(systemAccountSecretMatches(recreated, "root", []byte("new-root-password"))).To(BeTrue())
 			Expect(systemAccountSecretMatches(recreated, "root", []byte("old-password"))).To(BeFalse())
+		})
+
+		It("does not delete a recreated immutable system account secret", func() {
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
+			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
+
+			component := &kbappsv1.Component{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      constant.GenerateClusterComponentName("cluster", "mysql"),
+					UID:       types.UID("component-uid"),
+				},
+			}
+			immutable := true
+			oldSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      constant.GenerateAccountSecretName("cluster", "mysql", "root"),
+					UID:       types.UID("old-secret-uid"),
+				},
+				Immutable: &immutable,
+				Data: map[string][]byte{
+					constant.AccountNameForSecret:   []byte("root"),
+					constant.AccountPasswdForSecret: []byte("old-password"),
+				},
+			}
+			pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "data-target-0",
+			}}
+			baseClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(component, oldSecret).
+				Build()
+			replacementUID := types.UID("replacement-secret-uid")
+			deleteIntercepted := false
+			interceptedClient := interceptor.NewClient(baseClient, interceptor.Funcs{
+				Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					if deleteIntercepted {
+						return c.Delete(ctx, obj, opts...)
+					}
+					deleteIntercepted = true
+					Expect(c.Delete(ctx, obj)).Should(Succeed())
+					replacement := &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: obj.GetNamespace(),
+							Name:      obj.GetName(),
+							UID:       replacementUID,
+						},
+						Data: map[string][]byte{constant.AccountPasswdForSecret: []byte("replacement-password")},
+					}
+					Expect(c.Create(ctx, replacement)).Should(Succeed())
+
+					deleteOptions := &client.DeleteOptions{}
+					deleteOptions.ApplyOptions(opts)
+					if deleteOptions.Preconditions != nil && deleteOptions.Preconditions.UID != nil {
+						current := &corev1.Secret{}
+						Expect(c.Get(ctx, client.ObjectKeyFromObject(replacement), current)).Should(Succeed())
+						if current.UID != *deleteOptions.Preconditions.UID {
+							return apierrors.NewConflict(corev1.Resource("secrets"), current.Name,
+								fmt.Errorf("UID precondition does not match"))
+						}
+					}
+					return c.Delete(ctx, obj, opts...)
+				},
+			})
+			reconciler := &VolumePopulatorReconciler{Client: interceptedClient, Scheme: scheme}
+
+			err := reconciler.upsertSystemAccountSecret(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc,
+				systemAccountSecretScopeComponent, "cluster", "mysql", "root", []byte("new-password"), nil)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsConflict(err)).To(BeTrue(), "expected a UID-precondition conflict, got %v", err)
+			current := &corev1.Secret{}
+			Expect(baseClient.Get(context.Background(), client.ObjectKeyFromObject(oldSecret), current)).Should(Succeed())
+			Expect(current.UID).To(Equal(replacementUID))
+			Expect(current.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("replacement-password")))
 		})
 
 		It("removes the cluster finalizer before replacing immutable sharding account secrets", func() {

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -376,10 +376,14 @@ var _ = Describe("Volume Populator Controller test", func() {
 			Expect(intctrlutil.IsRequeueError(err)).To(BeTrue(), err.Error())
 
 			patched := &corev1.Secret{}
-			Expect(reconciler.Client.Get(context.Background(), client.ObjectKey{
+			err = reconciler.Client.Get(context.Background(), client.ObjectKey{
 				Namespace: "default",
 				Name:      secret.Name,
-			}, patched)).Should(Succeed())
+			}, patched)
+			if apierrors.IsNotFound(err) {
+				return
+			}
+			Expect(err).Should(Succeed())
 			Expect(patched.Finalizers).To(BeEmpty())
 			Expect(patched.DeletionTimestamp).NotTo(BeNil())
 		})

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -188,7 +188,7 @@ var _ = Describe("Volume Populator Controller test", func() {
 	})
 
 	Context("system account secret helpers", func() {
-		It("patches existing mutable secrets and recreates changed immutable secrets", func() {
+		It("patches existing mutable secrets and waits before recreating changed immutable secrets", func() {
 			scheme := runtime.NewScheme()
 			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
 			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
@@ -248,6 +248,15 @@ var _ = Describe("Volume Populator Controller test", func() {
 			Expect(patched.OwnerReferences).To(HaveLen(1))
 			Expect(patched.OwnerReferences[0].Kind).To(Equal("Component"))
 
+			err := reconciler.upsertSystemAccountSecret(reqCtx, pvc, systemAccountSecretScopeComponent,
+				"cluster", "mysql", "root", []byte("new-root-password"), map[string]string{"role": "root"})
+			Expect(err).To(HaveOccurred())
+			Expect(intctrlutil.IsRequeueError(err)).To(BeTrue(), err.Error())
+			Expect(reconciler.Client.Get(context.Background(), client.ObjectKey{
+				Namespace: "default",
+				Name:      immutableSecret.Name,
+			}, &corev1.Secret{})).To(MatchError(ContainSubstring("not found")))
+
 			Expect(reconciler.upsertSystemAccountSecret(reqCtx, pvc, systemAccountSecretScopeComponent,
 				"cluster", "mysql", "root", []byte("new-root-password"), map[string]string{"role": "root"})).Should(Succeed())
 			recreated := &corev1.Secret{}
@@ -260,6 +269,119 @@ var _ = Describe("Volume Populator Controller test", func() {
 			Expect(recreated.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("new-root-password")))
 			Expect(systemAccountSecretMatches(recreated, "root", []byte("new-root-password"))).To(BeTrue())
 			Expect(systemAccountSecretMatches(recreated, "root", []byte("old-password"))).To(BeFalse())
+		})
+
+		It("removes the cluster finalizer before replacing immutable sharding account secrets", func() {
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
+			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
+
+			cluster := &kbappsv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "cluster",
+					UID:       types.UID("cluster-uid"),
+				},
+			}
+			immutable := true
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:  "default",
+					Name:       "cluster-shard-root",
+					Finalizers: []string{constant.DBClusterFinalizerName},
+				},
+				Immutable: &immutable,
+				Data: map[string][]byte{
+					constant.AccountNameForSecret:   []byte("root"),
+					constant.AccountPasswdForSecret: []byte("old-password"),
+				},
+			}
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "data-target-0",
+				},
+			}
+			reconciler := &VolumePopulatorReconciler{
+				Client: fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(cluster, secret).
+					Build(),
+				Scheme: scheme,
+			}
+			reqCtx := intctrlutil.RequestCtx{Ctx: context.Background()}
+
+			err := reconciler.upsertSystemAccountSecret(reqCtx, pvc, systemAccountSecretScopeSharding,
+				"cluster", "shard", "root", []byte("new-password"),
+				map[string]string{constant.KBAppShardingNameLabelKey: "shard"})
+			Expect(err).To(HaveOccurred())
+			Expect(intctrlutil.IsRequeueError(err)).To(BeTrue(), err.Error())
+			Expect(reconciler.Client.Get(context.Background(), client.ObjectKey{
+				Namespace: "default",
+				Name:      secret.Name,
+			}, &corev1.Secret{})).To(MatchError(ContainSubstring("not found")))
+
+			Expect(reconciler.upsertSystemAccountSecret(reqCtx, pvc, systemAccountSecretScopeSharding,
+				"cluster", "shard", "root", []byte("new-password"),
+				map[string]string{constant.KBAppShardingNameLabelKey: "shard"})).Should(Succeed())
+			recreated := &corev1.Secret{}
+			Expect(reconciler.Client.Get(context.Background(), client.ObjectKey{
+				Namespace: "default",
+				Name:      secret.Name,
+			}, recreated)).Should(Succeed())
+			Expect(recreated.Finalizers).To(BeEmpty())
+			Expect(recreated.OwnerReferences).To(HaveLen(1))
+			Expect(recreated.OwnerReferences[0].Kind).To(Equal("Cluster"))
+			Expect(recreated.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("new-password")))
+		})
+
+		It("removes the cluster finalizer from deletion-stamped immutable sharding account secrets", func() {
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
+			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
+
+			deletionTime := metav1.Now()
+			immutable := true
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:         "default",
+					Name:              "cluster-shard-root",
+					DeletionTimestamp: &deletionTime,
+					Finalizers:        []string{constant.DBClusterFinalizerName},
+				},
+				Immutable: &immutable,
+				Data: map[string][]byte{
+					constant.AccountNameForSecret:   []byte("root"),
+					constant.AccountPasswdForSecret: []byte("old-password"),
+				},
+			}
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "data-target-0",
+				},
+			}
+			reconciler := &VolumePopulatorReconciler{
+				Client: fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(secret).
+					Build(),
+				Scheme: scheme,
+			}
+
+			err := reconciler.upsertSystemAccountSecret(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc,
+				systemAccountSecretScopeSharding, "cluster", "shard", "root", []byte("new-password"),
+				map[string]string{constant.KBAppShardingNameLabelKey: "shard"})
+			Expect(err).To(HaveOccurred())
+			Expect(intctrlutil.IsRequeueError(err)).To(BeTrue(), err.Error())
+
+			patched := &corev1.Secret{}
+			Expect(reconciler.Client.Get(context.Background(), client.ObjectKey{
+				Namespace: "default",
+				Name:      secret.Name,
+			}, patched)).Should(Succeed())
+			Expect(patched.Finalizers).To(BeEmpty())
+			Expect(patched.DeletionTimestamp).NotTo(BeNil())
 		})
 
 		It("validates PVC names against instance volume templates", func() {

--- a/pkg/constant/annotations.go
+++ b/pkg/constant/annotations.go
@@ -46,6 +46,14 @@ const (
 
 	// SystemAccountProvisionedAnnotationKey marks a system account secret whose account has already been prepared externally.
 	SystemAccountProvisionedAnnotationKey = "apps.kubeblocks.io/system-account-provisioned"
+	// SystemAccountRestoreTargetAnnotationKey names the system account Secret
+	// that an Apps-owned temporary request must converge. DataProtection writes
+	// the request; the Component or Cluster owner is the only controller allowed
+	// to mutate/delete/recreate the target or release its finalizer.
+	SystemAccountRestoreTargetAnnotationKey = "apps.kubeblocks.io/system-account-restore-target"
+	// SystemAccountRestoreRevisionAnnotationKey is the content-addressed
+	// revision that Apps copies from a restore request to the converged target.
+	SystemAccountRestoreRevisionAnnotationKey = "apps.kubeblocks.io/system-account-restore-revision"
 
 	// SkipPreTerminateAnnotationKey specifies to skip the pre-terminate action for a component.
 	SkipPreTerminateAnnotationKey = "apps.kubeblocks.io/skip-pre-terminate"

--- a/pkg/constant/labels.go
+++ b/pkg/constant/labels.go
@@ -48,6 +48,9 @@ const (
 	KBAppInstanceTemplateLabelKey   = "apps.kubeblocks.io/instance-template"
 	KBAppPodNameLabelKey            = "apps.kubeblocks.io/pod-name"
 	VolumeClaimTemplateNameLabelKey = "apps.kubeblocks.io/vct-name"
+	// SystemAccountRestoreRequestLabelKey selects temporary credential
+	// requests that must be reconciled by their Apps controller owner.
+	SystemAccountRestoreRequestLabelKey = "apps.kubeblocks.io/system-account-restore-request"
 
 	KBAppServiceVersionKey = "apps.kubeblocks.io/service-version"
 	KBAppReleasePhaseKey   = "apps.kubeblocks.io/release-phase" // TODO: release or service phase?

--- a/pkg/controller/systemaccount/restore.go
+++ b/pkg/controller/systemaccount/restore.go
@@ -1,0 +1,383 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package systemaccount
+
+import (
+	"cmp"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"reflect"
+	"slices"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/graph"
+	"github.com/apecloud/kubeblocks/pkg/controller/model"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+)
+
+const restoreRequestNamePrefix = "system-account-restore-"
+
+const restoreRequestRequeueAfter = time.Second
+
+type restoreRequestControllerIdentity struct {
+	APIVersion string    `json:"apiVersion"`
+	Kind       string    `json:"kind"`
+	Name       string    `json:"name"`
+	UID        types.UID `json:"uid"`
+}
+
+type restoreRequestRevisionPayload struct {
+	Namespace  string                           `json:"namespace"`
+	TargetName string                           `json:"targetName"`
+	Type       corev1.SecretType                `json:"type"`
+	Immutable  *bool                            `json:"immutable,omitempty"`
+	Data       map[string][]byte                `json:"data"`
+	Controller restoreRequestControllerIdentity `json:"controller"`
+}
+
+// RestoreRequestName returns the stable name of the replacement request for a
+// system account Secret. There is exactly one active request per target name.
+func RestoreRequestName(namespace, targetName string) string {
+	digest := sha256.Sum256([]byte(namespace + "/" + targetName))
+	return restoreRequestNamePrefix + hex.EncodeToString(digest[:8])
+}
+
+// SetRestoreRevision seals the request payload with a content-addressed
+// revision. Apps copies this revision to the target as the durable completion
+// marker observed by DataProtection. Labels and non-protocol annotations are
+// intentionally outside the seal so admission-added metadata remains valid.
+func SetRestoreRevision(request *corev1.Secret) error {
+	revision, err := restoreRevision(request)
+	if err != nil {
+		return err
+	}
+	if request.Annotations == nil {
+		request.Annotations = map[string]string{}
+	}
+	request.Annotations[constant.SystemAccountRestoreRevisionAnnotationKey] = revision
+	return nil
+}
+
+// ValidateRestoreRequest verifies the public metadata contract and the sealed
+// payload before Apps acts on a request.
+func ValidateRestoreRequest(request *corev1.Secret) error {
+	targetName := request.Annotations[constant.SystemAccountRestoreTargetAnnotationKey]
+	if targetName == "" {
+		return fmt.Errorf("system account restore request %s/%s has no target", request.Namespace, request.Name)
+	}
+	if request.Name != RestoreRequestName(request.Namespace, targetName) {
+		return fmt.Errorf("system account restore request %s/%s has a non-canonical name", request.Namespace, request.Name)
+	}
+	if request.Labels[constant.SystemAccountRestoreRequestLabelKey] != "true" {
+		return fmt.Errorf("system account restore request %s/%s has no request label", request.Namespace, request.Name)
+	}
+	if request.Annotations[constant.SystemAccountProvisionedAnnotationKey] != "true" {
+		return fmt.Errorf("system account restore request %s/%s is not marked provisioned", request.Namespace, request.Name)
+	}
+	if _, ok := request.Data[constant.AccountNameForSecret]; !ok {
+		return fmt.Errorf("system account restore request %s/%s has no account name", request.Namespace, request.Name)
+	}
+	if _, ok := request.Data[constant.AccountPasswdForSecret]; !ok {
+		return fmt.Errorf("system account restore request %s/%s has no account password", request.Namespace, request.Name)
+	}
+	expected, err := restoreRevision(request)
+	if err != nil {
+		return err
+	}
+	if actual := request.Annotations[constant.SystemAccountRestoreRevisionAnnotationKey]; actual != expected {
+		return fmt.Errorf("system account restore request %s/%s has an invalid revision", request.Namespace, request.Name)
+	}
+	return nil
+}
+
+// RestoreConverged reports whether Apps has committed this exact request to
+// the target. The persisted revision prevents an old request from being
+// mistaken for the current restore after a same-name replacement race.
+func RestoreConverged(target, request *corev1.Secret, ownedFinalizer string) bool {
+	if target == nil || request == nil || !target.DeletionTimestamp.IsZero() {
+		return false
+	}
+	if target.Namespace != request.Namespace ||
+		target.Name != request.Annotations[constant.SystemAccountRestoreTargetAnnotationKey] ||
+		target.Type != request.Type ||
+		!reflect.DeepEqual(target.Immutable, request.Immutable) ||
+		!reflect.DeepEqual(target.Data, request.Data) ||
+		!sameControllerIdentity(metav1.GetControllerOf(target), metav1.GetControllerOf(request)) ||
+		!controllerutil.ContainsFinalizer(target, ownedFinalizer) {
+		return false
+	}
+	if target.Labels[constant.SystemAccountRestoreRequestLabelKey] != "" ||
+		target.Annotations[constant.SystemAccountRestoreTargetAnnotationKey] != "" {
+		return false
+	}
+	for key, value := range requestTargetLabels(request) {
+		if target.Labels[key] != value {
+			return false
+		}
+	}
+	for key, value := range requestTargetAnnotations(request) {
+		if target.Annotations[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func restoreRevision(request *corev1.Secret) (string, error) {
+	targetName := request.Annotations[constant.SystemAccountRestoreTargetAnnotationKey]
+	if targetName == "" {
+		return "", fmt.Errorf("system account restore request %s/%s has no target", request.Namespace, request.Name)
+	}
+	controller := metav1.GetControllerOf(request)
+	if controller == nil {
+		return "", fmt.Errorf("system account restore request %s/%s has no controller owner", request.Namespace, request.Name)
+	}
+	payload := restoreRequestRevisionPayload{
+		Namespace:  request.Namespace,
+		TargetName: targetName,
+		Type:       request.Type,
+		Immutable:  request.Immutable,
+		Data:       request.Data,
+		Controller: restoreRequestControllerIdentity{
+			APIVersion: controller.APIVersion,
+			Kind:       controller.Kind,
+			Name:       controller.Name,
+			UID:        controller.UID,
+		},
+	}
+	serialized, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("serialize system account restore request %s/%s: %w", request.Namespace, request.Name, err)
+	}
+	digest := sha256.Sum256(serialized)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+// ReconcileRestoreRequests lets the Apps owner converge account Secret restore
+// requests. The caller owns all target mutations, finalizer handling, and
+// delete/recreate operations; the request writer never performs them.
+//
+// A request is a Secret selected by SystemAccountRestoreRequestLabelKey,
+// controlled by the target Component or Cluster, and sealed by
+// SystemAccountRestoreRevisionAnnotationKey. Apps keeps the request until it
+// has copied that revision and the requested credentials to an owned target.
+// This makes the target revision the commit point and the request the durable
+// retry state across delete/create races.
+func ReconcileRestoreRequests(ctx context.Context,
+	graphCli model.GraphClient,
+	dag *graph.DAG,
+	owner client.Object,
+	ownedFinalizer string) (bool, error) {
+	requests := &corev1.SecretList{}
+	if err := graphCli.List(ctx, requests,
+		client.InNamespace(owner.GetNamespace()),
+		client.MatchingLabels{constant.SystemAccountRestoreRequestLabelKey: "true"}); err != nil {
+		return false, err
+	}
+	slices.SortFunc(requests.Items, func(a, b corev1.Secret) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+	handled := false
+	seenTargets := map[string]string{}
+	for i := range requests.Items {
+		request := &requests.Items[i]
+		targetName := request.Annotations[constant.SystemAccountRestoreTargetAnnotationKey]
+		if !metav1.IsControlledBy(request, owner) {
+			continue
+		}
+		handled = true
+		if err := ValidateRestoreRequest(request); err != nil {
+			return true, err
+		}
+		if previous, ok := seenTargets[targetName]; ok {
+			return true, fmt.Errorf("multiple system account restore requests %s and %s target %s/%s",
+				previous, request.Name, request.Namespace, targetName)
+		}
+		seenTargets[targetName] = request.Name
+		if err := reconcileRestoreRequest(ctx, graphCli, dag, owner, ownedFinalizer, request, targetName); err != nil {
+			return true, err
+		}
+	}
+	if handled {
+		return true, intctrlutil.NewRequeueError(restoreRequestRequeueAfter,
+			fmt.Sprintf("waiting for system account restore requests owned by %s/%s", owner.GetNamespace(), owner.GetName()))
+	}
+	return handled, nil
+}
+
+func reconcileRestoreRequest(ctx context.Context,
+	graphCli model.GraphClient,
+	dag *graph.DAG,
+	owner client.Object,
+	ownedFinalizer string,
+	request *corev1.Secret,
+	targetName string) error {
+	if !request.DeletionTimestamp.IsZero() {
+		return nil
+	}
+
+	target := &corev1.Secret{}
+	key := client.ObjectKey{Namespace: request.Namespace, Name: targetName}
+	if err := graphCli.Get(ctx, key, target); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		desired, err := desiredTarget(request, owner, ownedFinalizer)
+		if err != nil {
+			return err
+		}
+		graphCli.Create(dag, desired)
+		return nil
+	}
+
+	expectedOwner := metav1.GetControllerOf(request)
+	if expectedOwner == nil {
+		return fmt.Errorf("system account restore request %s/%s has no controller owner", request.Namespace, request.Name)
+	}
+	if !hasOwnerReference(target, expectedOwner) {
+		if len(target.OwnerReferences) > 0 || !target.DeletionTimestamp.IsZero() {
+			return fmt.Errorf("system account restore target %s is not owned by %s %s",
+				key, expectedOwner.Kind, expectedOwner.Name)
+		}
+		adopted := target.DeepCopy()
+		if err := intctrlutil.SetOwnership(owner, adopted, model.GetScheme(), ownedFinalizer); err != nil {
+			return err
+		}
+		graphCli.Update(dag, target, adopted)
+		return nil
+	}
+
+	if !target.DeletionTimestamp.IsZero() {
+		if controllerutil.ContainsFinalizer(target, ownedFinalizer) {
+			updated := target.DeepCopy()
+			controllerutil.RemoveFinalizer(updated, ownedFinalizer)
+			graphCli.Update(dag, target, updated)
+		}
+		return nil
+	}
+
+	desired := target.DeepCopy()
+	desired.Type = request.Type
+	desired.Immutable = request.Immutable
+	desired.Data = maps.Clone(request.Data)
+	mergeStringMap(requestTargetLabels(request), &desired.Labels)
+	delete(desired.Labels, constant.SystemAccountRestoreRequestLabelKey)
+	mergeStringMap(requestTargetAnnotations(request), &desired.Annotations)
+	delete(desired.Annotations, constant.SystemAccountRestoreTargetAnnotationKey)
+	if err := intctrlutil.SetOwnership(owner, desired, model.GetScheme(), ownedFinalizer); err != nil {
+		return err
+	}
+	if reflect.DeepEqual(target, desired) {
+		if controllerutil.ContainsFinalizer(request, ownedFinalizer) {
+			updated := request.DeepCopy()
+			controllerutil.RemoveFinalizer(updated, ownedFinalizer)
+			graphCli.Update(dag, request, updated)
+		} else {
+			graphCli.Delete(dag, request)
+		}
+		return nil
+	}
+	if target.Immutable != nil && *target.Immutable &&
+		(!reflect.DeepEqual(target.Data, desired.Data) ||
+			!reflect.DeepEqual(target.Immutable, desired.Immutable) ||
+			target.Type != desired.Type) {
+		graphCli.Delete(dag, target)
+		return nil
+	}
+	graphCli.Update(dag, target, desired)
+	return nil
+}
+
+func desiredTarget(request *corev1.Secret, owner client.Object, ownedFinalizer string) (*corev1.Secret, error) {
+	targetName := request.Annotations[constant.SystemAccountRestoreTargetAnnotationKey]
+	if targetName == "" {
+		return nil, fmt.Errorf("system account restore request %s/%s has no target", request.Namespace, request.Name)
+	}
+	annotations := maps.Clone(request.Annotations)
+	delete(annotations, constant.SystemAccountRestoreTargetAnnotationKey)
+	target := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   request.Namespace,
+			Name:        targetName,
+			Labels:      requestTargetLabels(request),
+			Annotations: annotations,
+		},
+		Immutable: request.Immutable,
+		Type:      request.Type,
+		Data:      maps.Clone(request.Data),
+	}
+	if err := intctrlutil.SetOwnership(owner, target, model.GetScheme(), ownedFinalizer); err != nil {
+		return nil, err
+	}
+	return target, nil
+}
+
+func requestTargetLabels(request *corev1.Secret) map[string]string {
+	labels := maps.Clone(request.Labels)
+	delete(labels, constant.SystemAccountRestoreRequestLabelKey)
+	return labels
+}
+
+func requestTargetAnnotations(request *corev1.Secret) map[string]string {
+	annotations := maps.Clone(request.Annotations)
+	delete(annotations, constant.SystemAccountRestoreTargetAnnotationKey)
+	return annotations
+}
+
+func sameControllerIdentity(a, b *metav1.OwnerReference) bool {
+	return a != nil && b != nil &&
+		a.APIVersion == b.APIVersion &&
+		a.Kind == b.Kind &&
+		a.Name == b.Name &&
+		a.UID == b.UID
+}
+
+func hasOwnerReference(object client.Object, expected *metav1.OwnerReference) bool {
+	return expected != nil && slices.ContainsFunc(object.GetOwnerReferences(), func(actual metav1.OwnerReference) bool {
+		return actual.APIVersion == expected.APIVersion &&
+			actual.Kind == expected.Kind &&
+			actual.Name == expected.Name &&
+			actual.UID == expected.UID
+	})
+}
+
+func mergeStringMap(from map[string]string, to *map[string]string) {
+	if len(from) == 0 {
+		return
+	}
+	if *to == nil {
+		*to = map[string]string{}
+	}
+	for key, value := range from {
+		(*to)[key] = value
+	}
+}

--- a/pkg/controller/systemaccount/restore_test.go
+++ b/pkg/controller/systemaccount/restore_test.go
@@ -1,0 +1,347 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package systemaccount
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/graph"
+	"github.com/apecloud/kubeblocks/pkg/controller/model"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+)
+
+func TestReconcileRestoreRequestsKeepsFinalizerOwnership(t *testing.T) {
+	registerModelScheme(t)
+	testCases := []struct {
+		name      string
+		owner     client.Object
+		finalizer string
+	}{
+		{
+			name: "Component owner",
+			owner: &appsv1.Component{
+				TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Component"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster-mysql", UID: types.UID("component-uid")},
+			},
+			finalizer: constant.DBComponentFinalizerName,
+		},
+		{
+			name: "Cluster owner",
+			owner: &appsv1.Cluster{
+				TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Cluster"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster", UID: types.UID("cluster-uid")},
+			},
+			finalizer: constant.DBClusterFinalizerName,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, corev1.AddToScheme(scheme))
+			require.NoError(t, appsv1.AddToScheme(scheme))
+			deletionTime := metav1.Now()
+			target := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:         "default",
+					Name:              "cluster-mysql-root",
+					DeletionTimestamp: &deletionTime,
+					Finalizers:        []string{testCase.finalizer, "another.example.io/finalizer"},
+				},
+				Immutable: boolPtr(true),
+				Data: map[string][]byte{
+					constant.AccountNameForSecret:   []byte("root"),
+					constant.AccountPasswdForSecret: []byte("old-password"),
+				},
+			}
+			request := newTestRestoreRequest(target.Name)
+			require.NoError(t, controllerutil.SetControllerReference(testCase.owner, target, scheme))
+			require.NoError(t, controllerutil.SetControllerReference(testCase.owner, request, scheme))
+			require.NoError(t, SetRestoreRevision(request))
+			graphCli := model.NewGraphClient(fake.NewClientBuilder().WithScheme(scheme).WithObjects(target, request).Build())
+			dag := graph.NewDAG()
+			graphCli.Root(dag, testCase.owner.DeepCopyObject().(client.Object), testCase.owner, model.ActionStatusPtr())
+
+			handled, err := ReconcileRestoreRequests(context.Background(), graphCli, dag, testCase.owner, testCase.finalizer)
+
+			require.True(t, intctrlutil.IsRequeueError(err), err)
+			require.True(t, handled)
+			require.True(t, graphCli.IsAction(dag, target, model.ActionUpdatePtr()))
+			vertex := graphCli.FindMatchedVertex(dag, target).(*model.ObjectVertex)
+			updated := vertex.Obj.(*corev1.Secret)
+			require.NotContains(t, updated.Finalizers, testCase.finalizer)
+			require.Contains(t, updated.Finalizers, "another.example.io/finalizer")
+		})
+	}
+}
+
+func TestReconcileRestoreRequestsCreatesTargetBeforeDeletingRequest(t *testing.T) {
+	registerModelScheme(t)
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	owner := &appsv1.Component{
+		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Component"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster-mysql", UID: types.UID("component-uid")},
+	}
+	request := newTestRestoreRequest("cluster-mysql-root")
+	require.NoError(t, controllerutil.SetControllerReference(owner, request, scheme))
+	require.NoError(t, SetRestoreRevision(request))
+	graphCli := model.NewGraphClient(fake.NewClientBuilder().WithScheme(scheme).WithObjects(request).Build())
+	dag := graph.NewDAG()
+	graphCli.Root(dag, owner.DeepCopy(), owner, model.ActionStatusPtr())
+
+	handled, err := ReconcileRestoreRequests(context.Background(), graphCli, dag, owner, constant.DBComponentFinalizerName)
+
+	require.True(t, intctrlutil.IsRequeueError(err), err)
+	require.True(t, handled)
+	objects := graphCli.FindAll(dag, &corev1.Secret{})
+	require.Len(t, objects, 1)
+	target := objects[0].(*corev1.Secret)
+	require.Equal(t, "cluster-mysql-root", target.Name)
+	require.True(t, graphCli.IsAction(dag, target, model.ActionCreatePtr()))
+	require.Contains(t, target.Finalizers, constant.DBComponentFinalizerName)
+	require.Equal(t, []byte("new-password"), target.Data[constant.AccountPasswdForSecret])
+	require.NotContains(t, target.Annotations, constant.SystemAccountRestoreTargetAnnotationKey)
+	require.NotContains(t, target.Labels, constant.SystemAccountRestoreRequestLabelKey)
+	require.Equal(t, request.Annotations[constant.SystemAccountRestoreRevisionAnnotationKey],
+		target.Annotations[constant.SystemAccountRestoreRevisionAnnotationKey])
+	require.False(t, graphCli.IsAction(dag, request, model.ActionDeletePtr()), "request must survive the target-create commit")
+}
+
+func TestReconcileRestoreRequestsDeletesImmutableTargetWithoutReleasingFinalizer(t *testing.T) {
+	registerModelScheme(t)
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	owner := &appsv1.Component{
+		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Component"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster-mysql", UID: types.UID("component-uid")},
+	}
+	request := newTestRestoreRequest("cluster-mysql-root")
+	request.Immutable = nil
+	target := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  "default",
+			Name:       "cluster-mysql-root",
+			Finalizers: []string{constant.DBComponentFinalizerName},
+		},
+		Immutable: boolPtr(true),
+		Type:      corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			constant.AccountNameForSecret:   []byte("root"),
+			constant.AccountPasswdForSecret: []byte("old-password"),
+		},
+	}
+	require.NoError(t, controllerutil.SetControllerReference(owner, request, scheme))
+	require.NoError(t, controllerutil.SetOwnerReference(owner, target, scheme))
+	require.NoError(t, SetRestoreRevision(request))
+	graphCli := model.NewGraphClient(fake.NewClientBuilder().WithScheme(scheme).WithObjects(target, request).Build())
+	dag := graph.NewDAG()
+	graphCli.Root(dag, owner.DeepCopy(), owner, model.ActionStatusPtr())
+
+	handled, err := ReconcileRestoreRequests(context.Background(), graphCli, dag, owner, constant.DBComponentFinalizerName)
+
+	require.True(t, intctrlutil.IsRequeueError(err), err)
+	require.True(t, handled)
+	require.True(t, graphCli.IsAction(dag, target, model.ActionDeletePtr()))
+	require.Contains(t, target.Finalizers, constant.DBComponentFinalizerName,
+		"the owner releases its finalizer only after deletion is observed")
+	require.False(t, graphCli.IsAction(dag, request, model.ActionDeletePtr()))
+}
+
+func TestReconcileRestoreRequestsAdoptsTargetBeforeMutatingIt(t *testing.T) {
+	registerModelScheme(t)
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	owner := &appsv1.Component{
+		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Component"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster-mysql", UID: types.UID("component-uid")},
+	}
+	request := newTestRestoreRequest("cluster-mysql-root")
+	request.Immutable = nil
+	target := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster-mysql-root"},
+		Type:       corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			constant.AccountNameForSecret:   []byte("root"),
+			constant.AccountPasswdForSecret: []byte("old-password"),
+		},
+	}
+	require.NoError(t, controllerutil.SetControllerReference(owner, request, scheme))
+	require.NoError(t, SetRestoreRevision(request))
+	graphCli := model.NewGraphClient(fake.NewClientBuilder().WithScheme(scheme).WithObjects(target, request).Build())
+	dag := graph.NewDAG()
+	graphCli.Root(dag, owner.DeepCopy(), owner, model.ActionStatusPtr())
+
+	handled, err := ReconcileRestoreRequests(context.Background(), graphCli, dag, owner, constant.DBComponentFinalizerName)
+
+	require.True(t, intctrlutil.IsRequeueError(err), err)
+	require.True(t, handled)
+	require.True(t, graphCli.IsAction(dag, target, model.ActionUpdatePtr()))
+	updated := graphCli.FindMatchedVertex(dag, target).(*model.ObjectVertex).Obj.(*corev1.Secret)
+	require.Equal(t, []byte("old-password"), updated.Data[constant.AccountPasswdForSecret],
+		"the ownership commit must precede the credential mutation")
+	require.True(t, metav1.IsControlledBy(updated, owner))
+	require.Contains(t, updated.Finalizers, constant.DBComponentFinalizerName)
+}
+
+func TestReconcileRestoreRequestsDoesNotReleaseAnotherOwnersFinalizer(t *testing.T) {
+	registerModelScheme(t)
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	owner := &appsv1.Component{
+		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Component"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster-mysql", UID: types.UID("component-uid")},
+	}
+	otherOwner := &appsv1.Component{
+		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Component"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "other-mysql", UID: types.UID("other-component-uid")},
+	}
+	request := newTestRestoreRequest("cluster-mysql-root")
+	deletionTime := metav1.Now()
+	target := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Namespace:         "default",
+		Name:              "cluster-mysql-root",
+		DeletionTimestamp: &deletionTime,
+		Finalizers:        []string{constant.DBComponentFinalizerName},
+	}}
+	require.NoError(t, controllerutil.SetControllerReference(owner, request, scheme))
+	require.NoError(t, controllerutil.SetControllerReference(otherOwner, target, scheme))
+	require.NoError(t, SetRestoreRevision(request))
+	graphCli := model.NewGraphClient(fake.NewClientBuilder().WithScheme(scheme).WithObjects(target, request).Build())
+	dag := graph.NewDAG()
+	graphCli.Root(dag, owner.DeepCopy(), owner, model.ActionStatusPtr())
+
+	handled, err := ReconcileRestoreRequests(context.Background(), graphCli, dag, owner, constant.DBComponentFinalizerName)
+
+	require.ErrorContains(t, err, "is not owned")
+	require.True(t, handled)
+	require.False(t, graphCli.IsAction(dag, target, model.ActionUpdatePtr()))
+	require.Contains(t, target.Finalizers, constant.DBComponentFinalizerName)
+}
+
+func TestReconcileRestoreRequestsDeletesRequestOnlyAfterTargetConverges(t *testing.T) {
+	registerModelScheme(t)
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	owner := &appsv1.Cluster{
+		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Cluster"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster", UID: types.UID("cluster-uid")},
+	}
+	request := newTestRestoreRequest("cluster-shard-root")
+	target := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   "default",
+			Name:        "cluster-shard-root",
+			Labels:      map[string]string{"role": "root"},
+			Annotations: map[string]string{constant.SystemAccountProvisionedAnnotationKey: "true"},
+			Finalizers:  []string{constant.DBClusterFinalizerName},
+		},
+		Immutable: boolPtr(true),
+		Type:      corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			constant.AccountNameForSecret:   []byte("root"),
+			constant.AccountPasswdForSecret: []byte("new-password"),
+		},
+	}
+	require.NoError(t, controllerutil.SetControllerReference(owner, request, scheme))
+	require.NoError(t, controllerutil.SetControllerReference(owner, target, scheme))
+	require.NoError(t, SetRestoreRevision(request))
+	target.Annotations[constant.SystemAccountRestoreRevisionAnnotationKey] =
+		request.Annotations[constant.SystemAccountRestoreRevisionAnnotationKey]
+	graphCli := model.NewGraphClient(fake.NewClientBuilder().WithScheme(scheme).WithObjects(target, request).Build())
+	dag := graph.NewDAG()
+	graphCli.Root(dag, owner.DeepCopy(), owner, model.ActionStatusPtr())
+
+	handled, err := ReconcileRestoreRequests(context.Background(), graphCli, dag, owner, constant.DBClusterFinalizerName)
+
+	require.True(t, intctrlutil.IsRequeueError(err), err)
+	require.True(t, handled)
+	require.True(t, graphCli.IsAction(dag, request, model.ActionDeletePtr()))
+	require.False(t, graphCli.IsAction(dag, target, model.ActionUpdatePtr()))
+}
+
+func TestValidateRestoreRequestRejectsTamperedPayload(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	owner := &appsv1.Component{
+		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Component"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster-mysql", UID: types.UID("component-uid")},
+	}
+	request := newTestRestoreRequest("cluster-mysql-root")
+	require.NoError(t, controllerutil.SetControllerReference(owner, request, scheme))
+	require.NoError(t, SetRestoreRevision(request))
+	request.Labels["admission.example.io/injected"] = "true"
+	request.Annotations["admission.example.io/injected"] = "true"
+	require.NoError(t, ValidateRestoreRequest(request), "admission metadata is outside the sealed credential payload")
+	request.Data[constant.AccountPasswdForSecret] = []byte("tampered-password")
+
+	require.ErrorContains(t, ValidateRestoreRequest(request), "invalid revision")
+}
+
+func newTestRestoreRequest(targetName string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      RestoreRequestName("default", targetName),
+			Labels: map[string]string{
+				"role": "root",
+				constant.SystemAccountRestoreRequestLabelKey: "true",
+			},
+			Annotations: map[string]string{
+				constant.SystemAccountRestoreTargetAnnotationKey: targetName,
+				constant.SystemAccountProvisionedAnnotationKey:   "true",
+			},
+		},
+		Immutable: boolPtr(true),
+		Type:      corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			constant.AccountNameForSecret:   []byte("root"),
+			constant.AccountPasswdForSecret: []byte("new-password"),
+		},
+	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}
+
+func registerModelScheme(t *testing.T) {
+	t.Helper()
+	require.NoError(t, corev1.AddToScheme(model.GetScheme()))
+	require.NoError(t, appsv1.AddToScheme(model.GetScheme()))
+}


### PR DESCRIPTION
Fixes #10574.

## What changed
- DataProtection no longer creates, patches, deletes, or releases finalizers on system-account target Secrets. It writes a deterministic credential request Secret controlled by the target `Component` or `Cluster`.
- Added an explicit Apps/DataProtection metadata contract: a request label, target annotation, and content-addressed restore revision. Apps copies the revision to the target as the durable completion marker.
- Component and Cluster account transformers now own target adoption, metadata/data updates, immutable delete/recreate, and their respective finalizer removal. They preserve unrelated finalizers and commit the target before deleting the request.
- DataProtection accepts only the exact Apps-committed revision. Older valid requests are serialized instead of overwritten, and target/request API failures plus create races return typed requeues through the complete PVC reconciler.

## Why
The previous implementation removed an Apps-owned finalizer from DataProtection and knew only the Cluster finalizer. Component-owned Secrets could therefore remain Terminating forever, while same-name UID/create races could be swallowed by the outer PVC error handler after preserving a replacement Secret.

The request Secret is both the ownership handoff and durable retry state. The target revision is the commit point, so DataProtection cannot mistake a stale same-name Secret for the credentials requested by the current restore.

## Ownership and convergence contract
1. DataProtection creates one canonical request per target, with the desired credential payload and a controller owner reference to the target Component or Cluster.
2. Apps validates the sealed request. An unowned target is adopted in a separate committed update before any credential mutation; a target owned by another object is rejected.
3. Apps updates mutable targets or deletes/recreates immutable targets. Only the matching Apps owner removes its own finalizer after deletion is observed; unrelated finalizers are preserved.
4. Apps writes the requested revision to the converged target before deleting the request.
5. DataProtection proceeds only after target data, metadata, owner, finalizer, and revision all match. Otherwise it explicitly requeues.

## Validation
- `make test-go-generate`
- `make manifests`
- `KUBEBUILDER_ASSETS='<envtest 1.26.1>' go test -p 2 ./pkg/controller/systemaccount ./controllers/apps/component ./controllers/apps/cluster ./controllers/dataprotection`
- `go test -race ./pkg/controller/systemaccount`
- `KUBEBUILDER_ASSETS='<envtest 1.26.1>' go test -race ./controllers/dataprotection -run 'TestAPIs|TestRestoreSystemAccountSecrets' -ginkgo.focus='system account secret helpers|restores system account secrets before volume population'`
- `go vet ./pkg/controller/systemaccount ./controllers/apps/component ./controllers/apps/cluster ./controllers/dataprotection`
- `git diff --check origin/main...HEAD`

## Boundary
- Local source and envtest validation are green on exact head `3b2f205016ea18e7a60de51530e3f1c9657be999`.
- Runtime addon validation is still N=0; this PR does not claim a live Valkey restore result.
