### PR TITLE
chore(dataprotection): move volume restore execution to restore controller

### DIFF
--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -29,7 +29,6 @@ import (
 	"strings"
 
 	vsv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -42,9 +41,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
@@ -53,7 +50,6 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/instanceset"
 	"github.com/apecloud/kubeblocks/pkg/controller/instancetemplate"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
-	dperrors "github.com/apecloud/kubeblocks/pkg/dataprotection/errors"
 	dprestore "github.com/apecloud/kubeblocks/pkg/dataprotection/restore"
 	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 	"github.com/apecloud/kubeblocks/pkg/dataprotection/utils"
@@ -138,45 +134,7 @@ func (r *VolumePopulatorReconciler) handleSyncPVCError(reqCtx intctrlutil.Reques
 func (r *VolumePopulatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return intctrlutil.NewControllerManagedBy(mgr).
 		For(&corev1.PersistentVolumeClaim{}).
-		Owns(&batchv1.Job{}).
-		Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(r.parsePopulatePod)).
 		Complete(r)
-}
-
-func (r *VolumePopulatorReconciler) parsePopulatePod(ctx context.Context, object client.Object) []reconcile.Request {
-	labels := object.GetLabels()
-	if labels[dprestore.DataProtectionRestoreLabelKey] == "" ||
-		labels[dprestore.DataProtectionPopulatePVCLabelKey] == "" {
-		return nil
-	}
-	owner := metav1.GetControllerOf(object)
-	if owner == nil || owner.Kind != constant.JobKind {
-		return nil
-	}
-	job := &batchv1.Job{}
-	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: object.GetNamespace(), Name: owner.Name}, job); err != nil {
-		if !apierrors.IsNotFound(err) {
-			log.FromContext(ctx).V(1).Info("failed to map volume populate pod to job",
-				"pod", client.ObjectKeyFromObject(object),
-				"job", types.NamespacedName{Namespace: object.GetNamespace(), Name: owner.Name},
-				"error", err)
-		}
-		return nil
-	}
-	if job.Labels[dprestore.DataProtectionRestoreLabelKey] == "" ||
-		job.Labels[dprestore.DataProtectionPopulatePVCLabelKey] == "" {
-		return nil
-	}
-	pvcOwner := metav1.GetControllerOf(job)
-	if pvcOwner == nil || pvcOwner.Kind != constant.PersistentVolumeClaimKind {
-		return nil
-	}
-	return []reconcile.Request{{
-		NamespacedName: types.NamespacedName{
-			Namespace: job.Namespace,
-			Name:      pvcOwner.Name,
-		},
-	}}
 }
 
 func (r *VolumePopulatorReconciler) MatchToPopulate(pvc *corev1.PersistentVolumeClaim) (bool, error) {
@@ -215,20 +173,15 @@ func (r *VolumePopulatorReconciler) syncPVC(reqCtx intctrlutil.RequestCtx, pvc *
 	if !matched {
 		return nil
 	}
-	if pvc.Spec.DataSourceRef.Kind == dptypes.RestoreKind {
-		restoreMgr, err := r.validateRestoreRefAndBuildMGR(reqCtx, pvc)
-		if err != nil {
-			return err
-		}
-		if pvc.Spec.VolumeName == "" {
-			return r.Populate(reqCtx, pvc, &pvcRestoreContext{
-				restoreMgr: restoreMgr,
-				mode:       pvcRestoreModeRestoreData,
-			})
-		}
+	if !pvc.DeletionTimestamp.IsZero() {
 		return r.Cleanup(reqCtx, pvc)
 	}
-	restoreCtx, err := r.validateRestoreAndBuildMGR(reqCtx, pvc)
+	var restoreCtx *pvcRestoreContext
+	if pvc.Spec.DataSourceRef.Kind == dptypes.RestoreKind {
+		restoreCtx, err = r.validateRestoreRefAndBuildMGR(reqCtx, pvc)
+	} else {
+		restoreCtx, err = r.validateRestoreAndBuildMGR(reqCtx, pvc)
+	}
 	if err != nil {
 		return err
 	}
@@ -265,7 +218,7 @@ func (r *VolumePopulatorReconciler) dispatchUnboundPVC(reqCtx intctrlutil.Reques
 	return r.ProvisionOnly(reqCtx, pvc, restoreCtx)
 }
 
-func (r *VolumePopulatorReconciler) validateRestoreRefAndBuildMGR(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim) (*dprestore.RestoreManager, error) {
+func (r *VolumePopulatorReconciler) validateRestoreRefAndBuildMGR(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim) (*pvcRestoreContext, error) {
 	restore := &dpv1alpha1.Restore{}
 	if err := r.Client.Get(reqCtx.Ctx, types.NamespacedName{Name: pvc.Spec.DataSourceRef.Name,
 		Namespace: pvc.Namespace}, restore); err != nil {
@@ -287,7 +240,10 @@ func (r *VolumePopulatorReconciler) validateRestoreRefAndBuildMGR(reqCtx intctrl
 		}
 	}
 	restoreMgr.WorkerServiceAccount = saName
-	return restoreMgr, nil
+	return &pvcRestoreContext{
+		restoreMgr: restoreMgr,
+		mode:       pvcRestoreModeRestoreData,
+	}, nil
 }
 
 func (r *VolumePopulatorReconciler) validateRestoreAndBuildMGR(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim) (*pvcRestoreContext, error) {
@@ -360,15 +316,6 @@ func (r *VolumePopulatorReconciler) validateRestoreAndBuildMGR(reqCtx intctrluti
 	if err = r.restoreSystemAccountSecrets(reqCtx, pvc, backupNamespace); err != nil {
 		return nil, err
 	}
-	if decision.mode == pvcRestoreModeRestoreData {
-		restore, err = r.ensureInternalRestore(reqCtx, pvc, restore)
-		if err != nil {
-			return nil, err
-		}
-		if err = r.ensureInternalRestoreBackupRepoReady(reqCtx, restore); err != nil {
-			return nil, err
-		}
-	}
 	restoreMgr := dprestore.NewRestoreManager(restore, r.Recorder, r.Scheme, r.Client)
 	if err = dprestore.ValidateAndInitRestoreMGR(reqCtx, r.Client, restoreMgr); err != nil {
 		return nil, err
@@ -390,40 +337,6 @@ func (r *VolumePopulatorReconciler) validateRestoreAndBuildMGR(reqCtx intctrluti
 		mode:          decision.mode,
 		skipPostReady: decision.skipPostReady,
 	}, nil
-}
-
-func (r *VolumePopulatorReconciler) ensureInternalRestoreBackupRepoReady(reqCtx intctrlutil.RequestCtx,
-	restore *dpv1alpha1.Restore) error {
-	original := restore.DeepCopy()
-	repoName, err := CheckBackupRepoForRestore(reqCtx, r.Client, restore)
-	switch {
-	case intctrlutil.IsTargetError(err, dperrors.ErrorTypeWaitForBackupRepoPreparation):
-		dprestore.SetRestoreCheckBackupRepoCondition(restore, dprestore.ReasonWaitForBackupRepo, err.Error())
-		if restore.Labels == nil {
-			restore.Labels = map[string]string{}
-		}
-		restore.Labels[dataProtectionBackupRepoKey] = repoName
-		restore.Labels[dataProtectionWaitRepoPreparationKey] = trueVal
-		if patchErr := r.patchInternalRestoreMetaAndStatus(reqCtx, original, restore); patchErr != nil {
-			return patchErr
-		}
-		return intctrlutil.NewRequeueError(reconcileInterval, err.Error())
-	case intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal):
-		dprestore.SetRestoreCheckBackupRepoCondition(restore, dprestore.ReasonCheckBackupRepoFailed, err.Error())
-		if patchErr := r.patchInternalRestoreMetaAndStatus(reqCtx, original, restore); patchErr != nil {
-			return patchErr
-		}
-		return err
-	case err != nil:
-		dprestore.SetRestoreCheckBackupRepoCondition(restore, ReasonUnknownError, err.Error())
-		if patchErr := r.patchInternalRestoreMetaAndStatus(reqCtx, original, restore); patchErr != nil {
-			return patchErr
-		}
-		return err
-	default:
-		dprestore.SetRestoreCheckBackupRepoCondition(restore, dprestore.ReasonCheckBackupRepoSuccessfully, "")
-		return r.patchInternalRestoreMetaAndStatus(reqCtx, original, restore)
-	}
 }
 
 func (r *VolumePopulatorReconciler) resolveSourceTarget(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim, backupNamespace string) (*dpv1alpha1.BackupStatusTarget, error) {
@@ -812,7 +725,7 @@ func internalRestoreLabels(pvc *corev1.PersistentVolumeClaim) map[string]string 
 	return labels
 }
 
-func (r *VolumePopulatorReconciler) ensureInternalRestore(reqCtx intctrlutil.RequestCtx,
+func (r *VolumePopulatorReconciler) ensureExecutionRestore(reqCtx intctrlutil.RequestCtx,
 	pvc *corev1.PersistentVolumeClaim,
 	desired *dpv1alpha1.Restore) (*dpv1alpha1.Restore, error) {
 	if err := controllerutil.SetOwnerReference(pvc, desired, r.Scheme); err != nil {
@@ -830,12 +743,22 @@ func (r *VolumePopulatorReconciler) ensureInternalRestore(reqCtx intctrlutil.Req
 		return desired, nil
 	}
 	if !reflect.DeepEqual(existing.Spec, desired.Spec) {
-		return nil, intctrlutil.NewFatalError(fmt.Sprintf("internal restore %s/%s spec does not match current PVC restore intent",
+		return nil, intctrlutil.NewFatalError(fmt.Sprintf("execution restore %s/%s spec does not match current PVC restore intent",
 			existing.Namespace, existing.Name))
 	}
 	original := existing.DeepCopy()
-	existing.Labels = desired.Labels
-	existing.Annotations = desired.Annotations
+	if existing.Labels == nil {
+		existing.Labels = map[string]string{}
+	}
+	for key, value := range desired.Labels {
+		existing.Labels[key] = value
+	}
+	if existing.Annotations == nil {
+		existing.Annotations = map[string]string{}
+	}
+	for key, value := range desired.Annotations {
+		existing.Annotations[key] = value
+	}
 	existing.OwnerReferences = desired.OwnerReferences
 	if !reflect.DeepEqual(original.Labels, existing.Labels) ||
 		!reflect.DeepEqual(original.Annotations, existing.Annotations) ||
@@ -845,6 +768,51 @@ func (r *VolumePopulatorReconciler) ensureInternalRestore(reqCtx intctrlutil.Req
 		}
 	}
 	return existing, nil
+}
+
+func buildExecutionRestore(pvc, populatePVC *corev1.PersistentVolumeClaim, source *dpv1alpha1.Restore) *dpv1alpha1.Restore {
+	prepareDataConfig := source.Spec.PrepareDataConfig
+	claimSpec := corev1.PersistentVolumeClaimSpec{
+		AccessModes:      pvc.Spec.AccessModes,
+		Resources:        pvc.Spec.Resources,
+		StorageClassName: pvc.Spec.StorageClassName,
+		VolumeMode:       pvc.Spec.VolumeMode,
+	}
+	if populatePVC.Spec.DataSource != nil {
+		claimSpec.DataSource = populatePVC.Spec.DataSource.DeepCopy()
+	}
+	if populatePVC.Spec.DataSourceRef != nil {
+		claimSpec.DataSourceRef = populatePVC.Spec.DataSourceRef.DeepCopy()
+	}
+	claimMeta := metav1.ObjectMeta{
+		Name:      populatePVC.Name,
+		Namespace: populatePVC.Namespace,
+	}
+	return &dpv1alpha1.Restore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        getPopulatePVCName(pvc.UID),
+			Namespace:   pvc.Namespace,
+			Labels:      internalRestoreLabels(pvc),
+			Annotations: source.Annotations,
+		},
+		Spec: dpv1alpha1.RestoreSpec{
+			Backup:             source.Spec.Backup,
+			RestoreTime:        source.Spec.RestoreTime,
+			Env:                source.Spec.Env,
+			Parameters:         source.Spec.Parameters,
+			ServiceAccountName: source.Spec.ServiceAccountName,
+			PrepareDataConfig: &dpv1alpha1.PrepareDataConfig{
+				RequiredPolicyForAllPodSelection: prepareDataConfig.RequiredPolicyForAllPodSelection,
+				RestoreVolumeClaims: []dpv1alpha1.RestoreVolumeClaim{{
+					ObjectMeta:      claimMeta,
+					VolumeClaimSpec: claimSpec,
+					VolumeConfig:    *prepareDataConfig.DataSourceRef,
+				}},
+				VolumeClaimRestorePolicy: prepareDataConfig.VolumeClaimRestorePolicy,
+				SchedulingSpec:           prepareDataConfig.SchedulingSpec,
+			},
+		},
+	}
 }
 
 func restoreParametersMapFromPVC(pvc *corev1.PersistentVolumeClaim) (map[string]string, error) {
@@ -959,76 +927,28 @@ func (r *VolumePopulatorReconciler) Populate(reqCtx intctrlutil.RequestCtx, pvc 
 			corev1.LabelHostname: nodeName,
 		}
 	}
-	dprestore.SetRestoreStageCondition(restoreMgr.Restore, dpv1alpha1.PrepareData, dprestore.ReasonProcessing, "processing prepareData stage.")
-	var populatePVC *corev1.PersistentVolumeClaim
-	for i, v := range restoreMgr.PrepareDataBackupSets {
-		target := utils.GetBackupStatusTarget(v.Backup, restoreMgr.Restore.Spec.Backup.SourceTargetName)
-		if target == nil {
-			dprestore.SetRestoreStageCondition(restoreMgr.Restore, dpv1alpha1.PrepareData, dprestore.ReasonFailed, "can not found any source targe in backup "+v.Backup.Name)
-			if patchErr := r.patchInternalRestoreStatus(reqCtx, restoreMgr); patchErr != nil {
-				return patchErr
-			}
-			return intctrlutil.NewFatalError("can not found any source targe in backup " + v.Backup.Name)
-		}
-		if populatePVC == nil {
-			populatePVC, err = r.getPopulatePVC(reqCtx, pvc, v,
-				restoreMgr.Restore, target, nodeName)
-			if err != nil {
-				dprestore.SetRestoreStageCondition(restoreMgr.Restore, dpv1alpha1.PrepareData, dprestore.ReasonFailed, err.Error())
-				if patchErr := r.patchInternalRestoreStatus(reqCtx, restoreMgr); patchErr != nil {
-					return patchErr
-				}
-				return err
-			}
-		}
-
-		// 1. build populate job
-		job, err := restoreMgr.BuildVolumePopulateJob(reqCtx, r.Client, v, target, populatePVC, i)
-		if err != nil {
-			dprestore.SetRestoreStageCondition(restoreMgr.Restore, dpv1alpha1.PrepareData, dprestore.ReasonFailed, err.Error())
-			if patchErr := r.patchInternalRestoreStatus(reqCtx, restoreMgr); patchErr != nil {
-				return patchErr
-			}
-			return err
-		}
-		if job == nil {
-			continue
-		}
-
-		// 2. create job
-		jobs, err := restoreMgr.CreateJobsIfNotExist(reqCtx, r.Client, pvc, []*batchv1.Job{job})
-		if err != nil {
-			dprestore.SetRestoreStageCondition(restoreMgr.Restore, dpv1alpha1.PrepareData, dprestore.ReasonFailed, err.Error())
-			if patchErr := r.patchInternalRestoreStatus(reqCtx, restoreMgr); patchErr != nil {
-				return patchErr
-			}
-			return err
-		}
-
-		// 3. check if jobs are finished.
-		actionFinished, actionFailed, err := restoreMgr.CheckJobsDone(dpv1alpha1.PrepareData, "prepareData", v, jobs)
-		if err != nil {
-			dprestore.SetRestoreStageCondition(restoreMgr.Restore, dpv1alpha1.PrepareData, dprestore.ReasonFailed, err.Error())
-			if patchErr := r.patchInternalRestoreStatus(reqCtx, restoreMgr); patchErr != nil {
-				return patchErr
-			}
-			return err
-		}
-		if !actionFinished {
-			if err = r.patchInternalRestoreStatus(reqCtx, restoreMgr); err != nil {
-				return err
-			}
-			return nil
-		}
-		if actionFailed {
-			dprestore.SetRestoreStageCondition(restoreMgr.Restore, dpv1alpha1.PrepareData, dprestore.ReasonFailed, "restore prepareData job failed")
-			if err = r.patchInternalRestoreStatus(reqCtx, restoreMgr); err != nil {
-				return err
-			}
-			return intctrlutil.NewFatalError("restore prepareData job failed")
-		}
+	backupSet := restoreMgr.PrepareDataBackupSets[0]
+	target := utils.GetBackupStatusTarget(backupSet.Backup, restoreMgr.Restore.Spec.Backup.SourceTargetName)
+	if target == nil {
+		return intctrlutil.NewFatalError("can not found any source target in backup " + backupSet.Backup.Name)
 	}
-	// 4. if jobs are succeed, rebind the pvc and pv
+	populatePVC, err := r.getPopulatePVC(reqCtx, pvc, backupSet, restoreMgr.Restore, target, nodeName)
+	if err != nil {
+		return err
+	}
+	executionRestore, err := r.ensureExecutionRestore(reqCtx, pvc, buildExecutionRestore(pvc, populatePVC, restoreMgr.Restore))
+	if err != nil {
+		return err
+	}
+	switch executionRestore.Status.Phase {
+	case dpv1alpha1.RestorePhaseCompleted:
+		// continue with PV/PVC rebind
+	case dpv1alpha1.RestorePhaseFailed:
+		return intctrlutil.NewFatalError(fmt.Sprintf("execution restore %s/%s failed", executionRestore.Namespace, executionRestore.Name))
+	default:
+		return intctrlutil.NewRequeueError(reconcileInterval, "waiting for execution restore")
+	}
+	// If the execution Restore succeeds, rebind the PVC and PV.
 	rebound, err := r.rebindPVCAndPV(reqCtx, populatePVC, pvc)
 	if err != nil {
 		return err
@@ -1038,10 +958,6 @@ func (r *VolumePopulatorReconciler) Populate(reqCtx intctrlutil.RequestCtx, pvc 
 			return err
 		}
 		return intctrlutil.NewRequeueError(reconcileInterval, "waiting for populate PV to bind target PVC")
-	}
-	dprestore.SetRestoreStageCondition(restoreMgr.Restore, dpv1alpha1.PrepareData, dprestore.ReasonSucceed, "prepare data successfully")
-	if err = r.patchInternalRestoreStatus(reqCtx, restoreMgr); err != nil {
-		return err
 	}
 	return r.completeBoundPVCIfNeeded(reqCtx, pvc, restoreCtx)
 }
@@ -1078,36 +994,9 @@ func (r *VolumePopulatorReconciler) ProvisionOnly(reqCtx intctrlutil.RequestCtx,
 	return r.completeBoundPVCIfNeeded(reqCtx, pvc, restoreCtx)
 }
 
-func (r *VolumePopulatorReconciler) patchInternalRestoreStatus(reqCtx intctrlutil.RequestCtx, restoreMgr *dprestore.RestoreManager) error {
-	if reflect.DeepEqual(restoreMgr.OriginalRestore.Status, restoreMgr.Restore.Status) {
-		return nil
-	}
-	return r.Client.Status().Patch(reqCtx.Ctx, restoreMgr.Restore, client.MergeFrom(restoreMgr.OriginalRestore))
-}
-
-func (r *VolumePopulatorReconciler) patchInternalRestoreMetaAndStatus(reqCtx intctrlutil.RequestCtx,
-	original, restore *dpv1alpha1.Restore) error {
-	if !reflect.DeepEqual(original.ObjectMeta, restore.ObjectMeta) {
-		if err := r.Client.Patch(reqCtx.Ctx, restore, client.MergeFrom(original)); err != nil {
-			return err
-		}
-	}
-	if reflect.DeepEqual(original.Status, restore.Status) {
-		return nil
-	}
-	latest := &dpv1alpha1.Restore{}
-	if err := r.Client.Get(reqCtx.Ctx, client.ObjectKeyFromObject(restore), latest); err != nil {
-		return err
-	}
-	statusPatch := client.MergeFrom(latest.DeepCopy())
-	latest.Status = restore.Status
-	return r.Client.Status().Patch(reqCtx.Ctx, latest, statusPatch)
-}
-
 func (r *VolumePopulatorReconciler) completeBoundPVCIfNeeded(reqCtx intctrlutil.RequestCtx,
 	pvc *corev1.PersistentVolumeClaim,
 	restoreCtx *pvcRestoreContext) error {
-	restoreMgr := restoreCtx.restoreMgr
 	populateReleased := pvcPopulateReleased(pvc)
 	for i := range pvc.Status.Conditions {
 		condition := pvc.Status.Conditions[i]
@@ -1135,12 +1024,6 @@ func (r *VolumePopulatorReconciler) completeBoundPVCIfNeeded(reqCtx intctrlutil.
 		}
 		if err := r.updatePVCPopulatingCondition(reqCtx, pvc, reason, message); err != nil {
 			return err
-		}
-		if restoreCtx.mode == pvcRestoreModeRestoreData {
-			dprestore.SetRestoreStageCondition(restoreMgr.Restore, dpv1alpha1.PrepareData, dprestore.ReasonSucceed, "prepare data successfully")
-			if err := r.patchInternalRestoreStatus(reqCtx, restoreMgr); err != nil {
-				return err
-			}
 		}
 	}
 	if err := r.syncTargetPVCBoundStatusIfReady(reqCtx, pvc); err != nil {
@@ -1730,45 +1613,24 @@ func postReadyRestoreName(componentUID types.UID) string {
 }
 
 func (r *VolumePopulatorReconciler) Cleanup(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim) error {
+	populatePVC := &corev1.PersistentVolumeClaim{}
+	if err := r.Client.Get(reqCtx.Ctx, types.NamespacedName{Name: getPopulatePVCName(pvc.UID),
+		Namespace: pvc.Namespace}, populatePVC); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+	} else if err = r.Client.Delete(reqCtx.Ctx, populatePVC); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+
 	if slices.Contains(pvc.Finalizers, dptypes.DataProtectionFinalizerName) {
 		pvcPatch := client.MergeFrom(pvc.DeepCopy())
 		controllerutil.RemoveFinalizer(pvc, dptypes.DataProtectionFinalizerName)
 		if err := r.Client.Patch(reqCtx.Ctx, pvc, pvcPatch); err != nil {
-			return err
+			return client.IgnoreNotFound(err)
 		}
 	}
-
-	jobs := &batchv1.JobList{}
-	if err := r.Client.List(reqCtx.Ctx, jobs,
-		client.InNamespace(pvc.Namespace), client.MatchingLabels(map[string]string{
-			dprestore.DataProtectionPopulatePVCLabelKey: getPopulatePVCName(pvc.UID),
-		})); err != nil {
-		return err
-	}
-
-	for i := range jobs.Items {
-		job := &jobs.Items[i]
-		if controllerutil.ContainsFinalizer(job, dptypes.DataProtectionFinalizerName) {
-			patch := client.MergeFrom(job.DeepCopy())
-			controllerutil.RemoveFinalizer(job, dptypes.DataProtectionFinalizerName)
-			if err := r.Patch(reqCtx.Ctx, job, patch); err != nil {
-				return err
-			}
-		}
-		if !job.DeletionTimestamp.IsZero() {
-			continue
-		}
-		if err := intctrlutil.BackgroundDeleteObject(r.Client, reqCtx.Ctx, job); err != nil {
-			return err
-		}
-	}
-
-	populatePVC := &corev1.PersistentVolumeClaim{}
-	if err := r.Client.Get(reqCtx.Ctx, types.NamespacedName{Name: getPopulatePVCName(pvc.UID),
-		Namespace: pvc.Namespace}, populatePVC); err != nil {
-		return client.IgnoreNotFound(err)
-	}
-	return r.Client.Delete(reqCtx.Ctx, populatePVC)
+	return nil
 }
 
 func (r *VolumePopulatorReconciler) checkIntreeStorageClass(pvc *corev1.PersistentVolumeClaim, sc *storagev1.StorageClass) error {

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -799,6 +799,8 @@ func buildExecutionRestore(pvc, populatePVC *corev1.PersistentVolumeClaim, sourc
 			Backup:             source.Spec.Backup,
 			RestoreTime:        source.Spec.RestoreTime,
 			Env:                source.Spec.Env,
+			ContainerResources: source.Spec.ContainerResources,
+			BackoffLimit:       source.Spec.BackoffLimit,
 			Parameters:         source.Spec.Parameters,
 			ServiceAccountName: source.Spec.ServiceAccountName,
 			PrepareDataConfig: &dpv1alpha1.PrepareDataConfig{

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -1560,7 +1560,12 @@ func TestPopulateCreatesExecutionRestoreAndPolls(t *testing.T) {
 			RestoreTime:        "2026-07-13T01:02:03Z",
 			ServiceAccountName: "restore-worker",
 			Env:                []corev1.EnvVar{{Name: "RESTORE_ENV", Value: "value"}},
-			Parameters:         []dpv1alpha1.ParameterPair{{Name: "parameter", Value: "value"}},
+			ContainerResources: corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("250m")},
+				Limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+			},
+			BackoffLimit: ptr.To(int32(4)),
+			Parameters:   []dpv1alpha1.ParameterPair{{Name: "parameter", Value: "value"}},
 			PrepareDataConfig: &dpv1alpha1.PrepareDataConfig{
 				DataSourceRef: &dpv1alpha1.VolumeConfig{
 					VolumeSource: "data",
@@ -1627,6 +1632,8 @@ func TestPopulateCreatesExecutionRestoreAndPolls(t *testing.T) {
 	require.Equal(t, restore.Spec.RestoreTime, executionRestore.Spec.RestoreTime)
 	require.Equal(t, restore.Spec.ServiceAccountName, executionRestore.Spec.ServiceAccountName)
 	require.Equal(t, restore.Spec.Env, executionRestore.Spec.Env)
+	require.Equal(t, restore.Spec.ContainerResources, executionRestore.Spec.ContainerResources)
+	require.Equal(t, restore.Spec.BackoffLimit, executionRestore.Spec.BackoffLimit)
 	require.Equal(t, restore.Spec.Parameters, executionRestore.Spec.Parameters)
 	require.Equal(t, restore.Spec.PrepareDataConfig.RequiredPolicyForAllPodSelection,
 		executionRestore.Spec.PrepareDataConfig.RequiredPolicyForAllPodSelection)

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -31,6 +31,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -39,7 +40,6 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
@@ -449,14 +449,22 @@ var _ = Describe("Volume Populator Controller test", func() {
 			Eventually(testapps.CheckObj(&testCtx, types.NamespacedName{Namespace: testCtx.DefaultNamespace,
 				Name: populatePVCName}, func(g Gomega, restore *dpv1alpha1.Restore) {
 				g.Expect(restore.Spec.Backup.Name).Should(Equal(pvc.Spec.DataSourceRef.Name))
-				g.Expect(restore.Spec.PrepareDataConfig.DataSourceRef.VolumeSource).Should(Equal(testdp.DataVolumeName))
+				g.Expect(restore.Spec.PrepareDataConfig.DataSourceRef).Should(BeNil())
+				g.Expect(restore.Spec.PrepareDataConfig.RestoreVolumeClaims).Should(HaveLen(1))
+				g.Expect(restore.Spec.PrepareDataConfig.RestoreVolumeClaims[0].Name).Should(Equal(populatePVCName))
+				g.Expect(restore.Spec.PrepareDataConfig.RestoreVolumeClaims[0].VolumeSource).Should(Equal(testdp.DataVolumeName))
+				g.Expect(restore.Spec.ReadyConfig).Should(BeNil())
 				g.Expect(restore.OwnerReferences).ShouldNot(BeEmpty())
 				g.Expect(restore.OwnerReferences[0].UID).Should(Equal(pvc.UID))
+			})).Should(Succeed())
+			Eventually(testapps.CheckObj(&testCtx, types.NamespacedName{Namespace: testCtx.DefaultNamespace,
+				Name: populatePVCName}, func(g Gomega, restore *dpv1alpha1.Restore) {
+				g.Expect(restore.Status.Phase).Should(Equal(dpv1alpha1.RestorePhaseRunning))
 			})).Should(Succeed())
 
 			By("expect for job created")
 			Eventually(testapps.List(&testCtx, generics.JobSignature,
-				client.MatchingLabels{dprestore.DataProtectionPopulatePVCLabelKey: populatePVCName},
+				client.MatchingLabels{dprestore.DataProtectionRestoreLabelKey: populatePVCName},
 				client.InNamespace(testCtx.DefaultNamespace))).Should(HaveLen(1))
 
 			By("mock to create pv and bind to populate pvc")
@@ -465,8 +473,13 @@ var _ = Describe("Volume Populator Controller test", func() {
 			By("mock job to succeed")
 			jobList := &batchv1.JobList{}
 			Expect(k8sClient.List(ctx, jobList,
-				client.MatchingLabels{dprestore.DataProtectionPopulatePVCLabelKey: getPopulatePVCName(pvc.UID)},
+				client.MatchingLabels{dprestore.DataProtectionRestoreLabelKey: getPopulatePVCName(pvc.UID)},
 				client.InNamespace(testCtx.DefaultNamespace))).Should(Succeed())
+			Expect(jobList.Items).Should(HaveLen(1))
+			jobOwner := metav1.GetControllerOf(&jobList.Items[0])
+			Expect(jobOwner).ShouldNot(BeNil())
+			Expect(jobOwner.Kind).Should(Equal(dptypes.RestoreKind))
+			Expect(jobOwner.Name).Should(Equal(populatePVCName))
 			checkJobsSA(jobList)
 			testdp.ReplaceK8sJobStatus(&testCtx, client.ObjectKeyFromObject(&jobList.Items[0]), batchv1.JobComplete)
 
@@ -496,7 +509,7 @@ var _ = Describe("Volume Populator Controller test", func() {
 
 			By("expect for resources are cleaned up")
 			Eventually(testapps.List(&testCtx, generics.JobSignature,
-				client.MatchingLabels{dprestore.DataProtectionPopulatePVCLabelKey: populatePVCName},
+				client.MatchingLabels{dprestore.DataProtectionRestoreLabelKey: populatePVCName},
 				client.InNamespace(testCtx.DefaultNamespace))).Should(HaveLen(0))
 			Eventually(testapps.CheckObjExists(&testCtx, types.NamespacedName{Namespace: testCtx.DefaultNamespace,
 				Name: populatePVCName}, populatePVC, false))
@@ -1474,7 +1487,46 @@ func TestDispatchUnboundPVCFailsWhenNoRestoreActionsExist(t *testing.T) {
 		"expected fatal error when neither prepareData nor postReady exists, got: %v", err)
 }
 
-func TestPopulateDoesNotPollWhilePrepareDataJobIsStillActive(t *testing.T) {
+func TestDeletingTargetPVCCleansPopulationWithoutValidatingSource(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	apiGroup := dptypes.DataprotectionAPIGroup
+	now := metav1.Now()
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         "default",
+			Name:              "data-0",
+			UID:               "data-0-uid",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{dptypes.DataProtectionFinalizerName},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			DataSourceRef: &corev1.TypedObjectReference{
+				APIGroup: &apiGroup,
+				Kind:     dptypes.BackupKind,
+				Name:     "already-deleted-backup",
+			},
+		},
+	}
+	populatePVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: pvc.Namespace,
+			Name:      getPopulatePVCName(pvc.UID),
+		},
+	}
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc, populatePVC).Build(),
+		Scheme: scheme,
+	}
+
+	err := reconciler.syncPVC(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc)
+	require.NoError(t, err)
+	err = reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(populatePVC), &corev1.PersistentVolumeClaim{})
+	require.True(t, apierrors.IsNotFound(err), "populate PVC should be deleted, got: %v", err)
+}
+
+func TestPopulateCreatesExecutionRestoreAndPolls(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 	require.NoError(t, batchv1.AddToScheme(scheme))
@@ -1504,12 +1556,20 @@ func TestPopulateDoesNotPollWhilePrepareDataJobIsStillActive(t *testing.T) {
 			Name:      "restore",
 		},
 		Spec: dpv1alpha1.RestoreSpec{
-			Backup: dpv1alpha1.BackupRef{Name: "backup", Namespace: "default"},
+			Backup:             dpv1alpha1.BackupRef{Name: "backup", Namespace: "backup-ns", SourceTargetName: "source"},
+			RestoreTime:        "2026-07-13T01:02:03Z",
+			ServiceAccountName: "restore-worker",
+			Env:                []corev1.EnvVar{{Name: "RESTORE_ENV", Value: "value"}},
+			Parameters:         []dpv1alpha1.ParameterPair{{Name: "parameter", Value: "value"}},
 			PrepareDataConfig: &dpv1alpha1.PrepareDataConfig{
 				DataSourceRef: &dpv1alpha1.VolumeConfig{
 					VolumeSource: "data",
 					MountPath:    "/var/run/etcd/backup",
 				},
+				RequiredPolicyForAllPodSelection: &dpv1alpha1.RequiredPolicyForAllPodSelection{
+					DataRestorePolicy: dpv1alpha1.OneToOneRestorePolicy,
+				},
+				VolumeClaimRestorePolicy: dpv1alpha1.VolumeClaimRestorePolicySerial,
 			},
 		},
 	}
@@ -1549,89 +1609,93 @@ func TestPopulateDoesNotPollWhilePrepareDataJobIsStillActive(t *testing.T) {
 
 	err := reconciler.Populate(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreCtx)
 
-	require.NoError(t, err)
+	require.Error(t, err)
+	require.True(t, intctrlutil.IsRequeueError(err), err.Error())
 	jobs := &batchv1.JobList{}
 	require.NoError(t, reconciler.Client.List(context.Background(), jobs))
-	require.Len(t, jobs.Items, 1)
-	require.Empty(t, jobs.Items[0].Status.Conditions)
+	require.Empty(t, jobs.Items, "VolumePopulator must not create prepareData jobs")
+	executionRestore := &dpv1alpha1.Restore{}
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKey{
+		Namespace: pvc.Namespace,
+		Name:      getPopulatePVCName(pvc.UID),
+	}, executionRestore))
+	require.Nil(t, executionRestore.Spec.PrepareDataConfig.DataSourceRef)
+	require.Nil(t, executionRestore.Spec.ReadyConfig)
+	require.Len(t, executionRestore.Spec.PrepareDataConfig.RestoreVolumeClaims, 1)
+	require.Equal(t, getPopulatePVCName(pvc.UID), executionRestore.Spec.PrepareDataConfig.RestoreVolumeClaims[0].Name)
+	require.Equal(t, restore.Spec.Backup, executionRestore.Spec.Backup)
+	require.Equal(t, restore.Spec.RestoreTime, executionRestore.Spec.RestoreTime)
+	require.Equal(t, restore.Spec.ServiceAccountName, executionRestore.Spec.ServiceAccountName)
+	require.Equal(t, restore.Spec.Env, executionRestore.Spec.Env)
+	require.Equal(t, restore.Spec.Parameters, executionRestore.Spec.Parameters)
+	require.Equal(t, restore.Spec.PrepareDataConfig.RequiredPolicyForAllPodSelection,
+		executionRestore.Spec.PrepareDataConfig.RequiredPolicyForAllPodSelection)
+	require.Equal(t, restore.Spec.PrepareDataConfig.VolumeClaimRestorePolicy,
+		executionRestore.Spec.PrepareDataConfig.VolumeClaimRestorePolicy)
+	require.Equal(t, []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
+		executionRestore.Spec.PrepareDataConfig.SchedulingSpec.Tolerations)
+	require.Len(t, executionRestore.OwnerReferences, 1)
+	require.Equal(t, pvc.UID, executionRestore.OwnerReferences[0].UID)
+
+	populatePVC := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKey{
+		Namespace: pvc.Namespace,
+		Name:      getPopulatePVCName(pvc.UID),
+	}, populatePVC))
+	populatePVC.Annotations = map[string]string{"storage.example.io/provisioner-state": "selected"}
+	require.NoError(t, reconciler.Client.Update(context.Background(), populatePVC))
+	currentPVC := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), currentPVC))
+	err = reconciler.Populate(intctrlutil.RequestCtx{Ctx: context.Background()}, currentPVC, restoreCtx)
+	require.Error(t, err)
+	require.True(t, intctrlutil.IsRequeueError(err), err.Error())
+
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(executionRestore), executionRestore))
+	executionRestore.Status.Phase = dpv1alpha1.RestorePhaseFailed
+	require.NoError(t, reconciler.Client.Status().Update(context.Background(), executionRestore))
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), currentPVC))
+	err = reconciler.Populate(intctrlutil.RequestCtx{Ctx: context.Background()}, currentPVC, restoreCtx)
+	require.Error(t, err)
+	require.True(t, intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal), err.Error())
+	_, reconcileErr := reconciler.handleSyncPVCError(intctrlutil.RequestCtx{Ctx: context.Background()}, currentPVC, err)
+	require.NoError(t, reconcileErr)
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), currentPVC))
+	failedCondition := findPVCConditionByType(currentPVC, string(PersistentVolumeClaimPopulating))
+	require.NotNil(t, failedCondition)
+	require.Equal(t, ReasonPopulatingFailed, failedCondition.Reason)
 }
 
