### PR TITLE
fix: clean up deleting restore PVCs

### DIFF
--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -208,6 +208,12 @@ func (r *VolumePopulatorReconciler) MatchToPopulate(pvc *corev1.PersistentVolume
 }
 
 func (r *VolumePopulatorReconciler) syncPVC(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim) error {
+	if !pvc.DeletionTimestamp.IsZero() {
+		if slices.Contains(pvc.Finalizers, dptypes.DataProtectionFinalizerName) {
+			return r.Cleanup(reqCtx, pvc)
+		}
+		return nil
+	}
 	matched, err := r.MatchToPopulate(pvc)
 	if err != nil {
 		return err
@@ -1730,14 +1736,7 @@ func postReadyRestoreName(componentUID types.UID) string {
 }
 
 func (r *VolumePopulatorReconciler) Cleanup(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim) error {
-	if slices.Contains(pvc.Finalizers, dptypes.DataProtectionFinalizerName) {
-		pvcPatch := client.MergeFrom(pvc.DeepCopy())
-		controllerutil.RemoveFinalizer(pvc, dptypes.DataProtectionFinalizerName)
-		if err := r.Client.Patch(reqCtx.Ctx, pvc, pvcPatch); err != nil {
-			return err
-		}
-	}
-
+	dependentsPending := false
 	jobs := &batchv1.JobList{}
 	if err := r.Client.List(reqCtx.Ctx, jobs,
 		client.InNamespace(pvc.Namespace), client.MatchingLabels(map[string]string{
@@ -1748,6 +1747,7 @@ func (r *VolumePopulatorReconciler) Cleanup(reqCtx intctrlutil.RequestCtx, pvc *
 
 	for i := range jobs.Items {
 		job := &jobs.Items[i]
+		dependentsPending = true
 		if controllerutil.ContainsFinalizer(job, dptypes.DataProtectionFinalizerName) {
 			patch := client.MergeFrom(job.DeepCopy())
 			controllerutil.RemoveFinalizer(job, dptypes.DataProtectionFinalizerName)
@@ -1766,9 +1766,29 @@ func (r *VolumePopulatorReconciler) Cleanup(reqCtx intctrlutil.RequestCtx, pvc *
 	populatePVC := &corev1.PersistentVolumeClaim{}
 	if err := r.Client.Get(reqCtx.Ctx, types.NamespacedName{Name: getPopulatePVCName(pvc.UID),
 		Namespace: pvc.Namespace}, populatePVC); err != nil {
-		return client.IgnoreNotFound(err)
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+	} else {
+		dependentsPending = true
+		if populatePVC.DeletionTimestamp.IsZero() {
+			if err := r.Client.Delete(reqCtx.Ctx, populatePVC); err != nil && !apierrors.IsNotFound(err) {
+				return err
+			}
+		}
 	}
-	return r.Client.Delete(reqCtx.Ctx, populatePVC)
+	if dependentsPending && !pvc.DeletionTimestamp.IsZero() {
+		return intctrlutil.NewRequeueError(reconcileInterval, "waiting for volume populate dependents to be deleted")
+	}
+
+	if slices.Contains(pvc.Finalizers, dptypes.DataProtectionFinalizerName) {
+		pvcPatch := client.MergeFrom(pvc.DeepCopy())
+		controllerutil.RemoveFinalizer(pvc, dptypes.DataProtectionFinalizerName)
+		if err := r.Client.Patch(reqCtx.Ctx, pvc, pvcPatch); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
 }
 
 func (r *VolumePopulatorReconciler) checkIntreeStorageClass(pvc *corev1.PersistentVolumeClaim, sc *storagev1.StorageClass) error {

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -22,6 +22,7 @@ package dataprotection
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -31,6 +32,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -39,6 +41,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
@@ -2290,6 +2293,237 @@ func newRestorePVCForSerialTest(name, volumeName string) *corev1.PersistentVolum
 				Kind:     dptypes.BackupKind,
 				Name:     "backup",
 			},
+		},
+	}
+}
+
+func TestSyncPVCDeletionCleansUpWhenBackupIsMissing(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+
+	apiGroup := dptypes.DataprotectionAPIGroup
+	deletionTime := metav1.Now()
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         "default",
+			Name:              "restore-data-mysql-0",
+			UID:               types.UID("target-pvc-uid"),
+			DeletionTimestamp: &deletionTime,
+			Finalizers:        []string{dptypes.DataProtectionFinalizerName},
+			Annotations: map[string]string{
+				constant.RestoreSourceNamespaceAnnotationKey: "default",
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			DataSourceRef: &corev1.TypedObjectReference{
+				APIGroup: &apiGroup,
+				Kind:     dptypes.BackupKind,
+				Name:     "deleted-backup",
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Conditions: []corev1.PersistentVolumeClaimCondition{{
+				Type:   PersistentVolumeClaimPopulating,
+				Status: corev1.ConditionTrue,
+				Reason: ReasonPopulatingProcessing,
+			}},
+		},
+	}
+	populatePVCName := getPopulatePVCName(pvc.UID)
+	populatePVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  pvc.Namespace,
+			Name:       populatePVCName,
+			Finalizers: []string{"test.kubeblocks.io/hold"},
+		},
+	}
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  pvc.Namespace,
+			Name:       "populate-job",
+			Finalizers: []string{dptypes.DataProtectionFinalizerName, "test.kubeblocks.io/hold"},
+			Labels: map[string]string{
+				dprestore.DataProtectionPopulatePVCLabelKey: populatePVCName,
+			},
+		},
+	}
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc, populatePVC, job).Build(),
+		Scheme: scheme,
+	}
+
+	err := reconciler.syncPVC(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc)
+
+	require.Error(t, err)
+	require.True(t, intctrlutil.IsRequeueError(err), err)
+	currentPVC := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), currentPVC))
+	require.Contains(t, currentPVC.Finalizers, dptypes.DataProtectionFinalizerName)
+	currentPopulatePVC := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(populatePVC), currentPopulatePVC))
+	require.False(t, currentPopulatePVC.DeletionTimestamp.IsZero())
+	currentJob := &batchv1.Job{}
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(job), currentJob))
+	require.False(t, currentJob.DeletionTimestamp.IsZero())
+	require.NotContains(t, currentJob.Finalizers, dptypes.DataProtectionFinalizerName)
+
+	jobPatch := client.MergeFrom(currentJob.DeepCopy())
+	currentJob.Finalizers = nil
+	require.NoError(t, reconciler.Client.Patch(context.Background(), currentJob, jobPatch))
+	populatePVCPatch := client.MergeFrom(currentPopulatePVC.DeepCopy())
+	currentPopulatePVC.Finalizers = nil
+	require.NoError(t, reconciler.Client.Patch(context.Background(), currentPopulatePVC, populatePVCPatch))
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), currentPVC))
+
+	err = reconciler.syncPVC(intctrlutil.RequestCtx{Ctx: context.Background()}, currentPVC)
+
+	require.NoError(t, err)
+	err = reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(currentPVC), &corev1.PersistentVolumeClaim{})
+	require.True(t, apierrors.IsNotFound(err), err)
+	err = reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(populatePVC), &corev1.PersistentVolumeClaim{})
+	require.True(t, apierrors.IsNotFound(err), err)
+	err = reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(job), &batchv1.Job{})
+	require.True(t, apierrors.IsNotFound(err), err)
+}
+
+func TestSyncPVCDeletionReleasesFinalizerWhenDependentsAreAbsent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	pvc := newDeletingBackupRestorePVC()
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc).Build(),
+		Scheme: scheme,
+	}
+
+	err := reconciler.syncPVC(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc)
+
+	require.NoError(t, err)
+	err = reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), &corev1.PersistentVolumeClaim{})
+	require.True(t, apierrors.IsNotFound(err), err)
+}
+
+func TestSyncPVCDeletionKeepsFinalizerOnCleanupAPIErrors(t *testing.T) {
+	testCases := []struct {
+		name              string
+		failurePoint      string
+		jobExists         bool
+		jobHasDPFinalizer bool
+		helperPVCExists   bool
+	}{
+		{name: "list jobs", failurePoint: "list-jobs"},
+		{name: "patch job finalizer", failurePoint: "patch-job", jobExists: true, jobHasDPFinalizer: true},
+		{name: "delete job", failurePoint: "delete-job", jobExists: true},
+		{name: "get helper PVC", failurePoint: "get-helper"},
+		{name: "delete helper PVC", failurePoint: "delete-helper", helperPVCExists: true},
+		{name: "patch target PVC", failurePoint: "patch-target"},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, corev1.AddToScheme(scheme))
+			require.NoError(t, batchv1.AddToScheme(scheme))
+			require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+			pvc := newDeletingBackupRestorePVC()
+			helperPVCName := getPopulatePVCName(pvc.UID)
+			jobName := "populate-job"
+			objects := []client.Object{pvc}
+			if testCase.jobExists {
+				jobFinalizers := []string(nil)
+				if testCase.jobHasDPFinalizer {
+					jobFinalizers = []string{dptypes.DataProtectionFinalizerName}
+				}
+				objects = append(objects, &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+					Namespace:  pvc.Namespace,
+					Name:       jobName,
+					Finalizers: jobFinalizers,
+					Labels: map[string]string{
+						dprestore.DataProtectionPopulatePVCLabelKey: helperPVCName,
+					},
+				}})
+			}
+			if testCase.helperPVCExists {
+				objects = append(objects, &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{Namespace: pvc.Namespace, Name: helperPVCName},
+				})
+			}
+			injectedErr := errors.New("injected cleanup error")
+			cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).WithInterceptorFuncs(interceptor.Funcs{
+				List: func(ctx context.Context, cli client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+					if testCase.failurePoint == "list-jobs" {
+						if _, ok := list.(*batchv1.JobList); ok {
+							return injectedErr
+						}
+					}
+					return cli.List(ctx, list, opts...)
+				},
+				Get: func(ctx context.Context, cli client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if testCase.failurePoint == "get-helper" && key.Name == helperPVCName {
+						return injectedErr
+					}
+					return cli.Get(ctx, key, obj, opts...)
+				},
+				Delete: func(ctx context.Context, cli client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					if testCase.failurePoint == "delete-job" && obj.GetName() == jobName {
+						return injectedErr
+					}
+					if testCase.failurePoint == "delete-helper" && obj.GetName() == helperPVCName {
+						return injectedErr
+					}
+					return cli.Delete(ctx, obj, opts...)
+				},
+				Patch: func(ctx context.Context, cli client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					if testCase.failurePoint == "patch-job" && obj.GetName() == jobName {
+						return injectedErr
+					}
+					if testCase.failurePoint == "patch-target" && obj.GetName() == pvc.Name {
+						return injectedErr
+					}
+					return cli.Patch(ctx, obj, patch, opts...)
+				},
+			}).Build()
+			reconciler := &VolumePopulatorReconciler{Client: cli, Scheme: scheme}
+
+			err := reconciler.syncPVC(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc)
+
+			require.ErrorIs(t, err, injectedErr)
+			currentPVC := &corev1.PersistentVolumeClaim{}
+			require.NoError(t, cli.Get(context.Background(), client.ObjectKeyFromObject(pvc), currentPVC))
+			require.Contains(t, currentPVC.Finalizers, dptypes.DataProtectionFinalizerName)
+		})
+	}
+}
+
+func newDeletingBackupRestorePVC() *corev1.PersistentVolumeClaim {
+	apiGroup := dptypes.DataprotectionAPIGroup
+	deletionTime := metav1.Now()
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         "default",
+			Name:              "restore-data-mysql-0",
+			UID:               types.UID("target-pvc-uid"),
+			DeletionTimestamp: &deletionTime,
+			Finalizers:        []string{dptypes.DataProtectionFinalizerName},
+			Annotations: map[string]string{
+				constant.RestoreSourceNamespaceAnnotationKey: "default",
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			DataSourceRef: &corev1.TypedObjectReference{
+				APIGroup: &apiGroup,
+				Kind:     dptypes.BackupKind,
+				Name:     "deleted-backup",
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Conditions: []corev1.PersistentVolumeClaimCondition{{
+				Type:   PersistentVolumeClaimPopulating,
+				Status: corev1.ConditionTrue,
+				Reason: ReasonPopulatingProcessing,
+			}},
 		},
 	}
 }


### PR DESCRIPTION
## Summary

- handle a deleting restore PVC before validating its source Backup
- keep the target PVC finalizer while owned populate Jobs or the helper PVC still exist
- release the target finalizer only after a fresh reconcile confirms the dependents are absent
- preserve the existing non-deletion cleanup behavior for bound PVC completion

## Tests

- `go test ./controllers/dataprotection -run '^TestSyncPVCDeletion' -count=1`
- `go test ./controllers/dataprotection -run '^Test(SyncPVCDeletion|CompleteBoundPVC|ProvisionOnly)' -count=1`
- `KUBEBUILDER_ASSETS='<envtest 1.26.1 assets>' go test ./controllers/dataprotection -count=1`
- `git diff HEAD^..HEAD --check`

The PR remains draft until the patch image is validated against the focused restore cleanup scenario.
