### PR TITLE
fix: add common labels to s3-compatible provider

### DIFF
--- a/deploy/helm/templates/storageprovider/s3-compatible.yaml
+++ b/deploy/helm/templates/storageprovider/s3-compatible.yaml
@@ -2,6 +2,8 @@ apiVersion: dataprotection.kubeblocks.io/v1alpha1
 kind: StorageProvider
 metadata:
   name: s3-compatible
+  labels:
+    {{- include "kubeblocks.labels" . | nindent 4 }}
 spec:
   csiDriverName: ru.yandex.s3.csi
   csiDriverSecretTemplate: |

--- a/test/helm/storageprovider_labels_test.go
+++ b/test/helm/storageprovider_labels_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2026 The KubeBlocks Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helm
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStorageProviderTemplatesUseCommonLabels(t *testing.T) {
+	templates, err := filepath.Glob("../../deploy/helm/templates/storageprovider/*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(templates) == 0 {
+		t.Fatal("no StorageProvider templates found")
+	}
+
+	for _, template := range templates {
+		content, err := os.ReadFile(template)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !metadataUsesCommonLabels(string(content)) {
+			t.Errorf("%s metadata does not use the common KubeBlocks labels", filepath.Base(template))
+		}
+	}
+}
+
+func metadataUsesCommonLabels(content string) bool {
+	const metadataStart = "metadata:\n"
+	const specStart = "\nspec:\n"
+	const labelsLine = "  labels:"
+	const commonLabelsLine = `    {{- include "kubeblocks.labels" . | nindent 4 }}`
+
+	start := strings.Index(content, metadataStart)
+	if start == -1 {
+		return false
+	}
+	metadata := content[start+len(metadataStart):]
+	end := strings.Index(metadata, specStart)
+	if end == -1 {
+		return false
+	}
+	lines := strings.Split(metadata[:end], "\n")
+	for i := 0; i+1 < len(lines); i++ {
+		if lines[i] == labelsLine && lines[i+1] == commonLabelsLine {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## What

- add the existing `kubeblocks.labels` helper to the `s3-compatible` StorageProvider template
- add a regression test outside the chart package that requires every StorageProvider template to use the helper in `metadata.labels`

## Why

A failed-install cleanup audit found that 10 rendered StorageProviders carried the chart's five common labels, while `s3-compatible` carried only Helm's managed-by label. The live object matched the rendered manifest, so this is a chart metadata inconsistency rather than runtime drift.

The first local test location under `deploy/helm/tests` was withdrawn because it would have added Go source to the packaged chart. The final test lives under `test/helm`; base and fixed chart package file lists are identical (77 entries, no `.go` files).

Base: `5a57a85922ef7fb8f704cc1d51f656a62f771485`.

This PR is independent of the current TiDB runtime candidate and is not included in that candidate.

## Tests

- regression test injected into the unfixed base: RED only for `s3-compatible.yaml`
- `go test ./test/helm -count=1`
- `helm lint deploy/helm`
- focused `helm template` render verifies all five common labels
- base/fixed `helm package` file-list comparison: identical 77 entries, no Go files
- `make check-license-header`
- `git diff --check`
