### PR TITLE
fix(dataprotection): observe completed backup jobs first

### DIFF
--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -542,16 +542,29 @@ func (r *BackupReconciler) patchBackupStatus(
 	} else if request.BackupPolicy.Spec.EncryptionConfig != nil {
 		request.Status.EncryptionConfig = request.BackupPolicy.Spec.EncryptionConfig
 	}
-	// Keep the existing live target validation, then persist the complete action
-	// inventory for every selected target pod in the same status update.
-	if _, err := request.BuildActions(); err != nil {
-		return err
+	var actionStatuses []dpv1alpha1.ActionStatus
+	targets := dputils.GetBackupTargets(request.BackupPolicy, request.BackupMethod)
+	for i := range targets {
+		if err := r.prepareRequestTargetInfo(request.RequestCtx, request, &targets[i]); err != nil {
+			return err
+		}
+		actions, err := request.BuildActions()
+		if err != nil {
+			return err
+		}
+		for targetPodName, acts := range actions {
+			for _, act := range acts {
+				actionStatuses = append(actionStatuses, dpv1alpha1.ActionStatus{
+					Name:          act.GetName(),
+					TargetPodName: targetPodName,
+					Phase:         dpv1alpha1.ActionPhaseNew,
+					ActionType:    act.Type(),
+					ObjectRef:     act.BuildObjectRef(),
+				})
+			}
+		}
 	}
-	actionPlan, err := request.BuildActionStatusPlan()
-	if err != nil {
-		return err
-	}
-	request.Status.Actions = actionPlan
+	request.Status.Actions = actionStatuses
 
 	// update phase to running
 	request.Status.Phase = dpv1alpha1.BackupPhaseRunning
@@ -565,7 +578,7 @@ func (r *BackupReconciler) patchBackupStatus(
 		request.Status.BaseBackupName = request.BaseBackup.Name
 	}
 
-	if err = dpbackup.SetExpirationTime(request.Backup); err != nil {
+	if err := dpbackup.SetExpirationTime(request.Backup); err != nil {
 		return err
 	}
 	return r.Client.Status().Patch(request.Ctx, request.Backup, client.MergeFrom(original))
@@ -592,6 +605,13 @@ func (r *BackupReconciler) handleRunningPhase(
 			return intctrlutil.Reconciled()
 		}
 	}
+	observedBackup := backup.DeepCopy()
+	if completed, err := r.syncCompletedJobActions(reqCtx.Ctx, observedBackup); err != nil {
+		return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "sync completed backup jobs failed")
+	} else if completed {
+		updateBackupStatusByActionStatus(&observedBackup.Status)
+		return r.completeBackup(reqCtx, backup, observedBackup)
+	}
 	request, err := r.prepareBackupRequest(reqCtx, backup)
 	if err != nil {
 		return r.updateStatusIfFailed(reqCtx, backup.DeepCopy(), backup, err)
@@ -613,14 +633,6 @@ func (r *BackupReconciler) handleRunningPhase(
 	)
 	for i := range targets {
 		if err = r.prepareRequestTargetInfo(reqCtx, request, &targets[i]); err != nil {
-			if intctrlutil.IsNotFound(err) {
-				if completed, syncErr := r.syncCompletedJobActions(reqCtx.Ctx, request); syncErr != nil {
-					return intctrlutil.CheckedRequeueWithError(syncErr, reqCtx.Log, "sync completed backup jobs failed")
-				} else if completed {
-					updateBackupStatusByActionStatus(&request.Status)
-					return r.completeBackup(reqCtx, backup, request.Backup)
-				}
-			}
 			return r.updateStatusIfFailed(reqCtx, backup, request.Backup, err)
 		}
 		// there are actions not completed, continue to handle following actions
@@ -676,52 +688,42 @@ func (r *BackupReconciler) handleRunningPhase(
 	return r.completeBackup(reqCtx, backup, request.Backup)
 }
 
-func (r *BackupReconciler) syncCompletedJobActions(ctx context.Context, request *dpbackup.Request) (bool, error) {
-	actionPlan, err := request.BuildActionStatusPlan()
-	if err != nil {
-		return false, err
-	}
-	if len(actionPlan) == 0 {
+func (r *BackupReconciler) syncCompletedJobActions(ctx context.Context, backup *dpv1alpha1.Backup) (bool, error) {
+	if len(backup.Status.Actions) == 0 {
 		return false, nil
 	}
 
-	type actionKey struct {
-		name          string
-		targetPodName string
-	}
-	existing := make(map[actionKey]*dpv1alpha1.ActionStatus, len(request.Status.Actions))
-	for i := range request.Status.Actions {
-		actionStatus := &request.Status.Actions[i]
-		existing[actionKey{name: actionStatus.Name, targetPodName: actionStatus.TargetPodName}] = actionStatus
-	}
-
-	for i := range actionPlan {
-		expected := actionPlan[i]
-		key := actionKey{name: expected.Name, targetPodName: expected.TargetPodName}
-		if actionStatus := existing[key]; actionStatus != nil {
-			actionPlan[i] = *actionStatus.DeepCopy()
-		}
-		actionStatus := &actionPlan[i]
-		if actionStatus.Phase == dpv1alpha1.ActionPhaseCompleted {
-			continue
-		}
-		if expected.ActionType != dpv1alpha1.ActionTypeJob {
+	jobs := make([]*batchv1.Job, len(backup.Status.Actions))
+	for i := range backup.Status.Actions {
+		actionStatus := &backup.Status.Actions[i]
+		objectRef := actionStatus.ObjectRef
+		if objectRef == nil || objectRef.APIVersion != batchv1.SchemeGroupVersion.String() ||
+			objectRef.Kind != constant.JobKind || objectRef.Namespace == "" || objectRef.Name == "" {
 			return false, nil
 		}
-		actionStatus.ActionType = expected.ActionType
 
-		job, err := r.getJobForActionStatus(ctx, request.Backup, actionStatus)
-		if err != nil {
-			return false, err
+		job := &batchv1.Job{}
+		if err := r.Client.Get(ctx, client.ObjectKey{Namespace: objectRef.Namespace, Name: objectRef.Name}, job); err != nil {
+			return false, client.IgnoreNotFound(err)
 		}
-		if job == nil {
+		if objectRef.UID != "" && objectRef.UID != job.UID {
+			return false, nil
+		}
+		if job.Labels[dptypes.BackupNameLabelKey] != backup.Name {
 			return false, nil
 		}
 		_, finishedType, _ := dputils.IsJobFinished(job)
 		if finishedType != batchv1.JobComplete {
 			return false, nil
 		}
+		jobs[i] = job
+	}
+
+	for i := range backup.Status.Actions {
+		actionStatus := &backup.Status.Actions[i]
+		job := jobs[i]
 		actionStatus.Phase = dpv1alpha1.ActionPhaseCompleted
+		actionStatus.ActionType = dpv1alpha1.ActionTypeJob
 		actionStatus.StartTimestamp = job.CreationTimestamp.DeepCopy()
 		if job.Status.CompletionTime != nil {
 			actionStatus.CompletionTimestamp = job.Status.CompletionTime.DeepCopy()
@@ -736,50 +738,7 @@ func (r *BackupReconciler) syncCompletedJobActions(ctx context.Context, request 
 			UID:        job.UID,
 		}
 	}
-	request.Status.Actions = actionPlan
 	return true, nil
-}
-
-func (r *BackupReconciler) getJobForActionStatus(ctx context.Context,
-	backup *dpv1alpha1.Backup,
-	actionStatus *dpv1alpha1.ActionStatus) (*batchv1.Job, error) {
-	var keys []client.ObjectKey
-	if actionStatus.ObjectRef != nil && actionStatus.ObjectRef.Kind == constant.JobKind {
-		keys = append(keys, client.ObjectKey{
-			Namespace: actionStatus.ObjectRef.Namespace,
-			Name:      actionStatus.ObjectRef.Name,
-		})
-	}
-
-	jobName := dpbackup.GenerateBackupJobName(backup, actionStatus.Name)
-	keys = append(keys, client.ObjectKey{Namespace: backup.Namespace, Name: jobName})
-	if namespace := viper.GetString(constant.CfgKeyCtrlrMgrNS); namespace != backup.Namespace {
-		keys = append(keys, client.ObjectKey{Namespace: namespace, Name: jobName})
-	}
-
-	checked := map[client.ObjectKey]struct{}{}
-	for _, key := range keys {
-		if _, ok := checked[key]; ok || key.Name == "" || key.Namespace == "" {
-			continue
-		}
-		checked[key] = struct{}{}
-
-		job := &batchv1.Job{}
-		if err := r.Client.Get(ctx, key, job); err != nil {
-			if client.IgnoreNotFound(err) == nil {
-				continue
-			}
-			return nil, err
-		}
-		if job.Labels[dptypes.BackupNameLabelKey] != backup.Name {
-			continue
-		}
-		if job.Namespace != backup.Namespace && job.Labels[dptypes.BackupNamespaceLabelKey] != backup.Namespace {
-			continue
-		}
-		return job, nil
-	}
-	return nil, nil
 }
 
 func (r *BackupReconciler) completeBackup(reqCtx intctrlutil.RequestCtx,

--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -638,15 +638,10 @@ func (r *BackupReconciler) handleRunningPhase(
 	)
 	for i := range targets {
 		if err = r.prepareRequestTargetInfo(reqCtx, request, &targets[i]); err != nil {
-			jobWaiting, jobFailed, syncErr := r.syncJobActions(reqCtx.Ctx, request.Backup)
-			if intctrlutil.IsTargetError(syncErr, intctrlutil.ErrorTypeFatal) {
+			waiting, existFailedAction, err = r.syncJobActions(reqCtx.Ctx, request.Backup, err)
+			if err != nil {
 				return r.updateStatusIfFailed(reqCtx, backup, request.Backup, err)
 			}
-			if syncErr != nil {
-				return intctrlutil.CheckedRequeueWithError(syncErr, reqCtx.Log, "sync backup jobs failed")
-			}
-			waiting = jobWaiting
-			existFailedAction = jobFailed
 			break
 		}
 		// there are actions not completed, continue to handle following actions
@@ -703,10 +698,10 @@ func (r *BackupReconciler) handleRunningPhase(
 }
 
 func (r *BackupReconciler) syncJobActions(ctx context.Context,
-	backup *dpv1alpha1.Backup) (waiting, failed bool, err error) {
-	notApplicableErr := intctrlutil.NewFatalError("backup job actions are not applicable")
+	backup *dpv1alpha1.Backup,
+	targetErr error) (waiting, failed bool, err error) {
 	if len(backup.Status.Actions) == 0 {
-		return false, false, notApplicableErr
+		return false, false, targetErr
 	}
 
 	for i := range backup.Status.Actions {
@@ -714,21 +709,22 @@ func (r *BackupReconciler) syncJobActions(ctx context.Context,
 		objectRef := actionStatus.ObjectRef
 		if objectRef == nil || objectRef.APIVersion != batchv1.SchemeGroupVersion.String() ||
 			objectRef.Kind != constant.JobKind || objectRef.Namespace == "" || objectRef.Name == "" {
-			return false, false, notApplicableErr
+			return false, false, targetErr
 		}
 
 		job := &batchv1.Job{}
 		if err := r.Client.Get(ctx, client.ObjectKey{Namespace: objectRef.Namespace, Name: objectRef.Name}, job); err != nil {
 			if apierrors.IsNotFound(err) {
-				return false, false, notApplicableErr
+				return false, false, targetErr
 			}
-			return false, false, err
+			return false, false, intctrlutil.NewErrorf(intctrlutil.ErrorTypeRequeue,
+				"sync backup jobs failed: %v", err)
 		}
 		if objectRef.UID != "" && objectRef.UID != job.UID {
-			return false, false, notApplicableErr
+			return false, false, targetErr
 		}
 		if job.Labels[dptypes.BackupNameLabelKey] != backup.Name {
-			return false, false, notApplicableErr
+			return false, false, targetErr
 		}
 
 		_, finishedType, failureReason := dputils.IsJobFinished(job)

--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -645,17 +645,14 @@ func (r *BackupReconciler) handleRunningPhase(
 			updateBackupStatusByActionStatus(&request.Status)
 			switch jobPhase {
 			case dpv1alpha1.ActionPhaseCompleted:
-				return r.completeBackup(reqCtx, backup, request.Backup)
 			case dpv1alpha1.ActionPhaseFailed:
-				return r.updateStatusIfFailed(reqCtx, backup, request.Backup,
-					fmt.Errorf("there are failed actions, you can obtain the more information in the status.actions"))
+				existFailedAction = true
 			case dpv1alpha1.ActionPhaseRunning:
 				waiting = true
+			default:
+				return r.updateStatusIfFailed(reqCtx, backup, request.Backup, err)
 			}
-			if waiting {
-				break
-			}
-			return r.updateStatusIfFailed(reqCtx, backup, request.Backup, err)
+			break
 		}
 		// there are actions not completed, continue to handle following actions
 		actions, err := request.BuildActions()

--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -542,21 +542,16 @@ func (r *BackupReconciler) patchBackupStatus(
 	} else if request.BackupPolicy.Spec.EncryptionConfig != nil {
 		request.Status.EncryptionConfig = request.BackupPolicy.Spec.EncryptionConfig
 	}
-	// init action status
-	actions, err := request.BuildActions()
+	// Keep the existing live target validation, then persist the complete action
+	// inventory for every selected target pod in the same status update.
+	if _, err := request.BuildActions(); err != nil {
+		return err
+	}
+	actionPlan, err := request.BuildActionStatusPlan()
 	if err != nil {
 		return err
 	}
-	for targetPodName, acts := range actions {
-		for _, act := range acts {
-			request.Status.Actions = append(request.Status.Actions, dpv1alpha1.ActionStatus{
-				Name:          act.GetName(),
-				TargetPodName: targetPodName,
-				Phase:         dpv1alpha1.ActionPhaseNew,
-				ActionType:    act.Type(),
-			})
-		}
-	}
+	request.Status.Actions = actionPlan
 
 	// update phase to running
 	request.Status.Phase = dpv1alpha1.BackupPhaseRunning
@@ -604,12 +599,13 @@ func (r *BackupReconciler) handleRunningPhase(
 	if err = r.syncContinuousBackupEncryptionConfig(reqCtx, backup, request.BackupPolicy); err != nil {
 		return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "sync continuous backup encryption config failed")
 	}
-	if completed, err := r.syncCompletedJobActions(reqCtx.Ctx, request.Backup); err != nil {
+	if completed, err := r.syncCompletedJobActions(reqCtx.Ctx, request); err != nil {
 		return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "sync completed backup jobs failed")
 	} else if completed {
 		updateBackupStatusByActionStatus(&request.Status)
 		return r.completeBackup(reqCtx, backup, request.Backup)
 	}
+	targets := dputils.GetBackupTargets(request.BackupPolicy, request.BackupMethod)
 	var (
 		existFailedAction bool
 		waiting           bool
@@ -620,7 +616,6 @@ func (r *BackupReconciler) handleRunningPhase(
 			Scheme:           r.Scheme,
 			RestClientConfig: r.RestConfig,
 		}
-		targets = dputils.GetBackupTargets(request.BackupPolicy, request.BackupMethod)
 	)
 	for i := range targets {
 		if err = r.prepareRequestTargetInfo(reqCtx, request, &targets[i]); err != nil {
@@ -679,22 +674,41 @@ func (r *BackupReconciler) handleRunningPhase(
 	return r.completeBackup(reqCtx, backup, request.Backup)
 }
 
-func (r *BackupReconciler) syncCompletedJobActions(ctx context.Context, backup *dpv1alpha1.Backup) (bool, error) {
-	if len(backup.Status.Actions) == 0 {
+func (r *BackupReconciler) syncCompletedJobActions(ctx context.Context, request *dpbackup.Request) (bool, error) {
+	actionPlan, err := request.BuildActionStatusPlan()
+	if err != nil {
+		return false, err
+	}
+	if len(actionPlan) == 0 {
 		return false, nil
 	}
 
-	jobs := make([]*batchv1.Job, len(backup.Status.Actions))
-	for i := range backup.Status.Actions {
-		actionStatus := &backup.Status.Actions[i]
+	type actionKey struct {
+		name          string
+		targetPodName string
+	}
+	existing := make(map[actionKey]*dpv1alpha1.ActionStatus, len(request.Status.Actions))
+	for i := range request.Status.Actions {
+		actionStatus := &request.Status.Actions[i]
+		existing[actionKey{name: actionStatus.Name, targetPodName: actionStatus.TargetPodName}] = actionStatus
+	}
+
+	for i := range actionPlan {
+		expected := actionPlan[i]
+		key := actionKey{name: expected.Name, targetPodName: expected.TargetPodName}
+		if actionStatus := existing[key]; actionStatus != nil {
+			actionPlan[i] = *actionStatus.DeepCopy()
+		}
+		actionStatus := &actionPlan[i]
 		if actionStatus.Phase == dpv1alpha1.ActionPhaseCompleted {
 			continue
 		}
-		if actionStatus.ActionType != dpv1alpha1.ActionTypeJob {
+		if expected.ActionType != dpv1alpha1.ActionTypeJob {
 			return false, nil
 		}
+		actionStatus.ActionType = expected.ActionType
 
-		job, err := r.getJobForActionStatus(ctx, backup, actionStatus)
+		job, err := r.getJobForActionStatus(ctx, request.Backup, actionStatus)
 		if err != nil {
 			return false, err
 		}
@@ -705,15 +719,6 @@ func (r *BackupReconciler) syncCompletedJobActions(ctx context.Context, backup *
 		if finishedType != batchv1.JobComplete {
 			return false, nil
 		}
-		jobs[i] = job
-	}
-
-	for i := range backup.Status.Actions {
-		actionStatus := &backup.Status.Actions[i]
-		if actionStatus.Phase == dpv1alpha1.ActionPhaseCompleted {
-			continue
-		}
-		job := jobs[i]
 		actionStatus.Phase = dpv1alpha1.ActionPhaseCompleted
 		actionStatus.StartTimestamp = job.CreationTimestamp.DeepCopy()
 		if job.Status.CompletionTime != nil {
@@ -729,6 +734,7 @@ func (r *BackupReconciler) syncCompletedJobActions(ctx context.Context, backup *
 			UID:        job.UID,
 		}
 	}
+	request.Status.Actions = actionPlan
 	return true, nil
 }
 

--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -365,21 +365,17 @@ func (r *BackupReconciler) recordBackupStatusTargets(
 			return err
 		} else {
 			request.Status.Target = statusTarget
-			request.Status.Targets = nil
 		}
 		return nil
 	}
 	setStatusTargets := func(targets []dpv1alpha1.BackupTarget) error {
-		statusTargets := make([]dpv1alpha1.BackupStatusTarget, 0, len(targets))
 		for i := range targets {
 			if statusTarget, err := buildStatusTarget(&targets[i]); err != nil {
 				return err
 			} else {
-				statusTargets = append(statusTargets, *statusTarget)
+				request.Status.Targets = append(request.Status.Targets, *statusTarget)
 			}
 		}
-		request.Status.Target = nil
-		request.Status.Targets = statusTargets
 		return nil
 	}
 	var err error

--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -604,6 +604,12 @@ func (r *BackupReconciler) handleRunningPhase(
 	if err = r.syncContinuousBackupEncryptionConfig(reqCtx, backup, request.BackupPolicy); err != nil {
 		return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "sync continuous backup encryption config failed")
 	}
+	if completed, err := r.syncCompletedJobActions(reqCtx.Ctx, request.Backup); err != nil {
+		return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "sync completed backup jobs failed")
+	} else if completed {
+		updateBackupStatusByActionStatus(&request.Status)
+		return r.completeBackup(reqCtx, backup, request.Backup)
+	}
 	var (
 		existFailedAction bool
 		waiting           bool
@@ -670,20 +676,119 @@ func (r *BackupReconciler) handleRunningPhase(
 		return r.updateStatusIfFailed(reqCtx, backup, request.Backup,
 			fmt.Errorf("there are failed actions, you can obtain the more information in the status.actions"))
 	}
-	// all actions completed, update backup status to completed
-	request.Status.Phase = dpv1alpha1.BackupPhaseCompleted
-	request.Status.CompletionTimestamp = &metav1.Time{Time: r.clock.Now().UTC()}
-	if !request.Status.StartTimestamp.IsZero() {
+	return r.completeBackup(reqCtx, backup, request.Backup)
+}
+
+func (r *BackupReconciler) syncCompletedJobActions(ctx context.Context, backup *dpv1alpha1.Backup) (bool, error) {
+	if len(backup.Status.Actions) == 0 {
+		return false, nil
+	}
+
+	jobs := make([]*batchv1.Job, len(backup.Status.Actions))
+	for i := range backup.Status.Actions {
+		actionStatus := &backup.Status.Actions[i]
+		if actionStatus.Phase == dpv1alpha1.ActionPhaseCompleted {
+			continue
+		}
+		if actionStatus.ActionType != dpv1alpha1.ActionTypeJob {
+			return false, nil
+		}
+
+		job, err := r.getJobForActionStatus(ctx, backup, actionStatus)
+		if err != nil {
+			return false, err
+		}
+		if job == nil {
+			return false, nil
+		}
+		_, finishedType, _ := dputils.IsJobFinished(job)
+		if finishedType != batchv1.JobComplete {
+			return false, nil
+		}
+		jobs[i] = job
+	}
+
+	for i := range backup.Status.Actions {
+		actionStatus := &backup.Status.Actions[i]
+		if actionStatus.Phase == dpv1alpha1.ActionPhaseCompleted {
+			continue
+		}
+		job := jobs[i]
+		actionStatus.Phase = dpv1alpha1.ActionPhaseCompleted
+		actionStatus.StartTimestamp = job.CreationTimestamp.DeepCopy()
+		if job.Status.CompletionTime != nil {
+			actionStatus.CompletionTimestamp = job.Status.CompletionTime.DeepCopy()
+		} else {
+			actionStatus.CompletionTimestamp = &metav1.Time{Time: r.clock.Now().UTC()}
+		}
+		actionStatus.ObjectRef = &corev1.ObjectReference{
+			APIVersion: batchv1.SchemeGroupVersion.String(),
+			Kind:       constant.JobKind,
+			Namespace:  job.Namespace,
+			Name:       job.Name,
+			UID:        job.UID,
+		}
+	}
+	return true, nil
+}
+
+func (r *BackupReconciler) getJobForActionStatus(ctx context.Context,
+	backup *dpv1alpha1.Backup,
+	actionStatus *dpv1alpha1.ActionStatus) (*batchv1.Job, error) {
+	var keys []client.ObjectKey
+	if actionStatus.ObjectRef != nil && actionStatus.ObjectRef.Kind == constant.JobKind {
+		keys = append(keys, client.ObjectKey{
+			Namespace: actionStatus.ObjectRef.Namespace,
+			Name:      actionStatus.ObjectRef.Name,
+		})
+	}
+
+	jobName := dpbackup.GenerateBackupJobName(backup, actionStatus.Name)
+	keys = append(keys, client.ObjectKey{Namespace: backup.Namespace, Name: jobName})
+	if namespace := viper.GetString(constant.CfgKeyCtrlrMgrNS); namespace != backup.Namespace {
+		keys = append(keys, client.ObjectKey{Namespace: namespace, Name: jobName})
+	}
+
+	checked := map[client.ObjectKey]struct{}{}
+	for _, key := range keys {
+		if _, ok := checked[key]; ok || key.Name == "" || key.Namespace == "" {
+			continue
+		}
+		checked[key] = struct{}{}
+
+		job := &batchv1.Job{}
+		if err := r.Client.Get(ctx, key, job); err != nil {
+			if client.IgnoreNotFound(err) == nil {
+				continue
+			}
+			return nil, err
+		}
+		if job.Labels[dptypes.BackupNameLabelKey] != backup.Name {
+			continue
+		}
+		if job.Namespace != backup.Namespace && job.Labels[dptypes.BackupNamespaceLabelKey] != backup.Namespace {
+			continue
+		}
+		return job, nil
+	}
+	return nil, nil
+}
+
+func (r *BackupReconciler) completeBackup(reqCtx intctrlutil.RequestCtx,
+	original *dpv1alpha1.Backup,
+	backup *dpv1alpha1.Backup) (ctrl.Result, error) {
+	backup.Status.Phase = dpv1alpha1.BackupPhaseCompleted
+	backup.Status.CompletionTimestamp = &metav1.Time{Time: r.clock.Now().UTC()}
+	if !backup.Status.StartTimestamp.IsZero() {
 		// round the duration to a multiple of seconds.
-		duration := request.Status.CompletionTimestamp.Sub(request.Status.StartTimestamp.Time).Round(time.Second)
-		request.Status.Duration = &metav1.Duration{Duration: duration}
+		duration := backup.Status.CompletionTimestamp.Sub(backup.Status.StartTimestamp.Time).Round(time.Second)
+		backup.Status.Duration = &metav1.Duration{Duration: duration}
 	}
-	err = dpbackup.SetExpirationTime(request.Backup)
-	if err != nil {
-		return r.updateStatusIfFailed(reqCtx, backup, request.Backup, fmt.Errorf("failed to set expiration time, %v", err))
+	if err := dpbackup.SetExpirationTime(backup); err != nil {
+		return r.updateStatusIfFailed(reqCtx, original, backup, fmt.Errorf("failed to set expiration time, %v", err))
 	}
-	r.Recorder.Event(backup, corev1.EventTypeNormal, "CreatedBackup", "Completed backup")
-	if err = r.Client.Status().Patch(reqCtx.Ctx, request.Backup, client.MergeFrom(backup)); err != nil {
+	r.Recorder.Event(original, corev1.EventTypeNormal, "CreatedBackup", "Completed backup")
+	if err := r.Client.Status().Patch(reqCtx.Ctx, backup, client.MergeFrom(original)); err != nil {
 		return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "")
 	}
 	return intctrlutil.Reconciled()

--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -638,20 +638,15 @@ func (r *BackupReconciler) handleRunningPhase(
 	)
 	for i := range targets {
 		if err = r.prepareRequestTargetInfo(reqCtx, request, &targets[i]); err != nil {
-			jobActionPhase, syncErr := r.syncJobActions(reqCtx.Ctx, request.Backup)
+			jobWaiting, jobFailed, syncErr := r.syncJobActions(reqCtx.Ctx, request.Backup)
+			if intctrlutil.IsTargetError(syncErr, intctrlutil.ErrorTypeFatal) {
+				return r.updateStatusIfFailed(reqCtx, backup, request.Backup, err)
+			}
 			if syncErr != nil {
 				return intctrlutil.CheckedRequeueWithError(syncErr, reqCtx.Log, "sync backup jobs failed")
 			}
-			updateBackupStatusByActionStatus(&request.Status)
-			switch jobActionPhase {
-			case dpv1alpha1.ActionPhaseCompleted:
-			case dpv1alpha1.ActionPhaseFailed:
-				existFailedAction = true
-			case dpv1alpha1.ActionPhaseRunning:
-				waiting = true
-			default:
-				return r.updateStatusIfFailed(reqCtx, backup, request.Backup, err)
-			}
+			waiting = jobWaiting
+			existFailedAction = jobFailed
 			break
 		}
 		// there are actions not completed, continue to handle following actions
@@ -707,32 +702,33 @@ func (r *BackupReconciler) handleRunningPhase(
 	return r.completeBackup(reqCtx, backup, request.Backup)
 }
 
-func (r *BackupReconciler) syncJobActions(ctx context.Context, backup *dpv1alpha1.Backup) (dpv1alpha1.ActionPhase, error) {
+func (r *BackupReconciler) syncJobActions(ctx context.Context,
+	backup *dpv1alpha1.Backup) (waiting, failed bool, err error) {
+	notApplicableErr := intctrlutil.NewFatalError("backup job actions are not applicable")
 	if len(backup.Status.Actions) == 0 {
-		return "", nil
+		return false, false, notApplicableErr
 	}
 
-	var waiting, existFailed bool
 	for i := range backup.Status.Actions {
 		actionStatus := &backup.Status.Actions[i]
 		objectRef := actionStatus.ObjectRef
 		if objectRef == nil || objectRef.APIVersion != batchv1.SchemeGroupVersion.String() ||
 			objectRef.Kind != constant.JobKind || objectRef.Namespace == "" || objectRef.Name == "" {
-			return "", nil
+			return false, false, notApplicableErr
 		}
 
 		job := &batchv1.Job{}
 		if err := r.Client.Get(ctx, client.ObjectKey{Namespace: objectRef.Namespace, Name: objectRef.Name}, job); err != nil {
 			if apierrors.IsNotFound(err) {
-				return "", nil
+				return false, false, notApplicableErr
 			}
-			return "", err
+			return false, false, err
 		}
 		if objectRef.UID != "" && objectRef.UID != job.UID {
-			return "", nil
+			return false, false, notApplicableErr
 		}
 		if job.Labels[dptypes.BackupNameLabelKey] != backup.Name {
-			return "", nil
+			return false, false, notApplicableErr
 		}
 
 		_, finishedType, failureReason := dputils.IsJobFinished(job)
@@ -754,7 +750,7 @@ func (r *BackupReconciler) syncJobActions(ctx context.Context, backup *dpv1alpha
 			actionStatus.Phase = dpv1alpha1.ActionPhaseCompleted
 		case batchv1.JobFailed:
 			actionStatus.Phase = dpv1alpha1.ActionPhaseFailed
-			existFailed = true
+			failed = true
 		default:
 			actionStatus.Phase = dpv1alpha1.ActionPhaseRunning
 			actionStatus.CompletionTimestamp = nil
@@ -767,13 +763,8 @@ func (r *BackupReconciler) syncJobActions(ctx context.Context, backup *dpv1alpha
 			actionStatus.CompletionTimestamp = &metav1.Time{Time: r.clock.Now().UTC()}
 		}
 	}
-	if waiting {
-		return dpv1alpha1.ActionPhaseRunning, nil
-	}
-	if existFailed {
-		return dpv1alpha1.ActionPhaseFailed, nil
-	}
-	return dpv1alpha1.ActionPhaseCompleted, nil
+	updateBackupStatusByActionStatus(&backup.Status)
+	return waiting, failed, nil
 }
 
 func (r *BackupReconciler) completeBackup(reqCtx intctrlutil.RequestCtx,

--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -31,6 +31,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
@@ -637,13 +638,22 @@ func (r *BackupReconciler) handleRunningPhase(
 	)
 	for i := range targets {
 		if err = r.prepareRequestTargetInfo(reqCtx, request, &targets[i]); err != nil {
-			if intctrlutil.IsNotFound(err) {
-				if completed, syncErr := r.syncCompletedJobActions(reqCtx.Ctx, request.Backup); syncErr != nil {
-					return intctrlutil.CheckedRequeueWithError(syncErr, reqCtx.Log, "sync completed backup jobs failed")
-				} else if completed {
-					updateBackupStatusByActionStatus(&request.Status)
-					return r.completeBackup(reqCtx, backup, request.Backup)
-				}
+			jobPhase, syncErr := r.syncJobActions(reqCtx.Ctx, request.Backup)
+			if syncErr != nil {
+				return intctrlutil.CheckedRequeueWithError(syncErr, reqCtx.Log, "sync backup jobs failed")
+			}
+			updateBackupStatusByActionStatus(&request.Status)
+			switch jobPhase {
+			case dpv1alpha1.ActionPhaseCompleted:
+				return r.completeBackup(reqCtx, backup, request.Backup)
+			case dpv1alpha1.ActionPhaseFailed:
+				return r.updateStatusIfFailed(reqCtx, backup, request.Backup,
+					fmt.Errorf("there are failed actions, you can obtain the more information in the status.actions"))
+			case dpv1alpha1.ActionPhaseRunning:
+				waiting = true
+			}
+			if waiting {
+				break
 			}
 			return r.updateStatusIfFailed(reqCtx, backup, request.Backup, err)
 		}
@@ -700,48 +710,37 @@ func (r *BackupReconciler) handleRunningPhase(
 	return r.completeBackup(reqCtx, backup, request.Backup)
 }
 
-func (r *BackupReconciler) syncCompletedJobActions(ctx context.Context, backup *dpv1alpha1.Backup) (bool, error) {
+func (r *BackupReconciler) syncJobActions(ctx context.Context, backup *dpv1alpha1.Backup) (dpv1alpha1.ActionPhase, error) {
 	if len(backup.Status.Actions) == 0 {
-		return false, nil
+		return "", nil
 	}
 
-	jobs := make([]*batchv1.Job, len(backup.Status.Actions))
+	var waiting, existFailed bool
 	for i := range backup.Status.Actions {
 		actionStatus := &backup.Status.Actions[i]
 		objectRef := actionStatus.ObjectRef
 		if objectRef == nil || objectRef.APIVersion != batchv1.SchemeGroupVersion.String() ||
 			objectRef.Kind != constant.JobKind || objectRef.Namespace == "" || objectRef.Name == "" {
-			return false, nil
+			return "", nil
 		}
 
 		job := &batchv1.Job{}
 		if err := r.Client.Get(ctx, client.ObjectKey{Namespace: objectRef.Namespace, Name: objectRef.Name}, job); err != nil {
-			return false, client.IgnoreNotFound(err)
+			if apierrors.IsNotFound(err) {
+				return "", nil
+			}
+			return "", err
 		}
 		if objectRef.UID != "" && objectRef.UID != job.UID {
-			return false, nil
+			return "", nil
 		}
 		if job.Labels[dptypes.BackupNameLabelKey] != backup.Name {
-			return false, nil
+			return "", nil
 		}
-		_, finishedType, _ := dputils.IsJobFinished(job)
-		if finishedType != batchv1.JobComplete {
-			return false, nil
-		}
-		jobs[i] = job
-	}
 
-	for i := range backup.Status.Actions {
-		actionStatus := &backup.Status.Actions[i]
-		job := jobs[i]
-		actionStatus.Phase = dpv1alpha1.ActionPhaseCompleted
+		_, finishedType, failureReason := dputils.IsJobFinished(job)
 		actionStatus.ActionType = dpv1alpha1.ActionTypeJob
 		actionStatus.StartTimestamp = job.CreationTimestamp.DeepCopy()
-		if job.Status.CompletionTime != nil {
-			actionStatus.CompletionTimestamp = job.Status.CompletionTime.DeepCopy()
-		} else {
-			actionStatus.CompletionTimestamp = &metav1.Time{Time: r.clock.Now().UTC()}
-		}
 		actionStatus.ObjectRef = &corev1.ObjectReference{
 			APIVersion: batchv1.SchemeGroupVersion.String(),
 			Kind:       constant.JobKind,
@@ -749,8 +748,35 @@ func (r *BackupReconciler) syncCompletedJobActions(ctx context.Context, backup *
 			Name:       job.Name,
 			UID:        job.UID,
 		}
+		if !strings.HasPrefix(actionStatus.FailureReason, dptypes.LogCollectorOutput) {
+			actionStatus.FailureReason = failureReason
+		}
+
+		switch finishedType {
+		case batchv1.JobComplete:
+			actionStatus.Phase = dpv1alpha1.ActionPhaseCompleted
+		case batchv1.JobFailed:
+			actionStatus.Phase = dpv1alpha1.ActionPhaseFailed
+			existFailed = true
+		default:
+			actionStatus.Phase = dpv1alpha1.ActionPhaseRunning
+			actionStatus.CompletionTimestamp = nil
+			waiting = true
+			continue
+		}
+		if job.Status.CompletionTime != nil {
+			actionStatus.CompletionTimestamp = job.Status.CompletionTime.DeepCopy()
+		} else {
+			actionStatus.CompletionTimestamp = &metav1.Time{Time: r.clock.Now().UTC()}
+		}
 	}
-	return true, nil
+	if waiting {
+		return dpv1alpha1.ActionPhaseRunning, nil
+	}
+	if existFailed {
+		return dpv1alpha1.ActionPhaseFailed, nil
+	}
+	return dpv1alpha1.ActionPhaseCompleted, nil
 }
 
 func (r *BackupReconciler) completeBackup(reqCtx intctrlutil.RequestCtx,

--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -638,12 +638,12 @@ func (r *BackupReconciler) handleRunningPhase(
 	)
 	for i := range targets {
 		if err = r.prepareRequestTargetInfo(reqCtx, request, &targets[i]); err != nil {
-			jobPhase, syncErr := r.syncJobActions(reqCtx.Ctx, request.Backup)
+			jobActionPhase, syncErr := r.syncJobActions(reqCtx.Ctx, request.Backup)
 			if syncErr != nil {
 				return intctrlutil.CheckedRequeueWithError(syncErr, reqCtx.Log, "sync backup jobs failed")
 			}
 			updateBackupStatusByActionStatus(&request.Status)
-			switch jobPhase {
+			switch jobActionPhase {
 			case dpv1alpha1.ActionPhaseCompleted:
 			case dpv1alpha1.ActionPhaseFailed:
 				existFailedAction = true

--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -622,13 +622,6 @@ func (r *BackupReconciler) handleRunningPhase(
 			return intctrlutil.Reconciled()
 		}
 	}
-	observedBackup := backup.DeepCopy()
-	if completed, err := r.syncCompletedJobActions(reqCtx.Ctx, observedBackup); err != nil {
-		return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "sync completed backup jobs failed")
-	} else if completed {
-		updateBackupStatusByActionStatus(&observedBackup.Status)
-		return r.completeBackup(reqCtx, backup, observedBackup)
-	}
 	request, err := r.prepareBackupRequest(reqCtx, backup)
 	if err != nil {
 		return r.updateStatusIfFailed(reqCtx, backup.DeepCopy(), backup, err)
@@ -650,6 +643,14 @@ func (r *BackupReconciler) handleRunningPhase(
 	)
 	for i := range targets {
 		if err = r.prepareRequestTargetInfo(reqCtx, request, &targets[i]); err != nil {
+			if intctrlutil.IsNotFound(err) {
+				if completed, syncErr := r.syncCompletedJobActions(reqCtx.Ctx, request.Backup); syncErr != nil {
+					return intctrlutil.CheckedRequeueWithError(syncErr, reqCtx.Log, "sync completed backup jobs failed")
+				} else if completed {
+					updateBackupStatusByActionStatus(&request.Status)
+					return r.completeBackup(reqCtx, backup, request.Backup)
+				}
+			}
 			return r.updateStatusIfFailed(reqCtx, backup, request.Backup, err)
 		}
 		// there are actions not completed, continue to handle following actions

--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -345,12 +345,6 @@ func (r *BackupReconciler) recordBackupStatusTargets(
 		return nil
 	}
 	if request.Backup.Status.Target != nil || len(request.Backup.Status.Targets) > 0 {
-		targets := dputils.GetBackupTargets(request.BackupPolicy, request.BackupMethod)
-		for i := range targets {
-			if err := prepareTarget(&targets[i]); err != nil {
-				return err
-			}
-		}
 		return nil
 	}
 	buildStatusTarget := func(target *dpv1alpha1.BackupTarget) (*dpv1alpha1.BackupStatusTarget, error) {
@@ -371,17 +365,21 @@ func (r *BackupReconciler) recordBackupStatusTargets(
 			return err
 		} else {
 			request.Status.Target = statusTarget
+			request.Status.Targets = nil
 		}
 		return nil
 	}
 	setStatusTargets := func(targets []dpv1alpha1.BackupTarget) error {
+		statusTargets := make([]dpv1alpha1.BackupStatusTarget, 0, len(targets))
 		for i := range targets {
 			if statusTarget, err := buildStatusTarget(&targets[i]); err != nil {
 				return err
 			} else {
-				request.Status.Targets = append(request.Status.Targets, *statusTarget)
+				statusTargets = append(statusTargets, *statusTarget)
 			}
 		}
+		request.Status.Target = nil
+		request.Status.Targets = statusTargets
 		return nil
 	}
 	var err error

--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -599,12 +599,6 @@ func (r *BackupReconciler) handleRunningPhase(
 	if err = r.syncContinuousBackupEncryptionConfig(reqCtx, backup, request.BackupPolicy); err != nil {
 		return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "sync continuous backup encryption config failed")
 	}
-	if completed, err := r.syncCompletedJobActions(reqCtx.Ctx, request); err != nil {
-		return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "sync completed backup jobs failed")
-	} else if completed {
-		updateBackupStatusByActionStatus(&request.Status)
-		return r.completeBackup(reqCtx, backup, request.Backup)
-	}
 	targets := dputils.GetBackupTargets(request.BackupPolicy, request.BackupMethod)
 	var (
 		existFailedAction bool
@@ -619,6 +613,14 @@ func (r *BackupReconciler) handleRunningPhase(
 	)
 	for i := range targets {
 		if err = r.prepareRequestTargetInfo(reqCtx, request, &targets[i]); err != nil {
+			if intctrlutil.IsNotFound(err) {
+				if completed, syncErr := r.syncCompletedJobActions(reqCtx.Ctx, request); syncErr != nil {
+					return intctrlutil.CheckedRequeueWithError(syncErr, reqCtx.Log, "sync completed backup jobs failed")
+				} else if completed {
+					updateBackupStatusByActionStatus(&request.Status)
+					return r.completeBackup(reqCtx, backup, request.Backup)
+				}
+			}
 			return r.updateStatusIfFailed(reqCtx, backup, request.Backup, err)
 		}
 		// there are actions not completed, continue to handle following actions

--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -333,11 +333,28 @@ func (r *BackupReconciler) handleNewPhase(
 func (r *BackupReconciler) recordBackupStatusTargets(
 	reqCtx intctrlutil.RequestCtx,
 	request *dpbackup.Request) error {
+	prepareTarget := func(target *dpv1alpha1.BackupTarget) error {
+		if err := r.prepareRequestTargetInfo(reqCtx, request, target); err != nil {
+			return err
+		}
+		request.PreparedTargets = append(request.PreparedTargets, dpbackup.PreparedTarget{
+			Target:               target,
+			TargetPods:           request.TargetPods,
+			WorkerServiceAccount: request.WorkerServiceAccount,
+		})
+		return nil
+	}
 	if request.Backup.Status.Target != nil || len(request.Backup.Status.Targets) > 0 {
+		targets := dputils.GetBackupTargets(request.BackupPolicy, request.BackupMethod)
+		for i := range targets {
+			if err := prepareTarget(&targets[i]); err != nil {
+				return err
+			}
+		}
 		return nil
 	}
 	buildStatusTarget := func(target *dpv1alpha1.BackupTarget) (*dpv1alpha1.BackupStatusTarget, error) {
-		if err := r.prepareRequestTargetInfo(reqCtx, request, target); err != nil {
+		if err := prepareTarget(target); err != nil {
 			return nil, err
 		}
 		var selectedTargetPods []string
@@ -543,11 +560,11 @@ func (r *BackupReconciler) patchBackupStatus(
 		request.Status.EncryptionConfig = request.BackupPolicy.Spec.EncryptionConfig
 	}
 	var actionStatuses []dpv1alpha1.ActionStatus
-	targets := dputils.GetBackupTargets(request.BackupPolicy, request.BackupMethod)
-	for i := range targets {
-		if err := r.prepareRequestTargetInfo(request.RequestCtx, request, &targets[i]); err != nil {
-			return err
-		}
+	for i := range request.PreparedTargets {
+		preparedTarget := &request.PreparedTargets[i]
+		request.Target = preparedTarget.Target
+		request.TargetPods = preparedTarget.TargetPods
+		request.WorkerServiceAccount = preparedTarget.WorkerServiceAccount
 		actions, err := request.BuildActions()
 		if err != nil {
 			return err

--- a/controllers/dataprotection/backup_controller_test.go
+++ b/controllers/dataprotection/backup_controller_test.go
@@ -551,28 +551,6 @@ var _ = Describe("Backup Controller test", func() {
 					g.Expect(fetched.Status.Expiration.Second()).Should(Equal(fetched.Status.CompletionTimestamp.Add(time.Hour).Second()))
 				})).Should(Succeed())
 			})
-
-			It("returns not found when a previously selected target pod is missing", func() {
-				target := &dpv1alpha1.BackupTarget{
-					PodSelector: &dpv1alpha1.PodSelector{
-						LabelSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								constant.AppInstanceLabelKey:    testdp.ClusterName,
-								constant.KBAppComponentLabelKey: testdp.ComponentName,
-							},
-						},
-					},
-				}
-				reqCtx := intctrlutil.RequestCtx{Ctx: ctx, Req: ctrl.Request{NamespacedName: client.ObjectKeyFromObject(backupPolicy)}}
-				for _, strategy := range []dpv1alpha1.PodSelectionStrategy{
-					dpv1alpha1.PodSelectionStrategyAny,
-					dpv1alpha1.PodSelectionStrategyAll,
-				} {
-					target.PodSelector.Strategy = strategy
-					_, err := GetTargetPods(reqCtx, k8sClient, []string{"missing-pod"}, backupPolicy, target, dpv1alpha1.BackupTypeFull)
-					Expect(intctrlutil.IsNotFound(err)).To(BeTrue())
-				}
-			})
 		})
 
 		It("create a backup with backupMethod and multi targets", func() {
@@ -615,6 +593,13 @@ var _ = Describe("Backup Controller test", func() {
 					fmt.Sprintf("%s-%s-0", dpbackup.BackupDataJobNamePrefix, targets[0].Name),
 					fmt.Sprintf("%s-%s-0", dpbackup.BackupDataJobNamePrefix, targets[1].Name),
 				))
+				for _, actionStatus := range fetched.Status.Actions {
+					g.Expect(actionStatus.ObjectRef).ShouldNot(BeNil())
+					g.Expect(actionStatus.ObjectRef.APIVersion).Should(Equal(batchv1.SchemeGroupVersion.String()))
+					g.Expect(actionStatus.ObjectRef.Kind).Should(Equal(constant.JobKind))
+					g.Expect(actionStatus.ObjectRef.Namespace).Should(Equal(backup.Namespace))
+					g.Expect(actionStatus.ObjectRef.Name).Should(Equal(dpbackup.GenerateBackupJobName(backup, actionStatus.Name)))
+				}
 			})).Should(Succeed())
 			By("mock backup jobs to completed and backup should be completed")
 			testdp.PatchK8sJobStatus(&testCtx, getJobKey(targets[0].Name), batchv1.JobComplete)
@@ -624,7 +609,7 @@ var _ = Describe("Backup Controller test", func() {
 			})).Should(Succeed())
 		})
 
-		It("reconstructs a complete multi-target action status from completed jobs", func() {
+		It("completes a multi-target backup from persisted job object refs", func() {
 			By("Set backupMethod's targets")
 			Expect(testapps.ChangeObj(&testCtx, backupPolicy, func(bp *dpv1alpha1.BackupPolicy) {
 				podSelector := &dpv1alpha1.PodSelector{
@@ -655,7 +640,7 @@ var _ = Describe("Backup Controller test", func() {
 			Eventually(testapps.CheckObjExists(&testCtx, getJobKey(targets[0].Name), &batchv1.Job{}, true)).Should(Succeed())
 			Eventually(testapps.CheckObjExists(&testCtx, getJobKey(targets[1].Name), &batchv1.Job{}, true)).Should(Succeed())
 
-			By("pause reconciliation and retain only the last target action in status")
+			By("pause reconciliation")
 			Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
 				if fetched.Annotations == nil {
 					fetched.Annotations = map[string]string{}
@@ -665,21 +650,15 @@ var _ = Describe("Backup Controller test", func() {
 			Consistently(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
 				g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseRunning))
 			}), time.Second).Should(Succeed())
-			Eventually(testapps.GetAndChangeObjStatus(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
-				fetched.Status.Actions = []dpv1alpha1.ActionStatus{{
-					Name:          fmt.Sprintf("%s-%s-0", dpbackup.BackupDataJobNamePrefix, targets[1].Name),
-					TargetPodName: targetPod.Name,
-					Phase:         dpv1alpha1.ActionPhaseRunning,
-					ActionType:    dpv1alpha1.ActionTypeJob,
-				}}
-			})).Should(Succeed())
 
 			testdp.PatchK8sJobStatus(&testCtx, getJobKey(targets[0].Name), batchv1.JobComplete)
 			testdp.PatchK8sJobStatus(&testCtx, getJobKey(targets[1].Name), batchv1.JobComplete)
+			By("delete the live ActionSet after the action refs have been persisted")
+			Expect(k8sClient.Delete(ctx, actionSet)).Should(Succeed())
 			Expect(k8sClient.Delete(ctx, targetPod)).Should(Succeed())
 			Eventually(testapps.CheckObjExists(&testCtx, client.ObjectKeyFromObject(targetPod), &corev1.Pod{}, false)).Should(Succeed())
 
-			By("resume reconciliation and reconstruct the complete status from both jobs")
+			By("resume reconciliation and observe both jobs before resolving targets")
 			Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
 				delete(fetched.Annotations, dptypes.SkipReconciliationAnnotationKey)
 			})).Should(Succeed())
@@ -692,7 +671,7 @@ var _ = Describe("Backup Controller test", func() {
 			})).Should(Succeed())
 		})
 
-		It("does not complete a multi-target backup from an incomplete action status", func() {
+		It("does not complete a multi-target backup while a referenced job is incomplete", func() {
 			By("Set backupMethod's targets")
 			Expect(testapps.ChangeObj(&testCtx, backupPolicy, func(bp *dpv1alpha1.BackupPolicy) {
 				podSelector := &dpv1alpha1.PodSelector{
@@ -723,7 +702,7 @@ var _ = Describe("Backup Controller test", func() {
 			Eventually(testapps.CheckObjExists(&testCtx, getJobKey(targets[0].Name), &batchv1.Job{}, true)).Should(Succeed())
 			Eventually(testapps.CheckObjExists(&testCtx, getJobKey(targets[1].Name), &batchv1.Job{}, true)).Should(Succeed())
 
-			By("pause reconciliation and retain only the last target action in status")
+			By("pause reconciliation")
 			Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
 				if fetched.Annotations == nil {
 					fetched.Annotations = map[string]string{}
@@ -733,20 +712,12 @@ var _ = Describe("Backup Controller test", func() {
 			Consistently(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
 				g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseRunning))
 			}), time.Second).Should(Succeed())
-			Eventually(testapps.GetAndChangeObjStatus(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
-				fetched.Status.Actions = []dpv1alpha1.ActionStatus{{
-					Name:          fmt.Sprintf("%s-%s-0", dpbackup.BackupDataJobNamePrefix, targets[1].Name),
-					TargetPodName: targetPod.Name,
-					Phase:         dpv1alpha1.ActionPhaseRunning,
-					ActionType:    dpv1alpha1.ActionTypeJob,
-				}}
-			})).Should(Succeed())
 
 			testdp.PatchK8sJobStatus(&testCtx, getJobKey(targets[1].Name), batchv1.JobComplete)
 			Expect(k8sClient.Delete(ctx, targetPod)).Should(Succeed())
 			Eventually(testapps.CheckObjExists(&testCtx, client.ObjectKeyFromObject(targetPod), &corev1.Pod{}, false)).Should(Succeed())
 
-			By("resume reconciliation and expect the incomplete plan not to succeed")
+			By("resume reconciliation and expect the incomplete jobs not to succeed")
 			Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
 				delete(fetched.Annotations, dptypes.SkipReconciliationAnnotationKey)
 			})).Should(Succeed())

--- a/controllers/dataprotection/backup_controller_test.go
+++ b/controllers/dataprotection/backup_controller_test.go
@@ -66,26 +66,38 @@ func TestSyncJobActions(t *testing.T) {
 	tests := []struct {
 		name           string
 		jobConditions  []batchv1.JobConditionType
-		expectedPhase  dpv1alpha1.ActionPhase
+		fatal          bool
+		waiting        bool
+		failed         bool
 		expectedAction []dpv1alpha1.ActionPhase
 	}{
 		{
+			name:  "no actions",
+			fatal: true,
+		},
+		{
 			name:           "all jobs completed",
 			jobConditions:  []batchv1.JobConditionType{batchv1.JobComplete, batchv1.JobComplete},
-			expectedPhase:  dpv1alpha1.ActionPhaseCompleted,
 			expectedAction: []dpv1alpha1.ActionPhase{dpv1alpha1.ActionPhaseCompleted, dpv1alpha1.ActionPhaseCompleted},
 		},
 		{
 			name:           "one job still running",
 			jobConditions:  []batchv1.JobConditionType{batchv1.JobComplete, ""},
-			expectedPhase:  dpv1alpha1.ActionPhaseRunning,
+			waiting:        true,
 			expectedAction: []dpv1alpha1.ActionPhase{dpv1alpha1.ActionPhaseCompleted, dpv1alpha1.ActionPhaseRunning},
 		},
 		{
 			name:           "job failed",
 			jobConditions:  []batchv1.JobConditionType{batchv1.JobFailed},
-			expectedPhase:  dpv1alpha1.ActionPhaseFailed,
+			failed:         true,
 			expectedAction: []dpv1alpha1.ActionPhase{dpv1alpha1.ActionPhaseFailed},
+		},
+		{
+			name:           "one job failed while another is running",
+			jobConditions:  []batchv1.JobConditionType{batchv1.JobFailed, ""},
+			waiting:        true,
+			failed:         true,
+			expectedAction: []dpv1alpha1.ActionPhase{dpv1alpha1.ActionPhaseFailed, dpv1alpha1.ActionPhaseRunning},
 		},
 	}
 
@@ -131,9 +143,14 @@ func TestSyncJobActions(t *testing.T) {
 				Client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(objects...).Build(),
 				clock:  clock.RealClock{},
 			}
-			phase, err := reconciler.syncJobActions(context.Background(), backup)
+			waiting, failed, err := reconciler.syncJobActions(context.Background(), backup)
+			if tt.fatal {
+				g.Expect(intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal)).To(BeTrue())
+				return
+			}
 			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(phase).To(Equal(tt.expectedPhase))
+			g.Expect(waiting).To(Equal(tt.waiting))
+			g.Expect(failed).To(Equal(tt.failed))
 			for i := range backup.Status.Actions {
 				actionStatus := backup.Status.Actions[i]
 				g.Expect(actionStatus.Phase).To(Equal(tt.expectedAction[i]))

--- a/controllers/dataprotection/backup_controller_test.go
+++ b/controllers/dataprotection/backup_controller_test.go
@@ -479,6 +479,9 @@ var _ = Describe("Backup Controller test", func() {
 			})
 
 			It("should fail after job fails", func() {
+				By("wait for the backup job to be created")
+				Eventually(testapps.CheckObjExists(&testCtx, getJobKey(), &batchv1.Job{}, true)).Should(Succeed())
+
 				By("pause backup reconciliation before failing the job")
 				Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
 					if fetched.Annotations == nil {
@@ -731,19 +734,26 @@ var _ = Describe("Backup Controller test", func() {
 					{Name: testdp.ComponentName + "-1", PodSelector: podSelector},
 				}
 			})).Should(Succeed())
-			targets := backupPolicy.Spec.BackupMethods[0].Targets
 			backup := testdp.NewFakeBackup(&testCtx, nil)
 			backupKey := client.ObjectKeyFromObject(backup)
-			getJobKey := func(targetName string) client.ObjectKey {
-				return client.ObjectKey{
-					Name:      dpbackup.GenerateBackupJobName(backup, fmt.Sprintf("%s-%s-0", dpbackup.BackupDataJobNamePrefix, targetName)),
-					Namespace: backup.Namespace,
-				}
-			}
 
-			By("wait for both target jobs to be created")
-			Eventually(testapps.CheckObjExists(&testCtx, getJobKey(targets[0].Name), &batchv1.Job{}, true)).Should(Succeed())
-			Eventually(testapps.CheckObjExists(&testCtx, getJobKey(targets[1].Name), &batchv1.Job{}, true)).Should(Succeed())
+			By("wait for all target jobs to be recorded and created")
+			var jobKeys []client.ObjectKey
+			Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+				g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseRunning))
+				g.Expect(fetched.Status.Actions).To(HaveLen(4))
+				jobKeys = jobKeys[:0]
+				for _, actionStatus := range fetched.Status.Actions {
+					g.Expect(actionStatus.ObjectRef).NotTo(BeNil())
+					jobKeys = append(jobKeys, client.ObjectKey{
+						Namespace: actionStatus.ObjectRef.Namespace,
+						Name:      actionStatus.ObjectRef.Name,
+					})
+				}
+			})).Should(Succeed())
+			for _, jobKey := range jobKeys {
+				Eventually(testapps.CheckObjExists(&testCtx, jobKey, &batchv1.Job{}, true)).Should(Succeed())
+			}
 
 			By("pause reconciliation")
 			Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
@@ -756,8 +766,9 @@ var _ = Describe("Backup Controller test", func() {
 				g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseRunning))
 			}), time.Second).Should(Succeed())
 
-			testdp.PatchK8sJobStatus(&testCtx, getJobKey(targets[0].Name), batchv1.JobComplete)
-			testdp.PatchK8sJobStatus(&testCtx, getJobKey(targets[1].Name), batchv1.JobComplete)
+			for _, jobKey := range jobKeys {
+				testdp.PatchK8sJobStatus(&testCtx, jobKey, batchv1.JobComplete)
+			}
 			Expect(k8sClient.Delete(ctx, targetPod)).Should(Succeed())
 			Eventually(testapps.CheckObjExists(&testCtx, client.ObjectKeyFromObject(targetPod), &corev1.Pod{}, false)).Should(Succeed())
 
@@ -767,7 +778,7 @@ var _ = Describe("Backup Controller test", func() {
 			})).Should(Succeed())
 			Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
 				g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseCompleted))
-				g.Expect(fetched.Status.Actions).To(HaveLen(2))
+				g.Expect(fetched.Status.Actions).To(HaveLen(len(jobKeys)))
 				for _, actionStatus := range fetched.Status.Actions {
 					g.Expect(actionStatus.Phase).To(Equal(dpv1alpha1.ActionPhaseCompleted))
 				}

--- a/controllers/dataprotection/backup_controller_test.go
+++ b/controllers/dataprotection/backup_controller_test.go
@@ -423,6 +423,33 @@ var _ = Describe("Backup Controller test", func() {
 					g.Expect(fetched.Status.Phase).To(BeEmpty())
 				})).Should(Succeed())
 			})
+
+			It("returns not found when a previously selected target pod is missing", func() {
+				target := &dpv1alpha1.BackupTarget{
+					PodSelector: &dpv1alpha1.PodSelector{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								constant.AppInstanceLabelKey:    testdp.ClusterName,
+								constant.KBAppComponentLabelKey: testdp.ComponentName,
+							},
+						},
+					},
+				}
+				reqCtx := intctrlutil.RequestCtx{Ctx: ctx, Req: ctrl.Request{NamespacedName: client.ObjectKeyFromObject(backupPolicy)}}
+				for _, strategy := range []dpv1alpha1.PodSelectionStrategy{
+					dpv1alpha1.PodSelectionStrategyAny,
+					dpv1alpha1.PodSelectionStrategyAll,
+				} {
+					target.PodSelector.Strategy = strategy
+					_, err := GetTargetPods(reqCtx, k8sClient, []string{"missing-pod"}, backupPolicy, target, dpv1alpha1.BackupTypeFull)
+					Expect(intctrlutil.IsNotFound(err)).To(BeTrue())
+				}
+
+				target.PodSelector.Strategy = dpv1alpha1.PodSelectionStrategyAll
+				target.PodSelector.LabelSelector.MatchLabels["missing"] = "true"
+				_, err := GetTargetPods(reqCtx, k8sClient, []string{"missing-pod"}, backupPolicy, target, dpv1alpha1.BackupTypeFull)
+				Expect(intctrlutil.IsNotFound(err)).To(BeTrue())
+			})
 		})
 
 		Context("create an invalid backup", func() {
@@ -653,12 +680,10 @@ var _ = Describe("Backup Controller test", func() {
 
 			testdp.PatchK8sJobStatus(&testCtx, getJobKey(targets[0].Name), batchv1.JobComplete)
 			testdp.PatchK8sJobStatus(&testCtx, getJobKey(targets[1].Name), batchv1.JobComplete)
-			By("delete the live ActionSet after the action refs have been persisted")
-			Expect(k8sClient.Delete(ctx, actionSet)).Should(Succeed())
 			Expect(k8sClient.Delete(ctx, targetPod)).Should(Succeed())
 			Eventually(testapps.CheckObjExists(&testCtx, client.ObjectKeyFromObject(targetPod), &corev1.Pod{}, false)).Should(Succeed())
 
-			By("resume reconciliation and observe both jobs before resolving targets")
+			By("resume reconciliation and fall back to the persisted job refs")
 			Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
 				delete(fetched.Annotations, dptypes.SkipReconciliationAnnotationKey)
 			})).Should(Succeed())

--- a/controllers/dataprotection/backup_controller_test.go
+++ b/controllers/dataprotection/backup_controller_test.go
@@ -355,6 +355,41 @@ var _ = Describe("Backup Controller test", func() {
 				Eventually(testapps.CheckObjExists(&testCtx, getJobKey(), &batchv1.Job{}, false)).Should(Succeed())
 			})
 
+			It("should succeed when the target pod disappears after the job completes", func() {
+				By("wait for the backup job to be created")
+				Eventually(testapps.CheckObjExists(&testCtx, getJobKey(), &batchv1.Job{}, true)).Should(Succeed())
+
+				By("pause backup reconciliation before completing the job")
+				Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
+					if fetched.Annotations == nil {
+						fetched.Annotations = map[string]string{}
+					}
+					fetched.Annotations[dptypes.SkipReconciliationAnnotationKey] = "true"
+				})).Should(Succeed())
+				Consistently(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+					g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseRunning))
+				}), time.Second).Should(Succeed())
+
+				testdp.PatchK8sJobStatus(&testCtx, getJobKey(), batchv1.JobComplete)
+				Consistently(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+					g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseRunning))
+				}), time.Second).Should(Succeed())
+
+				By("delete the selected target pod before the job result is observed")
+				Expect(k8sClient.Delete(ctx, targetPod)).Should(Succeed())
+				Eventually(testapps.CheckObjExists(&testCtx, client.ObjectKeyFromObject(targetPod), &corev1.Pod{}, false)).Should(Succeed())
+
+				By("resume backup reconciliation")
+				Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
+					delete(fetched.Annotations, dptypes.SkipReconciliationAnnotationKey)
+				})).Should(Succeed())
+
+				By("expect the completed job to win over the missing target pod")
+				Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+					g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseCompleted))
+				})).Should(Succeed())
+			})
+
 			It("should fail after job fails", func() {
 				testdp.PatchK8sJobStatus(&testCtx, getJobKey(), batchv1.JobFailed)
 

--- a/controllers/dataprotection/backup_controller_test.go
+++ b/controllers/dataprotection/backup_controller_test.go
@@ -551,6 +551,28 @@ var _ = Describe("Backup Controller test", func() {
 					g.Expect(fetched.Status.Expiration.Second()).Should(Equal(fetched.Status.CompletionTimestamp.Add(time.Hour).Second()))
 				})).Should(Succeed())
 			})
+
+			It("returns not found when a previously selected target pod is missing", func() {
+				target := &dpv1alpha1.BackupTarget{
+					PodSelector: &dpv1alpha1.PodSelector{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								constant.AppInstanceLabelKey:    testdp.ClusterName,
+								constant.KBAppComponentLabelKey: testdp.ComponentName,
+							},
+						},
+					},
+				}
+				reqCtx := intctrlutil.RequestCtx{Ctx: ctx, Req: ctrl.Request{NamespacedName: client.ObjectKeyFromObject(backupPolicy)}}
+				for _, strategy := range []dpv1alpha1.PodSelectionStrategy{
+					dpv1alpha1.PodSelectionStrategyAny,
+					dpv1alpha1.PodSelectionStrategyAll,
+				} {
+					target.PodSelector.Strategy = strategy
+					_, err := GetTargetPods(reqCtx, k8sClient, []string{"missing-pod"}, backupPolicy, target, dpv1alpha1.BackupTypeFull)
+					Expect(intctrlutil.IsNotFound(err)).To(BeTrue())
+				}
+			})
 		})
 
 		It("create a backup with backupMethod and multi targets", func() {

--- a/controllers/dataprotection/backup_controller_test.go
+++ b/controllers/dataprotection/backup_controller_test.go
@@ -62,18 +62,32 @@ import (
 	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
 
+type getErrorClient struct {
+	client.Client
+}
+
+func (c *getErrorClient) Get(context.Context, client.ObjectKey, client.Object, ...client.GetOption) error {
+	return fmt.Errorf("get failed")
+}
+
 func TestSyncJobActions(t *testing.T) {
 	tests := []struct {
 		name           string
 		jobConditions  []batchv1.JobConditionType
-		fatal          bool
+		notApplicable  bool
+		getError       bool
 		waiting        bool
 		failed         bool
 		expectedAction []dpv1alpha1.ActionPhase
 	}{
 		{
-			name:  "no actions",
-			fatal: true,
+			name:          "no actions",
+			notApplicable: true,
+		},
+		{
+			name:          "job get error",
+			jobConditions: []batchv1.JobConditionType{""},
+			getError:      true,
 		},
 		{
 			name:           "all jobs completed",
@@ -139,13 +153,22 @@ func TestSyncJobActions(t *testing.T) {
 				})
 			}
 
+			var cli client.Client = fake.NewClientBuilder().WithScheme(testScheme).WithObjects(objects...).Build()
+			if tt.getError {
+				cli = &getErrorClient{Client: cli}
+			}
 			reconciler := &BackupReconciler{
-				Client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(objects...).Build(),
+				Client: cli,
 				clock:  clock.RealClock{},
 			}
-			waiting, failed, err := reconciler.syncJobActions(context.Background(), backup)
-			if tt.fatal {
-				g.Expect(intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal)).To(BeTrue())
+			targetErr := fmt.Errorf("target unavailable")
+			waiting, failed, err := reconciler.syncJobActions(context.Background(), backup, targetErr)
+			if tt.notApplicable {
+				g.Expect(err).To(MatchError(targetErr))
+				return
+			}
+			if tt.getError {
+				g.Expect(intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeRequeue)).To(BeTrue())
 				return
 			}
 			g.Expect(err).NotTo(HaveOccurred())

--- a/controllers/dataprotection/backup_controller_test.go
+++ b/controllers/dataprotection/backup_controller_test.go
@@ -578,17 +578,158 @@ var _ = Describe("Backup Controller test", func() {
 			Expect(targetPods).Should(HaveLen(1))
 			By("create a backup")
 			backup := testdp.NewFakeBackup(&testCtx, nil)
+			backupKey := client.ObjectKeyFromObject(backup)
 			getJobKey := func(targetName string) client.ObjectKey {
 				return client.ObjectKey{
 					Name:      dpbackup.GenerateBackupJobName(backup, fmt.Sprintf("%s-%s-0", dpbackup.BackupDataJobNamePrefix, targetName)),
 					Namespace: backup.Namespace,
 				}
 			}
+			By("check the complete action plan is persisted")
+			Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+				g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseRunning))
+				g.Expect(fetched.Status.Actions).To(HaveLen(2))
+				g.Expect([]string{fetched.Status.Actions[0].Name, fetched.Status.Actions[1].Name}).To(ConsistOf(
+					fmt.Sprintf("%s-%s-0", dpbackup.BackupDataJobNamePrefix, targets[0].Name),
+					fmt.Sprintf("%s-%s-0", dpbackup.BackupDataJobNamePrefix, targets[1].Name),
+				))
+			})).Should(Succeed())
 			By("mock backup jobs to completed and backup should be completed")
 			testdp.PatchK8sJobStatus(&testCtx, getJobKey(targets[0].Name), batchv1.JobComplete)
 			testdp.PatchK8sJobStatus(&testCtx, getJobKey(targets[1].Name), batchv1.JobComplete)
-			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(backup), func(g Gomega, fetched *dpv1alpha1.Backup) {
+			Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
 				g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseCompleted))
+			})).Should(Succeed())
+		})
+
+		It("reconstructs a complete multi-target action status from completed jobs", func() {
+			By("Set backupMethod's targets")
+			Expect(testapps.ChangeObj(&testCtx, backupPolicy, func(bp *dpv1alpha1.BackupPolicy) {
+				podSelector := &dpv1alpha1.PodSelector{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							constant.AppInstanceLabelKey:    testdp.ClusterName,
+							constant.KBAppComponentLabelKey: testdp.ComponentName,
+						},
+					},
+					Strategy: dpv1alpha1.PodSelectionStrategyAny,
+				}
+				backupPolicy.Spec.BackupMethods[0].Targets = []dpv1alpha1.BackupTarget{
+					{Name: testdp.ComponentName + "-0", PodSelector: podSelector},
+					{Name: testdp.ComponentName + "-1", PodSelector: podSelector},
+				}
+			})).Should(Succeed())
+			targets := backupPolicy.Spec.BackupMethods[0].Targets
+			backup := testdp.NewFakeBackup(&testCtx, nil)
+			backupKey := client.ObjectKeyFromObject(backup)
+			getJobKey := func(targetName string) client.ObjectKey {
+				return client.ObjectKey{
+					Name:      dpbackup.GenerateBackupJobName(backup, fmt.Sprintf("%s-%s-0", dpbackup.BackupDataJobNamePrefix, targetName)),
+					Namespace: backup.Namespace,
+				}
+			}
+
+			By("wait for both target jobs to be created")
+			Eventually(testapps.CheckObjExists(&testCtx, getJobKey(targets[0].Name), &batchv1.Job{}, true)).Should(Succeed())
+			Eventually(testapps.CheckObjExists(&testCtx, getJobKey(targets[1].Name), &batchv1.Job{}, true)).Should(Succeed())
+
+			By("pause reconciliation and retain only the last target action in status")
+			Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
+				if fetched.Annotations == nil {
+					fetched.Annotations = map[string]string{}
+				}
+				fetched.Annotations[dptypes.SkipReconciliationAnnotationKey] = "true"
+			})).Should(Succeed())
+			Consistently(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+				g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseRunning))
+			}), time.Second).Should(Succeed())
+			Eventually(testapps.GetAndChangeObjStatus(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
+				fetched.Status.Actions = []dpv1alpha1.ActionStatus{{
+					Name:          fmt.Sprintf("%s-%s-0", dpbackup.BackupDataJobNamePrefix, targets[1].Name),
+					TargetPodName: targetPod.Name,
+					Phase:         dpv1alpha1.ActionPhaseRunning,
+					ActionType:    dpv1alpha1.ActionTypeJob,
+				}}
+			})).Should(Succeed())
+
+			testdp.PatchK8sJobStatus(&testCtx, getJobKey(targets[0].Name), batchv1.JobComplete)
+			testdp.PatchK8sJobStatus(&testCtx, getJobKey(targets[1].Name), batchv1.JobComplete)
+			Expect(k8sClient.Delete(ctx, targetPod)).Should(Succeed())
+			Eventually(testapps.CheckObjExists(&testCtx, client.ObjectKeyFromObject(targetPod), &corev1.Pod{}, false)).Should(Succeed())
+
+			By("resume reconciliation and reconstruct the complete status from both jobs")
+			Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
+				delete(fetched.Annotations, dptypes.SkipReconciliationAnnotationKey)
+			})).Should(Succeed())
+			Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+				g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseCompleted))
+				g.Expect(fetched.Status.Actions).To(HaveLen(2))
+				for _, actionStatus := range fetched.Status.Actions {
+					g.Expect(actionStatus.Phase).To(Equal(dpv1alpha1.ActionPhaseCompleted))
+				}
+			})).Should(Succeed())
+		})
+
+		It("does not complete a multi-target backup from an incomplete action status", func() {
+			By("Set backupMethod's targets")
+			Expect(testapps.ChangeObj(&testCtx, backupPolicy, func(bp *dpv1alpha1.BackupPolicy) {
+				podSelector := &dpv1alpha1.PodSelector{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							constant.AppInstanceLabelKey:    testdp.ClusterName,
+							constant.KBAppComponentLabelKey: testdp.ComponentName,
+						},
+					},
+					Strategy: dpv1alpha1.PodSelectionStrategyAny,
+				}
+				backupPolicy.Spec.BackupMethods[0].Targets = []dpv1alpha1.BackupTarget{
+					{Name: testdp.ComponentName + "-0", PodSelector: podSelector},
+					{Name: testdp.ComponentName + "-1", PodSelector: podSelector},
+				}
+			})).Should(Succeed())
+			targets := backupPolicy.Spec.BackupMethods[0].Targets
+			backup := testdp.NewFakeBackup(&testCtx, nil)
+			backupKey := client.ObjectKeyFromObject(backup)
+			getJobKey := func(targetName string) client.ObjectKey {
+				return client.ObjectKey{
+					Name:      dpbackup.GenerateBackupJobName(backup, fmt.Sprintf("%s-%s-0", dpbackup.BackupDataJobNamePrefix, targetName)),
+					Namespace: backup.Namespace,
+				}
+			}
+
+			By("wait for both target jobs to be created")
+			Eventually(testapps.CheckObjExists(&testCtx, getJobKey(targets[0].Name), &batchv1.Job{}, true)).Should(Succeed())
+			Eventually(testapps.CheckObjExists(&testCtx, getJobKey(targets[1].Name), &batchv1.Job{}, true)).Should(Succeed())
+
+			By("pause reconciliation and retain only the last target action in status")
+			Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
+				if fetched.Annotations == nil {
+					fetched.Annotations = map[string]string{}
+				}
+				fetched.Annotations[dptypes.SkipReconciliationAnnotationKey] = "true"
+			})).Should(Succeed())
+			Consistently(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+				g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseRunning))
+			}), time.Second).Should(Succeed())
+			Eventually(testapps.GetAndChangeObjStatus(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
+				fetched.Status.Actions = []dpv1alpha1.ActionStatus{{
+					Name:          fmt.Sprintf("%s-%s-0", dpbackup.BackupDataJobNamePrefix, targets[1].Name),
+					TargetPodName: targetPod.Name,
+					Phase:         dpv1alpha1.ActionPhaseRunning,
+					ActionType:    dpv1alpha1.ActionTypeJob,
+				}}
+			})).Should(Succeed())
+
+			testdp.PatchK8sJobStatus(&testCtx, getJobKey(targets[1].Name), batchv1.JobComplete)
+			Expect(k8sClient.Delete(ctx, targetPod)).Should(Succeed())
+			Eventually(testapps.CheckObjExists(&testCtx, client.ObjectKeyFromObject(targetPod), &corev1.Pod{}, false)).Should(Succeed())
+
+			By("resume reconciliation and expect the incomplete plan not to succeed")
+			Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
+				delete(fetched.Annotations, dptypes.SkipReconciliationAnnotationKey)
+			})).Should(Succeed())
+			Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+				g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseFailed))
 			})).Should(Succeed())
 		})
 

