### PR TITLE
feat(kbagent): support atomic reconfigure argument batches

### DIFF
--- a/apis/apps/v1/componentdefinition_types.go
+++ b/apis/apps/v1/componentdefinition_types.go
@@ -1985,6 +1985,15 @@ type ExecAction struct {
 	// +optional
 	Args []string `json:"args,omitempty"`
 
+	// BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+	//
+	// When false, the command is executed once for every runtime argument group.
+	// When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+	// This allows the command to validate a complete parameter update before applying any change.
+	//
+	// +optional
+	BatchRuntimeArgs bool `json:"batchRuntimeArgs,omitempty"`
+
 	// Defines the criteria used to select the target Pod(s) for executing the Action.
 	// This is useful when there is no default target replica identified.
 	// It allows for precise control over which Pod(s) the Action should run in.

--- a/apis/parameters/v1alpha1/parametersdefinition_types.go
+++ b/apis/parameters/v1alpha1/parametersdefinition_types.go
@@ -148,8 +148,9 @@ type ParametersDefinitionSpec struct {
 	// List dynamic parameters.
 	// Modifications to these parameters trigger a configuration reload without requiring a process restart.
 	// When parameter updates are applied through a ComponentDefinition config template reconfigure ExecAction,
-	// the controller invokes the action once for each updated
-	// parameter and appends the parameter name and value as the last arguments.
+	// the controller appends each parameter name and value as runtime arguments. By default, it invokes the action
+	// once for each updated parameter. Set ExecAction.BatchRuntimeArgs to deliver all updated parameters to one
+	// invocation so the action can validate the complete request before applying changes.
 	// If the config volume mount path can be resolved from the workload pod template,
 	// KubeBlocks also guards the action with the target rendered file checksum.
 	// When the mount path cannot be resolved, the action is invoked without the checksum guard.

--- a/config/crd/bases/apps.kubeblocks.io_clusters.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusters.yaml
@@ -314,6 +314,14 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                  batchRuntimeArgs:
+                                    description: |-
+                                      BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                      When false, the command is executed once for every runtime argument group.
+                                      When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                      This allows the command to validate a complete parameter update before applying any change.
+                                    type: boolean
                                   command:
                                     description: |-
                                       Specifies the command to be executed inside the container.
@@ -11534,6 +11542,14 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                      batchRuntimeArgs:
+                                        description: |-
+                                          BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                          When false, the command is executed once for every runtime argument group.
+                                          When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                          This allows the command to validate a complete parameter update before applying any change.
+                                        type: boolean
                                       command:
                                         description: |-
                                           Specifies the command to be executed inside the container.

--- a/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
@@ -3758,6 +3758,14 @@ spec:
                               items:
                                 type: string
                               type: array
+                            batchRuntimeArgs:
+                              description: |-
+                                BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                When false, the command is executed once for every runtime argument group.
+                                When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                This allows the command to validate a complete parameter update before applying any change.
+                              type: boolean
                             command:
                               description: |-
                                 Specifies the command to be executed inside the container.
@@ -4345,6 +4353,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -4756,6 +4772,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -5207,6 +5231,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -5629,6 +5661,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -6054,6 +6094,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -6481,6 +6529,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -6898,6 +6954,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -7315,6 +7379,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -7732,6 +7804,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -8151,6 +8231,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -8562,6 +8650,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -9010,6 +9106,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -9461,6 +9565,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -17600,6 +17712,14 @@ spec:
                               items:
                                 type: string
                               type: array
+                            batchRuntimeArgs:
+                              description: |-
+                                BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                When false, the command is executed once for every runtime argument group.
+                                When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                This allows the command to validate a complete parameter update before applying any change.
+                              type: boolean
                             command:
                               description: |-
                                 Specifies the command to be executed inside the container.

--- a/config/crd/bases/apps.kubeblocks.io_components.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_components.yaml
@@ -200,6 +200,14 @@ spec:
                               items:
                                 type: string
                               type: array
+                            batchRuntimeArgs:
+                              description: |-
+                                BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                When false, the command is executed once for every runtime argument group.
+                                When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                This allows the command to validate a complete parameter update before applying any change.
+                              type: boolean
                             command:
                               description: |-
                                 Specifies the command to be executed inside the container.
@@ -635,6 +643,14 @@ spec:
                               items:
                                 type: string
                               type: array
+                            batchRuntimeArgs:
+                              description: |-
+                                BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                When false, the command is executed once for every runtime argument group.
+                                When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                This allows the command to validate a complete parameter update before applying any change.
+                              type: boolean
                             command:
                               description: |-
                                 Specifies the command to be executed inside the container.

--- a/config/crd/bases/apps.kubeblocks.io_rollouts.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_rollouts.yaml
@@ -158,6 +158,14 @@ spec:
                                               items:
                                                 type: string
                                               type: array
+                                            batchRuntimeArgs:
+                                              description: |-
+                                                BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                                When false, the command is executed once for every runtime argument group.
+                                                When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                                This allows the command to validate a complete parameter update before applying any change.
+                                              type: boolean
                                             command:
                                               description: |-
                                                 Specifies the command to be executed inside the container.
@@ -588,6 +596,14 @@ spec:
                                               items:
                                                 type: string
                                               type: array
+                                            batchRuntimeArgs:
+                                              description: |-
+                                                BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                                When false, the command is executed once for every runtime argument group.
+                                                When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                                This allows the command to validate a complete parameter update before applying any change.
+                                              type: boolean
                                             command:
                                               description: |-
                                                 Specifies the command to be executed inside the container.
@@ -3495,6 +3511,14 @@ spec:
                                               items:
                                                 type: string
                                               type: array
+                                            batchRuntimeArgs:
+                                              description: |-
+                                                BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                                When false, the command is executed once for every runtime argument group.
+                                                When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                                This allows the command to validate a complete parameter update before applying any change.
+                                              type: boolean
                                             command:
                                               description: |-
                                                 Specifies the command to be executed inside the container.
@@ -3925,6 +3949,14 @@ spec:
                                               items:
                                                 type: string
                                               type: array
+                                            batchRuntimeArgs:
+                                              description: |-
+                                                BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                                When false, the command is executed once for every runtime argument group.
+                                                When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                                This allows the command to validate a complete parameter update before applying any change.
+                                              type: boolean
                                             command:
                                               description: |-
                                                 Specifies the command to be executed inside the container.

--- a/config/crd/bases/apps.kubeblocks.io_shardingdefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_shardingdefinitions.yaml
@@ -89,6 +89,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -525,6 +533,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -956,6 +972,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -1387,6 +1411,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.

--- a/config/crd/bases/apps.kubeblocks.io_sidecardefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_sidecardefinitions.yaml
@@ -134,6 +134,14 @@ spec:
                               items:
                                 type: string
                               type: array
+                            batchRuntimeArgs:
+                              description: |-
+                                BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                When false, the command is executed once for every runtime argument group.
+                                When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                This allows the command to validate a complete parameter update before applying any change.
+                              type: boolean
                             command:
                               description: |-
                                 Specifies the command to be executed inside the container.
@@ -1997,6 +2005,14 @@ spec:
                               items:
                                 type: string
                               type: array
+                            batchRuntimeArgs:
+                              description: |-
+                                BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                When false, the command is executed once for every runtime argument group.
+                                When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                This allows the command to validate a complete parameter update before applying any change.
+                              type: boolean
                             command:
                               description: |-
                                 Specifies the command to be executed inside the container.

--- a/config/crd/bases/parameters.kubeblocks.io_componentparameters.yaml
+++ b/config/crd/bases/parameters.kubeblocks.io_componentparameters.yaml
@@ -224,6 +224,14 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                batchRuntimeArgs:
+                                  description: |-
+                                    BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                    When false, the command is executed once for every runtime argument group.
+                                    When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                    This allows the command to validate a complete parameter update before applying any change.
+                                  type: boolean
                                 command:
                                   description: |-
                                     Specifies the command to be executed inside the container.

--- a/config/crd/bases/parameters.kubeblocks.io_parametersdefinitions.yaml
+++ b/config/crd/bases/parameters.kubeblocks.io_parametersdefinitions.yaml
@@ -89,8 +89,9 @@ spec:
                   List dynamic parameters.
                   Modifications to these parameters trigger a configuration reload without requiring a process restart.
                   When parameter updates are applied through a ComponentDefinition config template reconfigure ExecAction,
-                  the controller invokes the action once for each updated
-                  parameter and appends the parameter name and value as the last arguments.
+                  the controller appends each parameter name and value as runtime arguments. By default, it invokes the action
+                  once for each updated parameter. Set ExecAction.BatchRuntimeArgs to deliver all updated parameters to one
+                  invocation so the action can validate the complete request before applying changes.
                   If the config volume mount path can be resolved from the workload pod template,
                   KubeBlocks also guards the action with the target rendered file checksum.
                   When the mount path cannot be resolved, the action is invoked without the checksum guard.

--- a/config/crd/bases/workloads.kubeblocks.io_instances.yaml
+++ b/config/crd/bases/workloads.kubeblocks.io_instances.yaml
@@ -96,6 +96,14 @@ spec:
                               items:
                                 type: string
                               type: array
+                            batchRuntimeArgs:
+                              description: |-
+                                BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                When false, the command is executed once for every runtime argument group.
+                                When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                This allows the command to validate a complete parameter update before applying any change.
+                              type: boolean
                             command:
                               description: |-
                                 Specifies the command to be executed inside the container.
@@ -1520,6 +1528,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -1929,6 +1945,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.

--- a/config/crd/bases/workloads.kubeblocks.io_instancesets.yaml
+++ b/config/crd/bases/workloads.kubeblocks.io_instancesets.yaml
@@ -96,6 +96,14 @@ spec:
                               items:
                                 type: string
                               type: array
+                            batchRuntimeArgs:
+                              description: |-
+                                BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                When false, the command is executed once for every runtime argument group.
+                                When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                This allows the command to validate a complete parameter update before applying any change.
+                              type: boolean
                             command:
                               description: |-
                                 Specifies the command to be executed inside the container.
@@ -2500,6 +2508,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -2909,6 +2925,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.

--- a/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
@@ -314,6 +314,14 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                  batchRuntimeArgs:
+                                    description: |-
+                                      BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                      When false, the command is executed once for every runtime argument group.
+                                      When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                      This allows the command to validate a complete parameter update before applying any change.
+                                    type: boolean
                                   command:
                                     description: |-
                                       Specifies the command to be executed inside the container.
@@ -11534,6 +11542,14 @@ spec:
                                         items:
                                           type: string
                                         type: array
+                                      batchRuntimeArgs:
+                                        description: |-
+                                          BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                          When false, the command is executed once for every runtime argument group.
+                                          When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                          This allows the command to validate a complete parameter update before applying any change.
+                                        type: boolean
                                       command:
                                         description: |-
                                           Specifies the command to be executed inside the container.

--- a/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
@@ -3758,6 +3758,14 @@ spec:
                               items:
                                 type: string
                               type: array
+                            batchRuntimeArgs:
+                              description: |-
+                                BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                When false, the command is executed once for every runtime argument group.
+                                When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                This allows the command to validate a complete parameter update before applying any change.
+                              type: boolean
                             command:
                               description: |-
                                 Specifies the command to be executed inside the container.
@@ -4345,6 +4353,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -4756,6 +4772,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -5207,6 +5231,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -5629,6 +5661,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -6054,6 +6094,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -6481,6 +6529,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -6898,6 +6954,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -7315,6 +7379,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -7732,6 +7804,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -8151,6 +8231,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -8562,6 +8650,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -9010,6 +9106,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -9461,6 +9565,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -17600,6 +17712,14 @@ spec:
                               items:
                                 type: string
                               type: array
+                            batchRuntimeArgs:
+                              description: |-
+                                BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                When false, the command is executed once for every runtime argument group.
+                                When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                This allows the command to validate a complete parameter update before applying any change.
+                              type: boolean
                             command:
                               description: |-
                                 Specifies the command to be executed inside the container.

--- a/deploy/helm/crds/apps.kubeblocks.io_components.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_components.yaml
@@ -200,6 +200,14 @@ spec:
                               items:
                                 type: string
                               type: array
+                            batchRuntimeArgs:
+                              description: |-
+                                BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                When false, the command is executed once for every runtime argument group.
+                                When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                This allows the command to validate a complete parameter update before applying any change.
+                              type: boolean
                             command:
                               description: |-
                                 Specifies the command to be executed inside the container.
@@ -635,6 +643,14 @@ spec:
                               items:
                                 type: string
                               type: array
+                            batchRuntimeArgs:
+                              description: |-
+                                BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                When false, the command is executed once for every runtime argument group.
+                                When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                This allows the command to validate a complete parameter update before applying any change.
+                              type: boolean
                             command:
                               description: |-
                                 Specifies the command to be executed inside the container.

--- a/deploy/helm/crds/apps.kubeblocks.io_rollouts.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_rollouts.yaml
@@ -158,6 +158,14 @@ spec:
                                               items:
                                                 type: string
                                               type: array
+                                            batchRuntimeArgs:
+                                              description: |-
+                                                BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                                When false, the command is executed once for every runtime argument group.
+                                                When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                                This allows the command to validate a complete parameter update before applying any change.
+                                              type: boolean
                                             command:
                                               description: |-
                                                 Specifies the command to be executed inside the container.
@@ -588,6 +596,14 @@ spec:
                                               items:
                                                 type: string
                                               type: array
+                                            batchRuntimeArgs:
+                                              description: |-
+                                                BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                                When false, the command is executed once for every runtime argument group.
+                                                When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                                This allows the command to validate a complete parameter update before applying any change.
+                                              type: boolean
                                             command:
                                               description: |-
                                                 Specifies the command to be executed inside the container.
@@ -3495,6 +3511,14 @@ spec:
                                               items:
                                                 type: string
                                               type: array
+                                            batchRuntimeArgs:
+                                              description: |-
+                                                BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                                When false, the command is executed once for every runtime argument group.
+                                                When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                                This allows the command to validate a complete parameter update before applying any change.
+                                              type: boolean
                                             command:
                                               description: |-
                                                 Specifies the command to be executed inside the container.
@@ -3925,6 +3949,14 @@ spec:
                                               items:
                                                 type: string
                                               type: array
+                                            batchRuntimeArgs:
+                                              description: |-
+                                                BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                                When false, the command is executed once for every runtime argument group.
+                                                When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                                This allows the command to validate a complete parameter update before applying any change.
+                                              type: boolean
                                             command:
                                               description: |-
                                                 Specifies the command to be executed inside the container.

--- a/deploy/helm/crds/apps.kubeblocks.io_shardingdefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_shardingdefinitions.yaml
@@ -89,6 +89,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -525,6 +533,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -956,6 +972,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -1387,6 +1411,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.

--- a/deploy/helm/crds/apps.kubeblocks.io_sidecardefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_sidecardefinitions.yaml
@@ -134,6 +134,14 @@ spec:
                               items:
                                 type: string
                               type: array
+                            batchRuntimeArgs:
+                              description: |-
+                                BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                When false, the command is executed once for every runtime argument group.
+                                When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                This allows the command to validate a complete parameter update before applying any change.
+                              type: boolean
                             command:
                               description: |-
                                 Specifies the command to be executed inside the container.
@@ -1997,6 +2005,14 @@ spec:
                               items:
                                 type: string
                               type: array
+                            batchRuntimeArgs:
+                              description: |-
+                                BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                When false, the command is executed once for every runtime argument group.
+                                When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                This allows the command to validate a complete parameter update before applying any change.
+                              type: boolean
                             command:
                               description: |-
                                 Specifies the command to be executed inside the container.

--- a/deploy/helm/crds/parameters.kubeblocks.io_componentparameters.yaml
+++ b/deploy/helm/crds/parameters.kubeblocks.io_componentparameters.yaml
@@ -224,6 +224,14 @@ spec:
                                   items:
                                     type: string
                                   type: array
+                                batchRuntimeArgs:
+                                  description: |-
+                                    BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                    When false, the command is executed once for every runtime argument group.
+                                    When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                    This allows the command to validate a complete parameter update before applying any change.
+                                  type: boolean
                                 command:
                                   description: |-
                                     Specifies the command to be executed inside the container.

--- a/deploy/helm/crds/parameters.kubeblocks.io_parametersdefinitions.yaml
+++ b/deploy/helm/crds/parameters.kubeblocks.io_parametersdefinitions.yaml
@@ -89,8 +89,9 @@ spec:
                   List dynamic parameters.
                   Modifications to these parameters trigger a configuration reload without requiring a process restart.
                   When parameter updates are applied through a ComponentDefinition config template reconfigure ExecAction,
-                  the controller invokes the action once for each updated
-                  parameter and appends the parameter name and value as the last arguments.
+                  the controller appends each parameter name and value as runtime arguments. By default, it invokes the action
+                  once for each updated parameter. Set ExecAction.BatchRuntimeArgs to deliver all updated parameters to one
+                  invocation so the action can validate the complete request before applying changes.
                   If the config volume mount path can be resolved from the workload pod template,
                   KubeBlocks also guards the action with the target rendered file checksum.
                   When the mount path cannot be resolved, the action is invoked without the checksum guard.

--- a/deploy/helm/crds/workloads.kubeblocks.io_instances.yaml
+++ b/deploy/helm/crds/workloads.kubeblocks.io_instances.yaml
@@ -96,6 +96,14 @@ spec:
                               items:
                                 type: string
                               type: array
+                            batchRuntimeArgs:
+                              description: |-
+                                BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                When false, the command is executed once for every runtime argument group.
+                                When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                This allows the command to validate a complete parameter update before applying any change.
+                              type: boolean
                             command:
                               description: |-
                                 Specifies the command to be executed inside the container.
@@ -1520,6 +1528,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -1929,6 +1945,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.

--- a/deploy/helm/crds/workloads.kubeblocks.io_instancesets.yaml
+++ b/deploy/helm/crds/workloads.kubeblocks.io_instancesets.yaml
@@ -96,6 +96,14 @@ spec:
                               items:
                                 type: string
                               type: array
+                            batchRuntimeArgs:
+                              description: |-
+                                BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                                When false, the command is executed once for every runtime argument group.
+                                When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                                This allows the command to validate a complete parameter update before applying any change.
+                              type: boolean
                             command:
                               description: |-
                                 Specifies the command to be executed inside the container.
@@ -2500,6 +2508,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.
@@ -2909,6 +2925,14 @@ spec:
                             items:
                               type: string
                             type: array
+                          batchRuntimeArgs:
+                            description: |-
+                              BatchRuntimeArgs controls how runtime argument groups are delivered to the command.
+
+                              When false, the command is executed once for every runtime argument group.
+                              When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+                              This allows the command to validate a complete parameter update before applying any change.
+                            type: boolean
                           command:
                             description: |-
                               Specifies the command to be executed inside the container.

--- a/docs/developer_docs/api-reference/cluster.md
+++ b/docs/developer_docs/api-reference/cluster.md
@@ -8391,6 +8391,21 @@ If the shell is required, it must be explicitly invoked in the command.</p>
 </tr>
 <tr>
 <td>
+<code>batchRuntimeArgs</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>BatchRuntimeArgs controls how runtime argument groups are delivered to the command.</p>
+<p>When false, the command is executed once for every runtime argument group.
+When true, all runtime argument groups are flattened in order and delivered to one command invocation.
+This allows the command to validate a complete parameter update before applying any change.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>targetPodSelector</code><br/>
 <em>
 <a href="#apps.kubeblocks.io/v1.TargetPodSelector">

--- a/docs/developer_docs/api-reference/parameters.md
+++ b/docs/developer_docs/api-reference/parameters.md
@@ -802,8 +802,9 @@ Modifications to any of these parameters require a restart of the process to tak
 <p>List dynamic parameters.
 Modifications to these parameters trigger a configuration reload without requiring a process restart.
 When parameter updates are applied through a ComponentDefinition config template reconfigure ExecAction,
-the controller invokes the action once for each updated
-parameter and appends the parameter name and value as the last arguments.
+the controller appends each parameter name and value as runtime arguments. By default, it invokes the action
+once for each updated parameter. Set ExecAction.BatchRuntimeArgs to deliver all updated parameters to one
+invocation so the action can validate the complete request before applying changes.
 If the config volume mount path can be resolved from the workload pod template,
 KubeBlocks also guards the action with the target rendered file checksum.
 When the mount path cannot be resolved, the action is invoked without the checksum guard.
@@ -3049,8 +3050,9 @@ Modifications to any of these parameters require a restart of the process to tak
 <p>List dynamic parameters.
 Modifications to these parameters trigger a configuration reload without requiring a process restart.
 When parameter updates are applied through a ComponentDefinition config template reconfigure ExecAction,
-the controller invokes the action once for each updated
-parameter and appends the parameter name and value as the last arguments.
+the controller appends each parameter name and value as runtime arguments. By default, it invokes the action
+once for each updated parameter. Set ExecAction.BatchRuntimeArgs to deliver all updated parameters to one
+invocation so the action can validate the complete request before applying changes.
 If the config volume mount path can be resolved from the workload pod template,
 KubeBlocks also guards the action with the target rendered file checksum.
 When the mount path cannot be resolved, the action is invoked without the checksum guard.

--- a/pkg/controller/component/kbagent.go
+++ b/pkg/controller/component/kbagent.go
@@ -396,8 +396,9 @@ func buildAction4KBAgent(action *appsv1.Action, name string) *proto.Action {
 	}
 	if action.Exec != nil {
 		a.Exec = &proto.ExecAction{
-			Commands: action.Exec.Command,
-			Args:     action.Exec.Args,
+			Commands:         action.Exec.Command,
+			Args:             action.Exec.Args,
+			BatchRuntimeArgs: action.Exec.BatchRuntimeArgs,
 		}
 	}
 	if action.HTTP != nil {

--- a/pkg/controller/component/kbagent_test.go
+++ b/pkg/controller/component/kbagent_test.go
@@ -433,7 +433,8 @@ var _ = Describe("kb-agent", func() {
 		It("user-defined actions", func() {
 			synthesizedComp.LifecycleActions.Reconfigure = &appsv1.Action{
 				Exec: &appsv1.ExecAction{
-					Command: []string{"echo", "reconfigure"},
+					Command:          []string{"echo", "reconfigure"},
+					BatchRuntimeArgs: true,
 				},
 			}
 			synthesizedComp.FileTemplates = []SynthesizedFileTemplate{
@@ -503,7 +504,8 @@ var _ = Describe("kb-agent", func() {
 			Expect(actions).Should(ContainElement(proto.Action{
 				Name: "reconfigure",
 				Exec: &proto.ExecAction{
-					Commands: []string{"echo", "reconfigure"},
+					Commands:         []string{"echo", "reconfigure"},
+					BatchRuntimeArgs: true,
 				},
 			}))
 			Expect(actions).Should(ContainElement(proto.Action{

--- a/pkg/kbagent/proto/proto.go
+++ b/pkg/kbagent/proto/proto.go
@@ -33,8 +33,9 @@ type Action struct {
 }
 
 type ExecAction struct {
-	Commands []string `json:"command,omitempty"`
-	Args     []string `json:"args,omitempty"`
+	Commands         []string `json:"command,omitempty"`
+	Args             []string `json:"args,omitempty"`
+	BatchRuntimeArgs bool     `json:"batchRuntimeArgs,omitempty"`
 }
 
 type HTTPAction struct {

--- a/pkg/kbagent/service/action.go
+++ b/pkg/kbagent/service/action.go
@@ -181,6 +181,9 @@ func callActionWithRetry(ctx context.Context, action *proto.Action, parameters m
 	if action.Exec == nil {
 		return nil, errors.Wrapf(proto.ErrBadRequest, "runtime arguments are only supported for exec actions")
 	}
+	if action.Exec.BatchRuntimeArgs {
+		return callActionWithRetryOnce(ctx, action, parameters, flattenRuntimeArguments(arguments), timeout, retryPolicy)
+	}
 	output := bytes.NewBuffer(nil)
 	for _, args := range arguments {
 		out, err := callActionWithRetryOnce(ctx, action, parameters, args, timeout, retryPolicy)
@@ -208,6 +211,18 @@ func nonBlockingCallActionWithRetry(ctx context.Context, action *proto.Action, p
 		}
 	}()
 	return resultChan, nil
+}
+
+func flattenRuntimeArguments(arguments [][]string) []string {
+	size := 0
+	for _, group := range arguments {
+		size += len(group)
+	}
+	flattened := make([]string, 0, size)
+	for _, group := range arguments {
+		flattened = append(flattened, group...)
+	}
+	return flattened
 }
 
 func callActionWithRetryOnce(ctx context.Context, action *proto.Action, parameters map[string]string, arguments []string, timeout *int32, retryPolicy *proto.RetryPolicy) ([]byte, error) {

--- a/pkg/kbagent/service/action_test.go
+++ b/pkg/kbagent/service/action_test.go
@@ -116,6 +116,38 @@ var _ = Describe("action", func() {
 			Expect(errors.Is(err, proto.ErrBadRequest)).Should(BeTrue())
 		})
 
+		It("rejects malformed reconfigure batches before the command can write", func() {
+			f, err := os.CreateTemp("", "kbagent-reconfigure-preflight-*")
+			Expect(err).Should(BeNil())
+			path := f.Name()
+			Expect(f.Close()).Should(Succeed())
+			defer os.Remove(path)
+
+			svc, err := newActionService(logr.Discard(), []proto.Action{{
+				Name: "reconfigure",
+				Exec: &proto.ExecAction{
+					Commands:         []string{"/bin/bash", "-c", `printf applied >> "$0"`, path},
+					BatchRuntimeArgs: true,
+				},
+			}})
+			Expect(err).Should(BeNil())
+
+			for _, arguments := range [][][]string{
+				{{"first"}, {"middle", "2"}, {"last", "3"}},
+				{{"first", "1"}, {"middle"}, {"last", "3"}},
+				{{"first", "1"}, {"middle", "2"}, {"last"}},
+				{{"first", "1"}, {"first", "2"}},
+				{{"first", "1", "extra"}},
+			} {
+				_, err = svc.handleRequest(ctx, &proto.ActionRequest{Action: "reconfigure", Arguments: arguments})
+				Expect(errors.Is(err, proto.ErrBadRequest)).Should(BeTrue())
+			}
+
+			content, err := os.ReadFile(path)
+			Expect(err).Should(BeNil())
+			Expect(content).Should(BeEmpty())
+		})
+
 		It("resolves timeout preference", func() {
 			actionTimeout := int32(10)
 			requestTimeout := int32(1)

--- a/pkg/kbagent/service/action_utils_test.go
+++ b/pkg/kbagent/service/action_utils_test.go
@@ -346,6 +346,43 @@ var _ = Describe("action utils", func() {
 			Expect(string(content)).Should(Equal("static:maxmemory=1gb\nstatic:timeout=30\n"))
 		})
 
+		It("blocking - batched runtime arguments execute once after full prevalidation", func() {
+			f, err := os.CreateTemp("", "kbagent-batched-args-*")
+			Expect(err).Should(BeNil())
+			path := f.Name()
+			Expect(f.Close()).Should(Succeed())
+			defer os.Remove(path)
+
+			action := &proto.Action{
+				Exec: &proto.ExecAction{
+					Commands: []string{"/bin/bash", "-c", `
+						[ "$#" -gt 0 ] || exit 1
+						[ $(( $# % 2 )) -eq 0 ] || exit 2
+						for value in "$@"; do
+							[ -n "$value" ] || exit 3
+							done
+						printf "%s\n" "$*" >> "$0"
+					`, path},
+					BatchRuntimeArgs: true,
+				},
+			}
+			_, err = callActionWithRetry(ctx, action, nil, nil, nil, nil)
+			Expect(err).ShouldNot(BeNil())
+
+			_, err = callActionWithRetry(ctx, action, nil, [][]string{{"maxmemory", "1gb"}, {"timeout", ""}}, nil, nil)
+			Expect(err).ShouldNot(BeNil())
+
+			content, err := os.ReadFile(path)
+			Expect(err).Should(BeNil())
+			Expect(content).Should(BeEmpty())
+
+			_, err = callActionWithRetry(ctx, action, nil, [][]string{{"maxmemory", "1gb"}, {"timeout", "30"}}, nil, nil)
+			Expect(err).Should(BeNil())
+			content, err = os.ReadFile(path)
+			Expect(err).Should(BeNil())
+			Expect(string(content)).Should(Equal("maxmemory 1gb timeout 30\n"))
+		})
+
 		It("blocking - runtime argument group output is aggregated in order", func() {
 			action := &proto.Action{
 				Exec: &proto.ExecAction{

--- a/pkg/kbagent/service/reconfigure.go
+++ b/pkg/kbagent/service/reconfigure.go
@@ -51,6 +51,28 @@ func checkReconfigure(_ context.Context, req *proto.ActionRequest) error {
 	if err := checkReconfigureUpdated(req); err != nil {
 		return err
 	}
+	if err := checkReconfigureArguments(req); err != nil {
+		return err
+	}
+	return nil
+}
+
+func checkReconfigureArguments(req *proto.ActionRequest) error {
+	seen := make(map[string]struct{}, len(req.Arguments))
+	for i, arguments := range req.Arguments {
+		if len(arguments) != 2 {
+			return errors.Wrapf(proto.ErrBadRequest,
+				"reconfigure - argument group %d must contain exactly one name and value", i)
+		}
+		name := arguments[0]
+		if name == "" {
+			return errors.Wrapf(proto.ErrBadRequest, "reconfigure - argument group %d has an empty name", i)
+		}
+		if _, ok := seen[name]; ok {
+			return errors.Wrapf(proto.ErrBadRequest, "reconfigure - duplicate argument name: %s", name)
+		}
+		seen[name] = struct{}{}
+	}
 	return nil
 }
 

--- a/pkg/kbagent/service/reconfigure_test.go
+++ b/pkg/kbagent/service/reconfigure_test.go
@@ -71,6 +71,20 @@ var _ = Describe("reconfigure", func() {
 			Expect(err).Should(BeNil())
 		})
 
+		DescribeTable("rejects malformed reconfigure argument groups before execution",
+			func(arguments [][]string) {
+				req := &proto.ActionRequest{Action: "reconfigure", Arguments: arguments}
+				err := checkReconfigure(ctx, req)
+				Expect(errors.Is(err, proto.ErrBadRequest)).Should(BeTrue())
+			},
+			Entry("first value missing", [][]string{{"first"}, {"middle", "2"}, {"last", "3"}}),
+			Entry("middle value missing", [][]string{{"first", "1"}, {"middle"}, {"last", "3"}}),
+			Entry("last value missing", [][]string{{"first", "1"}, {"middle", "2"}, {"last"}}),
+			Entry("empty key", [][]string{{"", "1"}}),
+			Entry("duplicate key", [][]string{{"first", "1"}, {"first", "2"}}),
+			Entry("argument count mismatch", [][]string{{"first", "1", "extra"}}),
+		)
+
 		It("bad request", func() {
 			req := &proto.ActionRequest{
 				Action: "reconfigure",


### PR DESCRIPTION
## Problem

KubeBlocks parameter reconfigure currently delivers runtime arguments to an exec action one key/value group at a time. That is compatible with actions that update one parameter per process, but it gives an action no way to validate a complete multi-parameter request before its first engine write.

Concrete source evidence:

- merged PR #10350 documents that full-parameters payload support is not available on this path;
- `callActionWithRetry` executes each `[][]string` argument group sequentially and stops only after a group fails;
- therefore a later malformed or engine-invalid parameter can be reported after an earlier invocation has already changed the engine.

This is a controller/interface contract fix. The Dameng runtime failure that motivated the audit was captured on the older env-based alpha path, so it is not claimed as an A/B runtime reproduction of current `main`.

## Solution

- add opt-in `ExecAction.batchRuntimeArgs`;
- preserve the current one-invocation-per-group behavior when it is false;
- when true, flatten all ordered runtime groups and invoke the command once, allowing the command to validate the full request before applying changes;
- reject malformed reconfigure groups, empty names, and duplicate names in kbagent before command execution;
- propagate the field into kbagent action serialization and generated API/CRD docs.

## Tests

- red before implementation: new tests did not compile because the batch field/path did not exist;
- `go test ./pkg/kbagent/service` PASS;
- `go test ./pkg/controller/instance ./pkg/controller/instanceset` PASS;
- affected controller packages compile with `go test ... -run '^$'`;
- `go vet` PASS for kbagent service and affected controller packages;
- `git diff --check` PASS.

The tests prove:

- malformed first/middle/last groups, duplicate names, and group-size mismatch fail before a side-effect command writes;
- zero-argument and later-empty batches produce zero writes when the action prevalidates;
- a valid two-key batch executes once with the complete ordered payload;
- default per-group behavior remains covered.

## Boundary

Full controller Ginkgo/envtest suites did not start locally because `/usr/local/kubebuilder/bin/etcd` is absent. I did not create a local Kubernetes API server; CI/approved infrastructure must run those suites. No live addon/runtime PASS is claimed for this PR yet.

## Review focus

- whether `batchRuntimeArgs` is the right compatibility-preserving API surface for full-request prevalidation;
- whether reconfigure group validation should remain generic at kbagent or be narrowed further;
- retry semantics for a single batched invocation.
