### PR TITLE
chore(parameters): align mixed renderer compatibility lifecycle

### DIFF
--- a/controllers/parameters/componentparameter_controller_test.go
+++ b/controllers/parameters/componentparameter_controller_test.go
@@ -21,6 +21,7 @@ package parameters
 
 import (
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -350,12 +351,12 @@ var _ = Describe("ComponentParameter Controller", func() {
 			}
 			Expect(testCtx.CreateObj(testCtx.Ctx, pcr)).Should(Succeed())
 
-			By("touch the component to regenerate ComponentParameter from mixed sources")
-			Eventually(testapps.GetAndChangeObj(&testCtx, client.ObjectKeyFromObject(compObj), func(comp *appsv1.Component) {
-				if comp.Annotations == nil {
-					comp.Annotations = map[string]string{}
+			By("touch the ComponentParameter to regenerate it from mixed sources")
+			Eventually(testapps.GetAndChangeObj(&testCtx, cfgKey, func(cfg *parametersv1alpha1.ComponentParameter) {
+				if cfg.Annotations == nil {
+					cfg.Annotations = map[string]string{}
 				}
-				comp.Annotations["parameters.kubeblocks.io/mixed-mode-test"] = "true"
+				cfg.Annotations["parameters.kubeblocks.io/mixed-mode-test"] = time.Now().Format(time.RFC3339Nano)
 			})).Should(Succeed())
 
 			configKey := client.ObjectKey{

--- a/controllers/parameters/componentparameter_controller_test.go
+++ b/controllers/parameters/componentparameter_controller_test.go
@@ -21,7 +21,6 @@ package parameters
 
 import (
 	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -309,7 +308,54 @@ var _ = Describe("ComponentParameter Controller", func() {
 		})
 
 		It("should render both new PD and legacy PCR files in mixed mode", func() {
-			templateObj, _, compObj, _, _ := mockReconcileResource()
+			const legacyFile = "log.conf"
+			mockReconcileResource(func(templateObj *corev1.ConfigMap, compDefObj *appsv1.ComponentDefinition) {
+				By("prepare the legacy PCR compatibility resources before creating the Component")
+				Eventually(testapps.GetAndChangeObj(&testCtx, client.ObjectKeyFromObject(templateObj), func(tpl *corev1.ConfigMap) {
+					tpl.Data[legacyFile] = "slow_query_log=1\n"
+				})).Should(Succeed())
+
+				legacyPD := testparameters.NewParametersDefinitionFactory("legacy-log-params").
+					SetConfigFile(legacyFile).
+					Create(&testCtx).
+					GetObject()
+				Expect(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKeyFromObject(legacyPD), func(obj *parametersv1alpha1.ParametersDefinition) {
+					obj.Status.Phase = parametersv1alpha1.PDAvailablePhase
+				})()).Should(Succeed())
+
+				pcr := &parametersv1alpha1.ParamConfigRenderer{
+					ObjectMeta: metav1.ObjectMeta{Name: pdcrName + "-mixed"},
+					Spec: parametersv1alpha1.ParamConfigRendererSpec{
+						ComponentDef:   compDefObj.Name,
+						ServiceVersion: "8.0.30",
+						ParametersDefs: []string{legacyPD.Name},
+						Configs: []parametersv1alpha1.ComponentConfigDescription{{
+							Name:         legacyFile,
+							TemplateName: configSpecName,
+							FileFormatConfig: &parametersv1alpha1.FileFormatConfig{
+								Format: parametersv1alpha1.Properties,
+							},
+						}},
+					},
+				}
+				Expect(testCtx.CreateObj(testCtx.Ctx, pcr)).Should(Succeed())
+
+				By("wait until the controller cache resolves both new and legacy parameter bindings")
+				Eventually(func(g Gomega) {
+					cachedTemplate := &corev1.ConfigMap{}
+					g.Expect(testCtx.Cli.Get(testCtx.Ctx, client.ObjectKeyFromObject(templateObj), cachedTemplate)).Should(Succeed())
+					g.Expect(cachedTemplate.Data).Should(HaveKeyWithValue(legacyFile, "slow_query_log=1\n"))
+
+					cachedCompDef := &appsv1.ComponentDefinition{}
+					g.Expect(testCtx.Cli.Get(testCtx.Ctx, client.ObjectKeyFromObject(compDefObj), cachedCompDef)).Should(Succeed())
+					configDescs, paramsDefs, err := parameters.ResolveCmpdParametersDefs(testCtx.Ctx, testCtx.Cli, cachedCompDef)
+					g.Expect(err).ShouldNot(HaveOccurred())
+					g.Expect(configDescs).Should(HaveLen(2))
+					g.Expect(paramsDefs).Should(HaveLen(2))
+					g.Expect(configDescs).Should(ContainElement(HaveField("Name", legacyFile)))
+					g.Expect(paramsDefs).Should(ContainElement(HaveField("Name", legacyPD.Name)))
+				}).Should(Succeed())
+			})
 
 			cfgKey := client.ObjectKey{
 				Namespace: testCtx.DefaultNamespace,
@@ -317,46 +363,7 @@ var _ = Describe("ComponentParameter Controller", func() {
 			}
 			Eventually(testapps.CheckObj(&testCtx, cfgKey, func(g Gomega, cfg *parametersv1alpha1.ComponentParameter) {
 				g.Expect(cfg.Status.Phase).Should(BeEquivalentTo(parametersv1alpha1.CFinishedPhase))
-			})).Should(Succeed())
-
-			By("add a legacy-only file to the component template")
-			const legacyFile = "log.conf"
-			Eventually(testapps.GetAndChangeObj(&testCtx, client.ObjectKeyFromObject(templateObj), func(tpl *corev1.ConfigMap) {
-				tpl.Data[legacyFile] = "slow_query_log=1\n"
-			})).Should(Succeed())
-
-			By("create a legacy-only ParametersDefinition and ParamConfigRenderer binding")
-			legacyPD := testparameters.NewParametersDefinitionFactory("legacy-log-params").
-				SetConfigFile(legacyFile).
-				Create(&testCtx).
-				GetObject()
-			Expect(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKeyFromObject(legacyPD), func(obj *parametersv1alpha1.ParametersDefinition) {
-				obj.Status.Phase = parametersv1alpha1.PDAvailablePhase
-			})()).Should(Succeed())
-
-			pcr := &parametersv1alpha1.ParamConfigRenderer{
-				ObjectMeta: metav1.ObjectMeta{Name: pdcrName + "-mixed"},
-				Spec: parametersv1alpha1.ParamConfigRendererSpec{
-					ComponentDef:   compObj.Spec.CompDef,
-					ServiceVersion: "8.0.30",
-					ParametersDefs: []string{legacyPD.Name},
-					Configs: []parametersv1alpha1.ComponentConfigDescription{{
-						Name:         legacyFile,
-						TemplateName: configSpecName,
-						FileFormatConfig: &parametersv1alpha1.FileFormatConfig{
-							Format: parametersv1alpha1.Properties,
-						},
-					}},
-				},
-			}
-			Expect(testCtx.CreateObj(testCtx.Ctx, pcr)).Should(Succeed())
-
-			By("touch the ComponentParameter to regenerate it from mixed sources")
-			Eventually(testapps.GetAndChangeObj(&testCtx, cfgKey, func(cfg *parametersv1alpha1.ComponentParameter) {
-				if cfg.Annotations == nil {
-					cfg.Annotations = map[string]string{}
-				}
-				cfg.Annotations["parameters.kubeblocks.io/mixed-mode-test"] = time.Now().Format(time.RFC3339Nano)
+				g.Expect(parameters.GetConfigTemplateItem(&cfg.Spec, configSpecName)).ShouldNot(BeNil())
 			})).Should(Succeed())
 
 			configKey := client.ObjectKey{

--- a/controllers/parameters/utils_test.go
+++ b/controllers/parameters/utils_test.go
@@ -92,7 +92,7 @@ func mockConfigResource() (*corev1.ConfigMap, *parametersv1alpha1.ParametersDefi
 	return configmap, paramsdef
 }
 
-func mockReconcileResource() (*corev1.ConfigMap, *appsv1.Cluster, *appsv1.Component, *component.SynthesizedComponent, *workloads.InstanceSet) {
+func mockReconcileResource(setupBeforeComponent ...func(*corev1.ConfigMap, *appsv1.ComponentDefinition)) (*corev1.ConfigMap, *appsv1.Cluster, *appsv1.Component, *component.SynthesizedComponent, *workloads.InstanceSet) {
 	configmap, paramsDef := mockConfigResource()
 
 	By("Create a component definition obj and mock to available")
@@ -126,6 +126,10 @@ func mockReconcileResource() (*corev1.ConfigMap, *appsv1.Cluster, *appsv1.Compon
 		g.Expect(configDescs[0].TemplateName).Should(BeEquivalentTo(configSpecName))
 		g.Expect(paramsDefs[0].Name).Should(BeEquivalentTo(paramsDef.Name))
 	}).Should(Succeed())
+
+	for _, setup := range setupBeforeComponent {
+		setup(configmap, compDefObj)
+	}
 
 	By("Creating a cluster")
 	clusterObj := testapps.NewClusterFactory(testCtx.DefaultNamespace, clusterName, "").


### PR DESCRIPTION
## What changed

Prepare the legacy ParamConfigRenderer compatibility resources before creating the Component, then wait until the manager client resolves both the current ParametersDefinition and legacy PCR bindings before the initial ComponentParameter reconciliation.

The test now asserts both `my.cnf` and legacy `log.conf` are rendered without touching Component or ComponentParameter to manufacture another reconcile.

## Why

ParamConfigRenderer is deprecated in 1.2 and retained for compatibility with existing objects. The previous test created a PCR after the Component was already running, then manually touched another resource. Production has no PCR-to-ComponentParameter watch for that dynamic lifecycle, so the test trigger hid an unsupported contract instead of proving the compatibility path.

This keeps production behavior unchanged and tests the supported upgrade lifecycle: legacy PD/PCR resources already exist when the Component is created.

## Validation

- focused mixed-renderer spec: 6/6 repeated envtest runs passed with Kubernetes 1.26.1 assets
- `go test ./controllers/parameters -run TestAPIs -count=1`: passed
- `go vet ./controllers/parameters`: passed
- `git diff --check`: passed
- focused `-race` reached the spec assertion successfully, but the suite still reports the existing unrelated race in `pkg/controllerutil.namespacePredicateFilter`; this PR does not touch that path

Fixes #10622
