### PR TITLE
fix(dataprotection): watch populate restore pods to close reconcile starvation

### DIFF
--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -42,7 +42,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
@@ -137,7 +139,44 @@ func (r *VolumePopulatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return intctrlutil.NewControllerManagedBy(mgr).
 		For(&corev1.PersistentVolumeClaim{}).
 		Owns(&batchv1.Job{}).
+		Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(r.parsePopulatePod)).
 		Complete(r)
+}
+
+func (r *VolumePopulatorReconciler) parsePopulatePod(ctx context.Context, object client.Object) []reconcile.Request {
+	labels := object.GetLabels()
+	if labels[dprestore.DataProtectionRestoreLabelKey] == "" ||
+		labels[dprestore.DataProtectionPopulatePVCLabelKey] == "" {
+		return nil
+	}
+	owner := metav1.GetControllerOf(object)
+	if owner == nil || owner.Kind != constant.JobKind {
+		return nil
+	}
+	job := &batchv1.Job{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: object.GetNamespace(), Name: owner.Name}, job); err != nil {
+		if !apierrors.IsNotFound(err) {
+			log.FromContext(ctx).V(1).Info("failed to map volume populate pod to job",
+				"pod", client.ObjectKeyFromObject(object),
+				"job", types.NamespacedName{Namespace: object.GetNamespace(), Name: owner.Name},
+				"error", err)
+		}
+		return nil
+	}
+	if job.Labels[dprestore.DataProtectionRestoreLabelKey] == "" ||
+		job.Labels[dprestore.DataProtectionPopulatePVCLabelKey] == "" {
+		return nil
+	}
+	pvcOwner := metav1.GetControllerOf(job)
+	if pvcOwner == nil || pvcOwner.Kind != constant.PersistentVolumeClaimKind {
+		return nil
+	}
+	return []reconcile.Request{{
+		NamespacedName: types.NamespacedName{
+			Namespace: job.Namespace,
+			Name:      pvcOwner.Name,
+		},
+	}}
 }
 
 func (r *VolumePopulatorReconciler) MatchToPopulate(pvc *corev1.PersistentVolumeClaim) (bool, error) {

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
@@ -1471,6 +1472,166 @@ func TestDispatchUnboundPVCFailsWhenNoRestoreActionsExist(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal),
 		"expected fatal error when neither prepareData nor postReady exists, got: %v", err)
