### PR TITLE
feat(reconfigure): add durable execution protocol

### DIFF
--- a/pkg/reconfigure/protocol/doc.go
+++ b/pkg/reconfigure/protocol/doc.go
@@ -28,4 +28,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 // continue to count against RegistryLimits. A controller must rotate to a new
 // installation fence before capacity is exhausted; this package does not
 // compact or reclaim tombstones in place.
+//
+// A Lease with malformed session metadata and no complete, positive expiry
+// evidence is treated as unexpired and is not replaced automatically. After
+// verifying that no holder is active, an operator may delete it explicitly to
+// let the next acquisition create a fresh Lease identity.
 package protocol

--- a/pkg/reconfigure/protocol/doc.go
+++ b/pkg/reconfigure/protocol/doc.go
@@ -1,0 +1,31 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// Package protocol defines the durable reconfigure execution protocol.
+//
+// FenceState values are immutable snapshots. Persisting a returned state must
+// use resourceVersion compare-and-swap against the exact fence object read to
+// construct the input state. The package does not merge concurrent snapshots;
+// callers must reread and retry after a conflict.
+//
+// Consumed registrations and effects are durable tombstones and intentionally
+// continue to count against RegistryLimits. A controller must rotate to a new
+// installation fence before capacity is exhausted; this package does not
+// compact or reclaim tombstones in place.
+package protocol

--- a/pkg/reconfigure/protocol/lease.go
+++ b/pkg/reconfigure/protocol/lease.go
@@ -27,7 +27,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"math"
 	"strconv"
+	"sync"
 	"time"
 
 	coordinationv1 "k8s.io/api/coordination/v1"