--- a/controllers/dataprotection/backup_controller_test.go
+++ b/controllers/dataprotection/backup_controller_test.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"slices"
 	"strconv"
+	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -40,6 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -59,6 +61,92 @@ import (
 	testk8s "github.com/apecloud/kubeblocks/pkg/testutil/k8s"
 	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
+
+func TestSyncJobActions(t *testing.T) {
+	tests := []struct {
+		name           string
+		jobConditions  []batchv1.JobConditionType
+		expectedPhase  dpv1alpha1.ActionPhase
+		expectedAction []dpv1alpha1.ActionPhase
+	}{
+		{
+			name:           "all jobs completed",
+			jobConditions:  []batchv1.JobConditionType{batchv1.JobComplete, batchv1.JobComplete},
+			expectedPhase:  dpv1alpha1.ActionPhaseCompleted,
+			expectedAction: []dpv1alpha1.ActionPhase{dpv1alpha1.ActionPhaseCompleted, dpv1alpha1.ActionPhaseCompleted},
+		},
+		{
+			name:           "one job still running",
+			jobConditions:  []batchv1.JobConditionType{batchv1.JobComplete, ""},
+			expectedPhase:  dpv1alpha1.ActionPhaseRunning,
+			expectedAction: []dpv1alpha1.ActionPhase{dpv1alpha1.ActionPhaseCompleted, dpv1alpha1.ActionPhaseRunning},
+		},
+		{
+			name:           "job failed",
+			jobConditions:  []batchv1.JobConditionType{batchv1.JobFailed},
+			expectedPhase:  dpv1alpha1.ActionPhaseFailed,
+			expectedAction: []dpv1alpha1.ActionPhase{dpv1alpha1.ActionPhaseFailed},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			testScheme := runtime.NewScheme()
+			g.Expect(batchv1.AddToScheme(testScheme)).To(Succeed())
+
+			backup := &dpv1alpha1.Backup{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "backup"}}
+			objects := make([]client.Object, 0, len(tt.jobConditions))
+			for i, conditionType := range tt.jobConditions {
+				jobName := fmt.Sprintf("job-%d", i)
+				job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+					Namespace:         backup.Namespace,
+					Name:              jobName,
+					UID:               types.UID(jobName),
+					CreationTimestamp: metav1.Now(),
+					Labels:            map[string]string{dptypes.BackupNameLabelKey: backup.Name},
+				}}
+				if conditionType != "" {
+					job.Status.Conditions = []batchv1.JobCondition{{
+						Type:    conditionType,
+						Status:  corev1.ConditionTrue,
+						Reason:  "reason",
+						Message: "message",
+					}}
+				}
+				objects = append(objects, job)
+				backup.Status.Actions = append(backup.Status.Actions, dpv1alpha1.ActionStatus{
+					Name: jobName,
+					ObjectRef: &corev1.ObjectReference{
+						APIVersion: batchv1.SchemeGroupVersion.String(),
+						Kind:       constant.JobKind,
+						Namespace:  job.Namespace,
+						Name:       job.Name,
+						UID:        job.UID,
+					},
+				})
+			}
+
+			reconciler := &BackupReconciler{
+				Client: fake.NewClientBuilder().WithScheme(testScheme).WithObjects(objects...).Build(),
+				clock:  clock.RealClock{},
+			}
+			phase, err := reconciler.syncJobActions(context.Background(), backup)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(phase).To(Equal(tt.expectedPhase))
+			for i := range backup.Status.Actions {
+				actionStatus := backup.Status.Actions[i]
+				g.Expect(actionStatus.Phase).To(Equal(tt.expectedAction[i]))
+				g.Expect(actionStatus.StartTimestamp).NotTo(BeNil())
+				if actionStatus.Phase == dpv1alpha1.ActionPhaseRunning {
+					g.Expect(actionStatus.CompletionTimestamp).To(BeNil())
+				} else {
+					g.Expect(actionStatus.CompletionTimestamp).NotTo(BeNil())
+				}
+			}
+		})
+	}
+}
 
 var _ = Describe("Backup Controller test", func() {
 	cleanEnv := func() {
@@ -391,7 +479,17 @@ var _ = Describe("Backup Controller test", func() {
 			})
 
 			It("should fail after job fails", func() {
+				By("pause backup reconciliation before failing the job")
+				Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
+					if fetched.Annotations == nil {
+						fetched.Annotations = map[string]string{}
+					}
+					fetched.Annotations[dptypes.SkipReconciliationAnnotationKey] = "true"
+				})).Should(Succeed())
+
 				testdp.PatchK8sJobStatus(&testCtx, getJobKey(), batchv1.JobFailed)
+				Expect(k8sClient.Delete(ctx, targetPod)).Should(Succeed())
+				Eventually(testapps.CheckObjExists(&testCtx, client.ObjectKeyFromObject(targetPod), &corev1.Pod{}, false)).Should(Succeed())
 
 				By("check backup job failed")
 				Eventually(testapps.CheckObj(&testCtx, getJobKey(), func(g Gomega, fetched *batchv1.Job) {
@@ -399,9 +497,16 @@ var _ = Describe("Backup Controller test", func() {
 					g.Expect(finishedType).To(Equal(batchv1.JobFailed))
 				})).Should(Succeed())
 
-				By("check backup failed")
+				By("resume reconciliation without the target pod")
+				Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
+					delete(fetched.Annotations, dptypes.SkipReconciliationAnnotationKey)
+				})).Should(Succeed())
+
+				By("check backup failed from the persisted job status")
 				Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
 					g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseFailed))
