### PR TITLE
fix(dataprotection): record post-ready stage errors

### DIFF
--- a/controllers/dataprotection/restore_controller.go
+++ b/controllers/dataprotection/restore_controller.go
@@ -420,7 +420,7 @@ func (r *RestoreReconciler) postReady(reqCtx intctrlutil.RequestCtx, restoreMgr 
 		isCompleted bool
 	)
 	defer func() {
-		r.handleRestoreStageError(restoreMgr.Restore, dpv1alpha1.PrepareData, err)
+		r.handleRestoreStageError(restoreMgr.Restore, dpv1alpha1.PostReady, err)
 	}()
 	if readyConfig.ReadinessProbe != nil && !meta.IsStatusConditionTrue(restoreMgr.Restore.Status.Conditions, dprestore.ConditionTypeReadinessProbe) {
 		// TODO: check readiness probe, use a job and kubectl exec?
@@ -527,7 +527,11 @@ func (r *RestoreReconciler) handleBackupActionSet(reqCtx intctrlutil.RequestCtx,
 
 func (r *RestoreReconciler) handleRestoreStageError(restore *dpv1alpha1.Restore, stage dpv1alpha1.RestoreStage, err error) {
 	if intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal) {
-		condition := meta.FindStatusCondition(restore.Status.Conditions, dprestore.ConditionTypeRestorePreparedData)
+		conditionType := dprestore.ConditionTypeRestorePreparedData
+		if stage == dpv1alpha1.PostReady {
+			conditionType = dprestore.ConditionTypeRestorePostReady
+		}
+		condition := meta.FindStatusCondition(restore.Status.Conditions, conditionType)
 		if condition != nil && condition.Reason != dprestore.ReasonFailed {
 			dprestore.SetRestoreStageCondition(restore, stage, dprestore.ReasonFailed, err.Error())
 		}

--- a/controllers/dataprotection/restore_controller_test.go
+++ b/controllers/dataprotection/restore_controller_test.go
@@ -37,6 +37,7 @@ import (
 
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	dprestore "github.com/apecloud/kubeblocks/pkg/dataprotection/restore"
 	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 	dputils "github.com/apecloud/kubeblocks/pkg/dataprotection/utils"
@@ -480,6 +481,30 @@ var _ = Describe("Restore Controller test", func() {
 				mockAndCheckRestoreCompleted(restore)
 			})
 
+		})
+
+		It("records a postReady fatal error on the postReady condition", func() {
+			restore := &dpv1alpha1.Restore{
+				ObjectMeta: metav1.ObjectMeta{Name: "post-ready-error", Namespace: testCtx.DefaultNamespace},
+				Spec:       dpv1alpha1.RestoreSpec{ReadyConfig: &dpv1alpha1.ReadyConfig{}},
+			}
+			restoreMgr := &dprestore.RestoreManager{
+				Restore: restore,
+				PostReadyBackupSets: []dprestore.BackupActionSet{{
+					Backup: &dpv1alpha1.Backup{ObjectMeta: metav1.ObjectMeta{Name: "backup"}},
+					ActionSet: &dpv1alpha1.ActionSet{Spec: dpv1alpha1.ActionSetSpec{Restore: &dpv1alpha1.RestoreActionSpec{
+						PostReady: []dpv1alpha1.ActionSpec{{}},
+					}}},
+				}},
+			}
+
+			completed, err := (&RestoreReconciler{}).postReady(intctrlutil.RequestCtx{Ctx: ctx}, restoreMgr)
+			Expect(completed).Should(BeFalse())
+			Expect(intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal)).Should(BeTrue())
+			postReadyCondition := meta.FindStatusCondition(restore.Status.Conditions, dprestore.ConditionTypeRestorePostReady)
+			Expect(postReadyCondition).ShouldNot(BeNil())
+			Expect(postReadyCondition.Reason).Should(Equal(dprestore.ReasonFailed))
+			Expect(meta.FindStatusCondition(restore.Status.Conditions, dprestore.ConditionTypeRestorePreparedData)).Should(BeNil())
 		})
 
 		Context("test postReady stage", func() {


### PR DESCRIPTION
Fixes #10617

## Summary
- pass the PostReady stage to restore stage error handling
- inspect the condition that belongs to the failing restore stage
- cover a postReady-only fatal error without creating a PreparedData condition

## Tests
- focused postReady fatal-error spec
- go test ./controllers/dataprotection -count=1
- go vet ./controllers/dataprotection
- git diff --check