### PR TITLE
feat(dataprotection): propagate restore target identity facts

### DIFF
--- a/apis/dataprotection/v1alpha1/backuppolicy_types.go
+++ b/apis/dataprotection/v1alpha1/backuppolicy_types.go
@@ -266,6 +266,14 @@ type BackupMethod struct {
 	// +optional
 	RuntimeSettings *RuntimeSettings `json:"runtimeSettings,omitempty"`
 
+	// Specifies the target identity facts that the restore controller must resolve
+	// from the live target before running postReady Job actions.
+	//
+	// +optional
+	// +listType=set
+	// +kubebuilder:validation:MaxItems=2
+	RestoreTargetIdentityFacts []RestoreTargetIdentityFact `json:"restoreTargetIdentityFacts,omitempty"`
+
 	// Specifies the target information to back up, it will override the target in backup policy.
 	//
 	// +optional

--- a/apis/dataprotection/v1alpha1/backuppolicytemplate_types.go
+++ b/apis/dataprotection/v1alpha1/backuppolicytemplate_types.go
@@ -122,6 +122,14 @@ type BackupMethodTPL struct {
 	// +optional
 	RuntimeSettings *RuntimeSettings `json:"runtimeSettings,omitempty"`
 
+	// Specifies the target identity facts that the restore controller must resolve
+	// from the live target before running postReady Job actions.
+	//
+	// +optional
+	// +listType=set
+	// +kubebuilder:validation:MaxItems=2
+	RestoreTargetIdentityFacts []RestoreTargetIdentityFact `json:"restoreTargetIdentityFacts,omitempty"`
+
 	// If set, specifies the method for selecting the replica to be backed up using the criteria defined here.
 	// If this field is not set, the selection method specified in `backupPolicy.target` is used.
 	//

--- a/apis/dataprotection/v1alpha1/restore_types.go
+++ b/apis/dataprotection/v1alpha1/restore_types.go
@@ -23,6 +23,7 @@ import (
 
 // RestoreSpec defines the desired state of Restore
 // +kubebuilder:validation:XValidation:rule="has(oldSelf.parameters) == has(self.parameters)",message="forbidden to update spec.parameters"
+// +kubebuilder:validation:XValidation:rule="(has(self.readyConfig) && has(self.readyConfig.jobAction) && has(self.readyConfig.jobAction.target.restoreTargetIdentityFacts) && size(self.readyConfig.jobAction.target.restoreTargetIdentityFacts) > 0) == (has(oldSelf.readyConfig) && has(oldSelf.readyConfig.jobAction) && has(oldSelf.readyConfig.jobAction.target.restoreTargetIdentityFacts) && size(oldSelf.readyConfig.jobAction.target.restoreTargetIdentityFacts) > 0) && (!(has(self.readyConfig) && has(self.readyConfig.jobAction) && has(self.readyConfig.jobAction.target.restoreTargetIdentityFacts) && size(self.readyConfig.jobAction.target.restoreTargetIdentityFacts) > 0) || self.readyConfig.jobAction.target.restoreTargetIdentityFacts == oldSelf.readyConfig.jobAction.target.restoreTargetIdentityFacts)",message="forbidden to update spec.readyConfig.jobAction.target.restoreTargetIdentityFacts"
 type RestoreSpec struct {
 	// Specifies the backup to be restored. The restore behavior is based on the backup type:
 	//
@@ -254,6 +255,20 @@ type ExecActionTarget struct {
 	PodSelector metav1.LabelSelector `json:"podSelector"`
 }
 
+// RestoreTargetIdentityFact identifies a controller-resolved target fact that
+// a postReady Job action requires.
+//
+// +enum
+// +kubebuilder:validation:Enum={ClusterTopology,ComponentServiceVersion}
+type RestoreTargetIdentityFact string
+
+const (
+	// RestoreTargetIdentityFactClusterTopology requests the target Cluster topology.
+	RestoreTargetIdentityFactClusterTopology RestoreTargetIdentityFact = "ClusterTopology"
+	// RestoreTargetIdentityFactComponentServiceVersion requests the target Component service version.
+	RestoreTargetIdentityFactComponentServiceVersion RestoreTargetIdentityFact = "ComponentServiceVersion"
+)
+
 type JobActionTarget struct {
 	// Selects one of the pods, identified by labels, to build the job spec.
 	// This includes mounting required volumes and injecting built-in environment variables of the selected pod.
@@ -267,6 +282,14 @@ type JobActionTarget struct {
 	// +patchStrategy=merge,retainKeys
 	// +optional
 	VolumeMounts []corev1.VolumeMount `json:"volumeMounts,omitempty"`
+
+	// Specifies the target identity facts that the controller must resolve from
+	// the selected live target and inject into the postReady Job.
+	//
+	// +optional
+	// +listType=set
+	// +kubebuilder:validation:MaxItems=2
+	RestoreTargetIdentityFacts []RestoreTargetIdentityFact `json:"restoreTargetIdentityFacts,omitempty"`
 }
 
 type VolumeConfig struct {

--- a/apis/dataprotection/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/dataprotection/v1alpha1/zz_generated.deepcopy.go
@@ -383,6 +383,11 @@ func (in *BackupMethod) DeepCopyInto(out *BackupMethod) {
 		*out = new(RuntimeSettings)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.RestoreTargetIdentityFacts != nil {
+		in, out := &in.RestoreTargetIdentityFacts, &out.RestoreTargetIdentityFacts
+		*out = make([]RestoreTargetIdentityFact, len(*in))
+		copy(*out, *in)
+	}
 	if in.Target != nil {
 		in, out := &in.Target, &out.Target
 		*out = new(BackupTarget)
@@ -431,6 +436,11 @@ func (in *BackupMethodTPL) DeepCopyInto(out *BackupMethodTPL) {
 		in, out := &in.RuntimeSettings, &out.RuntimeSettings
 		*out = new(RuntimeSettings)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.RestoreTargetIdentityFacts != nil {
+		in, out := &in.RestoreTargetIdentityFacts, &out.RestoreTargetIdentityFacts
+		*out = make([]RestoreTargetIdentityFact, len(*in))
+		copy(*out, *in)
 	}
 	if in.Target != nil {
 		in, out := &in.Target, &out.Target
@@ -1322,6 +1332,11 @@ func (in *JobActionTarget) DeepCopyInto(out *JobActionTarget) {
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.RestoreTargetIdentityFacts != nil {
+		in, out := &in.RestoreTargetIdentityFacts, &out.RestoreTargetIdentityFacts
+		*out = make([]RestoreTargetIdentityFact, len(*in))
+		copy(*out, *in)
 	}
 }
 

--- a/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -195,6 +195,21 @@ spec:
                       description: The name of backup method.
                       pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                       type: string
+                    restoreTargetIdentityFacts:
+                      description: |-
+                        Specifies the target identity facts that the restore controller must resolve
+                        from the live target before running postReady Job actions.
+                      items:
+                        description: |-
+                          RestoreTargetIdentityFact identifies a controller-resolved target fact that
+                          a postReady Job action requires.
+                        enum:
+                        - ClusterTopology
+                        - ComponentServiceVersion
+                        type: string
+                      maxItems: 2
+                      type: array
+                      x-kubernetes-list-type: set
                     runtimeSettings:
                       description: Specifies runtime settings for the backup workload
                         container.

--- a/config/crd/bases/dataprotection.kubeblocks.io_backuppolicytemplates.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backuppolicytemplates.yaml
@@ -134,6 +134,21 @@ spec:
                       description: The name of backup method.
                       pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                       type: string
+                    restoreTargetIdentityFacts:
+                      description: |-
+                        Specifies the target identity facts that the restore controller must resolve
+                        from the live target before running postReady Job actions.
+                      items:
+                        description: |-
+                          RestoreTargetIdentityFact identifies a controller-resolved target fact that
+                          a postReady Job action requires.
+                        enum:
+                        - ClusterTopology
+                        - ComponentServiceVersion
+                        type: string
+                      maxItems: 2
+                      type: array
+                      x-kubernetes-list-type: set
                     runtimeSettings:
                       description: Specifies runtime settings for the backup workload
                         container.

--- a/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
@@ -417,6 +417,21 @@ spec:
                     description: The name of backup method.
                     pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                     type: string
+                  restoreTargetIdentityFacts:
+                    description: |-
+                      Specifies the target identity facts that the restore controller must resolve
+                      from the live target before running postReady Job actions.
+                    items:
+                      description: |-
+                        RestoreTargetIdentityFact identifies a controller-resolved target fact that
+                        a postReady Job action requires.
+                      enum:
+                      - ClusterTopology
+                      - ComponentServiceVersion
+                      type: string
+                    maxItems: 2
+                    type: array
+                    x-kubernetes-list-type: set
                   runtimeSettings:
                     description: Specifies runtime settings for the backup workload
                       container.

--- a/config/crd/bases/dataprotection.kubeblocks.io_restores.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_restores.yaml
@@ -2258,6 +2258,21 @@ spec:
                                 type: boolean
                             type: object
                             x-kubernetes-map-type: atomic
+                          restoreTargetIdentityFacts:
+                            description: |-
+                              Specifies the target identity facts that the controller must resolve from
+                              the selected live target and inject into the postReady Job.
+                            items:
+                              description: |-
+                                RestoreTargetIdentityFact identifies a controller-resolved target fact that
+                                a postReady Job action requires.
+                              enum:
+                              - ClusterTopology
+                              - ComponentServiceVersion
+                              type: string
+                            maxItems: 2
+                            type: array
+                            x-kubernetes-list-type: set
                           volumeMounts:
                             description: Defines which volumes of the selected pod
                               need to be mounted on the restoring pod.
@@ -2434,6 +2449,17 @@ spec:
             x-kubernetes-validations:
             - message: forbidden to update spec.parameters
               rule: has(oldSelf.parameters) == has(self.parameters)
+            - message: forbidden to update spec.readyConfig.jobAction.target.restoreTargetIdentityFacts
+              rule: (has(self.readyConfig) && has(self.readyConfig.jobAction) && has(self.readyConfig.jobAction.target.restoreTargetIdentityFacts)
+                && size(self.readyConfig.jobAction.target.restoreTargetIdentityFacts)
+                > 0) == (has(oldSelf.readyConfig) && has(oldSelf.readyConfig.jobAction)
+                && has(oldSelf.readyConfig.jobAction.target.restoreTargetIdentityFacts)
+                && size(oldSelf.readyConfig.jobAction.target.restoreTargetIdentityFacts)
+                > 0) && (!(has(self.readyConfig) && has(self.readyConfig.jobAction)
+                && has(self.readyConfig.jobAction.target.restoreTargetIdentityFacts)
+                && size(self.readyConfig.jobAction.target.restoreTargetIdentityFacts)
+                > 0) || self.readyConfig.jobAction.target.restoreTargetIdentityFacts
+                == oldSelf.readyConfig.jobAction.target.restoreTargetIdentityFacts)
           status:
             description: RestoreStatus defines the observed state of Restore
             properties:

--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -520,36 +520,42 @@ func (r *BackupReconciler) prepareRequestTargetInfo(reqCtx intctrlutil.RequestCt
 func (r *BackupReconciler) patchBackupStatus(
 	original *dpv1alpha1.Backup,
 	request *dpbackup.Request) error {
-	request.Status.FormatVersion = dpbackup.FormatVersion
-	if !request.SnapshotVolumes {
-		request.Status.Path = dpbackup.BuildBaseBackupPath(
-			request.Backup, request.BackupRepo.Spec.PathPrefix, request.BackupPolicy.Spec.PathPrefix)
+	desiredRequest := *request
+	desiredRequest.Backup = request.Backup.DeepCopy()
+	desiredRequest.BackupMethod = request.BackupMethod.DeepCopy()
+	desiredRequest.BackupMethod.RestoreTargetIdentityFacts = dputils.CanonicalRestoreTargetIdentityFacts(
+		desiredRequest.BackupMethod.RestoreTargetIdentityFacts)
+
+	desiredRequest.Status.FormatVersion = dpbackup.FormatVersion
+	if !desiredRequest.SnapshotVolumes {
+		desiredRequest.Status.Path = dpbackup.BuildBaseBackupPath(
+			desiredRequest.Backup, desiredRequest.BackupRepo.Spec.PathPrefix, desiredRequest.BackupPolicy.Spec.PathPrefix)
 	}
-	request.Status.BackupMethod = request.BackupMethod
-	if request.BackupRepo != nil {
-		request.Status.BackupRepoName = request.BackupRepo.Name
+	desiredRequest.Status.BackupMethod = desiredRequest.BackupMethod
+	if desiredRequest.BackupRepo != nil {
+		desiredRequest.Status.BackupRepoName = desiredRequest.BackupRepo.Name
 	}
-	if request.BackupRepoPVC != nil {
-		request.Status.PersistentVolumeClaimName = request.BackupRepoPVC.Name
+	if desiredRequest.BackupRepoPVC != nil {
+		desiredRequest.Status.PersistentVolumeClaimName = desiredRequest.BackupRepoPVC.Name
 	}
-	if !request.SnapshotVolumes && request.BackupPolicy.Spec.UseKopia {
-		request.Status.KopiaRepoPath = dpbackup.BuildKopiaRepoPath(
-			request.Backup, request.BackupRepo.Spec.PathPrefix, request.BackupPolicy.Spec.PathPrefix)
+	if !desiredRequest.SnapshotVolumes && desiredRequest.BackupPolicy.Spec.UseKopia {
+		desiredRequest.Status.KopiaRepoPath = dpbackup.BuildKopiaRepoPath(
+			desiredRequest.Backup, desiredRequest.BackupRepo.Spec.PathPrefix, desiredRequest.BackupPolicy.Spec.PathPrefix)
 	}
-	if request.ParentBackup != nil {
+	if desiredRequest.ParentBackup != nil {
 		// inherit encryption config from parent backup
-		request.Status.EncryptionConfig = request.ParentBackup.Status.EncryptionConfig
-	} else if request.BackupPolicy.Spec.EncryptionConfig != nil {
-		request.Status.EncryptionConfig = request.BackupPolicy.Spec.EncryptionConfig
+		desiredRequest.Status.EncryptionConfig = desiredRequest.ParentBackup.Status.EncryptionConfig
+	} else if desiredRequest.BackupPolicy.Spec.EncryptionConfig != nil {
+		desiredRequest.Status.EncryptionConfig = desiredRequest.BackupPolicy.Spec.EncryptionConfig
 	}
 	// init action status
-	actions, err := request.BuildActions()
+	actions, err := desiredRequest.BuildActions()
 	if err != nil {
 		return err
 	}
 	for targetPodName, acts := range actions {
 		for _, act := range acts {
-			request.Status.Actions = append(request.Status.Actions, dpv1alpha1.ActionStatus{
+			desiredRequest.Status.Actions = append(desiredRequest.Status.Actions, dpv1alpha1.ActionStatus{
 				Name:          act.GetName(),
 				TargetPodName: targetPodName,
 				Phase:         dpv1alpha1.ActionPhaseNew,
@@ -559,21 +565,25 @@ func (r *BackupReconciler) patchBackupStatus(
 	}
 
 	// update phase to running
-	request.Status.Phase = dpv1alpha1.BackupPhaseRunning
-	request.Status.StartTimestamp = &metav1.Time{Time: r.clock.Now().UTC()}
+	desiredRequest.Status.Phase = dpv1alpha1.BackupPhaseRunning
+	desiredRequest.Status.StartTimestamp = &metav1.Time{Time: r.clock.Now().UTC()}
 
 	// set status parent backup and base backup name
-	if request.ParentBackup != nil {
-		request.Status.ParentBackupName = request.ParentBackup.Name
+	if desiredRequest.ParentBackup != nil {
+		desiredRequest.Status.ParentBackupName = desiredRequest.ParentBackup.Name
 	}
-	if request.BaseBackup != nil {
-		request.Status.BaseBackupName = request.BaseBackup.Name
+	if desiredRequest.BaseBackup != nil {
+		desiredRequest.Status.BaseBackupName = desiredRequest.BaseBackup.Name
 	}
 
-	if err = dpbackup.SetExpirationTime(request.Backup); err != nil {
+	if err = dpbackup.SetExpirationTime(desiredRequest.Backup); err != nil {
 		return err
 	}
-	return r.Client.Status().Patch(request.Ctx, request.Backup, client.MergeFrom(original))
+	if err = r.Client.Status().Patch(desiredRequest.Ctx, desiredRequest.Backup, client.MergeFrom(original)); err != nil {
+		return err
+	}
+	request.Backup.Status = *desiredRequest.Backup.Status.DeepCopy()
+	return nil
 }
 
 func (r *BackupReconciler) handleRunningPhase(

--- a/controllers/dataprotection/backup_controller_test.go
+++ b/controllers/dataprotection/backup_controller_test.go
@@ -22,6 +22,7 @@ package dataprotection
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"strconv"
@@ -61,6 +62,154 @@ import (
 )
 
 var _ = Describe("Backup Controller test", func() {
+	It("publishes the selected backup method only after the Running status patch commits", func() {
+		method := &dpv1alpha1.BackupMethod{
+			Name:            "full",
+			SnapshotVolumes: pointer.Bool(true),
+			RestoreTargetIdentityFacts: []dpv1alpha1.RestoreTargetIdentityFact{
+				dpv1alpha1.RestoreTargetIdentityFactComponentServiceVersion,
+				dpv1alpha1.RestoreTargetIdentityFactClusterTopology,
+				dpv1alpha1.RestoreTargetIdentityFactComponentServiceVersion,
+			},
+		}
+		backup := &dpv1alpha1.Backup{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "backup"},
+			Spec:       dpv1alpha1.BackupSpec{RetentionPeriod: "1d"},
+		}
+		request := &dpbackup.Request{
+			Backup:          backup,
+			RequestCtx:      intctrlutil.RequestCtx{Ctx: context.Background()},
+			BackupPolicy:    &dpv1alpha1.BackupPolicy{},
+			BackupMethod:    method,
+			SnapshotVolumes: true,
+		}
+		writer := &recordingBackupStatusWriter{err: errors.New("injected status patch failure")}
+		reconciler := &BackupReconciler{Client: &recordingBackupStatusClient{writer: writer}}
+
+		err := reconciler.patchBackupStatus(backup.DeepCopy(), request)
+
+		Expect(err).Should(MatchError("injected status patch failure"))
+		Expect(writer.patched).ShouldNot(BeNil())
+		Expect(writer.patched.Status.Phase).Should(Equal(dpv1alpha1.BackupPhaseRunning))
+		Expect(writer.patched.Status.BackupMethod.RestoreTargetIdentityFacts).Should(Equal(
+			[]dpv1alpha1.RestoreTargetIdentityFact{
+				dpv1alpha1.RestoreTargetIdentityFactClusterTopology,
+				dpv1alpha1.RestoreTargetIdentityFactComponentServiceVersion,
+			}))
+		Expect(request.Status.Phase).Should(BeEmpty())
+		Expect(request.Status.BackupMethod).Should(BeNil())
+
+		writer.err = nil
+		Expect(reconciler.patchBackupStatus(backup.DeepCopy(), request)).Should(Succeed())
+		method.RestoreTargetIdentityFacts[0] = dpv1alpha1.RestoreTargetIdentityFactClusterTopology
+		Expect(request.Status.BackupMethod.RestoreTargetIdentityFacts).Should(Equal(
+			[]dpv1alpha1.RestoreTargetIdentityFact{
+				dpv1alpha1.RestoreTargetIdentityFactClusterTopology,
+				dpv1alpha1.RestoreTargetIdentityFactComponentServiceVersion,
+			}))
+	})
+
+	It("persists the selected backup method snapshot across policy and actionSet drift", func() {
+		method := dpv1alpha1.BackupMethod{
+			Name:            "full",
+			ActionSetName:   "identity-freeze-actionset",
+			SnapshotVolumes: pointer.Bool(true),
+			RestoreTargetIdentityFacts: []dpv1alpha1.RestoreTargetIdentityFact{
+				dpv1alpha1.RestoreTargetIdentityFactComponentServiceVersion,
+				dpv1alpha1.RestoreTargetIdentityFactClusterTopology,
+			},
+		}
+		policy := &dpv1alpha1.BackupPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testCtx.DefaultNamespace,
+				Name:      "identity-freeze-policy",
+				Labels:    map[string]string{testCtx.TestObjLabelKey: "true"},
+				Annotations: map[string]string{
+					disableSyncFromTemplateAnnotation: "true",
+				},
+			},
+			Spec: dpv1alpha1.BackupPolicySpec{
+				Target:        &dpv1alpha1.BackupTarget{PodSelector: &dpv1alpha1.PodSelector{}},
+				BackupMethods: []dpv1alpha1.BackupMethod{method},
+			},
+		}
+		actionSet := &dpv1alpha1.ActionSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   method.ActionSetName,
+				Labels: map[string]string{testCtx.TestObjLabelKey: "true"},
+			},
+			Spec: dpv1alpha1.ActionSetSpec{BackupType: dpv1alpha1.BackupTypeFull},
+		}
+		backup := &dpv1alpha1.Backup{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testCtx.DefaultNamespace,
+				Name:      "identity-freeze-backup",
+				Labels:    map[string]string{testCtx.TestObjLabelKey: "true"},
+				Annotations: map[string]string{
+					dptypes.SkipReconciliationAnnotationKey: "true",
+				},
+			},
+			Spec: dpv1alpha1.BackupSpec{
+				BackupPolicyName: policy.Name,
+				BackupMethod:     method.Name,
+				DeletionPolicy:   dpv1alpha1.BackupDeletionPolicyDelete,
+				RetentionPeriod:  "1d",
+			},
+		}
+		Expect(testCtx.Cli.Create(testCtx.Ctx, policy)).Should(Succeed())
+		Expect(testCtx.Cli.Create(testCtx.Ctx, actionSet)).Should(Succeed())
+		Expect(testCtx.Cli.Create(testCtx.Ctx, backup)).Should(Succeed())
+
+		persistedPolicy := &dpv1alpha1.BackupPolicy{}
+		persistedBackup := &dpv1alpha1.Backup{}
+		Expect(testCtx.Cli.Get(testCtx.Ctx, client.ObjectKeyFromObject(policy), persistedPolicy)).Should(Succeed())
+		Expect(testCtx.Cli.Get(testCtx.Ctx, client.ObjectKeyFromObject(backup), persistedBackup)).Should(Succeed())
+		request := &dpbackup.Request{
+			Backup:          persistedBackup,
+			RequestCtx:      intctrlutil.RequestCtx{Ctx: testCtx.Ctx},
+			BackupPolicy:    persistedPolicy,
+			BackupMethod:    &persistedPolicy.Spec.BackupMethods[0],
+			SnapshotVolumes: true,
+		}
+		reconciler := &BackupReconciler{Client: testCtx.Cli}
+		Expect(reconciler.patchBackupStatus(persistedBackup.DeepCopy(), request)).Should(Succeed())
+
+		committed := &dpv1alpha1.Backup{}
+		Expect(testCtx.Cli.Get(testCtx.Ctx, client.ObjectKeyFromObject(backup), committed)).Should(Succeed())
+		Expect(committed.Status.Phase).Should(Equal(dpv1alpha1.BackupPhaseRunning))
+		Expect(committed.Status.BackupMethod.RestoreTargetIdentityFacts).Should(Equal(
+			[]dpv1alpha1.RestoreTargetIdentityFact{
+				dpv1alpha1.RestoreTargetIdentityFactClusterTopology,
+				dpv1alpha1.RestoreTargetIdentityFactComponentServiceVersion,
+			}))
+
+		Eventually(func() error {
+			currentPolicy := &dpv1alpha1.BackupPolicy{}
+			if err := testCtx.Cli.Get(testCtx.Ctx, client.ObjectKeyFromObject(policy), currentPolicy); err != nil {
+				return err
+			}
+			currentPolicy.Spec.BackupMethods[0].RestoreTargetIdentityFacts =
+				[]dpv1alpha1.RestoreTargetIdentityFact{dpv1alpha1.RestoreTargetIdentityFactClusterTopology}
+			return testCtx.Cli.Update(testCtx.Ctx, currentPolicy)
+		}).Should(Succeed())
+		Eventually(func() error {
+			currentActionSet := &dpv1alpha1.ActionSet{}
+			if err := testCtx.Cli.Get(testCtx.Ctx, client.ObjectKeyFromObject(actionSet), currentActionSet); err != nil {
+				return err
+			}
+			currentActionSet.Spec.Env = []corev1.EnvVar{{Name: "POST_COMMIT_DRIFT", Value: "true"}}
+			return testCtx.Cli.Update(testCtx.Ctx, currentActionSet)
+		}).Should(Succeed())
+
+		committed = &dpv1alpha1.Backup{}
+		Expect(testCtx.Cli.Get(testCtx.Ctx, client.ObjectKeyFromObject(backup), committed)).Should(Succeed())
+		Expect(committed.Status.BackupMethod.RestoreTargetIdentityFacts).Should(Equal(
+			[]dpv1alpha1.RestoreTargetIdentityFact{
+				dpv1alpha1.RestoreTargetIdentityFactClusterTopology,
+				dpv1alpha1.RestoreTargetIdentityFactComponentServiceVersion,
+			}))
+	})
+
 	cleanEnv := func() {
 		// must wait till resources deleted and no longer existed before the testcases start,
 		// otherwise if later it needs to create some new resource objects with the same name,
@@ -1806,3 +1955,24 @@ var _ = Describe("Backup Controller test", func() {
 		})
 	})
 })
+
+type recordingBackupStatusClient struct {
+	client.Client
+	writer *recordingBackupStatusWriter
+}
+
+func (c *recordingBackupStatusClient) Status() client.SubResourceWriter {
+	return c.writer
+}
+
+type recordingBackupStatusWriter struct {
+	client.SubResourceWriter
+	patched *dpv1alpha1.Backup
+	err     error
+}
+
+func (w *recordingBackupStatusWriter) Patch(_ context.Context, obj client.Object, _ client.Patch,
+	_ ...client.SubResourcePatchOption) error {
+	w.patched = obj.(*dpv1alpha1.Backup).DeepCopy()
+	return w.err
+}

--- a/controllers/dataprotection/backuppolicydriver_controller.go
+++ b/controllers/dataprotection/backuppolicydriver_controller.go
@@ -425,6 +425,8 @@ func (r *backupPolicyAndScheduleBuilder) buildBackupMethods(backupPolicy *dpv1al
 			SnapshotVolumes:  backupMethodTPL.SnapshotVolumes,
 			TargetVolumes:    backupMethodTPL.TargetVolumes,
 			RuntimeSettings:  backupMethodTPL.RuntimeSettings,
+			RestoreTargetIdentityFacts: dputils.CanonicalRestoreTargetIdentityFacts(
+				backupMethodTPL.RestoreTargetIdentityFacts),
 		}
 		if backupMethodTPL.Target != nil {
 			if r.isSharding {

--- a/controllers/dataprotection/backuppolicydriver_controller_test.go
+++ b/controllers/dataprotection/backuppolicydriver_controller_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
@@ -102,6 +103,57 @@ var _ = Describe("BackupPolicyDriver Controller test", func() {
 	})
 
 	Context("expect to create a backup policy", func() {
+		It("rejects unknown restore target identity facts at the API boundary", func() {
+			Eventually(func() bool {
+				invalid := &dpv1alpha1.BackupPolicyTemplate{}
+				if err := testCtx.Cli.Get(testCtx.Ctx, client.ObjectKeyFromObject(bpt), invalid); err != nil {
+					return false
+				}
+				invalid.Spec.BackupMethods[0].RestoreTargetIdentityFacts =
+					[]dpv1alpha1.RestoreTargetIdentityFact{"UnknownFact"}
+				return apierrors.IsInvalid(testCtx.Cli.Update(testCtx.Ctx, invalid))
+			}).Should(BeTrue())
+		})
+
+		It("copies restore target identity facts into the policy in canonical order", func() {
+			builder := &backupPolicyAndScheduleBuilder{
+				backupPolicyTPL: &dpv1alpha1.BackupPolicyTemplate{
+					Spec: dpv1alpha1.BackupPolicyTemplateSpec{
+						BackupMethods: []dpv1alpha1.BackupMethodTPL{{
+							Name: "full",
+							RestoreTargetIdentityFacts: []dpv1alpha1.RestoreTargetIdentityFact{
+								dpv1alpha1.RestoreTargetIdentityFactComponentServiceVersion,
+								dpv1alpha1.RestoreTargetIdentityFactClusterTopology,
+								dpv1alpha1.RestoreTargetIdentityFactComponentServiceVersion,
+							},
+						}},
+					},
+				},
+				compSpec: &appsv1.ClusterComponentSpec{},
+			}
+			policy := &dpv1alpha1.BackupPolicy{}
+
+			Expect(builder.buildBackupMethods(policy)).Should(Succeed())
+			Expect(policy.Spec.BackupMethods).Should(HaveLen(1))
+			Expect(policy.Spec.BackupMethods[0].RestoreTargetIdentityFacts).Should(Equal(
+				[]dpv1alpha1.RestoreTargetIdentityFact{
+					dpv1alpha1.RestoreTargetIdentityFactClusterTopology,
+					dpv1alpha1.RestoreTargetIdentityFactComponentServiceVersion,
+				}))
+
+			policy.Annotations = map[string]string{disableSyncFromTemplateAnnotation: "true"}
+			policy.Spec.BackupMethods[0].RestoreTargetIdentityFacts =
+				[]dpv1alpha1.RestoreTargetIdentityFact{dpv1alpha1.RestoreTargetIdentityFactComponentServiceVersion}
+			builder.backupPolicyTPL.Spec.BackupMethods[0].RestoreTargetIdentityFacts =
+				[]dpv1alpha1.RestoreTargetIdentityFact{dpv1alpha1.RestoreTargetIdentityFactClusterTopology}
+
+			Expect(builder.buildBackupMethods(policy)).Should(Succeed())
+			Expect(policy.Spec.BackupMethods[0].RestoreTargetIdentityFacts).Should(Equal(
+				[]dpv1alpha1.RestoreTargetIdentityFact{
+					dpv1alpha1.RestoreTargetIdentityFactComponentServiceVersion,
+				}))
+		})
+
 		It("resolves backup method env values by exact match before prefix match", func() {
 			exactValue := "tools:8.0.33"
 			prefixValue := "tools:8.0"

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -1278,6 +1278,11 @@ func (r *VolumePopulatorReconciler) buildPostReadyRestore(reqCtx intctrlutil.Req
 	if roleName != "" {
 		jobActionLabels[instanceset.RoleLabelKey] = roleName
 	}
+	restoreTargetIdentityFacts, err := restoreTargetIdentityFactsFromPostReadyBackupSets(
+		restoreMgr.PostReadyBackupSets)
+	if err != nil {
+		return nil, err
+	}
 	readyConfig := &dpv1alpha1.ReadyConfig{
 		ExecAction: &dpv1alpha1.ExecAction{
 			Target: dpv1alpha1.ExecActionTarget{
@@ -1293,6 +1298,7 @@ func (r *VolumePopulatorReconciler) buildPostReadyRestore(reqCtx intctrlutil.Req
 						MatchLabels: jobActionLabels,
 					},
 				},
+				RestoreTargetIdentityFacts: restoreTargetIdentityFacts,
 			},
 		},
 		ConnectionCredential: connectionCredential,
@@ -1336,16 +1342,61 @@ func (r *VolumePopulatorReconciler) buildPostReadyRestore(reqCtx intctrlutil.Req
 	return restore, nil
 }
 
+func restoreTargetIdentityFactsFromPostReadyBackupSets(
+	backupSets []dprestore.BackupActionSet,
+) ([]dpv1alpha1.RestoreTargetIdentityFact, error) {
+	var facts []dpv1alpha1.RestoreTargetIdentityFact
+	for i := range backupSets {
+		backupSet := &backupSets[i]
+		if backupSet.Backup == nil || backupSet.Backup.Status.BackupMethod == nil {
+			continue
+		}
+		requested := backupSet.Backup.Status.BackupMethod.RestoreTargetIdentityFacts
+		if len(requested) == 0 {
+			continue
+		}
+		hasJobAction := false
+		if backupSet.ActionSet != nil && backupSet.ActionSet.Spec.Restore != nil {
+			for j := range backupSet.ActionSet.Spec.Restore.PostReady {
+				if backupSet.ActionSet.Spec.Restore.PostReady[j].Job != nil {
+					hasJobAction = true
+					break
+				}
+			}
+		}
+		if !hasJobAction {
+			return nil, intctrlutil.NewFatalError(fmt.Sprintf(
+				"restore target identity facts require a postReady Job action for backup %s",
+				backupSet.Backup.Name))
+		}
+		facts = append(facts, requested...)
+	}
+	return utils.CanonicalRestoreTargetIdentityFacts(facts), nil
+}
+
 func validatePostReadyRestore(existing, desired *dpv1alpha1.Restore, comp *appsv1.Component) error {
 	if !hasOwnerReference(existing.OwnerReferences, comp.UID) {
 		return intctrlutil.NewFatalError(fmt.Sprintf("postReady restore %s/%s is not owned by component %s/%s",
 			existing.Namespace, existing.Name, comp.Namespace, comp.Name))
 	}
-	if !reflect.DeepEqual(existing.Spec, desired.Spec) {
+	existingSpec := canonicalPostReadyRestoreSpecForIntentComparison(existing.Spec)
+	desiredSpec := canonicalPostReadyRestoreSpecForIntentComparison(desired.Spec)
+	if !reflect.DeepEqual(existingSpec, desiredSpec) {
 		return intctrlutil.NewFatalError(fmt.Sprintf("postReady restore %s/%s spec does not match current restore intent",
 			existing.Namespace, existing.Name))
 	}
 	return nil
+}
+
+func canonicalPostReadyRestoreSpecForIntentComparison(spec dpv1alpha1.RestoreSpec) *dpv1alpha1.RestoreSpec {
+	canonical := spec.DeepCopy()
+	if canonical.ReadyConfig == nil || canonical.ReadyConfig.JobAction == nil {
+		return canonical
+	}
+	canonical.ReadyConfig.JobAction.Target.RestoreTargetIdentityFacts =
+		utils.CanonicalRestoreTargetIdentityFacts(
+			canonical.ReadyConfig.JobAction.Target.RestoreTargetIdentityFacts)
+	return canonical
 }
 
 func hasOwnerReference(ownerRefs []metav1.OwnerReference, uid types.UID) bool {

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -34,6 +34,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -47,6 +48,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/instanceset"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	dpbackup "github.com/apecloud/kubeblocks/pkg/dataprotection/backup"
 	dprestore "github.com/apecloud/kubeblocks/pkg/dataprotection/restore"
 	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 	"github.com/apecloud/kubeblocks/pkg/generics"
@@ -94,6 +96,270 @@ var _ = Describe("Volume Populator Controller test", func() {
 
 	AfterEach(func() {
 		cleanEnv()
+	})
+
+	It("keeps synthesized restore target identity facts immutable with set semantics", func() {
+		newRestore := func(name string, facts []dpv1alpha1.RestoreTargetIdentityFact) *dpv1alpha1.Restore {
+			return &dpv1alpha1.Restore{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testCtx.DefaultNamespace,
+					Name:      name,
+					Labels:    map[string]string{testCtx.TestObjLabelKey: "true"},
+				},
+				Spec: dpv1alpha1.RestoreSpec{
+					Backup: dpv1alpha1.BackupRef{Name: "backup", Namespace: testCtx.DefaultNamespace},
+					ReadyConfig: &dpv1alpha1.ReadyConfig{JobAction: &dpv1alpha1.JobAction{
+						Target: dpv1alpha1.JobActionTarget{
+							PodSelector:                dpv1alpha1.PodSelector{},
+							RestoreTargetIdentityFacts: facts,
+						},
+					}},
+				},
+			}
+		}
+		withFacts := newRestore("immutable-target-facts", []dpv1alpha1.RestoreTargetIdentityFact{
+			dpv1alpha1.RestoreTargetIdentityFactClusterTopology,
+			dpv1alpha1.RestoreTargetIdentityFactComponentServiceVersion,
+		})
+		withoutFacts := newRestore("immutable-target-facts-absent", nil)
+		Expect(testCtx.Cli.Create(testCtx.Ctx, withFacts)).Should(Succeed())
+		Expect(testCtx.Cli.Create(testCtx.Ctx, withoutFacts)).Should(Succeed())
+
+		Eventually(func() bool {
+			current := &dpv1alpha1.Restore{}
+			if err := testCtx.Cli.Get(testCtx.Ctx, client.ObjectKeyFromObject(withFacts), current); err != nil {
+				return false
+			}
+			current.Spec.ReadyConfig.JobAction.Target.RestoreTargetIdentityFacts =
+				[]dpv1alpha1.RestoreTargetIdentityFact{dpv1alpha1.RestoreTargetIdentityFactClusterTopology}
+			return apierrors.IsInvalid(testCtx.Cli.Update(testCtx.Ctx, current))
+		}).Should(BeTrue())
+
+		Eventually(func() bool {
+			current := &dpv1alpha1.Restore{}
+			if err := testCtx.Cli.Get(testCtx.Ctx, client.ObjectKeyFromObject(withoutFacts), current); err != nil {
+				return false
+			}
+			current.Spec.ReadyConfig.JobAction.Target.RestoreTargetIdentityFacts =
+				[]dpv1alpha1.RestoreTargetIdentityFact{dpv1alpha1.RestoreTargetIdentityFactClusterTopology}
+			return apierrors.IsInvalid(testCtx.Cli.Update(testCtx.Ctx, current))
+		}).Should(BeTrue())
+	})
+
+	It("treats absent and explicit empty restore target identity facts as the same legacy state", func() {
+		newRestore := func(name string, facts []any, includeFacts bool) *unstructured.Unstructured {
+			target := map[string]any{"podSelector": map[string]any{}}
+			if includeFacts {
+				target["restoreTargetIdentityFacts"] = facts
+			}
+			return &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": dpv1alpha1.GroupVersion.String(),
+				"kind":       "Restore",
+				"metadata": map[string]any{
+					"namespace": testCtx.DefaultNamespace,
+					"name":      name,
+					"labels":    map[string]any{testCtx.TestObjLabelKey: "true"},
+				},
+				"spec": map[string]any{
+					"backup": map[string]any{"name": "backup", "namespace": testCtx.DefaultNamespace},
+					"readyConfig": map[string]any{
+						"jobAction": map[string]any{"target": target},
+					},
+				},
+			}}
+		}
+		updateFacts := func(restore *unstructured.Unstructured, facts []any, includeFacts bool) error {
+			current := &unstructured.Unstructured{}
+			current.SetAPIVersion(dpv1alpha1.GroupVersion.String())
+			current.SetKind("Restore")
+			if err := testCtx.Cli.Get(testCtx.Ctx, client.ObjectKeyFromObject(restore), current); err != nil {
+				return err
+			}
+			path := []string{"spec", "readyConfig", "jobAction", "target", "restoreTargetIdentityFacts"}
+			if includeFacts {
+				if err := unstructured.SetNestedSlice(current.Object, facts, path...); err != nil {
+					return err
+				}
+			} else {
+				unstructured.RemoveNestedField(current.Object, path...)
+			}
+			return testCtx.Cli.Update(testCtx.Ctx, current)
+		}
+		validateFactsIntent := func(restore *unstructured.Unstructured,
+			desiredFacts []dpv1alpha1.RestoreTargetIdentityFact,
+		) (*dpv1alpha1.Restore, error) {
+			current := &dpv1alpha1.Restore{}
+			if err := testCtx.Cli.Get(testCtx.Ctx, client.ObjectKeyFromObject(restore), current); err != nil {
+				return nil, err
+			}
+			component := &kbappsv1.Component{ObjectMeta: metav1.ObjectMeta{
+				Namespace: current.Namespace,
+				Name:      "intent-owner",
+				UID:       types.UID("intent-owner-uid"),
+			}}
+			current.OwnerReferences = []metav1.OwnerReference{{UID: component.UID}}
+			desired := current.DeepCopy()
+			if desiredFacts == nil {
+				desired.Spec.ReadyConfig.JobAction.Target.RestoreTargetIdentityFacts = nil
+			} else {
+				desired.Spec.ReadyConfig.JobAction.Target.RestoreTargetIdentityFacts =
+					append([]dpv1alpha1.RestoreTargetIdentityFact{}, desiredFacts...)
+			}
+			return current, validatePostReadyRestore(current, desired, component)
+		}
+
+		absent := newRestore("identity-facts-absent-to-empty", nil, false)
+		empty := newRestore("identity-facts-empty-to-absent", []any{}, true)
+		emptyToPresent := newRestore("identity-facts-empty-to-present", []any{}, true)
+		presentToEmpty := newRestore("identity-facts-present-to-empty", []any{
+			string(dpv1alpha1.RestoreTargetIdentityFactClusterTopology),
+		}, true)
+		presentToAbsent := newRestore("identity-facts-present-to-absent", []any{
+			string(dpv1alpha1.RestoreTargetIdentityFactClusterTopology),
+		}, true)
+		presentReordered := newRestore("identity-facts-present-reordered", []any{
+			string(dpv1alpha1.RestoreTargetIdentityFactClusterTopology),
+			string(dpv1alpha1.RestoreTargetIdentityFactComponentServiceVersion),
+		}, true)
+		Expect(testCtx.Cli.Create(testCtx.Ctx, absent)).Should(Succeed())
+		Expect(testCtx.Cli.Create(testCtx.Ctx, empty)).Should(Succeed())
+		Expect(testCtx.Cli.Create(testCtx.Ctx, emptyToPresent)).Should(Succeed())
+		Expect(testCtx.Cli.Create(testCtx.Ctx, presentToEmpty)).Should(Succeed())
+		Expect(testCtx.Cli.Create(testCtx.Ctx, presentToAbsent)).Should(Succeed())
+		Expect(testCtx.Cli.Create(testCtx.Ctx, presentReordered)).Should(Succeed())
+
+		Eventually(func() error {
+			return updateFacts(absent, []any{}, true)
+		}).Should(Succeed())
+		current, err := validateFactsIntent(absent, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(current.Spec.ReadyConfig.JobAction.Target.RestoreTargetIdentityFacts).NotTo(BeNil())
+		Expect(current.Spec.ReadyConfig.JobAction.Target.RestoreTargetIdentityFacts).To(BeEmpty())
+
+		Eventually(func() error {
+			return updateFacts(empty, nil, false)
+		}).Should(Succeed())
+		_, err = validateFactsIntent(empty, []dpv1alpha1.RestoreTargetIdentityFact{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func() bool {
+			return apierrors.IsInvalid(updateFacts(emptyToPresent, []any{
+				string(dpv1alpha1.RestoreTargetIdentityFactClusterTopology),
+			}, true))
+		}).Should(BeTrue())
+		Eventually(func() bool {
+			return apierrors.IsInvalid(updateFacts(presentToEmpty, []any{}, true))
+		}).Should(BeTrue())
+		Eventually(func() bool {
+			return apierrors.IsInvalid(updateFacts(presentToAbsent, nil, false))
+		}).Should(BeTrue())
+		Eventually(func() error {
+			return updateFacts(presentReordered, []any{
+				string(dpv1alpha1.RestoreTargetIdentityFactComponentServiceVersion),
+				string(dpv1alpha1.RestoreTargetIdentityFactClusterTopology),
+			}, true)
+		}).Should(Succeed())
+		_, err = validateFactsIntent(presentReordered, []dpv1alpha1.RestoreTargetIdentityFact{
+			dpv1alpha1.RestoreTargetIdentityFactClusterTopology,
+			dpv1alpha1.RestoreTargetIdentityFactComponentServiceVersion,
+		})
+		Expect(err).NotTo(HaveOccurred())
+		_, err = validateFactsIntent(presentReordered, []dpv1alpha1.RestoreTargetIdentityFact{
+			dpv1alpha1.RestoreTargetIdentityFactClusterTopology,
+		})
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("rejects adding restore target identity facts when readyConfig was absent", func() {
+		restore := &dpv1alpha1.Restore{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testCtx.DefaultNamespace,
+				Name:      "immutable-target-facts-parent-absent",
+				Labels:    map[string]string{testCtx.TestObjLabelKey: "true"},
+			},
+			Spec: dpv1alpha1.RestoreSpec{
+				Backup: dpv1alpha1.BackupRef{Name: "backup", Namespace: testCtx.DefaultNamespace},
+			},
+		}
+		Expect(testCtx.Cli.Create(testCtx.Ctx, restore)).Should(Succeed())
+
+		Eventually(func() bool {
+			current := &dpv1alpha1.Restore{}
+			if err := testCtx.Cli.Get(testCtx.Ctx, client.ObjectKeyFromObject(restore), current); err != nil {
+				return false
+			}
+			current.Spec.ReadyConfig = &dpv1alpha1.ReadyConfig{JobAction: &dpv1alpha1.JobAction{
+				Target: dpv1alpha1.JobActionTarget{
+					PodSelector: dpv1alpha1.PodSelector{},
+					RestoreTargetIdentityFacts: []dpv1alpha1.RestoreTargetIdentityFact{
+						dpv1alpha1.RestoreTargetIdentityFactClusterTopology,
+					},
+				},
+			}}
+			return apierrors.IsInvalid(testCtx.Cli.Update(testCtx.Ctx, current))
+		}).Should(BeTrue())
+	})
+
+	It("rejects changing restore target identity facts through optional parent fields", func() {
+		newRestore := func(name string, readyConfig *dpv1alpha1.ReadyConfig) *dpv1alpha1.Restore {
+			return &dpv1alpha1.Restore{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testCtx.DefaultNamespace,
+					Name:      name,
+					Labels:    map[string]string{testCtx.TestObjLabelKey: "true"},
+				},
+				Spec: dpv1alpha1.RestoreSpec{
+					Backup:      dpv1alpha1.BackupRef{Name: "backup", Namespace: testCtx.DefaultNamespace},
+					ReadyConfig: readyConfig,
+				},
+			}
+		}
+		jobAction := func() *dpv1alpha1.JobAction {
+			return &dpv1alpha1.JobAction{Target: dpv1alpha1.JobActionTarget{
+				PodSelector: dpv1alpha1.PodSelector{},
+				RestoreTargetIdentityFacts: []dpv1alpha1.RestoreTargetIdentityFact{
+					dpv1alpha1.RestoreTargetIdentityFactClusterTopology,
+				},
+			}}
+		}
+		execAction := &dpv1alpha1.ExecAction{Target: dpv1alpha1.ExecActionTarget{
+			PodSelector: metav1.LabelSelector{},
+		}}
+
+		withoutJobAction := newRestore("immutable-target-facts-job-action-absent",
+			&dpv1alpha1.ReadyConfig{ExecAction: execAction})
+		withFacts := newRestore("immutable-target-facts-parent-removal",
+			&dpv1alpha1.ReadyConfig{JobAction: jobAction()})
+		Expect(testCtx.Cli.Create(testCtx.Ctx, withoutJobAction)).Should(Succeed())
+		Expect(testCtx.Cli.Create(testCtx.Ctx, withFacts)).Should(Succeed())
+
+		Eventually(func() bool {
+			current := &dpv1alpha1.Restore{}
+			if err := testCtx.Cli.Get(testCtx.Ctx, client.ObjectKeyFromObject(withoutJobAction), current); err != nil {
+				return false
+			}
+			current.Spec.ReadyConfig.JobAction = jobAction()
+			return apierrors.IsInvalid(testCtx.Cli.Update(testCtx.Ctx, current))
+		}).Should(BeTrue())
+
+		Eventually(func() bool {
+			current := &dpv1alpha1.Restore{}
+			if err := testCtx.Cli.Get(testCtx.Ctx, client.ObjectKeyFromObject(withFacts), current); err != nil {
+				return false
+			}
+			current.Spec.ReadyConfig = nil
+			return apierrors.IsInvalid(testCtx.Cli.Update(testCtx.Ctx, current))
+		}).Should(BeTrue())
+
+		Eventually(func() bool {
+			current := &dpv1alpha1.Restore{}
+			if err := testCtx.Cli.Get(testCtx.Ctx, client.ObjectKeyFromObject(withFacts), current); err != nil {
+				return false
+			}
+			current.Spec.ReadyConfig.JobAction = nil
+			current.Spec.ReadyConfig.ExecAction = execAction
+			return apierrors.IsInvalid(testCtx.Cli.Update(testCtx.Ctx, current))
+		}).Should(BeTrue())
 	})
 
 	Context("backup target selector helpers", func() {
@@ -1741,6 +2007,186 @@ func TestBuildPostReadyRestoreSelectsHighestPriorityRole(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "leader", restore.Spec.ReadyConfig.JobAction.Target.PodSelector.LabelSelector.MatchLabels[instanceset.RoleLabelKey])
 	require.NotContains(t, restore.Spec.ReadyConfig.ExecAction.Target.PodSelector.MatchLabels, instanceset.RoleLabelKey)
+}
+
+func TestRestoreTargetIdentityFactsWriterChainFromTemplateToDataSourceRestore(t *testing.T) {
+	policyBuilder := &backupPolicyAndScheduleBuilder{
+		backupPolicyTPL: &dpv1alpha1.BackupPolicyTemplate{Spec: dpv1alpha1.BackupPolicyTemplateSpec{
+			BackupMethods: []dpv1alpha1.BackupMethodTPL{{
+				Name:            "full",
+				SnapshotVolumes: ptr.To(true),
+				RestoreTargetIdentityFacts: []dpv1alpha1.RestoreTargetIdentityFact{
+					dpv1alpha1.RestoreTargetIdentityFactClusterTopology,
+				},
+			}},
+		}},
+		compSpec: &kbappsv1.ClusterComponentSpec{},
+	}
+	policy := &dpv1alpha1.BackupPolicy{}
+	require.NoError(t, policyBuilder.buildBackupMethods(policy))
+
+	// A policy change before the New -> Running status commit is an input to the
+	// new Backup. Later policy changes must not rewrite the committed snapshot.
+	policy.Spec.BackupMethods[0].RestoreTargetIdentityFacts = []dpv1alpha1.RestoreTargetIdentityFact{
+		dpv1alpha1.RestoreTargetIdentityFactComponentServiceVersion,
+	}
+	backup := &dpv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "backup"},
+		Spec:       dpv1alpha1.BackupSpec{RetentionPeriod: "1d"},
+	}
+	request := &dpbackup.Request{
+		Backup:          backup,
+		RequestCtx:      intctrlutil.RequestCtx{Ctx: context.Background()},
+		BackupPolicy:    policy,
+		BackupMethod:    &policy.Spec.BackupMethods[0],
+		SnapshotVolumes: true,
+	}
+	writer := &recordingBackupStatusWriter{}
+	backupReconciler := &BackupReconciler{Client: &recordingBackupStatusClient{writer: writer}}
+	require.NoError(t, backupReconciler.patchBackupStatus(backup.DeepCopy(), request))
+	policy.Spec.BackupMethods[0].RestoreTargetIdentityFacts = []dpv1alpha1.RestoreTargetIdentityFact{
+		dpv1alpha1.RestoreTargetIdentityFactClusterTopology,
+	}
+	require.Equal(t, []dpv1alpha1.RestoreTargetIdentityFact{
+		dpv1alpha1.RestoreTargetIdentityFactComponentServiceVersion,
+	}, request.Backup.Status.BackupMethod.RestoreTargetIdentityFacts)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, kbappsv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	jobActionSet := &dpv1alpha1.ActionSet{Spec: dpv1alpha1.ActionSetSpec{
+		Restore: &dpv1alpha1.RestoreActionSpec{PostReady: []dpv1alpha1.ActionSpec{{
+			Job: &dpv1alpha1.JobActionSpec{},
+		}}},
+	}}
+	comp := &kbappsv1.Component{ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      constant.GenerateClusterComponentName("cluster", "mysql"),
+	}}
+	pvc := newPVCForRestoreDecision("data", "mysql", "")
+	pvc.Spec.DataSourceRef = &corev1.TypedObjectReference{Name: request.Backup.Name}
+	pvc.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = request.Backup.Namespace
+	volumeReconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(request.Backup).Build(),
+		Scheme: scheme,
+	}
+	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{}, nil, scheme, volumeReconciler.Client)
+	restoreMgr.PostReadyBackupSets = []dprestore.BackupActionSet{{
+		Backup: request.Backup, ActionSet: jobActionSet,
+	}}
+
+	restore, err := volumeReconciler.buildPostReadyRestore(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp, "", nil)
+
+	require.NoError(t, err)
+	require.Equal(t, []dpv1alpha1.RestoreTargetIdentityFact{
+		dpv1alpha1.RestoreTargetIdentityFactComponentServiceVersion,
+	}, restore.Spec.ReadyConfig.JobAction.Target.RestoreTargetIdentityFacts)
+}
+
+func TestBuildPostReadyRestoreUnionsCommittedTargetIdentityFactsWithoutEffectiveTarget(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, kbappsv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	backup := newBackupForRestoreDecision([]string{"data"}, nil)
+	backup.Spec.ParentBackupName = "base-backup"
+	backup.Status.BackupMethod.ActionSetName = "differential-action"
+	backup.Status.BackupMethod.RestoreTargetIdentityFacts = []dpv1alpha1.RestoreTargetIdentityFact{
+		dpv1alpha1.RestoreTargetIdentityFactComponentServiceVersion,
+	}
+	baseBackup := backup.DeepCopy()
+	baseBackup.Name = "base-backup"
+	baseBackup.Spec.ParentBackupName = ""
+	baseBackup.Status.BackupMethod.ActionSetName = "full-action"
+	baseBackup.Status.BackupMethod.RestoreTargetIdentityFacts = []dpv1alpha1.RestoreTargetIdentityFact{
+		dpv1alpha1.RestoreTargetIdentityFactComponentServiceVersion,
+		dpv1alpha1.RestoreTargetIdentityFactClusterTopology,
+	}
+	fullActionSet := &dpv1alpha1.ActionSet{ObjectMeta: metav1.ObjectMeta{Name: "full-action"}, Spec: dpv1alpha1.ActionSetSpec{
+		BackupType: dpv1alpha1.BackupTypeFull,
+		Restore: &dpv1alpha1.RestoreActionSpec{PostReady: []dpv1alpha1.ActionSpec{{
+			Job: &dpv1alpha1.JobActionSpec{},
+		}}},
+	}}
+	differentialActionSet := fullActionSet.DeepCopy()
+	differentialActionSet.Name = "differential-action"
+	differentialActionSet.Spec.BackupType = dpv1alpha1.BackupTypeDifferential
+	comp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "mysql"),
+		},
+	}
+	pvc := newPVCForRestoreDecision("data", "mysql", "")
+	pvc.Spec.DataSourceRef = &corev1.TypedObjectReference{Name: backup.Name}
+	pvc.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(backup, baseBackup, fullActionSet, differentialActionSet).Build(),
+		Scheme: scheme,
+	}
+	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{}, nil, scheme, reconciler.Client)
+	reqCtx := intctrlutil.RequestCtx{Ctx: context.Background()}
+	require.NoError(t, restoreMgr.BuildDifferentialBackupActionSets(reqCtx, reconciler.Client,
+		dprestore.BackupActionSet{Backup: backup, ActionSet: differentialActionSet}))
+	require.Len(t, restoreMgr.PostReadyBackupSets, 2)
+	require.Equal(t, []string{"base-backup", "backup"}, []string{
+		restoreMgr.PostReadyBackupSets[0].Backup.Name,
+		restoreMgr.PostReadyBackupSets[1].Backup.Name,
+	})
+
+	restore, err := reconciler.buildPostReadyRestore(
+		reqCtx, pvc, restoreMgr, comp, "", nil)
+
+	require.NoError(t, err)
+	require.Equal(t, []dpv1alpha1.RestoreTargetIdentityFact{
+		dpv1alpha1.RestoreTargetIdentityFactClusterTopology,
+		dpv1alpha1.RestoreTargetIdentityFactComponentServiceVersion,
+	}, restore.Spec.ReadyConfig.JobAction.Target.RestoreTargetIdentityFacts)
+}
+
+func TestBuildPostReadyRestoreRejectsIdentityFactsForExecOnlyStage(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, kbappsv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	backup := newBackupForRestoreDecision([]string{"data"}, nil)
+	backup.Status.BackupMethod.RestoreTargetIdentityFacts = []dpv1alpha1.RestoreTargetIdentityFact{
+		dpv1alpha1.RestoreTargetIdentityFactClusterTopology,
+	}
+	execActionSet := &dpv1alpha1.ActionSet{Spec: dpv1alpha1.ActionSetSpec{
+		Restore: &dpv1alpha1.RestoreActionSpec{PostReady: []dpv1alpha1.ActionSpec{{
+			Exec: &dpv1alpha1.ExecActionSpec{Command: []string{"true"}},
+		}}},
+	}}
+	comp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "mysql"),
+		},
+	}
+	pvc := newPVCForRestoreDecision("data", "mysql", "")
+	pvc.Spec.DataSourceRef = &corev1.TypedObjectReference{Name: backup.Name}
+	pvc.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(backup).Build(),
+		Scheme: scheme,
+	}
+	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{}, nil, scheme, reconciler.Client)
+	restoreMgr.PostReadyBackupSets = []dprestore.BackupActionSet{{Backup: backup, ActionSet: execActionSet}}
+
+	_, err := reconciler.buildPostReadyRestore(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp, "", nil)
+
+	require.ErrorContains(t, err, "restore target identity facts require a postReady Job action")
+
+	backup.Status.BackupMethod.RestoreTargetIdentityFacts = nil
+	legacyRestore, err := reconciler.buildPostReadyRestore(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp, "", nil)
+	require.NoError(t, err)
+	require.Empty(t, legacyRestore.Spec.ReadyConfig.JobAction.Target.RestoreTargetIdentityFacts)
 }
 
 func TestBuildPostReadyRestoreUsesInitAccountFromComponentDefinition(t *testing.T) {

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicies.yaml
@@ -195,6 +195,21 @@ spec:
                       description: The name of backup method.
                       pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                       type: string
+                    restoreTargetIdentityFacts:
+                      description: |-
+                        Specifies the target identity facts that the restore controller must resolve
+                        from the live target before running postReady Job actions.
+                      items:
+                        description: |-
+                          RestoreTargetIdentityFact identifies a controller-resolved target fact that
+                          a postReady Job action requires.
+                        enum:
+                        - ClusterTopology
+                        - ComponentServiceVersion
+                        type: string
+                      maxItems: 2
+                      type: array
+                      x-kubernetes-list-type: set
                     runtimeSettings:
                       description: Specifies runtime settings for the backup workload
                         container.

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicytemplates.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backuppolicytemplates.yaml
@@ -134,6 +134,21 @@ spec:
                       description: The name of backup method.
                       pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                       type: string
+                    restoreTargetIdentityFacts:
+                      description: |-
+                        Specifies the target identity facts that the restore controller must resolve
+                        from the live target before running postReady Job actions.
+                      items:
+                        description: |-
+                          RestoreTargetIdentityFact identifies a controller-resolved target fact that
+                          a postReady Job action requires.
+                        enum:
+                        - ClusterTopology
+                        - ComponentServiceVersion
+                        type: string
+                      maxItems: 2
+                      type: array
+                      x-kubernetes-list-type: set
                     runtimeSettings:
                       description: Specifies runtime settings for the backup workload
                         container.

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
@@ -417,6 +417,21 @@ spec:
                     description: The name of backup method.
                     pattern: ^[a-z0-9]([a-z0-9\.\-]*[a-z0-9])?$
                     type: string
+                  restoreTargetIdentityFacts:
+                    description: |-
+                      Specifies the target identity facts that the restore controller must resolve
+                      from the live target before running postReady Job actions.
+                    items:
+                      description: |-
+                        RestoreTargetIdentityFact identifies a controller-resolved target fact that
+                        a postReady Job action requires.
+                      enum:
+                      - ClusterTopology
+                      - ComponentServiceVersion
+                      type: string
+                    maxItems: 2
+                    type: array
+                    x-kubernetes-list-type: set
                   runtimeSettings:
                     description: Specifies runtime settings for the backup workload
                       container.

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_restores.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_restores.yaml
@@ -2258,6 +2258,21 @@ spec:
                                 type: boolean
                             type: object
                             x-kubernetes-map-type: atomic
+                          restoreTargetIdentityFacts:
+                            description: |-
+                              Specifies the target identity facts that the controller must resolve from
+                              the selected live target and inject into the postReady Job.
+                            items:
+                              description: |-
+                                RestoreTargetIdentityFact identifies a controller-resolved target fact that
+                                a postReady Job action requires.
+                              enum:
+                              - ClusterTopology
+                              - ComponentServiceVersion
+                              type: string
+                            maxItems: 2
+                            type: array
+                            x-kubernetes-list-type: set
                           volumeMounts:
                             description: Defines which volumes of the selected pod
                               need to be mounted on the restoring pod.
@@ -2434,6 +2449,17 @@ spec:
             x-kubernetes-validations:
             - message: forbidden to update spec.parameters
               rule: has(oldSelf.parameters) == has(self.parameters)
+            - message: forbidden to update spec.readyConfig.jobAction.target.restoreTargetIdentityFacts
+              rule: (has(self.readyConfig) && has(self.readyConfig.jobAction) && has(self.readyConfig.jobAction.target.restoreTargetIdentityFacts)
+                && size(self.readyConfig.jobAction.target.restoreTargetIdentityFacts)
+                > 0) == (has(oldSelf.readyConfig) && has(oldSelf.readyConfig.jobAction)
+                && has(oldSelf.readyConfig.jobAction.target.restoreTargetIdentityFacts)
+                && size(oldSelf.readyConfig.jobAction.target.restoreTargetIdentityFacts)
+                > 0) && (!(has(self.readyConfig) && has(self.readyConfig.jobAction)
+                && has(self.readyConfig.jobAction.target.restoreTargetIdentityFacts)
+                && size(self.readyConfig.jobAction.target.restoreTargetIdentityFacts)
+                > 0) || self.readyConfig.jobAction.target.restoreTargetIdentityFacts
+                == oldSelf.readyConfig.jobAction.target.restoreTargetIdentityFacts)
           status:
             description: RestoreStatus defines the observed state of Restore
             properties:

--- a/docs/developer_docs/api-reference/dataprotection.md
+++ b/docs/developer_docs/api-reference/dataprotection.md
@@ -2023,6 +2023,21 @@ RuntimeSettings
 </tr>
 <tr>
 <td>
+<code>restoreTargetIdentityFacts</code><br/>
+<em>
+<a href="#dataprotection.kubeblocks.io/v1alpha1.RestoreTargetIdentityFact">
+[]RestoreTargetIdentityFact
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Specifies the target identity facts that the restore controller must resolve
+from the live target before running postReady Job actions.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>target</code><br/>
 <em>
 <a href="#dataprotection.kubeblocks.io/v1alpha1.BackupTarget">
@@ -2158,6 +2173,21 @@ RuntimeSettings
 <td>
 <em>(Optional)</em>
 <p>Specifies runtime settings for the backup workload container.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>restoreTargetIdentityFacts</code><br/>
+<em>
+<a href="#dataprotection.kubeblocks.io/v1alpha1.RestoreTargetIdentityFact">
+[]RestoreTargetIdentityFact
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Specifies the target identity facts that the restore controller must resolve
+from the live target before running postReady Job actions.</p>
 </td>
 </tr>
 <tr>
@@ -4524,6 +4554,21 @@ This includes mounting required volumes and injecting built-in environment varia
 <p>Defines which volumes of the selected pod need to be mounted on the restoring pod.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>restoreTargetIdentityFacts</code><br/>
+<em>
+<a href="#dataprotection.kubeblocks.io/v1alpha1.RestoreTargetIdentityFact">
+[]RestoreTargetIdentityFact
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Specifies the target identity facts that the controller must resolve from
+the selected live target and inject into the postReady Job.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="dataprotection.kubeblocks.io/v1alpha1.KubeResources">KubeResources
@@ -5711,6 +5756,30 @@ Kubernetes meta/v1.Time
 </td>
 </tr>
 </tbody>
+</table>
+<h3 id="dataprotection.kubeblocks.io/v1alpha1.RestoreTargetIdentityFact">RestoreTargetIdentityFact
+(<code>string</code> alias)</h3>
+<p>
+(<em>Appears on:</em><a href="#dataprotection.kubeblocks.io/v1alpha1.BackupMethod">BackupMethod</a>, <a href="#dataprotection.kubeblocks.io/v1alpha1.BackupMethodTPL">BackupMethodTPL</a>, <a href="#dataprotection.kubeblocks.io/v1alpha1.JobActionTarget">JobActionTarget</a>)
+</p>
+<div>
+<p>RestoreTargetIdentityFact identifies a controller-resolved target fact that
+a postReady Job action requires.</p>
+</div>
+<table>
+<thead>
+<tr>
+<th>Value</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody><tr><td><p>&#34;ClusterTopology&#34;</p></td>
+<td><p>RestoreTargetIdentityFactClusterTopology requests the target Cluster topology.</p>
+</td>
+</tr><tr><td><p>&#34;ComponentServiceVersion&#34;</p></td>
+<td><p>RestoreTargetIdentityFactComponentServiceVersion requests the target Component service version.</p>
+</td>
+</tr></tbody>
 </table>
 <h3 id="dataprotection.kubeblocks.io/v1alpha1.RestoreVolumeClaim">RestoreVolumeClaim
 </h3>

--- a/pkg/dataprotection/utils/utils.go
+++ b/pkg/dataprotection/utils/utils.go
@@ -65,6 +65,28 @@ func AddTolerations(podSpec *corev1.PodSpec) (err error) {
 	return nil
 }
 
+// CanonicalRestoreTargetIdentityFacts returns a sorted, duplicate-free copy of
+// the requested restore target identity facts.
+func CanonicalRestoreTargetIdentityFacts(
+	facts []dpv1alpha1.RestoreTargetIdentityFact,
+) []dpv1alpha1.RestoreTargetIdentityFact {
+	if len(facts) == 0 {
+		return nil
+	}
+	set := make(map[dpv1alpha1.RestoreTargetIdentityFact]struct{}, len(facts))
+	for _, fact := range facts {
+		set[fact] = struct{}{}
+	}
+	canonical := make([]dpv1alpha1.RestoreTargetIdentityFact, 0, len(set))
+	for fact := range set {
+		canonical = append(canonical, fact)
+	}
+	sort.Slice(canonical, func(i, j int) bool {
+		return canonical[i] < canonical[j]
+	})
+	return canonical
+}
+
 // IsJobFinished if the job is completed or failed, return true.
 // if the job is failed, return the failed message.
 func IsJobFinished(job *batchv1.Job) (bool, batchv1.JobConditionType, string) {


### PR DESCRIPTION
Closes #10654.

## What this PR does

Adds an explicit, frozen contract for post-ready restore jobs that need live target identity:

- lets a backup method request `ClusterTopology` and/or `ComponentServiceVersion`;
- copies the opt-in from `BackupPolicyTemplate` to `BackupPolicy`;
- freezes the canonical fact set in `Backup.status.backupMethod` only after the New-to-Running status patch succeeds;
- unions the fact sets from all actual post-ready backup action sets and carries them into `Restore.spec.readyConfig.jobAction.target`;
- rejects post-create enablement, disablement, or value changes while treating absent and explicit empty sets as the same legacy state;
- canonicalizes only this set before existing post-ready Restore intent comparison, leaving all other Restore fields strict.

Legacy backup methods that do not request facts keep the existing behavior. A fact request without a post-ready Job action fails explicitly.

## Why

Post-ready restore actions may need target topology or component service-version values, but the restore producer previously had no durable way to state which values were required. The contract now originates in the backup method, is frozen with the selected method, and is propagated through the authoritative DataProtection writer chain without making the consumer infer intent from mutable policy objects.

## Tests

- `go test ./controllers/dataprotection -count=1`
- `go test ./pkg/dataprotection/utils -count=1`
- focused writer-chain tests repeated with `-count=3`
- focused envtest for API immutability, status freeze, and post-ready intent validation
- API package compile check
- scoped `go vet`
- `make test-go-generate`
- `make generate`
- `make manifests`
- `make doc`
- `git diff --check`

Generated config and Helm DataProtection CRDs were compared pairwise.

## Validation boundary

This PR has source, unit, envtest, and generated-artifact coverage. A live StarRocks Restore using the downstream environment resolver has not yet been run and is intentionally not claimed here.
