### PR TITLE
fix: clean up deleting restore PVCs

### DIFF
--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -1619,6 +1619,27 @@ func postReadyRestoreName(componentUID types.UID) string {
 }
 
 func (r *VolumePopulatorReconciler) Cleanup(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim) error {
+	if !pvc.DeletionTimestamp.IsZero() {
+		executionRestore := &dpv1alpha1.Restore{}
+		executionRestoreKey := types.NamespacedName{
+			Namespace: pvc.Namespace,
+			Name:      getPopulatePVCName(pvc.UID),
+		}
+		if err := r.Client.Get(reqCtx.Ctx, executionRestoreKey, executionRestore); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return err
+			}
+		} else {
+			if executionRestore.DeletionTimestamp.IsZero() {
+				uid := executionRestore.UID
+				if err := r.Client.Delete(reqCtx.Ctx, executionRestore, client.Preconditions{UID: &uid}); err != nil && !apierrors.IsNotFound(err) {
+					return err
+				}
+			}
+			return intctrlutil.NewRequeueError(reconcileInterval, "waiting for execution restore to be deleted")
+		}
+	}
+
 	dependentsPending := false
 	jobs := &batchv1.JobList{}
 	if err := r.Client.List(reqCtx.Ctx, jobs,

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -124,6 +124,14 @@ func (r *VolumePopulatorReconciler) handleSyncPVCError(reqCtx intctrlutil.Reques
 	if requeueErr, ok := err.(intctrlutil.RequeueError); ok {
 		return intctrlutil.RequeueAfter(requeueErr.RequeueAfter(), reqCtx.Log, requeueErr.Reason())
 	}
+	if !pvc.DeletionTimestamp.IsZero() {
+		// Cleanup is selected from the PVC deletion state. Do not re-check the
+		// finalizer here: Cleanup may have removed it from this in-memory object
+		// immediately before its Patch failed. An existing Populating condition
+		// must not suppress the error because no other watch guarantees another
+		// cleanup attempt.
+		return RecorderEventAndRequeue(reqCtx, r.Recorder, pvc, err)
+	}
 	if r.ContainPopulatingCondition(pvc) {
 		// Ignore the error if an external controller handles this PVC.
 		return intctrlutil.Reconciled()

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 
 	vsv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -166,15 +167,18 @@ func (r *VolumePopulatorReconciler) MatchToPopulate(pvc *corev1.PersistentVolume
 }
 
 func (r *VolumePopulatorReconciler) syncPVC(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim) error {
+	if !pvc.DeletionTimestamp.IsZero() {
+		if slices.Contains(pvc.Finalizers, dptypes.DataProtectionFinalizerName) {
+			return r.Cleanup(reqCtx, pvc)
+		}
+		return nil
+	}
 	matched, err := r.MatchToPopulate(pvc)
 	if err != nil {
 		return err
 	}
 	if !matched {
 		return nil
-	}
-	if !pvc.DeletionTimestamp.IsZero() {
-		return r.Cleanup(reqCtx, pvc)
 	}
 	var restoreCtx *pvcRestoreContext
 	if pvc.Spec.DataSourceRef.Kind == dptypes.RestoreKind {
@@ -1615,21 +1619,56 @@ func postReadyRestoreName(componentUID types.UID) string {
 }
 
 func (r *VolumePopulatorReconciler) Cleanup(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim) error {
+	dependentsPending := false
+	jobs := &batchv1.JobList{}
+	if err := r.Client.List(reqCtx.Ctx, jobs,
+		client.InNamespace(pvc.Namespace), client.MatchingLabels(map[string]string{
+			dprestore.DataProtectionPopulatePVCLabelKey: getPopulatePVCName(pvc.UID),
+		})); err != nil {
+		return err
+	}
+
+	for i := range jobs.Items {
+		job := &jobs.Items[i]
+		dependentsPending = true
+		if controllerutil.ContainsFinalizer(job, dptypes.DataProtectionFinalizerName) {
+			patch := client.MergeFrom(job.DeepCopy())
+			controllerutil.RemoveFinalizer(job, dptypes.DataProtectionFinalizerName)
+			if err := r.Patch(reqCtx.Ctx, job, patch); err != nil {
+				return err
+			}
+		}
+		if !job.DeletionTimestamp.IsZero() {
+			continue
+		}
+		if err := intctrlutil.BackgroundDeleteObject(r.Client, reqCtx.Ctx, job); err != nil {
+			return err
+		}
+	}
+
 	populatePVC := &corev1.PersistentVolumeClaim{}
 	if err := r.Client.Get(reqCtx.Ctx, types.NamespacedName{Name: getPopulatePVCName(pvc.UID),
 		Namespace: pvc.Namespace}, populatePVC); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return err
 		}
-	} else if err = r.Client.Delete(reqCtx.Ctx, populatePVC); err != nil && !apierrors.IsNotFound(err) {
-		return err
+	} else {
+		dependentsPending = true
+		if populatePVC.DeletionTimestamp.IsZero() {
+			if err := r.Client.Delete(reqCtx.Ctx, populatePVC); err != nil && !apierrors.IsNotFound(err) {
+				return err
+			}
+		}
+	}
+	if dependentsPending && !pvc.DeletionTimestamp.IsZero() {
+		return intctrlutil.NewRequeueError(reconcileInterval, "waiting for volume populate dependents to be deleted")
 	}
 
 	if slices.Contains(pvc.Finalizers, dptypes.DataProtectionFinalizerName) {
 		pvcPatch := client.MergeFrom(pvc.DeepCopy())
 		controllerutil.RemoveFinalizer(pvc, dptypes.DataProtectionFinalizerName)
-		if err := r.Client.Patch(reqCtx.Ctx, pvc, pvcPatch); err != nil {
-			return client.IgnoreNotFound(err)
+		if err := r.Client.Patch(reqCtx.Ctx, pvc, pvcPatch); err != nil && !apierrors.IsNotFound(err) {
+			return err
 		}
 	}
 	return nil

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -24,7 +24,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -528,6 +530,72 @@ var _ = Describe("Volume Populator Controller test", func() {
 
 			It("test VolumePopulator when backup uses volume snapshot", func() {
 				testVolumePopulate(storagev1.VolumeBindingWaitForFirstConsumer, true)
+			})
+
+			It("stops the execution restore before cleaning populate dependents", func() {
+				pvc := initResources(storagev1.VolumeBindingImmediate, false, true)
+				restoreKey := types.NamespacedName{
+					Namespace: pvc.Namespace,
+					Name:      getPopulatePVCName(pvc.UID),
+				}
+				Eventually(testapps.CheckObj(&testCtx, restoreKey, func(g Gomega, restore *dpv1alpha1.Restore) {
+					g.Expect(restore.Status.Phase).Should(Equal(dpv1alpha1.RestorePhaseRunning))
+				})).Should(Succeed())
+				Eventually(testapps.List(&testCtx, generics.JobSignature,
+					client.MatchingLabels{dprestore.DataProtectionRestoreLabelKey: restoreKey.Name},
+					client.InNamespace(pvc.Namespace))).Should(HaveLen(1))
+
+				const holdFinalizer = "test.kubeblocks.io/hold-restore-deletion"
+				restore := &dpv1alpha1.Restore{}
+				Expect(k8sClient.Get(ctx, restoreKey, restore)).Should(Succeed())
+				Expect(testapps.ChangeObj(&testCtx, restore, func(current *dpv1alpha1.Restore) {
+					current.Finalizers = append(current.Finalizers, holdFinalizer)
+				})).Should(Succeed())
+
+				targetPVC := &corev1.PersistentVolumeClaim{}
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pvc), targetPVC)).Should(Succeed())
+				Expect(k8sClient.Delete(ctx, targetPVC)).Should(Succeed())
+
+				Eventually(testapps.CheckObj(&testCtx, restoreKey, func(g Gomega, current *dpv1alpha1.Restore) {
+					g.Expect(current.DeletionTimestamp.IsZero()).Should(BeFalse())
+					g.Expect(current.Finalizers).Should(ContainElement(holdFinalizer))
+				})).Should(Succeed())
+				Consistently(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(pvc), func(g Gomega, current *corev1.PersistentVolumeClaim) {
+					g.Expect(current.Finalizers).Should(ContainElement(dptypes.DataProtectionFinalizerName))
+				}), 500*time.Millisecond, 50*time.Millisecond).Should(Succeed())
+				Consistently(testapps.CheckObj(&testCtx, restoreKey, func(g Gomega, current *corev1.PersistentVolumeClaim) {
+					g.Expect(current.DeletionTimestamp.IsZero()).Should(BeTrue())
+				}), 500*time.Millisecond, 50*time.Millisecond).Should(Succeed())
+
+				Expect(k8sClient.Get(ctx, restoreKey, restore)).Should(Succeed())
+				Expect(testapps.ChangeObj(&testCtx, restore, func(current *dpv1alpha1.Restore) {
+					current.Finalizers = slices.DeleteFunc(current.Finalizers, func(finalizer string) bool {
+						return finalizer == holdFinalizer
+					})
+				})).Should(Succeed())
+
+				Eventually(testapps.CheckObjExists(&testCtx, restoreKey, &dpv1alpha1.Restore{}, false)).Should(Succeed())
+				Eventually(testapps.List(&testCtx, generics.JobSignature,
+					client.MatchingLabels{dprestore.DataProtectionRestoreLabelKey: restoreKey.Name},
+					client.InNamespace(pvc.Namespace))).Should(HaveLen(0))
+				helperPVC := &corev1.PersistentVolumeClaim{}
+				Eventually(testapps.CheckObj(&testCtx, restoreKey, func(g Gomega, current *corev1.PersistentVolumeClaim) {
+					g.Expect(current.DeletionTimestamp.IsZero()).Should(BeFalse())
+				})).Should(Succeed())
+				Expect(k8sClient.Get(ctx, restoreKey, helperPVC)).Should(Succeed())
+				Expect(testapps.ChangeObj(&testCtx, helperPVC, func(current *corev1.PersistentVolumeClaim) {
+					current.Finalizers = nil
+				})).Should(Succeed())
+				Eventually(testapps.CheckObjExists(&testCtx, restoreKey, &corev1.PersistentVolumeClaim{}, false)).Should(Succeed())
+				Eventually(func(g Gomega) {
+					current := &corev1.PersistentVolumeClaim{}
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(pvc), current)
+					if apierrors.IsNotFound(err) {
+						return
+					}
+					g.Expect(err).ShouldNot(HaveOccurred())
+					g.Expect(current.Finalizers).ShouldNot(ContainElement(dptypes.DataProtectionFinalizerName))
+				}).Should(Succeed())
 			})
 
 			It("infers source target from PVC labels for multi-target backups", func() {
@@ -2488,12 +2556,15 @@ func TestSyncPVCDeletionReleasesFinalizerWhenDependentsAreAbsent(t *testing.T) {
 
 func TestSyncPVCDeletionKeepsFinalizerOnCleanupAPIErrors(t *testing.T) {
 	testCases := []struct {
-		name              string
-		failurePoint      string
-		jobExists         bool
-		jobHasDPFinalizer bool
-		helperPVCExists   bool
+		name                   string
+		failurePoint           string
+		executionRestoreExists bool
+		jobExists              bool
+		jobHasDPFinalizer      bool
+		helperPVCExists        bool
 	}{
+		{name: "get execution Restore", failurePoint: "get-restore"},
+		{name: "delete execution Restore", failurePoint: "delete-restore", executionRestoreExists: true},
 		{name: "list jobs", failurePoint: "list-jobs"},
 		{name: "patch job finalizer", failurePoint: "patch-job", jobExists: true, jobHasDPFinalizer: true},
 		{name: "delete job", failurePoint: "delete-job", jobExists: true},
@@ -2511,6 +2582,13 @@ func TestSyncPVCDeletionKeepsFinalizerOnCleanupAPIErrors(t *testing.T) {
 			helperPVCName := getPopulatePVCName(pvc.UID)
 			jobName := "populate-job"
 			objects := []client.Object{pvc}
+			if testCase.executionRestoreExists {
+				objects = append(objects, &dpv1alpha1.Restore{ObjectMeta: metav1.ObjectMeta{
+					Namespace: pvc.Namespace,
+					Name:      helperPVCName,
+					UID:       types.UID("execution-restore-uid"),
+				}})
+			}
 			if testCase.jobExists {
 				jobFinalizers := []string(nil)
 				if testCase.jobHasDPFinalizer {
@@ -2541,12 +2619,24 @@ func TestSyncPVCDeletionKeepsFinalizerOnCleanupAPIErrors(t *testing.T) {
 					return cli.List(ctx, list, opts...)
 				},
 				Get: func(ctx context.Context, cli client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-					if testCase.failurePoint == "get-helper" && key.Name == helperPVCName {
-						return injectedErr
+					if testCase.failurePoint == "get-restore" {
+						if _, ok := obj.(*dpv1alpha1.Restore); ok {
+							return injectedErr
+						}
+					}
+					if testCase.failurePoint == "get-helper" {
+						if _, ok := obj.(*corev1.PersistentVolumeClaim); ok && key.Name == helperPVCName {
+							return injectedErr
+						}
 					}
 					return cli.Get(ctx, key, obj, opts...)
 				},
 				Delete: func(ctx context.Context, cli client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					if testCase.failurePoint == "delete-restore" {
+						if _, ok := obj.(*dpv1alpha1.Restore); ok {
+							return injectedErr
+						}
+					}
 					if testCase.failurePoint == "delete-job" && obj.GetName() == jobName {
 						return injectedErr
 					}

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -2655,11 +2656,18 @@ func TestSyncPVCDeletionKeepsFinalizerOnCleanupAPIErrors(t *testing.T) {
 					return cli.Patch(ctx, obj, patch, opts...)
 				},
 			}).Build()
-			reconciler := &VolumePopulatorReconciler{Client: cli, Scheme: scheme}
+			reconciler := &VolumePopulatorReconciler{
+				Client:   cli,
+				Scheme:   scheme,
+				Recorder: record.NewFakeRecorder(10),
+			}
 
-			err := reconciler.syncPVC(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc)
+			result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: client.ObjectKeyFromObject(pvc),
+			})
 
 			require.ErrorIs(t, err, injectedErr)
+			require.Zero(t, result)
 			currentPVC := &corev1.PersistentVolumeClaim{}
 			require.NoError(t, cli.Get(context.Background(), client.ObjectKeyFromObject(pvc), currentPVC))
 			require.Contains(t, currentPVC.Finalizers, dptypes.DataProtectionFinalizerName)

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -22,6 +22,7 @@ package dataprotection
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -40,6 +41,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
@@ -1490,6 +1492,7 @@ func TestDispatchUnboundPVCFailsWhenNoRestoreActionsExist(t *testing.T) {
 func TestDeletingTargetPVCCleansPopulationWithoutValidatingSource(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
 	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
 	apiGroup := dptypes.DataprotectionAPIGroup
 	now := metav1.Now()
@@ -1521,9 +1524,18 @@ func TestDeletingTargetPVCCleansPopulationWithoutValidatingSource(t *testing.T) 
 	}
 
 	err := reconciler.syncPVC(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc)
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.True(t, intctrlutil.IsRequeueError(err), err)
 	err = reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(populatePVC), &corev1.PersistentVolumeClaim{})
 	require.True(t, apierrors.IsNotFound(err), "populate PVC should be deleted, got: %v", err)
+	currentPVC := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), currentPVC))
+	require.Contains(t, currentPVC.Finalizers, dptypes.DataProtectionFinalizerName)
+
+	err = reconciler.syncPVC(intctrlutil.RequestCtx{Ctx: context.Background()}, currentPVC)
+	require.NoError(t, err)
+	err = reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), &corev1.PersistentVolumeClaim{})
+	require.True(t, apierrors.IsNotFound(err), err)
 }
 
 func TestPopulateCreatesExecutionRestoreAndPolls(t *testing.T) {
@@ -2361,6 +2373,237 @@ func newRestorePVCForSerialTest(name, volumeName string) *corev1.PersistentVolum
 				Kind:     dptypes.BackupKind,
 				Name:     "backup",
 			},
+		},
+	}
+}
+
+func TestSyncPVCDeletionCleansUpWhenBackupIsMissing(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+
+	apiGroup := dptypes.DataprotectionAPIGroup
+	deletionTime := metav1.Now()
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         "default",
+			Name:              "restore-data-mysql-0",
+			UID:               types.UID("target-pvc-uid"),
+			DeletionTimestamp: &deletionTime,
+			Finalizers:        []string{dptypes.DataProtectionFinalizerName},
+			Annotations: map[string]string{
+				constant.RestoreSourceNamespaceAnnotationKey: "default",
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			DataSourceRef: &corev1.TypedObjectReference{
+				APIGroup: &apiGroup,
+				Kind:     dptypes.BackupKind,
+				Name:     "deleted-backup",
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Conditions: []corev1.PersistentVolumeClaimCondition{{
+				Type:   PersistentVolumeClaimPopulating,
+				Status: corev1.ConditionTrue,
+				Reason: ReasonPopulatingProcessing,
+			}},
+		},
+	}
+	populatePVCName := getPopulatePVCName(pvc.UID)
+	populatePVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  pvc.Namespace,
+			Name:       populatePVCName,
+			Finalizers: []string{"test.kubeblocks.io/hold"},
+		},
+	}
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  pvc.Namespace,
+			Name:       "populate-job",
+			Finalizers: []string{dptypes.DataProtectionFinalizerName, "test.kubeblocks.io/hold"},
+			Labels: map[string]string{
+				dprestore.DataProtectionPopulatePVCLabelKey: populatePVCName,
+			},
+		},
+	}
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc, populatePVC, job).Build(),
+		Scheme: scheme,
+	}
+
+	err := reconciler.syncPVC(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc)
+
+	require.Error(t, err)
+	require.True(t, intctrlutil.IsRequeueError(err), err)
+	currentPVC := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), currentPVC))
+	require.Contains(t, currentPVC.Finalizers, dptypes.DataProtectionFinalizerName)
+	currentPopulatePVC := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(populatePVC), currentPopulatePVC))
+	require.False(t, currentPopulatePVC.DeletionTimestamp.IsZero())
+	currentJob := &batchv1.Job{}
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(job), currentJob))
+	require.False(t, currentJob.DeletionTimestamp.IsZero())
+	require.NotContains(t, currentJob.Finalizers, dptypes.DataProtectionFinalizerName)
+
+	jobPatch := client.MergeFrom(currentJob.DeepCopy())
+	currentJob.Finalizers = nil
+	require.NoError(t, reconciler.Client.Patch(context.Background(), currentJob, jobPatch))
+	populatePVCPatch := client.MergeFrom(currentPopulatePVC.DeepCopy())
+	currentPopulatePVC.Finalizers = nil
+	require.NoError(t, reconciler.Client.Patch(context.Background(), currentPopulatePVC, populatePVCPatch))
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), currentPVC))
+
+	err = reconciler.syncPVC(intctrlutil.RequestCtx{Ctx: context.Background()}, currentPVC)
+
+	require.NoError(t, err)
+	err = reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(currentPVC), &corev1.PersistentVolumeClaim{})
+	require.True(t, apierrors.IsNotFound(err), err)
+	err = reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(populatePVC), &corev1.PersistentVolumeClaim{})
+	require.True(t, apierrors.IsNotFound(err), err)
+	err = reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(job), &batchv1.Job{})
+	require.True(t, apierrors.IsNotFound(err), err)
+}
+
+func TestSyncPVCDeletionReleasesFinalizerWhenDependentsAreAbsent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, batchv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	pvc := newDeletingBackupRestorePVC()
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc).Build(),
+		Scheme: scheme,
+	}
+
+	err := reconciler.syncPVC(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc)
+
+	require.NoError(t, err)
+	err = reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), &corev1.PersistentVolumeClaim{})
+	require.True(t, apierrors.IsNotFound(err), err)
+}
+
+func TestSyncPVCDeletionKeepsFinalizerOnCleanupAPIErrors(t *testing.T) {
+	testCases := []struct {
+		name              string
+		failurePoint      string
+		jobExists         bool
+		jobHasDPFinalizer bool
+		helperPVCExists   bool
+	}{
+		{name: "list jobs", failurePoint: "list-jobs"},
+		{name: "patch job finalizer", failurePoint: "patch-job", jobExists: true, jobHasDPFinalizer: true},
+		{name: "delete job", failurePoint: "delete-job", jobExists: true},
+		{name: "get helper PVC", failurePoint: "get-helper"},
+		{name: "delete helper PVC", failurePoint: "delete-helper", helperPVCExists: true},
+		{name: "patch target PVC", failurePoint: "patch-target"},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, corev1.AddToScheme(scheme))
+			require.NoError(t, batchv1.AddToScheme(scheme))
+			require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+			pvc := newDeletingBackupRestorePVC()
+			helperPVCName := getPopulatePVCName(pvc.UID)
+			jobName := "populate-job"
+			objects := []client.Object{pvc}
+			if testCase.jobExists {
+				jobFinalizers := []string(nil)
+				if testCase.jobHasDPFinalizer {
+					jobFinalizers = []string{dptypes.DataProtectionFinalizerName}
+				}
+				objects = append(objects, &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+					Namespace:  pvc.Namespace,
+					Name:       jobName,
+					Finalizers: jobFinalizers,
+					Labels: map[string]string{
+						dprestore.DataProtectionPopulatePVCLabelKey: helperPVCName,
+					},
+				}})
+			}
+			if testCase.helperPVCExists {
+				objects = append(objects, &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{Namespace: pvc.Namespace, Name: helperPVCName},
+				})
+			}
+			injectedErr := errors.New("injected cleanup error")
+			cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).WithInterceptorFuncs(interceptor.Funcs{
+				List: func(ctx context.Context, cli client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+					if testCase.failurePoint == "list-jobs" {
+						if _, ok := list.(*batchv1.JobList); ok {
+							return injectedErr
+						}
+					}
+					return cli.List(ctx, list, opts...)
+				},
+				Get: func(ctx context.Context, cli client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if testCase.failurePoint == "get-helper" && key.Name == helperPVCName {
+						return injectedErr
+					}
+					return cli.Get(ctx, key, obj, opts...)
+				},
+				Delete: func(ctx context.Context, cli client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					if testCase.failurePoint == "delete-job" && obj.GetName() == jobName {
+						return injectedErr
+					}
+					if testCase.failurePoint == "delete-helper" && obj.GetName() == helperPVCName {
+						return injectedErr
+					}
+					return cli.Delete(ctx, obj, opts...)
+				},
+				Patch: func(ctx context.Context, cli client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					if testCase.failurePoint == "patch-job" && obj.GetName() == jobName {
+						return injectedErr
+					}
+					if testCase.failurePoint == "patch-target" && obj.GetName() == pvc.Name {
+						return injectedErr
+					}
+					return cli.Patch(ctx, obj, patch, opts...)
+				},
+			}).Build()
+			reconciler := &VolumePopulatorReconciler{Client: cli, Scheme: scheme}
+
+			err := reconciler.syncPVC(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc)
+
+			require.ErrorIs(t, err, injectedErr)
+			currentPVC := &corev1.PersistentVolumeClaim{}
+			require.NoError(t, cli.Get(context.Background(), client.ObjectKeyFromObject(pvc), currentPVC))
+			require.Contains(t, currentPVC.Finalizers, dptypes.DataProtectionFinalizerName)
+		})
+	}
+}
+
+func newDeletingBackupRestorePVC() *corev1.PersistentVolumeClaim {
+	apiGroup := dptypes.DataprotectionAPIGroup
+	deletionTime := metav1.Now()
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         "default",
+			Name:              "restore-data-mysql-0",
+			UID:               types.UID("target-pvc-uid"),
+			DeletionTimestamp: &deletionTime,
+			Finalizers:        []string{dptypes.DataProtectionFinalizerName},
+			Annotations: map[string]string{
+				constant.RestoreSourceNamespaceAnnotationKey: "default",
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			DataSourceRef: &corev1.TypedObjectReference{
+				APIGroup: &apiGroup,
+				Kind:     dptypes.BackupKind,
+				Name:     "deleted-backup",
+			},
+		},
+		Status: corev1.PersistentVolumeClaimStatus{
+			Conditions: []corev1.PersistentVolumeClaimCondition{{
+				Type:   PersistentVolumeClaimPopulating,
+				Status: corev1.ConditionTrue,
+				Reason: ReasonPopulatingProcessing,
+			}},
 		},
 	}
 }


