### PR TITLE
fix(ops): tighten scale-out restore contract

### DIFF
--- a/apis/dataprotection/v1alpha1/restore_types.go
+++ b/apis/dataprotection/v1alpha1/restore_types.go
@@ -104,7 +104,10 @@ type BackupRef struct {
 	// +kubebuilder:validation:Required
 	Name string `json:"name"`
 
-	// Specifies the backup namespace.
+	// Specifies the backup namespace. When this differs from the Restore namespace,
+	// a Gateway API ReferenceGrant in the backup namespace must allow Restores from
+	// the Restore namespace to reference the Backup. Cross-namespace VolumeSnapshot
+	// restores are not supported.
 	//
 	// +kubebuilder:validation:Required
 	Namespace string `json:"namespace"`

--- a/apis/operations/v1alpha1/opsrequest_types.go
+++ b/apis/operations/v1alpha1/opsrequest_types.go
@@ -513,8 +513,11 @@ type FromBackup struct {
 	// +kubebuilder:validation:Required
 	Name string `json:"name"`
 
-	// Specifies the namespace of the Backup namespace.
+	// Specifies the namespace of the Backup.
 	// If not specified, the namespace of the OpsRequest will be used.
+	// Cross-namespace references require a Gateway API ReferenceGrant in the Backup
+	// namespace that allows Restores from the OpsRequest namespace to reference the
+	// Backup. Cross-namespace VolumeSnapshot restores are not supported.
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
 

--- a/cmd/dataprotection/main.go
+++ b/cmd/dataprotection/main.go
@@ -46,6 +46,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	// +kubebuilder:scaffold:imports
 
@@ -98,6 +99,7 @@ func init() {
 	utilruntime.Must(dpv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(snapshotv1.AddToScheme(scheme))
 	utilruntime.Must(snapshotv1beta1.AddToScheme(scheme))
+	utilruntime.Must(gatewayv1beta1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 
 	viper.SetConfigName("config")                          // name of config file (without extension)

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -47,6 +47,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	// +kubebuilder:scaffold:imports
 
@@ -122,6 +123,7 @@ func init() {
 	utilruntime.Must(dpv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(snapshotv1.AddToScheme(scheme))
 	utilruntime.Must(snapshotv1beta1.AddToScheme(scheme))
+	utilruntime.Must(gatewayv1beta1.AddToScheme(scheme))
 	utilruntime.Must(extensionsv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(workloadsv1.AddToScheme(scheme))
 	utilruntime.Must(experimentalv1alpha1.AddToScheme(scheme))

--- a/config/crd/bases/dataprotection.kubeblocks.io_restores.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_restores.yaml
@@ -83,7 +83,11 @@ spec:
                     description: Specifies the backup name.
                     type: string
                   namespace:
-                    description: Specifies the backup namespace.
+                    description: |-
+                      Specifies the backup namespace. When this differs from the Restore namespace,
+                      a Gateway API ReferenceGrant in the backup namespace must allow Restores from
+                      the Restore namespace to reference the Backup. Cross-namespace VolumeSnapshot
+                      restores are not supported.
                     type: string
                   sourceTargetName:
                     description: Specifies the source target for restoration, identified

--- a/config/crd/bases/operations.kubeblocks.io_opsrequests.yaml
+++ b/config/crd/bases/operations.kubeblocks.io_opsrequests.yaml
@@ -619,8 +619,11 @@ spec:
                               type: string
                             namespace:
                               description: |-
-                                Specifies the namespace of the Backup namespace.
+                                Specifies the namespace of the Backup.
                                 If not specified, the namespace of the OpsRequest will be used.
+                                Cross-namespace references require a Gateway API ReferenceGrant in the Backup
+                                namespace that allows Restores from the OpsRequest namespace to reference the
+                                Backup. Cross-namespace VolumeSnapshot restores are not supported.
                               type: string
                             restoreEnv:
                               description: |-

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -365,6 +365,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - referencegrants
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - operations.kubeblocks.io
   resources:
   - opsdefinitions

--- a/controllers/dataprotection/backuprepo_controller_test.go
+++ b/controllers/dataprotection/backuprepo_controller_test.go
@@ -1322,6 +1322,11 @@ new-item=new-value
 			backup := createBackupSpec(func(backup *dpv1alpha1.Backup) {
 				backup.Namespace = testCtx.DefaultNamespace
 			})
+			grant := newBackupReferenceGrant("allow-backup-repo-restore", backup.Namespace, namespace2, backup.Name)
+			Expect(k8sClient.Create(ctx, grant)).Should(Succeed())
+			DeferCleanup(func() {
+				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, grant))).Should(Succeed())
+			})
 			By("creating a Restore object in the namespace")
 			createRestoreSpec(func(restore *dpv1alpha1.Restore) {
 				restore.Namespace = namespace2

--- a/controllers/dataprotection/restore_controller.go
+++ b/controllers/dataprotection/restore_controller.go
@@ -64,6 +64,7 @@ type RestoreReconciler struct {
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=referencegrants,verbs=get;list;watch
 
 func (r *RestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reqCtx := intctrlutil.RequestCtx{
@@ -159,6 +160,9 @@ func (r *RestoreReconciler) deleteExternalResources(reqCtx intctrlutil.RequestCt
 }
 
 func CheckBackupRepoForRestore(reqCtx intctrlutil.RequestCtx, cli client.Client, restore *dpv1alpha1.Restore) (string, error) {
+	if err := dprestore.ValidateBackupReferenceGrant(reqCtx, cli, restore); err != nil {
+		return "", err
+	}
 	backupName := restore.Spec.Backup.Name
 	backupNamespace := restore.Spec.Backup.Namespace
 	backup := &dpv1alpha1.Backup{}

--- a/controllers/dataprotection/restore_controller_test.go
+++ b/controllers/dataprotection/restore_controller_test.go
@@ -664,6 +664,11 @@ var _ = Describe("Restore Controller test", func() {
 
 		Context("test cross namespace", func() {
 			It("should wait for preparation of backup repo", func() {
+				grant := newBackupReferenceGrant("allow-cross-namespace-restore", testCtx.DefaultNamespace, namespace2, "")
+				Expect(k8sClient.Create(ctx, grant)).Should(Succeed())
+				DeferCleanup(func() {
+					Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, grant))).Should(Succeed())
+				})
 				By("creating a restore in a different namespace from backup")
 				initResourcesAndWaitRestore(true, false, true, "", dpv1alpha1.RestorePhaseRunning,
 					func(f *testdp.MockRestoreFactory) {

--- a/controllers/dataprotection/restore_referencegrant_test.go
+++ b/controllers/dataprotection/restore_referencegrant_test.go
@@ -33,6 +33,29 @@ import (
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 )
 
+func newBackupReferenceGrant(name, backupNamespace, restoreNamespace, backupName string) *gatewayv1beta1.ReferenceGrant {
+	var grantedBackupName *gatewayv1beta1.ObjectName
+	if backupName != "" {
+		name := gatewayv1beta1.ObjectName(backupName)
+		grantedBackupName = &name
+	}
+	return &gatewayv1beta1.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: backupNamespace},
+		Spec: gatewayv1beta1.ReferenceGrantSpec{
+			From: []gatewayv1beta1.ReferenceGrantFrom{{
+				Group:     gatewayv1beta1.Group(dpv1alpha1.GroupVersion.Group),
+				Kind:      gatewayv1beta1.Kind("Restore"),
+				Namespace: gatewayv1beta1.Namespace(restoreNamespace),
+			}},
+			To: []gatewayv1beta1.ReferenceGrantTo{{
+				Group: gatewayv1beta1.Group(dpv1alpha1.GroupVersion.Group),
+				Kind:  gatewayv1beta1.Kind("Backup"),
+				Name:  grantedBackupName,
+			}},
+		},
+	}
+}
+
 func TestCheckBackupRepoForRestoreAuthorizesBeforeBackupRead(t *testing.T) {
 	scheme := runtime.NewScheme()
 	if err := dpv1alpha1.AddToScheme(scheme); err != nil {

--- a/controllers/dataprotection/restore_referencegrant_test.go
+++ b/controllers/dataprotection/restore_referencegrant_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package dataprotection
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+
+	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+)
+
+func TestCheckBackupRepoForRestoreAuthorizesBeforeBackupRead(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := dpv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := gatewayv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+	restore := &dpv1alpha1.Restore{
+		ObjectMeta: metav1.ObjectMeta{Name: "restore", Namespace: "target"},
+		Spec: dpv1alpha1.RestoreSpec{
+			Backup: dpv1alpha1.BackupRef{Name: "backup", Namespace: "source"},
+		},
+	}
+
+	_, err := CheckBackupRepoForRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, cli, restore)
+	if err == nil || !strings.Contains(err.Error(), "ReferenceGrant") {
+		t.Fatalf("expected ReferenceGrant error before Backup lookup, got %v", err)
+	}
+	if strings.Contains(err.Error(), "backups.dataprotection.kubeblocks.io") {
+		t.Fatalf("Backup was read before authorization: %v", err)
+	}
+}

--- a/controllers/dataprotection/suite_test.go
+++ b/controllers/dataprotection/suite_test.go
@@ -45,6 +45,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
@@ -105,6 +106,8 @@ var _ = BeforeSuite(func() {
 			// resolved by ref: https://github.com/operator-framework/operator-sdk/issues/4434#issuecomment-786794418
 			filepath.Join(build.Default.GOPATH, "pkg", "mod", "github.com", "kubernetes-csi/external-snapshotter/",
 				"client/v6@v6.2.0", "config", "crd"),
+			filepath.Join(build.Default.GOPATH, "pkg", "mod", "sigs.k8s.io", "gateway-api@v1.0.0",
+				"config", "crd", "standard"),
 		},
 		ErrorIfCRDPathMissing: true,
 	}
@@ -127,6 +130,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = dpv1alpha1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = gatewayv1beta1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme

--- a/deploy/helm/config/rbac/role.yaml
+++ b/deploy/helm/config/rbac/role.yaml
@@ -365,6 +365,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - gateway.networking.k8s.io
+  resources:
+  - referencegrants
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - operations.kubeblocks.io
   resources:
   - opsdefinitions

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_restores.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_restores.yaml
@@ -83,7 +83,11 @@ spec:
                     description: Specifies the backup name.
                     type: string
                   namespace:
-                    description: Specifies the backup namespace.
+                    description: |-
+                      Specifies the backup namespace. When this differs from the Restore namespace,
+                      a Gateway API ReferenceGrant in the backup namespace must allow Restores from
+                      the Restore namespace to reference the Backup. Cross-namespace VolumeSnapshot
+                      restores are not supported.
                     type: string
                   sourceTargetName:
                     description: Specifies the source target for restoration, identified

--- a/deploy/helm/crds/operations.kubeblocks.io_opsrequests.yaml
+++ b/deploy/helm/crds/operations.kubeblocks.io_opsrequests.yaml
@@ -619,8 +619,11 @@ spec:
                               type: string
                             namespace:
                               description: |-
-                                Specifies the namespace of the Backup namespace.
+                                Specifies the namespace of the Backup.
                                 If not specified, the namespace of the OpsRequest will be used.
+                                Cross-namespace references require a Gateway API ReferenceGrant in the Backup
+                                namespace that allows Restores from the OpsRequest namespace to reference the
+                                Backup. Cross-namespace VolumeSnapshot restores are not supported.
                               type: string
                             restoreEnv:
                               description: |-

--- a/docs/developer_docs/api-reference/dataprotection.md
+++ b/docs/developer_docs/api-reference/dataprotection.md
@@ -2841,7 +2841,10 @@ string
 </em>
 </td>
 <td>
-<p>Specifies the backup namespace.</p>
+<p>Specifies the backup namespace. When this differs from the Restore namespace,
+a Gateway API ReferenceGrant in the backup namespace must allow Restores from
+the Restore namespace to reference the Backup. Cross-namespace VolumeSnapshot
+restores are not supported.</p>
 </td>
 </tr>
 <tr>

--- a/docs/developer_docs/api-reference/operations.md
+++ b/docs/developer_docs/api-reference/operations.md
@@ -1087,8 +1087,11 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Specifies the namespace of the Backup namespace.
-If not specified, the namespace of the OpsRequest will be used.</p>
+<p>Specifies the namespace of the Backup.
+If not specified, the namespace of the OpsRequest will be used.
+Cross-namespace references require a Gateway API ReferenceGrant in the Backup
+namespace that allows Restores from the OpsRequest namespace to reference the
+Backup. Cross-namespace VolumeSnapshot restores are not supported.</p>
 </td>
 </tr>
 <tr>

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	k8s.io/kubectl v0.29.0
 	k8s.io/utils v0.0.0-20231127182322-b307cd553661
 	sigs.k8s.io/controller-runtime v0.17.2
+	sigs.k8s.io/gateway-api v1.0.0
 	sigs.k8s.io/yaml v1.4.0
 )
 
@@ -81,7 +82,7 @@ require (
 	github.com/fatih/camelcase v1.0.0 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
-	github.com/go-openapi/jsonpointer v0.19.6 // indirect
+	github.com/go-openapi/jsonpointer v0.20.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.4 // indirect
 	github.com/go-task/slim-sprig/v3 v3.0.0 // indirect
@@ -98,7 +99,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.1-0.20210315223345-82c243799c99 // indirect
 	github.com/hashicorp/hcl v1.0.1-vault-5 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect
-	github.com/imdario/mergo v0.3.14 // indirect
+	github.com/imdario/mergo v0.3.16 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/lib/pq v1.10.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,9 @@ github.com/go-logr/zapr v1.3.0/go.mod h1:YKepepNBd1u/oyhd/yQmtjVXmm9uML4IXUgMOwR
 github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+35s3my2LFTysnkMfxsJBAMHj/DoqoB9knIWoYG/Vk0=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
-github.com/go-openapi/jsonpointer v0.19.6 h1:eCs3fxoIi3Wh6vtgmLTOjdhSpiqphQ+DaPn38N2ZdrE=
 github.com/go-openapi/jsonpointer v0.19.6/go.mod h1:osyAmYz/mB/C3I+WsTTSgw1ONzaLJoLCyoi6/zppojs=
+github.com/go-openapi/jsonpointer v0.20.0 h1:ESKJdU9ASRfaPNOPRx12IUyA1vn3R9GiE3KYD14BXdQ=
+github.com/go-openapi/jsonpointer v0.20.0/go.mod h1:6PGzBjjIIumbLYysB73Klnms1mwnU4G3YHOECG3CedA=
 github.com/go-openapi/jsonreference v0.0.0-20160704190145-13c6e3589ad9/go.mod h1:W3Z9FmVs9qj+KR4zFKmDPGiLdk1D9Rlm7cyMvf57TTg=
 github.com/go-openapi/jsonreference v0.19.2/go.mod h1:jMjeRr2HHw6nAVajTXJ4eiUwohSTlpa0o73RUL1owJc=
 github.com/go-openapi/jsonreference v0.19.3/go.mod h1:rjx6GuL8TTa9VaixXglHmQmIL98+wF9xc8zWvFonSJ8=
@@ -295,8 +296,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
-github.com/imdario/mergo v0.3.14 h1:fOqeC1+nCuuk6PKQdg9YmosXX7Y7mHX6R/0ZldI9iHo=
-github.com/imdario/mergo v0.3.14/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
+github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
+github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
@@ -952,6 +953,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.28.0 h1:TgtAeesdhpm2S
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.28.0/go.mod h1:VHVDI/KrK4fjnV61bE2g3sA7tiETLn8sooImelsCx3Y=
 sigs.k8s.io/controller-runtime v0.17.2 h1:FwHwD1CTUemg0pW2otk7/U5/i5m2ymzvOXdbeGOUvw0=
 sigs.k8s.io/controller-runtime v0.17.2/go.mod h1:+MngTvIQQQhfXtwfdGw/UOQ/aIaqsYywfCINOtwMO/s=
+sigs.k8s.io/gateway-api v1.0.0 h1:iPTStSv41+d9p0xFydll6d7f7MOBGuqXM6p2/zVYMAs=
+sigs.k8s.io/gateway-api v1.0.0/go.mod h1:4cUgr0Lnp5FZ0Cdq8FdRwCvpiWws7LVhLHGIudLlf4c=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/kustomize/api v0.13.5-0.20230601165947-6ce0bf390ce3 h1:XX3Ajgzov2RKUdc5jW3t5jwY7Bo7dcRm+tFxT+NfgY0=

--- a/pkg/controller/plan/restore.go
+++ b/pkg/controller/plan/restore.go
@@ -50,16 +50,17 @@ type RestoreManager struct {
 	Cluster *appsv1.Cluster
 	Scheme  *k8sruntime.Scheme
 
+	RestoreTime       string
+	RestoreEnv        []corev1.EnvVar
+	RestoreNamePrefix string
+
 	// private
 	namespace           string
-	RestoreTime         string
-	env                 []corev1.EnvVar
 	parameters          []dpv1alpha1.ParameterPair
 	volumeRestorePolicy dpv1alpha1.VolumeClaimRestorePolicy
 	startingIndex       int32
 	replicas            int32
 	restoreLabels       map[string]string
-	RestoreNamePrefix   string
 }
 
 func NewRestoreManager(ctx context.Context,
@@ -188,7 +189,7 @@ func (r *RestoreManager) BuildPrepareDataRestore(comp *component.SynthesizedComp
 				SourceTargetName: sourceTargetName,
 			},
 			RestoreTime: r.RestoreTime,
-			Env:         r.env,
+			Env:         r.RestoreEnv,
 			Parameters:  r.parameters,
 			PrepareDataConfig: &dpv1alpha1.PrepareDataConfig{
 				RequiredPolicyForAllPodSelection: r.buildRequiredPolicy(sourceTarget),
@@ -250,7 +251,7 @@ func (r *RestoreManager) DoPostReady(comp *component.SynthesizedComponent,
 				SourceTargetName: sourceTargetName,
 			},
 			RestoreTime: r.RestoreTime,
-			Env:         r.env,
+			Env:         r.RestoreEnv,
 			Parameters:  r.parameters,
 			ReadyConfig: &dpv1alpha1.ReadyConfig{
 				ExecAction: &dpv1alpha1.ExecAction{

--- a/pkg/controller/plan/restore.go
+++ b/pkg/controller/plan/restore.go
@@ -184,7 +184,7 @@ func (r *RestoreManager) BuildPrepareDataRestore(comp *component.SynthesizedComp
 		Spec: dpv1alpha1.RestoreSpec{
 			Backup: dpv1alpha1.BackupRef{
 				Name:             backupObj.Name,
-				Namespace:        r.namespace,
+				Namespace:        backupObj.Namespace,
 				SourceTargetName: sourceTargetName,
 			},
 			RestoreTime: r.RestoreTime,
@@ -246,7 +246,7 @@ func (r *RestoreManager) DoPostReady(comp *component.SynthesizedComponent,
 		Spec: dpv1alpha1.RestoreSpec{
 			Backup: dpv1alpha1.BackupRef{
 				Name:             backupObj.Name,
-				Namespace:        r.namespace,
+				Namespace:        backupObj.Namespace,
 				SourceTargetName: sourceTargetName,
 			},
 			RestoreTime: r.RestoreTime,

--- a/pkg/controller/plan/restore_test.go
+++ b/pkg/controller/plan/restore_test.go
@@ -209,6 +209,7 @@ func TestBuildPersistentVolumeClaimLabels(t *testing.T) {
 
 func TestRestoreManagerBuildPrepareDataRestore(t *testing.T) {
 	manager := newRestoreManagerForTest()
+	manager.RestoreEnv = []corev1.EnvVar{{Name: "RESTORE_ENV", Value: "from-plan-intent"}}
 	comp := &component.SynthesizedComponent{
 		Name:     "mysql",
 		Replicas: 2,
@@ -265,6 +266,9 @@ func TestRestoreManagerBuildPrepareDataRestore(t *testing.T) {
 		restore.Spec.Backup.Namespace != "backup-source" ||
 		restore.Spec.Backup.SourceTargetName != "target-a" {
 		t.Fatalf("unexpected backup ref: %#v", restore.Spec.Backup)
+	}
+	if !reflect.DeepEqual(restore.Spec.Env, manager.RestoreEnv) {
+		t.Fatalf("restore env = %#v, want %#v", restore.Spec.Env, manager.RestoreEnv)
 	}
 	cfg := restore.Spec.PrepareDataConfig
 	if cfg == nil {

--- a/pkg/controller/plan/restore_test.go
+++ b/pkg/controller/plan/restore_test.go
@@ -234,7 +234,7 @@ func TestRestoreManagerBuildPrepareDataRestore(t *testing.T) {
 		SchedulingPolicy: &appsv1.SchedulingPolicy{NodeName: "node-a"},
 	}
 	backup := &dpv1alpha1.Backup{
-		ObjectMeta: metav1.ObjectMeta{Name: "backup"},
+		ObjectMeta: metav1.ObjectMeta{Name: "backup", Namespace: "backup-source"},
 		Status: dpv1alpha1.BackupStatus{
 			Targets: []dpv1alpha1.BackupStatusTarget{{
 				BackupTarget: dpv1alpha1.BackupTarget{
@@ -262,7 +262,7 @@ func TestRestoreManagerBuildPrepareDataRestore(t *testing.T) {
 		return
 	}
 	if restore.Spec.Backup.Name != "backup" ||
-		restore.Spec.Backup.Namespace != "default" ||
+		restore.Spec.Backup.Namespace != "backup-source" ||
 		restore.Spec.Backup.SourceTargetName != "target-a" {
 		t.Fatalf("unexpected backup ref: %#v", restore.Spec.Backup)
 	}

--- a/pkg/dataprotection/restore/utils.go
+++ b/pkg/dataprotection/restore/utils.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
@@ -229,10 +230,48 @@ func deleteRestoreJob(reqCtx intctrlutil.RequestCtx, cli client.Client, jobKey s
 	return intctrlutil.BackgroundDeleteObject(cli, reqCtx.Ctx, job)
 }
 
+// ValidateBackupReferenceGrant authorizes a cross-namespace Restore to read its referenced Backup.
+func ValidateBackupReferenceGrant(reqCtx intctrlutil.RequestCtx, cli client.Client, restore *dpv1alpha1.Restore) error {
+	backupRef := restore.Spec.Backup
+	if backupRef.Namespace == restore.Namespace {
+		return nil
+	}
+
+	grants := &gatewayv1beta1.ReferenceGrantList{}
+	if err := cli.List(reqCtx.Ctx, grants, client.InNamespace(backupRef.Namespace)); err != nil {
+		return fmt.Errorf("failed to evaluate ReferenceGrant for Backup %s/%s: %w", backupRef.Namespace, backupRef.Name, err)
+	}
+	group := dpv1alpha1.GroupVersion.Group
+	for i := range grants.Items {
+		fromAllowed := false
+		for _, from := range grants.Items[i].Spec.From {
+			if string(from.Group) == group && string(from.Kind) == "Restore" && string(from.Namespace) == restore.Namespace {
+				fromAllowed = true
+				break
+			}
+		}
+		if !fromAllowed {
+			continue
+		}
+		for _, to := range grants.Items[i].Spec.To {
+			if string(to.Group) != group || string(to.Kind) != "Backup" {
+				continue
+			}
+			if to.Name == nil || string(*to.Name) == backupRef.Name {
+				return nil
+			}
+		}
+	}
+	return intctrlutil.NewFatalError(fmt.Sprintf("cross-namespace Backup %s/%s requires a matching ReferenceGrant for Restore namespace %s", backupRef.Namespace, backupRef.Name, restore.Namespace))
+}
+
 // ValidateAndInitRestoreMGR validate if the restore CR is valid and init the restore manager.
 func ValidateAndInitRestoreMGR(reqCtx intctrlutil.RequestCtx,
 	cli client.Client,
 	restoreMgr *RestoreManager) error {
+	if err := ValidateBackupReferenceGrant(reqCtx, cli, restoreMgr.Restore); err != nil {
+		return err
+	}
 
 	// get backupActionSet based on the specified backup name.
 	backupName := restoreMgr.Restore.Spec.Backup.Name
@@ -248,7 +287,9 @@ func ValidateAndInitRestoreMGR(reqCtx intctrlutil.RequestCtx,
 		}
 	}
 
-	// TODO: check if there is permission for cross namespace recovery.
+	if backupSet.UseVolumeSnapshot && backupSet.Backup.Namespace != restoreMgr.Restore.Namespace {
+		return intctrlutil.NewFatalError(fmt.Sprintf("cross-namespace VolumeSnapshot restore from Backup %s/%s is not supported", backupSet.Backup.Namespace, backupName))
+	}
 
 	// check if the backup is completed exclude continuous backup.
 	backupType := utils.GetBackupType(backupSet.ActionSet, &backupSet.UseVolumeSnapshot)

--- a/pkg/dataprotection/restore/utils_test.go
+++ b/pkg/dataprotection/restore/utils_test.go
@@ -32,6 +32,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
@@ -318,6 +319,90 @@ func TestValidateAndInitRestoreMGRFullBackup(t *testing.T) {
 	assert.NoError(t, cli.Update(context.Background(), backup))
 	mgr = &RestoreManager{Restore: restoreObj}
 	assert.Error(t, ValidateAndInitRestoreMGR(reqCtx, cli, mgr))
+}
+
+func TestValidateAndInitRestoreMGRCrossNamespaceBackup(t *testing.T) {
+	scheme := runtime.NewScheme()
+	assert.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	assert.NoError(t, gatewayv1beta1.AddToScheme(scheme))
+
+	actionSet := &dpv1alpha1.ActionSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "full-action"},
+		Spec: dpv1alpha1.ActionSetSpec{
+			BackupType: dpv1alpha1.BackupTypeFull,
+			Restore:    &dpv1alpha1.RestoreActionSpec{PrepareData: &dpv1alpha1.JobActionSpec{}},
+		},
+	}
+	backup := &dpv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: "backup", Namespace: "source"},
+		Status: dpv1alpha1.BackupStatus{
+			Phase:        dpv1alpha1.BackupPhaseCompleted,
+			BackupMethod: &dpv1alpha1.BackupMethod{Name: "full", ActionSetName: actionSet.Name},
+		},
+	}
+	restoreObj := &dpv1alpha1.Restore{
+		ObjectMeta: metav1.ObjectMeta{Name: "restore", Namespace: "target"},
+		Spec: dpv1alpha1.RestoreSpec{
+			Backup: dpv1alpha1.BackupRef{Name: backup.Name, Namespace: backup.Namespace},
+		},
+	}
+	reqCtx := intctrlutil.RequestCtx{
+		Ctx: context.Background(),
+		Req: ctrl.Request{NamespacedName: client.ObjectKeyFromObject(restoreObj)},
+	}
+	grantForBackup := func(name string) *gatewayv1beta1.ReferenceGrant {
+		backupName := gatewayv1beta1.ObjectName(name)
+		return &gatewayv1beta1.ReferenceGrant{
+			ObjectMeta: metav1.ObjectMeta{Name: "restore-backup", Namespace: backup.Namespace},
+			Spec: gatewayv1beta1.ReferenceGrantSpec{
+				From: []gatewayv1beta1.ReferenceGrantFrom{{
+					Group:     gatewayv1beta1.Group(dpv1alpha1.GroupVersion.Group),
+					Kind:      gatewayv1beta1.Kind("Restore"),
+					Namespace: gatewayv1beta1.Namespace(restoreObj.Namespace),
+				}},
+				To: []gatewayv1beta1.ReferenceGrantTo{{
+					Group: gatewayv1beta1.Group(dpv1alpha1.GroupVersion.Group),
+					Kind:  gatewayv1beta1.Kind("Backup"),
+					Name:  &backupName,
+				}},
+			},
+		}
+	}
+
+	t.Run("requires a ReferenceGrant before reading the Backup", func(t *testing.T) {
+		cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+		err := ValidateAndInitRestoreMGR(reqCtx, cli, &RestoreManager{Restore: restoreObj.DeepCopy()})
+		assert.ErrorContains(t, err, "ReferenceGrant")
+		assert.NotContains(t, err.Error(), "backups.dataprotection.kubeblocks.io")
+		assert.True(t, intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal))
+	})
+
+	t.Run("allows an exact Restore to Backup grant", func(t *testing.T) {
+		grant := grantForBackup(backup.Name)
+		cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(actionSet, backup, grant).Build()
+		mgr := &RestoreManager{Restore: restoreObj.DeepCopy()}
+		assert.NoError(t, ValidateAndInitRestoreMGR(reqCtx, cli, mgr))
+		assert.Len(t, mgr.PrepareDataBackupSets, 1)
+	})
+
+	t.Run("rejects a grant for a different Backup", func(t *testing.T) {
+		grant := grantForBackup("other-backup")
+		cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(actionSet, backup, grant).Build()
+		err := ValidateAndInitRestoreMGR(reqCtx, cli, &RestoreManager{Restore: restoreObj.DeepCopy()})
+		assert.ErrorContains(t, err, "ReferenceGrant")
+		assert.True(t, intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal))
+	})
+
+	t.Run("rejects cross namespace VolumeSnapshot restore after authorization", func(t *testing.T) {
+		snapshotBackup := backup.DeepCopy()
+		snapshotBackup.Status.BackupMethod.SnapshotVolumes = new(bool)
+		*snapshotBackup.Status.BackupMethod.SnapshotVolumes = true
+		grant := grantForBackup(backup.Name)
+		cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(actionSet, snapshotBackup, grant).Build()
+		err := ValidateAndInitRestoreMGR(reqCtx, cli, &RestoreManager{Restore: restoreObj.DeepCopy()})
+		assert.ErrorContains(t, err, "VolumeSnapshot")
+		assert.True(t, intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal))
+	})
 }
 
 func TestRestoreManagerStopsManagerContainer(t *testing.T) {

--- a/pkg/operations/horizontal_scaling.go
+++ b/pkg/operations/horizontal_scaling.go
@@ -230,10 +230,6 @@ func (hs horizontalScalingOpsHandler) createRestore(reqCtx intctrlutil.RequestCt
 		// TODO: support explicit source target selection for scale-out restore from multi-target backups.
 		return intctrlutil.NewFatalError(fmt.Sprintf("scale-out from backup %s/%s is not supported because it has multiple source targets", backupObj.Namespace, backupObj.Name))
 	}
-	if backupObj.Status.BackupMethod == nil {
-		return intctrlutil.NewFatalError(fmt.Sprintf(`scale-out from backup %s/%s is not supported because status.backupMethod is empty`,
-			backupObj.Namespace, backupObj.Name))
-	}
 	// create restore
 	restore, err := restoreMGR.BuildPrepareDataRestore(synthesizedComponent, backupObj, getTemplate(templateName))
 	if err != nil {

--- a/pkg/operations/horizontal_scaling.go
+++ b/pkg/operations/horizontal_scaling.go
@@ -42,6 +42,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
 	"github.com/apecloud/kubeblocks/pkg/controller/plan"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	dputils "github.com/apecloud/kubeblocks/pkg/dataprotection/utils"
 )
 
 type horizontalScalingOpsHandler struct{}
@@ -212,6 +213,7 @@ func (hs horizontalScalingOpsHandler) createRestore(reqCtx intctrlutil.RequestCt
 	restoreMGR *plan.RestoreManager,
 	compSpecDeepyCopy *appsv1.ClusterComponentSpec,
 	backupObj *dpv1alpha1.Backup,
+	restoreEnv []corev1.EnvVar,
 	templateName string) error {
 	getTemplate := func(templateName string) *appsv1.InstanceTemplate {
 		if templateName == "" {
@@ -228,6 +230,10 @@ func (hs horizontalScalingOpsHandler) createRestore(reqCtx intctrlutil.RequestCt
 		// TODO: support explicit source target selection for scale-out restore from multi-target backups.
 		return intctrlutil.NewFatalError(fmt.Sprintf("scale-out from backup %s/%s is not supported because it has multiple source targets", backupObj.Namespace, backupObj.Name))
 	}
+	if backupObj.Status.BackupMethod == nil {
+		return intctrlutil.NewFatalError(fmt.Sprintf(`scale-out from backup %s/%s is not supported because status.backupMethod is empty`,
+			backupObj.Namespace, backupObj.Name))
+	}
 	// create restore
 	restore, err := restoreMGR.BuildPrepareDataRestore(synthesizedComponent, backupObj, getTemplate(templateName))
 	if err != nil {
@@ -237,6 +243,7 @@ func (hs horizontalScalingOpsHandler) createRestore(reqCtx intctrlutil.RequestCt
 		return intctrlutil.NewFatalError(fmt.Sprintf("scale-out from backup %s/%s is not supported because backup method %q has no target volumes matching component %q",
 			backupObj.Namespace, backupObj.Name, backupObj.Status.BackupMethod.Name, synthesizedComponent.Name))
 	}
+	restore.Spec.Env = dputils.MergeEnv(restore.Spec.Env, restoreEnv)
 	scheme, _ := opsv1alpha1.SchemeBuilder.Build()
 	if err := intctrlutil.SetOwnership(opsRes.OpsRequest, restore, scheme, ""); err != nil {
 		return err
@@ -305,7 +312,7 @@ func (hs horizontalScalingOpsHandler) restoreDataFromBackup(reqCtx intctrlutil.R
 		if err := cli.Get(reqCtx.Ctx, types.NamespacedName{Namespace: opsRes.Cluster.Namespace, Name: restoreMeta.Name}, restore); err != nil {
 			if apierrors.IsNotFound(err) {
 				allRestoreCompleted = false
-				if err = hs.createRestore(reqCtx, cli, opsRes, synthesizedComponent, restoreMGR, compSpecDeepyCopy, backupObj, templateName); err != nil {
+				if err = hs.createRestore(reqCtx, cli, opsRes, synthesizedComponent, restoreMGR, compSpecDeepyCopy, backupObj, fromBackup.RestoreEnv, templateName); err != nil {
 					return err
 				}
 				continue

--- a/pkg/operations/horizontal_scaling.go
+++ b/pkg/operations/horizontal_scaling.go
@@ -42,7 +42,6 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
 	"github.com/apecloud/kubeblocks/pkg/controller/plan"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
-	dputils "github.com/apecloud/kubeblocks/pkg/dataprotection/utils"
 )
 
 type horizontalScalingOpsHandler struct{}
@@ -213,7 +212,6 @@ func (hs horizontalScalingOpsHandler) createRestore(reqCtx intctrlutil.RequestCt
 	restoreMGR *plan.RestoreManager,
 	compSpecDeepyCopy *appsv1.ClusterComponentSpec,
 	backupObj *dpv1alpha1.Backup,
-	restoreEnv []corev1.EnvVar,
 	templateName string) error {
 	getTemplate := func(templateName string) *appsv1.InstanceTemplate {
 		if templateName == "" {
@@ -239,7 +237,6 @@ func (hs horizontalScalingOpsHandler) createRestore(reqCtx intctrlutil.RequestCt
 		return intctrlutil.NewFatalError(fmt.Sprintf("scale-out from backup %s/%s is not supported because backup method %q has no target volumes matching component %q",
 			backupObj.Namespace, backupObj.Name, backupObj.Status.BackupMethod.Name, synthesizedComponent.Name))
 	}
-	restore.Spec.Env = dputils.MergeEnv(restore.Spec.Env, restoreEnv)
 	scheme, _ := opsv1alpha1.SchemeBuilder.Build()
 	if err := intctrlutil.SetOwnership(opsRes.OpsRequest, restore, scheme, ""); err != nil {
 		return err
@@ -301,6 +298,7 @@ func (hs horizontalScalingOpsHandler) restoreDataFromBackup(reqCtx intctrlutil.R
 			constant.KBAppComponentLabelKey: pgRes.compOps.GetComponentName(),
 		}, 1, int32(podIndexInt))
 		restoreMGR.RestoreTime = fromBackup.RestorePointInTime
+		restoreMGR.RestoreEnv = fromBackup.RestoreEnv
 		restoreMGR.RestoreNamePrefix = string(opsRes.OpsRequest.UID[:8])
 		// check restore status
 		restoreMeta := restoreMGR.GetRestoreObjectMeta(synthesizedComponent, dpv1alpha1.PrepareData, templateName)
@@ -308,7 +306,7 @@ func (hs horizontalScalingOpsHandler) restoreDataFromBackup(reqCtx intctrlutil.R
 		if err := cli.Get(reqCtx.Ctx, types.NamespacedName{Namespace: opsRes.Cluster.Namespace, Name: restoreMeta.Name}, restore); err != nil {
 			if apierrors.IsNotFound(err) {
 				allRestoreCompleted = false
-				if err = hs.createRestore(reqCtx, cli, opsRes, synthesizedComponent, restoreMGR, compSpecDeepyCopy, backupObj, fromBackup.RestoreEnv, templateName); err != nil {
+				if err = hs.createRestore(reqCtx, cli, opsRes, synthesizedComponent, restoreMGR, compSpecDeepyCopy, backupObj, templateName); err != nil {
 					return err
 				}
 				continue

--- a/pkg/operations/horizontal_scaling_test.go
+++ b/pkg/operations/horizontal_scaling_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -1008,10 +1009,12 @@ func TestHorizontalScalingCreateRestoreReturnsFatalWhenNoRestoreBuilt(t *testing
 	testCases := []struct {
 		name         string
 		backupMethod *dpv1alpha1.BackupMethod
+		expectError  string
 	}{{
 		// logical backups (e.g. TiDB BR) have no targetVolumes at all
 		name:         "backup method without target volumes",
 		backupMethod: &dpv1alpha1.BackupMethod{Name: "br"},
+		expectError:  "has no target volumes matching component",
 	}, {
 		// targetVolumes exist but none match the component's volume claim templates
 		name: "backup method target volumes match no component volume",
@@ -1021,6 +1024,10 @@ func TestHorizontalScalingCreateRestoreReturnsFatalWhenNoRestoreBuilt(t *testing
 				Volumes: []string{"other-data"},
 			},
 		},
+		expectError: "has no target volumes matching component",
+	}, {
+		name:        "backup method missing from backup status",
+		expectError: "status.backupMethod is empty",
 	}}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1080,14 +1087,14 @@ func TestHorizontalScalingCreateRestoreReturnsFatalWhenNoRestoreBuilt(t *testing
 			}, 1, 3)
 
 			err := horizontalScalingOpsHandler{}.createRestore(intctrlutil.RequestCtx{Ctx: ctx}, cli, opsRes,
-				synthesizedComponent, restoreMGR, &appsv1.ClusterComponentSpec{Name: "tikv"}, backup, "")
+				synthesizedComponent, restoreMGR, &appsv1.ClusterComponentSpec{Name: "tikv"}, backup, nil, "")
 			if err == nil {
 				t.Fatal("expected fatal error when backup method cannot build prepareData restore")
 			}
 			if !intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal) {
 				t.Fatalf("expected fatal error, got %T: %v", err, err)
 			}
-			if !strings.Contains(err.Error(), "has no target volumes matching component") {
+			if !strings.Contains(err.Error(), tc.expectError) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
@@ -1099,5 +1106,85 @@ func TestHorizontalScalingCreateRestoreReturnsFatalWhenNoRestoreBuilt(t *testing
 				t.Fatalf("expected no restore to be created, got %d", len(restoreList.Items))
 			}
 		})
+	}
+}
+
+func TestHorizontalScalingCreateRestorePropagatesRestoreEnv(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	for _, addToScheme := range []func(*runtime.Scheme) error{
+		corev1.AddToScheme,
+		appsv1.AddToScheme,
+		dpv1alpha1.AddToScheme,
+		opsv1alpha1.AddToScheme,
+	} {
+		if err := addToScheme(scheme); err != nil {
+			t.Fatalf("add scheme: %v", err)
+		}
+	}
+
+	cluster := &appsv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mysql",
+			Namespace: "default",
+			UID:       types.UID("cluster1"),
+		},
+	}
+	opsRequest := &opsv1alpha1.OpsRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "scale-out-from-backup",
+			Namespace: "default",
+			UID:       types.UID("opsreq1"),
+		},
+	}
+	backup := &dpv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "xtrabackup-full",
+			Namespace: "default",
+		},
+		Status: dpv1alpha1.BackupStatus{
+			Phase: dpv1alpha1.BackupPhaseCompleted,
+			BackupMethod: &dpv1alpha1.BackupMethod{
+				Name: "xtrabackup",
+				TargetVolumes: &dpv1alpha1.TargetVolumeInfo{
+					Volumes: []string{"data"},
+				},
+			},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster, opsRequest, backup).Build()
+	opsRes := &OpsResource{
+		Cluster:    cluster,
+		OpsRequest: opsRequest,
+	}
+	synthesizedComponent := &component.SynthesizedComponent{
+		Name: "mysql",
+		VolumeClaimTemplates: []corev1.PersistentVolumeClaimTemplate{{
+			ObjectMeta: metav1.ObjectMeta{Name: "data"},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			},
+		}},
+	}
+	restoreMGR := plan.NewRestoreManager(ctx, cli, cluster, scheme, map[string]string{
+		constant.OpsRequestNameLabelKey: opsRequest.Name,
+	}, 1, 3)
+	restoreEnv := []corev1.EnvVar{{Name: "RESTORE_ENV", Value: "true"}}
+
+	err := horizontalScalingOpsHandler{}.createRestore(intctrlutil.RequestCtx{Ctx: ctx, Recorder: record.NewFakeRecorder(1)}, cli, opsRes,
+		synthesizedComponent, restoreMGR, &appsv1.ClusterComponentSpec{Name: "mysql"}, backup, restoreEnv, "")
+	if err != nil {
+		t.Fatalf("create restore: %v", err)
+	}
+
+	restoreList := &dpv1alpha1.RestoreList{}
+	if err := cli.List(ctx, restoreList, client.InNamespace("default")); err != nil {
+		t.Fatalf("list restores: %v", err)
+	}
+	if len(restoreList.Items) != 1 {
+		t.Fatalf("expected one restore to be created, got %d", len(restoreList.Items))
+	}
+	if len(restoreList.Items[0].Spec.Env) != 1 || restoreList.Items[0].Spec.Env[0] != restoreEnv[0] {
+		t.Fatalf("expected restore env %v, got %v", restoreEnv, restoreList.Items[0].Spec.Env)
 	}
 }

--- a/pkg/operations/horizontal_scaling_test.go
+++ b/pkg/operations/horizontal_scaling_test.go
@@ -1084,7 +1084,7 @@ func TestHorizontalScalingCreateRestoreReturnsFatalWhenNoRestoreBuilt(t *testing
 			}, 1, 3)
 
 			err := horizontalScalingOpsHandler{}.createRestore(intctrlutil.RequestCtx{Ctx: ctx}, cli, opsRes,
-				synthesizedComponent, restoreMGR, &appsv1.ClusterComponentSpec{Name: "tikv"}, backup, nil, "")
+				synthesizedComponent, restoreMGR, &appsv1.ClusterComponentSpec{Name: "tikv"}, backup, "")
 			if err == nil {
 				t.Fatal("expected fatal error when backup method cannot build prepareData restore")
 			}
@@ -1167,9 +1167,10 @@ func TestHorizontalScalingCreateRestorePropagatesRestoreEnv(t *testing.T) {
 		constant.OpsRequestNameLabelKey: opsRequest.Name,
 	}, 1, 3)
 	restoreEnv := []corev1.EnvVar{{Name: "RESTORE_ENV", Value: "true"}}
+	restoreMGR.RestoreEnv = restoreEnv
 
 	err := horizontalScalingOpsHandler{}.createRestore(intctrlutil.RequestCtx{Ctx: ctx, Recorder: record.NewFakeRecorder(1)}, cli, opsRes,
-		synthesizedComponent, restoreMGR, &appsv1.ClusterComponentSpec{Name: "mysql"}, backup, restoreEnv, "")
+		synthesizedComponent, restoreMGR, &appsv1.ClusterComponentSpec{Name: "mysql"}, backup, "")
 	if err != nil {
 		t.Fatalf("create restore: %v", err)
 	}
@@ -1210,7 +1211,7 @@ func TestHorizontalScalingCreateRestoreDefersBackupMethodValidationToRestorePlan
 	opsRes := &OpsResource{Cluster: cluster, OpsRequest: opsRequest}
 
 	err := horizontalScalingOpsHandler{}.createRestore(intctrlutil.RequestCtx{Ctx: ctx}, cli, opsRes,
-		&component.SynthesizedComponent{}, restoreMGR, &appsv1.ClusterComponentSpec{}, backup, nil, "")
+		&component.SynthesizedComponent{}, restoreMGR, &appsv1.ClusterComponentSpec{}, backup, "")
 	if err == nil {
 		t.Fatal("expected the restore plan to reject the incomplete Backup status")
 	}

--- a/pkg/operations/horizontal_scaling_test.go
+++ b/pkg/operations/horizontal_scaling_test.go
@@ -1025,9 +1025,6 @@ func TestHorizontalScalingCreateRestoreReturnsFatalWhenNoRestoreBuilt(t *testing
 			},
 		},
 		expectError: "has no target volumes matching component",
-	}, {
-		name:        "backup method missing from backup status",
-		expectError: "status.backupMethod is empty",
 	}}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1140,7 +1137,7 @@ func TestHorizontalScalingCreateRestorePropagatesRestoreEnv(t *testing.T) {
 	backup := &dpv1alpha1.Backup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "xtrabackup-full",
-			Namespace: "default",
+			Namespace: "backup-source",
 		},
 		Status: dpv1alpha1.BackupStatus{
 			Phase: dpv1alpha1.BackupPhaseCompleted,
@@ -1186,5 +1183,41 @@ func TestHorizontalScalingCreateRestorePropagatesRestoreEnv(t *testing.T) {
 	}
 	if len(restoreList.Items[0].Spec.Env) != 1 || restoreList.Items[0].Spec.Env[0] != restoreEnv[0] {
 		t.Fatalf("expected restore env %v, got %v", restoreEnv, restoreList.Items[0].Spec.Env)
+	}
+	if restoreList.Items[0].Spec.Backup.Namespace != backup.Namespace {
+		t.Fatalf("expected source backup namespace %q, got %q", backup.Namespace, restoreList.Items[0].Spec.Backup.Namespace)
+	}
+}
+
+func TestHorizontalScalingCreateRestoreDefersBackupMethodValidationToRestorePlan(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	for _, addToScheme := range []func(*runtime.Scheme) error{
+		corev1.AddToScheme,
+		appsv1.AddToScheme,
+		dpv1alpha1.AddToScheme,
+		opsv1alpha1.AddToScheme,
+	} {
+		if err := addToScheme(scheme); err != nil {
+			t.Fatalf("add scheme: %v", err)
+		}
+	}
+	cluster := &appsv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "mysql", Namespace: "default"}}
+	opsRequest := &opsv1alpha1.OpsRequest{ObjectMeta: metav1.ObjectMeta{Name: "scale-out", Namespace: "default"}}
+	backup := &dpv1alpha1.Backup{ObjectMeta: metav1.ObjectMeta{Name: "backup", Namespace: "backup-source"}}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster, opsRequest).Build()
+	restoreMGR := plan.NewRestoreManager(ctx, cli, cluster, scheme, nil, 1, 1)
+	opsRes := &OpsResource{Cluster: cluster, OpsRequest: opsRequest}
+
+	err := horizontalScalingOpsHandler{}.createRestore(intctrlutil.RequestCtx{Ctx: ctx}, cli, opsRes,
+		&component.SynthesizedComponent{}, restoreMGR, &appsv1.ClusterComponentSpec{}, backup, nil, "")
+	if err == nil {
+		t.Fatal("expected the restore plan to reject the incomplete Backup status")
+	}
+	if intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal) {
+		t.Fatalf("Ops must not reclassify DataProtection BackupMethod state as fatal: %v", err)
+	}
+	if !strings.Contains(err.Error(), "status.backupMethod") {
+		t.Fatalf("unexpected restore plan error: %v", err)
 	}
 }


### PR DESCRIPTION
Fixes #10596.

## What changed

- Preserve the source Backup namespace in generated Restore objects.
- Require a matching Gateway API `ReferenceGrant` in the Backup namespace before DataProtection reads a cross-namespace Backup. Both Restore and VolumePopulator entry paths enforce the same authorization contract.
- Reject cross-namespace VolumeSnapshot restores before PVC creation, because Kubernetes VolumeSnapshot data sources are namespace-scoped.
- Carry `scaleOut.fromBackup.restoreEnv` as public plan intent and write it into `Restore.spec.env`; the DataProtection builder remains the sole owner of final environment merge precedence.
- Keep incomplete or unsupported Backup state in the DataProtection/restore layer instead of treating it as a terminal Ops-layer error.
- Document the cross-namespace grant requirement and unsupported cross-namespace snapshot boundary in the API reference and generated CRDs.

## Scope

This PR does not add multi-target Backup selector support; that is handled by #10594. Logical/action-based scale-out restore remains out of scope.

## Validation

- Focused RED/GREEN tests for missing grants, authorized cross-namespace Backup reads, authorized-but-cross-namespace snapshot rejection, and Restore env propagation.
- Full `pkg/dataprotection/restore`, `pkg/controller/plan`, and `pkg/operations` package tests.
- `go test ./... -run '^$'`
- `make generate`, `make manifests`, and `make doc` idempotence.
- `gofmt` and `git diff --check`.

Runtime/product validation is not claimed by this PR test packet.
