### PR TITLE
fix(instanceset): cap rolling update participants

### DIFF
--- a/controllers/workloads/instanceset_controller_2_test.go
+++ b/controllers/workloads/instanceset_controller_2_test.go
@@ -258,7 +258,7 @@ var _ = Describe("InstanceSet Controller 2", func() {
 				f.SetInstanceUpdateStrategy(&workloads.InstanceUpdateStrategy{
 					Type: kbappsv1.RollingUpdateStrategyType,
 					RollingUpdate: &workloads.RollingUpdate{
-						Replicas: &intstr.IntOrString{
+						MaxUnavailable: &intstr.IntOrString{
 							Type:   intstr.Int,
 							IntVal: 1, // one instance at a time
 						},

--- a/controllers/workloads/instanceset_controller_test.go
+++ b/controllers/workloads/instanceset_controller_test.go
@@ -191,7 +191,7 @@ var _ = Describe("InstanceSet Controller", func() {
 					SetInstanceUpdateStrategy(&workloads.InstanceUpdateStrategy{
 						Type: kbappsv1.RollingUpdateStrategyType,
 						RollingUpdate: &workloads.RollingUpdate{
-							Replicas: &intstr.IntOrString{
+							MaxUnavailable: &intstr.IntOrString{
 								Type:   intstr.Int,
 								IntVal: 1, // one instance at a time
 							},

--- a/pkg/controller/instanceset/reconciler_update.go
+++ b/pkg/controller/instanceset/reconciler_update.go
@@ -233,13 +233,25 @@ func (r *updateReconciler) rollingUpdateQuota(its *workloads.InstanceSet, podLis
 		return -1, -1, err
 	}
 	currentUnavailable := 0
+	updatedReplicas := 0
 	for _, pod := range podList {
 		if !intctrlutil.IsPodAvailable(pod, its.Spec.MinReadySeconds) {
 			currentUnavailable++
 		}
+		updated, err := r.isInstUpdated(its, pod)
+		if err != nil {
+			return -1, -1, err
+		}
+		if updated {
+			updatedReplicas++
+		}
 	}
 	unavailable := maxUnavailable - currentUnavailable
-	return replicas, unavailable, nil
+	remainingReplicas := replicas - updatedReplicas
+	if remainingReplicas < 0 {
+		remainingReplicas = 0
+	}
+	return remainingReplicas, unavailable, nil
 }
 
 func (r *updateReconciler) memberUpdateQuota(its *workloads.InstanceSet, podList []*corev1.Pod) (int, error) {

--- a/pkg/controller/instanceset/reconciler_update_test.go
+++ b/pkg/controller/instanceset/reconciler_update_test.go
@@ -228,7 +228,31 @@ var _ = Describe("update reconciler test", func() {
 			res, err = reconciler.Reconcile(partitionTree)
 			Expect(err).Should(BeNil())
 			Expect(res).Should(Equal(kubebuilderx.Continue))
-			expectUpdatedPods(partitionTree, []string{"bar-foo-0", "bar-3"})
+			expectUpdatedPods(partitionTree, []string{"bar-foo-0"})
+
+			By("do not update more pods after rollingUpdate.replicas are updated")
+			partitionTree, err = tree.DeepCopy()
+			Expect(err).Should(BeNil())
+			root, ok = partitionTree.GetRoot().(*workloads.InstanceSet)
+			Expect(ok).Should(BeTrue())
+			root.Spec.InstanceUpdateStrategy = &workloads.InstanceUpdateStrategy{
+				RollingUpdate: &workloads.RollingUpdate{
+					Replicas:       &updateReplicas,
+					MaxUnavailable: &maxUnavailable,
+				},
+			}
+			for _, name := range []string{"bar-hello-0", "bar-foo-1", "bar-foo-0"} {
+				pod := builder.NewPodBuilder(namespace, name).GetObject()
+				object, err := partitionTree.Get(pod)
+				Expect(err).Should(BeNil())
+				pod, ok = object.(*corev1.Pod)
+				Expect(ok).Should(BeTrue())
+				makePodLatestRevision(pod)
+			}
+			res, err = reconciler.Reconcile(partitionTree)
+			Expect(err).Should(BeNil())
+			Expect(res).Should(Equal(kubebuilderx.Continue))
+			expectUpdatedPods(partitionTree, []string{})
 
 			By("reconcile with UpdateStrategy='OnDelete'")
 			onDeleteTree, err := tree.DeepCopy()

--- a/pkg/controller/instanceset2/reconciler_update.go
+++ b/pkg/controller/instanceset2/reconciler_update.go
@@ -100,12 +100,20 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 		return kubebuilderx.Continue, err
 	}
 	currentUnavailable := 0
+	updatedReplicas := 0
 	for _, inst := range oldInstanceList {
 		if !intctrlutil.IsInstanceAvailable(inst) {
 			currentUnavailable++
 		}
+		if isInstanceUpdated(its, inst) {
+			updatedReplicas++
+		}
 	}
 	unavailable := maxUnavailable - currentUnavailable
+	remainingReplicas := replicas - updatedReplicas
+	if remainingReplicas < 0 {
+		remainingReplicas = 0
+	}
 
 	// if it's a roleful InstanceSet, we use updateCount to represent Pods can be updated according to the spec.memberUpdateStrategy.
 	updateCount := len(oldInstanceList)
@@ -139,7 +147,7 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 	}
 
 	for _, inst := range oldInstanceList {
-		if updatingInstances >= min(replicas, unavailable, updateCount) {
+		if updatingInstances >= min(remainingReplicas, unavailable, updateCount) {
 			break
 		}
 


### PR DESCRIPTION
## Summary

- Cap `instanceUpdateStrategy.rollingUpdate.replicas` by subtracting replicas that have already reached the target revision/config state.
- Apply the same cap to both legacy pod-backed InstanceSet updates and Instance API-backed updates.
- Add regression coverage that prevents a later reconcile from updating more pods after the configured participant count has already been updated.

## Root Cause

`rollingUpdate.replicas` was parsed correctly but then used as a fresh per-reconcile update quota. After the first selected pods reached the target revision, a subsequent reconcile could select additional old pods, eventually updating all replicas even when the user configured a smaller participant count.

## Tests

```text
GOCACHE=/tmp/go-cache go test ./pkg/controller/instanceset -run 'TestAPIs/update_reconciler_test/PreCondition_&_Reconcile/should_work_well' -count=1
GOCACHE=/tmp/go-cache go test ./pkg/controller/instanceset2 -count=1
git diff --check
```

Fixes https://github.com/apecloud/kubeblocks/issues/10641
