### PR TITLE
feat: support source target for scale-out restore

### DIFF
--- a/apis/operations/v1alpha1/opsrequest_types.go
+++ b/apis/operations/v1alpha1/opsrequest_types.go
@@ -518,6 +518,13 @@ type FromBackup struct {
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
 
+	// Specifies the backup source target name to restore from.
+	// This field is required when the referenced Backup has multiple source targets.
+	// It is propagated to Restore.spec.backup.sourceTargetName.
+	//
+	// +optional
+	SourceTargetName string `json:"sourceTargetName,omitempty"`
+
 	// Defines container environment variables for the restore process.
 	// merged with the ones specified in the Backup and ActionSet resources.
 	//

--- a/config/crd/bases/operations.kubeblocks.io_opsrequests.yaml
+++ b/config/crd/bases/operations.kubeblocks.io_opsrequests.yaml
@@ -757,6 +757,12 @@ spec:
                                 - RFC3339 format, e.g. "2023-11-25T18:52:53Z"
                                 - A human-readable date-time format, e.g. "Jul 25,2023 18:52:53 UTC+0800"
                               type: string
+                            sourceTargetName:
+                              description: |-
+                                Specifies the backup source target name to restore from.
+                                This field is required when the referenced Backup has multiple source targets.
+                                It is propagated to Restore.spec.backup.sourceTargetName.
+                              type: string
                           required:
                           - name
                           type: object

--- a/deploy/helm/crds/operations.kubeblocks.io_opsrequests.yaml
+++ b/deploy/helm/crds/operations.kubeblocks.io_opsrequests.yaml
@@ -757,6 +757,12 @@ spec:
                                 - RFC3339 format, e.g. "2023-11-25T18:52:53Z"
                                 - A human-readable date-time format, e.g. "Jul 25,2023 18:52:53 UTC+0800"
                               type: string
+                            sourceTargetName:
+                              description: |-
+                                Specifies the backup source target name to restore from.
+                                This field is required when the referenced Backup has multiple source targets.
+                                It is propagated to Restore.spec.backup.sourceTargetName.
+                              type: string
                           required:
                           - name
                           type: object

--- a/docs/developer_docs/api-reference/operations.md
+++ b/docs/developer_docs/api-reference/operations.md
@@ -1093,6 +1093,20 @@ If not specified, the namespace of the OpsRequest will be used.</p>
 </tr>
 <tr>
 <td>
+<code>sourceTargetName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Specifies the backup source target name to restore from.
+This field is required when the referenced Backup has multiple source targets.
+It is propagated to Restore.spec.backup.sourceTargetName.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>restoreEnv</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#envvar-v1-core">

--- a/pkg/controller/plan/restore.go
+++ b/pkg/controller/plan/restore.go
@@ -60,6 +60,7 @@ type RestoreManager struct {
 	replicas            int32
 	restoreLabels       map[string]string
 	RestoreNamePrefix   string
+	SourceTargetName    string
 }
 
 func NewRestoreManager(ctx context.Context,
@@ -175,6 +176,14 @@ func (r *RestoreManager) BuildPrepareDataRestore(comp *component.SynthesizedComp
 		return nil, nil
 	}
 	sourceTargetName, sourceTarget := backupSourceTargetForRestore(backupObj)
+	if r.SourceTargetName != "" {
+		sourceTargetName = r.SourceTargetName
+		sourceTarget = backupSourceTargetByName(backupObj, r.SourceTargetName)
+		if sourceTarget == nil {
+			return nil, intctrlutil.NewErrorf(intctrlutil.ErrorTypeRestoreFailed,
+				`source target "%s" not found in backup "%s"`, r.SourceTargetName, backupObj.Name)
+		}
+	}
 	restore := &dpv1alpha1.Restore{
 		ObjectMeta: r.GetRestoreObjectMeta(comp, dpv1alpha1.PrepareData, templateName),
 		Spec: dpv1alpha1.RestoreSpec{
@@ -292,6 +301,24 @@ func backupSourceTargetForRestore(backupObj *dpv1alpha1.Backup) (string, *dpv1al
 		return backupObj.Status.Targets[0].Name, &backupObj.Status.Targets[0]
 	}
 	return "", nil
+}
+
+func backupSourceTargetByName(backupObj *dpv1alpha1.Backup, sourceTargetName string) *dpv1alpha1.BackupStatusTarget {
+	if backupObj == nil || sourceTargetName == "" {
+		return nil
+	}
+	if backupObj.Status.Target != nil {
+		if backupObj.Status.Target.Name == sourceTargetName {
+			return backupObj.Status.Target
+		}
+		return nil
+	}
+	for i := range backupObj.Status.Targets {
+		if backupObj.Status.Targets[i].Name == sourceTargetName {
+			return &backupObj.Status.Targets[i]
+		}
+	}
+	return nil
 }
 
 func (r *RestoreManager) buildRequiredPolicy(sourceTarget *dpv1alpha1.BackupStatusTarget) *dpv1alpha1.RequiredPolicyForAllPodSelection {

--- a/pkg/controller/plan/restore_test.go
+++ b/pkg/controller/plan/restore_test.go
@@ -293,6 +293,84 @@ func TestRestoreManagerBuildPrepareDataRestore(t *testing.T) {
 	}
 }
 
+func TestRestoreManagerBuildPrepareDataRestoreWithExplicitSourceTarget(t *testing.T) {
+	manager := newRestoreManagerForTest()
+	manager.SourceTargetName = "target-b"
+	comp := &component.SynthesizedComponent{
+		Name:     "mysql",
+		Replicas: 1,
+		VolumeClaimTemplates: []corev1.PersistentVolumeClaimTemplate{{
+			ObjectMeta: metav1.ObjectMeta{Name: "data"},
+		}},
+	}
+	backup := &dpv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: "backup"},
+		Status: dpv1alpha1.BackupStatus{
+			Targets: []dpv1alpha1.BackupStatusTarget{
+				{BackupTarget: dpv1alpha1.BackupTarget{
+					Name:        "target-a",
+					PodSelector: &dpv1alpha1.PodSelector{},
+				}},
+				{BackupTarget: dpv1alpha1.BackupTarget{
+					Name:        "target-b",
+					PodSelector: &dpv1alpha1.PodSelector{},
+				}},
+			},
+			BackupMethod: &dpv1alpha1.BackupMethod{
+				Name: "snapshot",
+				TargetVolumes: &dpv1alpha1.TargetVolumeInfo{
+					Volumes: []string{"data"},
+				},
+			},
+		},
+	}
+
+	restore, err := manager.BuildPrepareDataRestore(comp, backup, nil)
+	if err != nil {
+		t.Fatalf("BuildPrepareDataRestore() error = %v", err)
+	}
+	if restore == nil {
+		t.Fatal("restore is nil")
+	}
+	if restore.Spec.Backup.SourceTargetName != "target-b" {
+		t.Fatalf("source target name = %q, want target-b", restore.Spec.Backup.SourceTargetName)
+	}
+}
+
+func TestRestoreManagerBuildPrepareDataRestoreRejectsUnknownSourceTarget(t *testing.T) {
+	manager := newRestoreManagerForTest()
+	manager.SourceTargetName = "missing-target"
+	comp := &component.SynthesizedComponent{
+		Name:     "mysql",
+		Replicas: 1,
+		VolumeClaimTemplates: []corev1.PersistentVolumeClaimTemplate{{
+			ObjectMeta: metav1.ObjectMeta{Name: "data"},
+		}},
+	}
+	backup := &dpv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: "backup"},
+		Status: dpv1alpha1.BackupStatus{
+			Targets: []dpv1alpha1.BackupStatusTarget{{
+				BackupTarget: dpv1alpha1.BackupTarget{
+					Name:        "target-a",
+					PodSelector: &dpv1alpha1.PodSelector{},
+				},
+			}},
+			BackupMethod: &dpv1alpha1.BackupMethod{
+				Name: "snapshot",
+				TargetVolumes: &dpv1alpha1.TargetVolumeInfo{
+					Volumes: []string{"data"},
+				},
+			},
+		},
+	}
+
+	_, err := manager.BuildPrepareDataRestore(comp, backup, nil)
+	if err == nil {
+		t.Fatal("expected unknown source target error")
+	}
+}
+
 func TestRestoreManagerBuildPrepareDataRestoreWithoutVolumes(t *testing.T) {
 	manager := newRestoreManagerForTest()
 	comp := &component.SynthesizedComponent{

--- a/pkg/operations/horizontal_scaling.go
+++ b/pkg/operations/horizontal_scaling.go
@@ -224,9 +224,8 @@ func (hs horizontalScalingOpsHandler) createRestore(reqCtx intctrlutil.RequestCt
 		}
 		return nil
 	}
-	if len(backupObj.Status.Targets) > 1 {
-		// TODO: support explicit source target selection for scale-out restore from multi-target backups.
-		return intctrlutil.NewFatalError(fmt.Sprintf("scale-out from backup %s/%s is not supported because it has multiple source targets", backupObj.Namespace, backupObj.Name))
+	if len(backupObj.Status.Targets) > 1 && restoreMGR.SourceTargetName == "" {
+		return intctrlutil.NewFatalError(fmt.Sprintf("scale-out from backup %s/%s requires sourceTargetName because it has multiple source targets", backupObj.Namespace, backupObj.Name))
 	}
 	// create restore
 	restore, err := restoreMGR.BuildPrepareDataRestore(synthesizedComponent, backupObj, getTemplate(templateName))
@@ -295,6 +294,7 @@ func (hs horizontalScalingOpsHandler) restoreDataFromBackup(reqCtx intctrlutil.R
 		}, 1, int32(podIndexInt))
 		restoreMGR.RestoreTime = fromBackup.RestorePointInTime
 		restoreMGR.RestoreNamePrefix = string(opsRes.OpsRequest.UID[:8])
+		restoreMGR.SourceTargetName = fromBackup.SourceTargetName
 		// check restore status
 		restoreMeta := restoreMGR.GetRestoreObjectMeta(synthesizedComponent, dpv1alpha1.PrepareData, templateName)
 		restore := &dpv1alpha1.Restore{}

--- a/pkg/operations/horizontal_scaling_test.go
+++ b/pkg/operations/horizontal_scaling_test.go
@@ -278,18 +278,37 @@ var _ = Describe("HorizontalScaling OpsRequest", func() {
 						Volumes: []string{"data"},
 					},
 				}
+				backup.Status.Targets = []dpv1alpha1.BackupStatusTarget{
+					{BackupTarget: dpv1alpha1.BackupTarget{
+						Name:        "target-a",
+						PodSelector: &dpv1alpha1.PodSelector{},
+					}},
+					{BackupTarget: dpv1alpha1.BackupTarget{
+						Name:        "target-b",
+						PodSelector: &dpv1alpha1.PodSelector{},
+					}},
+				}
 			})).Should(Succeed())
 
 			By("scale out replicas from a full backup")
 			horizontalScaling := opsv1alpha1.HorizontalScaling{ScaleOut: &opsv1alpha1.ScaleOut{
 				FromBackup: &opsv1alpha1.FromBackup{
-					Name: backupName,
+					Name:             backupName,
+					SourceTargetName: "target-b",
 				},
 			}}
 
 			horizontalScaling.ScaleOut.ReplicaChanges = pointer.Int32(2)
 			reqCtx := intctrlutil.RequestCtx{Ctx: testCtx.Ctx, Recorder: eventRecorder}
 			opsRes, _ := commonHScaleConsensusCompTest(reqCtx, nil, horizontalScaling, false, true)
