### PR TITLE
fix(dataprotection): complete observed backup jobs

### DIFF
--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -604,6 +604,11 @@ func (r *BackupReconciler) handleRunningPhase(
 	if err = r.syncContinuousBackupEncryptionConfig(reqCtx, backup, request.BackupPolicy); err != nil {
 		return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "sync continuous backup encryption config failed")
 	}
+	if completed, err := r.completeFromRecordedActions(reqCtx, backup, request); err != nil {
+		return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "")
+	} else if completed {
+		return intctrlutil.Reconciled()
+	}
 	var (
 		existFailedAction bool
 		waiting           bool
@@ -687,6 +692,57 @@ func (r *BackupReconciler) handleRunningPhase(
 		return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "")
 	}
 	return intctrlutil.Reconciled()
+}
+
+func (r *BackupReconciler) completeFromRecordedActions(reqCtx intctrlutil.RequestCtx, original *dpv1alpha1.Backup, request *dpbackup.Request) (bool, error) {
+	if len(request.Status.Actions) == 0 {
+		return false, nil
+	}
+	for i := range request.Status.Actions {
+		actionStatus := &request.Status.Actions[i]
+		if actionStatus.Phase == dpv1alpha1.ActionPhaseCompleted {
+			continue
+		}
+		if actionStatus.ActionType != dpv1alpha1.ActionTypeJob || actionStatus.ObjectRef == nil {
+			return false, nil
+		}
+		job := &batchv1.Job{}
+		key := client.ObjectKey{Namespace: actionStatus.ObjectRef.Namespace, Name: actionStatus.ObjectRef.Name}
+		exists, err := intctrlutil.CheckResourceExists(reqCtx.Ctx, r.Client, key, job)
+		if err != nil {
+			return false, err
+		}
+		if !exists {
+			return false, nil
+		}
+		_, finishedType, msg := dputils.IsJobFinished(job)
+		if finishedType != batchv1.JobComplete {
+			if finishedType == batchv1.JobFailed {
+				actionStatus.Phase = dpv1alpha1.ActionPhaseFailed
+				actionStatus.FailureReason = msg
+			}
+			return false, nil
+		}
+		actionStatus.Phase = dpv1alpha1.ActionPhaseCompleted
+		actionStatus.CompletionTimestamp = &metav1.Time{Time: r.clock.Now().UTC()}
+	}
+
+	updateBackupStatusByActionStatus(&request.Status)
+	request.Status.Phase = dpv1alpha1.BackupPhaseCompleted
+	request.Status.CompletionTimestamp = &metav1.Time{Time: r.clock.Now().UTC()}
+	if !request.Status.StartTimestamp.IsZero() {
+		duration := request.Status.CompletionTimestamp.Sub(request.Status.StartTimestamp.Time).Round(time.Second)
+		request.Status.Duration = &metav1.Duration{Duration: duration}
+	}
+	if err := dpbackup.SetExpirationTime(request.Backup); err != nil {
+		reqCtx.Log.Error(err, "failed to set expiration time for completed backup")
+	}
+	r.Recorder.Event(request.Backup, corev1.EventTypeNormal, "CreatedBackup", "Completed backup")
+	if err := r.Client.Status().Patch(reqCtx.Ctx, request.Backup, client.MergeFrom(original)); err != nil {
+		reqCtx.Log.Error(err, "failed to patch completed backup status")
+		return false, err
+	}
+	return true, nil
 }
 
 func (r *BackupReconciler) syncContinuousBackupEncryptionConfig(reqCtx intctrlutil.RequestCtx, backup *dpv1alpha1.Backup, backupPolicy *dpv1alpha1.BackupPolicy) error {

--- a/controllers/dataprotection/backup_controller_test.go
+++ b/controllers/dataprotection/backup_controller_test.go
@@ -355,6 +355,34 @@ var _ = Describe("Backup Controller test", func() {
 				Eventually(testapps.CheckObjExists(&testCtx, getJobKey(), &batchv1.Job{}, false)).Should(Succeed())
 			})
 
+			It("should complete when target pod disappears after job completes", func() {
+				By("check backup is running")
+				Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+					g.Expect(fetched.Status.Phase).Should(Equal(dpv1alpha1.BackupPhaseRunning))
+					g.Expect(fetched.Status.Actions).ShouldNot(BeEmpty())
+					g.Expect(fetched.Status.Actions[0].Phase).Should(Equal(dpv1alpha1.ActionPhaseRunning))
+					g.Expect(fetched.Status.Actions[0].ObjectRef).ShouldNot(BeNil())
+				})).Should(Succeed())
+
+				By("mark backup job complete before the selected target pod disappears")
+				testdp.PatchK8sJobStatus(&testCtx, getJobKey(), batchv1.JobComplete)
+				Eventually(testapps.CheckObj(&testCtx, getJobKey(), func(g Gomega, fetched *batchv1.Job) {
+					_, finishedType, _ := dputils.IsJobFinished(fetched)
+					g.Expect(finishedType).To(Equal(batchv1.JobComplete))
+				})).Should(Succeed())
+
+				By("delete the selected target pod before backup status observes completion")
+				Expect(k8sClient.Delete(ctx, targetPod)).Should(Succeed())
+				Eventually(testapps.CheckObjExists(&testCtx, client.ObjectKeyFromObject(targetPod), &corev1.Pod{}, false)).Should(Succeed())
+
+				By("backup should complete from recorded action status")
+				Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+					g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseCompleted))
+					g.Expect(fetched.Status.FailureReason).Should(BeEmpty())
+					g.Expect(fetched.Status.Actions[0].Phase).Should(Equal(dpv1alpha1.ActionPhaseCompleted))
+				})).Should(Succeed())
+			})
+
 			It("should fail after job fails", func() {
 				testdp.PatchK8sJobStatus(&testCtx, getJobKey(), batchv1.JobFailed)
 

--- a/pkg/dataprotection/action/action_job.go
+++ b/pkg/dataprotection/action/action_job.go
@@ -120,7 +120,11 @@ func (j *JobAction) Execute(actCtx ActionContext) (*dpv1alpha1.ActionStatus, err
 	}
 	msg := fmt.Sprintf("creating job %s/%s", job.Namespace, job.Name)
 	actCtx.Recorder.Event(j.Owner, corev1.EventTypeNormal, "CreatingJob", msg)
-	return handleErr(client.IgnoreAlreadyExists(actCtx.Client.Create(actCtx.Ctx, job)))
+	if err = client.IgnoreAlreadyExists(actCtx.Client.Create(actCtx.Ctx, job)); err != nil {
+		return handleErr(err)
+	}
+	objRef, _ := ref.GetReference(actCtx.Scheme, job)
+	return sb.objectRef(objRef).build(), nil
 }
 
 func (j *JobAction) validate() error {


### PR DESCRIPTION
## Summary

- Record the created backup Job object reference in running Job action status.
- Before resolving live target Pods during Running reconciliation, observe recorded Job actions and complete the Backup when those Jobs have already completed.
- Add regression coverage for the race where the selected target Pod disappears after the backup Job completes but before Backup status observes it.

## Root Cause

During every Running reconciliation, the Backup controller rebuilt action inputs from the live selected target Pod before observing existing action resources. If the Job had already completed but the selected target Pod disappeared first, target resolution failed and the non-continuous Backup was marked terminally Failed before `JobAction.Execute` could read the completed Job.

## Tests

```text
GOCACHE=/tmp/go-cache go test ./controllers/dataprotection -run '^$' -count=1
git diff --check
```

Local envtest note: the focused dataprotection controller regression could not run on this machine because `/usr/local/kubebuilder/bin/etcd` is not installed; GitHub CI should run the envtest suite in its configured environment.

Fixes https://github.com/apecloud/kubeblocks/issues/10643
