### PR TITLE
test(parameters): trigger mixed renderer via componentparameter

### DIFF
--- a/controllers/parameters/componentparameter_controller_test.go
+++ b/controllers/parameters/componentparameter_controller_test.go
@@ -21,6 +21,7 @@ package parameters
 
 import (
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -350,12 +351,12 @@ var _ = Describe("ComponentParameter Controller", func() {
 			}
 			Expect(testCtx.CreateObj(testCtx.Ctx, pcr)).Should(Succeed())
 
-			By("touch the component to regenerate ComponentParameter from mixed sources")
-			Eventually(testapps.GetAndChangeObj(&testCtx, client.ObjectKeyFromObject(compObj), func(comp *appsv1.Component) {
-				if comp.Annotations == nil {
-					comp.Annotations = map[string]string{}
+			By("touch the ComponentParameter to regenerate it from mixed sources")
+			Eventually(testapps.GetAndChangeObj(&testCtx, cfgKey, func(cfg *parametersv1alpha1.ComponentParameter) {
+				if cfg.Annotations == nil {
+					cfg.Annotations = map[string]string{}
 				}
-				comp.Annotations["parameters.kubeblocks.io/mixed-mode-test"] = "true"
+				cfg.Annotations["parameters.kubeblocks.io/mixed-mode-test"] = time.Now().Format(time.RFC3339Nano)
 			})).Should(Succeed())
 
 			configKey := client.ObjectKey{


### PR DESCRIPTION
## What changed

Trigger the mixed ParametersDefinition/ParamConfigRenderer reconciliation by updating the `ComponentParameter` watched by the parameters controller, instead of touching its owning `Component` and relying on an indirect regeneration path.

## Why

The existing mixed-renderer test intermittently times out with only `my.cnf` rendered and the legacy `log.conf` missing. Across PR #10556 CI reruns, the same spec failed twice and passed once without code changes in this path. The direct trigger removes the cache/watch ordering dependency while preserving the same rendered-output assertions.

This is the test-only part previously explored in closed PR #10523. It does not include that PR's service-version behavior changes.

## Validation

- focused mixed-renderer spec: 10/10 sequential runs passed
- `go test ./controllers/parameters -count=1`: passed with local envtest assets
- `git diff --check`: passed