+			restoreList := &dpv1alpha1.RestoreList{}
+			Expect(k8sClient.List(ctx, restoreList, client.MatchingLabels{
+				constant.OpsRequestNameLabelKey: opsRes.OpsRequest.Name,
+			}, client.InNamespace(opsRes.OpsRequest.Namespace))).Should(Succeed())
+			Expect(restoreList.Items).Should(HaveLen(2))
+			for i := range restoreList.Items {
+				Expect(restoreList.Items[i].Spec.Backup.SourceTargetName).Should(Equal("target-b"))
+			}
 
 			By("mock restore phase to completed")
 			comp, compDef, err := component.GetCompNCompDefByName(reqCtx.Ctx, k8sClient, opsRes.Cluster.Namespace, constant.GenerateClusterComponentName(opsRes.Cluster.Name, defaultCompName))
@@ -321,6 +340,35 @@ var _ = Describe("HorizontalScaling OpsRequest", func() {
 			createPods("", 3, 4)
 			testapps.MockInstanceSetStatus(testCtx, opsRes.Cluster, defaultCompName)
 			checkOpsRequestPhaseIsSucceed(reqCtx, opsRes)
+		})
+
+		It("fails scale-out from a multi-target backup without source target name", func() {
+			backup := &dpv1alpha1.Backup{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testCtx.DefaultNamespace,
+					Name:      "multi-target-backup-" + randomStr,
+				},
+				Status: dpv1alpha1.BackupStatus{
+					Targets: []dpv1alpha1.BackupStatusTarget{
+						{BackupTarget: dpv1alpha1.BackupTarget{Name: "target-a"}},
+						{BackupTarget: dpv1alpha1.BackupTarget{Name: "target-b"}},
+					},
+				},
+			}
+			restoreMGR := plan.NewRestoreManager(ctx, k8sClient, &appsv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: clusterName, Namespace: testCtx.DefaultNamespace},
+			}, model.GetScheme(), nil, 1, 0)
+			err := horizontalScalingOpsHandler{}.createRestore(
+				intctrlutil.RequestCtx{Ctx: ctx},
+				k8sClient,
+				&OpsResource{OpsRequest: &opsv1alpha1.OpsRequest{}},
+				nil,
+				restoreMGR,
+				&appsv1.ClusterComponentSpec{},
+				backup,
+				"")
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("requires sourceTargetName"))
 		})
 
 		It("test to scale in replicas with `scaleIn`", func() {


### PR DESCRIPTION
## Summary
- add scaleOut.fromBackup.sourceTargetName and propagate it to Restore.spec.backup.sourceTargetName
- keep multi-target backups fail-fast unless sourceTargetName is specified
- validate explicit source target selection in RestoreManager and preserve single-target inference
- sync CRD, Helm CRD, and API reference docs

## Tests
- go test ./pkg/controller/plan -run 'TestRestoreManagerBuildPrepareDataRestore'
- KUBEBUILDER_ASSETS="$(./bin/setup-envtest-release-0.21 use 1.26.1 -p path)" go test ./pkg/controller/plan
- KUBEBUILDER_ASSETS="$(./bin/setup-envtest-release-0.21 use 1.26.1 -p path)" go test ./pkg/operations -run TestAPIs -args -ginkgo.focus 'scale out replicas from a full backup|multi-target backup without source target name'
- KUBEBUILDER_ASSETS="$(./bin/setup-envtest-release-0.21 use 1.26.1 -p path)" go test ./pkg/operations -run TestAPIs -args -ginkgo.focus 'HorizontalScaling OpsRequest'
- git diff --check