-func TestParsePopulatePodMapsJobPodToTargetPVC(t *testing.T) {
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
-	require.NoError(t, batchv1.AddToScheme(scheme))
+func TestBuildExecutionRestoreIsIndependentOfDataSourceEntry(t *testing.T) {
+	apiGroup := dptypes.DataprotectionAPIGroup
 	pvc := &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "data-etcd-restore-0",
-			UID:       "data-etcd-restore-0-uid",
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "data-0", UID: "data-0-uid"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			DataSourceRef: &corev1.TypedObjectReference{APIGroup: &apiGroup, Name: "source"},
 		},
 	}
-	job := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "populate-job",
-			UID:       "populate-job-uid",
-			Labels: map[string]string{
-				dprestore.DataProtectionRestoreLabelKey:     "restore",
-				dprestore.DataProtectionPopulatePVCLabelKey: "populate-pvc",
-			},
-			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion:         "v1",
-				Kind:               constant.PersistentVolumeClaimKind,
-				Name:               pvc.Name,
-				UID:                pvc.UID,
-				Controller:         ptr.To(true),
-				BlockOwnerDeletion: ptr.To(true),
-			}},
+	populatePVC := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Namespace: pvc.Namespace, Name: getPopulatePVCName(pvc.UID)},
+	}
+	sourceSpec := dpv1alpha1.RestoreSpec{
+		Backup: dpv1alpha1.BackupRef{Name: "backup", Namespace: "backup-ns", SourceTargetName: "source-target"},
+		PrepareDataConfig: &dpv1alpha1.PrepareDataConfig{
+			DataSourceRef: &dpv1alpha1.VolumeConfig{VolumeSource: "data", MountPath: "/data"},
 		},
 	}
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "populate-job-pod",
-			Labels: map[string]string{
-				dprestore.DataProtectionRestoreLabelKey:     "restore",
-				dprestore.DataProtectionPopulatePVCLabelKey: "populate-pvc",
-			},
-			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion:         "batch/v1",
-				Kind:               constant.JobKind,
-				Name:               job.Name,
-				UID:                job.UID,
-				Controller:         ptr.To(true),
-				BlockOwnerDeletion: ptr.To(true),
-			}},
-		},
-	}
-	reconciler := &VolumePopulatorReconciler{
-		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc, job).Build(),
-		Scheme: scheme,
-	}
+	backupSource := &dpv1alpha1.Restore{Spec: *sourceSpec.DeepCopy()}
+	restoreSource := &dpv1alpha1.Restore{Spec: *sourceSpec.DeepCopy()}
 