+					g.Expect(fetched.Status.Actions).To(HaveLen(1))
+					g.Expect(fetched.Status.Actions[0].Phase).To(Equal(dpv1alpha1.ActionPhaseFailed))
 				})).Should(Succeed())
 			})
 
@@ -422,33 +527,6 @@ var _ = Describe("Backup Controller test", func() {
 				Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(bp), func(g Gomega, fetched *dpv1alpha1.Backup) {
 					g.Expect(fetched.Status.Phase).To(BeEmpty())
 				})).Should(Succeed())
-			})
-
-			It("returns not found when a previously selected target pod is missing", func() {
-				target := &dpv1alpha1.BackupTarget{
-					PodSelector: &dpv1alpha1.PodSelector{
-						LabelSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								constant.AppInstanceLabelKey:    testdp.ClusterName,
-								constant.KBAppComponentLabelKey: testdp.ComponentName,
-							},
-						},
-					},
-				}
-				reqCtx := intctrlutil.RequestCtx{Ctx: ctx, Req: ctrl.Request{NamespacedName: client.ObjectKeyFromObject(backupPolicy)}}
-				for _, strategy := range []dpv1alpha1.PodSelectionStrategy{
-					dpv1alpha1.PodSelectionStrategyAny,
-					dpv1alpha1.PodSelectionStrategyAll,
-				} {
-					target.PodSelector.Strategy = strategy
-					_, err := GetTargetPods(reqCtx, k8sClient, []string{"missing-pod"}, backupPolicy, target, dpv1alpha1.BackupTypeFull)
-					Expect(intctrlutil.IsNotFound(err)).To(BeTrue())
-				}
-
-				target.PodSelector.Strategy = dpv1alpha1.PodSelectionStrategyAll
-				target.PodSelector.LabelSelector.MatchLabels["missing"] = "true"
-				_, err := GetTargetPods(reqCtx, k8sClient, []string{"missing-pod"}, backupPolicy, target, dpv1alpha1.BackupTypeFull)
-				Expect(intctrlutil.IsNotFound(err)).To(BeTrue())
 			})
 		})
 