@@ -372,12 +374,17 @@ type SessionLeaseLockConfig struct {
 }
 
 type SessionLeaseLock struct {
-	config   SessionLeaseLockConfig
-	leaseUID types.UID
+	config SessionLeaseLockConfig
+	mu     sync.RWMutex
+
+	leaseUID       types.UID
+	committedEpoch int64
 }
 
 func NewSessionLeaseLock(config SessionLeaseLockConfig) (*SessionLeaseLock, error) {
-	if config.Client == nil || config.Namespace == "" || config.Name == "" || config.HolderIdentity == "" || config.LeaseDuration <= 0 {
+	duration := config.LeaseDuration / time.Second
+	if config.Client == nil || config.Namespace == "" || config.Name == "" || config.HolderIdentity == "" ||
+		config.LeaseDuration < time.Second || config.LeaseDuration%time.Second != 0 || duration > math.MaxInt32 {
 		return nil, ErrLeaseSessionKeyUnavailable
 	}
 	if !validSessionPublicKey(config.KeyPair.Algorithm, config.KeyPair.PublicKey, fingerprintSessionKey(config.KeyPair.PublicKey)) {
@@ -409,7 +416,23 @@ func (lock *SessionLeaseLock) Acquire(ctx context.Context) (LeaseSession, error)
 	default:
 		current, parseErr := leaseSessionFromLease(lease)
 		if parseErr != nil {
-			return LeaseSession{}, parseErr
+			if !leaseExpired(lease, time.Now()) || lease.UID == "" || lease.ResourceVersion == "" {
+				return LeaseSession{}, parseErr
+			}
+			uid := lease.UID
+			resourceVersion := lease.ResourceVersion
+			if err := leases.Delete(ctx, lock.config.Name, metav1.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid, ResourceVersion: &resourceVersion}}); err != nil {
+				return LeaseSession{}, err
+			}
+			now := metav1.NewMicroTime(time.Now())
+			holder := lock.config.HolderIdentity
+			duration := int32(lock.config.LeaseDuration / time.Second)
+			replacement := &coordinationv1.Lease{ObjectMeta: metav1.ObjectMeta{Name: lock.config.Name, Namespace: lock.config.Namespace, Annotations: lock.annotations(1)}, Spec: coordinationv1.LeaseSpec{HolderIdentity: &holder, LeaseDurationSeconds: &duration, AcquireTime: &now, RenewTime: &now}}
+			lease, err = leases.Create(ctx, replacement, metav1.CreateOptions{})
+			if err != nil {
+				return LeaseSession{}, err
+			}
+			break
 		}
 		if !leaseExpired(lease, time.Now()) && current.HolderIdentity != lock.config.HolderIdentity {
 			return LeaseSession{}, ErrLeaseSessionHeld
@@ -426,7 +449,6 @@ func (lock *SessionLeaseLock) Acquire(ctx context.Context) (LeaseSession, error)
 		now := metav1.NewMicroTime(time.Now())
 		updated.Spec.AcquireTime = &now
 		updated.Spec.RenewTime = &now
-		lock.leaseUID = lease.UID
 		lease, err = leases.Update(ctx, updated, metav1.UpdateOptions{})
 		if err != nil {
 			return LeaseSession{}, err
@@ -436,7 +458,7 @@ func (lock *SessionLeaseLock) Acquire(ctx context.Context) (LeaseSession, error)
 	if err != nil {
 		return LeaseSession{}, err
 	}
-	lock.leaseUID = session.LeaseUID
+	lock.commitSession(session)
 	return session, nil
 }
 
@@ -445,14 +467,15 @@ func (lock *SessionLeaseLock) Renew(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	if lock.leaseUID != "" && lease.UID != lock.leaseUID {
+	leaseUID, committedEpoch := lock.committedSession()
+	if leaseUID != "" && lease.UID != leaseUID {
 		return ErrLeaseUIDChanged
 	}
 	current, err := leaseSessionFromLease(lease)
 	if err != nil {
 		return ErrLeaseSessionKeyChanged
 	}
-	_, err = RenewLeaseSession(current, LeaseRenewRequest{HolderIdentity: lock.config.HolderIdentity, Epoch: current.Epoch, SessionKeyAlgorithm: lock.config.KeyPair.Algorithm, SessionPublicKey: lock.config.KeyPair.PublicKey, SessionKeyFingerprint: fingerprintSessionKey(lock.config.KeyPair.PublicKey)})
+	_, err = RenewLeaseSession(current, LeaseRenewRequest{HolderIdentity: lock.config.HolderIdentity, Epoch: committedEpoch, SessionKeyAlgorithm: lock.config.KeyPair.Algorithm, SessionPublicKey: lock.config.KeyPair.PublicKey, SessionKeyFingerprint: fingerprintSessionKey(lock.config.KeyPair.PublicKey)})
 	if err != nil {
 		return err
 	}
@@ -468,7 +491,8 @@ func (lock *SessionLeaseLock) RecoverCommittedSession(ctx context.Context, keyPa
 	if err != nil {
 		return LeaseSession{}, err
 	}
-	if lock.leaseUID != "" && lease.UID != lock.leaseUID {
+	leaseUID, _ := lock.committedSession()
+	if leaseUID != "" && lease.UID != leaseUID {
 		return LeaseSession{}, ErrLeaseUIDChanged
 	}
 	current, err := leaseSessionFromLease(lease)
@@ -479,8 +503,21 @@ func (lock *SessionLeaseLock) RecoverCommittedSession(ctx context.Context, keyPa
 	if err != nil {
 		return LeaseSession{}, err
 	}
-	lock.leaseUID = recovered.LeaseUID
+	lock.commitSession(recovered)
 	return recovered, nil
+}
+
+func (lock *SessionLeaseLock) commitSession(session LeaseSession) {
+	lock.mu.Lock()
+	defer lock.mu.Unlock()
+	lock.leaseUID = session.LeaseUID
+	lock.committedEpoch = session.Epoch
+}
+
+func (lock *SessionLeaseLock) committedSession() (types.UID, int64) {
+	lock.mu.RLock()
+	defer lock.mu.RUnlock()
+	return lock.leaseUID, lock.committedEpoch
 }
 
 func (lock *SessionLeaseLock) annotations(epoch int64) map[string]string {
@@ -503,8 +540,8 @@ func leaseSessionFromLease(lease *coordinationv1.Lease) (LeaseSession, error) {
 }
 
 func leaseExpired(lease *coordinationv1.Lease, now time.Time) bool {
-	if lease.Spec.RenewTime == nil || lease.Spec.LeaseDurationSeconds == nil {
-		return true
+	if lease.Spec.RenewTime == nil || lease.Spec.LeaseDurationSeconds == nil || *lease.Spec.LeaseDurationSeconds <= 0 {
+		return false
 	}
 	return lease.Spec.RenewTime.Add(time.Duration(*lease.Spec.LeaseDurationSeconds) * time.Second).Before(now)
 }

--- a/pkg/reconfigure/protocol/lease.go
+++ b/pkg/reconfigure/protocol/lease.go
@@ -1,0 +1,519 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package protocol
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strconv"
+	"time"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	types "k8s.io/apimachinery/pkg/types"
+	coordinationclient "k8s.io/client-go/kubernetes/typed/coordination/v1"
+)
+
+const (
+	SessionKeyAlgorithmEd25519 = "Ed25519"
+
+	LeaseSessionEpochAnnotation          = "reconfigure.kubeblocks.io/session-epoch"
+	LeaseSessionKeyAlgorithmAnnotation   = "reconfigure.kubeblocks.io/session-key-algorithm"
+	LeaseSessionPublicKeyAnnotation      = "reconfigure.kubeblocks.io/session-public-key"
+	LeaseSessionKeyFingerprintAnnotation = "reconfigure.kubeblocks.io/session-key-fingerprint"
+
+	WindowCreatePermitProtocolV1 = "kubeblocks.io/reconfigure-window-create-permit/v1"
+)
+
+var (
+	ErrLeaseSessionKeyChanged       = errors.New("lease session key changed")
+	ErrLeaseSessionKeyUnavailable   = errors.New("lease session key unavailable")
+	ErrLeaseUIDChanged              = errors.New("lease UID changed")
+	ErrLeaseSessionHeld             = errors.New("lease session held")
+	ErrSessionKeyBindingUnsupported = errors.New("session key binding unsupported")
+	ErrWindowCreatePermitInvalid    = errors.New("window create permit invalid")
+	ErrWindowImmutableSpecInvalid   = errors.New("window immutable spec invalid")
+)
+
+type LeaseSession struct {
+	LeaseUID              types.UID
+	HolderIdentity        string
+	Epoch                 int64
+	SessionKeyAlgorithm   string
+	SessionPublicKey      []byte
+	SessionKeyFingerprint string
+}
+
+type LeaseAcquireRequest struct {
+	HolderIdentity        string
+	NextEpoch             int64
+	SessionKeyAlgorithm   string
+	SessionPublicKey      []byte
+	SessionKeyFingerprint string
+}
+
+type LeaseRenewRequest struct {
+	HolderIdentity        string
+	Epoch                 int64
+	SessionKeyAlgorithm   string
+	SessionPublicKey      []byte
+	SessionKeyFingerprint string
+}
+
+type SessionKeyPair struct {
+	Algorithm  string
+	PublicKey  ed25519.PublicKey
+	PrivateKey ed25519.PrivateKey
+}
+
+type LeaseRecoveryRequest struct {
+	HolderIdentity string
+	KeyPair        SessionKeyPair
+}
+
+func AcquireLeaseSession(current LeaseSession, request LeaseAcquireRequest) (LeaseSession, error) {
+	if request.HolderIdentity == "" || request.NextEpoch != current.Epoch+1 || !validSessionPublicKey(request.SessionKeyAlgorithm, request.SessionPublicKey, request.SessionKeyFingerprint) {
+		return current, ErrLeaseSessionKeyChanged
+	}
+	return LeaseSession{LeaseUID: current.LeaseUID, HolderIdentity: request.HolderIdentity, Epoch: request.NextEpoch, SessionKeyAlgorithm: request.SessionKeyAlgorithm, SessionPublicKey: append([]byte(nil), request.SessionPublicKey...), SessionKeyFingerprint: request.SessionKeyFingerprint}, nil
+}
+
+func RenewLeaseSession(current LeaseSession, request LeaseRenewRequest) (LeaseSession, error) {
+	if request.HolderIdentity != current.HolderIdentity || request.Epoch != current.Epoch || request.SessionKeyAlgorithm != current.SessionKeyAlgorithm || request.SessionKeyFingerprint != current.SessionKeyFingerprint || !bytes.Equal(request.SessionPublicKey, current.SessionPublicKey) {
+		return current, ErrLeaseSessionKeyChanged
+	}
+	return current, nil
+}
+
+func RecoverLeaseSession(current LeaseSession, request LeaseRecoveryRequest) (LeaseSession, error) {
+	if request.HolderIdentity != current.HolderIdentity || request.KeyPair.Algorithm != current.SessionKeyAlgorithm || !bytes.Equal(request.KeyPair.PublicKey, current.SessionPublicKey) || len(request.KeyPair.PrivateKey) != ed25519.PrivateKeySize || !bytes.Equal(request.KeyPair.PrivateKey.Public().(ed25519.PublicKey), current.SessionPublicKey) {
+		return current, ErrLeaseSessionKeyUnavailable
+	}
+	return current, nil
+}
+
+func validSessionPublicKey(algorithm string, publicKey []byte, fingerprint string) bool {
+	return algorithm == SessionKeyAlgorithmEd25519 && len(publicKey) == ed25519.PublicKeySize && ValidateIdentityDigest(fingerprint) == nil && fingerprint == fingerprintSessionKey(publicKey)
+}
+
+func fingerprintSessionKey(publicKey []byte) string { return digest(string(publicKey)) }
+func encodeSessionKey(publicKey []byte) string {
+	return base64.RawStdEncoding.EncodeToString(publicKey)
+}
+func decodeSessionKey(value string) ([]byte, error)  { return base64.RawStdEncoding.DecodeString(value) }
+func encodeSessionPublicKey(publicKey []byte) string { return encodeSessionKey(publicKey) }
+
+type EvidenceFingerprintAlgorithm string
+
+const EvidenceFingerprintAlgorithmHMACSHA256 EvidenceFingerprintAlgorithm = "HMAC-SHA256"
+
+type GateKind string
+
+const (
+	GateKindTargetFence GateKind = "TargetFence"
+	GateKindCredential  GateKind = "Credential"
+)
+
+type TargetFenceWindowIdentity struct {
+	TargetStructuralKey  string `json:"targetStructuralKey"`
+	ExpectedTemplateHash string `json:"expectedTemplateHash"`
+}
+
+type CredentialWindowIdentity struct {
+	PriorGateUID            types.UID `json:"priorGateUID"`
+	TargetFingerprintDomain string    `json:"targetFingerprintDomain"`
+}
+
+type WindowImmutableSpec struct {
+	Name                  string                       `json:"name"`
+	PhysicalAPIID         string                       `json:"physicalAPIID"`
+	WorkloadNamespaceName string                       `json:"workloadNamespaceName"`
+	WorkloadNamespaceUID  types.UID                    `json:"workloadNamespaceUID"`
+	ExecutionUID          types.UID                    `json:"executionUID"`
+	AttemptID             string                       `json:"attemptID"`
+	ProtocolVersion       string                       `json:"protocolVersion"`
+	GateKind              GateKind                     `json:"gateKind"`
+	DurationSeconds       int64                        `json:"durationSeconds"`
+	ProtocolFenceUID      types.UID                    `json:"protocolFenceUID"`
+	InstallationEpoch     string                       `json:"installationEpoch"`
+	Target                EffectObjectTarget           `json:"target"`
+	KeySecretName         string                       `json:"keySecretName"`
+	KeySecretUID          types.UID                    `json:"keySecretUID"`
+	KeyVersion            int64                        `json:"keyVersion"`
+	KeyAlgorithm          EvidenceFingerprintAlgorithm `json:"keyAlgorithm"`
+	TargetFence           *TargetFenceWindowIdentity   `json:"targetFence,omitempty"`
+	Credential            *CredentialWindowIdentity    `json:"credential,omitempty"`
+}
+
+func ValidateWindowImmutableSpec(spec WindowImmutableSpec) error {
+	if spec.Name == "" || spec.PhysicalAPIID == "" || spec.WorkloadNamespaceName == "" || spec.WorkloadNamespaceUID == "" || spec.ExecutionUID == "" || spec.AttemptID == "" || spec.ProtocolVersion == "" || spec.DurationSeconds <= 0 || spec.ProtocolFenceUID == "" || spec.InstallationEpoch == "" || spec.Target.APIVersion == "" || spec.Target.Kind == "" || spec.Target.Namespace == "" || spec.Target.Name == "" || spec.KeySecretName == "" || spec.KeySecretUID == "" || spec.KeyVersion <= 0 || spec.KeyAlgorithm != EvidenceFingerprintAlgorithmHMACSHA256 {
+		return ErrWindowImmutableSpecInvalid
+	}
+	switch spec.GateKind {
+	case GateKindTargetFence:
+		if spec.TargetFence == nil || spec.Credential != nil || spec.TargetFence.TargetStructuralKey == "" || ValidateIdentityDigest(spec.TargetFence.ExpectedTemplateHash) != nil {
+			return ErrWindowImmutableSpecInvalid
+		}
+	case GateKindCredential:
+		if spec.Credential == nil || spec.TargetFence != nil || spec.Credential.PriorGateUID == "" || spec.Credential.TargetFingerprintDomain != "kubeblocks.io/credential-target/v1" {
+			return ErrWindowImmutableSpecInvalid
+		}
+	default:
+		return ErrWindowImmutableSpecInvalid
+	}
+	return nil
+}
+
+func CanonicalWindowImmutableSpecDigest(spec WindowImmutableSpec) string {
+	data, _ := json.Marshal(spec)
+	return digest("kubeblocks.io/reconfigure-window-immutable-spec/v1\x00" + string(data))
+}
+
+type WindowCreatePermit struct {
+	ProtocolVersion              string
+	GateKind                     GateKind
+	WindowSpecDigest             string
+	LeaseUID                     types.UID
+	LeaseEpoch                   int64
+	LeaseKeyAlgorithm            string
+	LeaseKeyFingerprint          string
+	ProtocolFenceUID             types.UID
+	ProtocolFenceResourceVersion string
+	InstallationEpoch            string
+	AuthorityUID                 types.UID
+	AuthorityResourceVersion     string
+	PriorGateUID                 types.UID
+	PriorGateResourceVersion     string
+	RegistrationKey              string
+	EffectKey                    string
+	EffectIdentityDigest         string
+	EffectState                  EffectState
+	Signature                    []byte
+}
+
+type WindowPermitContext struct {
+	ProtocolVersion              string
+	ExpectedGateKind             GateKind
+	ExpectedWindowSpec           WindowImmutableSpec
+	CurrentLeaseUID              types.UID
+	CurrentLeaseEpoch            int64
+	CurrentLeaseKeyAlgorithm     string
+	CurrentLeaseKeyFingerprint   string
+	CurrentLeasePublicKey        ed25519.PublicKey
+	ProtocolFenceUID             types.UID
+	ProtocolFenceResourceVersion string
+	InstallationEpoch            string
+	AuthorityUID                 types.UID
+	AuthorityResourceVersion     string
+	PriorGateUID                 types.UID
+	PriorGateResourceVersion     string
+	RegistrationKey              string
+	EffectKey                    string
+	EffectIdentityDigest         string
+	EffectState                  EffectState
+}
+
+type windowPermitBinding struct {
+	ProtocolVersion              string
+	GateKind                     GateKind
+	WindowSpecDigest             string
+	LeaseUID                     types.UID
+	LeaseEpoch                   int64
+	LeaseKeyAlgorithm            string
+	LeaseKeyFingerprint          string
+	ProtocolFenceUID             types.UID
+	ProtocolFenceResourceVersion string
+	InstallationEpoch            string
+	AuthorityUID                 types.UID
+	AuthorityResourceVersion     string
+	PriorGateUID                 types.UID
+	PriorGateResourceVersion     string
+	RegistrationKey              string
+	EffectKey                    string
+	EffectIdentityDigest         string
+	EffectState                  EffectState
+}
+
+func CanonicalWindowCreatePermitBytes(permit WindowCreatePermit) ([]byte, error) {
+	unsigned := permit
+	unsigned.Signature = nil
+	data, err := json.Marshal(unsigned)
+	if err != nil {
+		return nil, err
+	}
+	return append([]byte(WindowCreatePermitProtocolV1+"\x00"), data...), nil
+}
+
+func CanonicalProtocolDigest(domain string, data []byte) []byte {
+	sum := sha256Bytes(append(append([]byte(domain), 0), data...))
+	return sum
+}
+
+func sha256Bytes(data []byte) []byte {
+	sum := sha256Sum(data)
+	return sum[:]
+}
+
+func WindowCreatePermitDigest(permit WindowCreatePermit) []byte {
+	canonical, _ := CanonicalWindowCreatePermitBytes(permit)
+	return CanonicalProtocolDigest(WindowCreatePermitProtocolV1, canonical)
+}
+
+func ValidateWindowCreatePermit(context WindowPermitContext, permit WindowCreatePermit) error {
+	if context.EffectState != EffectStatePlanned {
+		return ErrEffectNotPlanned
+	}
+	if ValidateWindowImmutableSpec(context.ExpectedWindowSpec) != nil || CanonicalWindowImmutableSpecDigest(context.ExpectedWindowSpec) != permit.WindowSpecDigest {
+		return ErrWindowCreatePermitInvalid
+	}
+	if context.ProtocolVersion != WindowCreatePermitProtocolV1 || context.ExpectedGateKind != context.ExpectedWindowSpec.GateKind {
+		return ErrWindowCreatePermitInvalid
+	}
+	permitBinding := windowBindingFromPermit(permit)
+	contextBinding := windowBindingFromContext(context)
+	if permitBinding != contextBinding || !validWindowPermitBinding(permitBinding) {
+		return ErrWindowCreatePermitInvalid
+	}
+	if context.ProtocolFenceUID != context.ExpectedWindowSpec.ProtocolFenceUID || context.InstallationEpoch != context.ExpectedWindowSpec.InstallationEpoch {
+		return ErrWindowCreatePermitInvalid
+	}
+	if context.ExpectedWindowSpec.GateKind == GateKindCredential && context.PriorGateUID != context.ExpectedWindowSpec.Credential.PriorGateUID {
+		return ErrWindowCreatePermitInvalid
+	}
+	if !validSessionPublicKey(permit.LeaseKeyAlgorithm, context.CurrentLeasePublicKey, permit.LeaseKeyFingerprint) || len(permit.Signature) != ed25519.SignatureSize || !ed25519.Verify(context.CurrentLeasePublicKey, WindowCreatePermitDigest(permit), permit.Signature) {
+		return ErrWindowCreatePermitInvalid
+	}
+	return nil
+}
+
+func validWindowPermitBinding(binding windowPermitBinding) bool {
+	if binding.ProtocolVersion == "" || binding.GateKind == "" || binding.LeaseUID == "" || binding.LeaseEpoch <= 0 || binding.LeaseKeyAlgorithm == "" || binding.ProtocolFenceUID == "" || binding.ProtocolFenceResourceVersion == "" || binding.InstallationEpoch == "" || binding.AuthorityUID == "" || binding.AuthorityResourceVersion == "" || binding.PriorGateUID == "" || binding.PriorGateResourceVersion == "" {
+		return false
+	}
+	return ValidateIdentityDigest(binding.WindowSpecDigest) == nil && ValidateIdentityDigest(binding.LeaseKeyFingerprint) == nil && ValidateIdentityDigest(binding.RegistrationKey) == nil && ValidateIdentityDigest(binding.EffectKey) == nil && ValidateIdentityDigest(binding.EffectIdentityDigest) == nil
+}
+
+func windowBindingFromPermit(permit WindowCreatePermit) windowPermitBinding {
+	return windowPermitBinding{
+		ProtocolVersion:              permit.ProtocolVersion,
+		GateKind:                     permit.GateKind,
+		WindowSpecDigest:             permit.WindowSpecDigest,
+		LeaseUID:                     permit.LeaseUID,
+		LeaseEpoch:                   permit.LeaseEpoch,
+		LeaseKeyAlgorithm:            permit.LeaseKeyAlgorithm,
+		LeaseKeyFingerprint:          permit.LeaseKeyFingerprint,
+		ProtocolFenceUID:             permit.ProtocolFenceUID,
+		ProtocolFenceResourceVersion: permit.ProtocolFenceResourceVersion,
+		InstallationEpoch:            permit.InstallationEpoch,
+		AuthorityUID:                 permit.AuthorityUID,
+		AuthorityResourceVersion:     permit.AuthorityResourceVersion,
+		PriorGateUID:                 permit.PriorGateUID,
+		PriorGateResourceVersion:     permit.PriorGateResourceVersion,
+		RegistrationKey:              permit.RegistrationKey,
+		EffectKey:                    permit.EffectKey,
+		EffectIdentityDigest:         permit.EffectIdentityDigest,
+		EffectState:                  permit.EffectState,
+	}
+}
+
+func windowBindingFromContext(context WindowPermitContext) windowPermitBinding {
+	return windowPermitBinding{
+		ProtocolVersion:              context.ProtocolVersion,
+		GateKind:                     context.ExpectedGateKind,
+		WindowSpecDigest:             CanonicalWindowImmutableSpecDigest(context.ExpectedWindowSpec),
+		LeaseUID:                     context.CurrentLeaseUID,
+		LeaseEpoch:                   context.CurrentLeaseEpoch,
+		LeaseKeyAlgorithm:            context.CurrentLeaseKeyAlgorithm,
+		LeaseKeyFingerprint:          context.CurrentLeaseKeyFingerprint,
+		ProtocolFenceUID:             context.ProtocolFenceUID,
+		ProtocolFenceResourceVersion: context.ProtocolFenceResourceVersion,
+		InstallationEpoch:            context.InstallationEpoch,
+		AuthorityUID:                 context.AuthorityUID,
+		AuthorityResourceVersion:     context.AuthorityResourceVersion,
+		PriorGateUID:                 context.PriorGateUID,
+		PriorGateResourceVersion:     context.PriorGateResourceVersion,
+		RegistrationKey:              context.RegistrationKey,
+		EffectKey:                    context.EffectKey,
+		EffectIdentityDigest:         context.EffectIdentityDigest,
+		EffectState:                  context.EffectState,
+	}
+}
+
+type SessionLeaseLockConfig struct {
+	Client         coordinationclient.CoordinationV1Interface
+	Namespace      string
+	Name           string
+	HolderIdentity string
+	KeyPair        SessionKeyPair
+	LeaseDuration  time.Duration
+}
+
+type SessionLeaseLock struct {
+	config   SessionLeaseLockConfig
+	leaseUID types.UID
+}
+
+func NewSessionLeaseLock(config SessionLeaseLockConfig) (*SessionLeaseLock, error) {
+	if config.Client == nil || config.Namespace == "" || config.Name == "" || config.HolderIdentity == "" || config.LeaseDuration <= 0 {
+		return nil, ErrLeaseSessionKeyUnavailable
+	}
+	if !validSessionPublicKey(config.KeyPair.Algorithm, config.KeyPair.PublicKey, fingerprintSessionKey(config.KeyPair.PublicKey)) {
+		return nil, ErrLeaseSessionKeyUnavailable
+	}
+	if len(config.KeyPair.PrivateKey) != ed25519.PrivateKeySize || !bytes.Equal(config.KeyPair.PrivateKey.Public().(ed25519.PublicKey), config.KeyPair.PublicKey) {
+		return nil, ErrLeaseSessionKeyUnavailable
+	}
+	config.KeyPair.PublicKey = append(ed25519.PublicKey(nil), config.KeyPair.PublicKey...)
+	config.KeyPair.PrivateKey = nil
+	return &SessionLeaseLock{config: config}, nil
+}
+
+func (lock *SessionLeaseLock) Acquire(ctx context.Context) (LeaseSession, error) {
+	leases := lock.config.Client.Leases(lock.config.Namespace)
+	lease, err := leases.Get(ctx, lock.config.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		now := metav1.NewMicroTime(time.Now())
+		holder := lock.config.HolderIdentity
+		duration := int32(lock.config.LeaseDuration / time.Second)
+		created := &coordinationv1.Lease{ObjectMeta: metav1.ObjectMeta{Name: lock.config.Name, Namespace: lock.config.Namespace, Annotations: lock.annotations(1)}, Spec: coordinationv1.LeaseSpec{HolderIdentity: &holder, LeaseDurationSeconds: &duration, AcquireTime: &now, RenewTime: &now}}
+		lease, err = leases.Create(ctx, created, metav1.CreateOptions{})
+		if err != nil {
+			return LeaseSession{}, err
+		}
+	} else if err != nil {
+		return LeaseSession{}, err
+	} else {
+		current, parseErr := leaseSessionFromLease(lease)
+		if parseErr != nil {
+			return LeaseSession{}, parseErr
+		}
+		if !leaseExpired(lease, time.Now()) && current.HolderIdentity != lock.config.HolderIdentity {
+			return LeaseSession{}, ErrLeaseSessionHeld
+		}
+		next, acquireErr := AcquireLeaseSession(current, LeaseAcquireRequest{HolderIdentity: lock.config.HolderIdentity, NextEpoch: current.Epoch + 1, SessionKeyAlgorithm: lock.config.KeyPair.Algorithm, SessionPublicKey: lock.config.KeyPair.PublicKey, SessionKeyFingerprint: fingerprintSessionKey(lock.config.KeyPair.PublicKey)})
+		if acquireErr != nil {
+			return LeaseSession{}, acquireErr
+		}
+		updated := lease.DeepCopy()
+		updated.Annotations = lock.annotations(next.Epoch)
+		updated.Spec.HolderIdentity = &next.HolderIdentity
+		duration := int32(lock.config.LeaseDuration / time.Second)
+		updated.Spec.LeaseDurationSeconds = &duration
+		now := metav1.NewMicroTime(time.Now())
+		updated.Spec.AcquireTime = &now
+		updated.Spec.RenewTime = &now
+		lock.leaseUID = lease.UID
+		lease, err = leases.Update(ctx, updated, metav1.UpdateOptions{})
+		if err != nil {
+			return LeaseSession{}, err
+		}
+	}
+	session, err := leaseSessionFromLease(lease)
+	if err != nil {
+		return LeaseSession{}, err
+	}
+	lock.leaseUID = session.LeaseUID
+	return session, nil
+}
+
+func (lock *SessionLeaseLock) Renew(ctx context.Context) error {
+	lease, err := lock.config.Client.Leases(lock.config.Namespace).Get(ctx, lock.config.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if lock.leaseUID != "" && lease.UID != lock.leaseUID {
+		return ErrLeaseUIDChanged
+	}
+	current, err := leaseSessionFromLease(lease)
+	if err != nil {
+		return ErrLeaseSessionKeyChanged
+	}
+	_, err = RenewLeaseSession(current, LeaseRenewRequest{HolderIdentity: lock.config.HolderIdentity, Epoch: current.Epoch, SessionKeyAlgorithm: lock.config.KeyPair.Algorithm, SessionPublicKey: lock.config.KeyPair.PublicKey, SessionKeyFingerprint: fingerprintSessionKey(lock.config.KeyPair.PublicKey)})
+	if err != nil {
+		return err
+	}
+	updated := lease.DeepCopy()
+	now := metav1.NewMicroTime(time.Now())
+	updated.Spec.RenewTime = &now
+	_, err = lock.config.Client.Leases(lock.config.Namespace).Update(ctx, updated, metav1.UpdateOptions{})
+	return err
+}
+
+func (lock *SessionLeaseLock) RecoverCommittedSession(ctx context.Context, keyPair SessionKeyPair) (LeaseSession, error) {
+	lease, err := lock.config.Client.Leases(lock.config.Namespace).Get(ctx, lock.config.Name, metav1.GetOptions{})
+	if err != nil {
+		return LeaseSession{}, err
+	}
+	if lock.leaseUID != "" && lease.UID != lock.leaseUID {
+		return LeaseSession{}, ErrLeaseUIDChanged
+	}
+	current, err := leaseSessionFromLease(lease)
+	if err != nil {
+		return LeaseSession{}, err
+	}
+	recovered, err := RecoverLeaseSession(current, LeaseRecoveryRequest{HolderIdentity: lock.config.HolderIdentity, KeyPair: keyPair})
+	if err != nil {
+		return LeaseSession{}, err
+	}
+	lock.leaseUID = recovered.LeaseUID
+	return recovered, nil
+}
+
+func (lock *SessionLeaseLock) annotations(epoch int64) map[string]string {
+	return map[string]string{LeaseSessionEpochAnnotation: strconv.FormatInt(epoch, 10), LeaseSessionKeyAlgorithmAnnotation: lock.config.KeyPair.Algorithm, LeaseSessionPublicKeyAnnotation: encodeSessionKey(lock.config.KeyPair.PublicKey), LeaseSessionKeyFingerprintAnnotation: fingerprintSessionKey(lock.config.KeyPair.PublicKey)}
+}
+
+func leaseSessionFromLease(lease *coordinationv1.Lease) (LeaseSession, error) {
+	if lease == nil || lease.Spec.HolderIdentity == nil {
+		return LeaseSession{}, ErrLeaseSessionKeyUnavailable
+	}
+	epoch, err := strconv.ParseInt(lease.Annotations[LeaseSessionEpochAnnotation], 10, 64)
+	if err != nil {
+		return LeaseSession{}, ErrLeaseSessionKeyUnavailable
+	}
+	publicKey, err := decodeSessionKey(lease.Annotations[LeaseSessionPublicKeyAnnotation])
+	if err != nil || !validSessionPublicKey(lease.Annotations[LeaseSessionKeyAlgorithmAnnotation], publicKey, lease.Annotations[LeaseSessionKeyFingerprintAnnotation]) {
+		return LeaseSession{}, ErrLeaseSessionKeyUnavailable
+	}
+	return LeaseSession{LeaseUID: lease.UID, HolderIdentity: *lease.Spec.HolderIdentity, Epoch: epoch, SessionKeyAlgorithm: lease.Annotations[LeaseSessionKeyAlgorithmAnnotation], SessionPublicKey: publicKey, SessionKeyFingerprint: lease.Annotations[LeaseSessionKeyFingerprintAnnotation]}, nil
+}
+
+func leaseExpired(lease *coordinationv1.Lease, now time.Time) bool {
+	if lease.Spec.RenewTime == nil || lease.Spec.LeaseDurationSeconds == nil {
+		return true
+	}
+	return lease.Spec.RenewTime.Add(time.Duration(*lease.Spec.LeaseDurationSeconds) * time.Second).Before(now)
+}
+
+func ValidateSessionKeyBindingLock(lock any) error {
+	if _, ok := lock.(*SessionLeaseLock); !ok {
+		return ErrSessionKeyBindingUnsupported
+	}
+	return nil
+}
+
+// Local wrappers keep crypto implementation details out of protocol call sites.
+func sha256Sum(data []byte) [32]byte { return sha256.Sum256(data) }

--- a/pkg/reconfigure/protocol/lease.go
+++ b/pkg/reconfigure/protocol/lease.go
@@ -394,7 +394,8 @@ func NewSessionLeaseLock(config SessionLeaseLockConfig) (*SessionLeaseLock, erro
 func (lock *SessionLeaseLock) Acquire(ctx context.Context) (LeaseSession, error) {
 	leases := lock.config.Client.Leases(lock.config.Namespace)
 	lease, err := leases.Get(ctx, lock.config.Name, metav1.GetOptions{})
-	if apierrors.IsNotFound(err) {
+	switch {
+	case apierrors.IsNotFound(err):
 		now := metav1.NewMicroTime(time.Now())
 		holder := lock.config.HolderIdentity
 		duration := int32(lock.config.LeaseDuration / time.Second)
@@ -403,9 +404,9 @@ func (lock *SessionLeaseLock) Acquire(ctx context.Context) (LeaseSession, error)
 		if err != nil {
 			return LeaseSession{}, err
 		}
-	} else if err != nil {
+	case err != nil:
 		return LeaseSession{}, err
-	} else {
+	default:
 		current, parseErr := leaseSessionFromLease(lease)
 		if parseErr != nil {
 			return LeaseSession{}, parseErr

--- a/pkg/reconfigure/protocol/lease_session_lock_test.go
+++ b/pkg/reconfigure/protocol/lease_session_lock_test.go
@@ -1,0 +1,357 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package protocol
+
+import (
+	"context"
+	"crypto/ed25519"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	types "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+)
+
+func TestSessionLeaseLockAcquireAndRenewKeepEpochAndKeyAtomic(t *testing.T) {
+	ctx := context.Background()
+	client := fakeClientAssigningLeaseUID(types.UID("lease-uid-1"))
+	publicKey, privateKey := testEd25519KeyPair(t)
+	lock, err := NewSessionLeaseLock(SessionLeaseLockConfig{
+		Client:         client.CoordinationV1(),
+		Namespace:      "kb-system",
+		Name:           "reconfigure-protocol",
+		HolderIdentity: "controller-pod-uid-1/process-1",
+		KeyPair: SessionKeyPair{
+			Algorithm:  SessionKeyAlgorithmEd25519,
+			PublicKey:  publicKey,
+			PrivateKey: privateKey,
+		},
+		LeaseDuration: 30 * time.Second,
+	})
+	require.NoError(t, err)
+
+	session, err := lock.Acquire(ctx)
+	require.NoError(t, err)
+	lease, err := client.CoordinationV1().Leases("kb-system").Get(ctx, "reconfigure-protocol", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, types.UID("lease-uid-1"), lease.UID)
+	require.Equal(t, session.HolderIdentity, *lease.Spec.HolderIdentity)
+	require.Equal(t, "1", lease.Annotations[LeaseSessionEpochAnnotation])
+	require.Equal(t, SessionKeyAlgorithmEd25519, lease.Annotations[LeaseSessionKeyAlgorithmAnnotation])
+	require.Equal(t, encodeSessionPublicKey(publicKey), lease.Annotations[LeaseSessionPublicKeyAnnotation])
+	require.Equal(t, sessionKeyFingerprint(publicKey), lease.Annotations[LeaseSessionKeyFingerprintAnnotation])
+	require.Equal(t, []string{"create"}, mutatingLeaseVerbs(client.Actions()), "acquire must not patch key metadata after leadership")
+
+	keyAnnotations := leaseSessionKeyAnnotations(lease)
+	holderBefore := *lease.Spec.HolderIdentity
+	require.NoError(t, lock.Renew(ctx))
+	renewed, err := client.CoordinationV1().Leases("kb-system").Get(ctx, lease.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, keyAnnotations, leaseSessionKeyAnnotations(renewed), "renew may only update lease timing fields")
+	require.Equal(t, holderBefore, *renewed.Spec.HolderIdentity)
+	require.Equal(t, []string{"create", "update"}, mutatingLeaseVerbs(client.Actions()))
+}
+
+func TestSessionLeaseLockRecoversCommittedUpdateAfterResponseLoss(t *testing.T) {
+	ctx := context.Background()
+	oldPublicKey, _ := testEd25519KeyPair(t)
+	oldHolder := "controller-pod-uid-1/process-1"
+	expired := &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "kb-system",
+			Name:      "reconfigure-protocol",
+			UID:       types.UID("lease-uid-1"),
+			Annotations: map[string]string{
+				LeaseSessionEpochAnnotation:          "7",
+				LeaseSessionKeyAlgorithmAnnotation:   SessionKeyAlgorithmEd25519,
+				LeaseSessionPublicKeyAnnotation:      encodeSessionPublicKey(oldPublicKey),
+				LeaseSessionKeyFingerprintAnnotation: sessionKeyFingerprint(oldPublicKey),
+			},
+		},
+		Spec: coordinationv1.LeaseSpec{
+			HolderIdentity:       &oldHolder,
+			LeaseDurationSeconds: ptr(int32(1)),
+			RenewTime:            &metav1.MicroTime{Time: time.Now().Add(-time.Minute)},
+		},
+	}
+	client := fake.NewSimpleClientset(expired)
+	updateLost := false
+	client.PrependReactor("update", "leases", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		if updateLost {
+			return false, nil, nil
+		}
+		updateLost = true
+		update := action.(k8stesting.UpdateAction)
+		lease := update.GetObject().(*coordinationv1.Lease).DeepCopy()
+		require.Equal(t, "8", lease.Annotations[LeaseSessionEpochAnnotation])
+		require.Equal(t, SessionKeyAlgorithmEd25519, lease.Annotations[LeaseSessionKeyAlgorithmAnnotation])
+		require.NotEmpty(t, lease.Annotations[LeaseSessionPublicKeyAnnotation])
+		require.NotEmpty(t, lease.Annotations[LeaseSessionKeyFingerprintAnnotation])
+		err := client.Tracker().Update(leaseGVR(), lease, lease.Namespace)
+		require.NoError(t, err)
+		return true, nil, errors.New("simulated response loss after committed update")
+	})
+
+	publicKey, privateKey := testEd25519KeyPair(t)
+	keyPair := SessionKeyPair{
+		Algorithm:  SessionKeyAlgorithmEd25519,
+		PublicKey:  publicKey,
+		PrivateKey: privateKey,
+	}
+	lock, err := NewSessionLeaseLock(SessionLeaseLockConfig{
+		Client:         client.CoordinationV1(),
+		Namespace:      "kb-system",
+		Name:           "reconfigure-protocol",
+		HolderIdentity: "controller-pod-uid-1/process-2",
+		KeyPair:        keyPair,
+		LeaseDuration:  30 * time.Second,
+	})
+	require.NoError(t, err)
+	_, err = lock.Acquire(ctx)
+	require.Error(t, err)
+
+	recovered, err := lock.RecoverCommittedSession(ctx, keyPair)
+	require.NoError(t, err)
+	require.Equal(t, int64(8), recovered.Epoch)
+	require.Equal(t, sessionKeyFingerprint(publicKey), recovered.SessionKeyFingerprint)
+	require.Equal(t, types.UID("lease-uid-1"), recovered.LeaseUID)
+	require.Equal(t, []string{"update"}, mutatingLeaseVerbs(client.Actions()), "recovery must only read the committed Lease")
+
+	_, wrongPrivateKey := testEd25519KeyPair(t)
+	wrongKeyPair := keyPair
+	wrongKeyPair.PrivateKey = wrongPrivateKey
+	_, err = lock.RecoverCommittedSession(ctx, wrongKeyPair)
+	require.ErrorIs(t, err, ErrLeaseSessionKeyUnavailable)
+	missingPrivateKey := keyPair
+	missingPrivateKey.PrivateKey = nil
+	_, err = lock.RecoverCommittedSession(ctx, missingPrivateKey)
+	require.ErrorIs(t, err, ErrLeaseSessionKeyUnavailable)
+	require.Equal(t, []string{"update"}, mutatingLeaseVerbs(client.Actions()))
+}
+
+func TestSessionLeaseLockRecoversCommittedCreateAfterResponseLoss(t *testing.T) {
+	ctx := context.Background()
+	client := fake.NewSimpleClientset()
+	client.PrependReactor("create", "leases", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		create := action.(k8stesting.CreateAction)
+		lease := create.GetObject().(*coordinationv1.Lease).DeepCopy()
+		lease.UID = types.UID("lease-uid-1")
+		require.Equal(t, "1", lease.Annotations[LeaseSessionEpochAnnotation])
+		require.NotEmpty(t, lease.Annotations[LeaseSessionPublicKeyAnnotation])
+		require.NoError(t, client.Tracker().Create(leaseGVR(), lease, lease.Namespace))
+		return true, nil, errors.New("simulated response loss after committed create")
+	})
+
+	publicKey, privateKey := testEd25519KeyPair(t)
+	keyPair := SessionKeyPair{
+		Algorithm:  SessionKeyAlgorithmEd25519,
+		PublicKey:  publicKey,
+		PrivateKey: privateKey,
+	}
+	lock, err := NewSessionLeaseLock(SessionLeaseLockConfig{
+		Client:         client.CoordinationV1(),
+		Namespace:      "kb-system",
+		Name:           "reconfigure-protocol",
+		HolderIdentity: "controller-pod-uid-1/process-1",
+		KeyPair:        keyPair,
+		LeaseDuration:  30 * time.Second,
+	})
+	require.NoError(t, err)
+	_, err = lock.Acquire(ctx)
+	require.Error(t, err)
+	require.Equal(t, []string{"create"}, mutatingLeaseVerbs(client.Actions()))
+
+	recovered, err := lock.RecoverCommittedSession(ctx, keyPair)
+	require.NoError(t, err)
+	require.Equal(t, types.UID("lease-uid-1"), recovered.LeaseUID)
+	require.Equal(t, int64(1), recovered.Epoch)
+	require.Equal(t, sessionKeyFingerprint(publicKey), recovered.SessionKeyFingerprint)
+	require.Equal(t, []string{"create"}, mutatingLeaseVerbs(client.Actions()), "recovery must not rewrite the Lease")
+
+	_, wrongPrivateKey := testEd25519KeyPair(t)
+	wrongKeyPair := keyPair
+	wrongKeyPair.PrivateKey = wrongPrivateKey
+	_, err = lock.RecoverCommittedSession(ctx, wrongKeyPair)
+	require.ErrorIs(t, err, ErrLeaseSessionKeyUnavailable)
+	missingPrivateKey := keyPair
+	missingPrivateKey.PrivateKey = nil
+	_, err = lock.RecoverCommittedSession(ctx, missingPrivateKey)
+	require.ErrorIs(t, err, ErrLeaseSessionKeyUnavailable)
+
+	lease, err := client.CoordinationV1().Leases("kb-system").Get(ctx, "reconfigure-protocol", metav1.GetOptions{})
+	require.NoError(t, err)
+	lease.UID = types.UID("lease-uid-2")
+	require.NoError(t, client.Tracker().Update(leaseGVR(), lease, lease.Namespace))
+	_, err = lock.RecoverCommittedSession(ctx, keyPair)
+	require.ErrorIs(t, err, ErrLeaseUIDChanged)
+	require.Equal(t, []string{"create"}, mutatingLeaseVerbs(client.Actions()))
+}
+
+func TestSessionLeaseLockRejectsUnsupportedAndConflictingPaths(t *testing.T) {
+	require.ErrorIs(t, ValidateSessionKeyBindingLock(&resourcelock.LeaseLock{}), ErrSessionKeyBindingUnsupported)
+
+	t.Run("second contender cannot acquire current lease", func(t *testing.T) {
+		ctx := context.Background()
+		client := fakeClientAssigningLeaseUID(types.UID("lease-uid-1"))
+		first := newTestSessionLeaseLock(t, client, "controller-pod-uid-1/process-1")
+		second := newTestSessionLeaseLock(t, client, "controller-pod-uid-2/process-1")
+		_, err := first.Acquire(ctx)
+		require.NoError(t, err)
+		_, err = second.Acquire(ctx)
+		require.ErrorIs(t, err, ErrLeaseSessionHeld)
+	})
+
+	t.Run("same epoch key metadata patch fails closed", func(t *testing.T) {
+		ctx := context.Background()
+		client := fakeClientAssigningLeaseUID(types.UID("lease-uid-1"))
+		lock := newTestSessionLeaseLock(t, client, "controller-pod-uid-1/process-1")
+		_, err := lock.Acquire(ctx)
+		require.NoError(t, err)
+		lease, err := client.CoordinationV1().Leases("kb-system").Get(ctx, "reconfigure-protocol", metav1.GetOptions{})
+		require.NoError(t, err)
+		lease.Annotations[LeaseSessionKeyFingerprintAnnotation] = testDigest("forged-key")
+		_, err = client.CoordinationV1().Leases("kb-system").Update(ctx, lease, metav1.UpdateOptions{})
+		require.NoError(t, err)
+		require.ErrorIs(t, lock.Renew(ctx), ErrLeaseSessionKeyChanged)
+	})
+
+	t.Run("same name new lease UID fails closed", func(t *testing.T) {
+		ctx := context.Background()
+		client := fakeClientAssigningLeaseUID(types.UID("lease-uid-1"))
+		lock := newTestSessionLeaseLock(t, client, "controller-pod-uid-1/process-1")
+		_, err := lock.Acquire(ctx)
+		require.NoError(t, err)
+		lease, err := client.CoordinationV1().Leases("kb-system").Get(ctx, "reconfigure-protocol", metav1.GetOptions{})
+		require.NoError(t, err)
+		lease.UID = types.UID("lease-uid-2")
+		require.NoError(t, client.Tracker().Update(leaseGVR(), lease, lease.Namespace))
+		require.ErrorIs(t, lock.Renew(ctx), ErrLeaseUIDChanged)
+	})
+}
+
+func TestSessionLeaseLockOwnsPublicBindingAndDoesNotRetainPrivateKey(t *testing.T) {
+	ctx := context.Background()
+	client := fakeClientAssigningLeaseUID(types.UID("lease-uid-1"))
+	publicKey, privateKey := testEd25519KeyPair(t)
+	expectedPublic := append(ed25519.PublicKey(nil), publicKey...)
+	expectedPrivate := append(ed25519.PrivateKey(nil), privateKey...)
+	lock, err := NewSessionLeaseLock(SessionLeaseLockConfig{
+		Client:         client.CoordinationV1(),
+		Namespace:      "kb-system",
+		Name:           "reconfigure-protocol",
+		HolderIdentity: "controller-pod-uid-1/process-1",
+		KeyPair: SessionKeyPair{
+			Algorithm:  SessionKeyAlgorithmEd25519,
+			PublicKey:  publicKey,
+			PrivateKey: privateKey,
+		},
+		LeaseDuration: 30 * time.Second,
+	})
+	require.NoError(t, err)
+	require.Equal(t, expectedPublic, lock.config.KeyPair.PublicKey)
+	require.Nil(t, lock.config.KeyPair.PrivateKey, "private key ownership remains with the external keystore/caller")
+
+	publicKey[0] ^= 0xff
+	privateKey[0] ^= 0xff
+	session, err := lock.Acquire(ctx)
+	require.NoError(t, err)
+	require.Equal(t, expectedPublic, ed25519.PublicKey(session.SessionPublicKey))
+	lease, err := client.CoordinationV1().Leases("kb-system").Get(ctx, "reconfigure-protocol", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, encodeSessionPublicKey(expectedPublic), lease.Annotations[LeaseSessionPublicKeyAnnotation])
+	require.Equal(t, sessionKeyFingerprint(expectedPublic), lease.Annotations[LeaseSessionKeyFingerprintAnnotation])
+
+	session.SessionPublicKey[0] ^= 0xff
+	require.NoError(t, lock.Renew(ctx))
+	_, err = lock.RecoverCommittedSession(ctx, SessionKeyPair{Algorithm: SessionKeyAlgorithmEd25519, PublicKey: expectedPublic, PrivateKey: expectedPrivate})
+	require.NoError(t, err)
+}
+
+func fakeClientAssigningLeaseUID(uid types.UID) *fake.Clientset {
+	client := fake.NewSimpleClientset()
+	client.PrependReactor("create", "leases", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		create := action.(k8stesting.CreateAction)
+		lease := create.GetObject().(*coordinationv1.Lease).DeepCopy()
+		lease.UID = uid
+		if err := client.Tracker().Create(leaseGVR(), lease, lease.Namespace); err != nil {
+			return true, nil, err
+		}
+		return true, lease, nil
+	})
+	return client
+}
+
+func newTestSessionLeaseLock(t *testing.T, client *fake.Clientset, holder string) *SessionLeaseLock {
+	t.Helper()
+	publicKey, privateKey := testEd25519KeyPair(t)
+	lock, err := NewSessionLeaseLock(SessionLeaseLockConfig{
+		Client:         client.CoordinationV1(),
+		Namespace:      "kb-system",
+		Name:           "reconfigure-protocol",
+		HolderIdentity: holder,
+		KeyPair: SessionKeyPair{
+			Algorithm:  SessionKeyAlgorithmEd25519,
+			PublicKey:  publicKey,
+			PrivateKey: privateKey,
+		},
+		LeaseDuration: 30 * time.Second,
+	})
+	require.NoError(t, err)
+	return lock
+}
+
+func leaseSessionKeyAnnotations(lease *coordinationv1.Lease) map[string]string {
+	return map[string]string{
+		LeaseSessionEpochAnnotation:          lease.Annotations[LeaseSessionEpochAnnotation],
+		LeaseSessionKeyAlgorithmAnnotation:   lease.Annotations[LeaseSessionKeyAlgorithmAnnotation],
+		LeaseSessionPublicKeyAnnotation:      lease.Annotations[LeaseSessionPublicKeyAnnotation],
+		LeaseSessionKeyFingerprintAnnotation: lease.Annotations[LeaseSessionKeyFingerprintAnnotation],
+	}
+}
+
+func leaseGVR() schema.GroupVersionResource {
+	return coordinationv1.SchemeGroupVersion.WithResource("leases")
+}
+
+func mutatingLeaseVerbs(actions []k8stesting.Action) []string {
+	var verbs []string
+	for _, action := range actions {
+		if action.GetResource().Resource != "leases" {
+			continue
+		}
+		switch action.GetVerb() {
+		case "create", "update", "patch":
+			verbs = append(verbs, action.GetVerb())
+		}
+	}
+	return verbs
+}
+
+func ptr[T any](value T) *T {
+	return &value
+}

--- a/pkg/reconfigure/protocol/lease_session_lock_test.go
+++ b/pkg/reconfigure/protocol/lease_session_lock_test.go
@@ -23,6 +23,8 @@ import (
 	"context"
 	"crypto/ed25519"
 	"errors"
+	"math"
+	"sync"
 	"testing"
 	"time"
 
@@ -215,6 +217,138 @@ func TestSessionLeaseLockRecoversCommittedCreateAfterResponseLoss(t *testing.T) 
 func TestSessionLeaseLockRejectsUnsupportedAndConflictingPaths(t *testing.T) {
 	require.ErrorIs(t, ValidateSessionKeyBindingLock(&resourcelock.LeaseLock{}), ErrSessionKeyBindingUnsupported)
 
+	t.Run("subsecond lease duration is rejected", func(t *testing.T) {
+		publicKey, privateKey := testEd25519KeyPair(t)
+		_, err := NewSessionLeaseLock(SessionLeaseLockConfig{
+			Client: fake.NewSimpleClientset().CoordinationV1(), Namespace: "kb-system", Name: "reconfigure-protocol",
+			HolderIdentity: "controller-pod-uid-1/process-1",
+			KeyPair:        SessionKeyPair{Algorithm: SessionKeyAlgorithmEd25519, PublicKey: publicKey, PrivateKey: privateKey},
+			LeaseDuration:  time.Second - time.Nanosecond,
+		})
+		require.ErrorIs(t, err, ErrLeaseSessionKeyUnavailable)
+	})
+
+	t.Run("fractional and overflowing lease durations are rejected", func(t *testing.T) {
+		publicKey, privateKey := testEd25519KeyPair(t)
+		for _, duration := range []time.Duration{time.Second + 900*time.Millisecond, (time.Duration(math.MaxInt32) + 1) * time.Second} {
+			_, err := NewSessionLeaseLock(SessionLeaseLockConfig{
+				Client: fake.NewSimpleClientset().CoordinationV1(), Namespace: "kb-system", Name: "reconfigure-protocol",
+				HolderIdentity: "controller-pod-uid-1/process-1",
+				KeyPair:        SessionKeyPair{Algorithm: SessionKeyAlgorithmEd25519, PublicKey: publicKey, PrivateKey: privateKey},
+				LeaseDuration:  duration,
+			})
+			require.ErrorIs(t, err, ErrLeaseSessionKeyUnavailable)
+		}
+	})
+
+	t.Run("whole-second lease duration boundaries are accepted", func(t *testing.T) {
+		publicKey, privateKey := testEd25519KeyPair(t)
+		for _, duration := range []time.Duration{time.Second, time.Duration(math.MaxInt32) * time.Second} {
+			_, err := NewSessionLeaseLock(SessionLeaseLockConfig{
+				Client: fake.NewSimpleClientset().CoordinationV1(), Namespace: "kb-system", Name: "reconfigure-protocol",
+				HolderIdentity: "controller-pod-uid-1/process-1",
+				KeyPair:        SessionKeyPair{Algorithm: SessionKeyAlgorithmEd25519, PublicKey: publicKey, PrivateKey: privateKey},
+				LeaseDuration:  duration,
+			})
+			require.NoError(t, err)
+		}
+	})
+
+	t.Run("expired malformed lease is replaced with a new UID", func(t *testing.T) {
+		ctx := context.Background()
+		holder := "stale-holder"
+		malformed := &coordinationv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "kb-system", Name: "reconfigure-protocol", UID: types.UID("stale-uid"), ResourceVersion: "7"},
+			Spec:       coordinationv1.LeaseSpec{HolderIdentity: &holder, LeaseDurationSeconds: ptr(int32(1)), RenewTime: &metav1.MicroTime{Time: time.Now().Add(-time.Minute)}},
+		}
+		client := fake.NewSimpleClientset(malformed)
+		client.PrependReactor("delete", "leases", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			preconditions := action.(k8stesting.DeleteAction).GetDeleteOptions().Preconditions
+			require.NotNil(t, preconditions)
+			require.Equal(t, malformed.UID, *preconditions.UID)
+			require.Equal(t, malformed.ResourceVersion, *preconditions.ResourceVersion)
+			return false, nil, nil
+		})
+		client.PrependReactor("create", "leases", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			lease := action.(k8stesting.CreateAction).GetObject().(*coordinationv1.Lease).DeepCopy()
+			lease.UID = types.UID("replacement-uid")
+			require.NoError(t, client.Tracker().Create(leaseGVR(), lease, lease.Namespace))
+			return true, lease, nil
+		})
+		lock := newTestSessionLeaseLock(t, client, "controller-pod-uid-2/process-1")
+		session, err := lock.Acquire(ctx)
+		require.NoError(t, err)
+		require.Equal(t, types.UID("replacement-uid"), session.LeaseUID)
+		require.Equal(t, int64(1), session.Epoch)
+	})
+
+	t.Run("unexpired malformed lease fails closed", func(t *testing.T) {
+		ctx := context.Background()
+		holder := "active-holder"
+		malformed := &coordinationv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "kb-system", Name: "reconfigure-protocol", UID: types.UID("active-uid")},
+			Spec:       coordinationv1.LeaseSpec{HolderIdentity: &holder, LeaseDurationSeconds: ptr(int32(30)), RenewTime: &metav1.MicroTime{Time: time.Now()}},
+		}
+		client := fake.NewSimpleClientset(malformed)
+		lock := newTestSessionLeaseLock(t, client, "controller-pod-uid-2/process-1")
+		_, err := lock.Acquire(ctx)
+		require.ErrorIs(t, err, ErrLeaseSessionKeyUnavailable)
+		_, err = client.CoordinationV1().Leases("kb-system").Get(ctx, "reconfigure-protocol", metav1.GetOptions{})
+		require.NoError(t, err)
+		require.Empty(t, mutatingLeaseVerbs(client.Actions()))
+	})
+
+	t.Run("expired malformed lease without resource version fails closed", func(t *testing.T) {
+		ctx := context.Background()
+		holder := "stale-holder"
+		malformed := &coordinationv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "kb-system", Name: "reconfigure-protocol", UID: types.UID("stale-uid")},
+			Spec:       coordinationv1.LeaseSpec{HolderIdentity: &holder, LeaseDurationSeconds: ptr(int32(1)), RenewTime: &metav1.MicroTime{Time: time.Now().Add(-time.Minute)}},
+		}
+		client := fake.NewSimpleClientset(malformed)
+		lock := newTestSessionLeaseLock(t, client, "controller-pod-uid-2/process-1")
+		_, err := lock.Acquire(ctx)
+		require.ErrorIs(t, err, ErrLeaseSessionKeyUnavailable)
+		require.Empty(t, mutatingLeaseVerbs(client.Actions()))
+	})
+
+	t.Run("malformed lease without positive expiry evidence fails closed", func(t *testing.T) {
+		now := metav1.MicroTime{Time: time.Now().Add(-time.Minute)}
+		for name, mutate := range map[string]func(*coordinationv1.Lease){
+			"missing renew time": func(lease *coordinationv1.Lease) { lease.Spec.RenewTime = nil },
+			"missing duration":   func(lease *coordinationv1.Lease) { lease.Spec.LeaseDurationSeconds = nil },
+			"zero duration":      func(lease *coordinationv1.Lease) { lease.Spec.LeaseDurationSeconds = ptr(int32(0)) },
+			"negative duration":  func(lease *coordinationv1.Lease) { lease.Spec.LeaseDurationSeconds = ptr(int32(-1)) },
+		} {
+			t.Run(name, func(t *testing.T) {
+				holder := "stale-holder"
+				lease := &coordinationv1.Lease{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "kb-system", Name: "reconfigure-protocol", UID: types.UID("stale-uid"), ResourceVersion: "7"},
+					Spec:       coordinationv1.LeaseSpec{HolderIdentity: &holder, LeaseDurationSeconds: ptr(int32(1)), RenewTime: &now},
+				}
+				mutate(lease)
+				client := fake.NewSimpleClientset(lease)
+				lock := newTestSessionLeaseLock(t, client, "controller-pod-uid-2/process-1")
+				_, err := lock.Acquire(context.Background())
+				require.ErrorIs(t, err, ErrLeaseSessionKeyUnavailable)
+				require.Empty(t, mutatingLeaseVerbs(client.Actions()))
+			})
+		}
+	})
+
+	t.Run("expired malformed lease without UID fails closed", func(t *testing.T) {
+		holder := "stale-holder"
+		lease := &coordinationv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "kb-system", Name: "reconfigure-protocol", ResourceVersion: "7"},
+			Spec:       coordinationv1.LeaseSpec{HolderIdentity: &holder, LeaseDurationSeconds: ptr(int32(1)), RenewTime: &metav1.MicroTime{Time: time.Now().Add(-time.Minute)}},
+		}
+		client := fake.NewSimpleClientset(lease)
+		lock := newTestSessionLeaseLock(t, client, "controller-pod-uid-2/process-1")
+		_, err := lock.Acquire(context.Background())
+		require.ErrorIs(t, err, ErrLeaseSessionKeyUnavailable)
+		require.Empty(t, mutatingLeaseVerbs(client.Actions()))
+	})
+
 	t.Run("second contender cannot acquire current lease", func(t *testing.T) {
 		ctx := context.Background()
 		client := fakeClientAssigningLeaseUID(types.UID("lease-uid-1"))
@@ -235,6 +369,20 @@ func TestSessionLeaseLockRejectsUnsupportedAndConflictingPaths(t *testing.T) {
 		lease, err := client.CoordinationV1().Leases("kb-system").Get(ctx, "reconfigure-protocol", metav1.GetOptions{})
 		require.NoError(t, err)
 		lease.Annotations[LeaseSessionKeyFingerprintAnnotation] = testDigest("forged-key")
+		_, err = client.CoordinationV1().Leases("kb-system").Update(ctx, lease, metav1.UpdateOptions{})
+		require.NoError(t, err)
+		require.ErrorIs(t, lock.Renew(ctx), ErrLeaseSessionKeyChanged)
+	})
+
+	t.Run("renew checks locally committed epoch", func(t *testing.T) {
+		ctx := context.Background()
+		client := fakeClientAssigningLeaseUID(types.UID("lease-uid-1"))
+		lock := newTestSessionLeaseLock(t, client, "controller-pod-uid-1/process-1")
+		_, err := lock.Acquire(ctx)
+		require.NoError(t, err)
+		lease, err := client.CoordinationV1().Leases("kb-system").Get(ctx, "reconfigure-protocol", metav1.GetOptions{})
+		require.NoError(t, err)
+		lease.Annotations[LeaseSessionEpochAnnotation] = "2"
 		_, err = client.CoordinationV1().Leases("kb-system").Update(ctx, lease, metav1.UpdateOptions{})
 		require.NoError(t, err)
 		require.ErrorIs(t, lock.Renew(ctx), ErrLeaseSessionKeyChanged)
@@ -290,6 +438,40 @@ func TestSessionLeaseLockOwnsPublicBindingAndDoesNotRetainPrivateKey(t *testing.
 	require.NoError(t, lock.Renew(ctx))
 	_, err = lock.RecoverCommittedSession(ctx, SessionKeyPair{Algorithm: SessionKeyAlgorithmEd25519, PublicKey: expectedPublic, PrivateKey: expectedPrivate})
 	require.NoError(t, err)
+}
+
+func TestSessionLeaseLockConcurrentRenewAndRecoveryAreRaceFree(t *testing.T) {
+	ctx := context.Background()
+	client := fakeClientAssigningLeaseUID(types.UID("lease-uid-1"))
+	publicKey, privateKey := testEd25519KeyPair(t)
+	keyPair := SessionKeyPair{Algorithm: SessionKeyAlgorithmEd25519, PublicKey: publicKey, PrivateKey: privateKey}
+	lock, err := NewSessionLeaseLock(SessionLeaseLockConfig{
+		Client: client.CoordinationV1(), Namespace: "kb-system", Name: "reconfigure-protocol",
+		HolderIdentity: "controller-pod-uid-1/process-1", KeyPair: keyPair, LeaseDuration: 30 * time.Second,
+	})
+	require.NoError(t, err)
+	_, err = lock.Acquire(ctx)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	errors := make(chan error, 40)
+	for range 20 {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			errors <- lock.Renew(ctx)
+		}()
+		go func() {
+			defer wg.Done()
+			_, err := lock.RecoverCommittedSession(ctx, keyPair)
+			errors <- err
+		}()
+	}
+	wg.Wait()
+	close(errors)
+	for err := range errors {
+		require.NoError(t, err)
+	}
 }
 
 func fakeClientAssigningLeaseUID(uid types.UID) *fake.Clientset {

--- a/pkg/reconfigure/protocol/lease_session_test.go
+++ b/pkg/reconfigure/protocol/lease_session_test.go
@@ -1,0 +1,655 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package protocol
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	types "k8s.io/apimachinery/pkg/types"
+)
+
+func TestLeaseAcquireBindsStrictNextEpochAndRealSessionKey(t *testing.T) {
+	publicKey, _ := testEd25519KeyPair(t)
+	request := LeaseAcquireRequest{
+		HolderIdentity:        "controller-pod-uid-1/process-1",
+		NextEpoch:             1,
+		SessionKeyAlgorithm:   SessionKeyAlgorithmEd25519,
+		SessionPublicKey:      append([]byte(nil), publicKey...),
+		SessionKeyFingerprint: sessionKeyFingerprint(publicKey),
+	}
+	lease := LeaseSession{LeaseUID: types.UID("lease-uid-1")}
+
+	acquired, err := AcquireLeaseSession(lease, request)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), acquired.Epoch)
+	require.Equal(t, request.HolderIdentity, acquired.HolderIdentity)
+	require.Equal(t, request.SessionKeyFingerprint, acquired.SessionKeyFingerprint)
+
+	request.SessionPublicKey[0] ^= 0xff
+	require.Equal(t, publicKey, ed25519.PublicKey(acquired.SessionPublicKey), "state must not alias caller key bytes")
+
+	for name, mutate := range map[string]func(*LeaseAcquireRequest){
+		"same epoch":           func(v *LeaseAcquireRequest) { v.NextEpoch = 1 },
+		"skipped epoch":        func(v *LeaseAcquireRequest) { v.NextEpoch = 3 },
+		"empty holder":         func(v *LeaseAcquireRequest) { v.HolderIdentity = "" },
+		"empty algorithm":      func(v *LeaseAcquireRequest) { v.SessionKeyAlgorithm = "" },
+		"unknown algorithm":    func(v *LeaseAcquireRequest) { v.SessionKeyAlgorithm = "RSA" },
+		"empty key":            func(v *LeaseAcquireRequest) { v.SessionPublicKey = nil },
+		"malformed key":        func(v *LeaseAcquireRequest) { v.SessionPublicKey = []byte("short") },
+		"empty fingerprint":    func(v *LeaseAcquireRequest) { v.SessionKeyFingerprint = "" },
+		"fingerprint mismatch": func(v *LeaseAcquireRequest) { v.SessionKeyFingerprint = testDigest("other-key") },
+		"noncanonical digest": func(v *LeaseAcquireRequest) {
+			v.SessionKeyFingerprint = "SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			nextPublicKey, _ := testEd25519KeyPair(t)
+			next := LeaseAcquireRequest{
+				HolderIdentity:        "controller-pod-uid-1/process-2",
+				NextEpoch:             2,
+				SessionKeyAlgorithm:   SessionKeyAlgorithmEd25519,
+				SessionPublicKey:      nextPublicKey,
+				SessionKeyFingerprint: sessionKeyFingerprint(nextPublicKey),
+			}
+			mutate(&next)
+			_, err := AcquireLeaseSession(acquired, next)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestLeaseRenewRequiresByteExactSessionIdentity(t *testing.T) {
+	current := testLeaseSession(t, 7, "controller-pod-uid-1/process-1")
+	exact := LeaseRenewRequest{
+		HolderIdentity:        current.HolderIdentity,
+		Epoch:                 current.Epoch,
+		SessionKeyAlgorithm:   current.SessionKeyAlgorithm,
+		SessionPublicKey:      append([]byte(nil), current.SessionPublicKey...),
+		SessionKeyFingerprint: current.SessionKeyFingerprint,
+	}
+
+	renewed, err := RenewLeaseSession(current, exact)
+	require.NoError(t, err)
+	require.Equal(t, current, renewed)
+
+	for name, mutate := range map[string]func(*LeaseRenewRequest){
+		"holder":      func(v *LeaseRenewRequest) { v.HolderIdentity = "controller-pod-uid-2/process-1" },
+		"epoch":       func(v *LeaseRenewRequest) { v.Epoch++ },
+		"algorithm":   func(v *LeaseRenewRequest) { v.SessionKeyAlgorithm = "RSA" },
+		"public key":  func(v *LeaseRenewRequest) { v.SessionPublicKey[0] ^= 0xff },
+		"fingerprint": func(v *LeaseRenewRequest) { v.SessionKeyFingerprint = testDigest("other-key") },
+	} {
+		t.Run(name, func(t *testing.T) {
+			changed := exact
+			changed.SessionPublicKey = append([]byte(nil), exact.SessionPublicKey...)
+			mutate(&changed)
+			_, err := RenewLeaseSession(current, changed)
+			require.ErrorIs(t, err, ErrLeaseSessionKeyChanged)
+		})
+	}
+}
+
+func TestLeaseRecoveryRequiresExactLocalKeyAndRestartUsesNextEpoch(t *testing.T) {
+	publicKey, privateKey := testEd25519KeyPair(t)
+	current := LeaseSession{
+		LeaseUID:              types.UID("lease-uid-1"),
+		HolderIdentity:        "controller-pod-uid-1/process-1",
+		Epoch:                 7,
+		SessionKeyAlgorithm:   SessionKeyAlgorithmEd25519,
+		SessionPublicKey:      publicKey,
+		SessionKeyFingerprint: sessionKeyFingerprint(publicKey),
+	}
+	exactKeyPair := SessionKeyPair{
+		Algorithm:  SessionKeyAlgorithmEd25519,
+		PublicKey:  publicKey,
+		PrivateKey: privateKey,
+	}
+
+	recovered, err := RecoverLeaseSession(current, LeaseRecoveryRequest{
+		HolderIdentity: current.HolderIdentity,
+		KeyPair:        exactKeyPair,
+	})
+	require.NoError(t, err)
+	require.Equal(t, current, recovered)
+
+	_, wrongPrivateKey := testEd25519KeyPair(t)
+	wrongPublicKey, wrongKeyPairPrivate := testEd25519KeyPair(t)
+	for name, keyPair := range map[string]SessionKeyPair{
+		"public fingerprint only": {
+			Algorithm: SessionKeyAlgorithmEd25519,
+			PublicKey: publicKey,
+		},
+		"wrong private key": {
+			Algorithm:  SessionKeyAlgorithmEd25519,
+			PublicKey:  publicKey,
+			PrivateKey: wrongPrivateKey,
+		},
+		"wrong keypair": {
+			Algorithm:  SessionKeyAlgorithmEd25519,
+			PublicKey:  wrongPublicKey,
+			PrivateKey: wrongKeyPairPrivate,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := RecoverLeaseSession(current, LeaseRecoveryRequest{
+				HolderIdentity: current.HolderIdentity,
+				KeyPair:        keyPair,
+			})
+			require.ErrorIs(t, err, ErrLeaseSessionKeyUnavailable)
+		})
+	}
+
+	nextPublicKey, _ := testEd25519KeyPair(t)
+	next, err := AcquireLeaseSession(current, LeaseAcquireRequest{
+		HolderIdentity:        "controller-pod-uid-1/process-2",
+		NextEpoch:             current.Epoch + 1,
+		SessionKeyAlgorithm:   SessionKeyAlgorithmEd25519,
+		SessionPublicKey:      nextPublicKey,
+		SessionKeyFingerprint: sessionKeyFingerprint(nextPublicKey),
+	})
+	require.NoError(t, err)
+	require.Equal(t, current.Epoch+1, next.Epoch)
+	require.NotEqual(t, current.HolderIdentity, next.HolderIdentity)
+	require.NotEqual(t, current.SessionKeyFingerprint, next.SessionKeyFingerprint)
+}
+
+func TestWindowPermitBindsEveryLeaseGateAndEffectField(t *testing.T) {
+	publicKey, privateKey := testEd25519KeyPair(t)
+	permit := testWindowCreatePermit(publicKey)
+	canonical, err := CanonicalWindowCreatePermitBytes(permit)
+	require.NoError(t, err)
+	require.True(t, bytes.HasPrefix(canonical, []byte("kubeblocks.io/reconfigure-window-create-permit/v1\x00")))
+	permit.Signature = ed25519.Sign(privateKey, WindowCreatePermitDigest(permit))
+	context := testWindowPermitContext(permit, publicKey)
+
+	require.NoError(t, ValidateWindowCreatePermit(context, permit))
+
+	permitMutations := map[string]func(*WindowCreatePermit){
+		"protocol version":   func(v *WindowCreatePermit) { v.ProtocolVersion = "v2" },
+		"gate kind":          func(v *WindowCreatePermit) { v.GateKind = "Credential" },
+		"window spec digest": func(v *WindowCreatePermit) { v.WindowSpecDigest = testDigest("other-window-spec") },
+		"lease UID":          func(v *WindowCreatePermit) { v.LeaseUID = types.UID("lease-uid-2") },
+		"lease epoch":        func(v *WindowCreatePermit) { v.LeaseEpoch++ },
+		"lease algorithm":    func(v *WindowCreatePermit) { v.LeaseKeyAlgorithm = "RSA" },
+		"lease fingerprint":  func(v *WindowCreatePermit) { v.LeaseKeyFingerprint = testDigest("other-key") },
+		"protocol fence UID": func(v *WindowCreatePermit) { v.ProtocolFenceUID = types.UID("protocol-fence-uid-2") },
+		"protocol fence RV":  func(v *WindowCreatePermit) { v.ProtocolFenceResourceVersion = "202" },
+		"installation epoch": func(v *WindowCreatePermit) { v.InstallationEpoch = "install-8" },
+		"authority UID":      func(v *WindowCreatePermit) { v.AuthorityUID = types.UID("authority-uid-2") },
+		"authority RV":       func(v *WindowCreatePermit) { v.AuthorityResourceVersion = "302" },
+		"prior gate UID":     func(v *WindowCreatePermit) { v.PriorGateUID = types.UID("prior-gate-uid-2") },
+		"prior gate RV":      func(v *WindowCreatePermit) { v.PriorGateResourceVersion = "402" },
+		"registration key":   func(v *WindowCreatePermit) { v.RegistrationKey = testDigest("registration-2") },
+		"effect key":         func(v *WindowCreatePermit) { v.EffectKey = testDigest("effect-key-2") },
+		"effect digest":      func(v *WindowCreatePermit) { v.EffectIdentityDigest = testDigest("effect-2") },
+		"effect state":       func(v *WindowCreatePermit) { v.EffectState = EffectStateObjectBound },
+	}
+	for name, mutate := range permitMutations {
+		t.Run("signed payload tamper "+name, func(t *testing.T) {
+			changed := permit
+			changed.Signature = append([]byte(nil), permit.Signature...)
+			mutate(&changed)
+			err := ValidateWindowCreatePermit(context, changed)
+			require.ErrorIs(t, err, ErrWindowCreatePermitInvalid)
+		})
+	}
+
+	contextMutations := map[string]func(*WindowPermitContext){
+		"protocol version":   func(v *WindowPermitContext) { v.ProtocolVersion = "v2" },
+		"gate kind":          func(v *WindowPermitContext) { v.ExpectedGateKind = "Credential" },
+		"lease UID":          func(v *WindowPermitContext) { v.CurrentLeaseUID = types.UID("lease-uid-2") },
+		"lease epoch":        func(v *WindowPermitContext) { v.CurrentLeaseEpoch++ },
+		"lease algorithm":    func(v *WindowPermitContext) { v.CurrentLeaseKeyAlgorithm = "RSA" },
+		"lease fingerprint":  func(v *WindowPermitContext) { v.CurrentLeaseKeyFingerprint = testDigest("other-key") },
+		"protocol fence UID": func(v *WindowPermitContext) { v.ProtocolFenceUID = types.UID("protocol-fence-uid-2") },
+		"protocol fence RV":  func(v *WindowPermitContext) { v.ProtocolFenceResourceVersion = "202" },
+		"installation epoch": func(v *WindowPermitContext) { v.InstallationEpoch = "install-8" },
+		"authority UID":      func(v *WindowPermitContext) { v.AuthorityUID = types.UID("authority-uid-2") },
+		"authority RV":       func(v *WindowPermitContext) { v.AuthorityResourceVersion = "302" },
+		"prior gate UID":     func(v *WindowPermitContext) { v.PriorGateUID = types.UID("prior-gate-uid-2") },
+		"prior gate RV":      func(v *WindowPermitContext) { v.PriorGateResourceVersion = "402" },
+		"registration key":   func(v *WindowPermitContext) { v.RegistrationKey = testDigest("registration-2") },
+		"effect key":         func(v *WindowPermitContext) { v.EffectKey = testDigest("effect-key-2") },
+		"effect digest":      func(v *WindowPermitContext) { v.EffectIdentityDigest = testDigest("effect-2") },
+	}
+	for name, mutate := range contextMutations {
+		t.Run("fresh context mismatch "+name, func(t *testing.T) {
+			changed := context
+			changed.CurrentLeasePublicKey = append([]byte(nil), context.CurrentLeasePublicKey...)
+			mutate(&changed)
+			err := ValidateWindowCreatePermit(changed, permit)
+			require.ErrorIs(t, err, ErrWindowCreatePermitInvalid)
+		})
+	}
+
+	for name, mutate := range map[string]func(*WindowImmutableSpec){
+		"name":                    func(v *WindowImmutableSpec) { v.Name = "other-window" },
+		"physical API":            func(v *WindowImmutableSpec) { v.PhysicalAPIID = "physical-api-2" },
+		"workload namespace name": func(v *WindowImmutableSpec) { v.WorkloadNamespaceName = "workload-2" },
+		"workload namespace UID":  func(v *WindowImmutableSpec) { v.WorkloadNamespaceUID = types.UID("namespace-uid-2") },
+		"execution UID":           func(v *WindowImmutableSpec) { v.ExecutionUID = types.UID("execution-uid-2") },
+		"attempt ID":              func(v *WindowImmutableSpec) { v.AttemptID = "attempt-4" },
+		"protocol version":        func(v *WindowImmutableSpec) { v.ProtocolVersion = "v2" },
+		"gate kind":               func(v *WindowImmutableSpec) { v.GateKind = GateKindCredential },
+		"installation epoch":      func(v *WindowImmutableSpec) { v.InstallationEpoch = "install-8" },
+		"duration":                func(v *WindowImmutableSpec) { v.DurationSeconds++ },
+		"protocol fence UID":      func(v *WindowImmutableSpec) { v.ProtocolFenceUID = types.UID("protocol-fence-uid-2") },
+		"target API version":      func(v *WindowImmutableSpec) { v.Target.APIVersion = "wrong.example.io/v1" },
+		"target kind":             func(v *WindowImmutableSpec) { v.Target.Kind = "WrongKind" },
+		"target namespace":        func(v *WindowImmutableSpec) { v.Target.Namespace = "other-namespace" },
+		"target name":             func(v *WindowImmutableSpec) { v.Target.Name = "other-target" },
+		"key secret name":         func(v *WindowImmutableSpec) { v.KeySecretName = "key-2" },
+		"key secret UID":          func(v *WindowImmutableSpec) { v.KeySecretUID = types.UID("key-secret-uid-2") },
+		"key version":             func(v *WindowImmutableSpec) { v.KeyVersion++ },
+		"key algorithm":           func(v *WindowImmutableSpec) { v.KeyAlgorithm = "RSA" },
+		"target structural key":   func(v *WindowImmutableSpec) { v.TargetFence.TargetStructuralKey = "target-2" },
+		"expected template hash":  func(v *WindowImmutableSpec) { v.TargetFence.ExpectedTemplateHash = testDigest("template-2") },
+	} {
+		t.Run("window spec "+name, func(t *testing.T) {
+			changed := context
+			changed.ExpectedWindowSpec = cloneWindowImmutableSpec(context.ExpectedWindowSpec)
+			mutate(&changed.ExpectedWindowSpec)
+			err := ValidateWindowCreatePermit(changed, permit)
+			require.ErrorIs(t, err, ErrWindowCreatePermitInvalid)
+		})
+	}
+}
+
+func TestWindowPermitRejectsJointlySignedInvalidBindings(t *testing.T) {
+	publicKey, privateKey := testEd25519KeyPair(t)
+	basePermit := testWindowCreatePermit(publicKey)
+	baseContext := testWindowPermitContext(basePermit, publicKey)
+
+	for name, mutate := range map[string]func(*WindowPermitContext, *WindowCreatePermit){
+		"spec protocol Fence UID mismatch": func(context *WindowPermitContext, permit *WindowCreatePermit) {
+			context.ProtocolFenceUID = types.UID("protocol-fence-uid-2")
+			permit.ProtocolFenceUID = context.ProtocolFenceUID
+		},
+		"spec installation epoch mismatch": func(context *WindowPermitContext, permit *WindowCreatePermit) {
+			context.InstallationEpoch = "install-8"
+			permit.InstallationEpoch = context.InstallationEpoch
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			context := baseContext
+			permit := basePermit
+			mutate(&context, &permit)
+			permit.Signature = ed25519.Sign(privateKey, WindowCreatePermitDigest(permit))
+			require.ErrorIs(t, ValidateWindowCreatePermit(context, permit), ErrWindowCreatePermitInvalid)
+		})
+	}
+
+	credentialSpec := testWindowImmutableSpec()
+	credentialSpec.GateKind = GateKindCredential
+	credentialSpec.TargetFence = nil
+	credentialSpec.Credential = &CredentialWindowIdentity{PriorGateUID: types.UID("prior-gate-uid-1"), TargetFingerprintDomain: "kubeblocks.io/credential-target/v1"}
+	credentialPermit := testWindowCreatePermitForSpec(publicKey, credentialSpec)
+	credentialContext := testWindowPermitContext(credentialPermit, publicKey)
+	credentialContext.ExpectedGateKind = GateKindCredential
+	credentialContext.ExpectedWindowSpec = credentialSpec
+	credentialPermit.PriorGateUID = types.UID("prior-gate-uid-2")
+	credentialContext.PriorGateUID = credentialPermit.PriorGateUID
+	credentialPermit.Signature = ed25519.Sign(privateKey, WindowCreatePermitDigest(credentialPermit))
+	require.ErrorIs(t, ValidateWindowCreatePermit(credentialContext, credentialPermit), ErrWindowCreatePermitInvalid)
+
+	for name, clear := range map[string]func(*WindowPermitContext, *WindowCreatePermit){
+		"Lease UID": func(context *WindowPermitContext, permit *WindowCreatePermit) {
+			context.CurrentLeaseUID = ""
+			permit.LeaseUID = ""
+		},
+		"Lease epoch": func(context *WindowPermitContext, permit *WindowCreatePermit) {
+			context.CurrentLeaseEpoch = 0
+			permit.LeaseEpoch = 0
+		},
+		"Fence UID": func(context *WindowPermitContext, permit *WindowCreatePermit) {
+			context.ProtocolFenceUID = ""
+			permit.ProtocolFenceUID = ""
+		},
+		"Fence RV": func(context *WindowPermitContext, permit *WindowCreatePermit) {
+			context.ProtocolFenceResourceVersion = ""
+			permit.ProtocolFenceResourceVersion = ""
+		},
+		"installation epoch": func(context *WindowPermitContext, permit *WindowCreatePermit) {
+			context.InstallationEpoch = ""
+			permit.InstallationEpoch = ""
+		},
+		"authority UID": func(context *WindowPermitContext, permit *WindowCreatePermit) {
+			context.AuthorityUID = ""
+			permit.AuthorityUID = ""
+		},
+		"authority RV": func(context *WindowPermitContext, permit *WindowCreatePermit) {
+			context.AuthorityResourceVersion = ""
+			permit.AuthorityResourceVersion = ""
+		},
+		"prior gate UID": func(context *WindowPermitContext, permit *WindowCreatePermit) {
+			context.PriorGateUID = ""
+			permit.PriorGateUID = ""
+		},
+		"prior gate RV": func(context *WindowPermitContext, permit *WindowCreatePermit) {
+			context.PriorGateResourceVersion = ""
+			permit.PriorGateResourceVersion = ""
+		},
+		"registration key": func(context *WindowPermitContext, permit *WindowCreatePermit) {
+			context.RegistrationKey = ""
+			permit.RegistrationKey = ""
+		},
+		"effect key": func(context *WindowPermitContext, permit *WindowCreatePermit) {
+			context.EffectKey = ""
+			permit.EffectKey = ""
+		},
+		"effect identity digest": func(context *WindowPermitContext, permit *WindowCreatePermit) {
+			context.EffectIdentityDigest = ""
+			permit.EffectIdentityDigest = ""
+		},
+	} {
+		t.Run("joint empty "+name, func(t *testing.T) {
+			context := baseContext
+			permit := basePermit
+			clear(&context, &permit)
+			permit.Signature = ed25519.Sign(privateKey, WindowCreatePermitDigest(permit))
+			require.ErrorIs(t, ValidateWindowCreatePermit(context, permit), ErrWindowCreatePermitInvalid)
+		})
+	}
+}
+
+func TestWindowImmutableSpecSeparatesNamespaceAttemptAndGateVariants(t *testing.T) {
+	base := testWindowImmutableSpec()
+	require.NoError(t, ValidateWindowImmutableSpec(base))
+	baseDigest := CanonicalWindowImmutableSpecDigest(base)
+	for name, algorithm := range map[string]EvidenceFingerprintAlgorithm{
+		"empty evidence algorithm":   "",
+		"Lease Ed25519 cross-domain": EvidenceFingerprintAlgorithm(SessionKeyAlgorithmEd25519),
+		"unknown evidence algorithm": "SHA512",
+	} {
+		t.Run(name, func(t *testing.T) {
+			invalid := cloneWindowImmutableSpec(base)
+			invalid.KeyAlgorithm = algorithm
+			require.ErrorIs(t, ValidateWindowImmutableSpec(invalid), ErrWindowImmutableSpecInvalid)
+		})
+	}
+
+	newNamespace := cloneWindowImmutableSpec(base)
+	newNamespace.WorkloadNamespaceUID = types.UID("namespace-uid-2")
+	require.NotEqual(t, baseDigest, CanonicalWindowImmutableSpecDigest(newNamespace))
+
+	newAttempt := cloneWindowImmutableSpec(base)
+	newAttempt.AttemptID = "attempt-4"
+	require.NotEqual(t, baseDigest, CanonicalWindowImmutableSpecDigest(newAttempt))
+
+	credential := cloneWindowImmutableSpec(base)
+	credential.GateKind = GateKindCredential
+	credential.TargetFence = nil
+	credential.Credential = &CredentialWindowIdentity{
+		PriorGateUID:            types.UID("prior-gate-uid-1"),
+		TargetFingerprintDomain: "kubeblocks.io/credential-target/v1",
+	}
+	require.NoError(t, ValidateWindowImmutableSpec(credential))
+	require.NotEqual(t, baseDigest, CanonicalWindowImmutableSpecDigest(credential))
+
+	for name, invalid := range map[string]WindowImmutableSpec{
+		"Credential with TargetFence only": func() WindowImmutableSpec {
+			value := cloneWindowImmutableSpec(base)
+			value.GateKind = GateKindCredential
+			return value
+		}(),
+		"TargetFence with Credential only": func() WindowImmutableSpec {
+			value := cloneWindowImmutableSpec(credential)
+			value.GateKind = GateKindTargetFence
+			return value
+		}(),
+		"unknown GateKind": func() WindowImmutableSpec {
+			value := cloneWindowImmutableSpec(base)
+			value.GateKind = "UnknownGate"
+			return value
+		}(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.ErrorIs(t, ValidateWindowImmutableSpec(invalid), ErrWindowImmutableSpecInvalid)
+		})
+	}
+
+	publicKey, privateKey := testEd25519KeyPair(t)
+	credentialPermit := testWindowCreatePermitForSpec(publicKey, credential)
+	credentialPermit.Signature = ed25519.Sign(privateKey, WindowCreatePermitDigest(credentialPermit))
+	credentialContext := testWindowPermitContext(credentialPermit, publicKey)
+	credentialContext.ExpectedGateKind = GateKindCredential
+	credentialContext.ExpectedWindowSpec = credential
+	require.NoError(t, ValidateWindowCreatePermit(credentialContext, credentialPermit))
+
+	for name, mutate := range map[string]func(*WindowImmutableSpec){
+		"prior gate UID": func(v *WindowImmutableSpec) {
+			v.Credential.PriorGateUID = types.UID("prior-gate-uid-2")
+		},
+		"fingerprint domain": func(v *WindowImmutableSpec) {
+			v.Credential.TargetFingerprintDomain = "kubeblocks.io/credential-target/v2"
+		},
+	} {
+		t.Run("Credential "+name, func(t *testing.T) {
+			changedSpec := cloneWindowImmutableSpec(credential)
+			mutate(&changedSpec)
+			require.NotEqual(t, CanonicalWindowImmutableSpecDigest(credential), CanonicalWindowImmutableSpecDigest(changedSpec))
+			changedContext := credentialContext
+			changedContext.ExpectedWindowSpec = changedSpec
+			require.ErrorIs(t, ValidateWindowCreatePermit(changedContext, credentialPermit), ErrWindowCreatePermitInvalid)
+		})
+	}
+
+	for name, domain := range map[string]string{
+		"empty fingerprint domain":   "",
+		"unknown fingerprint domain": "unversioned-domain",
+	} {
+		t.Run(name, func(t *testing.T) {
+			invalid := cloneWindowImmutableSpec(credential)
+			invalid.Credential.TargetFingerprintDomain = domain
+			require.ErrorIs(t, ValidateWindowImmutableSpec(invalid), ErrWindowImmutableSpecInvalid)
+		})
+	}
+	emptyPriorGate := cloneWindowImmutableSpec(credential)
+	emptyPriorGate.Credential.PriorGateUID = ""
+	require.ErrorIs(t, ValidateWindowImmutableSpec(emptyPriorGate), ErrWindowImmutableSpecInvalid)
+
+	illegal := cloneWindowImmutableSpec(base)
+	illegal.Credential = credential.Credential
+	require.ErrorIs(t, ValidateWindowImmutableSpec(illegal), ErrWindowImmutableSpecInvalid)
+
+	missingVariant := cloneWindowImmutableSpec(base)
+	missingVariant.TargetFence = nil
+	require.ErrorIs(t, ValidateWindowImmutableSpec(missingVariant), ErrWindowImmutableSpecInvalid)
+}
+
+func TestWindowPermitCanonicalEncodingSeparatesFieldsAndMessageDomains(t *testing.T) {
+	publicKey, privateKey := testEd25519KeyPair(t)
+	left := testWindowCreatePermit(publicKey)
+	left.AuthorityResourceVersion = "ab"
+	left.PriorGateResourceVersion = "c"
+	right := testWindowCreatePermit(publicKey)
+	right.AuthorityResourceVersion = "a"
+	right.PriorGateResourceVersion = "bc"
+	require.NotEqual(t, WindowCreatePermitDigest(left), WindowCreatePermitDigest(right))
+
+	signature := ed25519.Sign(privateKey, WindowCreatePermitDigest(left))
+	canonical, err := CanonicalWindowCreatePermitBytes(left)
+	require.NoError(t, err)
+	otherDomainDigest := CanonicalProtocolDigest("kubeblocks.io/reconfigure-lease-proof/v1", canonical)
+	require.False(t, ed25519.Verify(publicKey, otherDomainDigest, signature), "a Window CREATE signature must not authorize another protocol message")
+}
+
+func TestWindowPermitRejectsInvalidSignatureAndEveryNonPlannedState(t *testing.T) {
+	publicKey, privateKey := testEd25519KeyPair(t)
+	permit := testWindowCreatePermit(publicKey)
+	permit.Signature = ed25519.Sign(privateKey, WindowCreatePermitDigest(permit))
+	context := testWindowPermitContext(permit, publicKey)
+
+	wrongPublicKey, _ := testEd25519KeyPair(t)
+	wrongKeyContext := context
+	wrongKeyContext.CurrentLeasePublicKey = wrongPublicKey
+	require.ErrorIs(t, ValidateWindowCreatePermit(wrongKeyContext, permit), ErrWindowCreatePermitInvalid)
+
+	changedSignature := permit
+	changedSignature.Signature = append([]byte(nil), permit.Signature...)
+	changedSignature.Signature[0] ^= 0xff
+	require.ErrorIs(t, ValidateWindowCreatePermit(context, changedSignature), ErrWindowCreatePermitInvalid)
+
+	emptySignature := permit
+	emptySignature.Signature = nil
+	require.ErrorIs(t, ValidateWindowCreatePermit(context, emptySignature), ErrWindowCreatePermitInvalid)
+
+	unknownAlgorithm := permit
+	unknownAlgorithm.LeaseKeyAlgorithm = "RSA"
+	require.ErrorIs(t, ValidateWindowCreatePermit(context, unknownAlgorithm), ErrWindowCreatePermitInvalid)
+
+	for _, state := range []EffectState{
+		EffectStateUnknown,
+		EffectStateObjectBound,
+		EffectStateDispatchAuthorized,
+		EffectStateTerminal,
+		EffectStateManual,
+		EffectStateConsumed,
+	} {
+		t.Run(string(state), func(t *testing.T) {
+			changedContext := context
+			changedContext.EffectState = state
+			err := ValidateWindowCreatePermit(changedContext, permit)
+			require.ErrorIs(t, err, ErrEffectNotPlanned)
+		})
+	}
+}
+
+func testLeaseSession(t *testing.T, epoch int64, holder string) LeaseSession {
+	t.Helper()
+	publicKey, _ := testEd25519KeyPair(t)
+	return LeaseSession{
+		LeaseUID:              types.UID("lease-uid-1"),
+		HolderIdentity:        holder,
+		Epoch:                 epoch,
+		SessionKeyAlgorithm:   SessionKeyAlgorithmEd25519,
+		SessionPublicKey:      publicKey,
+		SessionKeyFingerprint: sessionKeyFingerprint(publicKey),
+	}
+}
+
+func testWindowCreatePermit(publicKey ed25519.PublicKey) WindowCreatePermit {
+	return testWindowCreatePermitForSpec(publicKey, testWindowImmutableSpec())
+}
+
+func testWindowCreatePermitForSpec(publicKey ed25519.PublicKey, windowSpec WindowImmutableSpec) WindowCreatePermit {
+	return WindowCreatePermit{
+		ProtocolVersion:              WindowCreatePermitProtocolV1,
+		GateKind:                     windowSpec.GateKind,
+		WindowSpecDigest:             CanonicalWindowImmutableSpecDigest(windowSpec),
+		LeaseUID:                     types.UID("lease-uid-1"),
+		LeaseEpoch:                   3,
+		LeaseKeyAlgorithm:            SessionKeyAlgorithmEd25519,
+		LeaseKeyFingerprint:          sessionKeyFingerprint(publicKey),
+		ProtocolFenceUID:             types.UID("protocol-fence-uid-1"),
+		ProtocolFenceResourceVersion: "201",
+		InstallationEpoch:            "install-7",
+		AuthorityUID:                 types.UID("authority-uid-1"),
+		AuthorityResourceVersion:     "301",
+		PriorGateUID:                 types.UID("prior-gate-uid-1"),
+		PriorGateResourceVersion:     "401",
+		RegistrationKey:              testDigest("registration-1"),
+		EffectKey:                    testDigest("effect-key-1"),
+		EffectIdentityDigest:         testDigest("effect-identity-1"),
+		EffectState:                  EffectStatePlanned,
+	}
+}
+
+func testWindowPermitContext(permit WindowCreatePermit, publicKey ed25519.PublicKey) WindowPermitContext {
+	return WindowPermitContext{
+		ProtocolVersion:              WindowCreatePermitProtocolV1,
+		ExpectedGateKind:             GateKindTargetFence,
+		ExpectedWindowSpec:           testWindowImmutableSpec(),
+		CurrentLeaseUID:              permit.LeaseUID,
+		CurrentLeaseEpoch:            permit.LeaseEpoch,
+		CurrentLeaseKeyAlgorithm:     permit.LeaseKeyAlgorithm,
+		CurrentLeaseKeyFingerprint:   permit.LeaseKeyFingerprint,
+		CurrentLeasePublicKey:        publicKey,
+		ProtocolFenceUID:             permit.ProtocolFenceUID,
+		ProtocolFenceResourceVersion: permit.ProtocolFenceResourceVersion,
+		InstallationEpoch:            permit.InstallationEpoch,
+		AuthorityUID:                 permit.AuthorityUID,
+		AuthorityResourceVersion:     permit.AuthorityResourceVersion,
+		PriorGateUID:                 permit.PriorGateUID,
+		PriorGateResourceVersion:     permit.PriorGateResourceVersion,
+		RegistrationKey:              permit.RegistrationKey,
+		EffectKey:                    permit.EffectKey,
+		EffectIdentityDigest:         permit.EffectIdentityDigest,
+		EffectState:                  permit.EffectState,
+	}
+}
+
+func testWindowImmutableSpec() WindowImmutableSpec {
+	return WindowImmutableSpec{
+		Name:                  "target-window-1",
+		PhysicalAPIID:         "physical-api-1",
+		WorkloadNamespaceName: "workload-1",
+		WorkloadNamespaceUID:  types.UID("namespace-uid-1"),
+		ExecutionUID:          types.UID("execution-uid-1"),
+		AttemptID:             "attempt-3",
+		ProtocolVersion:       "kubeblocks.io/reconfigure-window/v1",
+		GateKind:              GateKindTargetFence,
+		DurationSeconds:       600,
+		ProtocolFenceUID:      types.UID("protocol-fence-uid-1"),
+		InstallationEpoch:     "install-7",
+		Target: EffectObjectTarget{
+			APIVersion: "protocol.kubeblocks.io/v1alpha1",
+			Kind:       "UnitExecution",
+			Namespace:  "kb-system",
+			Name:       "unit-1",
+		},
+		KeySecretName: "evidence-key-v7",
+		KeySecretUID:  types.UID("key-secret-uid-1"),
+		KeyVersion:    7,
+		KeyAlgorithm:  EvidenceFingerprintAlgorithmHMACSHA256,
+		TargetFence: &TargetFenceWindowIdentity{
+			TargetStructuralKey:  "mysql/component-0/pod-0/mysql",
+			ExpectedTemplateHash: testDigest("template-1"),
+		},
+	}
+}
+
+func cloneWindowImmutableSpec(spec WindowImmutableSpec) WindowImmutableSpec {
+	cloned := spec
+	if spec.TargetFence != nil {
+		targetFence := *spec.TargetFence
+		cloned.TargetFence = &targetFence
+	}
+	if spec.Credential != nil {
+		credential := *spec.Credential
+		cloned.Credential = &credential
+	}
+	return cloned
+}
+
+func testEd25519KeyPair(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	return publicKey, privateKey
+}
+
+func sessionKeyFingerprint(publicKey ed25519.PublicKey) string {
+	return testDigest(string(publicKey))
+}

