### PR TITLE
chore: add common labels to s3-compatible provider

### DIFF
--- a/deploy/helm/templates/storageprovider/s3-compatible.yaml
+++ b/deploy/helm/templates/storageprovider/s3-compatible.yaml
@@ -2,6 +2,8 @@ apiVersion: dataprotection.kubeblocks.io/v1alpha1
 kind: StorageProvider
 metadata:
   name: s3-compatible
+  labels:
+    {{- include "kubeblocks.labels" . | nindent 4 }}
 spec:
   csiDriverName: ru.yandex.s3.csi
   csiDriverSecretTemplate: |


### PR DESCRIPTION
Fixes #10625.

## What

- add the existing `kubeblocks.labels` helper to the `s3-compatible` StorageProvider template
- add a regression test outside the chart package that requires every StorageProvider template to use the helper in `metadata.labels`

## Why

A failed-install cleanup audit found that 10 rendered StorageProviders carried the chart's five common labels, while `s3-compatible` carried only Helm's managed-by label. The live object matched the rendered manifest, so this is a chart metadata inconsistency rather than runtime drift.

The first local test location under `deploy/helm/tests` was withdrawn because it would have added Go source to the packaged chart. The final test lives under `test/helm`; base and fixed chart package file lists are identical (77 entries, no `.go` files).

Base: `5a57a85922ef7fb8f704cc1d51f656a62f771485`.

This PR is independent of the current TiDB runtime candidate and is not included in that candidate.

## Tests

- regression test injected into the unfixed base: RED only for `s3-compatible.yaml`
- `go test ./test/helm -count=1`
- `helm lint deploy/helm`
- focused `helm template` render verifies all five common labels
- base/fixed `helm package` file-list comparison: identical 77 entries, no Go files
- `make check-license-header`
- `git diff --check`