+}
+
+func TestPopulateDoesNotPollWhilePrepareDataJobIsStillActive(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	apiGroup := dptypes.DataprotectionAPIGroup
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "data-etcd-restore-0",
+			UID:       "data-etcd-restore-0-uid",
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+			},
+			DataSourceRef: &corev1.TypedObjectReference{
+				APIGroup: &apiGroup,
+				Kind:     dptypes.BackupKind,
+				Name:     "backup",
+			},
+		},
+	}
+	restore := &dpv1alpha1.Restore{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "restore",
+		},
+		Spec: dpv1alpha1.RestoreSpec{
+			Backup: dpv1alpha1.BackupRef{Name: "backup", Namespace: "default"},
+			PrepareDataConfig: &dpv1alpha1.PrepareDataConfig{
+				DataSourceRef: &dpv1alpha1.VolumeConfig{
+					VolumeSource: "data",
+					MountPath:    "/var/run/etcd/backup",
+				},
+			},
+		},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(pvc, restore).
+		WithObjects(pvc, restore).
+		Build()
+	reconciler := &VolumePopulatorReconciler{
+		Client:   cli,
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+	backup := newBackupForRestoreDecision([]string{"data"}, nil)
+	backup.Status.Target.PodSelector = &dpv1alpha1.PodSelector{Strategy: dpv1alpha1.PodSelectionStrategyAny}
+	actionSet := &dpv1alpha1.ActionSet{
+		Spec: dpv1alpha1.ActionSetSpec{
+			Restore: &dpv1alpha1.RestoreActionSpec{
+				PrepareData: &dpv1alpha1.JobActionSpec{
+					BaseJobActionSpec: dpv1alpha1.BaseJobActionSpec{
+						Image:   "restore-image",
+						Command: []string{"sh", "-c", "restore"},
+					},
+				},
+			},
+		},
+	}
+	restoreMgr := dprestore.NewRestoreManager(restore, record.NewFakeRecorder(10), scheme, reconciler.Client)
+	restoreMgr.PrepareDataBackupSets = []dprestore.BackupActionSet{{
+		Backup:    backup,
+		ActionSet: actionSet,
+	}}
+	restoreCtx := &pvcRestoreContext{
+		mode:       pvcRestoreModeRestoreData,
+		restoreMgr: restoreMgr,
+	}
+
+	err := reconciler.Populate(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreCtx)
+
+	require.NoError(t, err)
+	jobs := &batchv1.JobList{}
+	require.NoError(t, reconciler.Client.List(context.Background(), jobs))
+	require.Len(t, jobs.Items, 1)
+	require.Empty(t, jobs.Items[0].Status.Conditions)
+}
+
+func TestParsePopulatePodMapsJobPodToTargetPVC(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "data-etcd-restore-0",
+			UID:       "data-etcd-restore-0-uid",
+		},
+	}
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "populate-job",
+			UID:       "populate-job-uid",
+			Labels: map[string]string{
+				dprestore.DataProtectionRestoreLabelKey:     "restore",
+				dprestore.DataProtectionPopulatePVCLabelKey: "populate-pvc",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion:         "v1",
+				Kind:               constant.PersistentVolumeClaimKind,
+				Name:               pvc.Name,
+				UID:                pvc.UID,
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
+			}},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "populate-job-pod",
+			Labels: map[string]string{
+				dprestore.DataProtectionRestoreLabelKey:     "restore",
+				dprestore.DataProtectionPopulatePVCLabelKey: "populate-pvc",
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion:         "batch/v1",
+				Kind:               constant.JobKind,
+				Name:               job.Name,
+				UID:                job.UID,
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
+			}},
+		},
+	}
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc, job).Build(),
+		Scheme: scheme,
+	}
+
+	requests := reconciler.parsePopulatePod(context.Background(), pod)
+
+	require.Equal(t, []reconcile.Request{{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: pvc.Name},
+	}}, requests)
+}
+
+func TestParsePopulatePodIgnoresUnrelatedPods(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
+		Scheme: scheme,
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "unrelated",
+		},
+	}
+
+	require.Empty(t, reconciler.parsePopulatePod(context.Background(), pod))
 }
 
 func TestBuildPostReadyRestoreSelectsHighestPriorityRole(t *testing.T) {


### PR DESCRIPTION
## Problem

Fixes #10583 (also explains #10476 and likely #10222's populate-path cases)

Multi-replica `spec.restore` (VolumePopulator / AsDataSource path) populate Jobs can wedge **indefinitely** after their `restore` container exits successfully: the `restore-manager` sidecar loops waiting for the stop annotation that is never set.

## Root cause (now closed to a unique mechanism)

The stop-annotation gate (`finishedCount == len(fetchedJobs)` → `StopManagerContainerByJob`, `pkg/dataprotection/restore/manager.go`) for the populate path runs **inside the VolumePopulator's PVC reconcile** (`BuildVolumePopulateJob`/`CheckJobsDone` are driven from `volumepopulator_controller.go`), not in RestoreReconciler. The VolumePopulator controller watches only `For(PVC)` + `Owns(Job)`:

- the ending event — `restore` container termination — is a **Pod-status-only** change (the Job stays Active because the manager sidecar keeps the pod running): no event for this controller;
- the Restore CR label edits don't map to a PVC reconcile;
- and the PVC Bound event that would re-trigger the reconcile is **exactly what is blocked** on the Job finishing.

Circular wait; whether a replica escapes depends on incidental events (#10583's reproduction: one replica escaped in ~90s, the sibling wedged 12+ min, then converged **8 seconds** after a manual Job label touch — which fires precisely the `Owns(Job)` path).

RestoreReconciler's existing Pod watch (`parseRestorePod`) does not help: it enqueues the Restore CR, whose reconcile does not run this gate for populate-managed restores.

## Fix — the direction already prescribed in review

This continues closed PR #10481 and implements exactly the review direction from it (and from #10477's review): *"VolumePopulator should use an event-driven Pod/Job-to-PVC mapping instead of making every active populate restore reconcile periodically."* #10481 was closed under a process gate — *root-cause evidence not fully closed; one-owner investigation first* — which is now satisfied: #10583 carries the decisive starvation experiment, and this PR's description closes the mechanism to the VolumePopulator watch set. The code is the same final iteration that addressed the review (Pod → controller-owner Job (labels re-verified) → controller-owner target PVC; label-filtered on both restore and populate-PVC keys; no polling), rebased onto current main.

**What this does not change**: the stop-annotation semantics (set only when all of the Restore's populate jobs' restore containers have finished) are untouched — per the earlier by-design clarification, that gate is correct; the defect was solely that nothing re-ran it.

## Verification

- Ported mapper/ignore-path and active-Job no-poll tests included (from the reviewed #10481 iteration).
- `controllers/dataprotection` suite passes locally on this head.
- OwnerRef chain verified on current main: `CreateJobsIfNotExist` sets the target PVC as the populate Job's controller reference, so the Pod→Job→PVC mapping is total for populate pods.
- Runtime scenario validation (PostgreSQL 2-replica Parallel restore, per #10583's reproduction) to be run by the reporting team against a patch build.

/nopick (backport need for release-1.1, if the populate path is exposed there, left to the DP owner's call)