### PR TITLE
fix(dataprotection): observe completed backup jobs first

### DIFF
--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -604,6 +604,12 @@ func (r *BackupReconciler) handleRunningPhase(
 	if err = r.syncContinuousBackupEncryptionConfig(reqCtx, backup, request.BackupPolicy); err != nil {
 		return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "sync continuous backup encryption config failed")
 	}
+	if completed, err := r.syncCompletedJobActions(reqCtx.Ctx, request.Backup); err != nil {
+		return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "sync completed backup jobs failed")
+	} else if completed {
+		updateBackupStatusByActionStatus(&request.Status)
+		return r.completeBackup(reqCtx, backup, request.Backup)
+	}
 	var (
 		existFailedAction bool
 		waiting           bool
@@ -670,20 +676,119 @@ func (r *BackupReconciler) handleRunningPhase(
 		return r.updateStatusIfFailed(reqCtx, backup, request.Backup,
 			fmt.Errorf("there are failed actions, you can obtain the more information in the status.actions"))
 	}
-	// all actions completed, update backup status to completed
-	request.Status.Phase = dpv1alpha1.BackupPhaseCompleted
-	request.Status.CompletionTimestamp = &metav1.Time{Time: r.clock.Now().UTC()}
-	if !request.Status.StartTimestamp.IsZero() {
+	return r.completeBackup(reqCtx, backup, request.Backup)
+}
+
+func (r *BackupReconciler) syncCompletedJobActions(ctx context.Context, backup *dpv1alpha1.Backup) (bool, error) {
+	if len(backup.Status.Actions) == 0 {
+		return false, nil
+	}
+
+	jobs := make([]*batchv1.Job, len(backup.Status.Actions))
+	for i := range backup.Status.Actions {
+		actionStatus := &backup.Status.Actions[i]
+		if actionStatus.Phase == dpv1alpha1.ActionPhaseCompleted {
+			continue
+		}
+		if actionStatus.ActionType != dpv1alpha1.ActionTypeJob {
+			return false, nil
+		}
+
+		job, err := r.getJobForActionStatus(ctx, backup, actionStatus)
+		if err != nil {
+			return false, err
+		}
+		if job == nil {
+			return false, nil
+		}
+		_, finishedType, _ := dputils.IsJobFinished(job)
+		if finishedType != batchv1.JobComplete {
+			return false, nil
+		}
+		jobs[i] = job
+	}
+
+	for i := range backup.Status.Actions {
+		actionStatus := &backup.Status.Actions[i]
+		if actionStatus.Phase == dpv1alpha1.ActionPhaseCompleted {
+			continue
+		}
+		job := jobs[i]
+		actionStatus.Phase = dpv1alpha1.ActionPhaseCompleted
+		actionStatus.StartTimestamp = job.CreationTimestamp.DeepCopy()
+		if job.Status.CompletionTime != nil {
+			actionStatus.CompletionTimestamp = job.Status.CompletionTime.DeepCopy()
+		} else {
+			actionStatus.CompletionTimestamp = &metav1.Time{Time: r.clock.Now().UTC()}
+		}
+		actionStatus.ObjectRef = &corev1.ObjectReference{
+			APIVersion: batchv1.SchemeGroupVersion.String(),
+			Kind:       constant.JobKind,
+			Namespace:  job.Namespace,
+			Name:       job.Name,
+			UID:        job.UID,
+		}
+	}
+	return true, nil
+}
+
+func (r *BackupReconciler) getJobForActionStatus(ctx context.Context,
+	backup *dpv1alpha1.Backup,
+	actionStatus *dpv1alpha1.ActionStatus) (*batchv1.Job, error) {
+	var keys []client.ObjectKey
+	if actionStatus.ObjectRef != nil && actionStatus.ObjectRef.Kind == constant.JobKind {
+		keys = append(keys, client.ObjectKey{
+			Namespace: actionStatus.ObjectRef.Namespace,
+			Name:      actionStatus.ObjectRef.Name,
+		})
+	}
+
+	jobName := dpbackup.GenerateBackupJobName(backup, actionStatus.Name)
+	keys = append(keys, client.ObjectKey{Namespace: backup.Namespace, Name: jobName})
+	if namespace := viper.GetString(constant.CfgKeyCtrlrMgrNS); namespace != backup.Namespace {
+		keys = append(keys, client.ObjectKey{Namespace: namespace, Name: jobName})
+	}
+
+	checked := map[client.ObjectKey]struct{}{}
+	for _, key := range keys {
+		if _, ok := checked[key]; ok || key.Name == "" || key.Namespace == "" {
+			continue
+		}
+		checked[key] = struct{}{}
+
+		job := &batchv1.Job{}
+		if err := r.Client.Get(ctx, key, job); err != nil {
+			if client.IgnoreNotFound(err) == nil {
+				continue
+			}
+			return nil, err
+		}
+		if job.Labels[dptypes.BackupNameLabelKey] != backup.Name {
+			continue
+		}
+		if job.Namespace != backup.Namespace && job.Labels[dptypes.BackupNamespaceLabelKey] != backup.Namespace {
+			continue
+		}
+		return job, nil
+	}
+	return nil, nil
+}
+
+func (r *BackupReconciler) completeBackup(reqCtx intctrlutil.RequestCtx,
+	original *dpv1alpha1.Backup,
+	backup *dpv1alpha1.Backup) (ctrl.Result, error) {
+	backup.Status.Phase = dpv1alpha1.BackupPhaseCompleted
+	backup.Status.CompletionTimestamp = &metav1.Time{Time: r.clock.Now().UTC()}
+	if !backup.Status.StartTimestamp.IsZero() {
 		// round the duration to a multiple of seconds.
-		duration := request.Status.CompletionTimestamp.Sub(request.Status.StartTimestamp.Time).Round(time.Second)
-		request.Status.Duration = &metav1.Duration{Duration: duration}
+		duration := backup.Status.CompletionTimestamp.Sub(backup.Status.StartTimestamp.Time).Round(time.Second)
+		backup.Status.Duration = &metav1.Duration{Duration: duration}
 	}
-	err = dpbackup.SetExpirationTime(request.Backup)
-	if err != nil {
-		return r.updateStatusIfFailed(reqCtx, backup, request.Backup, fmt.Errorf("failed to set expiration time, %v", err))
+	if err := dpbackup.SetExpirationTime(backup); err != nil {
+		return r.updateStatusIfFailed(reqCtx, original, backup, fmt.Errorf("failed to set expiration time, %v", err))
 	}
-	r.Recorder.Event(backup, corev1.EventTypeNormal, "CreatedBackup", "Completed backup")
-	if err = r.Client.Status().Patch(reqCtx.Ctx, request.Backup, client.MergeFrom(backup)); err != nil {
+	r.Recorder.Event(original, corev1.EventTypeNormal, "CreatedBackup", "Completed backup")
+	if err := r.Client.Status().Patch(reqCtx.Ctx, backup, client.MergeFrom(original)); err != nil {
 		return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "")
 	}
 	return intctrlutil.Reconciled()

--- a/controllers/dataprotection/backup_controller_test.go
+++ b/controllers/dataprotection/backup_controller_test.go
@@ -355,6 +355,41 @@ var _ = Describe("Backup Controller test", func() {
 				Eventually(testapps.CheckObjExists(&testCtx, getJobKey(), &batchv1.Job{}, false)).Should(Succeed())
 			})
 
+			It("should succeed when the target pod disappears after the job completes", func() {
+				By("wait for the backup job to be created")
+				Eventually(testapps.CheckObjExists(&testCtx, getJobKey(), &batchv1.Job{}, true)).Should(Succeed())
+
+				By("pause backup reconciliation before completing the job")
+				Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
+					if fetched.Annotations == nil {
+						fetched.Annotations = map[string]string{}
+					}
+					fetched.Annotations[dptypes.SkipReconciliationAnnotationKey] = "true"
+				})).Should(Succeed())
+				Consistently(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+					g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseRunning))
+				}), time.Second).Should(Succeed())
+
+				testdp.PatchK8sJobStatus(&testCtx, getJobKey(), batchv1.JobComplete)
+				Consistently(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+					g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseRunning))
+				}), time.Second).Should(Succeed())
+
+				By("delete the selected target pod before the job result is observed")
+				Expect(k8sClient.Delete(ctx, targetPod)).Should(Succeed())
+				Eventually(testapps.CheckObjExists(&testCtx, client.ObjectKeyFromObject(targetPod), &corev1.Pod{}, false)).Should(Succeed())
+
+				By("resume backup reconciliation")
+				Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
+					delete(fetched.Annotations, dptypes.SkipReconciliationAnnotationKey)
+				})).Should(Succeed())
+
+				By("expect the completed job to win over the missing target pod")
+				Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+					g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseCompleted))
+				})).Should(Succeed())
+			})
+
 			It("should fail after job fails", func() {
 				testdp.PatchK8sJobStatus(&testCtx, getJobKey(), batchv1.JobFailed)
 


### PR DESCRIPTION
## What changed

The Backup controller now checks whether every recorded Job action has already completed before rebuilding actions from the live target Pod.

Completed Jobs are resolved from the action `ObjectRef` when available, with a deterministic Job-name fallback for in-flight Backups whose status has not recorded the reference yet. The fallback validates the Backup labels before accepting the Job.

The existing completion status update is shared by the normal action path and the completed-Job path.

## Why

A backup Job can reach `Complete` while its Backup CR is still `Running`. If the selected target Pod disappears before the next reconciliation, the controller currently resolves the target Pod first, marks the Backup `Failed` on `NotFound`, and never observes the successful Job.

The new path only completes the Backup when every recorded action is already complete or has a matching completed Job. If any action has not started, the controller keeps the existing target-Pod resolution and action-building behavior.

Fixes #10643.

## Validation

```bash
KUBEBUILDER_ASSETS=".../k8s/1.26.1-darwin-arm64" go test ./controllers/dataprotection -run TestAPIs -ginkgo.focus='should succeed when the target pod disappears after the job completes' -count=1
KUBEBUILDER_ASSETS=".../k8s/1.26.1-darwin-arm64" go test ./controllers/dataprotection -run TestAPIs -count=1
KUBEBUILDER_ASSETS=".../k8s/1.26.1-darwin-arm64" go test ./pkg/dataprotection/action ./pkg/dataprotection/backup -count=1
```
