### PR TITLE
fix(dataprotection): honor target port with credentials

### DIFF
--- a/pkg/dataprotection/utils/envvar.go
+++ b/pkg/dataprotection/utils/envvar.go
@@ -47,7 +47,10 @@ func BuildEnvByTarget(pod *corev1.Pod, credential *dpv1alpha1.ConnectionCredenti
 		if credential.PortKey != "" {
 			envVars = append(envVars, buildEnvBySecretKey(dptypes.DPDBPort, credential.SecretName, credential.PortKey))
 		} else {
-			portEnv, _ := GetDPDBPortEnv(pod, nil)
+			portEnv, err := GetDPDBPortEnv(pod, containerPort)
+			if err != nil {
+				return nil, err
+			}
 			envVars = append(envVars, *portEnv)
 		}
 		if credential.PasswordKey != "" {

--- a/pkg/dataprotection/utils/utils_test.go
+++ b/pkg/dataprotection/utils/utils_test.go
@@ -204,6 +204,38 @@ func TestBuildEnvByTargetAndParameters(t *testing.T) {
 	assert.Equal(t, []corev1.EnvVar{{Name: "P1", Value: "v1"}}, params)
 }
 
+func TestBuildEnvByTargetUsesNamedContainerPortWithCredentialFallback(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod-0", Namespace: "ns"},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Name: "fe",
+			Ports: []corev1.ContainerPort{
+				{Name: "http-port", ContainerPort: 8030},
+				{Name: "query-port", ContainerPort: 9030},
+			},
+		}}},
+	}
+	containerPort := &dpv1alpha1.ContainerPort{ContainerName: "fe", PortName: "query-port"}
+	credential := &dpv1alpha1.ConnectionCredential{
+		SecretName:  "conn",
+		UsernameKey: "username",
+		PasswordKey: "password",
+	}
+
+	envs, err := BuildEnvByTarget(pod, credential, containerPort)
+	assert.NoError(t, err)
+	assert.Contains(t, envs, corev1.EnvVar{Name: dptypes.DPDBPort, Value: "9030"})
+
+	envs, err = BuildEnvByTarget(pod, credential, &dpv1alpha1.ContainerPort{ContainerName: "fe", PortName: "missing"})
+	assert.Error(t, err)
+	assert.Nil(t, envs)
+
+	credential.PortKey = "port"
+	envs, err = BuildEnvByTarget(pod, credential, &dpv1alpha1.ContainerPort{ContainerName: "fe", PortName: "missing"})
+	assert.NoError(t, err)
+	assert.Contains(t, envs, buildEnvBySecretKey(dptypes.DPDBPort, "conn", "port"))
+}
+
 func TestBackupPolicyAndScheduleHelpers(t *testing.T) {
 	policies := &dpv1alpha1.BackupPolicyList{Items: []dpv1alpha1.BackupPolicy{
 		{


### PR DESCRIPTION
## What this fixes

When a backup target uses connection credentials without a `portKey`, `BuildEnvByTarget` ignored the target named `containerPort` and fell back to the pod first container port.

This change preserves the named target port in that credential fallback path, propagates an invalid named-port error, and keeps an explicit secret-backed `portKey` as the higher-priority source.

Fixes #10613

Related restore-side fix: #10616

## Tests

- `go test ./pkg/dataprotection/utils -run TestBuildEnvByTargetUsesNamedContainerPortWithCredentialFallback -count=1`
- `KUBEBUILDER_ASSETS=<k8s-1.26.1-assets> go test ./pkg/dataprotection/utils -count=1`
- `KUBEBUILDER_ASSETS=<k8s-1.26.1-assets> go test -race ./pkg/dataprotection/utils -count=1`
- `go vet ./pkg/dataprotection/utils`
- `git diff --check`

## Validation boundary

The focused and package-level tests pass. Exact patch runtime validation is in progress with the affected addon team; this draft does not claim runtime or release readiness.