### PR DESCRIPTION
## Summary

- handle a deleting restore PVC before validating its source Backup
- stop and wait for the execution Restore before removing populate dependents
- keep the target PVC finalizer while owned populate Jobs or the helper PVC still exist
- release the target finalizer only after a fresh reconcile confirms the dependents are absent
- propagate every transient deletion-cleanup API failure through the outer reconciler even when the PVC already has a Populating condition
- preserve the existing non-deletion cleanup behavior for bound PVC completion

Fixes #10606.

## Retry contract

A deleting PVC is still owned by the volume-populator controller until cleanup converges. Ordinary API errors from execution-Restore cleanup, Job cleanup, helper-PVC cleanup, or target-finalizer removal must therefore reach controller-runtime and be retried. The outer handler keys this rule from `deletionTimestamp`; it deliberately does not re-check the in-memory finalizer because Cleanup removes that local value before attempting the final Patch, and a failed Patch means the persisted finalizer still exists.

The existing Populating-condition suppression remains limited to non-deleting PVCs whose external controller owns subsequent progress.

## Tests

- focused cleanup tests cover deletion ordering, dependent absence, and all eight API failure points
- the eight-point failure matrix enters through the complete `Reconcile` path, asserts the injected error reaches controller-runtime, and proves the persisted target finalizer remains
- `KUBEBUILDER_ASSETS='<envtest 1.26.1 assets>' go test ./controllers/dataprotection -count=1`
- focused `go test -race` for deletion and outer-handler cases
- `go vet ./controllers/dataprotection`
- `git diff --check`

Validation on exact head `35f7f55c14e6c76208aab161d11c3ad35313e359` is green. Runtime environment coverage remains N=0.

Supersedes #10604, which was closed when its non-conforming source branch was renamed.
