### PR TITLE
fix: surface reconfigure action failures

### DIFF
--- a/controllers/parameters/reconfigure/sync.go
+++ b/controllers/parameters/reconfigure/sync.go
@@ -28,16 +28,25 @@ import (
 	"sort"
 	"strconv"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/instanceset"
 	"github.com/apecloud/kubeblocks/pkg/parameters"
 	"github.com/apecloud/kubeblocks/pkg/parameters/core"
 )
 
 const configFilesUpdated = "KB_CONFIG_FILES_UPDATED"
+
+type actionFailureRecord struct {
+	ConfigHash string `json:"configHash,omitempty"`
+	Message    string `json:"message,omitempty"`
+}
 
 func init() {
 	registerPolicy(SyncDynamicReloadPolicy, syncPolicy)
@@ -322,8 +331,44 @@ func syncReconfigureStatus(ctx Context) Status {
 			}
 		}
 	}
+	if message, ok := getReconfigureActionFailure(ctx, configHash); ok {
+		return makeStatus(StatusFailedAndRetry, withReason(message), withExpected(replicas), withSucceed(updated))
+	}
 	if updated == replicas {
 		return makeStatus(StatusNone, withReason("reconfigure completed"), withExpected(replicas), withSucceed(updated))
 	}
 	return makeStatus(StatusRetry, withReason("reconfiguring"), withExpected(replicas), withSucceed(updated))
+}
+
+func getReconfigureActionFailure(ctx Context, configHash *string) (string, bool) {
+	if ctx.Client == nil || ctx.ITS == nil || configHash == nil || *configHash == "" {
+		return "", false
+	}
+	pods := &corev1.PodList{}
+	if err := ctx.Client.List(ctx.Ctx, pods,
+		client.InNamespace(ctx.ITS.Namespace),
+		client.MatchingLabels(instanceset.GetMatchLabels(ctx.ITS.Name))); err != nil {
+		ctx.Log.Error(err, "failed to list pods for reconfigure action failure")
+		return "", false
+	}
+	for i := range pods.Items {
+		failures := parseActionFailures(pods.Items[i].Annotations)
+		failure, ok := failures[ctx.ConfigTemplate.Name]
+		if !ok || failure.ConfigHash != *configHash {
+			continue
+		}
+		return fmt.Sprintf("reconfigure action failed on pod %s: %s", pods.Items[i].Name, failure.Message), true
+	}
+	return "", false
+}
+
+func parseActionFailures(annotations map[string]string) map[string]actionFailureRecord {
+	if len(annotations) == 0 || annotations[constant.ReconfigureActionFailureAnnotationKey] == "" {
+		return nil
+	}
+	failures := map[string]actionFailureRecord{}
+	if err := json.Unmarshal([]byte(annotations[constant.ReconfigureActionFailureAnnotationKey]), &failures); err != nil {
+		return nil
+	}
+	return failures
 }

--- a/controllers/parameters/reconfigure/sync_test.go
+++ b/controllers/parameters/reconfigure/sync_test.go
@@ -32,12 +32,16 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/instanceset"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	"github.com/apecloud/kubeblocks/pkg/parameters/core"
 )
@@ -199,6 +203,31 @@ var _ = ginkgo.Describe("syncPolicy test", func() {
 			Expect(status.Status).Should(BeEquivalentTo(StatusNone))
 			Expect(status.ExpectedCount).Should(BeEquivalentTo(3))
 			Expect(status.SucceedCount).Should(BeEquivalentTo(3))
+		})
+
+		ginkgo.It("status surfaces action failures without terminal failure", func() {
+			ginkgo.By("mock submitted cluster spec")
+			rctx.ClusterComponent.Configs[0].ConfigHash = rctx.getTargetConfigHash()
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: rctx.ITS.Namespace,
+					Name:      "pod-0",
+					Labels:    instanceset.GetMatchLabels(rctx.ITS.Name),
+					Annotations: map[string]string{
+						constant.ReconfigureActionFailureAnnotationKey: `{"` + cfgName + `":{"configHash":"test-config-hash","message":"mysql rejected unknown variable expire_logs_days"}}`,
+					},
+				},
+			}
+			rctx.Client = fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(pod).Build()
+
+			ginkgo.By("status check")
+			status, err := syncPolicy(rctx)
+			Expect(err).Should(Succeed())
+			Expect(status.Status).Should(Equal(StatusFailedAndRetry))
+			Expect(status.Reason).Should(ContainSubstring("pod-0"))
+			Expect(status.Reason).Should(ContainSubstring("expire_logs_days"))
+			Expect(status.ExpectedCount).Should(BeEquivalentTo(3))
+			Expect(status.SucceedCount).Should(BeEquivalentTo(0))
 		})
 	})
 

