### PR TITLE
chore: execute lifecycle actions on all selected pods

### DIFF
--- a/pkg/controller/lifecycle/errors.go
+++ b/pkg/controller/lifecycle/errors.go
@@ -40,3 +40,35 @@ func IgnoreNotDefined(err error) error {
 	}
 	return err
 }
+
+type actionAggregateError struct {
+	errs []error
+}
+
+func newActionAggregateError(errs []error) error {
+	if len(errs) == 0 {
+		return nil
+	}
+	return &actionAggregateError{errs: append([]error(nil), errs...)}
+}
+
+func (e *actionAggregateError) Error() string {
+	return errors.Join(e.errs...).Error()
+}
+
+func (e *actionAggregateError) Is(target error) bool {
+	if target == ErrActionNotDefined {
+		for _, err := range e.errs {
+			if !errors.Is(err, target) {
+				return false
+			}
+		}
+		return true
+	}
+	for _, err := range e.errs {
+		if errors.Is(err, target) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/controller/lifecycle/kbagent.go
+++ b/pkg/controller/lifecycle/kbagent.go
@@ -21,7 +21,6 @@ package lifecycle
 
 import (
 	"context"
-	stderrors "errors"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -426,7 +425,7 @@ func (a *kbagent) callActionWithSelector(ctx context.Context, spec *appsv1.Actio
 		}
 	}
 	if len(actionErrors) > 0 {
-		return nil, stderrors.Join(actionErrors...)
+		return nil, newActionAggregateError(actionErrors)
 	}
 	return output, nil
 }

--- a/pkg/controller/lifecycle/kbagent.go
+++ b/pkg/controller/lifecycle/kbagent.go
@@ -21,6 +21,7 @@ package lifecycle
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -364,11 +365,14 @@ func (a *kbagent) callActionWithSelector(ctx context.Context, spec *appsv1.Actio
 	if len(pods) == 0 {
 		return nil, fmt.Errorf("no available pod to execute action %s", lfa.name())
 	}
+	selector, _ := resolveTargetPodSelector(spec)
+	aggregateErrors := selector == appsv1.AllReplicas
 
 	// TODO: impl
 	//  - back-off to retry
 	//  - timeout
 	var output []byte
+	var actionErrors []error
 	for _, pod := range pods {
 		endpoint := func() (string, int32, error) {
 			host, port, err := a.serverEndpoint(pod)
@@ -387,7 +391,11 @@ func (a *kbagent) callActionWithSelector(ctx context.Context, spec *appsv1.Actio
 			cli, err = kbacli.NewClient(endpoint)
 		}
 		if err != nil {
-			return nil, err // mock client error
+			if !aggregateErrors {
+				return nil, err // mock client error
+			}
+			actionErrors = append(actionErrors, errors.Wrapf(err, "error creating client to execute action %s at pod %s", lfa.name(), pod.Name))
+			continue
 		}
 		if cli == nil {
 			continue // not kb-agent container and port defined, for test only
@@ -397,15 +405,28 @@ func (a *kbagent) callActionWithSelector(ctx context.Context, spec *appsv1.Actio
 		_ = cli.Close()
 
 		if err != nil {
-			return nil, errors.Wrapf(err, "http error occurred when executing action %s at pod %s", lfa.name(), pod.Name)
+			actionErr := errors.Wrapf(err, "http error occurred when executing action %s at pod %s", lfa.name(), pod.Name)
+			if !aggregateErrors {
+				return nil, actionErr
+			}
+			actionErrors = append(actionErrors, actionErr)
+			continue
 		}
 		if len(rsp.Error) > 0 {
-			return nil, a.formatError(lfa, rsp, pod.Name)
+			actionErr := a.formatError(lfa, rsp, pod.Name)
+			if !aggregateErrors {
+				return nil, actionErr
+			}
+			actionErrors = append(actionErrors, actionErr)
+			continue
 		}
 		// take first non-nil output
 		if output == nil && rsp.Output != nil {
 			output = rsp.Output
 		}
+	}
+	if len(actionErrors) > 0 {
+		return nil, stderrors.Join(actionErrors...)
 	}
 	return output, nil
 }
@@ -459,13 +480,7 @@ func (a *kbagent) formatError(lfa lifecycleAction, rsp proto.ActionResponse, pod
 }
 
 func SelectTargetPods(pods []*corev1.Pod, pod *corev1.Pod, spec *appsv1.Action) ([]*corev1.Pod, error) {
-	selector := spec.TargetPodSelector
-	matchingKey := spec.MatchingKey
-	if len(selector) == 0 && spec.Exec != nil && len(spec.Exec.TargetPodSelector) > 0 {
-		// back-off to use spec.Exec
-		selector = spec.Exec.TargetPodSelector
-		matchingKey = spec.Exec.MatchingKey
-	}
+	selector, matchingKey := resolveTargetPodSelector(spec)
 	if len(selector) == 0 {
 		return []*corev1.Pod{pod}, nil
 	}
@@ -535,4 +550,15 @@ func SelectTargetPods(pods []*corev1.Pod, pod *corev1.Pod, spec *appsv1.Action) 
 	default:
 		return nil, fmt.Errorf("unknown pod selector: %s", selector)
 	}
+}
+
+func resolveTargetPodSelector(spec *appsv1.Action) (appsv1.TargetPodSelector, string) {
+	selector := spec.TargetPodSelector
+	matchingKey := spec.MatchingKey
+	if len(selector) == 0 && spec.Exec != nil && len(spec.Exec.TargetPodSelector) > 0 {
+		// back-off to use spec.Exec
+		selector = spec.Exec.TargetPodSelector
+		matchingKey = spec.Exec.MatchingKey
+	}
+	return selector, matchingKey
 }

--- a/pkg/controller/lifecycle/lifecycle_test.go
+++ b/pkg/controller/lifecycle/lifecycle_test.go
@@ -679,6 +679,93 @@ var _ = Describe("lifecycle", func() {
 			Expect(err).Should(BeNil())
 		})
 
+		It("pod selector - all attempts every pod after an error and can succeed next round", func() {
+			lifecycleActions.PostProvision.Exec.TargetPodSelector = appsv1.AllReplicas
+			pods = []*corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "pod-0"}},
+				{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "pod-1"}},
+			}
+
+			lifecycle, err := New(namespace, clusterName, compName, lifecycleActions, nil, nil, pods)
+			Expect(err).Should(BeNil())
+			Expect(lifecycle).ShouldNot(BeNil())
+
+			callCount := 0
+			mockKBAgentClient(func(recorder *kbacli.MockClientMockRecorder) {
+				recorder.Action(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, req proto.ActionRequest) (proto.ActionResponse, error) {
+					callCount++
+					if callCount == 1 {
+						return proto.ActionResponse{Error: proto.Error2Type(proto.ErrInProgress)}, nil
+					}
+					return proto.ActionResponse{}, nil
+				}).AnyTimes()
+			})
+
+			err = lifecycle.PostProvision(ctx, k8sClient, nil)
+			Expect(errors.Is(err, ErrActionInProgress)).Should(BeTrue())
+			Expect(callCount).Should(Equal(2))
+
+			err = lifecycle.PostProvision(ctx, k8sClient, nil)
+			Expect(err).Should(BeNil())
+			Expect(callCount).Should(Equal(4))
+		})
+
+		It("pod selector - all aggregates every pod error with pod identity", func() {
+			lifecycleActions.PostProvision.Exec.TargetPodSelector = appsv1.AllReplicas
+			pods = []*corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "pod-0"}},
+				{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "pod-1"}},
+			}
+
+			lifecycle, err := New(namespace, clusterName, compName, lifecycleActions, nil, nil, pods)
+			Expect(err).Should(BeNil())
+			Expect(lifecycle).ShouldNot(BeNil())
+
+			callCount := 0
+			mockKBAgentClient(func(recorder *kbacli.MockClientMockRecorder) {
+				recorder.Action(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, req proto.ActionRequest) (proto.ActionResponse, error) {
+					callCount++
+					if callCount == 1 {
+						return proto.ActionResponse{Error: proto.Error2Type(proto.ErrInProgress)}, nil
+					}
+					return proto.ActionResponse{Error: proto.Error2Type(proto.ErrBusy)}, nil
+				}).Times(2)
+			})
+
+			err = lifecycle.PostProvision(ctx, k8sClient, nil)
+			Expect(err).ShouldNot(BeNil())
+			Expect(errors.Is(err, ErrActionInProgress)).Should(BeTrue())
+			Expect(errors.Is(err, ErrActionBusy)).Should(BeTrue())
+			Expect(err.Error()).Should(ContainSubstring("pod-0"))
+			Expect(err.Error()).Should(ContainSubstring("pod-1"))
+			Expect(callCount).Should(Equal(2))
+		})
+
+		It("pod selector - role keeps first-error behavior", func() {
+			lifecycleActions.PostProvision.Exec.TargetPodSelector = appsv1.RoleSelector
+			lifecycleActions.PostProvision.Exec.MatchingKey = "leader"
+			pods = []*corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "pod-0", Labels: map[string]string{constant.RoleLabelKey: "leader"}}},
+				{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "pod-1", Labels: map[string]string{constant.RoleLabelKey: "leader"}}},
+			}
+
+			lifecycle, err := New(namespace, clusterName, compName, lifecycleActions, nil, nil, pods)
+			Expect(err).Should(BeNil())
+			Expect(lifecycle).ShouldNot(BeNil())
+
+			callCount := 0
+			mockKBAgentClient(func(recorder *kbacli.MockClientMockRecorder) {
+				recorder.Action(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, req proto.ActionRequest) (proto.ActionResponse, error) {
+					callCount++
+					return proto.ActionResponse{Error: proto.Error2Type(proto.ErrFailed)}, nil
+				}).Times(1)
+			})
+
+			err = lifecycle.PostProvision(ctx, k8sClient, nil)
+			Expect(errors.Is(err, ErrActionFailed)).Should(BeTrue())
+			Expect(callCount).Should(Equal(1))
+		})
+
 		It("pod selector - role", func() {
 			lifecycleActions.PostProvision.Exec.TargetPodSelector = appsv1.RoleSelector
 			lifecycleActions.PostProvision.Exec.MatchingKey = "leader"

--- a/pkg/controller/lifecycle/lifecycle_test.go
+++ b/pkg/controller/lifecycle/lifecycle_test.go
@@ -700,7 +700,7 @@ var _ = Describe("lifecycle", func() {
 					// The stable selection order is primary first, replica second. The
 					// primary cannot finish until the replica has executed its own action.
 					if roundCallCount == 1 && !replicaAttached {
-						return proto.ActionResponse{Error: proto.Error2Type(proto.ErrInProgress)}, nil
+						return proto.ActionResponse{Error: proto.Error2Type(proto.ErrFailed)}, nil
 					}
 					if roundCallCount == 2 {
 						replicaAttached = true
@@ -710,7 +710,7 @@ var _ = Describe("lifecycle", func() {
 			})
 
 			err = lifecycle.PostProvision(ctx, k8sClient, nil)
-			Expect(errors.Is(err, ErrActionInProgress)).Should(BeTrue())
+			Expect(errors.Is(err, ErrActionFailed)).Should(BeTrue())
 			Expect(roundCallCount).Should(Equal(2))
 			Expect(replicaAttached).Should(BeTrue())
 
@@ -750,6 +750,45 @@ var _ = Describe("lifecycle", func() {
 			Expect(err.Error()).Should(ContainSubstring("pod-0"))
 			Expect(err.Error()).Should(ContainSubstring("pod-1"))
 			Expect(callCount).Should(Equal(2))
+		})
+
+		It("pod selector - all ignores NotDefined only when every pod is NotDefined", func() {
+			lifecycleActions.PostProvision.Exec.TargetPodSelector = appsv1.AllReplicas
+			pods = []*corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "pod-0"}},
+				{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "pod-1"}},
+			}
+
+			lifecycle, err := New(namespace, clusterName, compName, lifecycleActions, nil, nil, pods)
+			Expect(err).Should(BeNil())
+			Expect(lifecycle).ShouldNot(BeNil())
+
+			callCount := 0
+			mockKBAgentClient(func(recorder *kbacli.MockClientMockRecorder) {
+				recorder.Action(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, req proto.ActionRequest) (proto.ActionResponse, error) {
+					callCount++
+					if callCount == 1 {
+						return proto.ActionResponse{Error: proto.Error2Type(proto.ErrNotDefined)}, nil
+					}
+					return proto.ActionResponse{Error: proto.Error2Type(proto.ErrFailed)}, nil
+				}).Times(2)
+			})
+
+			err = lifecycle.PostProvision(ctx, k8sClient, nil)
+			Expect(err).ShouldNot(BeNil())
+			Expect(errors.Is(err, ErrActionNotDefined)).Should(BeFalse())
+			Expect(errors.Is(err, ErrActionFailed)).Should(BeTrue())
+			Expect(IgnoreNotDefined(err)).ShouldNot(BeNil())
+			Expect(err.Error()).Should(ContainSubstring("pod-0"))
+			Expect(err.Error()).Should(ContainSubstring("pod-1"))
+
+			mockKBAgentClient(func(recorder *kbacli.MockClientMockRecorder) {
+				recorder.Action(gomock.Any(), gomock.Any()).Return(proto.ActionResponse{Error: proto.Error2Type(proto.ErrNotDefined)}, nil).Times(2)
+			})
+
+			err = lifecycle.PostProvision(ctx, k8sClient, nil)
+			Expect(errors.Is(err, ErrActionNotDefined)).Should(BeTrue())
+			Expect(IgnoreNotDefined(err)).Should(BeNil())
 		})
 
 		It("pod selector - role keeps first-error behavior", func() {

--- a/pkg/controller/lifecycle/lifecycle_test.go
+++ b/pkg/controller/lifecycle/lifecycle_test.go
@@ -679,23 +679,31 @@ var _ = Describe("lifecycle", func() {
 			Expect(err).Should(BeNil())
 		})
 
-		It("pod selector - all attempts every pod after an error and can succeed next round", func() {
+		It("pod selector - all lets a later replica unblock an earlier primary", func() {
 			lifecycleActions.PostProvision.Exec.TargetPodSelector = appsv1.AllReplicas
 			pods = []*corev1.Pod{
-				{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "pod-0"}},
-				{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "pod-1"}},
+				{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "primary-0"}},
+				{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "replica-0"}},
 			}
 
 			lifecycle, err := New(namespace, clusterName, compName, lifecycleActions, nil, nil, pods)
 			Expect(err).Should(BeNil())
 			Expect(lifecycle).ShouldNot(BeNil())
 
-			callCount := 0
+			totalCallCount := 0
+			roundCallCount := 0
+			replicaAttached := false
 			mockKBAgentClient(func(recorder *kbacli.MockClientMockRecorder) {
 				recorder.Action(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, req proto.ActionRequest) (proto.ActionResponse, error) {
-					callCount++
-					if callCount == 1 {
+					totalCallCount++
+					roundCallCount++
+					// The stable selection order is primary first, replica second. The
+					// primary cannot finish until the replica has executed its own action.
+					if roundCallCount == 1 && !replicaAttached {
 						return proto.ActionResponse{Error: proto.Error2Type(proto.ErrInProgress)}, nil
+					}
+					if roundCallCount == 2 {
+						replicaAttached = true
 					}
 					return proto.ActionResponse{}, nil
 				}).AnyTimes()
@@ -703,11 +711,14 @@ var _ = Describe("lifecycle", func() {
 
 			err = lifecycle.PostProvision(ctx, k8sClient, nil)
 			Expect(errors.Is(err, ErrActionInProgress)).Should(BeTrue())
-			Expect(callCount).Should(Equal(2))
+			Expect(roundCallCount).Should(Equal(2))
+			Expect(replicaAttached).Should(BeTrue())
 
+			roundCallCount = 0
 			err = lifecycle.PostProvision(ctx, k8sClient, nil)
 			Expect(err).Should(BeNil())
-			Expect(callCount).Should(Equal(4))
+			Expect(roundCallCount).Should(Equal(2))
+			Expect(totalCallCount).Should(Equal(4))
 		})
 
 		It("pod selector - all aggregates every pod error with pod identity", func() {


### PR DESCRIPTION
## What this fixes

When a lifecycle action selects `All`, the controller currently returns after the first pod-level client, HTTP, or action response error. Pods later in the selected slice do not receive the action in that round.

### Concrete user workflow

The motivating workflow is a six-Pod Valkey restore with three primaries and three replicas. Its blocking `postProvision` action uses `targetPodSelector: All`: every Pod must commit its own local restore-completion state, and each replica attaches itself to its primary.

With a stable primary-first selection order, a primary action can exit non-zero and be reported as `Failed` until a later replica has attached. That replica can attach only through its own action. Fail-fast returns before invoking it. Retrying in another reconciliation does not guarantee progress because Pod list order has no fairness or rotation contract; the same primary-first order can repeat indefinitely.

This change resolves the selector once using the existing top-level/Exec fallback contract, attempts every selected pod for `All`, and aggregates per-pod errors after the round. The replica action can therefore make monotonic progress even when an earlier primary fails; the next round can then close the primary. Every error retains its pod identity and sentinel behavior. `ErrActionNotDefined` is exposed to callers only when every selected Pod returned NotDefined, preventing a mixed NotDefined + real failure from being ignored as success. Other selectors retain their current first-error behavior.

Fixes #10628

## Tests

- fixed primary-first order: the blocking primary reports `Failed`, the later replica still executes and attaches, and the round returns `ErrActionFailed`;
- the next round succeeds because the replica-side dependency advanced;
- multiple `All` errors retain both pod identities and sentinel types;
- mixed NotDefined + Failed remains a failure, while all-NotDefined retains existing ignore behavior;
- Role with multiple matching Pods retains first-error behavior.

The fixed-order regression is RED on base `5a57a859`: only the primary is called (`1`, expected `2`). The mixed NotDefined + Failed regression is RED on the initial aggregation implementation because `errors.Is(err, ErrActionNotDefined)` incorrectly returns true. Both are GREEN at the current head.

Validated with:

- focused Ginkgo cases;
- `go test ./pkg/controller/lifecycle -count=1`;
- `go test -race ./pkg/controller/lifecycle -count=1`;
- `go vet ./pkg/controller/lifecycle`;
- `git diff --check`.

## Runtime evidence boundary

The original Valkey runtime observation proved only that the default selector completed after 3 of 6 Pods ran `postProvision`. The fixed-order `All` liveness cycle was then found by controller-path review and reproduced in the regression test; it was not inferred from an observed Pod product failure.

One later fresh Valkey restore using production-code commit `d094dc3aac8e61c316d973afa262d5bfec02830b` completed with all six Pods, but that is an `N=1` scoped observation. The current PR head adds review-driven error-precedence code and stronger regression tests, so the old runtime result is not relabeled as exact-current-head runtime evidence. This PR does not claim controller-wide frequency, all-scenario validation, or release readiness.

## Production-code runtime image identity

The pre-merge `linux/amd64` image built from production-code commit `d094dc3aac8e61c316d973afa262d5bfec02830b` keeps these identities distinct:

- OCI index: `sha256:ce543f50d343101a2b95b803a9c39e22418a9ef6c66ca42a922bfbd8926a2c54`
- platform manifest: `sha256:896a2dbd64b7cb989515090d70d7eb5792e9605d346d6cc859b0e70423754868`
- config digest / expected Kubernetes Pod status `imageID`: `sha256:0b3b420a140145a7db9704880f6427f1ee91443b00d4856fe76e62ea6f0a8563`
- final manager layer: `sha256:35567488695663e36b5f1c412d3654ba788c05843eb3fa827d8a7c398414477d`
- extracted `/manager`: `sha256:eb6af5dd660752a71bc855410082195d5f049b7b37fb7acb5b83819d9b4e4932`

The OCI index must not be reported as the live Pod `imageID`. This identity section intentionally remains bound to the earlier production-code commit and is not claimed as an exact-current-head runtime image.