--- a/pkg/reconfigure/protocol/registry.go
+++ b/pkg/reconfigure/protocol/registry.go
@@ -136,6 +136,7 @@ type EffectIdentity struct {
 	Kind               EffectKind
 	DeterministicName  string
 	FullIdentityDigest string
+	Namespace          string
 	PodUID             types.UID
 	ContainerName      string
 	FenceUID           types.UID
@@ -270,6 +271,7 @@ type storedEffectIdentity struct {
 	Kind               string    `json:"kind"`
 	DeterministicName  string    `json:"deterministicName"`
 	FullIdentityDigest string    `json:"fullIdentityDigest"`
+	Namespace          string    `json:"namespace"`
 	PodUID             types.UID `json:"podUID,omitempty"`
 	ContainerName      string    `json:"containerName,omitempty"`
 	FenceUID           types.UID `json:"fenceUID,omitempty"`
@@ -358,13 +360,13 @@ func CanonicalEffectIdentityBytes(registrationKey string, identity EffectIdentit
 	if identity.Kind != EffectKindUnitExecution && !isWindowKind(identity.Kind) {
 		return nil, ErrIdentityIncomplete
 	}
-	if identity.DeterministicName == "" || ValidateIdentityDigest(identity.FullIdentityDigest) != nil {
+	if identity.DeterministicName == "" || identity.Namespace == "" || ValidateIdentityDigest(identity.FullIdentityDigest) != nil {
 		return nil, ErrIdentityIncomplete
 	}
 	if identity.Kind == EffectKindUnitExecution && (identity.PodUID == "" || identity.ContainerName == "" || identity.FenceUID == "") {
 		return nil, ErrIdentityIncomplete
 	}
-	return canonicalFields("kubeblocks.io/reconfigure-effect/v1", registrationKey, string(identity.Kind), identity.DeterministicName, identity.FullIdentityDigest, string(identity.PodUID), identity.ContainerName, string(identity.FenceUID)), nil
+	return canonicalFields("kubeblocks.io/reconfigure-effect/v1", registrationKey, string(identity.Kind), identity.DeterministicName, identity.FullIdentityDigest, identity.Namespace, string(identity.PodUID), identity.ContainerName, string(identity.FenceUID)), nil
 }
 
 func EffectKey(registrationKey string, identity EffectIdentity) (string, error) {
@@ -425,7 +427,7 @@ func registrationIdentityStored(v RegistrationIdentity) storedRegistrationIdenti
 }
 
 func effectIdentityStored(v EffectIdentity) storedEffectIdentity {
-	return storedEffectIdentity{v.KindString(), v.DeterministicName, v.FullIdentityDigest, v.PodUID, v.ContainerName, v.FenceUID}
+	return storedEffectIdentity{v.KindString(), v.DeterministicName, v.FullIdentityDigest, v.Namespace, v.PodUID, v.ContainerName, v.FenceUID}
 }
 
 func (v EffectIdentity) KindString() string { return string(v.Kind) }
@@ -435,7 +437,7 @@ func registrationIdentityRuntime(v storedRegistrationIdentity) RegistrationIdent
 }
 
 func effectIdentityRuntime(v storedEffectIdentity) EffectIdentity {
-	return EffectIdentity{EffectKind(v.Kind), v.DeterministicName, v.FullIdentityDigest, v.PodUID, v.ContainerName, v.FenceUID}
+	return EffectIdentity{EffectKind(v.Kind), v.DeterministicName, v.FullIdentityDigest, v.Namespace, v.PodUID, v.ContainerName, v.FenceUID}
 }
 
 func RegisterExecution(state FenceState, identity RegistrationIdentity, limits RegistryLimits) (FenceState, string, error) {
@@ -486,16 +488,16 @@ func PlanEffect(state FenceState, registrationKey string, identity EffectIdentit
 	for _, effect := range registration.Effects {
 		if effect.Key == key {
 			if RegistrationPhase(registration.Phase) == RegistrationPhaseConsumed && len(registration.Effects) > 1 {
-				return state, key, ErrRegistrationAlreadyConsumed
+				return state, "", ErrRegistrationAlreadyConsumed
 			}
 			if EffectState(effect.State) == EffectStateConsumed {
-				return state, key, ErrEffectAlreadyConsumed
+				return state, "", ErrEffectAlreadyConsumed
 			}
 			return state, key, nil
 		}
-		if effect.Identity.Kind == string(identity.Kind) && effect.Identity.DeterministicName == identity.DeterministicName {
+		if effect.Identity.Kind == string(identity.Kind) && effect.Identity.Namespace == identity.Namespace && effect.Identity.DeterministicName == identity.DeterministicName {
 			if EffectState(effect.State) == EffectStateConsumed {
-				return state, key, ErrEffectAlreadyConsumed
+				return state, "", ErrEffectAlreadyConsumed
 			}
 			return state, "", ErrEffectIdentityConflict
 		}
@@ -625,6 +627,13 @@ func MarkEffectTerminal(state FenceState, registrationKey, effectKey string, evi
 	if (kind == EffectKindUnitExecution && evidence.CloseoutVariant != CloseoutVariantUnitExecuted) || (isWindowKind(kind) && evidence.CloseoutVariant != CloseoutVariantObservedTerminal) {
 		return state, ErrEffectCloseoutVariantMismatch
 	}
+	terminal := storedTerminal{Outcome: string(evidence.Outcome), ReasonCode: evidence.ReasonCode, EvidenceDigest: evidence.EvidenceDigest, RecoveryRequired: evidence.RecoveryRequired}
+	if EffectState(effect.State) == EffectStateTerminal {
+		if effect.CloseoutVariant == string(evidence.CloseoutVariant) && effect.Terminal != nil && *effect.Terminal == terminal {
+			return state, nil
+		}
+		return state, ErrEffectStateRegression
+	}
 	if kind == EffectKindUnitExecution && (EffectState(effect.State) != EffectStateDispatchAuthorized || effect.Dispatch == nil) {
 		return state, ErrEffectDispatchRequired
 	}
@@ -635,7 +644,7 @@ func MarkEffectTerminal(state FenceState, registrationKey, effectKey string, evi
 	effect, _, _ = findEffect(&next.status, registrationKey, effectKey)
 	effect.State = string(EffectStateTerminal)
 	effect.CloseoutVariant = string(evidence.CloseoutVariant)
-	effect.Terminal = &storedTerminal{Outcome: string(evidence.Outcome), ReasonCode: evidence.ReasonCode, EvidenceDigest: evidence.EvidenceDigest, RecoveryRequired: evidence.RecoveryRequired}
+	effect.Terminal = &terminal
 	return next, nil
 }
 
@@ -674,33 +683,6 @@ func ConsumeRegistration(state FenceState, registrationKey string) (FenceState, 
 	registration, _, _ = findRegistration(&next.status, registrationKey)
 	registration.Phase = string(RegistrationPhaseConsumed)
 	return next, nil
-}
-
-func AdvanceEffectState(state FenceState, registrationKey, effectKey string, target EffectState) (FenceState, error) {
-	effect, _, ok := findEffect(&state.status, registrationKey, effectKey)
-	if !ok {
-		return state, ErrEffectIdentityConflict
-	}
-	if effectStateOrder(target) <= effectStateOrder(EffectState(effect.State)) {
-		return state, ErrEffectStateRegression
-	}
-	return state, ErrEffectStateRegression
-}
-
-func effectStateOrder(state EffectState) int {
-	switch state {
-	case EffectStatePlanned:
-		return 1
-	case EffectStateObjectBound:
-		return 2
-	case EffectStateDispatchAuthorized:
-		return 3
-	case EffectStateTerminal:
-		return 4
-	case EffectStateConsumed:
-		return 5
-	}
-	return 0
 }
 
 func DrainNamespace(state FenceState, namespaceUID types.UID) (FenceState, error) {
@@ -1114,7 +1096,7 @@ func expectedTarget(identity EffectIdentity) EffectObjectTarget {
 	if identity.Kind == EffectKindUnitExecution {
 		kind = "UnitExecution"
 	}
-	return EffectObjectTarget{"protocol.kubeblocks.io/v1alpha1", kind, "kb-system", identity.DeterministicName}
+	return EffectObjectTarget{"protocol.kubeblocks.io/v1alpha1", kind, identity.Namespace, identity.DeterministicName}
 }
 
 func isWindowKind(kind EffectKind) bool {

--- a/pkg/reconfigure/protocol/registry.go
+++ b/pkg/reconfigure/protocol/registry.go
@@ -421,7 +421,7 @@ func digestExternalRV(rv string) string {
 }
 
 func registrationIdentityStored(v RegistrationIdentity) storedRegistrationIdentity {
-	return storedRegistrationIdentity{v.PhysicalAPIID, v.InstallationEpoch, v.ExecutionUID, v.AttemptID, v.NamespaceUID, v.KeySecretUID, v.AuthorityUID, v.QueueUID}
+	return storedRegistrationIdentity(v)
 }
 
 func effectIdentityStored(v EffectIdentity) storedEffectIdentity {
@@ -431,7 +431,7 @@ func effectIdentityStored(v EffectIdentity) storedEffectIdentity {
 func (v EffectIdentity) KindString() string { return string(v.Kind) }
 
 func registrationIdentityRuntime(v storedRegistrationIdentity) RegistrationIdentity {
-	return RegistrationIdentity{v.PhysicalAPIID, v.InstallationEpoch, v.ExecutionUID, v.AttemptID, v.NamespaceUID, v.KeySecretUID, v.AuthorityUID, v.QueueUID}
+	return RegistrationIdentity(v)
 }
 
 func effectIdentityRuntime(v storedEffectIdentity) EffectIdentity {
@@ -974,15 +974,16 @@ func validateStoredEffect(status storedStatus, registration storedRegistration, 
 		if effect.Tombstone != nil || effect.NotFound != nil || !validateTerminal() {
 			return ErrStoredStatusInvalid
 		}
-		if effect.CloseoutVariant == string(CloseoutVariantUnitExecuted) {
+		switch EffectCloseoutVariant(effect.CloseoutVariant) {
+		case CloseoutVariantUnitExecuted:
 			if kind != EffectKindUnitExecution || !validateDispatch() {
 				return ErrStoredStatusInvalid
 			}
-		} else if effect.CloseoutVariant == string(CloseoutVariantObservedTerminal) {
+		case CloseoutVariantObservedTerminal:
 			if !isWindowKind(kind) || !validateObject() || effect.Dispatch != nil {
 				return ErrStoredStatusInvalid
 			}
-		} else {
+		default:
 			return ErrStoredStatusInvalid
 		}
 	case EffectStateConsumed:

--- a/pkg/reconfigure/protocol/registry.go
+++ b/pkg/reconfigure/protocol/registry.go
@@ -1,0 +1,1281 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package protocol
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	types "k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	protocolFenceStatusV1               = "kubeblocks.io/reconfigure-protocol-fence-status/v1"
+	ReservedProtocolFenceStatusBytes    = 4 * 1024
+	MaxTerminalReasonCodeBytes          = 128
+	maxFenceResourceVersionBytes        = 32
+	maxEffectObjectUIDBytes             = 64
+	maxEffectObjectResourceVersionBytes = 32
+)
+
+var (
+	ErrIdentityIncomplete            = errors.New("identity incomplete")
+	ErrIdentityDigestInvalid         = errors.New("identity digest invalid")
+	ErrRegistrationIdentityConflict  = errors.New("registration identity conflict")
+	ErrEffectIdentityConflict        = errors.New("effect identity conflict")
+	ErrEffectAlreadyConsumed         = errors.New("effect already consumed")
+	ErrRegistrationAlreadyConsumed   = errors.New("registration already consumed")
+	ErrEffectObservationIncomplete   = errors.New("effect observation incomplete")
+	ErrEffectObservationMismatch     = errors.New("effect observation mismatch")
+	ErrEffectObservationInconclusive = errors.New("effect observation inconclusive")
+	ErrEffectObjectIdentityConflict  = errors.New("effect object identity conflict")
+	ErrEffectStillCreatable          = errors.New("effect still creatable")
+	ErrEffectObservationStale        = errors.New("effect observation stale")
+	ErrEffectObjectNotBound          = errors.New("effect object not bound")
+	ErrDispatchOutcomeUnknown        = errors.New("dispatch outcome unknown")
+	ErrEffectDispatchRequired        = errors.New("effect dispatch required")
+	ErrEffectCloseoutVariantMismatch = errors.New("effect closeout variant mismatch")
+	ErrEffectStateRegression         = errors.New("effect state regression")
+	ErrTerminalEvidenceTooLarge      = errors.New("terminal evidence too large")
+	ErrFenceReadbackMismatch         = errors.New("fence readback mismatch")
+	ErrDrainReadbackAlreadyBound     = errors.New("drain readback already bound")
+	ErrRegistryCapacity              = errors.New("registry capacity exceeded")
+	ErrStoredStatusIntegrity         = errors.New("stored status integrity mismatch")
+	ErrStoredStatusInvalid           = errors.New("stored status invalid")
+	ErrEffectNotPlanned              = errors.New("effect not planned")
+	ErrRegistryDraining              = errors.New("registry is draining")
+	ErrDrainNotCommitted             = errors.New("drain not committed")
+)
+
+type EffectKind string
+
+const (
+	EffectKindUnitExecution     EffectKind = "UnitExecution"
+	EffectKindTargetFenceWindow EffectKind = "TargetFenceWindow"
+	EffectKindCredentialWindow  EffectKind = "CredentialWindow"
+)
+
+type EffectState string
+
+const (
+	EffectStateUnknown            EffectState = "Unknown"
+	EffectStatePlanned            EffectState = "Planned"
+	EffectStateObjectBound        EffectState = "ObjectBound"
+	EffectStateDispatchAuthorized EffectState = "DispatchAuthorized"
+	EffectStateTerminal           EffectState = "Terminal"
+	EffectStateManual             EffectState = "Manual"
+	EffectStateConsumed           EffectState = "Consumed"
+)
+
+type RegistrationPhase string
+
+const (
+	RegistrationPhaseActive   RegistrationPhase = "Active"
+	RegistrationPhaseConsumed RegistrationPhase = "Consumed"
+)
+
+type EffectCloseoutVariant string
+
+const (
+	CloseoutVariantNotFound         EffectCloseoutVariant = "NotFound"
+	CloseoutVariantUnitExecuted     EffectCloseoutVariant = "UnitExecuted"
+	CloseoutVariantObservedTerminal EffectCloseoutVariant = "ObservedTerminal"
+)
+
+type EffectTerminalOutcome string
+
+const (
+	EffectTerminalSucceeded EffectTerminalOutcome = "Succeeded"
+	EffectTerminalFailed    EffectTerminalOutcome = "Failed"
+	EffectTerminalManual    EffectTerminalOutcome = "Manual"
+)
+
+type EffectObservationResult string
+
+const (
+	EffectObservationPresent     EffectObservationResult = "Present"
+	EffectObservationNotFound    EffectObservationResult = "NotFound"
+	EffectObservationTerminating EffectObservationResult = "Terminating"
+	EffectObservationAPIError    EffectObservationResult = "APIError"
+)
+
+type RegistrationIdentity struct {
+	PhysicalAPIID     string
+	InstallationEpoch string
+	ExecutionUID      types.UID
+	AttemptID         string
+	NamespaceUID      types.UID
+	KeySecretUID      types.UID
+	AuthorityUID      types.UID
+	QueueUID          types.UID
+}
+
+type EffectIdentity struct {
+	Kind               EffectKind
+	DeterministicName  string
+	FullIdentityDigest string
+	PodUID             types.UID
+	ContainerName      string
+	FenceUID           types.UID
+}
+
+type EffectObjectTarget struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Namespace  string `json:"namespace"`
+	Name       string `json:"name"`
+}
+
+type EffectObjectObservation struct {
+	Result                EffectObservationResult
+	Target                EffectObjectTarget
+	ObjectUID             types.UID
+	ObjectResourceVersion string
+	LookupResourceVersion string
+	ObservedAt            metav1.Time
+	DrainIdentity         DrainIdentity
+	ErrorClass            string
+}
+
+type EffectTerminalEvidence struct {
+	CloseoutVariant  EffectCloseoutVariant
+	Outcome          EffectTerminalOutcome
+	ReasonCode       string
+	EvidenceDigest   string
+	RecoveryRequired bool
+}
+
+type FenceObjectIdentity struct {
+	UID types.UID
+}
+
+type FenceObjectReadback struct {
+	UID                types.UID
+	ResourceVersion    string
+	StoredStatusDigest string
+}
+
+type DrainIdentity struct {
+	Token                      string
+	ManifestDigest             string
+	FenceUIDDigest             string
+	FenceResourceVersionDigest string
+}
+
+type DrainScope struct {
+	namespaceUID types.UID
+	installation bool
+}
+
+func NamespaceDrainScope(namespaceUID types.UID) DrainScope {
+	return DrainScope{namespaceUID: namespaceUID}
+}
+func InstallationDrainScope() DrainScope { return DrainScope{installation: true} }
+
+type RegistryLimits struct {
+	MaxNamespaces    int
+	MaxRegistrations int
+	MaxEffects       int
+	MaxStatusBytes   int
+}
+
+type FenceState struct {
+	status         storedStatus
+	fenceIdentity  FenceObjectIdentity
+	activeReadback *FenceObjectReadback
+}
+
+type storedStatus struct {
+	ProtocolVersion      string               `json:"protocolVersion"`
+	IntegrityDigest      string               `json:"integrityDigest"`
+	FenceUIDDigest       string               `json:"fenceUIDDigest"`
+	InstallationEpoch    string               `json:"installationEpoch"`
+	InstallationManifest *storedManifest      `json:"installationManifest,omitempty"`
+	Namespaces           []storedNamespace    `json:"namespaces"`
+	Registrations        []storedRegistration `json:"registrations,omitempty"`
+}
+
+type storedNamespace struct {
+	UID      types.UID       `json:"uid"`
+	Manifest *storedManifest `json:"manifest,omitempty"`
+}
+
+type storedManifest struct {
+	Token            string          `json:"token"`
+	Digest           string          `json:"digest"`
+	RegistrationKeys []string        `json:"registrationKeys"`
+	EffectKeys       []string        `json:"effectKeys"`
+	CommitReadback   *storedReadback `json:"commitReadback,omitempty"`
+}
+
+type storedReadback struct {
+	UIDDigest             string `json:"uidDigest"`
+	ResourceVersionDigest string `json:"resourceVersionDigest"`
+	StoredStatusDigest    string `json:"storedStatusDigest"`
+}
+
+type storedRegistration struct {
+	Key      string                     `json:"key"`
+	Identity storedRegistrationIdentity `json:"identity"`
+	Phase    string                     `json:"phase"`
+	Effects  []storedEffect             `json:"effects,omitempty"`
+}
+
+type storedRegistrationIdentity struct {
+	PhysicalAPIID     string    `json:"physicalAPIID"`
+	InstallationEpoch string    `json:"installationEpoch"`
+	ExecutionUID      types.UID `json:"executionUID"`
+	AttemptID         string    `json:"attemptID"`
+	NamespaceUID      types.UID `json:"namespaceUID"`
+	KeySecretUID      types.UID `json:"keySecretUID"`
+	AuthorityUID      types.UID `json:"authorityUID"`
+	QueueUID          types.UID `json:"queueUID"`
+}
+
+type storedEffect struct {
+	Key             string                   `json:"key"`
+	Identity        storedEffectIdentity     `json:"identity"`
+	State           string                   `json:"state"`
+	CloseoutVariant string                   `json:"closeoutVariant,omitempty"`
+	ObjectBinding   *storedObjectBinding     `json:"objectBinding,omitempty"`
+	Dispatch        *storedDispatch          `json:"dispatch,omitempty"`
+	Terminal        *storedTerminal          `json:"terminal,omitempty"`
+	NotFound        *storedNotFound          `json:"notFound,omitempty"`
+	Tombstone       *storedConsumedTombstone `json:"tombstone,omitempty"`
+}
+
+type storedEffectIdentity struct {
+	Kind               string    `json:"kind"`
+	DeterministicName  string    `json:"deterministicName"`
+	FullIdentityDigest string    `json:"fullIdentityDigest"`
+	PodUID             types.UID `json:"podUID,omitempty"`
+	ContainerName      string    `json:"containerName,omitempty"`
+	FenceUID           types.UID `json:"fenceUID,omitempty"`
+}
+
+type storedObjectBinding struct {
+	Target                EffectObjectTarget `json:"target"`
+	UIDDigest             string             `json:"uidDigest"`
+	ResourceVersionDigest string             `json:"resourceVersionDigest"`
+}
+
+type storedDispatch struct {
+	Token string `json:"token"`
+}
+
+type storedTerminal struct {
+	Outcome          string `json:"outcome"`
+	ReasonCode       string `json:"reasonCode"`
+	EvidenceDigest   string `json:"evidenceDigest"`
+	RecoveryRequired bool   `json:"recoveryRequired"`
+}
+
+type storedConsumedTombstone struct {
+	IdentityDigest string `json:"identityDigest"`
+}
+
+type storedNotFound struct {
+	Target                      EffectObjectTarget `json:"target"`
+	DrainToken                  string             `json:"drainToken"`
+	ManifestDigest              string             `json:"manifestDigest"`
+	FenceUIDDigest              string             `json:"fenceUIDDigest"`
+	FenceResourceVersionDigest  string             `json:"fenceResourceVersionDigest"`
+	LookupResourceVersionDigest string             `json:"lookupResourceVersionDigest"`
+	EvidenceDigest              string             `json:"evidenceDigest"`
+}
+
+func digest(input string) string {
+	sum := sha256.Sum256([]byte(input))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func ValidateIdentityDigest(value string) error {
+	if len(value) != len("sha256:")+64 || !strings.HasPrefix(value, "sha256:") {
+		return ErrIdentityDigestInvalid
+	}
+	if _, err := hex.DecodeString(strings.TrimPrefix(value, "sha256:")); err != nil || value != strings.ToLower(value) {
+		return ErrIdentityDigestInvalid
+	}
+	return nil
+}
+
+func canonicalFields(domain string, fields ...string) []byte {
+	var b strings.Builder
+	b.WriteString(domain)
+	b.WriteByte(0)
+	for _, field := range fields {
+		fmt.Fprintf(&b, "%d:", len(field))
+		b.WriteString(field)
+		b.WriteByte(0)
+	}
+	return []byte(b.String())
+}
+
+func CanonicalRegistrationIdentityBytes(identity RegistrationIdentity) ([]byte, error) {
+	fields := []string{identity.PhysicalAPIID, identity.InstallationEpoch, string(identity.ExecutionUID), identity.AttemptID, string(identity.NamespaceUID), string(identity.KeySecretUID), string(identity.AuthorityUID), string(identity.QueueUID)}
+	for _, value := range fields {
+		if value == "" {
+			return nil, ErrIdentityIncomplete
+		}
+	}
+	return canonicalFields("kubeblocks.io/reconfigure-registration/v1", fields...), nil
+}
+
+func RegistrationKey(identity RegistrationIdentity) (string, error) {
+	data, err := CanonicalRegistrationIdentityBytes(identity)
+	if err != nil {
+		return "", err
+	}
+	return digest(string(data)), nil
+}
+
+func CanonicalEffectIdentityBytes(registrationKey string, identity EffectIdentity) ([]byte, error) {
+	if err := ValidateIdentityDigest(registrationKey); err != nil {
+		return nil, err
+	}
+	if identity.Kind != EffectKindUnitExecution && !isWindowKind(identity.Kind) {
+		return nil, ErrIdentityIncomplete
+	}
+	if identity.DeterministicName == "" || ValidateIdentityDigest(identity.FullIdentityDigest) != nil {
+		return nil, ErrIdentityIncomplete
+	}
+	if identity.Kind == EffectKindUnitExecution && (identity.PodUID == "" || identity.ContainerName == "" || identity.FenceUID == "") {
+		return nil, ErrIdentityIncomplete
+	}
+	return canonicalFields("kubeblocks.io/reconfigure-effect/v1", registrationKey, string(identity.Kind), identity.DeterministicName, identity.FullIdentityDigest, string(identity.PodUID), identity.ContainerName, string(identity.FenceUID)), nil
+}
+
+func EffectKey(registrationKey string, identity EffectIdentity) (string, error) {
+	data, err := CanonicalEffectIdentityBytes(registrationKey, identity)
+	if err != nil {
+		return "", err
+	}
+	return digest(string(data)), nil
+}
+
+func NewFenceState(installationEpoch string, namespaceUID types.UID, identity FenceObjectIdentity) (FenceState, error) {
+	if installationEpoch == "" || namespaceUID == "" || identity.UID == "" {
+		return FenceState{}, ErrIdentityIncomplete
+	}
+	return FenceState{status: storedStatus{ProtocolVersion: protocolFenceStatusV1, FenceUIDDigest: digestExternalUID(identity.UID), InstallationEpoch: installationEpoch, Namespaces: []storedNamespace{{UID: namespaceUID}}}, fenceIdentity: identity}, nil
+}
+
+func IsZeroFenceState(state FenceState) bool { return state.status.ProtocolVersion == "" }
+
+func cloneState(state FenceState) FenceState {
+	data, _ := json.Marshal(state.status)
+	var status storedStatus
+	_ = json.Unmarshal(data, &status)
+	cloned := FenceState{status: status, fenceIdentity: state.fenceIdentity}
+	if state.activeReadback != nil {
+		value := *state.activeReadback
+		cloned.activeReadback = &value
+	}
+	return cloned
+}
+
+func StoredProtocolFenceStatusBytes(state FenceState) ([]byte, error) {
+	return marshalStoredStatus(state.status)
+}
+func CanonicalFenceStateBytes(state FenceState) ([]byte, error) {
+	return marshalStoredStatus(state.status)
+}
+
+func marshalStoredStatus(status storedStatus) ([]byte, error) {
+	status.IntegrityDigest = ""
+	unsigned, err := json.Marshal(status)
+	if err != nil {
+		return nil, err
+	}
+	status.IntegrityDigest = digest("kubeblocks.io/reconfigure-stored-status-integrity/v1\x00" + string(unsigned))
+	return json.Marshal(status)
+}
+
+func digestExternalUID(uid types.UID) string {
+	return digest("kubeblocks.io/reconfigure-external-uid/v1\x00" + string(uid))
+}
+func digestExternalRV(rv string) string {
+	return digest("kubeblocks.io/reconfigure-external-rv/v1\x00" + rv)
+}
+
+func registrationIdentityStored(v RegistrationIdentity) storedRegistrationIdentity {
+	return storedRegistrationIdentity{v.PhysicalAPIID, v.InstallationEpoch, v.ExecutionUID, v.AttemptID, v.NamespaceUID, v.KeySecretUID, v.AuthorityUID, v.QueueUID}
+}
+
+func effectIdentityStored(v EffectIdentity) storedEffectIdentity {
+	return storedEffectIdentity{v.KindString(), v.DeterministicName, v.FullIdentityDigest, v.PodUID, v.ContainerName, v.FenceUID}
+}
+
+func (v EffectIdentity) KindString() string { return string(v.Kind) }
+
+func registrationIdentityRuntime(v storedRegistrationIdentity) RegistrationIdentity {
+	return RegistrationIdentity{v.PhysicalAPIID, v.InstallationEpoch, v.ExecutionUID, v.AttemptID, v.NamespaceUID, v.KeySecretUID, v.AuthorityUID, v.QueueUID}
+}
+
+func effectIdentityRuntime(v storedEffectIdentity) EffectIdentity {
+	return EffectIdentity{EffectKind(v.Kind), v.DeterministicName, v.FullIdentityDigest, v.PodUID, v.ContainerName, v.FenceUID}
+}
+
+func RegisterExecution(state FenceState, identity RegistrationIdentity, limits RegistryLimits) (FenceState, string, error) {
+	key, err := RegistrationKey(identity)
+	if err != nil {
+		return state, "", err
+	}
+	for _, registration := range state.status.Registrations {
+		if registration.Key == key {
+			return state, key, nil
+		}
+	}
+	if state.status.InstallationManifest != nil || anyNamespaceDraining(state.status) {
+		return state, "", ErrRegistryDraining
+	}
+	for _, registration := range state.status.Registrations {
+		current := registrationIdentityRuntime(registration.Identity)
+		if current.PhysicalAPIID == identity.PhysicalAPIID && current.InstallationEpoch == identity.InstallationEpoch && current.ExecutionUID == identity.ExecutionUID && current.AttemptID == identity.AttemptID {
+			return state, "", ErrRegistrationIdentityConflict
+		}
+	}
+	if len(state.status.Registrations) >= limits.MaxRegistrations {
+		return state, "", ErrRegistryCapacity
+	}
+	next := cloneState(state)
+	if !hasNamespace(next.status, identity.NamespaceUID) {
+		if len(next.status.Namespaces) >= limits.MaxNamespaces {
+			return state, "", ErrRegistryCapacity
+		}
+		next.status.Namespaces = append(next.status.Namespaces, storedNamespace{UID: identity.NamespaceUID})
+	}
+	next.status.Registrations = append(next.status.Registrations, storedRegistration{Key: key, Identity: registrationIdentityStored(identity), Phase: string(RegistrationPhaseActive)})
+	if !withinCapacity(next, limits) {
+		return state, "", ErrRegistryCapacity
+	}
+	return next, key, nil
+}
+
+func PlanEffect(state FenceState, registrationKey string, identity EffectIdentity, limits RegistryLimits) (FenceState, string, error) {
+	key, err := EffectKey(registrationKey, identity)
+	if err != nil {
+		return state, "", err
+	}
+	registration, _, ok := findRegistration(&state.status, registrationKey)
+	if !ok {
+		return state, "", ErrRegistrationIdentityConflict
+	}
+	for _, effect := range registration.Effects {
+		if effect.Key == key {
+			if RegistrationPhase(registration.Phase) == RegistrationPhaseConsumed && len(registration.Effects) > 1 {
+				return state, key, ErrRegistrationAlreadyConsumed
+			}
+			if EffectState(effect.State) == EffectStateConsumed {
+				return state, key, ErrEffectAlreadyConsumed
+			}
+			return state, key, nil
+		}
+		if effect.Identity.Kind == string(identity.Kind) && effect.Identity.DeterministicName == identity.DeterministicName {
+			if EffectState(effect.State) == EffectStateConsumed {
+				return state, key, ErrEffectAlreadyConsumed
+			}
+			return state, "", ErrEffectIdentityConflict
+		}
+	}
+	if RegistrationPhase(registration.Phase) == RegistrationPhaseConsumed {
+		return state, "", ErrRegistrationAlreadyConsumed
+	}
+	if state.status.InstallationManifest != nil || anyNamespaceDraining(state.status) {
+		return state, "", ErrRegistryDraining
+	}
+	if TotalEffectCount(state) >= limits.MaxEffects {
+		return state, "", ErrRegistryCapacity
+	}
+	next := cloneState(state)
+	registration, _, _ = findRegistration(&next.status, registrationKey)
+	registration.Effects = append(registration.Effects, storedEffect{Key: key, Identity: effectIdentityStored(identity), State: string(EffectStatePlanned)})
+	if !withinCapacity(next, limits) {
+		return state, "", ErrRegistryCapacity
+	}
+	return next, key, nil
+}
+
+func ObserveEffectObject(state FenceState, registrationKey, effectKey string, observation EffectObjectObservation) (FenceState, error) {
+	effect, registration, ok := findEffect(&state.status, registrationKey, effectKey)
+	if !ok {
+		return state, ErrEffectIdentityConflict
+	}
+	identity := effectIdentityRuntime(effect.Identity)
+	if observation.Target != expectedTarget(identity) {
+		return state, ErrEffectObservationMismatch
+	}
+	if EffectState(effect.State) == EffectStateConsumed {
+		return state, ErrEffectAlreadyConsumed
+	}
+	switch observation.Result {
+	case EffectObservationAPIError, EffectObservationTerminating:
+		return state, ErrEffectObservationInconclusive
+	case EffectObservationPresent:
+		if observation.ObjectUID == "" || observation.ObjectResourceVersion == "" {
+			return state, ErrEffectObservationIncomplete
+		}
+		uidDigest := digestExternalUID(observation.ObjectUID)
+		rvDigest := digestExternalRV(observation.ObjectResourceVersion)
+		if effect.ObjectBinding != nil {
+			if effect.ObjectBinding.UIDDigest == uidDigest && effect.ObjectBinding.ResourceVersionDigest == rvDigest && effect.ObjectBinding.Target == observation.Target {
+				return state, nil
+			}
+			return state, ErrEffectObjectIdentityConflict
+		}
+		if EffectState(effect.State) != EffectStatePlanned {
+			return state, ErrEffectObjectIdentityConflict
+		}
+		next := cloneState(state)
+		effect, _, _ = findEffect(&next.status, registrationKey, effectKey)
+		effect.State = string(EffectStateObjectBound)
+		effect.ObjectBinding = &storedObjectBinding{Target: observation.Target, UIDDigest: uidDigest, ResourceVersionDigest: rvDigest}
+		return next, nil
+	case EffectObservationNotFound:
+		if !isWindowKind(identity.Kind) {
+			return state, ErrEffectCloseoutVariantMismatch
+		}
+		if observation.LookupResourceVersion == "" {
+			return state, ErrEffectObservationIncomplete
+		}
+		if EffectState(effect.State) != EffectStatePlanned {
+			return state, ErrEffectObservationStale
+		}
+		manifest := matchingCommittedManifest(state.status, registration.Identity.NamespaceUID, observation.DrainIdentity)
+		if manifest == nil {
+			if !anyNamespaceDraining(state.status) && state.status.InstallationManifest == nil {
+				return state, ErrEffectStillCreatable
+			}
+			return state, ErrEffectObservationStale
+		}
+		next := cloneState(state)
+		effect, _, _ = findEffect(&next.status, registrationKey, effectKey)
+		effect.State = string(EffectStateConsumed)
+		effect.CloseoutVariant = string(CloseoutVariantNotFound)
+		effect.NotFound = &storedNotFound{Target: observation.Target, DrainToken: observation.DrainIdentity.Token, ManifestDigest: observation.DrainIdentity.ManifestDigest, FenceUIDDigest: observation.DrainIdentity.FenceUIDDigest, FenceResourceVersionDigest: observation.DrainIdentity.FenceResourceVersionDigest, LookupResourceVersionDigest: digestExternalRV(observation.LookupResourceVersion)}
+		effect.NotFound.EvidenceDigest = notFoundEvidenceDigest(*effect.NotFound)
+		effect.Tombstone = &storedConsumedTombstone{IdentityDigest: consumedTombstoneDigest(effectKey)}
+		return next, nil
+	default:
+		return state, ErrEffectObservationInconclusive
+	}
+}
+
+func AuthorizeDispatch(state FenceState, registrationKey, effectKey string) (FenceState, error) {
+	effect, _, ok := findEffect(&state.status, registrationKey, effectKey)
+	if !ok {
+		return state, ErrEffectIdentityConflict
+	}
+	if EffectState(effect.State) == EffectStateConsumed {
+		return state, ErrEffectAlreadyConsumed
+	}
+	if EffectState(effect.State) == EffectStateDispatchAuthorized {
+		return state, ErrDispatchOutcomeUnknown
+	}
+	if EffectState(effect.State) != EffectStateObjectBound || effect.ObjectBinding == nil {
+		return state, ErrEffectObjectNotBound
+	}
+	if hasUncommittedDrain(state.status) {
+		return state, ErrRegistryDraining
+	}
+	if EffectKind(effect.Identity.Kind) != EffectKindUnitExecution {
+		return state, ErrEffectCloseoutVariantMismatch
+	}
+	next := cloneState(state)
+	effect, _, _ = findEffect(&next.status, registrationKey, effectKey)
+	effect.State = string(EffectStateDispatchAuthorized)
+	effect.Dispatch = &storedDispatch{Token: dispatchToken(registrationKey, effectKey, effect.ObjectBinding.UIDDigest)}
+	return next, nil
+}
+
+func MarkEffectTerminal(state FenceState, registrationKey, effectKey string, evidence EffectTerminalEvidence) (FenceState, error) {
+	effect, _, ok := findEffect(&state.status, registrationKey, effectKey)
+	if !ok {
+		return state, ErrEffectIdentityConflict
+	}
+	if len(evidence.ReasonCode) > MaxTerminalReasonCodeBytes {
+		return state, ErrTerminalEvidenceTooLarge
+	}
+	if evidence.ReasonCode == "" || !validTerminalOutcome(evidence.Outcome) || ValidateIdentityDigest(evidence.EvidenceDigest) != nil {
+		return state, ErrStoredStatusInvalid
+	}
+	kind := EffectKind(effect.Identity.Kind)
+	if (kind == EffectKindUnitExecution && evidence.CloseoutVariant != CloseoutVariantUnitExecuted) || (isWindowKind(kind) && evidence.CloseoutVariant != CloseoutVariantObservedTerminal) {
+		return state, ErrEffectCloseoutVariantMismatch
+	}
+	if kind == EffectKindUnitExecution && (EffectState(effect.State) != EffectStateDispatchAuthorized || effect.Dispatch == nil) {
+		return state, ErrEffectDispatchRequired
+	}
+	if isWindowKind(kind) && (EffectState(effect.State) != EffectStateObjectBound || effect.ObjectBinding == nil) {
+		return state, ErrEffectObjectNotBound
+	}
+	next := cloneState(state)
+	effect, _, _ = findEffect(&next.status, registrationKey, effectKey)
+	effect.State = string(EffectStateTerminal)
+	effect.CloseoutVariant = string(evidence.CloseoutVariant)
+	effect.Terminal = &storedTerminal{Outcome: string(evidence.Outcome), ReasonCode: evidence.ReasonCode, EvidenceDigest: evidence.EvidenceDigest, RecoveryRequired: evidence.RecoveryRequired}
+	return next, nil
+}
+
+func ConsumeEffect(state FenceState, registrationKey, effectKey string) (FenceState, error) {
+	effect, _, ok := findEffect(&state.status, registrationKey, effectKey)
+	if !ok {
+		return state, ErrEffectIdentityConflict
+	}
+	if EffectState(effect.State) == EffectStateConsumed {
+		return state, nil
+	}
+	if EffectState(effect.State) != EffectStateTerminal {
+		return state, ErrEffectStateRegression
+	}
+	if EffectKind(effect.Identity.Kind) == EffectKindUnitExecution && (state.status.InstallationManifest == nil || state.status.InstallationManifest.CommitReadback == nil) {
+		return state, ErrDrainNotCommitted
+	}
+	next := cloneState(state)
+	effect, _, _ = findEffect(&next.status, registrationKey, effectKey)
+	effect.State = string(EffectStateConsumed)
+	effect.Tombstone = &storedConsumedTombstone{IdentityDigest: consumedTombstoneDigest(effectKey)}
+	return next, nil
+}
+
+func ConsumeRegistration(state FenceState, registrationKey string) (FenceState, error) {
+	registration, _, ok := findRegistration(&state.status, registrationKey)
+	if !ok {
+		return state, ErrRegistrationIdentityConflict
+	}
+	for _, effect := range registration.Effects {
+		if EffectState(effect.State) != EffectStateConsumed {
+			return state, ErrEffectStateRegression
+		}
+	}
+	next := cloneState(state)
+	registration, _, _ = findRegistration(&next.status, registrationKey)
+	registration.Phase = string(RegistrationPhaseConsumed)
+	return next, nil
+}
+
+func AdvanceEffectState(state FenceState, registrationKey, effectKey string, target EffectState) (FenceState, error) {
+	effect, _, ok := findEffect(&state.status, registrationKey, effectKey)
+	if !ok {
+		return state, ErrEffectIdentityConflict
+	}
+	if effectStateOrder(target) <= effectStateOrder(EffectState(effect.State)) {
+		return state, ErrEffectStateRegression
+	}
+	return state, ErrEffectStateRegression
+}
+
+func effectStateOrder(state EffectState) int {
+	switch state {
+	case EffectStatePlanned:
+		return 1
+	case EffectStateObjectBound:
+		return 2
+	case EffectStateDispatchAuthorized:
+		return 3
+	case EffectStateTerminal:
+		return 4
+	case EffectStateConsumed:
+		return 5
+	}
+	return 0
+}
+
+func DrainNamespace(state FenceState, namespaceUID types.UID) (FenceState, error) {
+	next := cloneState(state)
+	for index := range next.status.Namespaces {
+		if next.status.Namespaces[index].UID == namespaceUID {
+			if next.status.Namespaces[index].Manifest != nil {
+				return state, ErrRegistryDraining
+			}
+			registrationKeys := registrationKeysForNamespace(next.status, namespaceUID)
+			effectKeys := effectKeysForNamespace(next.status, namespaceUID)
+			next.status.Namespaces[index].Manifest = newManifest("namespace:"+string(namespaceUID), registrationKeys, effectKeys)
+			return next, nil
+		}
+	}
+	return state, ErrIdentityIncomplete
+}
+
+func DrainInstallation(state FenceState) (FenceState, error) {
+	if state.status.InstallationManifest != nil {
+		return state, ErrRegistryDraining
+	}
+	next := cloneState(state)
+	next.status.InstallationManifest = newManifest("installation:"+next.status.InstallationEpoch, allRegistrationKeys(next.status), allEffectKeys(next.status))
+	return next, nil
+}
+
+func BindActiveFenceReadback(state FenceState, readback FenceObjectReadback) (FenceState, error) {
+	if err := validateReadback(state, readback); err != nil {
+		return state, err
+	}
+	next := cloneState(state)
+	next.activeReadback = &readback
+	return next, nil
+}
+
+func BindDrainCommitReadback(state FenceState, scope DrainScope, readback FenceObjectReadback) (FenceState, error) {
+	if err := validateReadback(state, readback); err != nil {
+		return state, err
+	}
+	next := cloneState(state)
+	manifest := manifestForScope(&next.status, scope)
+	if manifest == nil {
+		return state, ErrFenceReadbackMismatch
+	}
+	if manifest.CommitReadback != nil {
+		return state, ErrDrainReadbackAlreadyBound
+	}
+	manifest.CommitReadback = &storedReadback{UIDDigest: digestExternalUID(readback.UID), ResourceVersionDigest: digestExternalRV(readback.ResourceVersion), StoredStatusDigest: readback.StoredStatusDigest}
+	return next, nil
+}
+
+func RebindDrainCommitReadback(state FenceState, scope DrainScope, readback FenceObjectReadback) (FenceState, error) {
+	manifest := manifestForScope(&state.status, scope)
+	if manifest != nil && manifest.CommitReadback != nil {
+		return state, ErrDrainReadbackAlreadyBound
+	}
+	return BindDrainCommitReadback(state, scope, readback)
+}
+
+func validateReadback(state FenceState, readback FenceObjectReadback) error {
+	if readback.UID == "" || readback.ResourceVersion == "" || readback.StoredStatusDigest == "" || readback.UID != state.fenceIdentity.UID {
+		return ErrFenceReadbackMismatch
+	}
+	bytes, err := StoredProtocolFenceStatusBytes(state)
+	if err != nil || readback.StoredStatusDigest != digest(string(bytes)) {
+		return ErrFenceReadbackMismatch
+	}
+	return nil
+}
+
+func ActiveDrainIdentity(state FenceState) DrainIdentity {
+	if state.activeReadback == nil {
+		return DrainIdentity{}
+	}
+	return DrainIdentity{FenceUIDDigest: digestExternalUID(state.activeReadback.UID), FenceResourceVersionDigest: digestExternalRV(state.activeReadback.ResourceVersion)}
+}
+
+func NamespaceDrainIdentity(state FenceState, namespaceUID types.UID) DrainIdentity {
+	return drainIdentity(manifestForScope(&state.status, NamespaceDrainScope(namespaceUID)))
+}
+func InstallationDrainIdentity(state FenceState) DrainIdentity {
+	return drainIdentity(state.status.InstallationManifest)
+}
+
+func drainIdentity(manifest *storedManifest) DrainIdentity {
+	if manifest == nil {
+		return DrainIdentity{}
+	}
+	identity := DrainIdentity{Token: manifest.Token, ManifestDigest: manifest.Digest}
+	if manifest.CommitReadback != nil {
+		identity.FenceUIDDigest = manifest.CommitReadback.UIDDigest
+		identity.FenceResourceVersionDigest = manifest.CommitReadback.ResourceVersionDigest
+	}
+	return identity
+}
+
+func NamespaceManifestDigest(state FenceState, namespaceUID types.UID) string {
+	manifest := manifestForScope(&state.status, NamespaceDrainScope(namespaceUID))
+	if manifest == nil {
+		return ""
+	}
+	return manifest.Digest
+}
+func InstallationManifestDigest(state FenceState) string {
+	if state.status.InstallationManifest == nil {
+		return ""
+	}
+	return state.status.InstallationManifest.Digest
+}
+func NamespaceManifestContainsEffect(state FenceState, registrationKey, effectKey string) bool {
+	registration, _, ok := findRegistration(&state.status, registrationKey)
+	if !ok {
+		return false
+	}
+	manifest := manifestForScope(&state.status, NamespaceDrainScope(registration.Identity.NamespaceUID))
+	return manifestContains(manifest, effectKey)
+}
+func InstallationManifestContainsEffect(state FenceState, _, effectKey string) bool {
+	return manifestContains(state.status.InstallationManifest, effectKey)
+}
+
+func manifestContains(manifest *storedManifest, effectKey string) bool {
+	if manifest == nil {
+		return false
+	}
+	for _, key := range manifest.EffectKeys {
+		if key == effectKey {
+			return true
+		}
+	}
+	return false
+}
+
+func RegistrationCount(state FenceState) int { return len(state.status.Registrations) }
+func NamespaceCount(state FenceState) int    { return len(state.status.Namespaces) }
+func TotalEffectCount(state FenceState) int {
+	total := 0
+	for _, registration := range state.status.Registrations {
+		total += len(registration.Effects)
+	}
+	return total
+}
+func EffectCount(state FenceState, registrationKey string) int {
+	registration, _, ok := findRegistration(&state.status, registrationKey)
+	if !ok {
+		return 0
+	}
+	return len(registration.Effects)
+}
+func EffectStateOf(state FenceState, registrationKey, effectKey string) EffectState {
+	effect, _, ok := findEffect(&state.status, registrationKey, effectKey)
+	if !ok {
+		return EffectStateUnknown
+	}
+	return EffectState(effect.State)
+}
+func CanonicalManifestDigest(state FenceState) string {
+	data, _ := json.Marshal([]any{state.status.Namespaces, state.status.InstallationManifest})
+	return digest(string(data))
+}
+
+func DecodeStoredProtocolFenceStatus(data []byte, identity FenceObjectIdentity) (FenceState, error) {
+	var status storedStatus
+	if err := json.Unmarshal(data, &status); err != nil {
+		return FenceState{}, ErrStoredStatusInvalid
+	}
+	wantIntegrity := status.IntegrityDigest
+	status.IntegrityDigest = ""
+	unsigned, _ := json.Marshal(status)
+	if wantIntegrity != digest("kubeblocks.io/reconfigure-stored-status-integrity/v1\x00"+string(unsigned)) {
+		return FenceState{}, ErrStoredStatusIntegrity
+	}
+	status.IntegrityDigest = wantIntegrity
+	if status.FenceUIDDigest == "" {
+		return FenceState{}, ErrStoredStatusInvalid
+	}
+	if status.FenceUIDDigest != digestExternalUID(identity.UID) {
+		return FenceState{}, ErrFenceReadbackMismatch
+	}
+	if err := validateStoredStatus(status); err != nil {
+		return FenceState{}, err
+	}
+	return FenceState{status: status, fenceIdentity: identity}, nil
+}
+
+func validateStoredStatus(status storedStatus) error {
+	if status.ProtocolVersion != protocolFenceStatusV1 || status.InstallationEpoch == "" || ValidateIdentityDigest(status.FenceUIDDigest) != nil {
+		return ErrStoredStatusInvalid
+	}
+	namespaceSet := map[types.UID]bool{}
+	for _, namespace := range status.Namespaces {
+		if namespace.UID == "" || namespaceSet[namespace.UID] {
+			return ErrStoredStatusInvalid
+		}
+		namespaceSet[namespace.UID] = true
+	}
+	registrationKeys := map[string]bool{}
+	effectKeys := map[string]bool{}
+	for registrationIndex := range status.Registrations {
+		registration := &status.Registrations[registrationIndex]
+		key, err := RegistrationKey(registrationIdentityRuntime(registration.Identity))
+		if err != nil || key != registration.Key || registrationKeys[key] || !namespaceSet[registration.Identity.NamespaceUID] {
+			return ErrStoredStatusInvalid
+		}
+		registrationKeys[key] = true
+		phase := RegistrationPhase(registration.Phase)
+		if phase != RegistrationPhaseActive && phase != RegistrationPhaseConsumed {
+			return ErrStoredStatusInvalid
+		}
+		allConsumed := true
+		for effectIndex := range registration.Effects {
+			effect := &registration.Effects[effectIndex]
+			key, err := EffectKey(registration.Key, effectIdentityRuntime(effect.Identity))
+			if err != nil || key != effect.Key || effectKeys[key] {
+				return ErrStoredStatusInvalid
+			}
+			effectKeys[key] = true
+			if err := validateStoredEffect(status, *registration, *effect); err != nil {
+				return err
+			}
+			allConsumed = allConsumed && EffectState(effect.State) == EffectStateConsumed
+		}
+		if phase == RegistrationPhaseConsumed && !allConsumed {
+			return ErrStoredStatusInvalid
+		}
+	}
+	if err := validateManifest(status, status.InstallationManifest, "installation:"+status.InstallationEpoch, allRegistrationKeys(status), allEffectKeys(status)); err != nil {
+		return err
+	}
+	for _, namespace := range status.Namespaces {
+		if err := validateManifest(status, namespace.Manifest, "namespace:"+string(namespace.UID), registrationKeysForNamespace(status, namespace.UID), effectKeysForNamespace(status, namespace.UID)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateStoredEffect(status storedStatus, registration storedRegistration, effect storedEffect) error {
+	state := EffectState(effect.State)
+	kind := EffectKind(effect.Identity.Kind)
+	if kind != EffectKindUnitExecution && !isWindowKind(kind) {
+		return ErrStoredStatusInvalid
+	}
+	validateObject := func() bool {
+		return effect.ObjectBinding != nil && effect.ObjectBinding.Target == expectedTarget(effectIdentityRuntime(effect.Identity)) && ValidateIdentityDigest(effect.ObjectBinding.UIDDigest) == nil && ValidateIdentityDigest(effect.ObjectBinding.ResourceVersionDigest) == nil
+	}
+	validateDispatch := func() bool {
+		return effect.Dispatch != nil && validateObject() && effect.Dispatch.Token == dispatchToken(registration.Key, effect.Key, effect.ObjectBinding.UIDDigest)
+	}
+	validateTerminal := func() bool {
+		return effect.Terminal != nil && effect.Terminal.ReasonCode != "" && len(effect.Terminal.ReasonCode) <= MaxTerminalReasonCodeBytes && validTerminalOutcome(EffectTerminalOutcome(effect.Terminal.Outcome)) && ValidateIdentityDigest(effect.Terminal.EvidenceDigest) == nil
+	}
+	validateTombstone := func() bool {
+		return effect.Tombstone != nil && effect.Tombstone.IdentityDigest == consumedTombstoneDigest(effect.Key)
+	}
+	switch state {
+	case EffectStatePlanned:
+		if effect.CloseoutVariant != "" || effect.ObjectBinding != nil || effect.Dispatch != nil || effect.Terminal != nil || effect.NotFound != nil || effect.Tombstone != nil {
+			return ErrStoredStatusInvalid
+		}
+	case EffectStateObjectBound:
+		if effect.CloseoutVariant != "" || !validateObject() || effect.Dispatch != nil || effect.Terminal != nil || effect.NotFound != nil || effect.Tombstone != nil {
+			return ErrStoredStatusInvalid
+		}
+	case EffectStateDispatchAuthorized:
+		if kind != EffectKindUnitExecution || effect.CloseoutVariant != "" || !validateDispatch() || effect.Terminal != nil || effect.NotFound != nil || effect.Tombstone != nil {
+			return ErrStoredStatusInvalid
+		}
+	case EffectStateTerminal:
+		if effect.Tombstone != nil || effect.NotFound != nil || !validateTerminal() {
+			return ErrStoredStatusInvalid
+		}
+		if effect.CloseoutVariant == string(CloseoutVariantUnitExecuted) {
+			if kind != EffectKindUnitExecution || !validateDispatch() {
+				return ErrStoredStatusInvalid
+			}
+		} else if effect.CloseoutVariant == string(CloseoutVariantObservedTerminal) {
+			if !isWindowKind(kind) || !validateObject() || effect.Dispatch != nil {
+				return ErrStoredStatusInvalid
+			}
+		} else {
+			return ErrStoredStatusInvalid
+		}
+	case EffectStateConsumed:
+		if !validateTombstone() {
+			return ErrStoredStatusInvalid
+		}
+		switch EffectCloseoutVariant(effect.CloseoutVariant) {
+		case CloseoutVariantUnitExecuted:
+			if kind != EffectKindUnitExecution || status.InstallationManifest == nil || status.InstallationManifest.CommitReadback == nil || !validateDispatch() || !validateTerminal() || effect.NotFound != nil {
+				return ErrStoredStatusInvalid
+			}
+		case CloseoutVariantObservedTerminal:
+			if !isWindowKind(kind) || !validateObject() || effect.Dispatch != nil || !validateTerminal() || effect.NotFound != nil {
+				return ErrStoredStatusInvalid
+			}
+		case CloseoutVariantNotFound:
+			if !isWindowKind(kind) || effect.ObjectBinding != nil || effect.Dispatch != nil || effect.Terminal != nil || !validNotFound(status, registration, effect) {
+				return ErrStoredStatusInvalid
+			}
+		default:
+			return ErrStoredStatusInvalid
+		}
+	default:
+		return ErrStoredStatusInvalid
+	}
+	return nil
+}
+
+func validNotFound(status storedStatus, registration storedRegistration, effect storedEffect) bool {
+	value := effect.NotFound
+	if value == nil || value.Target != expectedTarget(effectIdentityRuntime(effect.Identity)) || ValidateIdentityDigest(value.LookupResourceVersionDigest) != nil || ValidateIdentityDigest(value.EvidenceDigest) != nil || value.EvidenceDigest != notFoundEvidenceDigest(*value) {
+		return false
+	}
+	identity := DrainIdentity{Token: value.DrainToken, ManifestDigest: value.ManifestDigest, FenceUIDDigest: value.FenceUIDDigest, FenceResourceVersionDigest: value.FenceResourceVersionDigest}
+	return matchingCommittedManifest(status, registration.Identity.NamespaceUID, identity) != nil
+}
+
+func validateManifest(_ storedStatus, manifest *storedManifest, scope string, expectedRegistrationKeys, expectedEffectKeys []string) error {
+	if manifest == nil {
+		return nil
+	}
+	if manifest.Token != drainToken(scope, expectedRegistrationKeys, expectedEffectKeys) || manifest.Digest != manifestDigest(expectedRegistrationKeys, expectedEffectKeys) || !stringSlicesEqual(manifest.RegistrationKeys, expectedRegistrationKeys) || !stringSlicesEqual(manifest.EffectKeys, expectedEffectKeys) {
+		return ErrStoredStatusInvalid
+	}
+	if manifest.CommitReadback != nil && (ValidateIdentityDigest(manifest.CommitReadback.UIDDigest) != nil || ValidateIdentityDigest(manifest.CommitReadback.ResourceVersionDigest) != nil || ValidateIdentityDigest(manifest.CommitReadback.StoredStatusDigest) != nil) {
+		return ErrStoredStatusInvalid
+	}
+	return nil
+}
+
+func RequiredCloseoutReserve(state FenceState) int {
+	current, _ := marshalStoredStatus(state.status)
+	closeout := maxLegalCloseoutStatus(state.status)
+	closeoutBytes, _ := marshalStoredStatus(closeout)
+	return len(closeoutBytes) - len(current)
+}
+
+func maxLegalCloseoutStatus(status storedStatus) storedStatus {
+	closeout := cloneStatus(status)
+	var allKeys []string
+	var allRegistrationKeys []string
+	for index := range closeout.Namespaces {
+		registrationKeys := registrationKeysForNamespace(closeout, closeout.Namespaces[index].UID)
+		effectKeys := effectKeysForNamespace(closeout, closeout.Namespaces[index].UID)
+		allRegistrationKeys = append(allRegistrationKeys, registrationKeys...)
+		allKeys = append(allKeys, effectKeys...)
+		closeout.Namespaces[index].Manifest = newManifest("namespace:"+string(closeout.Namespaces[index].UID), registrationKeys, effectKeys)
+		closeout.Namespaces[index].Manifest.CommitReadback = maxReadback()
+	}
+	closeout.InstallationManifest = newManifest("installation:"+closeout.InstallationEpoch, allRegistrationKeys, allKeys)
+	closeout.InstallationManifest.CommitReadback = maxReadback()
+	for r := range closeout.Registrations {
+		closeout.Registrations[r].Phase = string(RegistrationPhaseConsumed)
+		for e := range closeout.Registrations[r].Effects {
+			registration := &closeout.Registrations[r]
+			manifest := manifestForScope(&closeout, NamespaceDrainScope(registration.Identity.NamespaceUID))
+			options := legalStoredCloseoutEffects(registration.Key, registration.Effects[e], manifest)
+			selected := options[0]
+			selectedBytes, _ := json.Marshal(selected)
+			for _, option := range options[1:] {
+				optionBytes, _ := json.Marshal(option)
+				if len(optionBytes) > len(selectedBytes) {
+					selected = option
+					selectedBytes = optionBytes
+				}
+			}
+			registration.Effects[e] = selected
+		}
+	}
+	return closeout
+}
+
+func legalStoredCloseoutEffects(registrationKey string, planned storedEffect, manifest *storedManifest) []storedEffect {
+	base := planned
+	base.State = string(EffectStateConsumed)
+	base.Tombstone = &storedConsumedTombstone{IdentityDigest: consumedTombstoneDigest(base.Key)}
+	object := maxObjectBinding(base.Identity)
+	terminal := &storedTerminal{Outcome: string(EffectTerminalManual), ReasonCode: strings.Repeat("R", MaxTerminalReasonCodeBytes), EvidenceDigest: digest("max-terminal-evidence"), RecoveryRequired: true}
+	kind := EffectKind(base.Identity.Kind)
+	if kind == EffectKindUnitExecution {
+		base.CloseoutVariant = string(CloseoutVariantUnitExecuted)
+		base.ObjectBinding = object
+		base.Dispatch = &storedDispatch{Token: dispatchToken(registrationKey, base.Key, object.UIDDigest)}
+		base.Terminal = terminal
+		return []storedEffect{base}
+	}
+	if !isWindowKind(kind) {
+		return nil
+	}
+	notFound := base
+	notFound.CloseoutVariant = string(CloseoutVariantNotFound)
+	notFound.NotFound = &storedNotFound{Target: object.Target, DrainToken: manifest.Token, ManifestDigest: manifest.Digest, FenceUIDDigest: manifest.CommitReadback.UIDDigest, FenceResourceVersionDigest: manifest.CommitReadback.ResourceVersionDigest, LookupResourceVersionDigest: digestExternalRV(strings.Repeat("9", maxFenceResourceVersionBytes))}
+	notFound.NotFound.EvidenceDigest = notFoundEvidenceDigest(*notFound.NotFound)
+	observed := base
+	observed.CloseoutVariant = string(CloseoutVariantObservedTerminal)
+	observed.ObjectBinding = object
+	observed.Terminal = terminal
+	return []storedEffect{notFound, observed}
+}
+
+func withinCapacity(state FenceState, limits RegistryLimits) bool {
+	bytes, err := marshalStoredStatus(state.status)
+	return err == nil && len(bytes)+RequiredCloseoutReserve(state)+ReservedProtocolFenceStatusBytes <= limits.MaxStatusBytes
+}
+
+func expectedTarget(identity EffectIdentity) EffectObjectTarget {
+	kind := "GateWindow"
+	if identity.Kind == EffectKindUnitExecution {
+		kind = "UnitExecution"
+	}
+	return EffectObjectTarget{"protocol.kubeblocks.io/v1alpha1", kind, "kb-system", identity.DeterministicName}
+}
+
+func isWindowKind(kind EffectKind) bool {
+	return kind == EffectKindTargetFenceWindow || kind == EffectKindCredentialWindow
+}
+
+func validTerminalOutcome(outcome EffectTerminalOutcome) bool {
+	return outcome == EffectTerminalSucceeded || outcome == EffectTerminalFailed || outcome == EffectTerminalManual
+}
+func dispatchToken(registrationKey, effectKey, objectUIDDigest string) string {
+	return digest("kubeblocks.io/reconfigure-dispatch/v1\x00" + registrationKey + "\x00" + effectKey + "\x00" + objectUIDDigest)
+}
+func consumedTombstoneDigest(effectKey string) string {
+	return digest("kubeblocks.io/reconfigure-consumed/v1\x00" + effectKey)
+}
+func notFoundEvidenceDigest(v storedNotFound) string {
+	return digest(strings.Join([]string{"kubeblocks.io/reconfigure-notfound-evidence/v1", v.Target.APIVersion, v.Target.Kind, v.Target.Namespace, v.Target.Name, v.DrainToken, v.ManifestDigest, v.FenceUIDDigest, v.FenceResourceVersionDigest, v.LookupResourceVersionDigest}, "\x00"))
+}
+func drainToken(scope string, registrationKeys, effectKeys []string) string {
+	return digest("kubeblocks.io/reconfigure-drain-token/v1\x00" + scope + "\x00" + strings.Join(registrationKeys, "\x00") + "\x00" + strings.Join(effectKeys, "\x00"))
+}
+func manifestDigest(registrationKeys, effectKeys []string) string {
+	return digest("kubeblocks.io/reconfigure-manifest/v1\x00" + strings.Join(registrationKeys, "\x00") + "\x00" + strings.Join(effectKeys, "\x00"))
+}
+func newManifest(scope string, registrationKeys, effectKeys []string) *storedManifest {
+	copiedRegistrations := append([]string(nil), registrationKeys...)
+	copiedEffects := append([]string(nil), effectKeys...)
+	return &storedManifest{Token: drainToken(scope, copiedRegistrations, copiedEffects), Digest: manifestDigest(copiedRegistrations, copiedEffects), RegistrationKeys: copiedRegistrations, EffectKeys: copiedEffects}
+}
+func maxReadback() *storedReadback {
+	return &storedReadback{digestExternalUID(types.UID("protocol-fence-uid-1")), digestExternalRV(strings.Repeat("9", maxFenceResourceVersionBytes)), digest("max-stored-status")}
+}
+func maxObjectBinding(identity storedEffectIdentity) *storedObjectBinding {
+	return &storedObjectBinding{Target: expectedTarget(effectIdentityRuntime(identity)), UIDDigest: digestExternalUID(types.UID(strings.Repeat("u", maxEffectObjectUIDBytes))), ResourceVersionDigest: digestExternalRV(strings.Repeat("9", maxEffectObjectResourceVersionBytes))}
+}
+
+func newManifestReadbackIdentity(manifest *storedManifest) DrainIdentity {
+	return drainIdentity(manifest)
+}
+func matchingCommittedManifest(status storedStatus, namespaceUID types.UID, identity DrainIdentity) *storedManifest {
+	candidates := []*storedManifest{manifestForScope(&status, NamespaceDrainScope(namespaceUID)), status.InstallationManifest}
+	for _, manifest := range candidates {
+		if manifest == nil || manifest.CommitReadback == nil {
+			continue
+		}
+		current := newManifestReadbackIdentity(manifest)
+		if current == identity {
+			return manifest
+		}
+	}
+	return nil
+}
+func manifestForScope(status *storedStatus, scope DrainScope) *storedManifest {
+	if scope.installation {
+		return status.InstallationManifest
+	}
+	for index := range status.Namespaces {
+		if status.Namespaces[index].UID == scope.namespaceUID {
+			return status.Namespaces[index].Manifest
+		}
+	}
+	return nil
+}
+func hasNamespace(status storedStatus, uid types.UID) bool {
+	for _, namespace := range status.Namespaces {
+		if namespace.UID == uid {
+			return true
+		}
+	}
+	return false
+}
+func anyNamespaceDraining(status storedStatus) bool {
+	for _, namespace := range status.Namespaces {
+		if namespace.Manifest != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func hasUncommittedDrain(status storedStatus) bool {
+	if status.InstallationManifest != nil && status.InstallationManifest.CommitReadback == nil {
+		return true
+	}
+	for _, namespace := range status.Namespaces {
+		if namespace.Manifest != nil && namespace.Manifest.CommitReadback == nil {
+			return true
+		}
+	}
+	return false
+}
+func allEffectKeys(status storedStatus) []string {
+	var keys []string
+	for _, registration := range status.Registrations {
+		for _, effect := range registration.Effects {
+			keys = append(keys, effect.Key)
+		}
+	}
+	return keys
+}
+func allRegistrationKeys(status storedStatus) []string {
+	keys := make([]string, 0, len(status.Registrations))
+	for _, registration := range status.Registrations {
+		keys = append(keys, registration.Key)
+	}
+	return keys
+}
+func registrationKeysForNamespace(status storedStatus, uid types.UID) []string {
+	var keys []string
+	for _, registration := range status.Registrations {
+		if registration.Identity.NamespaceUID == uid {
+			keys = append(keys, registration.Key)
+		}
+	}
+	return keys
+}
+func effectKeysForNamespace(status storedStatus, uid types.UID) []string {
+	var keys []string
+	for _, registration := range status.Registrations {
+		if registration.Identity.NamespaceUID != uid {
+			continue
+		}
+		for _, effect := range registration.Effects {
+			keys = append(keys, effect.Key)
+		}
+	}
+	return keys
+}
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+func cloneStatus(status storedStatus) storedStatus {
+	data, _ := json.Marshal(status)
+	var cloned storedStatus
+	_ = json.Unmarshal(data, &cloned)
+	return cloned
+}
+func findRegistration(status *storedStatus, key string) (*storedRegistration, int, bool) {
+	for index := range status.Registrations {
+		if status.Registrations[index].Key == key {
+			return &status.Registrations[index], index, true
+		}
+	}
+	return nil, -1, false
+}
+func findEffect(status *storedStatus, registrationKey, effectKey string) (*storedEffect, *storedRegistration, bool) {
+	registration, _, ok := findRegistration(status, registrationKey)
+	if !ok {
+		return nil, nil, false
+	}
+	for index := range registration.Effects {
+		if registration.Effects[index].Key == effectKey {
+			return &registration.Effects[index], registration, true
+		}
+	}
+	return nil, registration, false
+}

--- a/pkg/reconfigure/protocol/registry_test.go
+++ b/pkg/reconfigure/protocol/registry_test.go
@@ -1,0 +1,2492 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package protocol
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	types "k8s.io/apimachinery/pkg/types"
+)
+
+func TestRegistrationKeyUsesVersionedCanonicalIdentity(t *testing.T) {
+	identity := testRegistrationIdentity()
+	canonical, err := CanonicalRegistrationIdentityBytes(identity)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(string(canonical), "kubeblocks.io/reconfigure-registration/v1\x00"))
+
+	first, err := RegistrationKey(identity)
+	require.NoError(t, err)
+	second, err := RegistrationKey(identity)
+	require.NoError(t, err)
+	require.Equal(t, first, second)
+
+	mutations := map[string]func(*RegistrationIdentity){
+		"physical API":       func(v *RegistrationIdentity) { v.PhysicalAPIID = "api-uid-2" },
+		"installation epoch": func(v *RegistrationIdentity) { v.InstallationEpoch = "install-8" },
+		"execution UID":      func(v *RegistrationIdentity) { v.ExecutionUID = types.UID("execution-uid-2") },
+		"attempt ID":         func(v *RegistrationIdentity) { v.AttemptID = "attempt-4" },
+		"namespace UID":      func(v *RegistrationIdentity) { v.NamespaceUID = types.UID("namespace-uid-2") },
+		"key secret UID":     func(v *RegistrationIdentity) { v.KeySecretUID = types.UID("key-secret-uid-2") },
+		"authority UID":      func(v *RegistrationIdentity) { v.AuthorityUID = types.UID("authority-uid-2") },
+		"queue UID":          func(v *RegistrationIdentity) { v.QueueUID = types.UID("queue-uid-2") },
+	}
+	for name, mutate := range mutations {
+		t.Run("binds "+name, func(t *testing.T) {
+			changed := identity
+			mutate(&changed)
+			key, err := RegistrationKey(changed)
+			require.NoError(t, err)
+			require.NotEqual(t, first, key)
+		})
+	}
+
+	emptyMutations := map[string]func(*RegistrationIdentity){
+		"physical API":       func(v *RegistrationIdentity) { v.PhysicalAPIID = "" },
+		"installation epoch": func(v *RegistrationIdentity) { v.InstallationEpoch = "" },
+		"execution UID":      func(v *RegistrationIdentity) { v.ExecutionUID = "" },
+		"attempt ID":         func(v *RegistrationIdentity) { v.AttemptID = "" },
+		"namespace UID":      func(v *RegistrationIdentity) { v.NamespaceUID = "" },
+		"key secret UID":     func(v *RegistrationIdentity) { v.KeySecretUID = "" },
+		"authority UID":      func(v *RegistrationIdentity) { v.AuthorityUID = "" },
+		"queue UID":          func(v *RegistrationIdentity) { v.QueueUID = "" },
+	}
+	for name, clear := range emptyMutations {
+		t.Run("rejects empty "+name, func(t *testing.T) {
+			changed := identity
+			clear(&changed)
+			_, err := RegistrationKey(changed)
+			require.ErrorIs(t, err, ErrIdentityIncomplete)
+		})
+	}
+
+	left := identity
+	left.PhysicalAPIID = "ab"
+	left.InstallationEpoch = "c"
+	right := identity
+	right.PhysicalAPIID = "a"
+	right.InstallationEpoch = "bc"
+	leftKey, err := RegistrationKey(left)
+	require.NoError(t, err)
+	rightKey, err := RegistrationKey(right)
+	require.NoError(t, err)
+	require.NotEqual(t, leftKey, rightKey, "field boundaries must not use raw concatenation")
+}
+
+func TestEffectKeyUsesVersionedCanonicalIdentity(t *testing.T) {
+	effect := testUnitEffect("unit-1")
+	registrationKey := testDigest("registration-1")
+	canonical, err := CanonicalEffectIdentityBytes(registrationKey, effect)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(string(canonical), "kubeblocks.io/reconfigure-effect/v1\x00"))
+
+	first, err := EffectKey(registrationKey, effect)
+	require.NoError(t, err)
+	replayed, err := EffectKey(registrationKey, effect)
+	require.NoError(t, err)
+	require.Equal(t, first, replayed)
+	otherRegistration, err := EffectKey(testDigest("registration-2"), effect)
+	require.NoError(t, err)
+	require.NotEqual(t, first, otherRegistration)
+
+	for name, invalidRegistrationKey := range map[string]string{
+		"empty":        "",
+		"unknown alg":  "sha512:0123",
+		"short":        "sha256:0123",
+		"non hex":      "sha256:zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+		"uppercase":    "sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"extra prefix": "SHA256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	} {
+		t.Run("registration key "+name, func(t *testing.T) {
+			_, err := CanonicalEffectIdentityBytes(invalidRegistrationKey, effect)
+			require.ErrorIs(t, err, ErrIdentityDigestInvalid)
+			_, err = EffectKey(invalidRegistrationKey, effect)
+			require.ErrorIs(t, err, ErrIdentityDigestInvalid)
+		})
+	}
+
+	for name, mutate := range map[string]func(*EffectIdentity){
+		"kind":   func(v *EffectIdentity) { v.Kind = EffectKindCredentialWindow },
+		"name":   func(v *EffectIdentity) { v.DeterministicName = "unit-2" },
+		"digest": func(v *EffectIdentity) { v.FullIdentityDigest = testDigest("unit-2") },
+	} {
+		t.Run(name, func(t *testing.T) {
+			changed := effect
+			mutate(&changed)
+			key, err := EffectKey(registrationKey, changed)
+			require.NoError(t, err)
+			require.NotEqual(t, first, key)
+		})
+	}
+
+	left := effect
+	left.DeterministicName = "ab"
+	left.FullIdentityDigest = testDigest("c")
+	right := effect
+	right.DeterministicName = "a"
+	right.FullIdentityDigest = testDigest("bc")
+	leftKey, err := EffectKey(registrationKey, left)
+	require.NoError(t, err)
+	rightKey, err := EffectKey(registrationKey, right)
+	require.NoError(t, err)
+	require.NotEqual(t, leftKey, rightKey)
+
+	actualRegistrationKey, err := RegistrationKey(testRegistrationIdentity())
+	require.NoError(t, err)
+	require.NotEqual(t, actualRegistrationKey, first, "registration and effect keys need distinct domains")
+}
+
+func TestIdentityDigestMustBeCanonicalSHA256(t *testing.T) {
+	require.NoError(t, ValidateIdentityDigest(testDigest("valid")))
+
+	for name, digest := range map[string]string{
+		"empty":        "",
+		"unknown alg":  "sha512:0123",
+		"short":        "sha256:0123",
+		"non hex":      "sha256:zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+		"uppercase":    "sha256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"extra prefix": "SHA256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.ErrorIs(t, ValidateIdentityDigest(digest), ErrIdentityDigestInvalid)
+		})
+	}
+}
+
+func TestFenceStateRequiresServerObjectIdentityBeforeActive(t *testing.T) {
+	_, err := NewFenceState("install-7", types.UID("namespace-uid-1"), FenceObjectIdentity{})
+	require.ErrorIs(t, err, ErrIdentityIncomplete)
+
+	_, err = NewFenceState("install-7", types.UID("namespace-uid-1"), testFenceObjectIdentity())
+	require.NoError(t, err)
+}
+
+func TestRegistrationAndEffectReplayAreIdempotent(t *testing.T) {
+	limits := generousRegistryLimits()
+	identity := testRegistrationIdentity()
+	state := newFenceState(t, identity.InstallationEpoch, identity.NamespaceUID, testFenceObjectIdentity())
+	registered, registrationKey, err := RegisterExecution(state, identity, limits)
+	require.NoError(t, err)
+	registeredBytes := canonicalStateBytes(t, registered)
+
+	for i := 0; i < 100; i++ {
+		replayed, replayedKey, err := RegisterExecution(registered, identity, limits)
+		require.NoError(t, err)
+		require.Equal(t, registrationKey, replayedKey)
+		require.Equal(t, 1, RegistrationCount(replayed))
+		require.Equal(t, registeredBytes, canonicalStateBytes(t, replayed))
+	}
+
+	conflicting := identity
+	conflicting.AuthorityUID = types.UID("authority-uid-2")
+	unchanged, _, err := RegisterExecution(registered, conflicting, limits)
+	require.ErrorIs(t, err, ErrRegistrationIdentityConflict)
+	requireStateEqual(t, registered, unchanged)
+
+	effect := testUnitEffect("unit-1")
+	planned, effectKey, err := PlanEffect(registered, registrationKey, effect, limits)
+	require.NoError(t, err)
+	plannedBytes := canonicalStateBytes(t, planned)
+
+	for i := 0; i < 100; i++ {
+		replayed, replayedKey, err := PlanEffect(planned, registrationKey, effect, limits)
+		require.NoError(t, err)
+		require.Equal(t, effectKey, replayedKey)
+		require.Equal(t, 1, EffectCount(replayed, registrationKey))
+		require.Equal(t, plannedBytes, canonicalStateBytes(t, replayed))
+	}
+
+	for name, mutate := range map[string]func(*EffectIdentity){
+		"digest":    func(v *EffectIdentity) { v.FullIdentityDigest = testDigest("other-unit") },
+		"pod UID":   func(v *EffectIdentity) { v.PodUID = types.UID("pod-uid-2") },
+		"container": func(v *EffectIdentity) { v.ContainerName = "sidecar" },
+		"fence UID": func(v *EffectIdentity) { v.FenceUID = types.UID("fence-uid-2") },
+	} {
+		t.Run("rejects replay with changed "+name, func(t *testing.T) {
+			changed := effect
+			mutate(&changed)
+			unchanged, _, err := PlanEffect(planned, registrationKey, changed, limits)
+			require.ErrorIs(t, err, ErrEffectIdentityConflict)
+			requireStateEqual(t, planned, unchanged)
+		})
+	}
+}
+
+func TestDrainFreezesRegistrationMembership(t *testing.T) {
+	for _, drain := range []struct {
+		name string
+		run  func(FenceState) (FenceState, error)
+	}{
+		{name: "namespace", run: func(state FenceState) (FenceState, error) {
+			return DrainNamespace(state, testRegistrationIdentity().NamespaceUID)
+		}},
+		{name: "installation", run: DrainInstallation},
+	} {
+		t.Run(drain.name, func(t *testing.T) {
+			state, registrationKey, limits := registeredFence(t)
+			draining, err := drain.run(state)
+			require.NoError(t, err)
+
+			replayed, replayedKey, err := RegisterExecution(draining, testRegistrationIdentity(), limits)
+			require.NoError(t, err)
+			require.Equal(t, registrationKey, replayedKey)
+			requireStateEqual(t, draining, replayed)
+
+			for name, mutate := range map[string]func(*RegistrationIdentity){
+				"conflicting identity": func(v *RegistrationIdentity) {
+					v.AuthorityUID = types.UID("authority-uid-2")
+				},
+				"same namespace": func(v *RegistrationIdentity) {
+					v.ExecutionUID = types.UID("execution-uid-2")
+					v.AttemptID = "attempt-4"
+				},
+				"new namespace": func(v *RegistrationIdentity) {
+					v.ExecutionUID = types.UID("execution-uid-2")
+					v.AttemptID = "attempt-4"
+					v.NamespaceUID = types.UID("namespace-uid-2")
+					v.AuthorityUID = types.UID("authority-uid-2")
+					v.QueueUID = types.UID("queue-uid-2")
+				},
+			} {
+				t.Run(name, func(t *testing.T) {
+					identity := testRegistrationIdentity()
+					mutate(&identity)
+					unchanged, _, err := RegisterExecution(draining, identity, limits)
+					require.ErrorIs(t, err, ErrRegistryDraining)
+					requireStateEqual(t, draining, unchanged)
+				})
+			}
+		})
+	}
+}
+
+func TestObjectBindingIsExactAndIdempotent(t *testing.T) {
+	state, registrationKey, limits := registeredFence(t)
+	effect := testWindowEffect("target-window-1")
+	planned, effectKey, err := PlanEffect(state, registrationKey, effect, limits)
+	require.NoError(t, err)
+	present := presentObservation(effect, types.UID("window-uid-1"))
+	for name, mutate := range map[string]func(*EffectObjectObservation){
+		"empty object UID": func(v *EffectObjectObservation) { v.ObjectUID = "" },
+		"empty object RV":  func(v *EffectObjectObservation) { v.ObjectResourceVersion = "" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			incomplete := present
+			mutate(&incomplete)
+			unchanged, err := ObserveEffectObject(planned, registrationKey, effectKey, incomplete)
+			require.ErrorIs(t, err, ErrEffectObservationIncomplete)
+			requireStateEqual(t, planned, unchanged)
+		})
+	}
+
+	bound, err := ObserveEffectObject(planned, registrationKey, effectKey, present)
+	require.NoError(t, err)
+	replayed, err := ObserveEffectObject(bound, registrationKey, effectKey, present)
+	require.NoError(t, err)
+	requireStateEqual(t, bound, replayed)
+
+	wrongUID := present
+	wrongUID.ObjectUID = types.UID("window-uid-2")
+	unchanged, err := ObserveEffectObject(bound, registrationKey, effectKey, wrongUID)
+	require.ErrorIs(t, err, ErrEffectObjectIdentityConflict)
+	requireStateEqual(t, bound, unchanged)
+
+	for name, observation := range map[string]EffectObjectObservation{
+		"terminating": terminatingObservation(effect, present.ObjectUID),
+		"API error":   apiErrorObservation(effect),
+	} {
+		t.Run(name, func(t *testing.T) {
+			unchanged, err := ObserveEffectObject(bound, registrationKey, effectKey, observation)
+			require.ErrorIs(t, err, ErrEffectObservationInconclusive)
+			requireStateEqual(t, bound, unchanged)
+		})
+	}
+
+	draining, err := DrainNamespace(bound, testRegistrationIdentity().NamespaceUID)
+	require.NoError(t, err)
+	terminal, err := MarkEffectTerminal(draining, registrationKey, effectKey, observedTerminalEvidence())
+	require.NoError(t, err)
+	consumed, err := ConsumeEffect(terminal, registrationKey, effectKey)
+	require.NoError(t, err)
+	var stored storedProtocolFenceStatusDTO
+	require.NoError(t, json.Unmarshal(storedStateBytes(t, consumed), &stored))
+	storedEffect := stored.Registrations[0].Effects[0]
+	require.Equal(t, string(CloseoutVariantObservedTerminal), storedEffect.CloseoutVariant)
+	require.NotNil(t, storedEffect.ObjectBinding)
+	require.Nil(t, storedEffect.Dispatch)
+	require.NotNil(t, storedEffect.Terminal)
+	require.Nil(t, storedEffect.NotFound)
+	require.NotNil(t, storedEffect.Tombstone)
+	restarted, err := DecodeStoredProtocolFenceStatus(storedStateBytes(t, consumed), testFenceObjectIdentity())
+	require.NoError(t, err)
+	unchanged, err = ObserveEffectObject(consumed, registrationKey, effectKey, present)
+	require.ErrorIs(t, err, ErrEffectAlreadyConsumed)
+	requireStateEqual(t, consumed, unchanged)
+	unchanged, err = ObserveEffectObject(restarted, registrationKey, effectKey, present)
+	require.ErrorIs(t, err, ErrEffectAlreadyConsumed)
+	requireStateEqual(t, restarted, unchanged)
+}
+
+func TestPlannedNotFoundRequiresDrainAndExactFreshObservation(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		drain          func(FenceState) (FenceState, error)
+		commit         func(FenceState) (FenceState, DrainIdentity)
+		otherIdentity  func(FenceState) DrainIdentity
+		manifestDigest func(FenceState) string
+	}{
+		{
+			name: "namespace",
+			drain: func(state FenceState) (FenceState, error) {
+				return DrainNamespace(state, testRegistrationIdentity().NamespaceUID)
+			},
+			commit: func(state FenceState) (FenceState, DrainIdentity) {
+				return commitNamespaceDrain(t, state, "502")
+			},
+			otherIdentity: func(state FenceState) DrainIdentity {
+				other, err := DrainInstallation(state)
+				require.NoError(t, err)
+				_, identity := commitInstallationDrain(t, other, "502")
+				return identity
+			},
+			manifestDigest: func(state FenceState) string {
+				return NamespaceManifestDigest(state, testRegistrationIdentity().NamespaceUID)
+			},
+		},
+		{
+			name:  "installation",
+			drain: DrainInstallation,
+			commit: func(state FenceState) (FenceState, DrainIdentity) {
+				return commitInstallationDrain(t, state, "502")
+			},
+			otherIdentity: func(state FenceState) DrainIdentity {
+				other, err := DrainNamespace(state, testRegistrationIdentity().NamespaceUID)
+				require.NoError(t, err)
+				_, identity := commitNamespaceDrain(t, other, "502")
+				return identity
+			},
+			manifestDigest: InstallationManifestDigest,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			state, registrationKey, limits := registeredFence(t)
+			effect := testWindowEffect("target-window-1")
+			planned, effectKey, err := PlanEffect(state, registrationKey, effect, limits)
+			require.NoError(t, err)
+			preDrain := notFoundObservation(effect, activeDrainIdentity(t, planned))
+
+			unchanged, err := ObserveEffectObject(planned, registrationKey, effectKey, preDrain)
+			require.ErrorIs(t, err, ErrEffectStillCreatable)
+			requireStateEqual(t, planned, unchanged)
+
+			draining, err := tc.drain(planned)
+			require.NoError(t, err)
+			draining, drainIdentity := tc.commit(draining)
+			require.NotEmpty(t, drainIdentity.Token)
+			require.NotEmpty(t, drainIdentity.ManifestDigest)
+			manifestBefore := tc.manifestDigest(draining)
+
+			unchanged, err = ObserveEffectObject(draining, registrationKey, effectKey, preDrain)
+			require.ErrorIs(t, err, ErrEffectObservationStale)
+			requireStateEqual(t, draining, unchanged)
+
+			for name, staleIdentity := range map[string]DrainIdentity{
+				"wrong scope token": tc.otherIdentity(planned),
+				"old token": func() DrainIdentity {
+					changed := drainIdentity
+					changed.Token = "old-drain-token"
+					return changed
+				}(),
+				"wrong manifest": func() DrainIdentity {
+					changed := drainIdentity
+					changed.ManifestDigest = testDigest("wrong-manifest")
+					return changed
+				}(),
+				"wrong fence UID": func() DrainIdentity {
+					changed := drainIdentity
+					changed.FenceUIDDigest = externalUIDDigest(types.UID("different-fence-uid"))
+					return changed
+				}(),
+				"wrong fence RV": func() DrainIdentity {
+					changed := drainIdentity
+					changed.FenceResourceVersionDigest = externalResourceVersionDigest("different-fence-rv")
+					return changed
+				}(),
+			} {
+				t.Run(name, func(t *testing.T) {
+					unchanged, err := ObserveEffectObject(draining, registrationKey, effectKey, notFoundObservation(effect, staleIdentity))
+					require.ErrorIs(t, err, ErrEffectObservationStale)
+					requireStateEqual(t, draining, unchanged)
+				})
+			}
+
+			fresh := notFoundObservation(effect, drainIdentity)
+			incomplete := fresh
+			incomplete.LookupResourceVersion = ""
+			unchanged, err = ObserveEffectObject(draining, registrationKey, effectKey, incomplete)
+			require.ErrorIs(t, err, ErrEffectObservationIncomplete)
+			requireStateEqual(t, draining, unchanged)
+
+			consumed, err := ObserveEffectObject(draining, registrationKey, effectKey, fresh)
+			require.NoError(t, err)
+			require.Equal(t, EffectStateConsumed, EffectStateOf(consumed, registrationKey, effectKey))
+			require.Equal(t, manifestBefore, tc.manifestDigest(consumed))
+			var stored storedProtocolFenceStatusDTO
+			require.NoError(t, json.Unmarshal(storedStateBytes(t, consumed), &stored))
+			storedEffect := stored.Registrations[0].Effects[0]
+			require.Equal(t, string(CloseoutVariantNotFound), storedEffect.CloseoutVariant)
+			require.Nil(t, storedEffect.ObjectBinding)
+			require.Nil(t, storedEffect.Dispatch)
+			require.Nil(t, storedEffect.Terminal)
+			require.Equal(t, storedNotFoundEvidenceDTOFrom(fresh), storedEffect.NotFound)
+			require.NotNil(t, storedEffect.Tombstone)
+			require.Equal(t, expectedConsumedTombstoneDigest(effectKey), storedEffect.Tombstone.IdentityDigest)
+			restarted, err := DecodeStoredProtocolFenceStatus(storedStateBytes(t, consumed), testFenceObjectIdentity())
+			require.NoError(t, err)
+
+			unchanged, _, err = PlanEffect(consumed, registrationKey, effect, limits)
+			require.ErrorIs(t, err, ErrEffectAlreadyConsumed)
+			requireStateEqual(t, consumed, unchanged)
+			changedDigest := effect
+			changedDigest.FullIdentityDigest = testDigest("different-target-window")
+			unchanged, _, err = PlanEffect(consumed, registrationKey, changedDigest, limits)
+			require.ErrorIs(t, err, ErrEffectAlreadyConsumed)
+			requireStateEqual(t, consumed, unchanged)
+			unchanged, err = ObserveEffectObject(consumed, registrationKey, effectKey, presentObservation(effect, types.UID("window-uid-1")))
+			require.ErrorIs(t, err, ErrEffectAlreadyConsumed)
+			requireStateEqual(t, consumed, unchanged)
+			unchanged, err = AuthorizeDispatch(consumed, registrationKey, effectKey)
+			require.ErrorIs(t, err, ErrEffectAlreadyConsumed)
+			requireStateEqual(t, consumed, unchanged)
+			unchanged, _, err = PlanEffect(restarted, registrationKey, effect, limits)
+			require.ErrorIs(t, err, ErrEffectAlreadyConsumed)
+			requireStateEqual(t, restarted, unchanged)
+		})
+	}
+}
+
+func TestUnitNotFoundIsRejectedBeforeStoredStateMutation(t *testing.T) {
+	state, registrationKey, limits := registeredFence(t)
+	effect := testUnitEffect("unit-1")
+	planned, effectKey, err := PlanEffect(state, registrationKey, effect, limits)
+	require.NoError(t, err)
+	draining, err := DrainNamespace(planned, testRegistrationIdentity().NamespaceUID)
+	require.NoError(t, err)
+	draining, drainIdentity := commitNamespaceDrain(t, draining, "502")
+
+	unchanged, err := ObserveEffectObject(draining, registrationKey, effectKey, notFoundObservation(effect, drainIdentity))
+	require.ErrorIs(t, err, ErrEffectCloseoutVariantMismatch)
+	requireStateEqual(t, draining, unchanged)
+}
+
+func TestUnitConsumeRequiresCommittedInstallationDrain(t *testing.T) {
+	state, registrationKey, limits := registeredFence(t)
+	effect := testUnitEffect("unit-1")
+	planned, effectKey, err := PlanEffect(state, registrationKey, effect, limits)
+	require.NoError(t, err)
+	bound, err := ObserveEffectObject(planned, registrationKey, effectKey, presentObservation(effect, types.UID("unit-object-uid-1")))
+	require.NoError(t, err)
+	authorized, err := AuthorizeDispatch(bound, registrationKey, effectKey)
+	require.NoError(t, err)
+	terminal, err := MarkEffectTerminal(authorized, registrationKey, effectKey, executedTerminalEvidence())
+	require.NoError(t, err)
+
+	unchanged, err := ConsumeEffect(terminal, registrationKey, effectKey)
+	require.ErrorIs(t, err, ErrDrainNotCommitted)
+	requireStateEqual(t, terminal, unchanged)
+
+	draining, err := DrainInstallation(terminal)
+	require.NoError(t, err)
+	unchanged, err = ConsumeEffect(draining, registrationKey, effectKey)
+	require.ErrorIs(t, err, ErrDrainNotCommitted)
+	requireStateEqual(t, draining, unchanged)
+
+	committed, _ := commitInstallationDrain(t, draining, "503")
+	consumed, err := ConsumeEffect(committed, registrationKey, effectKey)
+	require.NoError(t, err)
+	require.Equal(t, EffectStateConsumed, EffectStateOf(consumed, registrationKey, effectKey))
+}
+
+func TestTerminalCloseoutVariantMatchesEffectKindAtWriteSite(t *testing.T) {
+	t.Run("Unit rejects ObservedTerminal", func(t *testing.T) {
+		state, registrationKey, limits := registeredFence(t)
+		effect := testUnitEffect("unit-1")
+		planned, effectKey, err := PlanEffect(state, registrationKey, effect, limits)
+		require.NoError(t, err)
+		bound, err := ObserveEffectObject(planned, registrationKey, effectKey, presentObservation(effect, types.UID("unit-object-uid-1")))
+		require.NoError(t, err)
+		authorized, err := AuthorizeDispatch(bound, registrationKey, effectKey)
+		require.NoError(t, err)
+
+		unchanged, err := MarkEffectTerminal(authorized, registrationKey, effectKey, observedTerminalEvidence())
+		require.ErrorIs(t, err, ErrEffectCloseoutVariantMismatch)
+		requireStateEqual(t, authorized, unchanged)
+
+		terminal, err := MarkEffectTerminal(authorized, registrationKey, effectKey, executedTerminalEvidence())
+		require.NoError(t, err)
+		require.Equal(t, EffectStateTerminal, EffectStateOf(terminal, registrationKey, effectKey))
+	})
+
+	t.Run("Window rejects UnitExecuted", func(t *testing.T) {
+		state, registrationKey, limits := registeredFence(t)
+		effect := testWindowEffect("target-window-1")
+		planned, effectKey, err := PlanEffect(state, registrationKey, effect, limits)
+		require.NoError(t, err)
+		bound, err := ObserveEffectObject(planned, registrationKey, effectKey, presentObservation(effect, types.UID("window-object-uid-1")))
+		require.NoError(t, err)
+		draining, err := DrainNamespace(bound, testRegistrationIdentity().NamespaceUID)
+		require.NoError(t, err)
+
+		unchanged, err := MarkEffectTerminal(draining, registrationKey, effectKey, executedTerminalEvidence())
+		require.ErrorIs(t, err, ErrEffectCloseoutVariantMismatch)
+		requireStateEqual(t, draining, unchanged)
+
+		terminal, err := MarkEffectTerminal(draining, registrationKey, effectKey, observedTerminalEvidence())
+		require.NoError(t, err)
+		require.Equal(t, EffectStateTerminal, EffectStateOf(terminal, registrationKey, effectKey))
+	})
+}
+
+func TestEffectObservationTargetMatchesExactEffectKindAndLocation(t *testing.T) {
+	for _, effect := range []EffectIdentity{
+		testWindowEffect("shared-name"),
+		testUnitEffect("shared-name"),
+	} {
+		t.Run(string(effect.Kind), func(t *testing.T) {
+			state, registrationKey, limits := registeredFence(t)
+			planned, effectKey, err := PlanEffect(state, registrationKey, effect, limits)
+			require.NoError(t, err)
+			draining, err := DrainNamespace(planned, testRegistrationIdentity().NamespaceUID)
+			require.NoError(t, err)
+			draining, drainIdentity := commitNamespaceDrain(t, draining, "502")
+
+			for name, mutate := range map[string]func(*EffectObjectTarget){
+				"API version": func(v *EffectObjectTarget) { v.APIVersion = "wrong.example.io/v1" },
+				"kind":        func(v *EffectObjectTarget) { v.Kind = "WrongKind" },
+				"namespace":   func(v *EffectObjectTarget) { v.Namespace = "wrong-namespace" },
+				"name":        func(v *EffectObjectTarget) { v.Name = "wrong-name" },
+			} {
+				t.Run(name, func(t *testing.T) {
+					wrongPresent := presentObservation(effect, types.UID("object-uid-1"))
+					mutate(&wrongPresent.Target)
+					unchanged, err := ObserveEffectObject(planned, registrationKey, effectKey, wrongPresent)
+					require.ErrorIs(t, err, ErrEffectObservationMismatch)
+					requireStateEqual(t, planned, unchanged)
+
+					wrongNotFound := notFoundObservation(effect, drainIdentity)
+					mutate(&wrongNotFound.Target)
+					unchanged, err = ObserveEffectObject(draining, registrationKey, effectKey, wrongNotFound)
+					require.ErrorIs(t, err, ErrEffectObservationMismatch)
+					requireStateEqual(t, draining, unchanged)
+				})
+			}
+
+			_, err = ObserveEffectObject(planned, registrationKey, effectKey, presentObservation(effect, types.UID("object-uid-1")))
+			require.NoError(t, err)
+			unchanged, err := ObserveEffectObject(draining, registrationKey, effectKey, notFoundObservation(effect, drainIdentity))
+			if effect.Kind == EffectKindUnitExecution {
+				require.ErrorIs(t, err, ErrEffectCloseoutVariantMismatch)
+				requireStateEqual(t, draining, unchanged)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestDrainIdentityRequiresFreshCommittedFenceReadback(t *testing.T) {
+	state, registrationKey, limits := registeredFence(t)
+	planned, _, err := PlanEffect(state, registrationKey, testWindowEffect("target-window-1"), limits)
+	require.NoError(t, err)
+	preDrainStoredDigest := testDigest(string(storedStateBytes(t, planned)))
+	draining, err := DrainNamespace(planned, testRegistrationIdentity().NamespaceUID)
+	require.NoError(t, err)
+
+	for name, readback := range map[string]FenceObjectReadback{
+		"empty UID": {
+			ResourceVersion:    "502",
+			StoredStatusDigest: testDigest(string(storedStateBytes(t, draining))),
+		},
+		"empty RV": {
+			UID:                testFenceObjectIdentity().UID,
+			StoredStatusDigest: testDigest(string(storedStateBytes(t, draining))),
+		},
+		"same name new UID": {
+			UID:                types.UID("protocol-fence-uid-2"),
+			ResourceVersion:    "502",
+			StoredStatusDigest: testDigest(string(storedStateBytes(t, draining))),
+		},
+		"pre-commit status": {
+			UID:                testFenceObjectIdentity().UID,
+			ResourceVersion:    "501",
+			StoredStatusDigest: preDrainStoredDigest,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := BindDrainCommitReadback(draining, NamespaceDrainScope(testRegistrationIdentity().NamespaceUID), readback)
+			require.ErrorIs(t, err, ErrFenceReadbackMismatch)
+		})
+	}
+
+	readback := testFenceReadback(t, draining, "502")
+	view, err := BindDrainCommitReadback(draining, NamespaceDrainScope(testRegistrationIdentity().NamespaceUID), readback)
+	require.NoError(t, err)
+	identity := NamespaceDrainIdentity(view, testRegistrationIdentity().NamespaceUID)
+	require.Equal(t, externalUIDDigest(readback.UID), identity.FenceUIDDigest)
+	require.Equal(t, externalResourceVersionDigest(readback.ResourceVersion), identity.FenceResourceVersionDigest)
+	require.NotEmpty(t, identity.FenceUIDDigest)
+	require.NotEmpty(t, identity.FenceResourceVersionDigest)
+
+	_, err = RebindDrainCommitReadback(view, NamespaceDrainScope(testRegistrationIdentity().NamespaceUID), testFenceReadback(t, draining, "503"))
+	require.ErrorIs(t, err, ErrDrainReadbackAlreadyBound)
+}
+
+func TestDrainFreezesManifestWhileLivePhasesAdvance(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		drain    func(FenceState) (FenceState, error)
+		commit   func(FenceState) (FenceState, DrainIdentity)
+		digest   func(FenceState) string
+		contains func(FenceState, string, string) bool
+	}{
+		{
+			name: "namespace",
+			drain: func(state FenceState) (FenceState, error) {
+				return DrainNamespace(state, testRegistrationIdentity().NamespaceUID)
+			},
+			digest: func(state FenceState) string {
+				return NamespaceManifestDigest(state, testRegistrationIdentity().NamespaceUID)
+			},
+			commit: func(state FenceState) (FenceState, DrainIdentity) {
+				return commitNamespaceDrain(t, state, "502")
+			},
+			contains: NamespaceManifestContainsEffect,
+		},
+		{
+			name:  "installation",
+			drain: DrainInstallation,
+			commit: func(state FenceState) (FenceState, DrainIdentity) {
+				return commitInstallationDrain(t, state, "502")
+			},
+			digest:   InstallationManifestDigest,
+			contains: InstallationManifestContainsEffect,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			state, registrationKey, limits := registeredFence(t)
+			windowEffect := testWindowEffect("target-window-1")
+			unitEffect := testUnitEffect("unit-1")
+			planned, plannedKey, err := PlanEffect(state, registrationKey, windowEffect, limits)
+			require.NoError(t, err)
+			planned, boundKey, err := PlanEffect(planned, registrationKey, unitEffect, limits)
+			require.NoError(t, err)
+			bound, err := ObserveEffectObject(planned, registrationKey, boundKey, presentObservation(unitEffect, types.UID("unit-object-uid-1")))
+			require.NoError(t, err)
+
+			draining, err := tc.drain(bound)
+			require.NoError(t, err)
+			draining, drainIdentity := tc.commit(draining)
+			manifestDigest := tc.digest(draining)
+			require.NotEmpty(t, manifestDigest)
+			require.True(t, tc.contains(draining, registrationKey, plannedKey))
+			require.True(t, tc.contains(draining, registrationKey, boundKey))
+
+			consumedPlanned, err := ObserveEffectObject(draining, registrationKey, plannedKey, notFoundObservation(windowEffect, drainIdentity))
+			require.NoError(t, err)
+			unchanged, err := MarkEffectTerminal(consumedPlanned, registrationKey, boundKey, executedTerminalEvidence())
+			require.ErrorIs(t, err, ErrEffectDispatchRequired)
+			requireStateEqual(t, consumedPlanned, unchanged)
+			authorized, err := AuthorizeDispatch(consumedPlanned, registrationKey, boundKey)
+			require.NoError(t, err)
+			terminal, err := MarkEffectTerminal(authorized, registrationKey, boundKey, executedTerminalEvidence())
+			require.NoError(t, err)
+			if tc.name == "namespace" {
+				terminal, err = DrainInstallation(terminal)
+				require.NoError(t, err)
+				terminal, _ = commitInstallationDrain(t, terminal, "503")
+			}
+			consumed, err := ConsumeEffect(terminal, registrationKey, boundKey)
+			require.NoError(t, err)
+			require.Equal(t, manifestDigest, tc.digest(consumed))
+			require.True(t, tc.contains(consumed, registrationKey, plannedKey))
+			require.True(t, tc.contains(consumed, registrationKey, boundKey))
+
+			unchanged, err = AdvanceEffectState(consumed, registrationKey, boundKey, EffectStateObjectBound)
+			require.ErrorIs(t, err, ErrEffectStateRegression)
+			requireStateEqual(t, consumed, unchanged)
+			unchanged, _, err = PlanEffect(consumed, registrationKey, testWindowEffect("late-window"), limits)
+			require.Error(t, err)
+			requireStateEqual(t, consumed, unchanged)
+		})
+	}
+}
+
+func TestDispatchAuthorizationIsBoundAndNotReplayable(t *testing.T) {
+	state, registrationKey, limits := registeredFence(t)
+	effect := testUnitEffect("unit-1")
+	planned, effectKey, err := PlanEffect(state, registrationKey, effect, limits)
+	require.NoError(t, err)
+
+	unchanged, err := AuthorizeDispatch(planned, registrationKey, effectKey)
+	require.ErrorIs(t, err, ErrEffectObjectNotBound)
+	requireStateEqual(t, planned, unchanged)
+
+	bound, err := ObserveEffectObject(planned, registrationKey, effectKey, presentObservation(effect, types.UID("unit-object-uid-1")))
+	require.NoError(t, err)
+	authorized, err := AuthorizeDispatch(bound, registrationKey, effectKey)
+	require.NoError(t, err)
+	require.Equal(t, EffectStateDispatchAuthorized, EffectStateOf(authorized, registrationKey, effectKey))
+
+	unchanged, err = AuthorizeDispatch(authorized, registrationKey, effectKey)
+	require.ErrorIs(t, err, ErrDispatchOutcomeUnknown)
+	requireStateEqual(t, authorized, unchanged)
+
+	for _, drain := range []func(FenceState) (FenceState, error){
+		func(state FenceState) (FenceState, error) {
+			return DrainNamespace(state, testRegistrationIdentity().NamespaceUID)
+		},
+		DrainInstallation,
+	} {
+		draining, err := drain(bound)
+		require.NoError(t, err)
+		unchanged, err := AuthorizeDispatch(draining, registrationKey, effectKey)
+		require.Error(t, err)
+		requireStateEqual(t, draining, unchanged)
+	}
+}
+
+func TestStoredProtocolFenceStatusMatchesIndependentJSONContract(t *testing.T) {
+	identity := testRegistrationIdentity()
+	limits := generousRegistryLimits()
+	base := newFenceState(t, identity.InstallationEpoch, identity.NamespaceUID, testFenceObjectIdentity())
+	baseExpected := expectedStoredStatusBytes(t, identity.InstallationEpoch, identity.NamespaceUID, nil)
+	require.JSONEq(t, string(baseExpected), string(storedStateBytes(t, base)))
+	requireWrongFenceUIDDecodeRejected(t, baseExpected)
+
+	registered, registrationKey, err := RegisterExecution(base, identity, limits)
+	require.NoError(t, err)
+	registeredExpected := expectedStoredStatusBytes(t, identity.InstallationEpoch, identity.NamespaceUID, []storedRegistrationDTO{{
+		Key:      registrationKey,
+		Identity: storedRegistrationIdentityDTOFrom(identity),
+		Phase:    string(RegistrationPhaseActive),
+	}})
+	require.JSONEq(t, string(registeredExpected), string(storedStateBytes(t, registered)))
+	requireWrongFenceUIDDecodeRejected(t, registeredExpected)
+
+	effect := testWindowEffect("target-window-1")
+	planned, effectKey, err := PlanEffect(registered, registrationKey, effect, limits)
+	require.NoError(t, err)
+	plannedDTO := storedProtocolFenceStatusDTO{
+		ProtocolVersion:   storedProtocolFenceStatusV1,
+		FenceUIDDigest:    externalUIDDigest(testFenceObjectIdentity().UID),
+		InstallationEpoch: identity.InstallationEpoch,
+		Namespaces:        []storedNamespaceDTO{{UID: identity.NamespaceUID}},
+		Registrations: []storedRegistrationDTO{{
+			Key:      registrationKey,
+			Identity: storedRegistrationIdentityDTOFrom(identity),
+			Phase:    string(RegistrationPhaseActive),
+			Effects: []storedEffectDTO{{
+				Key:      effectKey,
+				Identity: storedEffectIdentityDTOFrom(effect),
+				State:    string(EffectStatePlanned),
+			}},
+		}},
+	}
+	plannedExpected := marshalExpectedStoredStatus(t, plannedDTO)
+	require.JSONEq(t, string(plannedExpected), string(storedStateBytes(t, planned)))
+	requireWrongFenceUIDDecodeRejected(t, plannedExpected)
+	require.Less(t, len(baseExpected), len(registeredExpected))
+	require.Less(t, len(registeredExpected), len(plannedExpected))
+
+	namespaceManifest := expectedStoredManifest("namespace:"+string(identity.NamespaceUID), []string{registrationKey}, []string{effectKey})
+	namespaceDraining, err := DrainNamespace(planned, identity.NamespaceUID)
+	require.NoError(t, err)
+	namespaceDTO := plannedDTO
+	namespaceDTO.Namespaces = []storedNamespaceDTO{{UID: identity.NamespaceUID, Manifest: namespaceManifest}}
+	namespaceUnboundExpected := marshalExpectedStoredStatus(t, namespaceDTO)
+	require.JSONEq(t, string(namespaceUnboundExpected), string(storedStateBytes(t, namespaceDraining)))
+	namespaceReadback := FenceObjectReadback{
+		UID:                testFenceObjectIdentity().UID,
+		ResourceVersion:    "502",
+		StoredStatusDigest: testDigest(string(namespaceUnboundExpected)),
+	}
+	namespaceCommitted, err := BindDrainCommitReadback(namespaceDraining, NamespaceDrainScope(identity.NamespaceUID), namespaceReadback)
+	require.NoError(t, err)
+	namespaceManifest.CommitReadback = storedFenceReadbackDTOFrom(namespaceReadback)
+	namespaceExpected := marshalExpectedStoredStatus(t, namespaceDTO)
+	require.JSONEq(t, string(namespaceExpected), string(storedStateBytes(t, namespaceCommitted)))
+	namespaceIdentity := NamespaceDrainIdentity(namespaceCommitted, identity.NamespaceUID)
+	require.Equal(t, namespaceManifest.Token, namespaceIdentity.Token)
+	require.Equal(t, namespaceManifest.Digest, namespaceIdentity.ManifestDigest)
+	require.Less(t, len(plannedExpected), len(namespaceExpected))
+
+	installationManifest := expectedStoredManifest("installation:"+identity.InstallationEpoch, []string{registrationKey}, []string{effectKey})
+	installationDraining, err := DrainInstallation(planned)
+	require.NoError(t, err)
+	installationDTO := plannedDTO
+	installationDTO.InstallationManifest = installationManifest
+	installationUnboundExpected := marshalExpectedStoredStatus(t, installationDTO)
+	require.JSONEq(t, string(installationUnboundExpected), string(storedStateBytes(t, installationDraining)))
+	installationReadback := FenceObjectReadback{
+		UID:                testFenceObjectIdentity().UID,
+		ResourceVersion:    "503",
+		StoredStatusDigest: testDigest(string(installationUnboundExpected)),
+	}
+	installationCommitted, err := BindDrainCommitReadback(installationDraining, InstallationDrainScope(), installationReadback)
+	require.NoError(t, err)
+	installationManifest.CommitReadback = storedFenceReadbackDTOFrom(installationReadback)
+	installationExpected := marshalExpectedStoredStatus(t, installationDTO)
+	require.JSONEq(t, string(installationExpected), string(storedStateBytes(t, installationCommitted)))
+	installationIdentity := InstallationDrainIdentity(installationCommitted)
+	require.Equal(t, installationManifest.Token, installationIdentity.Token)
+	require.Equal(t, installationManifest.Digest, installationIdentity.ManifestDigest)
+	require.Less(t, len(plannedExpected), len(installationExpected))
+}
+
+func TestStoredStatusRoundTripPreservesDurableEffectAndDrainEvidence(t *testing.T) {
+	identity := testRegistrationIdentity()
+	state, registrationKey, limits := registeredFence(t)
+	effect := testUnitEffect("unit-1")
+	planned, effectKey, err := PlanEffect(state, registrationKey, effect, limits)
+	require.NoError(t, err)
+	dto := storedProtocolFenceStatusDTO{
+		ProtocolVersion:   storedProtocolFenceStatusV1,
+		FenceUIDDigest:    externalUIDDigest(testFenceObjectIdentity().UID),
+		InstallationEpoch: identity.InstallationEpoch,
+		Namespaces:        []storedNamespaceDTO{{UID: identity.NamespaceUID}},
+		Registrations: []storedRegistrationDTO{{
+			Key:      registrationKey,
+			Identity: storedRegistrationIdentityDTOFrom(identity),
+			Phase:    string(RegistrationPhaseActive),
+			Effects: []storedEffectDTO{{
+				Key:      effectKey,
+				Identity: storedEffectIdentityDTOFrom(effect),
+				State:    string(EffectStatePlanned),
+			}},
+		}},
+	}
+	require.JSONEq(t, string(marshalExpectedStoredStatus(t, dto)), string(storedStateBytes(t, planned)))
+
+	present := presentObservation(effect, types.UID(strings.Repeat("u", testMaxEffectObjectUIDBytes)))
+	present.ObjectResourceVersion = strings.Repeat("9", testMaxEffectObjectResourceVersionBytes)
+	bound, err := ObserveEffectObject(planned, registrationKey, effectKey, present)
+	require.NoError(t, err)
+	dto.Registrations[0].Effects[0].State = string(EffectStateObjectBound)
+	dto.Registrations[0].Effects[0].ObjectBinding = &storedObjectBindingDTO{
+		Target:                present.Target,
+		UIDDigest:             externalUIDDigest(present.ObjectUID),
+		ResourceVersionDigest: externalResourceVersionDigest(present.ObjectResourceVersion),
+	}
+	boundExpected := marshalExpectedStoredStatus(t, dto)
+	require.JSONEq(t, string(boundExpected), string(storedStateBytes(t, bound)))
+	requireWrongFenceUIDDecodeRejected(t, boundExpected)
+	restartedBound, err := DecodeStoredProtocolFenceStatus(boundExpected, testFenceObjectIdentity())
+	require.NoError(t, err)
+	wrongUID := present
+	wrongUID.ObjectUID = types.UID("different-object-uid")
+	unchanged, err := ObserveEffectObject(restartedBound, registrationKey, effectKey, wrongUID)
+	require.ErrorIs(t, err, ErrEffectObjectIdentityConflict)
+	requireStateEqual(t, restartedBound, unchanged)
+
+	authorized, err := AuthorizeDispatch(bound, registrationKey, effectKey)
+	require.NoError(t, err)
+	dto.Registrations[0].Effects[0].State = string(EffectStateDispatchAuthorized)
+	dto.Registrations[0].Effects[0].Dispatch = &storedDispatchAuthorizationDTO{Token: expectedDispatchToken(registrationKey, effectKey, externalUIDDigest(present.ObjectUID))}
+	authorizedExpected := marshalExpectedStoredStatus(t, dto)
+	require.JSONEq(t, string(authorizedExpected), string(storedStateBytes(t, authorized)))
+	requireWrongFenceUIDDecodeRejected(t, authorizedExpected)
+	restartedAuthorized, err := DecodeStoredProtocolFenceStatus(authorizedExpected, testFenceObjectIdentity())
+	require.NoError(t, err)
+	unchanged, err = AuthorizeDispatch(restartedAuthorized, registrationKey, effectKey)
+	require.ErrorIs(t, err, ErrDispatchOutcomeUnknown)
+	requireStateEqual(t, restartedAuthorized, unchanged)
+
+	namespaceDraining, err := DrainNamespace(authorized, identity.NamespaceUID)
+	require.NoError(t, err)
+	namespaceManifest := expectedStoredManifest("namespace:"+string(identity.NamespaceUID), []string{registrationKey}, []string{effectKey})
+	dto.Namespaces[0].Manifest = namespaceManifest
+	namespaceUnboundExpected := marshalExpectedStoredStatus(t, dto)
+	require.JSONEq(t, string(namespaceUnboundExpected), string(storedStateBytes(t, namespaceDraining)))
+	namespaceReadback := FenceObjectReadback{
+		UID:                testFenceObjectIdentity().UID,
+		ResourceVersion:    strings.Repeat("8", testMaxFenceResourceVersionBytes),
+		StoredStatusDigest: testDigest(string(namespaceUnboundExpected)),
+	}
+	namespaceCommitted, err := BindDrainCommitReadback(namespaceDraining, NamespaceDrainScope(identity.NamespaceUID), namespaceReadback)
+	require.NoError(t, err)
+	namespaceManifest.CommitReadback = storedFenceReadbackDTOFrom(namespaceReadback)
+	require.JSONEq(t, string(marshalExpectedStoredStatus(t, dto)), string(storedStateBytes(t, namespaceCommitted)))
+
+	installationDraining, err := DrainInstallation(namespaceCommitted)
+	require.NoError(t, err)
+	installationManifest := expectedStoredManifest("installation:"+identity.InstallationEpoch, []string{registrationKey}, []string{effectKey})
+	dto.InstallationManifest = installationManifest
+	installationUnboundExpected := marshalExpectedStoredStatus(t, dto)
+	require.JSONEq(t, string(installationUnboundExpected), string(storedStateBytes(t, installationDraining)))
+	installationReadback := FenceObjectReadback{
+		UID:                testFenceObjectIdentity().UID,
+		ResourceVersion:    strings.Repeat("9", testMaxFenceResourceVersionBytes),
+		StoredStatusDigest: testDigest(string(installationUnboundExpected)),
+	}
+	installationCommitted, err := BindDrainCommitReadback(installationDraining, InstallationDrainScope(), installationReadback)
+	require.NoError(t, err)
+	installationManifest.CommitReadback = storedFenceReadbackDTOFrom(installationReadback)
+
+	terminalEvidence := maxTerminalEvidence()
+	terminal, err := MarkEffectTerminal(installationCommitted, registrationKey, effectKey, terminalEvidence)
+	require.NoError(t, err)
+	dto.Registrations[0].Effects[0].State = string(EffectStateTerminal)
+	dto.Registrations[0].Effects[0].CloseoutVariant = string(CloseoutVariantUnitExecuted)
+	dto.Registrations[0].Effects[0].Terminal = storedTerminalEvidenceDTOFrom(terminalEvidence)
+	require.JSONEq(t, string(marshalExpectedStoredStatus(t, dto)), string(storedStateBytes(t, terminal)))
+
+	consumed, err := ConsumeEffect(terminal, registrationKey, effectKey)
+	require.NoError(t, err)
+	dto.Registrations[0].Effects[0].State = string(EffectStateConsumed)
+	dto.Registrations[0].Effects[0].Tombstone = &storedConsumedTombstoneDTO{IdentityDigest: expectedConsumedTombstoneDigest(effectKey)}
+	consumed, err = ConsumeRegistration(consumed, registrationKey)
+	require.NoError(t, err)
+	dto.Registrations[0].Phase = string(RegistrationPhaseConsumed)
+	finalExpected := marshalExpectedStoredStatus(t, dto)
+	require.JSONEq(t, string(finalExpected), string(storedStateBytes(t, consumed)))
+	_, err = DecodeStoredProtocolFenceStatus(finalExpected, FenceObjectIdentity{UID: types.UID("protocol-fence-uid-2")})
+	require.ErrorIs(t, err, ErrFenceReadbackMismatch)
+
+	restarted, err := DecodeStoredProtocolFenceStatus(finalExpected, testFenceObjectIdentity())
+	require.NoError(t, err)
+	unchanged, err = RebindDrainCommitReadback(restarted, InstallationDrainScope(), FenceObjectReadback{
+		UID:                testFenceObjectIdentity().UID,
+		ResourceVersion:    "new-resource-version",
+		StoredStatusDigest: testDigest("new-status"),
+	})
+	require.ErrorIs(t, err, ErrDrainReadbackAlreadyBound)
+	requireStateEqual(t, restarted, unchanged)
+	unchanged, _, err = PlanEffect(restarted, registrationKey, effect, limits)
+	require.ErrorIs(t, err, ErrEffectAlreadyConsumed)
+	requireStateEqual(t, restarted, unchanged)
+}
+
+func TestDecodeStoredStatusRejectsEveryInconsistentInvariant(t *testing.T) {
+	valid := validFinalStoredStatusDTO(t)
+	validBytes := marshalExpectedStoredStatus(t, valid)
+	_, err := DecodeStoredProtocolFenceStatus(validBytes, testFenceObjectIdentity())
+	require.NoError(t, err)
+
+	for name, mutate := range map[string]func(*storedProtocolFenceStatusDTO){
+		"unknown protocol version":     func(v *storedProtocolFenceStatusDTO) { v.ProtocolVersion = "v2" },
+		"top Fence UID digest missing": func(v *storedProtocolFenceStatusDTO) { v.FenceUIDDigest = "" },
+		"registration key mismatch":    func(v *storedProtocolFenceStatusDTO) { v.Registrations[0].Key = testDigest("wrong-registration") },
+		"duplicate registration key":   func(v *storedProtocolFenceStatusDTO) { v.Registrations = append(v.Registrations, v.Registrations[0]) },
+		"drained manifest misses appended zero-effect registration": func(v *storedProtocolFenceStatusDTO) {
+			identity := testRegistrationIdentity()
+			identity.ExecutionUID = types.UID("execution-uid-2")
+			identity.AttemptID = "attempt-4"
+			key, err := RegistrationKey(identity)
+			require.NoError(t, err)
+			v.Registrations = append(v.Registrations, storedRegistrationDTO{Key: key, Identity: storedRegistrationIdentityDTOFrom(identity), Phase: string(RegistrationPhaseActive)})
+		},
+		"drained manifest retains removed registration": func(v *storedProtocolFenceStatusDTO) { v.Registrations = nil },
+		"unknown registration phase":                    func(v *storedProtocolFenceStatusDTO) { v.Registrations[0].Phase = "UnknownPhase" },
+		"effect key mismatch":                           func(v *storedProtocolFenceStatusDTO) { v.Registrations[0].Effects[0].Key = testDigest("wrong-effect") },
+		"duplicate effect key": func(v *storedProtocolFenceStatusDTO) {
+			v.Registrations[0].Effects = append(v.Registrations[0].Effects, v.Registrations[0].Effects[0])
+		},
+		"unknown effect state":   func(v *storedProtocolFenceStatusDTO) { v.Registrations[0].Effects[0].State = "UnknownState" },
+		"object binding missing": func(v *storedProtocolFenceStatusDTO) { v.Registrations[0].Effects[0].ObjectBinding = nil },
+		"object target mismatch": func(v *storedProtocolFenceStatusDTO) {
+			v.Registrations[0].Effects[0].ObjectBinding.Target.Kind = "GateWindow"
+		},
+		"object UID digest malformed": func(v *storedProtocolFenceStatusDTO) {
+			v.Registrations[0].Effects[0].ObjectBinding.UIDDigest = "sha256:short"
+		},
+		"object RV digest missing": func(v *storedProtocolFenceStatusDTO) {
+			v.Registrations[0].Effects[0].ObjectBinding.ResourceVersionDigest = ""
+		},
+		"dispatch token wrong": func(v *storedProtocolFenceStatusDTO) {
+			v.Registrations[0].Effects[0].Dispatch.Token = testDigest("wrong-dispatch")
+		},
+		"Planned carries dispatch": func(v *storedProtocolFenceStatusDTO) {
+			v.Registrations[0].Effects[0].State = string(EffectStatePlanned)
+		},
+		"terminal evidence missing":  func(v *storedProtocolFenceStatusDTO) { v.Registrations[0].Effects[0].Terminal = nil },
+		"Consumed tombstone missing": func(v *storedProtocolFenceStatusDTO) { v.Registrations[0].Effects[0].Tombstone = nil },
+		"Consumed tombstone wrong": func(v *storedProtocolFenceStatusDTO) {
+			v.Registrations[0].Effects[0].Tombstone.IdentityDigest = testDigest("wrong-tombstone")
+		},
+		"namespace manifest token wrong":            func(v *storedProtocolFenceStatusDTO) { v.Namespaces[0].Manifest.Token = testDigest("wrong-token") },
+		"namespace manifest digest wrong":           func(v *storedProtocolFenceStatusDTO) { v.Namespaces[0].Manifest.Digest = testDigest("wrong-manifest") },
+		"namespace manifest registration set wrong": func(v *storedProtocolFenceStatusDTO) { v.Namespaces[0].Manifest.RegistrationKeys = nil },
+		"namespace manifest effect set wrong":       func(v *storedProtocolFenceStatusDTO) { v.Namespaces[0].Manifest.EffectKeys = nil },
+		"namespace readback UID missing":            func(v *storedProtocolFenceStatusDTO) { v.Namespaces[0].Manifest.CommitReadback.UIDDigest = "" },
+		"namespace readback RV malformed": func(v *storedProtocolFenceStatusDTO) {
+			v.Namespaces[0].Manifest.CommitReadback.ResourceVersionDigest = "sha256:short"
+		},
+		"installation manifest missing": func(v *storedProtocolFenceStatusDTO) { v.InstallationManifest = nil },
+		"installation manifest digest wrong": func(v *storedProtocolFenceStatusDTO) {
+			v.InstallationManifest.Digest = testDigest("wrong-installation-manifest")
+		},
+		"installation readback status digest missing": func(v *storedProtocolFenceStatusDTO) { v.InstallationManifest.CommitReadback.StoredStatusDigest = "" },
+		"installation commit readback missing":        func(v *storedProtocolFenceStatusDTO) { v.InstallationManifest.CommitReadback = nil },
+	} {
+		t.Run(name, func(t *testing.T) {
+			invalid := cloneStoredStatusDTO(t, valid)
+			mutate(&invalid)
+			decoded, err := DecodeStoredProtocolFenceStatus(marshalExpectedStoredStatus(t, invalid), testFenceObjectIdentity())
+			require.ErrorIs(t, err, ErrStoredStatusInvalid)
+			require.True(t, IsZeroFenceState(decoded), "decoder must not return partially usable state")
+		})
+	}
+
+	t.Run("integrity digest mismatch", func(t *testing.T) {
+		invalid := cloneStoredStatusDTO(t, valid)
+		invalid.Registrations[0].Phase = "tampered-without-reseal"
+		data, err := json.Marshal(invalid)
+		require.NoError(t, err)
+		decoded, err := DecodeStoredProtocolFenceStatus(data, testFenceObjectIdentity())
+		require.ErrorIs(t, err, ErrStoredStatusIntegrity)
+		require.True(t, IsZeroFenceState(decoded))
+	})
+}
+
+func TestDecodeStoredStatusEnforcesExactPhaseEvidenceMatrix(t *testing.T) {
+	for _, phase := range []EffectState{
+		EffectStatePlanned,
+		EffectStateObjectBound,
+		EffectStateDispatchAuthorized,
+		EffectStateTerminal,
+		EffectStateConsumed,
+	} {
+		t.Run("valid "+string(phase), func(t *testing.T) {
+			valid := validStoredStatusForPhase(t, phase)
+			_, err := DecodeStoredProtocolFenceStatus(marshalExpectedStoredStatus(t, valid), testFenceObjectIdentity())
+			require.NoError(t, err)
+		})
+	}
+	for name, status := range map[string]storedProtocolFenceStatusDTO{
+		"valid Window namespace NotFound Consumed":    validWindowConsumedStatusDTO(t, CloseoutVariantNotFound),
+		"valid Window installation NotFound Consumed": validWindowInstallationNotFoundConsumedStatusDTO(t),
+		"valid Window ObservedTerminal Terminal":      validWindowTerminalStatusDTO(t),
+		"valid Window ObservedTerminal Consumed":      validWindowConsumedStatusDTO(t, CloseoutVariantObservedTerminal),
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := DecodeStoredProtocolFenceStatus(marshalExpectedStoredStatus(t, status), testFenceObjectIdentity())
+			require.NoError(t, err)
+		})
+	}
+	mixed := validMixedConsumedStatusDTO(t)
+	restartedMixed, err := DecodeStoredProtocolFenceStatus(marshalExpectedStoredStatus(t, mixed), testFenceObjectIdentity())
+	require.NoError(t, err)
+	for _, storedEffect := range mixed.Registrations[0].Effects {
+		unchanged, _, err := PlanEffect(restartedMixed, mixed.Registrations[0].Key, effectIdentityFromStored(storedEffect.Identity), generousRegistryLimits())
+		require.ErrorIs(t, err, ErrRegistrationAlreadyConsumed)
+		requireStateEqual(t, restartedMixed, unchanged)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		phase  EffectState
+		mutate func(*storedEffectDTO)
+	}{
+		{name: "Planned carries object", phase: EffectStatePlanned, mutate: func(v *storedEffectDTO) {
+			v.ObjectBinding = validFinalStoredStatusDTO(t).Registrations[0].Effects[0].ObjectBinding
+		}},
+		{name: "Planned carries dispatch", phase: EffectStatePlanned, mutate: func(v *storedEffectDTO) {
+			v.Dispatch = validFinalStoredStatusDTO(t).Registrations[0].Effects[0].Dispatch
+		}},
+		{name: "Planned carries terminal", phase: EffectStatePlanned, mutate: func(v *storedEffectDTO) {
+			v.Terminal = validFinalStoredStatusDTO(t).Registrations[0].Effects[0].Terminal
+		}},
+		{name: "Planned carries tombstone", phase: EffectStatePlanned, mutate: func(v *storedEffectDTO) {
+			v.Tombstone = validFinalStoredStatusDTO(t).Registrations[0].Effects[0].Tombstone
+		}},
+		{name: "Planned carries closeout variant", phase: EffectStatePlanned, mutate: func(v *storedEffectDTO) { v.CloseoutVariant = string(CloseoutVariantUnitExecuted) }},
+		{name: "Planned carries NotFound", phase: EffectStatePlanned, mutate: func(v *storedEffectDTO) {
+			v.NotFound = validWindowConsumedStatusDTO(t, CloseoutVariantNotFound).Registrations[0].Effects[0].NotFound
+		}},
+		{name: "ObjectBound missing object", phase: EffectStateObjectBound, mutate: func(v *storedEffectDTO) { v.ObjectBinding = nil }},
+		{name: "ObjectBound carries dispatch", phase: EffectStateObjectBound, mutate: func(v *storedEffectDTO) {
+			v.Dispatch = validFinalStoredStatusDTO(t).Registrations[0].Effects[0].Dispatch
+		}},
+		{name: "ObjectBound carries terminal", phase: EffectStateObjectBound, mutate: func(v *storedEffectDTO) {
+			v.Terminal = validFinalStoredStatusDTO(t).Registrations[0].Effects[0].Terminal
+		}},
+		{name: "ObjectBound carries tombstone", phase: EffectStateObjectBound, mutate: func(v *storedEffectDTO) {
+			v.Tombstone = validFinalStoredStatusDTO(t).Registrations[0].Effects[0].Tombstone
+		}},
+		{name: "ObjectBound carries closeout variant", phase: EffectStateObjectBound, mutate: func(v *storedEffectDTO) { v.CloseoutVariant = string(CloseoutVariantUnitExecuted) }},
+		{name: "ObjectBound carries NotFound", phase: EffectStateObjectBound, mutate: func(v *storedEffectDTO) {
+			v.NotFound = validWindowConsumedStatusDTO(t, CloseoutVariantNotFound).Registrations[0].Effects[0].NotFound
+		}},
+		{name: "DispatchAuthorized missing object", phase: EffectStateDispatchAuthorized, mutate: func(v *storedEffectDTO) { v.ObjectBinding = nil }},
+		{name: "DispatchAuthorized missing dispatch", phase: EffectStateDispatchAuthorized, mutate: func(v *storedEffectDTO) { v.Dispatch = nil }},
+		{name: "DispatchAuthorized carries terminal", phase: EffectStateDispatchAuthorized, mutate: func(v *storedEffectDTO) {
+			v.Terminal = validFinalStoredStatusDTO(t).Registrations[0].Effects[0].Terminal
+		}},
+		{name: "DispatchAuthorized carries tombstone", phase: EffectStateDispatchAuthorized, mutate: func(v *storedEffectDTO) {
+			v.Tombstone = validFinalStoredStatusDTO(t).Registrations[0].Effects[0].Tombstone
+		}},
+		{name: "DispatchAuthorized carries closeout variant", phase: EffectStateDispatchAuthorized, mutate: func(v *storedEffectDTO) { v.CloseoutVariant = string(CloseoutVariantUnitExecuted) }},
+		{name: "DispatchAuthorized carries NotFound", phase: EffectStateDispatchAuthorized, mutate: func(v *storedEffectDTO) {
+			v.NotFound = validWindowConsumedStatusDTO(t, CloseoutVariantNotFound).Registrations[0].Effects[0].NotFound
+		}},
+		{name: "Terminal missing object", phase: EffectStateTerminal, mutate: func(v *storedEffectDTO) { v.ObjectBinding = nil }},
+		{name: "Terminal missing dispatch", phase: EffectStateTerminal, mutate: func(v *storedEffectDTO) { v.Dispatch = nil }},
+		{name: "Terminal missing terminal evidence", phase: EffectStateTerminal, mutate: func(v *storedEffectDTO) { v.Terminal = nil }},
+		{name: "Terminal carries tombstone", phase: EffectStateTerminal, mutate: func(v *storedEffectDTO) {
+			v.Tombstone = validFinalStoredStatusDTO(t).Registrations[0].Effects[0].Tombstone
+		}},
+		{name: "Terminal missing closeout variant", phase: EffectStateTerminal, mutate: func(v *storedEffectDTO) { v.CloseoutVariant = "" }},
+		{name: "Unit Terminal uses Window variant", phase: EffectStateTerminal, mutate: func(v *storedEffectDTO) { v.CloseoutVariant = string(CloseoutVariantObservedTerminal) }},
+		{name: "Terminal carries NotFound", phase: EffectStateTerminal, mutate: func(v *storedEffectDTO) {
+			v.NotFound = validWindowConsumedStatusDTO(t, CloseoutVariantNotFound).Registrations[0].Effects[0].NotFound
+		}},
+		{name: "Consumed missing object", phase: EffectStateConsumed, mutate: func(v *storedEffectDTO) { v.ObjectBinding = nil }},
+		{name: "Consumed missing dispatch", phase: EffectStateConsumed, mutate: func(v *storedEffectDTO) { v.Dispatch = nil }},
+		{name: "Consumed missing terminal", phase: EffectStateConsumed, mutate: func(v *storedEffectDTO) { v.Terminal = nil }},
+		{name: "Consumed missing tombstone", phase: EffectStateConsumed, mutate: func(v *storedEffectDTO) { v.Tombstone = nil }},
+		{name: "Consumed missing closeout variant", phase: EffectStateConsumed, mutate: func(v *storedEffectDTO) { v.CloseoutVariant = "" }},
+		{name: "Consumed unknown closeout variant", phase: EffectStateConsumed, mutate: func(v *storedEffectDTO) { v.CloseoutVariant = "UnknownVariant" }},
+		{name: "Unit Consumed uses Window variant", phase: EffectStateConsumed, mutate: func(v *storedEffectDTO) { v.CloseoutVariant = string(CloseoutVariantObservedTerminal) }},
+		{name: "Unit Consumed carries NotFound", phase: EffectStateConsumed, mutate: func(v *storedEffectDTO) {
+			v.NotFound = validWindowConsumedStatusDTO(t, CloseoutVariantNotFound).Registrations[0].Effects[0].NotFound
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			invalid := validStoredStatusForPhase(t, tc.phase)
+			tc.mutate(&invalid.Registrations[0].Effects[0])
+			decoded, err := DecodeStoredProtocolFenceStatus(marshalExpectedStoredStatus(t, invalid), testFenceObjectIdentity())
+			require.ErrorIs(t, err, ErrStoredStatusInvalid)
+			require.True(t, IsZeroFenceState(decoded))
+		})
+	}
+
+	for _, tc := range []struct {
+		name    string
+		variant EffectCloseoutVariant
+		mutate  func(*storedEffectDTO)
+	}{
+		{name: "NotFound missing evidence", variant: CloseoutVariantNotFound, mutate: func(v *storedEffectDTO) { v.NotFound = nil }},
+		{name: "NotFound carries object", variant: CloseoutVariantNotFound, mutate: func(v *storedEffectDTO) {
+			v.ObjectBinding = validWindowConsumedStatusDTO(t, CloseoutVariantObservedTerminal).Registrations[0].Effects[0].ObjectBinding
+		}},
+		{name: "NotFound carries dispatch", variant: CloseoutVariantNotFound, mutate: func(v *storedEffectDTO) {
+			v.Dispatch = validFinalStoredStatusDTO(t).Registrations[0].Effects[0].Dispatch
+		}},
+		{name: "NotFound carries terminal", variant: CloseoutVariantNotFound, mutate: func(v *storedEffectDTO) {
+			v.Terminal = validWindowConsumedStatusDTO(t, CloseoutVariantObservedTerminal).Registrations[0].Effects[0].Terminal
+		}},
+		{name: "NotFound uses Observed variant", variant: CloseoutVariantNotFound, mutate: func(v *storedEffectDTO) { v.CloseoutVariant = string(CloseoutVariantObservedTerminal) }},
+		{name: "ObservedTerminal missing object", variant: CloseoutVariantObservedTerminal, mutate: func(v *storedEffectDTO) { v.ObjectBinding = nil }},
+		{name: "ObservedTerminal missing terminal", variant: CloseoutVariantObservedTerminal, mutate: func(v *storedEffectDTO) { v.Terminal = nil }},
+		{name: "ObservedTerminal carries dispatch", variant: CloseoutVariantObservedTerminal, mutate: func(v *storedEffectDTO) {
+			v.Dispatch = validFinalStoredStatusDTO(t).Registrations[0].Effects[0].Dispatch
+		}},
+		{name: "ObservedTerminal carries NotFound", variant: CloseoutVariantObservedTerminal, mutate: func(v *storedEffectDTO) {
+			v.NotFound = validWindowConsumedStatusDTO(t, CloseoutVariantNotFound).Registrations[0].Effects[0].NotFound
+		}},
+		{name: "ObservedTerminal uses Unit variant", variant: CloseoutVariantObservedTerminal, mutate: func(v *storedEffectDTO) { v.CloseoutVariant = string(CloseoutVariantUnitExecuted) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			invalid := validWindowConsumedStatusDTO(t, tc.variant)
+			tc.mutate(&invalid.Registrations[0].Effects[0])
+			decoded, err := DecodeStoredProtocolFenceStatus(marshalExpectedStoredStatus(t, invalid), testFenceObjectIdentity())
+			require.ErrorIs(t, err, ErrStoredStatusInvalid)
+			require.True(t, IsZeroFenceState(decoded))
+		})
+	}
+
+	for _, tc := range []struct {
+		name                   string
+		resealNotFoundEvidence bool
+		mutate                 func(*storedNotFoundEvidenceDTO)
+	}{
+		{name: "NotFound target API version mismatch", resealNotFoundEvidence: true, mutate: func(v *storedNotFoundEvidenceDTO) { v.Target.APIVersion = "wrong.example.io/v1" }},
+		{name: "NotFound target kind mismatch", resealNotFoundEvidence: true, mutate: func(v *storedNotFoundEvidenceDTO) { v.Target.Kind = "WrongKind" }},
+		{name: "NotFound target namespace mismatch", resealNotFoundEvidence: true, mutate: func(v *storedNotFoundEvidenceDTO) { v.Target.Namespace = "wrong-namespace" }},
+		{name: "NotFound target name mismatch", resealNotFoundEvidence: true, mutate: func(v *storedNotFoundEvidenceDTO) { v.Target.Name = "wrong-name" }},
+		{name: "NotFound drain token mismatch", resealNotFoundEvidence: true, mutate: func(v *storedNotFoundEvidenceDTO) { v.DrainToken = testDigest("wrong-drain-token") }},
+		{name: "NotFound manifest digest mismatch", resealNotFoundEvidence: true, mutate: func(v *storedNotFoundEvidenceDTO) { v.ManifestDigest = testDigest("wrong-manifest") }},
+		{name: "NotFound Fence UID digest mismatch", resealNotFoundEvidence: true, mutate: func(v *storedNotFoundEvidenceDTO) { v.FenceUIDDigest = externalUIDDigest(types.UID("wrong-fence-uid")) }},
+		{name: "NotFound Fence RV digest mismatch", resealNotFoundEvidence: true, mutate: func(v *storedNotFoundEvidenceDTO) {
+			v.FenceResourceVersionDigest = externalResourceVersionDigest("wrong-fence-rv")
+		}},
+		{name: "NotFound lookup RV digest empty", mutate: func(v *storedNotFoundEvidenceDTO) { v.LookupResourceVersionDigest = "" }},
+		{name: "NotFound lookup RV digest malformed", mutate: func(v *storedNotFoundEvidenceDTO) { v.LookupResourceVersionDigest = "not-a-digest" }},
+		{name: "NotFound lookup RV digest changed", mutate: func(v *storedNotFoundEvidenceDTO) {
+			v.LookupResourceVersionDigest = externalResourceVersionDigest("different-lookup-rv")
+		}},
+		{name: "NotFound evidence digest missing", mutate: func(v *storedNotFoundEvidenceDTO) { v.EvidenceDigest = "" }},
+		{name: "NotFound evidence digest mismatch", mutate: func(v *storedNotFoundEvidenceDTO) { v.EvidenceDigest = testDigest("wrong-notfound-evidence") }},
+	} {
+		for scope, valid := range map[string]storedProtocolFenceStatusDTO{
+			"namespace":    validWindowConsumedStatusDTO(t, CloseoutVariantNotFound),
+			"installation": validWindowInstallationNotFoundConsumedStatusDTO(t),
+		} {
+			t.Run(scope+"/"+tc.name, func(t *testing.T) {
+				invalid := cloneStoredStatusDTO(t, valid)
+				notFound := invalid.Registrations[0].Effects[0].NotFound
+				tc.mutate(notFound)
+				if tc.resealNotFoundEvidence {
+					notFound.EvidenceDigest = expectedNotFoundEvidenceDigest(*notFound)
+				}
+				decoded, err := DecodeStoredProtocolFenceStatus(marshalExpectedStoredStatus(t, invalid), testFenceObjectIdentity())
+				require.ErrorIs(t, err, ErrStoredStatusInvalid)
+				require.True(t, IsZeroFenceState(decoded))
+			})
+		}
+	}
+
+	t.Run("Consumed registration contains non-Consumed effect", func(t *testing.T) {
+		invalid := validStoredStatusForPhase(t, EffectStateTerminal)
+		invalid.Registrations[0].Phase = string(RegistrationPhaseConsumed)
+		decoded, err := DecodeStoredProtocolFenceStatus(marshalExpectedStoredStatus(t, invalid), testFenceObjectIdentity())
+		require.ErrorIs(t, err, ErrStoredStatusInvalid)
+		require.True(t, IsZeroFenceState(decoded))
+	})
+	t.Run("mixed Consumed registration contains one ObjectBound effect", func(t *testing.T) {
+		invalid := validMixedConsumedStatusDTO(t)
+		objectBoundUnit := validStoredStatusForPhase(t, EffectStateObjectBound).Registrations[0].Effects[0]
+		invalid.Registrations[0].Effects[0] = objectBoundUnit
+		decoded, err := DecodeStoredProtocolFenceStatus(marshalExpectedStoredStatus(t, invalid), testFenceObjectIdentity())
+		require.ErrorIs(t, err, ErrStoredStatusInvalid)
+		require.True(t, IsZeroFenceState(decoded))
+	})
+}
+
+func TestExternalEvidenceUsesFixedDigestsAndControllerEvidenceIsBounded(t *testing.T) {
+	state, registrationKey, limits := registeredFence(t)
+	effect := testUnitEffect("unit-1")
+	planned, effectKey, err := PlanEffect(state, registrationKey, effect, limits)
+	require.NoError(t, err)
+
+	var storedLengths []int
+	for _, size := range []int{testMaxEffectObjectUIDBytes, testMaxEffectObjectUIDBytes + 1} {
+		observation := presentObservation(effect, types.UID(strings.Repeat("u", size)))
+		observation.ObjectResourceVersion = strings.Repeat("9", testMaxEffectObjectResourceVersionBytes)
+		bound, err := ObserveEffectObject(planned, registrationKey, effectKey, observation)
+		require.NoError(t, err, "server-owned UID max+1 must be represented by a fixed digest, not rejected after child creation")
+		storedLengths = append(storedLengths, len(storedStateBytes(t, bound)))
+		replayed, err := ObserveEffectObject(bound, registrationKey, effectKey, observation)
+		require.NoError(t, err)
+		requireStateEqual(t, bound, replayed)
+	}
+	require.Equal(t, storedLengths[0], storedLengths[1])
+
+	storedLengths = nil
+	for _, size := range []int{testMaxEffectObjectResourceVersionBytes, testMaxEffectObjectResourceVersionBytes + 1} {
+		observation := presentObservation(effect, types.UID("unit-object-uid-1"))
+		observation.ObjectResourceVersion = strings.Repeat("9", size)
+		bound, err := ObserveEffectObject(planned, registrationKey, effectKey, observation)
+		require.NoError(t, err, "server-owned object RV max+1 must use a fixed digest")
+		storedLengths = append(storedLengths, len(storedStateBytes(t, bound)))
+	}
+	require.Equal(t, storedLengths[0], storedLengths[1])
+
+	storedLengths = nil
+	for _, size := range []int{testMaxFenceResourceVersionBytes, testMaxFenceResourceVersionBytes + 1} {
+		draining, err := DrainNamespace(planned, testRegistrationIdentity().NamespaceUID)
+		require.NoError(t, err)
+		readback := testFenceReadback(t, draining, strings.Repeat("9", size))
+		committed, err := BindDrainCommitReadback(draining, NamespaceDrainScope(testRegistrationIdentity().NamespaceUID), readback)
+		require.NoError(t, err, "server-owned Fence RV max+1 must use a fixed digest")
+		storedLengths = append(storedLengths, len(storedStateBytes(t, committed)))
+	}
+	require.Equal(t, storedLengths[0], storedLengths[1])
+
+	observation := presentObservation(effect, types.UID("unit-object-uid-1"))
+	bound, err := ObserveEffectObject(planned, registrationKey, effectKey, observation)
+	require.NoError(t, err)
+	authorized, err := AuthorizeDispatch(bound, registrationKey, effectKey)
+	require.NoError(t, err)
+	exactMax := maxTerminalEvidence()
+	terminal, err := MarkEffectTerminal(authorized, registrationKey, effectKey, exactMax)
+	require.NoError(t, err)
+	require.Equal(t, testMaxTerminalReasonCodeBytes, len(exactMax.ReasonCode))
+	require.NotEmpty(t, storedStateBytes(t, terminal))
+
+	tooLong := exactMax
+	tooLong.ReasonCode += "X"
+	unchanged, err := MarkEffectTerminal(authorized, registrationKey, effectKey, tooLong)
+	require.ErrorIs(t, err, ErrTerminalEvidenceTooLarge)
+	requireStateEqual(t, authorized, unchanged)
+}
+
+func TestRegistryCapacityBoundariesAreAtomic(t *testing.T) {
+	require.Equal(t, 4*1024, ReservedProtocolFenceStatusBytes, "reserve is frozen headroom for conditions and future status metadata")
+	require.Equal(t, testMaxTerminalReasonCodeBytes, MaxTerminalReasonCodeBytes)
+
+	t.Run("max namespaces", func(t *testing.T) {
+		limits := generousRegistryLimits()
+		limits.MaxNamespaces = 1
+		identity := testRegistrationIdentity()
+		state := newFenceState(t, identity.InstallationEpoch, identity.NamespaceUID, testFenceObjectIdentity())
+		registered, _, err := RegisterExecution(state, identity, limits)
+		require.NoError(t, err)
+		before := registrySnapshotOf(t, registered)
+
+		second := identity
+		second.ExecutionUID = types.UID("execution-uid-2")
+		second.AttemptID = "attempt-4"
+		second.NamespaceUID = types.UID("namespace-uid-2")
+		second.AuthorityUID = types.UID("authority-uid-2")
+		second.QueueUID = types.UID("queue-uid-2")
+		next, _, err := RegisterExecution(registered, second, limits)
+		require.ErrorIs(t, err, ErrRegistryCapacity)
+		requireRegistrySnapshotEqual(t, before, next)
+	})
+
+	t.Run("max registrations", func(t *testing.T) {
+		limits := generousRegistryLimits()
+		limits.MaxRegistrations = 1
+		state, _, _ := registeredFenceWithLimits(t, limits)
+		before := registrySnapshotOf(t, state)
+		second := testRegistrationIdentity()
+		second.ExecutionUID = types.UID("execution-uid-2")
+		second.AttemptID = "attempt-4"
+		next, _, err := RegisterExecution(state, second, limits)
+		require.ErrorIs(t, err, ErrRegistryCapacity)
+		requireRegistrySnapshotEqual(t, before, next)
+	})
+
+	t.Run("max effects", func(t *testing.T) {
+		limits := generousRegistryLimits()
+		limits.MaxEffects = 1
+		state, registrationKey, _ := registeredFenceWithLimits(t, limits)
+		planned, _, err := PlanEffect(state, registrationKey, testWindowEffect("target-window-1"), limits)
+		require.NoError(t, err)
+		before := registrySnapshotOf(t, planned)
+		next, _, err := PlanEffect(planned, registrationKey, testWindowEffect("target-window-2"), limits)
+		require.ErrorIs(t, err, ErrRegistryCapacity)
+		requireRegistrySnapshotEqual(t, before, next)
+	})
+
+	t.Run("registration status bytes boundary and plus one", func(t *testing.T) {
+		identity := testRegistrationIdentity()
+		identity.AttemptID = strings.Repeat("a", 512)
+		base := newFenceState(t, identity.InstallationEpoch, identity.NamespaceUID, testFenceObjectIdentity())
+		unlimited := generousRegistryLimits()
+		candidate, _, err := RegisterExecution(base, identity, unlimited)
+		require.NoError(t, err)
+		registrationKey, err := RegistrationKey(identity)
+		require.NoError(t, err)
+		expectedDTO := storedProtocolFenceStatusDTO{
+			ProtocolVersion:   storedProtocolFenceStatusV1,
+			FenceUIDDigest:    externalUIDDigest(testFenceObjectIdentity().UID),
+			InstallationEpoch: identity.InstallationEpoch,
+			Namespaces:        []storedNamespaceDTO{{UID: identity.NamespaceUID}},
+			Registrations: []storedRegistrationDTO{{
+				Key:      registrationKey,
+				Identity: storedRegistrationIdentityDTOFrom(identity),
+				Phase:    string(RegistrationPhaseActive),
+			}},
+		}
+		expected := marshalExpectedStoredStatus(t, expectedDTO)
+		require.JSONEq(t, string(expected), string(storedStateBytes(t, candidate)))
+		closeoutReserve := expectedCloseoutReserve(t, expectedDTO)
+		require.Equal(t, closeoutReserve, RequiredCloseoutReserve(candidate))
+		exact := len(expected) + closeoutReserve + ReservedProtocolFenceStatusBytes
+
+		limits := unlimited
+		limits.MaxStatusBytes = exact
+		_, _, err = RegisterExecution(base, identity, limits)
+		require.NoError(t, err)
+		limits.MaxStatusBytes = exact - 1
+		next, _, err := RegisterExecution(base, identity, limits)
+		require.ErrorIs(t, err, ErrRegistryCapacity)
+		requireRegistrySnapshotEqual(t, registrySnapshotOf(t, base), next)
+	})
+
+	t.Run("effect status bytes boundary and plus one", func(t *testing.T) {
+		state, registrationKey, limits := registeredFence(t)
+		effect := testWindowEffect(strings.Repeat("w", 512))
+		candidate, _, err := PlanEffect(state, registrationKey, effect, limits)
+		require.NoError(t, err)
+		effectKey, err := EffectKey(registrationKey, effect)
+		require.NoError(t, err)
+		expectedDTO := storedProtocolFenceStatusDTO{
+			ProtocolVersion:   storedProtocolFenceStatusV1,
+			FenceUIDDigest:    externalUIDDigest(testFenceObjectIdentity().UID),
+			InstallationEpoch: testRegistrationIdentity().InstallationEpoch,
+			Namespaces:        []storedNamespaceDTO{{UID: testRegistrationIdentity().NamespaceUID}},
+			Registrations: []storedRegistrationDTO{{
+				Key:      registrationKey,
+				Identity: storedRegistrationIdentityDTOFrom(testRegistrationIdentity()),
+				Phase:    string(RegistrationPhaseActive),
+				Effects: []storedEffectDTO{{
+					Key:      effectKey,
+					Identity: storedEffectIdentityDTOFrom(effect),
+					State:    string(EffectStatePlanned),
+				}},
+			}},
+		}
+		expected := marshalExpectedStoredStatus(t, expectedDTO)
+		require.JSONEq(t, string(expected), string(storedStateBytes(t, candidate)))
+		closeoutReserve := expectedCloseoutReserve(t, expectedDTO)
+		require.Equal(t, closeoutReserve, RequiredCloseoutReserve(candidate))
+		exact := len(expected) + closeoutReserve + ReservedProtocolFenceStatusBytes
+
+		limits.MaxStatusBytes = exact
+		_, _, err = PlanEffect(state, registrationKey, effect, limits)
+		require.NoError(t, err)
+		limits.MaxStatusBytes = exact - 1
+		next, _, err := PlanEffect(state, registrationKey, effect, limits)
+		require.ErrorIs(t, err, ErrRegistryCapacity)
+		requireRegistrySnapshotEqual(t, registrySnapshotOf(t, state), next)
+	})
+}
+
+func TestPlanEffectReservesTwoLevelCloseoutCapacity(t *testing.T) {
+	firstIdentity := testRegistrationIdentity()
+	secondIdentity := testRegistrationIdentity()
+	secondIdentity.ExecutionUID = types.UID("execution-uid-2")
+	secondIdentity.AttemptID = "attempt-4"
+	secondIdentity.NamespaceUID = types.UID("namespace-uid-2")
+	secondIdentity.AuthorityUID = types.UID("authority-uid-2")
+	secondIdentity.QueueUID = types.UID("queue-uid-2")
+	effects := []struct {
+		registration int
+		identity     EffectIdentity
+	}{
+		{registration: 0, identity: testUnitEffect("unit-" + strings.Repeat("a", 128))},
+		{registration: 1, identity: testUnitEffect("unit-" + strings.Repeat("b", 128))},
+		{registration: 0, identity: testUnitEffect("unit-" + strings.Repeat("c", 128))},
+		{registration: 1, identity: testWindowEffect("window-" + strings.Repeat("d", 128))},
+	}
+
+	probeLimits := generousRegistryLimits()
+	probe, probeRegistrationKeys := registerTwoNamespaces(t, firstIdentity, secondIdentity, probeLimits)
+	probeDTO := storedProtocolFenceStatusDTO{
+		ProtocolVersion:   storedProtocolFenceStatusV1,
+		FenceUIDDigest:    externalUIDDigest(testFenceObjectIdentity().UID),
+		InstallationEpoch: firstIdentity.InstallationEpoch,
+		Namespaces: []storedNamespaceDTO{
+			{UID: firstIdentity.NamespaceUID},
+			{UID: secondIdentity.NamespaceUID},
+		},
+		Registrations: []storedRegistrationDTO{
+			{Key: probeRegistrationKeys[0], Identity: storedRegistrationIdentityDTOFrom(firstIdentity), Phase: string(RegistrationPhaseActive)},
+			{Key: probeRegistrationKeys[1], Identity: storedRegistrationIdentityDTOFrom(secondIdentity), Phase: string(RegistrationPhaseActive)},
+		},
+	}
+	for _, effect := range effects {
+		var effectKey string
+		var err error
+		probe, effectKey, err = PlanEffect(probe, probeRegistrationKeys[effect.registration], effect.identity, probeLimits)
+		require.NoError(t, err)
+		probeDTO.Registrations[effect.registration].Effects = append(probeDTO.Registrations[effect.registration].Effects, storedEffectDTO{
+			Key:      effectKey,
+			Identity: storedEffectIdentityDTOFrom(effect.identity),
+			State:    string(EffectStatePlanned),
+		})
+	}
+	probePlannedBytes := marshalExpectedStoredStatus(t, probeDTO)
+	require.JSONEq(t, string(probePlannedBytes), string(storedStateBytes(t, probe)))
+	maxStatusBytes := len(probePlannedBytes) + expectedCloseoutReserve(t, probeDTO) + ReservedProtocolFenceStatusBytes
+
+	limits := probeLimits
+	limits.MaxEffects = 64
+	limits.MaxStatusBytes = maxStatusBytes
+	state, registrationKeys := registerTwoNamespaces(t, firstIdentity, secondIdentity, limits)
+	acceptedDTO := cloneStoredStatusDTO(t, storedProtocolFenceStatusDTO{
+		ProtocolVersion:   storedProtocolFenceStatusV1,
+		FenceUIDDigest:    externalUIDDigest(testFenceObjectIdentity().UID),
+		InstallationEpoch: firstIdentity.InstallationEpoch,
+		Namespaces: []storedNamespaceDTO{
+			{UID: firstIdentity.NamespaceUID},
+			{UID: secondIdentity.NamespaceUID},
+		},
+		Registrations: []storedRegistrationDTO{
+			{Key: registrationKeys[0], Identity: storedRegistrationIdentityDTOFrom(firstIdentity), Phase: string(RegistrationPhaseActive)},
+			{Key: registrationKeys[1], Identity: storedRegistrationIdentityDTOFrom(secondIdentity), Phase: string(RegistrationPhaseActive)},
+		},
+	})
+
+	for _, effect := range effects {
+		var effectKey string
+		var err error
+		state, effectKey, err = PlanEffect(state, registrationKeys[effect.registration], effect.identity, limits)
+		require.NoError(t, err)
+		acceptedDTO.Registrations[effect.registration].Effects = append(acceptedDTO.Registrations[effect.registration].Effects, storedEffectDTO{
+			Key:      effectKey,
+			Identity: storedEffectIdentityDTOFrom(effect.identity),
+			State:    string(EffectStatePlanned),
+		})
+		require.Equal(t, expectedCloseoutReserve(t, acceptedDTO), RequiredCloseoutReserve(state))
+		maxCloseoutDTO := expectedMaxLegalCloseoutStatus(t, acceptedDTO)
+
+		closeout := state
+		for registrationIndex, registration := range acceptedDTO.Registrations {
+			for _, storedEffect := range registration.Effects {
+				plannedIdentity := effectIdentityFromStored(storedEffect.Identity)
+				maxEffect := storedEffectByKey(t, maxCloseoutDTO, storedEffect.Key)
+				if plannedIdentity.Kind == EffectKindTargetFenceWindow && maxEffect.CloseoutVariant == string(CloseoutVariantNotFound) {
+					continue
+				}
+				observation := presentObservation(plannedIdentity, types.UID(strings.Repeat("u", testMaxEffectObjectUIDBytes)))
+				observation.ObjectResourceVersion = strings.Repeat("9", testMaxEffectObjectResourceVersionBytes)
+				closeout, err = ObserveEffectObject(closeout, registrationKeys[registrationIndex], storedEffect.Key, observation)
+				require.NoError(t, err)
+				requireStoredWithinLimit(t, closeout, limits)
+				if plannedIdentity.Kind == EffectKindUnitExecution {
+					closeout, err = AuthorizeDispatch(closeout, registrationKeys[registrationIndex], storedEffect.Key)
+					require.NoError(t, err)
+					requireStoredWithinLimit(t, closeout, limits)
+				}
+			}
+		}
+
+		closeout, err = DrainNamespace(closeout, firstIdentity.NamespaceUID)
+		require.NoError(t, err)
+		requireStoredWithinLimit(t, closeout, limits)
+		closeout, err = BindDrainCommitReadback(closeout, NamespaceDrainScope(firstIdentity.NamespaceUID), testFenceReadback(t, closeout, strings.Repeat("7", testMaxFenceResourceVersionBytes)))
+		require.NoError(t, err)
+		requireStoredWithinLimit(t, closeout, limits)
+		closeout, err = DrainNamespace(closeout, secondIdentity.NamespaceUID)
+		require.NoError(t, err)
+		requireStoredWithinLimit(t, closeout, limits)
+		closeout, err = BindDrainCommitReadback(closeout, NamespaceDrainScope(secondIdentity.NamespaceUID), testFenceReadback(t, closeout, strings.Repeat("8", testMaxFenceResourceVersionBytes)))
+		require.NoError(t, err)
+		requireStoredWithinLimit(t, closeout, limits)
+		closeout, err = DrainInstallation(closeout)
+		require.NoError(t, err)
+		requireStoredWithinLimit(t, closeout, limits)
+		closeout, err = BindDrainCommitReadback(closeout, InstallationDrainScope(), testFenceReadback(t, closeout, strings.Repeat("9", testMaxFenceResourceVersionBytes)))
+		require.NoError(t, err)
+		requireStoredWithinLimit(t, closeout, limits)
+
+		for registrationIndex, registration := range acceptedDTO.Registrations {
+			for _, storedEffect := range registration.Effects {
+				plannedIdentity := effectIdentityFromStored(storedEffect.Identity)
+				maxEffect := storedEffectByKey(t, maxCloseoutDTO, storedEffect.Key)
+				if plannedIdentity.Kind == EffectKindTargetFenceWindow && maxEffect.CloseoutVariant == string(CloseoutVariantNotFound) {
+					drainIdentity := NamespaceDrainIdentity(closeout, registration.Identity.NamespaceUID)
+					closeout, err = ObserveEffectObject(closeout, registrationKeys[registrationIndex], storedEffect.Key, notFoundObservation(plannedIdentity, drainIdentity))
+					require.NoError(t, err)
+					requireStoredWithinLimit(t, closeout, limits)
+				} else {
+					terminalEvidence := maxTerminalEvidence()
+					if plannedIdentity.Kind == EffectKindTargetFenceWindow {
+						terminalEvidence.CloseoutVariant = CloseoutVariantObservedTerminal
+					}
+					closeout, err = MarkEffectTerminal(closeout, registrationKeys[registrationIndex], storedEffect.Key, terminalEvidence)
+					require.NoError(t, err)
+					requireStoredWithinLimit(t, closeout, limits)
+					closeout, err = ConsumeEffect(closeout, registrationKeys[registrationIndex], storedEffect.Key)
+					require.NoError(t, err)
+					requireStoredWithinLimit(t, closeout, limits)
+				}
+			}
+			closeout, err = ConsumeRegistration(closeout, registrationKeys[registrationIndex])
+			require.NoError(t, err)
+			requireStoredWithinLimit(t, closeout, limits)
+		}
+	}
+
+	before := registrySnapshotOf(t, state)
+	tooLarge := testUnitEffect("unit-" + strings.Repeat("e", 128))
+	next, _, err := PlanEffect(state, registrationKeys[0], tooLarge, limits)
+	require.ErrorIs(t, err, ErrRegistryCapacity)
+	requireRegistrySnapshotEqual(t, before, next)
+}
+
+func TestUnitEffectRequiresFrozenTargetIdentity(t *testing.T) {
+	state, registrationKey, limits := registeredFence(t)
+	base := testUnitEffect("unit-1")
+	for name, clear := range map[string]func(*EffectIdentity){
+		"pod UID":   func(v *EffectIdentity) { v.PodUID = "" },
+		"container": func(v *EffectIdentity) { v.ContainerName = "" },
+		"fence UID": func(v *EffectIdentity) { v.FenceUID = "" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			changed := base
+			clear(&changed)
+			_, _, err := PlanEffect(state, registrationKey, changed, limits)
+			require.ErrorIs(t, err, ErrIdentityIncomplete)
+		})
+	}
+}
+
+type storedProtocolFenceStatusDTO struct {
+	ProtocolVersion      string                  `json:"protocolVersion"`
+	IntegrityDigest      string                  `json:"integrityDigest"`
+	FenceUIDDigest       string                  `json:"fenceUIDDigest"`
+	InstallationEpoch    string                  `json:"installationEpoch"`
+	InstallationManifest *storedManifestDTO      `json:"installationManifest,omitempty"`
+	Namespaces           []storedNamespaceDTO    `json:"namespaces"`
+	Registrations        []storedRegistrationDTO `json:"registrations,omitempty"`
+}
+
+const storedProtocolFenceStatusV1 = "kubeblocks.io/reconfigure-protocol-fence-status/v1"
+
+const (
+	testMaxTerminalReasonCodeBytes          = 128
+	testMaxFenceResourceVersionBytes        = 32
+	testMaxEffectObjectUIDBytes             = 64
+	testMaxEffectObjectResourceVersionBytes = 32
+)
+
+type storedNamespaceDTO struct {
+	UID      types.UID          `json:"uid"`
+	Manifest *storedManifestDTO `json:"manifest,omitempty"`
+}
+
+type storedManifestDTO struct {
+	Token            string                        `json:"token"`
+	Digest           string                        `json:"digest"`
+	RegistrationKeys []string                      `json:"registrationKeys"`
+	EffectKeys       []string                      `json:"effectKeys"`
+	CommitReadback   *storedFenceObjectReadbackDTO `json:"commitReadback,omitempty"`
+}
+
+type storedFenceObjectReadbackDTO struct {
+	UIDDigest             string `json:"uidDigest"`
+	ResourceVersionDigest string `json:"resourceVersionDigest"`
+	StoredStatusDigest    string `json:"storedStatusDigest"`
+}
+
+type storedRegistrationDTO struct {
+	Key      string                        `json:"key"`
+	Identity storedRegistrationIdentityDTO `json:"identity"`
+	Phase    string                        `json:"phase"`
+	Effects  []storedEffectDTO             `json:"effects,omitempty"`
+}
+
+type storedRegistrationIdentityDTO struct {
+	PhysicalAPIID     string    `json:"physicalAPIID"`
+	InstallationEpoch string    `json:"installationEpoch"`
+	ExecutionUID      types.UID `json:"executionUID"`
+	AttemptID         string    `json:"attemptID"`
+	NamespaceUID      types.UID `json:"namespaceUID"`
+	KeySecretUID      types.UID `json:"keySecretUID"`
+	AuthorityUID      types.UID `json:"authorityUID"`
+	QueueUID          types.UID `json:"queueUID"`
+}
+
+type storedEffectDTO struct {
+	Key             string                          `json:"key"`
+	Identity        storedEffectIdentityDTO         `json:"identity"`
+	State           string                          `json:"state"`
+	CloseoutVariant string                          `json:"closeoutVariant,omitempty"`
+	ObjectBinding   *storedObjectBindingDTO         `json:"objectBinding,omitempty"`
+	Dispatch        *storedDispatchAuthorizationDTO `json:"dispatch,omitempty"`
+	Terminal        *storedTerminalEvidenceDTO      `json:"terminal,omitempty"`
+	NotFound        *storedNotFoundEvidenceDTO      `json:"notFound,omitempty"`
+	Tombstone       *storedConsumedTombstoneDTO     `json:"tombstone,omitempty"`
+}
+
+type storedObjectBindingDTO struct {
+	Target                EffectObjectTarget `json:"target"`
+	UIDDigest             string             `json:"uidDigest"`
+	ResourceVersionDigest string             `json:"resourceVersionDigest"`
+}
+
+type storedDispatchAuthorizationDTO struct {
+	Token string `json:"token"`
+}
+
+type storedTerminalEvidenceDTO struct {
+	Outcome          string `json:"outcome"`
+	ReasonCode       string `json:"reasonCode"`
+	EvidenceDigest   string `json:"evidenceDigest"`
+	RecoveryRequired bool   `json:"recoveryRequired"`
+}
+
+type storedConsumedTombstoneDTO struct {
+	IdentityDigest string `json:"identityDigest"`
+}
+
+type storedNotFoundEvidenceDTO struct {
+	Target                      EffectObjectTarget `json:"target"`
+	DrainToken                  string             `json:"drainToken"`
+	ManifestDigest              string             `json:"manifestDigest"`
+	FenceUIDDigest              string             `json:"fenceUIDDigest"`
+	FenceResourceVersionDigest  string             `json:"fenceResourceVersionDigest"`
+	LookupResourceVersionDigest string             `json:"lookupResourceVersionDigest"`
+	EvidenceDigest              string             `json:"evidenceDigest"`
+}
+
+type storedEffectIdentityDTO struct {
+	Kind               string    `json:"kind"`
+	DeterministicName  string    `json:"deterministicName"`
+	FullIdentityDigest string    `json:"fullIdentityDigest"`
+	PodUID             types.UID `json:"podUID,omitempty"`
+	ContainerName      string    `json:"containerName,omitempty"`
+	FenceUID           types.UID `json:"fenceUID,omitempty"`
+}
+
+func expectedStoredStatusBytes(t *testing.T, installationEpoch string, namespaceUID types.UID, registrations []storedRegistrationDTO) []byte {
+	t.Helper()
+	return marshalExpectedStoredStatus(t, storedProtocolFenceStatusDTO{
+		ProtocolVersion:   storedProtocolFenceStatusV1,
+		FenceUIDDigest:    externalUIDDigest(testFenceObjectIdentity().UID),
+		InstallationEpoch: installationEpoch,
+		Namespaces:        []storedNamespaceDTO{{UID: namespaceUID}},
+		Registrations:     registrations,
+	})
+}
+
+func validFinalStoredStatusDTO(t *testing.T) storedProtocolFenceStatusDTO {
+	t.Helper()
+	identity := testRegistrationIdentity()
+	registrationKey, err := RegistrationKey(identity)
+	require.NoError(t, err)
+	effect := testUnitEffect("unit-1")
+	effectKey, err := EffectKey(registrationKey, effect)
+	require.NoError(t, err)
+	objectUID := types.UID("unit-object-uid-1")
+	namespaceManifest := expectedStoredManifest("namespace:"+string(identity.NamespaceUID), []string{registrationKey}, []string{effectKey})
+	namespaceManifest.CommitReadback = storedFenceReadbackDTOFrom(FenceObjectReadback{
+		UID:                testFenceObjectIdentity().UID,
+		ResourceVersion:    "502",
+		StoredStatusDigest: testDigest("namespace-drain-status"),
+	})
+	installationManifest := expectedStoredManifest("installation:"+identity.InstallationEpoch, []string{registrationKey}, []string{effectKey})
+	installationManifest.CommitReadback = storedFenceReadbackDTOFrom(FenceObjectReadback{
+		UID:                testFenceObjectIdentity().UID,
+		ResourceVersion:    "503",
+		StoredStatusDigest: testDigest("installation-drain-status"),
+	})
+	terminal := maxTerminalEvidence()
+	return storedProtocolFenceStatusDTO{
+		ProtocolVersion:      storedProtocolFenceStatusV1,
+		FenceUIDDigest:       externalUIDDigest(testFenceObjectIdentity().UID),
+		InstallationEpoch:    identity.InstallationEpoch,
+		InstallationManifest: installationManifest,
+		Namespaces:           []storedNamespaceDTO{{UID: identity.NamespaceUID, Manifest: namespaceManifest}},
+		Registrations: []storedRegistrationDTO{{
+			Key:      registrationKey,
+			Identity: storedRegistrationIdentityDTOFrom(identity),
+			Phase:    string(RegistrationPhaseConsumed),
+			Effects: []storedEffectDTO{{
+				Key:             effectKey,
+				Identity:        storedEffectIdentityDTOFrom(effect),
+				State:           string(EffectStateConsumed),
+				CloseoutVariant: string(CloseoutVariantUnitExecuted),
+				ObjectBinding: &storedObjectBindingDTO{
+					Target:                effectTarget(effect),
+					UIDDigest:             externalUIDDigest(objectUID),
+					ResourceVersionDigest: externalResourceVersionDigest("101"),
+				},
+				Dispatch:  &storedDispatchAuthorizationDTO{Token: expectedDispatchToken(registrationKey, effectKey, externalUIDDigest(objectUID))},
+				Terminal:  storedTerminalEvidenceDTOFrom(terminal),
+				Tombstone: &storedConsumedTombstoneDTO{IdentityDigest: expectedConsumedTombstoneDigest(effectKey)},
+			}},
+		}},
+	}
+}
+
+func validWindowConsumedStatusDTO(t *testing.T, variant EffectCloseoutVariant) storedProtocolFenceStatusDTO {
+	return validWindowConsumedStatusDTOForName(t, variant, "target-window-1")
+}
+
+func validWindowConsumedStatusDTOForName(t *testing.T, variant EffectCloseoutVariant, name string) storedProtocolFenceStatusDTO {
+	t.Helper()
+	identity := testRegistrationIdentity()
+	registrationKey, err := RegistrationKey(identity)
+	require.NoError(t, err)
+	effect := testWindowEffect(name)
+	effectKey, err := EffectKey(registrationKey, effect)
+	require.NoError(t, err)
+	namespaceManifest := expectedStoredManifest("namespace:"+string(identity.NamespaceUID), []string{registrationKey}, []string{effectKey})
+	namespaceReadback := FenceObjectReadback{
+		UID:                testFenceObjectIdentity().UID,
+		ResourceVersion:    "502",
+		StoredStatusDigest: testDigest("namespace-window-drain-status"),
+	}
+	namespaceManifest.CommitReadback = storedFenceReadbackDTOFrom(namespaceReadback)
+	storedEffect := storedEffectDTO{
+		Key:             effectKey,
+		Identity:        storedEffectIdentityDTOFrom(effect),
+		State:           string(EffectStateConsumed),
+		CloseoutVariant: string(variant),
+		Tombstone:       &storedConsumedTombstoneDTO{IdentityDigest: expectedConsumedTombstoneDigest(effectKey)},
+	}
+	switch variant {
+	case CloseoutVariantNotFound:
+		storedEffect.NotFound = &storedNotFoundEvidenceDTO{
+			Target:                      effectTarget(effect),
+			DrainToken:                  namespaceManifest.Token,
+			ManifestDigest:              namespaceManifest.Digest,
+			FenceUIDDigest:              externalUIDDigest(namespaceReadback.UID),
+			FenceResourceVersionDigest:  externalResourceVersionDigest(namespaceReadback.ResourceVersion),
+			LookupResourceVersionDigest: externalResourceVersionDigest("5001"),
+		}
+		storedEffect.NotFound.EvidenceDigest = expectedNotFoundEvidenceDigest(*storedEffect.NotFound)
+	case CloseoutVariantObservedTerminal:
+		storedEffect.ObjectBinding = &storedObjectBindingDTO{
+			Target:                effectTarget(effect),
+			UIDDigest:             externalUIDDigest(types.UID("window-object-uid-1")),
+			ResourceVersionDigest: externalResourceVersionDigest("101"),
+		}
+		storedEffect.Terminal = storedTerminalEvidenceDTOFrom(observedTerminalEvidence())
+	default:
+		require.FailNow(t, "unsupported Window closeout variant", string(variant))
+	}
+	return storedProtocolFenceStatusDTO{
+		ProtocolVersion:   storedProtocolFenceStatusV1,
+		FenceUIDDigest:    externalUIDDigest(testFenceObjectIdentity().UID),
+		InstallationEpoch: identity.InstallationEpoch,
+		Namespaces:        []storedNamespaceDTO{{UID: identity.NamespaceUID, Manifest: namespaceManifest}},
+		Registrations: []storedRegistrationDTO{{
+			Key:      registrationKey,
+			Identity: storedRegistrationIdentityDTOFrom(identity),
+			Phase:    string(RegistrationPhaseConsumed),
+			Effects:  []storedEffectDTO{storedEffect},
+		}},
+	}
+}
+
+func validWindowTerminalStatusDTO(t *testing.T) storedProtocolFenceStatusDTO {
+	t.Helper()
+	status := validWindowConsumedStatusDTO(t, CloseoutVariantObservedTerminal)
+	status.Registrations[0].Phase = string(RegistrationPhaseActive)
+	effect := &status.Registrations[0].Effects[0]
+	effect.State = string(EffectStateTerminal)
+	effect.Tombstone = nil
+	return status
+}
+
+func validWindowInstallationNotFoundConsumedStatusDTO(t *testing.T) storedProtocolFenceStatusDTO {
+	t.Helper()
+	status := validWindowConsumedStatusDTO(t, CloseoutVariantNotFound)
+	identity := testRegistrationIdentity()
+	effectKey := status.Registrations[0].Effects[0].Key
+	installationManifest := expectedStoredManifest("installation:"+identity.InstallationEpoch, []string{status.Registrations[0].Key}, []string{effectKey})
+	installationReadback := FenceObjectReadback{
+		UID:                testFenceObjectIdentity().UID,
+		ResourceVersion:    "503",
+		StoredStatusDigest: testDigest("installation-window-drain-status"),
+	}
+	installationManifest.CommitReadback = storedFenceReadbackDTOFrom(installationReadback)
+	status.Namespaces[0].Manifest = nil
+	status.InstallationManifest = installationManifest
+	notFound := status.Registrations[0].Effects[0].NotFound
+	notFound.DrainToken = installationManifest.Token
+	notFound.ManifestDigest = installationManifest.Digest
+	notFound.FenceUIDDigest = externalUIDDigest(installationReadback.UID)
+	notFound.FenceResourceVersionDigest = externalResourceVersionDigest(installationReadback.ResourceVersion)
+	notFound.EvidenceDigest = expectedNotFoundEvidenceDigest(*notFound)
+	return status
+}
+
+func validMixedConsumedStatusDTO(t *testing.T) storedProtocolFenceStatusDTO {
+	t.Helper()
+	status := validFinalStoredStatusDTO(t)
+	notFoundStatus := validWindowConsumedStatusDTOForName(t, CloseoutVariantNotFound, "window-notfound")
+	observedStatus := validWindowConsumedStatusDTOForName(t, CloseoutVariantObservedTerminal, "window-observed")
+	status.Registrations[0].Effects = append(status.Registrations[0].Effects,
+		notFoundStatus.Registrations[0].Effects[0],
+		observedStatus.Registrations[0].Effects[0],
+	)
+	var effectKeys []string
+	for _, effect := range status.Registrations[0].Effects {
+		effectKeys = append(effectKeys, effect.Key)
+	}
+	identity := testRegistrationIdentity()
+	namespaceManifest := expectedStoredManifest("namespace:"+string(identity.NamespaceUID), []string{status.Registrations[0].Key}, effectKeys)
+	namespaceReadback := FenceObjectReadback{
+		UID:                testFenceObjectIdentity().UID,
+		ResourceVersion:    "502",
+		StoredStatusDigest: testDigest("mixed-namespace-drain-status"),
+	}
+	namespaceManifest.CommitReadback = storedFenceReadbackDTOFrom(namespaceReadback)
+	status.Namespaces[0].Manifest = namespaceManifest
+	installationManifest := expectedStoredManifest("installation:"+identity.InstallationEpoch, []string{status.Registrations[0].Key}, effectKeys)
+	installationManifest.CommitReadback = storedFenceReadbackDTOFrom(FenceObjectReadback{
+		UID:                testFenceObjectIdentity().UID,
+		ResourceVersion:    "503",
+		StoredStatusDigest: testDigest("mixed-installation-drain-status"),
+	})
+	status.InstallationManifest = installationManifest
+	notFound := status.Registrations[0].Effects[1].NotFound
+	notFound.DrainToken = namespaceManifest.Token
+	notFound.ManifestDigest = namespaceManifest.Digest
+	notFound.FenceUIDDigest = externalUIDDigest(namespaceReadback.UID)
+	notFound.FenceResourceVersionDigest = externalResourceVersionDigest(namespaceReadback.ResourceVersion)
+	notFound.EvidenceDigest = expectedNotFoundEvidenceDigest(*notFound)
+	return status
+}
+
+func validStoredStatusForPhase(t *testing.T, phase EffectState) storedProtocolFenceStatusDTO {
+	t.Helper()
+	status := cloneStoredStatusDTO(t, validFinalStoredStatusDTO(t))
+	status.Registrations[0].Phase = string(RegistrationPhaseActive)
+	effect := &status.Registrations[0].Effects[0]
+	effect.State = string(phase)
+	switch phase {
+	case EffectStatePlanned:
+		effect.CloseoutVariant = ""
+		effect.ObjectBinding = nil
+		effect.Dispatch = nil
+		effect.Terminal = nil
+		effect.Tombstone = nil
+	case EffectStateObjectBound:
+		effect.CloseoutVariant = ""
+		effect.Dispatch = nil
+		effect.Terminal = nil
+		effect.Tombstone = nil
+	case EffectStateDispatchAuthorized:
+		effect.CloseoutVariant = ""
+		effect.Terminal = nil
+		effect.Tombstone = nil
+	case EffectStateTerminal:
+		effect.CloseoutVariant = string(CloseoutVariantUnitExecuted)
+		effect.Tombstone = nil
+	case EffectStateConsumed:
+		effect.CloseoutVariant = string(CloseoutVariantUnitExecuted)
+	default:
+		require.FailNow(t, "unsupported phase fixture", string(phase))
+	}
+	return status
+}
+
+func marshalExpectedStoredStatus(t *testing.T, status storedProtocolFenceStatusDTO) []byte {
+	t.Helper()
+	status.IntegrityDigest = ""
+	unsigned, err := json.Marshal(status)
+	require.NoError(t, err)
+	status.IntegrityDigest = testDigest("kubeblocks.io/reconfigure-stored-status-integrity/v1\x00" + string(unsigned))
+	data, err := json.Marshal(status)
+	require.NoError(t, err)
+	return data
+}
+
+func expectedStoredManifest(scope string, registrationKeys, effectKeys []string) *storedManifestDTO {
+	joinedRegistrations := strings.Join(registrationKeys, "\x00")
+	joinedKeys := strings.Join(effectKeys, "\x00")
+	return &storedManifestDTO{
+		Token:            testDigest("kubeblocks.io/reconfigure-drain-token/v1\x00" + scope + "\x00" + joinedRegistrations + "\x00" + joinedKeys),
+		Digest:           testDigest("kubeblocks.io/reconfigure-manifest/v1\x00" + joinedRegistrations + "\x00" + joinedKeys),
+		RegistrationKeys: registrationKeys,
+		EffectKeys:       effectKeys,
+	}
+}
+
+func storedFenceReadbackDTOFrom(readback FenceObjectReadback) *storedFenceObjectReadbackDTO {
+	return &storedFenceObjectReadbackDTO{
+		UIDDigest:             externalUIDDigest(readback.UID),
+		ResourceVersionDigest: externalResourceVersionDigest(readback.ResourceVersion),
+		StoredStatusDigest:    readback.StoredStatusDigest,
+	}
+}
+
+func externalUIDDigest(uid types.UID) string {
+	return testDigest("kubeblocks.io/reconfigure-external-uid/v1\x00" + string(uid))
+}
+
+func externalResourceVersionDigest(resourceVersion string) string {
+	return testDigest("kubeblocks.io/reconfigure-external-rv/v1\x00" + resourceVersion)
+}
+
+func expectedDispatchToken(registrationKey, effectKey, objectUIDDigest string) string {
+	return testDigest("kubeblocks.io/reconfigure-dispatch/v1\x00" + registrationKey + "\x00" + effectKey + "\x00" + objectUIDDigest)
+}
+
+func expectedConsumedTombstoneDigest(effectKey string) string {
+	return testDigest("kubeblocks.io/reconfigure-consumed/v1\x00" + effectKey)
+}
+
+func observedTerminalEvidence() EffectTerminalEvidence {
+	return EffectTerminalEvidence{
+		CloseoutVariant: CloseoutVariantObservedTerminal,
+		Outcome:         EffectTerminalSucceeded,
+		ReasonCode:      "Completed",
+		EvidenceDigest:  testDigest("terminal-success"),
+	}
+}
+
+func executedTerminalEvidence() EffectTerminalEvidence {
+	evidence := observedTerminalEvidence()
+	evidence.CloseoutVariant = CloseoutVariantUnitExecuted
+	return evidence
+}
+
+func maxTerminalEvidence() EffectTerminalEvidence {
+	return EffectTerminalEvidence{
+		CloseoutVariant:  CloseoutVariantUnitExecuted,
+		Outcome:          EffectTerminalManual,
+		ReasonCode:       strings.Repeat("R", testMaxTerminalReasonCodeBytes),
+		EvidenceDigest:   testDigest("max-terminal-evidence"),
+		RecoveryRequired: true,
+	}
+}
+
+func storedTerminalEvidenceDTOFrom(evidence EffectTerminalEvidence) *storedTerminalEvidenceDTO {
+	return &storedTerminalEvidenceDTO{
+		Outcome:          string(evidence.Outcome),
+		ReasonCode:       evidence.ReasonCode,
+		EvidenceDigest:   evidence.EvidenceDigest,
+		RecoveryRequired: evidence.RecoveryRequired,
+	}
+}
+
+func storedNotFoundEvidenceDTOFrom(observation EffectObjectObservation) *storedNotFoundEvidenceDTO {
+	evidence := &storedNotFoundEvidenceDTO{
+		Target:                      observation.Target,
+		DrainToken:                  observation.DrainIdentity.Token,
+		ManifestDigest:              observation.DrainIdentity.ManifestDigest,
+		FenceUIDDigest:              observation.DrainIdentity.FenceUIDDigest,
+		FenceResourceVersionDigest:  observation.DrainIdentity.FenceResourceVersionDigest,
+		LookupResourceVersionDigest: externalResourceVersionDigest(observation.LookupResourceVersion),
+	}
+	evidence.EvidenceDigest = expectedNotFoundEvidenceDigest(*evidence)
+	return evidence
+}
+
+func expectedNotFoundEvidenceDigest(evidence storedNotFoundEvidenceDTO) string {
+	return testDigest(strings.Join([]string{
+		"kubeblocks.io/reconfigure-notfound-evidence/v1",
+		evidence.Target.APIVersion,
+		evidence.Target.Kind,
+		evidence.Target.Namespace,
+		evidence.Target.Name,
+		evidence.DrainToken,
+		evidence.ManifestDigest,
+		evidence.FenceUIDDigest,
+		evidence.FenceResourceVersionDigest,
+		evidence.LookupResourceVersionDigest,
+	}, "\x00"))
+}
+
+func expectedCloseoutReserve(t *testing.T, planned storedProtocolFenceStatusDTO) int {
+	t.Helper()
+	plannedBytes := marshalExpectedStoredStatus(t, planned)
+	closeout := expectedMaxLegalCloseoutStatus(t, planned)
+	return len(marshalExpectedStoredStatus(t, closeout)) - len(plannedBytes)
+}
+
+func expectedMaxLegalCloseoutStatus(t *testing.T, planned storedProtocolFenceStatusDTO) storedProtocolFenceStatusDTO {
+	t.Helper()
+	closeout := cloneStoredStatusDTO(t, planned)
+	var allRegistrationKeys []string
+	var allEffectKeys []string
+	for namespaceIndex := range closeout.Namespaces {
+		namespaceUID := closeout.Namespaces[namespaceIndex].UID
+		var namespaceRegistrationKeys []string
+		var namespaceEffectKeys []string
+		for _, registration := range closeout.Registrations {
+			if registration.Identity.NamespaceUID != namespaceUID {
+				continue
+			}
+			namespaceRegistrationKeys = append(namespaceRegistrationKeys, registration.Key)
+			allRegistrationKeys = append(allRegistrationKeys, registration.Key)
+			for _, effect := range registration.Effects {
+				namespaceEffectKeys = append(namespaceEffectKeys, effect.Key)
+				allEffectKeys = append(allEffectKeys, effect.Key)
+			}
+		}
+		closeout.Namespaces[namespaceIndex].Manifest = expectedStoredManifest("namespace:"+string(namespaceUID), namespaceRegistrationKeys, namespaceEffectKeys)
+		closeout.Namespaces[namespaceIndex].Manifest.CommitReadback = maxStoredFenceReadbackDTO()
+	}
+	closeout.InstallationManifest = expectedStoredManifest("installation:"+closeout.InstallationEpoch, allRegistrationKeys, allEffectKeys)
+	closeout.InstallationManifest.CommitReadback = maxStoredFenceReadbackDTO()
+	type effectPosition struct {
+		registration int
+		effect       int
+	}
+	var positions []effectPosition
+	for registrationIndex := range closeout.Registrations {
+		closeout.Registrations[registrationIndex].Phase = string(RegistrationPhaseConsumed)
+		for effectIndex := range closeout.Registrations[registrationIndex].Effects {
+			positions = append(positions, effectPosition{registration: registrationIndex, effect: effectIndex})
+		}
+	}
+	var candidates []storedProtocolFenceStatusDTO
+	var build func(int)
+	build = func(positionIndex int) {
+		if positionIndex == len(positions) {
+			candidates = append(candidates, cloneStoredStatusDTO(t, closeout))
+			return
+		}
+		position := positions[positionIndex]
+		registration := &closeout.Registrations[position.registration]
+		plannedEffect := registration.Effects[position.effect]
+		namespaceManifest := namespaceManifestForRegistration(t, closeout, registration.Identity.NamespaceUID)
+		for _, legal := range legalCloseoutEffects(t, registration.Key, plannedEffect, namespaceManifest) {
+			registration.Effects[position.effect] = legal
+			build(positionIndex + 1)
+		}
+		registration.Effects[position.effect] = plannedEffect
+	}
+	build(0)
+	require.NotEmpty(t, candidates)
+	maxIndex := 0
+	maxBytes := -1
+	for index, candidate := range candidates {
+		data := marshalExpectedStoredStatus(t, candidate)
+		decoded, err := DecodeStoredProtocolFenceStatus(data, testFenceObjectIdentity())
+		require.NoError(t, err, "every reserve candidate must be a legal restart state")
+		require.False(t, IsZeroFenceState(decoded))
+		if len(data) > maxBytes {
+			maxIndex = index
+			maxBytes = len(data)
+		}
+	}
+	return candidates[maxIndex]
+}
+
+func legalCloseoutEffects(t *testing.T, registrationKey string, planned storedEffectDTO, namespaceManifest *storedManifestDTO) []storedEffectDTO {
+	t.Helper()
+	base := planned
+	base.State = string(EffectStateConsumed)
+	base.Tombstone = &storedConsumedTombstoneDTO{IdentityDigest: expectedConsumedTombstoneDigest(base.Key)}
+	objectBinding := maxStoredObjectBindingDTO(base.Identity)
+	terminal := &storedTerminalEvidenceDTO{
+		Outcome:          string(EffectTerminalManual),
+		ReasonCode:       strings.Repeat("R", testMaxTerminalReasonCodeBytes),
+		EvidenceDigest:   testDigest("max-terminal-evidence"),
+		RecoveryRequired: true,
+	}
+	switch base.Identity.Kind {
+	case string(EffectKindUnitExecution):
+		base.CloseoutVariant = string(CloseoutVariantUnitExecuted)
+		base.ObjectBinding = objectBinding
+		base.Dispatch = &storedDispatchAuthorizationDTO{Token: expectedDispatchToken(registrationKey, base.Key, objectBinding.UIDDigest)}
+		base.Terminal = terminal
+		return []storedEffectDTO{base}
+	case string(EffectKindTargetFenceWindow):
+		require.NotNil(t, namespaceManifest)
+		require.NotNil(t, namespaceManifest.CommitReadback)
+		notFound := base
+		notFound.CloseoutVariant = string(CloseoutVariantNotFound)
+		notFound.NotFound = &storedNotFoundEvidenceDTO{
+			Target:                      objectBinding.Target,
+			DrainToken:                  namespaceManifest.Token,
+			ManifestDigest:              namespaceManifest.Digest,
+			FenceUIDDigest:              namespaceManifest.CommitReadback.UIDDigest,
+			FenceResourceVersionDigest:  namespaceManifest.CommitReadback.ResourceVersionDigest,
+			LookupResourceVersionDigest: externalResourceVersionDigest(strings.Repeat("9", testMaxFenceResourceVersionBytes)),
+		}
+		notFound.NotFound.EvidenceDigest = expectedNotFoundEvidenceDigest(*notFound.NotFound)
+		observed := base
+		observed.CloseoutVariant = string(CloseoutVariantObservedTerminal)
+		observed.ObjectBinding = objectBinding
+		observed.Terminal = terminal
+		return []storedEffectDTO{notFound, observed}
+	default:
+		require.FailNow(t, "unsupported effect kind in capacity oracle", base.Identity.Kind)
+		return nil
+	}
+}
+
+func namespaceManifestForRegistration(t *testing.T, status storedProtocolFenceStatusDTO, namespaceUID types.UID) *storedManifestDTO {
+	t.Helper()
+	for _, namespace := range status.Namespaces {
+		if namespace.UID == namespaceUID {
+			return namespace.Manifest
+		}
+	}
+	require.FailNow(t, "registration namespace missing from stored status", string(namespaceUID))
+	return nil
+}
+
+func storedEffectByKey(t *testing.T, status storedProtocolFenceStatusDTO, effectKey string) storedEffectDTO {
+	t.Helper()
+	for _, registration := range status.Registrations {
+		for _, effect := range registration.Effects {
+			if effect.Key == effectKey {
+				return effect
+			}
+		}
+	}
+	require.FailNow(t, "effect missing from stored status", effectKey)
+	return storedEffectDTO{}
+}
+
+func maxStoredFenceReadbackDTO() *storedFenceObjectReadbackDTO {
+	return &storedFenceObjectReadbackDTO{
+		UIDDigest:             externalUIDDigest(testFenceObjectIdentity().UID),
+		ResourceVersionDigest: externalResourceVersionDigest(strings.Repeat("9", testMaxFenceResourceVersionBytes)),
+		StoredStatusDigest:    testDigest("max-stored-status"),
+	}
+}
+
+func maxStoredObjectBindingDTO(identity storedEffectIdentityDTO) *storedObjectBindingDTO {
+	kind := "GateWindow"
+	if identity.Kind == string(EffectKindUnitExecution) {
+		kind = "UnitExecution"
+	}
+	return &storedObjectBindingDTO{
+		Target: EffectObjectTarget{
+			APIVersion: "protocol.kubeblocks.io/v1alpha1",
+			Kind:       kind,
+			Namespace:  "kb-system",
+			Name:       identity.DeterministicName,
+		},
+		UIDDigest:             externalUIDDigest(types.UID(strings.Repeat("u", testMaxEffectObjectUIDBytes))),
+		ResourceVersionDigest: externalResourceVersionDigest(strings.Repeat("9", testMaxEffectObjectResourceVersionBytes)),
+	}
+}
+
+func cloneStoredStatusDTO(t *testing.T, status storedProtocolFenceStatusDTO) storedProtocolFenceStatusDTO {
+	t.Helper()
+	data := marshalExpectedStoredStatus(t, status)
+	var cloned storedProtocolFenceStatusDTO
+	require.NoError(t, json.Unmarshal(data, &cloned))
+	return cloned
+}
+
+func storedRegistrationIdentityDTOFrom(identity RegistrationIdentity) storedRegistrationIdentityDTO {
+	return storedRegistrationIdentityDTO{
+		PhysicalAPIID:     identity.PhysicalAPIID,
+		InstallationEpoch: identity.InstallationEpoch,
+		ExecutionUID:      identity.ExecutionUID,
+		AttemptID:         identity.AttemptID,
+		NamespaceUID:      identity.NamespaceUID,
+		KeySecretUID:      identity.KeySecretUID,
+		AuthorityUID:      identity.AuthorityUID,
+		QueueUID:          identity.QueueUID,
+	}
+}
+
+func storedEffectIdentityDTOFrom(identity EffectIdentity) storedEffectIdentityDTO {
+	return storedEffectIdentityDTO{
+		Kind:               string(identity.Kind),
+		DeterministicName:  identity.DeterministicName,
+		FullIdentityDigest: identity.FullIdentityDigest,
+		PodUID:             identity.PodUID,
+		ContainerName:      identity.ContainerName,
+		FenceUID:           identity.FenceUID,
+	}
+}
+
+func effectIdentityFromStored(identity storedEffectIdentityDTO) EffectIdentity {
+	return EffectIdentity{
+		Kind:               EffectKind(identity.Kind),
+		DeterministicName:  identity.DeterministicName,
+		FullIdentityDigest: identity.FullIdentityDigest,
+		PodUID:             identity.PodUID,
+		ContainerName:      identity.ContainerName,
+		FenceUID:           identity.FenceUID,
+	}
+}
+
+func requireStoredWithinLimit(t *testing.T, state FenceState, limits RegistryLimits) {
+	t.Helper()
+	require.LessOrEqual(t, len(storedStateBytes(t, state))+ReservedProtocolFenceStatusBytes, limits.MaxStatusBytes)
+}
+
+func requireWrongFenceUIDDecodeRejected(t *testing.T, data []byte) {
+	t.Helper()
+	decoded, err := DecodeStoredProtocolFenceStatus(data, FenceObjectIdentity{UID: types.UID("same-name-new-fence-uid")})
+	require.ErrorIs(t, err, ErrFenceReadbackMismatch)
+	require.True(t, IsZeroFenceState(decoded))
+}
+
+type registrySnapshot struct {
+	bytes         []byte
+	storedBytes   []byte
+	namespaces    int
+	registrations int
+	effects       int
+	manifest      string
+}
+
+func registrySnapshotOf(t *testing.T, state FenceState) registrySnapshot {
+	t.Helper()
+	return registrySnapshot{
+		bytes:         canonicalStateBytes(t, state),
+		storedBytes:   storedStateBytes(t, state),
+		namespaces:    NamespaceCount(state),
+		registrations: RegistrationCount(state),
+		effects:       TotalEffectCount(state),
+		manifest:      CanonicalManifestDigest(state),
+	}
+}
+
+func storedStateBytes(t *testing.T, state FenceState) []byte {
+	t.Helper()
+	data, err := StoredProtocolFenceStatusBytes(state)
+	require.NoError(t, err)
+	return data
+}
+
+func requireRegistrySnapshotEqual(t *testing.T, expected registrySnapshot, actual FenceState) {
+	t.Helper()
+	require.Equal(t, expected, registrySnapshotOf(t, actual))
+}
+
+func registeredFence(t *testing.T) (FenceState, string, RegistryLimits) {
+	t.Helper()
+	return registeredFenceWithLimits(t, generousRegistryLimits())
+}
+
+func registeredFenceWithLimits(t *testing.T, limits RegistryLimits) (FenceState, string, RegistryLimits) {
+	t.Helper()
+	identity := testRegistrationIdentity()
+	state := newFenceState(t, identity.InstallationEpoch, identity.NamespaceUID, testFenceObjectIdentity())
+	registered, registrationKey, err := RegisterExecution(state, identity, limits)
+	require.NoError(t, err)
+	return registered, registrationKey, limits
+}
+
+func registerTwoNamespaces(t *testing.T, first, second RegistrationIdentity, limits RegistryLimits) (FenceState, [2]string) {
+	t.Helper()
+	state := newFenceState(t, first.InstallationEpoch, first.NamespaceUID, testFenceObjectIdentity())
+	registered, firstKey, err := RegisterExecution(state, first, limits)
+	require.NoError(t, err)
+	registered, secondKey, err := RegisterExecution(registered, second, limits)
+	require.NoError(t, err)
+	return registered, [2]string{firstKey, secondKey}
+}
+
+func generousRegistryLimits() RegistryLimits {
+	return RegistryLimits{
+		MaxNamespaces:    8,
+		MaxRegistrations: 16,
+		MaxEffects:       64,
+		MaxStatusBytes:   128 * 1024,
+	}
+}
+
+func testRegistrationIdentity() RegistrationIdentity {
+	return RegistrationIdentity{
+		PhysicalAPIID:     "api-uid-1",
+		InstallationEpoch: "install-7",
+		ExecutionUID:      types.UID("execution-uid-1"),
+		AttemptID:         "attempt-3",
+		NamespaceUID:      types.UID("namespace-uid-1"),
+		KeySecretUID:      types.UID("key-secret-uid-1"),
+		AuthorityUID:      types.UID("authority-uid-1"),
+		QueueUID:          types.UID("queue-uid-1"),
+	}
+}
+
+func testFenceObjectIdentity() FenceObjectIdentity {
+	return FenceObjectIdentity{UID: types.UID("protocol-fence-uid-1")}
+}
+
+func newFenceState(t *testing.T, installationEpoch string, namespaceUID types.UID, identity FenceObjectIdentity) FenceState {
+	t.Helper()
+	state, err := NewFenceState(installationEpoch, namespaceUID, identity)
+	require.NoError(t, err)
+	return state
+}
+
+func testFenceReadback(t *testing.T, state FenceState, resourceVersion string) FenceObjectReadback {
+	t.Helper()
+	return FenceObjectReadback{
+		UID:                testFenceObjectIdentity().UID,
+		ResourceVersion:    resourceVersion,
+		StoredStatusDigest: testDigest(string(storedStateBytes(t, state))),
+	}
+}
+
+func activeDrainIdentity(t *testing.T, state FenceState) DrainIdentity {
+	t.Helper()
+	view, err := BindActiveFenceReadback(state, testFenceReadback(t, state, "501"))
+	require.NoError(t, err)
+	identity := ActiveDrainIdentity(view)
+	require.NotEmpty(t, identity.FenceUIDDigest)
+	require.NotEmpty(t, identity.FenceResourceVersionDigest)
+	return identity
+}
+
+func commitNamespaceDrain(t *testing.T, state FenceState, resourceVersion string) (FenceState, DrainIdentity) {
+	t.Helper()
+	committed, err := BindDrainCommitReadback(state, NamespaceDrainScope(testRegistrationIdentity().NamespaceUID), testFenceReadback(t, state, resourceVersion))
+	require.NoError(t, err)
+	identity := NamespaceDrainIdentity(committed, testRegistrationIdentity().NamespaceUID)
+	require.NotEmpty(t, identity.FenceUIDDigest)
+	require.NotEmpty(t, identity.FenceResourceVersionDigest)
+	return committed, identity
+}
+
+func commitInstallationDrain(t *testing.T, state FenceState, resourceVersion string) (FenceState, DrainIdentity) {
+	t.Helper()
+	committed, err := BindDrainCommitReadback(state, InstallationDrainScope(), testFenceReadback(t, state, resourceVersion))
+	require.NoError(t, err)
+	identity := InstallationDrainIdentity(committed)
+	require.NotEmpty(t, identity.FenceUIDDigest)
+	require.NotEmpty(t, identity.FenceResourceVersionDigest)
+	return committed, identity
+}
+
+func testWindowEffect(name string) EffectIdentity {
+	return EffectIdentity{
+		Kind:               EffectKindTargetFenceWindow,
+		DeterministicName:  name,
+		FullIdentityDigest: testDigest("window:" + name),
+	}
+}
+
+func testUnitEffect(name string) EffectIdentity {
+	return EffectIdentity{
+		Kind:               EffectKindUnitExecution,
+		DeterministicName:  name,
+		FullIdentityDigest: testDigest("unit:" + name),
+		PodUID:             types.UID("pod-uid-1"),
+		ContainerName:      "mysql",
+		FenceUID:           types.UID("fence-uid-1"),
+	}
+}
+
+func effectTarget(effect EffectIdentity) EffectObjectTarget {
+	kind := "GateWindow"
+	if effect.Kind == EffectKindUnitExecution {
+		kind = "UnitExecution"
+	}
+	return EffectObjectTarget{
+		APIVersion: "protocol.kubeblocks.io/v1alpha1",
+		Kind:       kind,
+		Namespace:  "kb-system",
+		Name:       effect.DeterministicName,
+	}
+}
+
+func presentObservation(effect EffectIdentity, uid types.UID) EffectObjectObservation {
+	return EffectObjectObservation{
+		Result:                EffectObservationPresent,
+		Target:                effectTarget(effect),
+		ObjectUID:             uid,
+		ObjectResourceVersion: "101",
+		LookupResourceVersion: "5001",
+		ObservedAt:            metav1.NewTime(time.Unix(1_752_211_200, 0)),
+	}
+}
+
+func terminatingObservation(effect EffectIdentity, uid types.UID) EffectObjectObservation {
+	observation := presentObservation(effect, uid)
+	observation.Result = EffectObservationTerminating
+	return observation
+}
+
+func notFoundObservation(effect EffectIdentity, drainIdentity DrainIdentity) EffectObjectObservation {
+	return EffectObjectObservation{
+		Result:                EffectObservationNotFound,
+		Target:                effectTarget(effect),
+		DrainIdentity:         drainIdentity,
+		LookupResourceVersion: "5001",
+		ObservedAt:            metav1.NewTime(time.Unix(1_752_211_200, 0)),
+	}
+}
+
+func apiErrorObservation(effect EffectIdentity) EffectObjectObservation {
+	return EffectObjectObservation{
+		Result:     EffectObservationAPIError,
+		Target:     effectTarget(effect),
+		ObservedAt: metav1.NewTime(time.Unix(1_752_211_200, 0)),
+		ErrorClass: "Timeout",
+	}
+}

--- a/pkg/reconfigure/protocol/registry_test.go
+++ b/pkg/reconfigure/protocol/registry_test.go
@@ -2248,16 +2248,7 @@ func cloneStoredStatusDTO(t *testing.T, status storedProtocolFenceStatusDTO) sto
 }
 
 func storedRegistrationIdentityDTOFrom(identity RegistrationIdentity) storedRegistrationIdentityDTO {
-	return storedRegistrationIdentityDTO{
-		PhysicalAPIID:     identity.PhysicalAPIID,
-		InstallationEpoch: identity.InstallationEpoch,
-		ExecutionUID:      identity.ExecutionUID,
-		AttemptID:         identity.AttemptID,
-		NamespaceUID:      identity.NamespaceUID,
-		KeySecretUID:      identity.KeySecretUID,
-		AuthorityUID:      identity.AuthorityUID,
-		QueueUID:          identity.QueueUID,
-	}
+	return storedRegistrationIdentityDTO(identity)
 }
 
 func storedEffectIdentityDTOFrom(identity EffectIdentity) storedEffectIdentityDTO {

--- a/pkg/reconfigure/protocol/registry_test.go
+++ b/pkg/reconfigure/protocol/registry_test.go
@@ -226,11 +226,41 @@ func TestRegistrationAndEffectReplayAreIdempotent(t *testing.T) {
 		t.Run("rejects replay with changed "+name, func(t *testing.T) {
 			changed := effect
 			mutate(&changed)
-			unchanged, _, err := PlanEffect(planned, registrationKey, changed, limits)
+			unchanged, returnedKey, err := PlanEffect(planned, registrationKey, changed, limits)
 			require.ErrorIs(t, err, ErrEffectIdentityConflict)
+			require.Empty(t, returnedKey)
 			requireStateEqual(t, planned, unchanged)
 		})
 	}
+}
+
+func TestEffectNameCollisionIsScopedToNamespace(t *testing.T) {
+	state, registrationKey, limits := registeredFence(t)
+	first := testUnitEffect("unit-1")
+	first.Namespace = "namespace-a"
+	second := first
+	second.Namespace = "namespace-b"
+
+	planned, firstKey, err := PlanEffect(state, registrationKey, first, limits)
+	require.NoError(t, err)
+	planned, secondKey, err := PlanEffect(planned, registrationKey, second, limits)
+	require.NoError(t, err)
+	require.NotEqual(t, firstKey, secondKey)
+	require.Equal(t, 2, EffectCount(planned, registrationKey))
+
+	bound, err := ObserveEffectObject(planned, registrationKey, firstKey, presentObservation(first, types.UID("unit-object-uid-a")))
+	require.NoError(t, err)
+	bound, err = ObserveEffectObject(bound, registrationKey, secondKey, presentObservation(second, types.UID("unit-object-uid-b")))
+	require.NoError(t, err)
+	require.Equal(t, EffectStateObjectBound, EffectStateOf(bound, registrationKey, firstKey))
+	require.Equal(t, EffectStateObjectBound, EffectStateOf(bound, registrationKey, secondKey))
+
+	conflicting := first
+	conflicting.FullIdentityDigest = testDigest("different-unit")
+	unchanged, returnedKey, err := PlanEffect(bound, registrationKey, conflicting, limits)
+	require.ErrorIs(t, err, ErrEffectIdentityConflict)
+	require.Empty(t, returnedKey)
+	requireStateEqual(t, bound, unchanged)
 }
 
 func TestDrainFreezesRegistrationMembership(t *testing.T) {
@@ -465,8 +495,9 @@ func TestPlannedNotFoundRequiresDrainAndExactFreshObservation(t *testing.T) {
 			restarted, err := DecodeStoredProtocolFenceStatus(storedStateBytes(t, consumed), testFenceObjectIdentity())
 			require.NoError(t, err)
 
-			unchanged, _, err = PlanEffect(consumed, registrationKey, effect, limits)
+			unchanged, returnedKey, err := PlanEffect(consumed, registrationKey, effect, limits)
 			require.ErrorIs(t, err, ErrEffectAlreadyConsumed)
+			require.Empty(t, returnedKey)
 			requireStateEqual(t, consumed, unchanged)
 			changedDigest := effect
 			changedDigest.FullIdentityDigest = testDigest("different-target-window")
@@ -479,8 +510,9 @@ func TestPlannedNotFoundRequiresDrainAndExactFreshObservation(t *testing.T) {
 			unchanged, err = AuthorizeDispatch(consumed, registrationKey, effectKey)
 			require.ErrorIs(t, err, ErrEffectAlreadyConsumed)
 			requireStateEqual(t, consumed, unchanged)
-			unchanged, _, err = PlanEffect(restarted, registrationKey, effect, limits)
+			unchanged, returnedKey, err = PlanEffect(restarted, registrationKey, effect, limits)
 			require.ErrorIs(t, err, ErrEffectAlreadyConsumed)
+			require.Empty(t, returnedKey)
 			requireStateEqual(t, restarted, unchanged)
 		})
 	}
@@ -732,9 +764,6 @@ func TestDrainFreezesManifestWhileLivePhasesAdvance(t *testing.T) {
 			require.True(t, tc.contains(consumed, registrationKey, plannedKey))
 			require.True(t, tc.contains(consumed, registrationKey, boundKey))
 
-			unchanged, err = AdvanceEffectState(consumed, registrationKey, boundKey, EffectStateObjectBound)
-			require.ErrorIs(t, err, ErrEffectStateRegression)
-			requireStateEqual(t, consumed, unchanged)
 			unchanged, _, err = PlanEffect(consumed, registrationKey, testWindowEffect("late-window"), limits)
 			require.Error(t, err)
 			requireStateEqual(t, consumed, unchanged)
@@ -774,6 +803,42 @@ func TestDispatchAuthorizationIsBoundAndNotReplayable(t *testing.T) {
 		require.Error(t, err)
 		requireStateEqual(t, draining, unchanged)
 	}
+}
+
+func TestMarkEffectTerminalExactReplayIsIdempotent(t *testing.T) {
+	state, registrationKey, limits := registeredFence(t)
+	effect := testUnitEffect("unit-1")
+	planned, effectKey, err := PlanEffect(state, registrationKey, effect, limits)
+	require.NoError(t, err)
+	bound, err := ObserveEffectObject(planned, registrationKey, effectKey, presentObservation(effect, types.UID("unit-object-uid-1")))
+	require.NoError(t, err)
+	authorized, err := AuthorizeDispatch(bound, registrationKey, effectKey)
+	require.NoError(t, err)
+	evidence := executedTerminalEvidence()
+	terminal, err := MarkEffectTerminal(authorized, registrationKey, effectKey, evidence)
+	require.NoError(t, err)
+
+	replayed, err := MarkEffectTerminal(terminal, registrationKey, effectKey, evidence)
+	require.NoError(t, err)
+	requireStateEqual(t, terminal, replayed)
+
+	conflicting := evidence
+	conflicting.ReasonCode = "different-reason"
+	unchanged, err := MarkEffectTerminal(terminal, registrationKey, effectKey, conflicting)
+	require.ErrorIs(t, err, ErrEffectStateRegression)
+	requireStateEqual(t, terminal, unchanged)
+}
+
+func TestEffectObservationUsesConfiguredNamespace(t *testing.T) {
+	state, registrationKey, limits := registeredFence(t)
+	effect := testUnitEffect("unit-1")
+	effect.Namespace = "custom-system"
+	planned, effectKey, err := PlanEffect(state, registrationKey, effect, limits)
+	require.NoError(t, err)
+
+	bound, err := ObserveEffectObject(planned, registrationKey, effectKey, presentObservation(effect, types.UID("unit-object-uid-1")))
+	require.NoError(t, err)
+	require.Equal(t, EffectStateObjectBound, EffectStateOf(bound, registrationKey, effectKey))
 }
 
 func TestStoredProtocolFenceStatusMatchesIndependentJSONContract(t *testing.T) {
@@ -1098,8 +1163,9 @@ func TestDecodeStoredStatusEnforcesExactPhaseEvidenceMatrix(t *testing.T) {
 	restartedMixed, err := DecodeStoredProtocolFenceStatus(marshalExpectedStoredStatus(t, mixed), testFenceObjectIdentity())
 	require.NoError(t, err)
 	for _, storedEffect := range mixed.Registrations[0].Effects {
-		unchanged, _, err := PlanEffect(restartedMixed, mixed.Registrations[0].Key, effectIdentityFromStored(storedEffect.Identity), generousRegistryLimits())
+		unchanged, returnedKey, err := PlanEffect(restartedMixed, mixed.Registrations[0].Key, effectIdentityFromStored(storedEffect.Identity), generousRegistryLimits())
 		require.ErrorIs(t, err, ErrRegistrationAlreadyConsumed)
+		require.Empty(t, returnedKey)
 		requireStateEqual(t, restartedMixed, unchanged)
 	}
 
@@ -1617,6 +1683,7 @@ func TestUnitEffectRequiresFrozenTargetIdentity(t *testing.T) {
 		"pod UID":   func(v *EffectIdentity) { v.PodUID = "" },
 		"container": func(v *EffectIdentity) { v.ContainerName = "" },
 		"fence UID": func(v *EffectIdentity) { v.FenceUID = "" },
+		"namespace": func(v *EffectIdentity) { v.Namespace = "" },
 	} {
 		t.Run(name, func(t *testing.T) {
 			changed := base
@@ -1730,6 +1797,7 @@ type storedEffectIdentityDTO struct {
 	Kind               string    `json:"kind"`
 	DeterministicName  string    `json:"deterministicName"`
 	FullIdentityDigest string    `json:"fullIdentityDigest"`
+	Namespace          string    `json:"namespace"`
 	PodUID             types.UID `json:"podUID,omitempty"`
 	ContainerName      string    `json:"containerName,omitempty"`
 	FenceUID           types.UID `json:"fenceUID,omitempty"`
@@ -2256,6 +2324,7 @@ func storedEffectIdentityDTOFrom(identity EffectIdentity) storedEffectIdentityDT
 		Kind:               string(identity.Kind),
 		DeterministicName:  identity.DeterministicName,
 		FullIdentityDigest: identity.FullIdentityDigest,
+		Namespace:          identity.Namespace,
 		PodUID:             identity.PodUID,
 		ContainerName:      identity.ContainerName,
 		FenceUID:           identity.FenceUID,
@@ -2267,6 +2336,7 @@ func effectIdentityFromStored(identity storedEffectIdentityDTO) EffectIdentity {
 		Kind:               EffectKind(identity.Kind),
 		DeterministicName:  identity.DeterministicName,
 		FullIdentityDigest: identity.FullIdentityDigest,
+		Namespace:          identity.Namespace,
 		PodUID:             identity.PodUID,
 		ContainerName:      identity.ContainerName,
 		FenceUID:           identity.FenceUID,
@@ -2419,6 +2489,7 @@ func testWindowEffect(name string) EffectIdentity {
 		Kind:               EffectKindTargetFenceWindow,
 		DeterministicName:  name,
 		FullIdentityDigest: testDigest("window:" + name),
+		Namespace:          "kb-system",
 	}
 }
 
@@ -2427,6 +2498,7 @@ func testUnitEffect(name string) EffectIdentity {
 		Kind:               EffectKindUnitExecution,
 		DeterministicName:  name,
 		FullIdentityDigest: testDigest("unit:" + name),
+		Namespace:          "kb-system",
 		PodUID:             types.UID("pod-uid-1"),
 		ContainerName:      "mysql",
 		FenceUID:           types.UID("fence-uid-1"),
@@ -2441,7 +2513,7 @@ func effectTarget(effect EffectIdentity) EffectObjectTarget {
 	return EffectObjectTarget{
 		APIVersion: "protocol.kubeblocks.io/v1alpha1",
 		Kind:       kind,
-		Namespace:  "kb-system",
+		Namespace:  effect.Namespace,
 		Name:       effect.DeterministicName,
 	}
 }

--- a/pkg/reconfigure/protocol/test_helpers_test.go
+++ b/pkg/reconfigure/protocol/test_helpers_test.go
@@ -1,0 +1,45 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package protocol
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func testDigest(input string) string {
+	digest := sha256.Sum256([]byte(input))
+	return "sha256:" + hex.EncodeToString(digest[:])
+}
+
+func requireStateEqual(t *testing.T, expected, actual FenceState) {
+	t.Helper()
+	require.Equal(t, canonicalStateBytes(t, expected), canonicalStateBytes(t, actual))
+}
+
+func canonicalStateBytes(t *testing.T, state FenceState) []byte {
+	t.Helper()
+	data, err := CanonicalFenceStateBytes(state)
+	require.NoError(t, err)
+	return data
+}


### PR DESCRIPTION
## Summary

- add a restart-safe execution registry with frozen registration/effect manifests and bounded closeout capacity
- add signed window permit validation and atomic Lease-backed session acquisition/recovery
- enforce fail-closed write-site and decode contracts for object identity, drain readback, closeout variants, and key ownership
- harden terminal replay, namespace-scoped effect identity, and malformed Lease takeover based on review findings

## Scope

This PR provides the standalone protocol primitives and tests. Controller producer/consumer integration, API/CRD wiring, and runtime validation will follow separately.

Fixes #10610. Part of #10578.

## Testing

- `go test ./pkg/reconfigure/protocol -count=1`
- `go test -race ./pkg/reconfigure/protocol -count=10`
- `go test ./pkg/reconfigure/protocol -shuffle=on -count=50`
- `go vet ./pkg/reconfigure/protocol`
- `KUBEBUILDER_ASSETS=<envtest-assets> go test ./pkg/...`
- `GOTOOLCHAIN=go1.25.10 make lint`
- `git diff --check`
