### PR TITLE
fix: align instance api pvc labels with instanceset

### DIFF
--- a/pkg/controller/instance/utils.go
+++ b/pkg/controller/instance/utils.go
@@ -87,6 +87,20 @@ func getMatchLabels(name string) map[string]string {
 	}
 }
 
+func pvcTemplateLabels(labels map[string]string) map[string]string {
+	if len(labels) == 0 {
+		return nil
+	}
+	copied := make(map[string]string, len(labels))
+	for k, v := range labels {
+		copied[k] = v
+	}
+	// PVCs use this label to identify their owning Instance; a pod template
+	// value must not override the PVC's own instance identity.
+	delete(copied, constant.KBAppInstanceNameLabelKey)
+	return copied
+}
+
 // isRoleReady returns true if pod has role label
 func isRoleReady(pod *corev1.Pod, roles []workloads.ReplicaRole) bool {
 	if len(roles) == 0 {
@@ -188,9 +202,10 @@ func buildInstancePVCs(inst *workloads.Instance) ([]*corev1.PersistentVolumeClai
 		pvcName := intctrlutil.ComposePVCName(corev1.PersistentVolumeClaim{ObjectMeta: claimTemplate.ObjectMeta}, inst.Spec.InstanceSetName, inst.Name)
 		pvc := builder.NewPVCBuilder(inst.Namespace, pvcName).
 			AddLabelsInMap(labels).
+			AddLabelsInMap(pvcTemplateLabels(inst.Spec.Template.Labels)).
 			AddLabelsInMap(claimTemplate.Labels).
-			AddLabels(constant.KBAppPodNameLabelKey, inst.Name).
 			AddLabels(constant.VolumeClaimTemplateNameLabelKey, claimTemplate.Name).
+			AddLabels(constant.KBAppPodNameLabelKey, inst.Name).
 			AddAnnotationsInMap(claimTemplate.Annotations).
 			SetSpec(*claimTemplate.Spec.DeepCopy()).
 			GetObject()

--- a/pkg/controller/instance/utils_test.go
+++ b/pkg/controller/instance/utils_test.go
@@ -401,9 +401,15 @@ func TestBuildInstancePodAndPVCs(t *testing.T) {
 	inst := builder.NewInstanceBuilder("default", "mysql-0").
 		SetUID(types.UID("12345678-1234-1234-1234-1234567890ab")).
 		AddAnnotations("instance-annotation", "true").
+		AddLabels("instance-only-label", "true").
 		SetPodTemplate(corev1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels:      map[string]string{"template-label": "true"},
+				Labels: map[string]string{
+					"template-label":                   "true",
+					constant.AppInstanceLabelKey:       "cluster",
+					constant.KBAppComponentLabelKey:    "mysql",
+					constant.KBAppInstanceNameLabelKey: "template-instance",
+				},
 				Annotations: map[string]string{"template-annotation": "true"},
 			},
 			Spec: corev1.PodSpec{
@@ -463,11 +469,18 @@ func TestBuildInstancePodAndPVCs(t *testing.T) {
 		t.Fatalf("pvcs = %d, want 1", len(pvcs))
 	}
 	pvc := pvcs[0]
-	if pvc.Labels[constant.KBAppPodNameLabelKey] != "mysql-0" ||
+	if pvc.Labels[constant.KBAppInstanceNameLabelKey] != "mysql-0" ||
+		pvc.Labels[constant.KBAppPodNameLabelKey] != "mysql-0" ||
 		pvc.Labels[constant.VolumeClaimTemplateNameLabelKey] != "data" ||
 		pvc.Labels[constant.KBAppInstanceTemplateLabelKey] != "az-a" ||
+		pvc.Labels[constant.AppInstanceLabelKey] != "cluster" ||
+		pvc.Labels[constant.KBAppComponentLabelKey] != "mysql" ||
+		pvc.Labels["template-label"] != "true" ||
 		pvc.Labels["pvc-label"] != "true" {
 		t.Fatalf("unexpected pvc labels: %#v", pvc.Labels)
+	}
+	if _, ok := pvc.Labels["instance-only-label"]; ok {
+		t.Fatalf("unexpected instance-only label on pvc: %#v", pvc.Labels)
 	}
 	if pvc.Annotations["pvc-annotation"] != "true" {
 		t.Fatalf("unexpected pvc annotations: %#v", pvc.Annotations)


### PR DESCRIPTION
## What changed

Instance API PVC creation now merges pod template labels into generated PVCs, matching the existing InstanceSet PVC label behavior.

## Why

The InstanceSet path adds template labels to PVCs. The InstanceSet2 + Instance API path already applies template labels to the Instance and Pod, but did not carry those labels into PVCs. That made PVCs miss component identity labels such as `app.kubernetes.io/instance` and `apps.kubeblocks.io/component-name`, so volume expansion progress lookup could not discover them by the existing label selector.

This keeps the behavior scoped to template labels and does not copy all Instance object labels to PVCs.
The Instance API PVC identity label `apps.kubeblocks.io/instance-name` remains owned by the Instance controller so deletion/retention reconciliation can still find the PVCs.

Fix #10576.

## Validation

```bash
go test ./pkg/controller/instance
go test ./controllers/workloads -run TestAPIs -ginkgo.focus "Instance Controller.*delete - (delete|retain) pvc" -count=1
go test ./controllers/workloads -run TestAPIs -count=1
```
