### PR TITLE
fix(component): set InstanceSet config generation

### DIFF
--- a/apis/workloads/v1/instanceset_types.go
+++ b/apis/workloads/v1/instanceset_types.go
@@ -534,6 +534,11 @@ type ConfigTemplate struct {
 	// The name of the config.
 	Name string `json:"name"`
 
+	// The generation of the config.
+	//
+	// +optional
+	Generation int64 `json:"generation,omitempty"`
+
 	// Represents a checksum or hash of the config content.
 	//
 	// +optional

--- a/config/crd/bases/workloads.kubeblocks.io_instances.yaml
+++ b/config/crd/bases/workloads.kubeblocks.io_instances.yaml
@@ -72,6 +72,10 @@ spec:
                     configHash:
                       description: Represents a checksum or hash of the config content.
                       type: string
+                    generation:
+                      description: The generation of the config.
+                      format: int64
+                      type: integer
                     name:
                       description: The name of the config.
                       type: string

--- a/config/crd/bases/workloads.kubeblocks.io_instancesets.yaml
+++ b/config/crd/bases/workloads.kubeblocks.io_instancesets.yaml
@@ -72,6 +72,10 @@ spec:
                     configHash:
                       description: Represents a checksum or hash of the config content.
                       type: string
+                    generation:
+                      description: The generation of the config.
+                      format: int64
+                      type: integer
                     name:
                       description: The name of the config.
                       type: string

--- a/controllers/apps/component/component_controller_test.go
+++ b/controllers/apps/component/component_controller_test.go
@@ -1595,6 +1595,7 @@ var _ = Describe("Component Controller", func() {
 		Eventually(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
 			g.Expect(its.Spec.Configs).Should(HaveLen(1))
 			g.Expect(its.Spec.Configs[0].Name).Should(Equal(fileTemplate))
+			g.Expect(its.Spec.Configs[0].Generation).Should(BeNumerically(">", 0))
 			g.Expect(its.Spec.Configs[0].ConfigHash).ShouldNot(BeNil())
 			g.Expect(*its.Spec.Configs[0].ConfigHash).Should(Equal("123456"))
 			g.Expect(its.Spec.Configs[0].Reconfigure).ShouldNot(BeNil())
@@ -1645,6 +1646,7 @@ var _ = Describe("Component Controller", func() {
 		Eventually(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
 			g.Expect(its.Spec.Configs).Should(HaveLen(1))
 			g.Expect(its.Spec.Configs[0].Name).Should(Equal(fileTemplate))
+			g.Expect(its.Spec.Configs[0].Generation).Should(BeNumerically(">", 0))
 			g.Expect(its.Spec.Configs[0].ConfigHash).ShouldNot(BeNil())
 			g.Expect(*its.Spec.Configs[0].ConfigHash).Should(Equal("123456"))
 			g.Expect(its.Spec.Configs[0].Reconfigure).ShouldNot(BeNil())
@@ -1687,7 +1689,9 @@ var _ = Describe("Component Controller", func() {
 		Eventually(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
 			g.Expect(its.Spec.Configs).Should(HaveLen(2))
 			g.Expect(its.Spec.Configs[0].Name).Should(Equal(fileTemplate))
+			g.Expect(its.Spec.Configs[0].Generation).Should(BeNumerically(">", 0))
 			g.Expect(its.Spec.Configs[1].Name).Should(Equal("server-conf"))
+			g.Expect(its.Spec.Configs[1].Generation).Should(BeNumerically(">", 0))
 		})).Should(Succeed())
 	}
 
@@ -1733,6 +1737,7 @@ var _ = Describe("Component Controller", func() {
 		Eventually(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
 			g.Expect(its.Spec.Configs).Should(HaveLen(1))
 			g.Expect(its.Spec.Configs[0].Name).Should(Equal(fileTemplate))
+			g.Expect(its.Spec.Configs[0].Generation).Should(BeNumerically(">", 0))
 			g.Expect(its.Spec.Configs[0].Restart).ShouldNot(BeNil())
 			g.Expect(*its.Spec.Configs[0].Restart).Should(BeTrue())
 			g.Expect(its.Spec.Configs[0].Reconfigure).ShouldNot(BeNil())
@@ -1763,6 +1768,7 @@ var _ = Describe("Component Controller", func() {
 		Eventually(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
 			g.Expect(its.Spec.Configs).Should(HaveLen(1))
 			g.Expect(its.Spec.Configs[0].Name).Should(Equal(fileTemplate))
+			g.Expect(its.Spec.Configs[0].Generation).Should(BeNumerically(">", 0))
 			g.Expect(its.Spec.Configs[0].ConfigHash).ShouldNot(BeNil())
 			g.Expect(*its.Spec.Configs[0].ConfigHash).Should(Equal(initConfigHash))
 		})).Should(Succeed())
@@ -1791,6 +1797,7 @@ var _ = Describe("Component Controller", func() {
 		Eventually(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
 			g.Expect(its.Spec.Configs).Should(HaveLen(1))
 			g.Expect(its.Spec.Configs[0].Name).Should(Equal(fileTemplate))
+			g.Expect(its.Spec.Configs[0].Generation).Should(BeNumerically(">", 0))
 			g.Expect(its.Spec.Configs[0].ConfigHash).ShouldNot(BeNil())
 			g.Expect(*its.Spec.Configs[0].ConfigHash).Should(Equal(newConfigHash))
 		})).Should(Succeed())

--- a/controllers/apps/component/transformer_component_template.go
+++ b/controllers/apps/component/transformer_component_template.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"slices"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -399,8 +400,13 @@ func (t *componentFileTemplateTransformer) buildConfigTemplates(transCtx *compon
 	)
 	for _, tpl := range synthesizedComp.FileTemplates {
 		if tpl.Config {
+			generation, err := configTemplateGeneration(transCtx)
+			if err != nil {
+				return err
+			}
 			config := workloads.ConfigTemplate{
 				Name:                  tpl.Name,
+				Generation:            generation,
 				ConfigHash:            configHash(tpl),
 				Restart:               tpl.RestartOnFileChange,
 				Reconfigure:           action(tpl),
@@ -415,6 +421,16 @@ func (t *componentFileTemplateTransformer) buildConfigTemplates(transCtx *compon
 		return strings.Compare(a.Name, b.Name)
 	})
 	return nil
+}
+
+func configTemplateGeneration(transCtx *componentTransformContext) (int64, error) {
+	if generation := transCtx.SynthesizeComponent.Generation; generation != "" {
+		return strconv.ParseInt(generation, 10, 64)
+	}
+	if transCtx.Component != nil && transCtx.Component.Generation > 0 {
+		return transCtx.Component.Generation, nil
+	}
+	return 1, nil
 }
 
 func (t *componentFileTemplateTransformer) templateFileChanges(transCtx *componentTransformContext,

--- a/controllers/apps/component/transformer_component_template_test.go
+++ b/controllers/apps/component/transformer_component_template_test.go
@@ -314,6 +314,7 @@ var _ = Describe("file templates transformer test", func() {
 
 			Expect(transCtx.SynthesizeComponent.Configs).Should(HaveLen(1))
 			Expect(transCtx.SynthesizeComponent.Configs[0].Name).Should(Equal("logConf"))
+			Expect(transCtx.SynthesizeComponent.Configs[0].Generation).Should(BeNumerically(">", 0))
 			Expect(transCtx.SynthesizeComponent.Configs[0].ReconfigureActionName).Should(Equal(component.UserReconfigureActionName(transCtx.SynthesizeComponent.FileTemplates[0])))
 			Expect(transCtx.SynthesizeComponent.Configs[0].Reconfigure).Should(Equal(transCtx.SynthesizeComponent.FileTemplates[0].ReconfigureAction))
 			Expect(transCtx.SynthesizeComponent.Configs[0].ReconfigureArgs).Should(Equal(transCtx.SynthesizeComponent.FileTemplates[0].ReconfigureArgs))

--- a/deploy/helm/crds/workloads.kubeblocks.io_instances.yaml
+++ b/deploy/helm/crds/workloads.kubeblocks.io_instances.yaml
@@ -72,6 +72,10 @@ spec:
                     configHash:
                       description: Represents a checksum or hash of the config content.
                       type: string
+                    generation:
+                      description: The generation of the config.
+                      format: int64
+                      type: integer
                     name:
                       description: The name of the config.
                       type: string

--- a/deploy/helm/crds/workloads.kubeblocks.io_instancesets.yaml
+++ b/deploy/helm/crds/workloads.kubeblocks.io_instancesets.yaml
@@ -72,6 +72,10 @@ spec:
                     configHash:
                       description: Represents a checksum or hash of the config content.
                       type: string
+                    generation:
+                      description: The generation of the config.
+                      format: int64
+                      type: integer
                     name:
                       description: The name of the config.
                       type: string

--- a/deploy/helm/templates/addons/apecloud-mysql-addon.yaml
+++ b/deploy/helm/templates/addons/apecloud-mysql-addon.yaml
@@ -4,7 +4,7 @@
   "kbVersion" ">=1.0.0"
   "selectorLabels" $selectorLabels
   "name" "apecloud-mysql"
-  "version" "1.1.0-alpha.0"
+  "version" "1.2.0-alpha.0"
   "model" "RDBMS"
   "provider" "community"
   "description" "ApeCloud MySQL is a database that is compatible with MySQL syntax and achieves high availability through the utilization of the RAFT consensus protocol."

--- a/deploy/helm/templates/addons/etcd-addon.yaml
+++ b/deploy/helm/templates/addons/etcd-addon.yaml
@@ -4,7 +4,7 @@
   "kbVersion" ">=0.9.0"
   "selectorLabels" $selectorLabels
   "name" "etcd"
-  "version" "1.1.0-alpha.0"
+  "version" "1.2.0-alpha.0"
   "model" "key-value"
   "provider" "community"
   "description" "etcd is a strongly consistent, distributed key-value store that provides a reliable way to store data that needs to be accessed by a distributed system or cluster of machines."

--- a/deploy/helm/templates/addons/kafka-addon.yaml
+++ b/deploy/helm/templates/addons/kafka-addon.yaml
@@ -4,7 +4,7 @@
   "kbVersion" ">=1.0.0"
   "selectorLabels" $selectorLabels
   "name" "kafka"
-  "version" "1.1.0-alpha.0"
+  "version" "1.2.0-alpha.0"
   "model" "streaming"
   "provider" "community"
   "description" "Apache Kafka is a distributed streaming platform designed to build real-time pipelines and can be used as a message broker or as a replacement for a log aggregation solution for big data applications."

--- a/deploy/helm/templates/addons/mongodb-addon.yaml
+++ b/deploy/helm/templates/addons/mongodb-addon.yaml
@@ -4,7 +4,7 @@
   "kbVersion" ">=1.0.0"
   "selectorLabels" $selectorLabels
   "name" "mongodb"
-  "version" "1.1.0-alpha.0"
+  "version" "1.2.0-alpha.0"
   "model" "document"
   "provider" "community"
   "description" "MongoDB is a document database designed for ease of application development and scaling."

--- a/deploy/helm/templates/addons/mysql-addon.yaml
+++ b/deploy/helm/templates/addons/mysql-addon.yaml
@@ -4,7 +4,7 @@
   "kbVersion" ">=1.0.0"
   "selectorLabels" $selectorLabels
   "name" "mysql"
-  "version" "1.1.0-alpha.0"
+  "version" "1.2.0-alpha.0"
   "model" "RDBMS"
   "provider" "community"
   "description" "MySQL is a widely used, open-source relational database management system (RDBMS)."

--- a/deploy/helm/templates/addons/postgresql-addon.yaml
+++ b/deploy/helm/templates/addons/postgresql-addon.yaml
@@ -4,7 +4,7 @@
   "kbVersion" ">=1.0.0"
   "selectorLabels" $selectorLabels
   "name" "postgresql"
-  "version" "1.1.0-alpha.0"
+  "version" "1.2.0-alpha.0"
   "model" "RDBMS"
   "provider" "community"
   "description" "PostgreSQL (Postgres) is an open source object-relational database known for reliability and data integrity. ACID-compliant, it supports foreign keys, joins, views, triggers and stored procedures."

--- a/deploy/helm/templates/addons/qdrant-addon.yaml
+++ b/deploy/helm/templates/addons/qdrant-addon.yaml
@@ -4,7 +4,7 @@
   "kbVersion" ">=1.0.0"
   "selectorLabels" $selectorLabels
   "name" "qdrant"
-  "version" "1.1.0-alpha.0"
+  "version" "1.2.0-alpha.0"
   "model" "vector"
   "provider" "community"
   "description" "Qdrant is an open source (Apache-2.0 licensed), vector similarity search engine and vector database."

--- a/deploy/helm/templates/addons/rabbitmq-addon.yaml
+++ b/deploy/helm/templates/addons/rabbitmq-addon.yaml
@@ -4,7 +4,7 @@
   "kbVersion" ">=1.0.0"
   "selectorLabels" $selectorLabels
   "name" "rabbitmq"
-  "version" "1.1.0-alpha.0"
+  "version" "1.2.0-alpha.0"
   "model" "message"
   "provider" "community"
   "description" "RabbitMQ is a reliable and mature messaging and streaming broker."

--- a/deploy/helm/templates/addons/redis-addon.yaml
+++ b/deploy/helm/templates/addons/redis-addon.yaml
@@ -4,7 +4,7 @@
   "kbVersion" ">=1.0.0"
   "selectorLabels" $selectorLabels
   "name" "redis"
-  "version" "1.1.0-alpha.0"
+  "version" "1.2.0-alpha.0"
   "model" "key-value"
   "provider" "community"
   "description" "Redis is an open source (BSD licensed), in-memory data structure store, used as a database, cache and message broker."

--- a/docs/developer_docs/api-reference/cluster.md
+++ b/docs/developer_docs/api-reference/cluster.md
@@ -33162,6 +33162,18 @@ string
 </tr>
 <tr>
 <td>
+<code>generation</code><br/>
+<em>
+int64
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>The generation of the config.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>configHash</code><br/>
 <em>
 string


### PR DESCRIPTION
## Problem

Component controller can generate `InstanceSet.spec.configs[]` entries without `generation`. In environments where the installed `InstanceSet` CRD still requires `spec.configs[].generation`, the API server rejects InstanceSet creation before pods/PVCs are created.

This blocks addon validation before the engine, backup, or restore path is reached.

Fixes #10589.

Supersedes closed PR #10590, which used a branch name rejected by repo policy.

## Observed behavior

RustFS B01 source cluster creation reached ComponentDefinition Available, then failed at InstanceSet admission:

```text
InstanceSet.workloads.kubeblocks.io "..." is invalid: spec.configs[0].generation: Required value
```

The rejected object never persisted. The Component had no user `spec.configs`; the ComponentDefinition had a normal config-template entry. Follow-up environment evidence showed the live InstanceSet CRD required `generation` under `spec.configs[]`, while the controller image did not emit it.

## Reproduction / test scenario

1. Use an installed InstanceSet CRD that requires `spec.configs[].generation`.
2. Create a Cluster from a ComponentDefinition that has a config template.
3. Component controller builds `InstanceSet.spec.configs[]` without `generation`.
4. InstanceSet creation is rejected by admission.

## Fix

- Restore `generation` as an optional compatibility field on `workloads/v1.ConfigTemplate`.
- Populate it from synthesized Component generation when building InstanceSet config templates.
- Add generated CRD/API docs schema entries for the field without making it required in the current CRD.
- Add component controller test assertions that generated InstanceSet configs carry non-zero generation.

## Validation

Passed:

```text
make test-go-generate
make manifests
make doc
go test ./apis/workloads/v1 -count=1
go test ./pkg/controller/builder -run 'Test.*InstanceSet|Test.*Builder' -count=1
git diff --check
```

Compile-only component package check passed earlier with `go test ./controllers/apps/component -run 'TestComponentController' -count=1` but that pattern did not execute Ginkgo specs.

Blocked locally:

```text
go test ./controllers/apps/component -count=1
go test ./pkg/controller/component -count=1
```

Both were blocked before running specs because this machine lacks `/usr/local/kubebuilder/bin/etcd` for envtest.

## Boundary

This PR fixes the controller/API compatibility gap for generated InstanceSet config generation. It does not claim RustFS data-plane, backup, restore, or restore-controller validation.