-	requests := reconciler.parsePopulatePod(context.Background(), pod)
+	backupPVC := pvc.DeepCopy()
+	backupPVC.Spec.DataSourceRef.Kind = dptypes.BackupKind
+	restorePVC := pvc.DeepCopy()
+	restorePVC.Spec.DataSourceRef.Kind = dptypes.RestoreKind
 
-	require.Equal(t, []reconcile.Request{{
-		NamespacedName: types.NamespacedName{Namespace: "default", Name: pvc.Name},
-	}}, requests)
-}
-
-func TestParsePopulatePodIgnoresUnrelatedPods(t *testing.T) {
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
-	require.NoError(t, batchv1.AddToScheme(scheme))
-	reconciler := &VolumePopulatorReconciler{
-		Client: fake.NewClientBuilder().WithScheme(scheme).Build(),
-		Scheme: scheme,
-	}
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "unrelated",
-		},
-	}
-
-	require.Empty(t, reconciler.parsePopulatePod(context.Background(), pod))
+	fromBackup := buildExecutionRestore(backupPVC, populatePVC, backupSource)
+	fromRestore := buildExecutionRestore(restorePVC, populatePVC, restoreSource)
+	require.Equal(t, fromBackup.Spec, fromRestore.Spec)
+	require.Equal(t, fromBackup.Labels, fromRestore.Labels)
+	require.Nil(t, fromBackup.Spec.PrepareDataConfig.DataSourceRef)
+	require.Len(t, fromBackup.Spec.PrepareDataConfig.RestoreVolumeClaims, 1)
 }
 
 func TestBuildPostReadyRestoreSelectsHighestPriorityRole(t *testing.T) {
@@ -2157,7 +2221,7 @@ func TestRestoreParametersToPairsSortsKeys(t *testing.T) {
 	}, pairs)
 }
 