@@ -646,7 +724,7 @@ var _ = Describe("Backup Controller test", func() {
 							constant.KBAppComponentLabelKey: testdp.ComponentName,
 						},
 					},
-					Strategy: dpv1alpha1.PodSelectionStrategyAny,
+					Strategy: dpv1alpha1.PodSelectionStrategyAll,
 				}
 				backupPolicy.Spec.BackupMethods[0].Targets = []dpv1alpha1.BackupTarget{
 					{Name: testdp.ComponentName + "-0", PodSelector: podSelector},
@@ -696,7 +774,7 @@ var _ = Describe("Backup Controller test", func() {
 			})).Should(Succeed())
 		})
 
-		It("does not complete a multi-target backup while a referenced job is incomplete", func() {
+		It("keeps reconciling a multi-target backup while a referenced job is incomplete", func() {
 			By("Set backupMethod's targets")
 			Expect(testapps.ChangeObj(&testCtx, backupPolicy, func(bp *dpv1alpha1.BackupPolicy) {
 				podSelector := &dpv1alpha1.PodSelector{
@@ -738,16 +816,37 @@ var _ = Describe("Backup Controller test", func() {
 				g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseRunning))
 			}), time.Second).Should(Succeed())
 
-			testdp.PatchK8sJobStatus(&testCtx, getJobKey(targets[1].Name), batchv1.JobComplete)
+			completedJobKey := getJobKey(targets[0].Name)
+			testdp.PatchK8sJobStatus(&testCtx, completedJobKey, batchv1.JobComplete)
 			Expect(k8sClient.Delete(ctx, targetPod)).Should(Succeed())
 			Eventually(testapps.CheckObjExists(&testCtx, client.ObjectKeyFromObject(targetPod), &corev1.Pod{}, false)).Should(Succeed())
 
-			By("resume reconciliation and expect the incomplete jobs not to succeed")
+			By("resume reconciliation and expect the backup to keep running")
 			Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
 				delete(fetched.Annotations, dptypes.SkipReconciliationAnnotationKey)
 			})).Should(Succeed())
 			Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
-				g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseFailed))
+				g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseRunning))
+				g.Expect(fetched.Status.Actions).To(HaveLen(2))
+				completedActionFound := false
+				for _, actionStatus := range fetched.Status.Actions {
+					if actionStatus.ObjectRef.Name == completedJobKey.Name {
+						completedActionFound = true
+						g.Expect(actionStatus.Phase).To(Equal(dpv1alpha1.ActionPhaseCompleted))
+					} else {
+						g.Expect(actionStatus.Phase).NotTo(Equal(dpv1alpha1.ActionPhaseCompleted))
+					}
+				}
+				g.Expect(completedActionFound).To(BeTrue())
+			})).Should(Succeed())
+
+			By("complete the remaining job and expect the backup to complete")
+			testdp.PatchK8sJobStatus(&testCtx, getJobKey(targets[1].Name), batchv1.JobComplete)
+			Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+				g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseCompleted))
+				for _, actionStatus := range fetched.Status.Actions {
+					g.Expect(actionStatus.Phase).To(Equal(dpv1alpha1.ActionPhaseCompleted))
+				}
 			})).Should(Succeed())
 		})
 