--- a/pkg/constant/config.go
+++ b/pkg/constant/config.go
@@ -40,6 +40,7 @@ const (
 	UpgradePolicyAnnotationKey                  = "config.kubeblocks.io/reconfigure-policy"
 	ConfigAppliedVersionAnnotationKey           = "config.kubeblocks.io/config-applied-version"
 	ParametersAppliedComponentGenerationKey     = "parameters.kubeblocks.io/latest-component-generation"
+	ReconfigureActionFailureAnnotationKey       = "config.kubeblocks.io/reconfigure-action-failure"
 )
 
 const (

--- a/pkg/controller/instanceset/reconciler_update.go
+++ b/pkg/controller/instanceset/reconciler_update.go
@@ -167,9 +167,13 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 		}
 
 		// Always call reconfigure to execute reconfigure actions
-		allUpdated, err1 := r.reconfigure(tree, its, pod)
+		allUpdated, reconfigureBlocked, err1 := r.reconfigure(tree, its, pod)
 		if err1 != nil {
 			return kubebuilderx.Continue, err1
+		}
+		if reconfigureBlocked {
+			needRetry = true
+			break
 		}
 		if !allUpdated && updatePolicy == noOpsPolicy {
 			updatingPods++
@@ -296,22 +300,26 @@ func (r *updateReconciler) switchover(tree *kubebuilderx.ObjectTree, its *worklo
 	return nil
 }
 
-func (r *updateReconciler) reconfigure(tree *kubebuilderx.ObjectTree, its *workloads.InstanceSet, pod *corev1.Pod) (bool, error) {
+func (r *updateReconciler) reconfigure(tree *kubebuilderx.ObjectTree, its *workloads.InstanceSet, pod *corev1.Pod) (bool, bool, error) {
 	toUpdate, err := configsToUpdate(its, pod)
 	if err != nil {
-		return false, err
+		return false, false, err
 	}
 	for _, config := range toUpdate {
-		if err = r.reconfigureInst(tree, its, pod, config); err != nil {
-			return false, err
+		blocked, err := r.reconfigureInst(tree, its, pod, config)
+		if err != nil {
+			return false, false, err
+		}
+		if blocked {
+			return false, true, nil
 		}
 	}
-	return len(toUpdate) == 0, nil
+	return len(toUpdate) == 0, false, nil
 }
 
-func (r *updateReconciler) reconfigureInst(tree *kubebuilderx.ObjectTree, its *workloads.InstanceSet, pod *corev1.Pod, config workloads.ConfigTemplate) error {
+func (r *updateReconciler) reconfigureInst(tree *kubebuilderx.ObjectTree, its *workloads.InstanceSet, pod *corev1.Pod, config workloads.ConfigTemplate) (bool, error) {
 	if config.Reconfigure == nil {
-		return nil // skip
+		return false, nil // skip
 	}
 
 	itsCopy := its.DeepCopy()
@@ -321,7 +329,7 @@ func (r *updateReconciler) reconfigureInst(tree *kubebuilderx.ObjectTree, its *w
 	itsCopy.Spec.LifecycleActions.Reconfigure = config.Reconfigure
 	lfa, err := newLifecycleAction(itsCopy, tree, pod)
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	opts := reconfigureOptions(config)
@@ -332,16 +340,32 @@ func (r *updateReconciler) reconfigureInst(tree *kubebuilderx.ObjectTree, its *w
 	}
 	if err != nil {
 		if errors.Is(err, lifecycle.ErrActionNotDefined) {
-			return nil
+			return false, nil
 		}
 		if errors.Is(err, lifecycle.ErrPreconditionFailed) {
-			return intctrlutil.NewDelayedRequeueError(time.Second,
+			return false, intctrlutil.NewDelayedRequeueError(time.Second,
 				fmt.Sprintf("replicas not up-to-date when reconfiguring: %s", err.Error()))
 		}
-		return err
+		if errors.Is(err, lifecycle.ErrActionFailed) {
+			if err1 := setReconfigureActionFailure(pod, config, err.Error()); err1 != nil {
+				return false, err1
+			}
+			if err1 := tree.Update(pod, kubebuilderx.WithPatch(true)); err1 != nil {
+				return false, err1
+			}
+			tree.Logger.Info("reconfigure action failed", "pod", pod.Name, "config", config.Name, "configHash", ptr.Deref(config.ConfigHash, ""), "error", err)
+			return true, nil
+		}
+		return false, err
+	}
+	if err = clearReconfigureActionFailure(pod, config); err != nil {
+		return false, err
+	}
+	if err = tree.Update(pod, kubebuilderx.WithPatch(true)); err != nil {
+		return false, err
 	}
 	tree.Logger.Info("successfully reconfigure the pod", "pod", pod.Name, "configHash", ptr.Deref(config.ConfigHash, ""))
-	return nil
+	return false, nil
 }
 
 func reconfigureOptions(config workloads.ConfigTemplate) *lifecycle.Options {

--- a/pkg/controller/instanceset/reconciler_update_test.go
+++ b/pkg/controller/instanceset/reconciler_update_test.go
@@ -21,6 +21,7 @@ package instanceset
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"time"
 
@@ -58,6 +59,44 @@ var _ = Describe("update reconciler test", func() {
 
 		It("uses nil options when reconfigure args are empty", func() {
 			Expect(reconfigureOptions(workloads.ConfigTemplate{})).Should(BeNil())
+		})
+
+		It("records action failures with the target config hash", func() {
+			spy := &lifecycleCallSpy{
+				reconfigureErr: fmt.Errorf("%w: mysql rejected unknown variable expire_logs_days", lifecycle.ErrActionFailed),
+			}
+			origNewLifecycleAction := newLifecycleAction
+			newLifecycleAction = func(_ *workloads.InstanceSet, _ *kubebuilderx.ObjectTree, _ *corev1.Pod) (lifecycle.Lifecycle, error) {
+				return spy, nil
+			}
+			defer func() { newLifecycleAction = origNewLifecycleAction }()
+
+			tree := kubebuilderx.NewObjectTree()
+			tree.SetRoot(its)
+			pod := builder.NewPodBuilder(namespace, name+"-0").GetObject()
+			Expect(tree.Add(pod)).Should(Succeed())
+
+			config := workloads.ConfigTemplate{
+				Name:       "mysql-config",
+				ConfigHash: ptr.To("target-hash"),
+				Reconfigure: &kbappsv1.Action{
+					Exec: &kbappsv1.ExecAction{Command: []string{"reload"}},
+				},
+			}
+
+			blocked, err := (&updateReconciler{}).reconfigureInst(tree, its, pod, config)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(blocked).Should(BeTrue())
+			Expect(spy.reconfigureCalls).Should(Equal(1))
+
+			failures := getReconfigureActionFailures(pod)
+			Expect(failures).Should(HaveKey("mysql-config"))
+			Expect(failures["mysql-config"].ConfigHash).Should(Equal("target-hash"))
+			Expect(failures["mysql-config"].Message).Should(ContainSubstring("expire_logs_days"))
+
+			_, option, err := tree.GetWithOption(pod)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(option.Patch).Should(BeTrue())
 		})
 	})
 
@@ -582,6 +621,7 @@ var _ = Describe("update reconciler test", func() {
 type lifecycleCallSpy struct {
 	switchoverCalls  int
 	reconfigureCalls int
+	reconfigureErr   error
 }
 
 func (s *lifecycleCallSpy) PostProvision(_ context.Context, _ client.Reader, _ *lifecycle.Options) error {
@@ -611,7 +651,7 @@ func (s *lifecycleCallSpy) MemberLeave(_ context.Context, _ client.Reader, _ *li
 
 func (s *lifecycleCallSpy) Reconfigure(_ context.Context, _ client.Reader, _ *lifecycle.Options, _ map[string]string) error {
 	s.reconfigureCalls++
-	return nil
+	return s.reconfigureErr
 }
 
 func (s *lifecycleCallSpy) AccountProvision(_ context.Context, _ client.Reader, _ *lifecycle.Options, _, _, _ string) error {

--- a/pkg/controller/instanceset/reconfigure_failure.go
+++ b/pkg/controller/instanceset/reconfigure_failure.go
@@ -1,0 +1,87 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package instanceset
+
+import (
+	"encoding/json"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+)
+
+type reconfigureActionFailureRecord struct {
+	ConfigHash string `json:"configHash,omitempty"`
+	Message    string `json:"message,omitempty"`
+}
+
+func setReconfigureActionFailure(pod *corev1.Pod, config workloads.ConfigTemplate, message string) error {
+	failures := getReconfigureActionFailures(pod)
+	if failures == nil {
+		failures = map[string]reconfigureActionFailureRecord{}
+	}
+	failures[config.Name] = reconfigureActionFailureRecord{
+		ConfigHash: ptr.Deref(config.ConfigHash, ""),
+		Message:    message,
+	}
+	return setReconfigureActionFailures(pod, failures)
+}
+
+func clearReconfigureActionFailure(pod *corev1.Pod, config workloads.ConfigTemplate) error {
+	failures := getReconfigureActionFailures(pod)
+	if len(failures) == 0 {
+		return nil
+	}
+	delete(failures, config.Name)
+	return setReconfigureActionFailures(pod, failures)
+}
+
+func getReconfigureActionFailures(pod *corev1.Pod) map[string]reconfigureActionFailureRecord {
+	annotations := pod.GetAnnotations()
+	if len(annotations) == 0 || annotations[constant.ReconfigureActionFailureAnnotationKey] == "" {
+		return nil
+	}
+	failures := map[string]reconfigureActionFailureRecord{}
+	if err := json.Unmarshal([]byte(annotations[constant.ReconfigureActionFailureAnnotationKey]), &failures); err != nil {
+		return nil
+	}
+	return failures
+}
+
+func setReconfigureActionFailures(pod *corev1.Pod, failures map[string]reconfigureActionFailureRecord) error {
+	annotations := pod.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	if len(failures) == 0 {
+		delete(annotations, constant.ReconfigureActionFailureAnnotationKey)
+		pod.SetAnnotations(annotations)
+		return nil
+	}
+	data, err := json.Marshal(failures)
+	if err != nil {
+		return err
+	}
+	annotations[constant.ReconfigureActionFailureAnnotationKey] = string(data)
+	pod.SetAnnotations(annotations)
+	return nil
+}


### PR DESCRIPTION
## Summary

Refs #10578.

This PR surfaces reconfigure action failures from the InstanceSet action path back into the parameters reconfigure status path.

## Problem

For file-template reconfigure, the parameters controller first submits the target config hash to the workload. The InstanceSet then runs the configured reconfigure action through kbagent.

When that action returns a generic action failure, the InstanceSet reconcile currently returns the error only in its own reconcile path. The failure detail does not reach the runtime ConfigMap revision status, ComponentParameter status, or the Reconfiguring OpsRequest view.

That leaves users with an action failure in kbagent logs but no matching reconfigure status detail.

## Changes

- Add `config.kubeblocks.io/reconfigure-action-failure` as a pod annotation used by InstanceSet to record reconfigure action failure detail.
- Record the config name, target config hash, and action error message when a reconfigure action returns `lifecycle.ErrActionFailed`.
- Keep `ActionNotDefined` and `PreconditionFailed` behavior unchanged.
- Keep generic `ErrActionFailed` non-terminal: the parameters reconfigure status maps the marker to `StatusFailedAndRetry`, not `StatusFailed`.
- Filter action failure markers by both config name and target config hash so stale failures from another target hash do not affect a new reconfigure.

## Non-goals

- This PR does not define permanent or fatal action failure classification.
- This PR does not change OpsRequest terminal semantics.
- This PR does not make generic `ErrActionFailed` fail the Reconfiguring OpsRequest.
- This PR does not roll back the generated ConfigMap or mounted config.

Terminal failure semantics should be handled separately after the action protocol has a reliable permanent/fatal signal.

## Tests

- `go generate -x ./pkg/testutil/k8s/mocks/...`
- `go test ./pkg/controller/instanceset -run TestAPIs -ginkgo.focus 'records action failures' -count=1`
- `KUBEBUILDER_ASSETS="$HOME/Library/Application Support/io.kubebuilder.envtest/k8s/1.26.1-darwin-arm64" go test ./controllers/parameters/reconfigure -run TestAPIs -ginkgo.focus 'status surfaces action failures' -count=1`
- `go test ./pkg/controller/instanceset -count=1`
- `KUBEBUILDER_ASSETS="$HOME/Library/Application Support/io.kubebuilder.envtest/k8s/1.26.1-darwin-arm64" go test ./controllers/parameters/reconfigure -count=1`
- `KUBEBUILDER_ASSETS="$HOME/Library/Application Support/io.kubebuilder.envtest/k8s/1.26.1-darwin-arm64" go test ./controllers/parameters -count=1`
- `KUBEBUILDER_ASSETS="$HOME/Library/Application Support/io.kubebuilder.envtest/k8s/1.26.1-darwin-arm64" go test ./pkg/operations -run 'TestReconfigure|TestOps' -count=1`
- `git diff --check`