-func TestEnsureInternalRestoreRejectsSpecMutation(t *testing.T) {
+func TestEnsureExecutionRestoreRejectsSpecMutation(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
@@ -2185,7 +2249,7 @@ func TestEnsureInternalRestoreRejectsSpecMutation(t *testing.T) {
 	desired := existing.DeepCopy()
 	desired.Spec.RestoreTime = "2026-05-02T00:00:00Z"
 
-	restore, err := reconciler.ensureInternalRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, desired)
+	restore, err := reconciler.ensureExecutionRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, desired)
 
 	require.Error(t, err)
 	require.Nil(t, restore)

--- a/pkg/dataprotection/restore/manager.go
+++ b/pkg/dataprotection/restore/manager.go
@@ -570,44 +570,6 @@ func (r *RestoreManager) BuildPrepareDataJobs(reqCtx intctrlutil.RequestCtx, cli
 	return restoreJobs, nil
 }
 
-func (r *RestoreManager) BuildVolumePopulateJob(
-	reqCtx intctrlutil.RequestCtx,
-	cli client.Client,
-	backupSet BackupActionSet,
-	target *dpv1alpha1.BackupStatusTarget,
-	populatePVC *corev1.PersistentVolumeClaim,
-	index int) (*batchv1.Job, error) {
-	prepareDataConfig := r.Restore.Spec.PrepareDataConfig
-	if prepareDataConfig == nil || prepareDataConfig.DataSourceRef == nil {
-		return nil, nil
-	}
-	if !backupSet.ActionSet.HasPrepareDataStage() {
-		return nil, nil
-	}
-	backupRepo, err := r.prepareBackupRepo(reqCtx, cli, backupSet)
-	if err != nil {
-		return nil, err
-	}
-	sourceTargetPodName, err := GetSourcePodNameFromTarget(target, prepareDataConfig.RequiredPolicyForAllPodSelection, 0)
-	if err != nil {
-		return nil, err
-	}
-	jobBuilder := newRestoreJobBuilder(r.Restore, backupSet, backupRepo, dpv1alpha1.PrepareData).
-		setJobName(fmt.Sprintf("%s-%d", populatePVC.Name, index)).
-		addLabel(DataProtectionPopulatePVCLabelKey, populatePVC.Name).
-		setImage(backupSet.ActionSet.Spec.Restore.PrepareData.Image).
-		setCommand(backupSet.ActionSet.Spec.Restore.PrepareData.Command).
-		setServiceAccount(r.WorkerServiceAccount).
-		attachBackupRepo().
-		addCommonEnv(sourceTargetPodName)
-	volume, volumeMount, err := jobBuilder.buildPVCVolumeAndMount(*prepareDataConfig.DataSourceRef, populatePVC.Name, "dp-claim")
-	if err != nil {
-		return nil, err
-	}
-	job := jobBuilder.addToSpecificVolumesAndMounts(volume, volumeMount).build()
-	return job, nil
-}
-
 // GetExistingActionJobs returns jobs already recorded in Restore status for an in-flight action.
 // If any recorded Processing Job is missing, it returns an empty list so callers can follow
 // the original build/create path.

--- a/pkg/dataprotection/restore/manager_test.go
+++ b/pkg/dataprotection/restore/manager_test.go
@@ -458,24 +458,6 @@ var _ = Describe("RestoreManager Test", func() {
 
 		})
 
-		It("test with BuildVolumePopulateJob function", func() {
-			reqCtx := getReqCtx()
-			restoreMGR, backupSet := initResources(reqCtx, 0, true, func(f *testdp.MockRestoreFactory) {
-				f.SetDataSourceRef(testdp.DataVolumeName, testdp.DataVolumeMountPath)
-			})
-
-			By("test BuildVolumePopulateJob function, expect for 1 job")
-			populatePVC := &corev1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-populate-pvc",
-				},
-			}
-			target := utils.GetBackupStatusTarget(backupSet.Backup, restoreMGR.Restore.Spec.Backup.SourceTargetName)
-			job, err := restoreMGR.BuildVolumePopulateJob(reqCtx, k8sClient, *backupSet, target, populatePVC, 0)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(job).ShouldNot(BeNil())
-		})
-
 		testPostReady := func(existVolume bool) {
 			kbNamespace := "kb-system"
 			execWorkerServiceAccountName := "dp-exec-worker"


### PR DESCRIPTION
## What this PR does

- moves PVC prepareData Job execution from VolumePopulator to a PVC-scoped Restore
- keeps VolumePopulator responsible for selected-node handling, populate PVC creation, Restore phase polling, PV rebind, and the existing postReady gates
- lets the Restore controller manage BackupRepo preparation, prepareData Jobs, status updates, and successful Job cleanup
- removes VolumePopulator Job/Pod watches and direct Job lifecycle coordination
- cleans up active population when the target PVC is deleted while retaining the execution Restore for audit until PVC deletion

## Behavior

- Backup and AsDataSource Restore entries derive the same ordinary execution Restore shape
- the execution Restore uses one populate PVC through `prepareDataConfig.volumeClaims`
- it does not set `prepareDataConfig.dataSourceRef` or `readyConfig`
- Running/New phases are polled, Completed proceeds to PV rebind, and Failed is propagated to PVC conditions
- existing postReady Component, post-provision, optional Cluster, sharding redirect, and condition aggregation behavior is unchanged

## Tests

- `go test ./controllers/dataprotection ./pkg/dataprotection/restore`
- `golangci-lint run ./...`
- `git diff --check`