--- a/controllers/dataprotection/utils.go
+++ b/controllers/dataprotection/utils.go
@@ -168,9 +168,6 @@ func GetTargetPods(reqCtx intctrlutil.RequestCtx,
 				// If the target pods have already been selected and the backup type is not Continuous, we should reuse them.
 				pod = &corev1.Pod{}
 				if err = cli.Get(reqCtx.Ctx, client.ObjectKey{Name: selectedPodNames[0], Namespace: reqCtx.Req.Namespace}, pod); err != nil {
-					if apierrors.IsNotFound(err) {
-						return nil, intctrlutil.NewNotFound(`target pod %q not found`, selectedPodNames[0])
-					}
 					return nil, err
 				}
 			}
@@ -186,7 +183,7 @@ func GetTargetPods(reqCtx intctrlutil.RequestCtx,
 			}
 			// if already selected target pods and backupType is not Continuous, we should re-use them.
 			if len(pods.Items) == 0 {
-				return nil, intctrlutil.NewNotFound("failed to find target pods by backup policy %s/%s",
+				return nil, fmt.Errorf("failed to find target pods by backup policy %s/%s",
 					backupPolicy.Namespace, backupPolicy.Name)
 			}
 			podMap := map[string]*corev1.Pod{}
@@ -196,7 +193,7 @@ func GetTargetPods(reqCtx intctrlutil.RequestCtx,
 			for _, podName := range selectedPodNames {
 				pod, ok := podMap[podName]
 				if !ok {
-					return nil, intctrlutil.NewNotFound(`target pod %q not found`, podName)
+					return nil, intctrlutil.NewFatalError(fmt.Sprintf(`can not found the target pod "%s"`, podName))
 				}
 				targetPods = append(targetPods, pod)
 			}

--- a/controllers/dataprotection/utils.go
+++ b/controllers/dataprotection/utils.go
@@ -168,6 +168,9 @@ func GetTargetPods(reqCtx intctrlutil.RequestCtx,
 				// If the target pods have already been selected and the backup type is not Continuous, we should reuse them.
 				pod = &corev1.Pod{}
 				if err = cli.Get(reqCtx.Ctx, client.ObjectKey{Name: selectedPodNames[0], Namespace: reqCtx.Req.Namespace}, pod); err != nil {
+					if apierrors.IsNotFound(err) {
+						return nil, intctrlutil.NewNotFound(`target pod %q not found`, selectedPodNames[0])
+					}
 					return nil, err
 				}
 			}
@@ -183,7 +186,7 @@ func GetTargetPods(reqCtx intctrlutil.RequestCtx,
 			}
 			// if already selected target pods and backupType is not Continuous, we should re-use them.
 			if len(pods.Items) == 0 {
-				return nil, fmt.Errorf("failed to find target pods by backup policy %s/%s",
+				return nil, intctrlutil.NewNotFound("failed to find target pods by backup policy %s/%s",
 					backupPolicy.Namespace, backupPolicy.Name)
 			}
 			podMap := map[string]*corev1.Pod{}
@@ -193,7 +196,7 @@ func GetTargetPods(reqCtx intctrlutil.RequestCtx,
 			for _, podName := range selectedPodNames {
 				pod, ok := podMap[podName]
 				if !ok {
-					return nil, intctrlutil.NewFatalError(fmt.Sprintf(`can not found the target pod "%s"`, podName))
+					return nil, intctrlutil.NewNotFound(`target pod %q not found`, podName)
 				}
 				targetPods = append(targetPods, pod)
 			}

--- a/controllers/dataprotection/utils.go
+++ b/controllers/dataprotection/utils.go
@@ -168,9 +168,6 @@ func GetTargetPods(reqCtx intctrlutil.RequestCtx,
 				// If the target pods have already been selected and the backup type is not Continuous, we should reuse them.
 				pod = &corev1.Pod{}
 				if err = cli.Get(reqCtx.Ctx, client.ObjectKey{Name: selectedPodNames[0], Namespace: reqCtx.Req.Namespace}, pod); err != nil {
-					if apierrors.IsNotFound(err) {
-						return nil, intctrlutil.NewNotFound(`target pod %q not found`, selectedPodNames[0])
-					}
 					return nil, err
 				}
 			}
@@ -185,6 +182,10 @@ func GetTargetPods(reqCtx intctrlutil.RequestCtx,
 				return targetPods, nil
 			}
 			// if already selected target pods and backupType is not Continuous, we should re-use them.
+			if len(pods.Items) == 0 {
+				return nil, fmt.Errorf("failed to find target pods by backup policy %s/%s",
+					backupPolicy.Namespace, backupPolicy.Name)
+			}
 			podMap := map[string]*corev1.Pod{}
 			for i := range pods.Items {
 				podMap[pods.Items[i].Name] = &pods.Items[i]
@@ -192,7 +193,7 @@ func GetTargetPods(reqCtx intctrlutil.RequestCtx,
 			for _, podName := range selectedPodNames {
 				pod, ok := podMap[podName]
 				if !ok {
-					return nil, intctrlutil.NewNotFound(`target pod %q not found`, podName)
+					return nil, intctrlutil.NewFatalError(fmt.Sprintf(`can not found the target pod "%s"`, podName))
 				}
 				targetPods = append(targetPods, pod)
 			}

--- a/controllers/dataprotection/utils.go
+++ b/controllers/dataprotection/utils.go
@@ -168,6 +168,9 @@ func GetTargetPods(reqCtx intctrlutil.RequestCtx,
 				// If the target pods have already been selected and the backup type is not Continuous, we should reuse them.
 				pod = &corev1.Pod{}
 				if err = cli.Get(reqCtx.Ctx, client.ObjectKey{Name: selectedPodNames[0], Namespace: reqCtx.Req.Namespace}, pod); err != nil {
+					if apierrors.IsNotFound(err) {
+						return nil, intctrlutil.NewNotFound(`target pod %q not found`, selectedPodNames[0])
+					}
 					return nil, err
 				}
 			}
@@ -182,10 +185,6 @@ func GetTargetPods(reqCtx intctrlutil.RequestCtx,
 				return targetPods, nil
 			}
 			// if already selected target pods and backupType is not Continuous, we should re-use them.
-			if len(pods.Items) == 0 {
-				return nil, fmt.Errorf("failed to find target pods by backup policy %s/%s",
-					backupPolicy.Namespace, backupPolicy.Name)
-			}
 			podMap := map[string]*corev1.Pod{}
 			for i := range pods.Items {
 				podMap[pods.Items[i].Name] = &pods.Items[i]
@@ -193,7 +192,7 @@ func GetTargetPods(reqCtx intctrlutil.RequestCtx,
 			for _, podName := range selectedPodNames {
 				pod, ok := podMap[podName]
 				if !ok {
-					return nil, intctrlutil.NewFatalError(fmt.Sprintf(`can not found the target pod "%s"`, podName))
+					return nil, intctrlutil.NewNotFound(`target pod %q not found`, podName)
 				}
 				targetPods = append(targetPods, pod)
 			}

--- a/pkg/dataprotection/action/action.go
+++ b/pkg/dataprotection/action/action.go
@@ -22,6 +22,7 @@ package action
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
@@ -39,6 +40,9 @@ type Action interface {
 
 	// Type returns the type of the action.
 	Type() dpv1alpha1.ActionType
+
+	// BuildObjectRef builds the reference to the object managed by the action.
+	BuildObjectRef() *corev1.ObjectReference
 }
 
 type ActionContext struct {

--- a/pkg/dataprotection/action/action_create_vs.go
+++ b/pkg/dataprotection/action/action_create_vs.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 	"github.com/apecloud/kubeblocks/pkg/dataprotection/utils"
@@ -85,6 +86,30 @@ func (c *CreateVolumeSnapshotAction) Type() dpv1alpha1.ActionType {
 	return dpv1alpha1.ActionTypeNone
 }
 
+func (c *CreateVolumeSnapshotAction) BuildObjectRef() *corev1.ObjectReference {
+	if len(c.PersistentVolumeClaimWrappers) != 1 {
+		return nil
+	}
+	key := c.buildVolumeSnapshotObjectKey(&c.PersistentVolumeClaimWrappers[0])
+	return &corev1.ObjectReference{
+		APIVersion: vsv1.SchemeGroupVersion.String(),
+		Kind:       constant.VolumeSnapshotKind,
+		Namespace:  key.Namespace,
+		Name:       key.Name,
+	}
+}
+
+func (c *CreateVolumeSnapshotAction) buildVolumeSnapshotObjectKey(w *PersistentVolumeClaimWrapper) client.ObjectKey {
+	prefix := c.ObjectMeta.Name
+	if c.TargetName != "" {
+		prefix += "-" + c.TargetName
+	}
+	return client.ObjectKey{
+		Namespace: w.PersistentVolumeClaim.Namespace,
+		Name:      utils.GetBackupVolumeSnapshotName(prefix, w.VolumeName, c.Index),
+	}
+}
+
 func (c *CreateVolumeSnapshotAction) Execute(actCtx ActionContext) (*dpv1alpha1.ActionStatus, error) {
 	sb := newStatusBuilder(c)
 	handleErr := func(err error) (*dpv1alpha1.ActionStatus, error) {
@@ -102,16 +127,9 @@ func (c *CreateVolumeSnapshotAction) Execute(actCtx ActionContext) (*dpv1alpha1.
 		snap            *vsv1.VolumeSnapshot
 		totalSize       = &resource.Quantity{}
 		volumeSnapshots []dpv1alpha1.VolumeSnapshotStatus
-		prefix          = c.ObjectMeta.Name
 	)
-	if c.TargetName != "" {
-		prefix += "-" + c.TargetName
-	}
 	for _, w := range c.PersistentVolumeClaimWrappers {
-		key := client.ObjectKey{
-			Namespace: w.PersistentVolumeClaim.Namespace,
-			Name:      utils.GetBackupVolumeSnapshotName(prefix, w.VolumeName, c.Index),
-		}
+		key := c.buildVolumeSnapshotObjectKey(&w)
 		// create volume snapshot
 		if err = c.createVolumeSnapshotIfNotExist(actCtx, &w.PersistentVolumeClaim, key); err != nil {
 			return handleErr(err)

--- a/pkg/dataprotection/action/action_create_vs_test.go
+++ b/pkg/dataprotection/action/action_create_vs_test.go
@@ -91,6 +91,11 @@ var _ = Describe("CreateVolumeSnapshotAction Test", func() {
 					},
 				},
 			}
+			objectRef := act.BuildObjectRef()
+			Expect(objectRef.APIVersion).Should(Equal(vsv1.SchemeGroupVersion.String()))
+			Expect(objectRef.Kind).Should(Equal(constant.VolumeSnapshotKind))
+			Expect(objectRef.Namespace).Should(Equal(testCtx.DefaultNamespace))
+			Expect(objectRef.Name).Should(Equal(dputils.GetBackupVolumeSnapshotName(actionName, volumeName, 0)))
 
 			// mock pv
 			testapps.NewPersistentVolumeFactory(testCtx.DefaultNamespace, volumeName, pvcName).

--- a/pkg/dataprotection/action/action_job.go
+++ b/pkg/dataprotection/action/action_job.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
 	ctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	"github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 	"github.com/apecloud/kubeblocks/pkg/dataprotection/utils"
@@ -58,6 +59,15 @@ func (j *JobAction) GetName() string {
 
 func (j *JobAction) Type() dpv1alpha1.ActionType {
 	return dpv1alpha1.ActionTypeJob
+}
+
+func (j *JobAction) BuildObjectRef() *corev1.ObjectReference {
+	return &corev1.ObjectReference{
+		APIVersion: batchv1.SchemeGroupVersion.String(),
+		Kind:       constant.JobKind,
+		Namespace:  j.ObjectMeta.Namespace,
+		Name:       j.ObjectMeta.Name,
+	}
 }
 
 func (j *JobAction) Execute(actCtx ActionContext) (*dpv1alpha1.ActionStatus, error) {

--- a/pkg/dataprotection/action/action_job_test.go
+++ b/pkg/dataprotection/action/action_job_test.go
@@ -96,6 +96,11 @@ var _ = Describe("JobAction Test", func() {
 				},
 				Owner: testdp.NewFakeBackup(&testCtx, nil),
 			}
+			objectRef := act.BuildObjectRef()
+			Expect(objectRef.APIVersion).Should(Equal(batchv1.SchemeGroupVersion.String()))
+			Expect(objectRef.Kind).Should(Equal(constant.JobKind))
+			Expect(objectRef.Namespace).Should(Equal(testCtx.DefaultNamespace))
+			Expect(objectRef.Name).Should(Equal(actionName))
 
 			By("should success to execute")
 			status, err := act.Execute(buildActionCtx())

--- a/pkg/dataprotection/action/action_stateful.go
+++ b/pkg/dataprotection/action/action_stateful.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 )
@@ -62,6 +63,15 @@ func (s *StatefulSetAction) Type() dpv1alpha1.ActionType {
 	return dpv1alpha1.ActionTypeStatefulSet
 }
 
+func (s *StatefulSetAction) BuildObjectRef() *corev1.ObjectReference {
+	return &corev1.ObjectReference{
+		APIVersion: appsv1.SchemeGroupVersion.String(),
+		Kind:       constant.StatefulSetKind,
+		Namespace:  s.ObjectMeta.Namespace,
+		Name:       s.ObjectMeta.Name,
+	}
+}
+
 func (s *StatefulSetAction) Execute(ctx ActionContext) (actionStatus *dpv1alpha1.ActionStatus, err error) {
 	defer func() {
 		if err != nil {
@@ -88,6 +98,7 @@ func (s *StatefulSetAction) Execute(ctx ActionContext) (actionStatus *dpv1alpha1
 			Name:           s.Name,
 			Phase:          dpv1alpha1.ActionPhaseRunning,
 			ActionType:     s.Type(),
+			ObjectRef:      s.BuildObjectRef(),
 			StartTimestamp: &metav1.Time{Time: time.Now()},
 		}, nil
 	}

--- a/pkg/dataprotection/action/action_stateful_test.go
+++ b/pkg/dataprotection/action/action_stateful_test.go
@@ -36,14 +36,24 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
 	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 )
 
 func TestStatefulSetActionHelpers(t *testing.T) {
-	action := &StatefulSetAction{Name: "continuous"}
+	action := &StatefulSetAction{
+		Name:       "continuous",
+		ObjectMeta: metav1.ObjectMeta{Name: "backup-sts", Namespace: "ns"},
+	}
 
 	assert.Equal(t, "continuous", action.GetName())
 	assert.Equal(t, dpv1alpha1.ActionTypeStatefulSet, action.Type())
+	assert.Equal(t, &corev1.ObjectReference{
+		APIVersion: appsv1.SchemeGroupVersion.String(),
+		Kind:       constant.StatefulSetKind,
+		Namespace:  "ns",
+		Name:       "backup-sts",
+	}, action.BuildObjectRef())
 	assert.Equal(t, "60s", action.getIntervalSeconds("@hourly"))
 	assert.Equal(t, "300s", action.getIntervalSeconds("*/5 * * * *"))
 	assert.Equal(t, "7200s", action.getIntervalSeconds("CRON_TZ=UTC 0 */2 * * *"))

--- a/pkg/dataprotection/action/builder_status.go
+++ b/pkg/dataprotection/action/builder_status.go
@@ -36,6 +36,7 @@ func newStatusBuilder(a Action) *statusBuilder {
 			Name:       a.GetName(),
 			ActionType: a.Type(),
 			Phase:      dpv1alpha1.ActionPhaseRunning,
+			ObjectRef:  a.BuildObjectRef(),
 		},
 	}
 	return sb.startTimestamp(nil)

--- a/pkg/dataprotection/backup/request.go
+++ b/pkg/dataprotection/backup/request.go
@@ -59,6 +59,7 @@ type Request struct {
 	BackupMethod         *dpv1alpha1.BackupMethod
 	ActionSet            *dpv1alpha1.ActionSet
 	TargetPods           []*corev1.Pod
+	PreparedTargets      []PreparedTarget
 	BackupRepoPVC        *corev1.PersistentVolumeClaim
 	BackupRepo           *dpv1alpha1.BackupRepo
 	ToolConfigSecret     *corev1.Secret
@@ -67,6 +68,12 @@ type Request struct {
 	Target               *dpv1alpha1.BackupTarget
 	ParentBackup         *dpv1alpha1.Backup
 	BaseBackup           *dpv1alpha1.Backup
+}
+
+type PreparedTarget struct {
+	Target               *dpv1alpha1.BackupTarget
+	TargetPods           []*corev1.Pod
+	WorkerServiceAccount string
 }
 
 func (r *Request) GetBackupType() string {

--- a/pkg/dataprotection/backup/request.go
+++ b/pkg/dataprotection/backup/request.go
@@ -102,14 +102,14 @@ func (r *Request) BuildActions() (map[string][]action.Action, error) {
 		}
 
 		// 2. build backup data action
-		backupDataAction, err := r.buildBackupDataAction(r.TargetPods[i], fmt.Sprintf("%s-%s%d", BackupDataJobNamePrefix, r.getActionTargetPrefix(), i))
+		backupDataAction, err := r.buildBackupDataAction(r.TargetPods[i], r.backupDataActionName(i))
 		if err != nil {
 			return nil, err
 		}
 		podActions = appendIgnoreNil(podActions, backupDataAction)
 
 		// 3. build create volume snapshot action
-		createVolumeSnapshotAction, err := r.buildCreateVolumeSnapshotAction(r.TargetPods[i], fmt.Sprintf("createVolumeSnapshot-%s%d", r.getActionTargetPrefix(), i), i)
+		createVolumeSnapshotAction, err := r.buildCreateVolumeSnapshotAction(r.TargetPods[i], r.volumeSnapshotActionName(i), i)
 		if err != nil {
 			return nil, err
 		}
@@ -126,11 +126,105 @@ func (r *Request) BuildActions() (map[string][]action.Action, error) {
 	return actions, nil
 }
 
-func (r *Request) getActionTargetPrefix() string {
-	if r.Target != nil && r.Target.Name != "" {
-		return r.Target.Name + "-"
+// BuildActionStatusPlan builds the complete action inventory from the target
+// pods persisted in the Backup status. It does not require the target pods to
+// still exist.
+func (r *Request) BuildActionStatusPlan() ([]dpv1alpha1.ActionStatus, error) {
+	var statusTargets []*dpv1alpha1.BackupStatusTarget
+	if r.Status.Target != nil {
+		statusTargets = append(statusTargets, r.Status.Target)
+	} else {
+		for i := range r.Status.Targets {
+			statusTargets = append(statusTargets, &r.Status.Targets[i])
+		}
+	}
+	if len(statusTargets) == 0 {
+		return nil, fmt.Errorf("backup status target/targets can not be empty")
+	}
+
+	var plan []dpv1alpha1.ActionStatus
+	appendAction := func(name, targetPodName string, actionType dpv1alpha1.ActionType) {
+		plan = append(plan, dpv1alpha1.ActionStatus{
+			Name:          name,
+			TargetPodName: targetPodName,
+			Phase:         dpv1alpha1.ActionPhaseNew,
+			ActionType:    actionType,
+		})
+	}
+	for _, statusTarget := range statusTargets {
+		if len(statusTarget.SelectedTargetPods) == 0 {
+			return nil, fmt.Errorf("selected target pods for target %q can not be empty", statusTarget.Name)
+		}
+		for podIndex, targetPodName := range statusTarget.SelectedTargetPods {
+			if r.backupActionSetExists() {
+				for actionIndex := range r.ActionSet.Spec.Backup.PreBackup {
+					name := preBackupActionName(&statusTarget.BackupTarget, actionIndex, podIndex)
+					if err := validateActionSpec(name, &r.ActionSet.Spec.Backup.PreBackup[actionIndex]); err != nil {
+						return nil, err
+					}
+					appendAction(name, targetPodName, dpv1alpha1.ActionTypeJob)
+				}
+
+				if r.ActionSet.Spec.Backup.BackupData != nil {
+					actionType := dpv1alpha1.ActionTypeJob
+					switch r.ActionSet.Spec.BackupType {
+					case dpv1alpha1.BackupTypeFull, dpv1alpha1.BackupTypeIncremental, dpv1alpha1.BackupTypeSelective:
+					case dpv1alpha1.BackupTypeContinuous:
+						actionType = dpv1alpha1.ActionTypeStatefulSet
+					default:
+						return nil, fmt.Errorf("unsupported backup type %s", r.ActionSet.Spec.BackupType)
+					}
+					appendAction(backupDataActionName(&statusTarget.BackupTarget, podIndex), targetPodName, actionType)
+				}
+			}
+
+			if r.BackupMethod != nil && boolptr.IsSetToTrue(r.BackupMethod.SnapshotVolumes) {
+				appendAction(volumeSnapshotActionName(&statusTarget.BackupTarget, podIndex), targetPodName, dpv1alpha1.ActionTypeNone)
+			}
+
+			if r.backupActionSetExists() {
+				for actionIndex := range r.ActionSet.Spec.Backup.PostBackup {
+					name := postBackupActionName(&statusTarget.BackupTarget, actionIndex, podIndex)
+					if err := validateActionSpec(name, &r.ActionSet.Spec.Backup.PostBackup[actionIndex]); err != nil {
+						return nil, err
+					}
+					appendAction(name, targetPodName, dpv1alpha1.ActionTypeJob)
+				}
+			}
+		}
+	}
+	return plan, nil
+}
+
+func getActionTargetPrefix(target *dpv1alpha1.BackupTarget) string {
+	if target != nil && target.Name != "" {
+		return target.Name + "-"
 	}
 	return ""
+}
+
+func preBackupActionName(target *dpv1alpha1.BackupTarget, actionIndex, podIndex int) string {
+	return fmt.Sprintf("%s-%s%d-%d", prebackupJobNamePrefix, getActionTargetPrefix(target), actionIndex, podIndex)
+}
+
+func backupDataActionName(target *dpv1alpha1.BackupTarget, podIndex int) string {
+	return fmt.Sprintf("%s-%s%d", BackupDataJobNamePrefix, getActionTargetPrefix(target), podIndex)
+}
+
+func volumeSnapshotActionName(target *dpv1alpha1.BackupTarget, podIndex int) string {
+	return fmt.Sprintf("createVolumeSnapshot-%s%d", getActionTargetPrefix(target), podIndex)
+}
+
+func postBackupActionName(target *dpv1alpha1.BackupTarget, actionIndex, podIndex int) string {
+	return fmt.Sprintf("%s-%s%d-%d", postbackupJobNamePrefix, getActionTargetPrefix(target), actionIndex, podIndex)
+}
+
+func (r *Request) backupDataActionName(podIndex int) string {
+	return backupDataActionName(r.Target, podIndex)
+}
+
+func (r *Request) volumeSnapshotActionName(podIndex int) string {
+	return volumeSnapshotActionName(r.Target, podIndex)
 }
 
 func (r *Request) buildPreBackupActions(podActions *[]action.Action, targetPod *corev1.Pod, index int) error {
@@ -139,7 +233,7 @@ func (r *Request) buildPreBackupActions(podActions *[]action.Action, targetPod *
 		return nil
 	}
 	for i, preBackup := range r.ActionSet.Spec.Backup.PreBackup {
-		a, err := r.buildAction(targetPod, fmt.Sprintf("%s-%s%d-%d", prebackupJobNamePrefix, r.getActionTargetPrefix(), i, index), &preBackup)
+		a, err := r.buildAction(targetPod, preBackupActionName(r.Target, i, index), &preBackup)
 		if err != nil {
 			return err
 		}
@@ -155,7 +249,7 @@ func (r *Request) buildPostBackupActions(podActions *[]action.Action, targetPod 
 	}
 
 	for i, postBackup := range r.ActionSet.Spec.Backup.PostBackup {
-		a, err := r.buildAction(targetPod, fmt.Sprintf("%s-%s%d-%d", postbackupJobNamePrefix, r.getActionTargetPrefix(), i, index), &postBackup)
+		a, err := r.buildAction(targetPod, postBackupActionName(r.Target, i, index), &postBackup)
 		if err != nil {
 			return err
 		}
@@ -250,11 +344,8 @@ func (r *Request) buildCreateVolumeSnapshotAction(targetPod *corev1.Pod, name st
 func (r *Request) buildAction(targetPod *corev1.Pod,
 	name string,
 	act *dpv1alpha1.ActionSpec) (action.Action, error) {
-	if act.Exec == nil && act.Job == nil {
-		return nil, fmt.Errorf("action %s has no exec or job", name)
-	}
-	if act.Exec != nil && act.Job != nil {
-		return nil, fmt.Errorf("action %s should have only one of exec or job", name)
+	if err := validateActionSpec(name, act); err != nil {
+		return nil, err
 	}
 	switch {
 	case act.Exec != nil:
@@ -263,6 +354,16 @@ func (r *Request) buildAction(targetPod *corev1.Pod,
 		return r.buildJobAction(targetPod, name, act.Job)
 	}
 	return nil, nil
+}
+
+func validateActionSpec(name string, act *dpv1alpha1.ActionSpec) error {
+	if act.Exec == nil && act.Job == nil {
+		return fmt.Errorf("action %s has no exec or job", name)
+	}
+	if act.Exec != nil && act.Job != nil {
+		return fmt.Errorf("action %s should have only one of exec or job", name)
+	}
+	return nil
 }
 
 func (r *Request) buildExecAction(targetPod *corev1.Pod,

--- a/pkg/dataprotection/backup/request.go
+++ b/pkg/dataprotection/backup/request.go
@@ -102,14 +102,14 @@ func (r *Request) BuildActions() (map[string][]action.Action, error) {
 		}
 
 		// 2. build backup data action
-		backupDataAction, err := r.buildBackupDataAction(r.TargetPods[i], r.backupDataActionName(i))
+		backupDataAction, err := r.buildBackupDataAction(r.TargetPods[i], fmt.Sprintf("%s-%s%d", BackupDataJobNamePrefix, r.getActionTargetPrefix(), i))
 		if err != nil {
 			return nil, err
 		}
 		podActions = appendIgnoreNil(podActions, backupDataAction)
 
 		// 3. build create volume snapshot action
-		createVolumeSnapshotAction, err := r.buildCreateVolumeSnapshotAction(r.TargetPods[i], r.volumeSnapshotActionName(i), i)
+		createVolumeSnapshotAction, err := r.buildCreateVolumeSnapshotAction(r.TargetPods[i], fmt.Sprintf("createVolumeSnapshot-%s%d", r.getActionTargetPrefix(), i), i)
 		if err != nil {
 			return nil, err
 		}
@@ -126,105 +126,11 @@ func (r *Request) BuildActions() (map[string][]action.Action, error) {
 	return actions, nil
 }
 
-// BuildActionStatusPlan builds the complete action inventory from the target
-// pods persisted in the Backup status. It does not require the target pods to
-// still exist.
-func (r *Request) BuildActionStatusPlan() ([]dpv1alpha1.ActionStatus, error) {
-	var statusTargets []*dpv1alpha1.BackupStatusTarget
-	if r.Status.Target != nil {
-		statusTargets = append(statusTargets, r.Status.Target)
-	} else {
-		for i := range r.Status.Targets {
-			statusTargets = append(statusTargets, &r.Status.Targets[i])
-		}
-	}
-	if len(statusTargets) == 0 {
-		return nil, fmt.Errorf("backup status target/targets can not be empty")
-	}
-
-	var plan []dpv1alpha1.ActionStatus
-	appendAction := func(name, targetPodName string, actionType dpv1alpha1.ActionType) {
-		plan = append(plan, dpv1alpha1.ActionStatus{
-			Name:          name,
-			TargetPodName: targetPodName,
-			Phase:         dpv1alpha1.ActionPhaseNew,
-			ActionType:    actionType,
-		})
-	}
-	for _, statusTarget := range statusTargets {
-		if len(statusTarget.SelectedTargetPods) == 0 {
-			return nil, fmt.Errorf("selected target pods for target %q can not be empty", statusTarget.Name)
-		}
-		for podIndex, targetPodName := range statusTarget.SelectedTargetPods {
-			if r.backupActionSetExists() {
-				for actionIndex := range r.ActionSet.Spec.Backup.PreBackup {
-					name := preBackupActionName(&statusTarget.BackupTarget, actionIndex, podIndex)
-					if err := validateActionSpec(name, &r.ActionSet.Spec.Backup.PreBackup[actionIndex]); err != nil {
-						return nil, err
-					}
-					appendAction(name, targetPodName, dpv1alpha1.ActionTypeJob)
-				}
-
-				if r.ActionSet.Spec.Backup.BackupData != nil {
-					actionType := dpv1alpha1.ActionTypeJob
-					switch r.ActionSet.Spec.BackupType {
-					case dpv1alpha1.BackupTypeFull, dpv1alpha1.BackupTypeIncremental, dpv1alpha1.BackupTypeSelective:
-					case dpv1alpha1.BackupTypeContinuous:
-						actionType = dpv1alpha1.ActionTypeStatefulSet
-					default:
-						return nil, fmt.Errorf("unsupported backup type %s", r.ActionSet.Spec.BackupType)
-					}
-					appendAction(backupDataActionName(&statusTarget.BackupTarget, podIndex), targetPodName, actionType)
-				}
-			}
-
-			if r.BackupMethod != nil && boolptr.IsSetToTrue(r.BackupMethod.SnapshotVolumes) {
-				appendAction(volumeSnapshotActionName(&statusTarget.BackupTarget, podIndex), targetPodName, dpv1alpha1.ActionTypeNone)
-			}
-
-			if r.backupActionSetExists() {
-				for actionIndex := range r.ActionSet.Spec.Backup.PostBackup {
-					name := postBackupActionName(&statusTarget.BackupTarget, actionIndex, podIndex)
-					if err := validateActionSpec(name, &r.ActionSet.Spec.Backup.PostBackup[actionIndex]); err != nil {
-						return nil, err
-					}
-					appendAction(name, targetPodName, dpv1alpha1.ActionTypeJob)
-				}
-			}
-		}
-	}
-	return plan, nil
-}
-
-func getActionTargetPrefix(target *dpv1alpha1.BackupTarget) string {
-	if target != nil && target.Name != "" {
-		return target.Name + "-"
+func (r *Request) getActionTargetPrefix() string {
+	if r.Target != nil && r.Target.Name != "" {
+		return r.Target.Name + "-"
 	}
 	return ""
-}
-
-func preBackupActionName(target *dpv1alpha1.BackupTarget, actionIndex, podIndex int) string {
-	return fmt.Sprintf("%s-%s%d-%d", prebackupJobNamePrefix, getActionTargetPrefix(target), actionIndex, podIndex)
-}
-
-func backupDataActionName(target *dpv1alpha1.BackupTarget, podIndex int) string {
-	return fmt.Sprintf("%s-%s%d", BackupDataJobNamePrefix, getActionTargetPrefix(target), podIndex)
-}
-
-func volumeSnapshotActionName(target *dpv1alpha1.BackupTarget, podIndex int) string {
-	return fmt.Sprintf("createVolumeSnapshot-%s%d", getActionTargetPrefix(target), podIndex)
-}
-
-func postBackupActionName(target *dpv1alpha1.BackupTarget, actionIndex, podIndex int) string {
-	return fmt.Sprintf("%s-%s%d-%d", postbackupJobNamePrefix, getActionTargetPrefix(target), actionIndex, podIndex)
-}
-
-func (r *Request) backupDataActionName(podIndex int) string {
-	return backupDataActionName(r.Target, podIndex)
-}
-
-func (r *Request) volumeSnapshotActionName(podIndex int) string {
-	return volumeSnapshotActionName(r.Target, podIndex)
 }
 
 func (r *Request) buildPreBackupActions(podActions *[]action.Action, targetPod *corev1.Pod, index int) error {
@@ -233,7 +139,7 @@ func (r *Request) buildPreBackupActions(podActions *[]action.Action, targetPod *
 		return nil
 	}
 	for i, preBackup := range r.ActionSet.Spec.Backup.PreBackup {
-		a, err := r.buildAction(targetPod, preBackupActionName(r.Target, i, index), &preBackup)
+		a, err := r.buildAction(targetPod, fmt.Sprintf("%s-%s%d-%d", prebackupJobNamePrefix, r.getActionTargetPrefix(), i, index), &preBackup)
 		if err != nil {
 			return err
 		}
@@ -249,7 +155,7 @@ func (r *Request) buildPostBackupActions(podActions *[]action.Action, targetPod 
 	}
 
 	for i, postBackup := range r.ActionSet.Spec.Backup.PostBackup {
-		a, err := r.buildAction(targetPod, postBackupActionName(r.Target, i, index), &postBackup)
+		a, err := r.buildAction(targetPod, fmt.Sprintf("%s-%s%d-%d", postbackupJobNamePrefix, r.getActionTargetPrefix(), i, index), &postBackup)
 		if err != nil {
 			return err
 		}
@@ -344,8 +250,11 @@ func (r *Request) buildCreateVolumeSnapshotAction(targetPod *corev1.Pod, name st
 func (r *Request) buildAction(targetPod *corev1.Pod,
 	name string,
 	act *dpv1alpha1.ActionSpec) (action.Action, error) {
-	if err := validateActionSpec(name, act); err != nil {
-		return nil, err
+	if act.Exec == nil && act.Job == nil {
+		return nil, fmt.Errorf("action %s has no exec or job", name)
+	}
+	if act.Exec != nil && act.Job != nil {
+		return nil, fmt.Errorf("action %s should have only one of exec or job", name)
 	}
 	switch {
 	case act.Exec != nil:
@@ -354,16 +263,6 @@ func (r *Request) buildAction(targetPod *corev1.Pod,
 		return r.buildJobAction(targetPod, name, act.Job)
 	}
 	return nil, nil
-}
-
-func validateActionSpec(name string, act *dpv1alpha1.ActionSpec) error {
-	if act.Exec == nil && act.Job == nil {
-		return fmt.Errorf("action %s has no exec or job", name)
-	}
-	if act.Exec != nil && act.Job != nil {
-		return fmt.Errorf("action %s should have only one of exec or job", name)
-	}
-	return nil
 }
 
 func (r *Request) buildExecAction(targetPod *corev1.Pod,

--- a/pkg/dataprotection/backup/request_test.go
+++ b/pkg/dataprotection/backup/request_test.go
@@ -161,6 +161,111 @@ func TestRequestBuildActionsIncludesPreAndPostHooks(t *testing.T) {
 	assert.Equal(t, dpv1alpha1.ActionTypeJob, actions[pod.Name][2].Type())
 }
 
+func newActionPlanTestRequest() *Request {
+	return &Request{
+		Backup:       &dpv1alpha1.Backup{},
+		BackupMethod: &dpv1alpha1.BackupMethod{},
+	}
+}
+
+func TestRequestBuildActionStatusPlanForMultipleTargets(t *testing.T) {
+	req := newActionPlanTestRequest()
+	req.ActionSet = &dpv1alpha1.ActionSet{Spec: dpv1alpha1.ActionSetSpec{
+		BackupType: dpv1alpha1.BackupTypeFull,
+		Backup: &dpv1alpha1.BackupActionSpec{
+			PreBackup:  []dpv1alpha1.ActionSpec{{Exec: &dpv1alpha1.ExecActionSpec{Command: []string{"pre"}}}},
+			BackupData: &dpv1alpha1.BackupDataActionSpec{JobActionSpec: dpv1alpha1.JobActionSpec{BaseJobActionSpec: dpv1alpha1.BaseJobActionSpec{Image: "busybox"}}},
+			PostBackup: []dpv1alpha1.ActionSpec{{Job: &dpv1alpha1.JobActionSpec{BaseJobActionSpec: dpv1alpha1.BaseJobActionSpec{Image: "busybox"}}}},
+		},
+	}}
+	req.Status.Targets = []dpv1alpha1.BackupStatusTarget{
+		{
+			BackupTarget:       dpv1alpha1.BackupTarget{Name: "target-0"},
+			SelectedTargetPods: []string{"pod-0"},
+		},
+		{
+			BackupTarget:       dpv1alpha1.BackupTarget{Name: "target-1"},
+			SelectedTargetPods: []string{"pod-1"},
+		},
+	}
+
+	plan, err := req.BuildActionStatusPlan()
+	assert.NoError(t, err)
+	assert.Equal(t, []dpv1alpha1.ActionStatus{
+		{Name: "dp-prebackup-target-0-0-0", TargetPodName: "pod-0", Phase: dpv1alpha1.ActionPhaseNew, ActionType: dpv1alpha1.ActionTypeJob},
+		{Name: "dp-backup-target-0-0", TargetPodName: "pod-0", Phase: dpv1alpha1.ActionPhaseNew, ActionType: dpv1alpha1.ActionTypeJob},
+		{Name: "dp-postbackup-target-0-0-0", TargetPodName: "pod-0", Phase: dpv1alpha1.ActionPhaseNew, ActionType: dpv1alpha1.ActionTypeJob},
+		{Name: "dp-prebackup-target-1-0-0", TargetPodName: "pod-1", Phase: dpv1alpha1.ActionPhaseNew, ActionType: dpv1alpha1.ActionTypeJob},
+		{Name: "dp-backup-target-1-0", TargetPodName: "pod-1", Phase: dpv1alpha1.ActionPhaseNew, ActionType: dpv1alpha1.ActionTypeJob},
+		{Name: "dp-postbackup-target-1-0-0", TargetPodName: "pod-1", Phase: dpv1alpha1.ActionPhaseNew, ActionType: dpv1alpha1.ActionTypeJob},
+	}, plan)
+}
+
+func TestRequestBuildActionStatusPlanTypesAndValidation(t *testing.T) {
+	t.Run("snapshot action", func(t *testing.T) {
+		req := newActionPlanTestRequest()
+		req.BackupMethod.SnapshotVolumes = boolptr.True()
+		req.Status.Target = &dpv1alpha1.BackupStatusTarget{
+			BackupTarget:       dpv1alpha1.BackupTarget{Name: "target"},
+			SelectedTargetPods: []string{"pod-0"},
+		}
+
+		plan, err := req.BuildActionStatusPlan()
+		assert.NoError(t, err)
+		assert.Equal(t, []dpv1alpha1.ActionStatus{{
+			Name:          "createVolumeSnapshot-target-0",
+			TargetPodName: "pod-0",
+			Phase:         dpv1alpha1.ActionPhaseNew,
+			ActionType:    dpv1alpha1.ActionTypeNone,
+		}}, plan)
+	})
+
+	t.Run("continuous action", func(t *testing.T) {
+		req := newActionPlanTestRequest()
+		req.ActionSet = &dpv1alpha1.ActionSet{Spec: dpv1alpha1.ActionSetSpec{
+			BackupType: dpv1alpha1.BackupTypeContinuous,
+			Backup: &dpv1alpha1.BackupActionSpec{
+				BackupData: &dpv1alpha1.BackupDataActionSpec{},
+			},
+		}}
+		req.Status.Target = &dpv1alpha1.BackupStatusTarget{
+			BackupTarget:       dpv1alpha1.BackupTarget{Name: "target"},
+			SelectedTargetPods: []string{"pod-0"},
+		}
+
+		plan, err := req.BuildActionStatusPlan()
+		assert.NoError(t, err)
+		assert.Equal(t, dpv1alpha1.ActionTypeStatefulSet, plan[0].ActionType)
+	})
+
+	t.Run("missing persisted target pod", func(t *testing.T) {
+		req := newActionPlanTestRequest()
+		req.Status.Target = &dpv1alpha1.BackupStatusTarget{
+			BackupTarget: dpv1alpha1.BackupTarget{Name: "target"},
+		}
+
+		_, err := req.BuildActionStatusPlan()
+		assert.Error(t, err)
+	})
+
+	t.Run("invalid hook action", func(t *testing.T) {
+		req := newActionPlanTestRequest()
+		req.ActionSet = &dpv1alpha1.ActionSet{Spec: dpv1alpha1.ActionSetSpec{
+			BackupType: dpv1alpha1.BackupTypeFull,
+			Backup: &dpv1alpha1.BackupActionSpec{
+				PreBackup: []dpv1alpha1.ActionSpec{{}},
+			},
+		}}
+		req.Status.Target = &dpv1alpha1.BackupStatusTarget{
+			BackupTarget:       dpv1alpha1.BackupTarget{Name: "target"},
+			SelectedTargetPods: []string{"pod-0"},
+		}
+
+		_, err := req.BuildActionStatusPlan()
+		assert.Error(t, err)
+	})
+}
+
 var _ = Describe("Request Test", func() {
 	buildRequest := func() *Request {
 		return &Request{

--- a/pkg/dataprotection/backup/request_test.go
+++ b/pkg/dataprotection/backup/request_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/stretchr/testify/assert"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -143,6 +144,10 @@ func TestRequestBuildBackupDataActions(t *testing.T) {
 }
 
 func TestRequestBuildActionsIncludesPreAndPostHooks(t *testing.T) {
+	oldNamespace := viper.GetString(constant.CfgKeyCtrlrMgrNS)
+	defer viper.Set(constant.CfgKeyCtrlrMgrNS, oldNamespace)
+	viper.Set(constant.CfgKeyCtrlrMgrNS, "kb-system")
+
 	req, pod := newRequestTestFixture(t)
 	req.ActionSet = &dpv1alpha1.ActionSet{Spec: dpv1alpha1.ActionSetSpec{
 		BackupType: dpv1alpha1.BackupTypeFull,
@@ -159,111 +164,18 @@ func TestRequestBuildActionsIncludesPreAndPostHooks(t *testing.T) {
 	assert.Equal(t, dpv1alpha1.ActionTypeJob, actions[pod.Name][0].Type())
 	assert.Equal(t, dpv1alpha1.ActionTypeJob, actions[pod.Name][1].Type())
 	assert.Equal(t, dpv1alpha1.ActionTypeJob, actions[pod.Name][2].Type())
-}
-
-func newActionPlanTestRequest() *Request {
-	return &Request{
-		Backup:       &dpv1alpha1.Backup{},
-		BackupMethod: &dpv1alpha1.BackupMethod{},
+	for i, act := range actions[pod.Name] {
+		objectRef := act.BuildObjectRef()
+		assert.NotNil(t, objectRef)
+		assert.Equal(t, batchv1.SchemeGroupVersion.String(), objectRef.APIVersion)
+		assert.Equal(t, constant.JobKind, objectRef.Kind)
+		assert.Equal(t, GenerateBackupJobName(req.Backup, act.GetName()), objectRef.Name)
+		if i == 0 {
+			assert.Equal(t, "kb-system", objectRef.Namespace)
+		} else {
+			assert.Equal(t, req.Namespace, objectRef.Namespace)
+		}
 	}
-}
-
-func TestRequestBuildActionStatusPlanForMultipleTargets(t *testing.T) {
-	req := newActionPlanTestRequest()
-	req.ActionSet = &dpv1alpha1.ActionSet{Spec: dpv1alpha1.ActionSetSpec{
-		BackupType: dpv1alpha1.BackupTypeFull,
-		Backup: &dpv1alpha1.BackupActionSpec{
-			PreBackup:  []dpv1alpha1.ActionSpec{{Exec: &dpv1alpha1.ExecActionSpec{Command: []string{"pre"}}}},
-			BackupData: &dpv1alpha1.BackupDataActionSpec{JobActionSpec: dpv1alpha1.JobActionSpec{BaseJobActionSpec: dpv1alpha1.BaseJobActionSpec{Image: "busybox"}}},
-			PostBackup: []dpv1alpha1.ActionSpec{{Job: &dpv1alpha1.JobActionSpec{BaseJobActionSpec: dpv1alpha1.BaseJobActionSpec{Image: "busybox"}}}},
-		},
-	}}
-	req.Status.Targets = []dpv1alpha1.BackupStatusTarget{
-		{
-			BackupTarget:       dpv1alpha1.BackupTarget{Name: "target-0"},
-			SelectedTargetPods: []string{"pod-0"},
-		},
-		{
-			BackupTarget:       dpv1alpha1.BackupTarget{Name: "target-1"},
-			SelectedTargetPods: []string{"pod-1"},
-		},
-	}
-
-	plan, err := req.BuildActionStatusPlan()
-	assert.NoError(t, err)
-	assert.Equal(t, []dpv1alpha1.ActionStatus{
-		{Name: "dp-prebackup-target-0-0-0", TargetPodName: "pod-0", Phase: dpv1alpha1.ActionPhaseNew, ActionType: dpv1alpha1.ActionTypeJob},
-		{Name: "dp-backup-target-0-0", TargetPodName: "pod-0", Phase: dpv1alpha1.ActionPhaseNew, ActionType: dpv1alpha1.ActionTypeJob},
-		{Name: "dp-postbackup-target-0-0-0", TargetPodName: "pod-0", Phase: dpv1alpha1.ActionPhaseNew, ActionType: dpv1alpha1.ActionTypeJob},
-		{Name: "dp-prebackup-target-1-0-0", TargetPodName: "pod-1", Phase: dpv1alpha1.ActionPhaseNew, ActionType: dpv1alpha1.ActionTypeJob},
-		{Name: "dp-backup-target-1-0", TargetPodName: "pod-1", Phase: dpv1alpha1.ActionPhaseNew, ActionType: dpv1alpha1.ActionTypeJob},
-		{Name: "dp-postbackup-target-1-0-0", TargetPodName: "pod-1", Phase: dpv1alpha1.ActionPhaseNew, ActionType: dpv1alpha1.ActionTypeJob},
-	}, plan)
-}
-
-func TestRequestBuildActionStatusPlanTypesAndValidation(t *testing.T) {
-	t.Run("snapshot action", func(t *testing.T) {
-		req := newActionPlanTestRequest()
-		req.BackupMethod.SnapshotVolumes = boolptr.True()
-		req.Status.Target = &dpv1alpha1.BackupStatusTarget{
-			BackupTarget:       dpv1alpha1.BackupTarget{Name: "target"},
-			SelectedTargetPods: []string{"pod-0"},
-		}
-
-		plan, err := req.BuildActionStatusPlan()
-		assert.NoError(t, err)
-		assert.Equal(t, []dpv1alpha1.ActionStatus{{
-			Name:          "createVolumeSnapshot-target-0",
-			TargetPodName: "pod-0",
-			Phase:         dpv1alpha1.ActionPhaseNew,
-			ActionType:    dpv1alpha1.ActionTypeNone,
-		}}, plan)
-	})
-
-	t.Run("continuous action", func(t *testing.T) {
-		req := newActionPlanTestRequest()
-		req.ActionSet = &dpv1alpha1.ActionSet{Spec: dpv1alpha1.ActionSetSpec{
-			BackupType: dpv1alpha1.BackupTypeContinuous,
-			Backup: &dpv1alpha1.BackupActionSpec{
-				BackupData: &dpv1alpha1.BackupDataActionSpec{},
-			},
-		}}
-		req.Status.Target = &dpv1alpha1.BackupStatusTarget{
-			BackupTarget:       dpv1alpha1.BackupTarget{Name: "target"},
-			SelectedTargetPods: []string{"pod-0"},
-		}
-
-		plan, err := req.BuildActionStatusPlan()
-		assert.NoError(t, err)
-		assert.Equal(t, dpv1alpha1.ActionTypeStatefulSet, plan[0].ActionType)
-	})
-
-	t.Run("missing persisted target pod", func(t *testing.T) {
-		req := newActionPlanTestRequest()
-		req.Status.Target = &dpv1alpha1.BackupStatusTarget{
-			BackupTarget: dpv1alpha1.BackupTarget{Name: "target"},
-		}
-
-		_, err := req.BuildActionStatusPlan()
-		assert.Error(t, err)
-	})
-
-	t.Run("invalid hook action", func(t *testing.T) {
-		req := newActionPlanTestRequest()
-		req.ActionSet = &dpv1alpha1.ActionSet{Spec: dpv1alpha1.ActionSetSpec{
-			BackupType: dpv1alpha1.BackupTypeFull,
-			Backup: &dpv1alpha1.BackupActionSpec{
-				PreBackup: []dpv1alpha1.ActionSpec{{}},
-			},
-		}}
-		req.Status.Target = &dpv1alpha1.BackupStatusTarget{
-			BackupTarget:       dpv1alpha1.BackupTarget{Name: "target"},
-			SelectedTargetPods: []string{"pod-0"},
-		}
-
-		_, err := req.BuildActionStatusPlan()
-		assert.Error(t, err)
-	})
 }
 
 var _ = Describe("Request Test", func() {


### PR DESCRIPTION
## What changed

- Added `Action.BuildObjectRef()` so Job, Exec, StatefulSet, and VolumeSnapshot actions can describe their execution object before it is created.
- The New phase builds every target action and persists the complete `status.actions` inventory, including each `ObjectRef`, in the same status patch that enters Running.
- The normal Running path continues to use `Action.Execute` without an extra Job scan.
- If target preparation returns an error, the controller first observes the Jobs referenced by the persisted action inventory:
  - if any Job is still running, the Backup remains Running and waits for the next Job event;
  - if all Jobs completed, the Backup completes;
  - if all Jobs are terminal and any Job failed, the Backup fails with the synchronized Action status;
  - if the action inventory cannot identify the Jobs safely, the original target preparation error is preserved.

## Why

A backup Job can reach a terminal state while its Backup CR is still Running. If the selected target Pod disappears before the next reconciliation, resolving the Pod first can hide the Job result and incorrectly fail or stall the Backup.

The persisted action inventory lets the Running phase observe the already-created Jobs without reconstructing actions from a missing target Pod. This also supports multi-target backups and preserves partial completed Action statuses while other Jobs are still running.

Fixes #10643.

## Validation

```bash
GOCACHE=/tmp/kubeblocks-go-cache go test ./controllers/dataprotection -run '^TestSyncJobActions$' -count=1
KUBEBUILDER_ASSETS=".../k8s/1.26.1-darwin-arm64" go test ./controllers/dataprotection -run TestAPIs -ginkgo.focus='(should fail after job fails|completes a multi-target backup from persisted job object refs)' -count=1
```
