### PR TITLE
docs(api): correct rollingUpdate.replicas semantics to per-round pacing, not partition

### DIFF
--- a/apis/apps/v1/types.go
+++ b/apis/apps/v1/types.go
@@ -640,12 +640,16 @@ const (
 
 // RollingUpdate specifies how the rolling update should be applied.
 type RollingUpdate struct {
-	// Indicates the number of instances that should be updated during a rolling update.
-	// The remaining instances will remain untouched. This is helpful in defining how many instances
-	// should participate in the update process.
+	// Indicates the maximum number of instances that can be updated concurrently within a single
+	// reconciliation round, controlling the pace of a rolling update. Instances that are already
+	// up to date do not count against this limit, so the rolling update always proceeds, round by
+	// round, until all instances are updated; this field is not a partition-style gate and does not
+	// pause the rollout after a fixed number of instances. To pause a rollout for observation
+	// (e.g., canary-style upgrades), use the OnDelete strategy instead, where instances are updated
+	// only when they are manually deleted.
 	// Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
 	// Absolute number is calculated from percentage by rounding up.
-	// The default value is ComponentSpec.Replicas (i.e., update all instances).
+	// The default value is ComponentSpec.Replicas (i.e., no concurrency limit beyond maxUnavailable).
 	//
 	// +optional
 	Replicas *intstr.IntOrString `json:"replicas,omitempty"`

--- a/config/crd/bases/apps.kubeblocks.io_clusters.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusters.yaml
@@ -894,12 +894,16 @@ spec:
                               - type: integer
                               - type: string
                               description: |-
-                                Indicates the number of instances that should be updated during a rolling update.
-                                The remaining instances will remain untouched. This is helpful in defining how many instances
-                                should participate in the update process.
+                                Indicates the maximum number of instances that can be updated concurrently within a single
+                                reconciliation round, controlling the pace of a rolling update. Instances that are already
+                                up to date do not count against this limit, so the rolling update always proceeds, round by
+                                round, until all instances are updated; this field is not a partition-style gate and does not
+                                pause the rollout after a fixed number of instances. To pause a rollout for observation
+                                (e.g., canary-style upgrades), use the OnDelete strategy instead, where instances are updated
+                                only when they are manually deleted.
                                 Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
                                 Absolute number is calculated from percentage by rounding up.
-                                The default value is ComponentSpec.Replicas (i.e., update all instances).
+                                The default value is ComponentSpec.Replicas (i.e., no concurrency limit beyond maxUnavailable).
                               x-kubernetes-int-or-string: true
                           type: object
                         type:
@@ -12119,12 +12123,16 @@ spec:
                                   - type: integer
                                   - type: string
                                   description: |-
-                                    Indicates the number of instances that should be updated during a rolling update.
-                                    The remaining instances will remain untouched. This is helpful in defining how many instances
-                                    should participate in the update process.
+                                    Indicates the maximum number of instances that can be updated concurrently within a single
+                                    reconciliation round, controlling the pace of a rolling update. Instances that are already
+                                    up to date do not count against this limit, so the rolling update always proceeds, round by
+                                    round, until all instances are updated; this field is not a partition-style gate and does not
+                                    pause the rollout after a fixed number of instances. To pause a rollout for observation
+                                    (e.g., canary-style upgrades), use the OnDelete strategy instead, where instances are updated
+                                    only when they are manually deleted.
                                     Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
                                     Absolute number is calculated from percentage by rounding up.
-                                    The default value is ComponentSpec.Replicas (i.e., update all instances).
+                                    The default value is ComponentSpec.Replicas (i.e., no concurrency limit beyond maxUnavailable).
                                   x-kubernetes-int-or-string: true
                               type: object
                             type:

--- a/config/crd/bases/apps.kubeblocks.io_components.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_components.yaml
@@ -1197,12 +1197,16 @@ spec:
                         - type: integer
                         - type: string
                         description: |-
-                          Indicates the number of instances that should be updated during a rolling update.
-                          The remaining instances will remain untouched. This is helpful in defining how many instances
-                          should participate in the update process.
+                          Indicates the maximum number of instances that can be updated concurrently within a single
+                          reconciliation round, controlling the pace of a rolling update. Instances that are already
+                          up to date do not count against this limit, so the rolling update always proceeds, round by
+                          round, until all instances are updated; this field is not a partition-style gate and does not
+                          pause the rollout after a fixed number of instances. To pause a rollout for observation
+                          (e.g., canary-style upgrades), use the OnDelete strategy instead, where instances are updated
+                          only when they are manually deleted.
                           Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
                           Absolute number is calculated from percentage by rounding up.
-                          The default value is ComponentSpec.Replicas (i.e., update all instances).
+                          The default value is ComponentSpec.Replicas (i.e., no concurrency limit beyond maxUnavailable).
                         x-kubernetes-int-or-string: true
                     type: object
                   type:

--- a/config/crd/bases/workloads.kubeblocks.io_instancesets.yaml
+++ b/config/crd/bases/workloads.kubeblocks.io_instancesets.yaml
@@ -612,12 +612,16 @@ spec:
                         - type: integer
                         - type: string
                         description: |-
-                          Indicates the number of instances that should be updated during a rolling update.
-                          The remaining instances will remain untouched. This is helpful in defining how many instances
-                          should participate in the update process.
+                          Indicates the maximum number of instances that can be updated concurrently within a single
+                          reconciliation round, controlling the pace of a rolling update. Instances that are already
+                          up to date do not count against this limit, so the rolling update always proceeds, round by
+                          round, until all instances are updated; this field is not a partition-style gate and does not
+                          pause the rollout after a fixed number of instances. To pause a rollout for observation
+                          (e.g., canary-style upgrades), use the OnDelete strategy instead, where instances are updated
+                          only when they are manually deleted.
                           Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
                           Absolute number is calculated from percentage by rounding up.
-                          The default value is ComponentSpec.Replicas (i.e., update all instances).
+                          The default value is ComponentSpec.Replicas (i.e., no concurrency limit beyond maxUnavailable).
                         x-kubernetes-int-or-string: true
                     type: object
                   type:

--- a/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
@@ -894,12 +894,16 @@ spec:
                               - type: integer
                               - type: string
                               description: |-
-                                Indicates the number of instances that should be updated during a rolling update.
-                                The remaining instances will remain untouched. This is helpful in defining how many instances
-                                should participate in the update process.
+                                Indicates the maximum number of instances that can be updated concurrently within a single
+                                reconciliation round, controlling the pace of a rolling update. Instances that are already
+                                up to date do not count against this limit, so the rolling update always proceeds, round by
+                                round, until all instances are updated; this field is not a partition-style gate and does not
+                                pause the rollout after a fixed number of instances. To pause a rollout for observation
+                                (e.g., canary-style upgrades), use the OnDelete strategy instead, where instances are updated
+                                only when they are manually deleted.
                                 Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
                                 Absolute number is calculated from percentage by rounding up.
-                                The default value is ComponentSpec.Replicas (i.e., update all instances).
+                                The default value is ComponentSpec.Replicas (i.e., no concurrency limit beyond maxUnavailable).
                               x-kubernetes-int-or-string: true
                           type: object
                         type:
@@ -12119,12 +12123,16 @@ spec:
                                   - type: integer
                                   - type: string
                                   description: |-
-                                    Indicates the number of instances that should be updated during a rolling update.
-                                    The remaining instances will remain untouched. This is helpful in defining how many instances
-                                    should participate in the update process.
+                                    Indicates the maximum number of instances that can be updated concurrently within a single
+                                    reconciliation round, controlling the pace of a rolling update. Instances that are already
+                                    up to date do not count against this limit, so the rolling update always proceeds, round by
+                                    round, until all instances are updated; this field is not a partition-style gate and does not
+                                    pause the rollout after a fixed number of instances. To pause a rollout for observation
+                                    (e.g., canary-style upgrades), use the OnDelete strategy instead, where instances are updated
+                                    only when they are manually deleted.
                                     Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
                                     Absolute number is calculated from percentage by rounding up.
-                                    The default value is ComponentSpec.Replicas (i.e., update all instances).
+                                    The default value is ComponentSpec.Replicas (i.e., no concurrency limit beyond maxUnavailable).
                                   x-kubernetes-int-or-string: true
                               type: object
                             type:

--- a/deploy/helm/crds/apps.kubeblocks.io_components.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_components.yaml
@@ -1197,12 +1197,16 @@ spec:
                         - type: integer
                         - type: string
                         description: |-
-                          Indicates the number of instances that should be updated during a rolling update.
-                          The remaining instances will remain untouched. This is helpful in defining how many instances
-                          should participate in the update process.
+                          Indicates the maximum number of instances that can be updated concurrently within a single
+                          reconciliation round, controlling the pace of a rolling update. Instances that are already
+                          up to date do not count against this limit, so the rolling update always proceeds, round by
+                          round, until all instances are updated; this field is not a partition-style gate and does not
+                          pause the rollout after a fixed number of instances. To pause a rollout for observation
+                          (e.g., canary-style upgrades), use the OnDelete strategy instead, where instances are updated
+                          only when they are manually deleted.
                           Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
                           Absolute number is calculated from percentage by rounding up.
-                          The default value is ComponentSpec.Replicas (i.e., update all instances).
+                          The default value is ComponentSpec.Replicas (i.e., no concurrency limit beyond maxUnavailable).
                         x-kubernetes-int-or-string: true
                     type: object
                   type:

--- a/deploy/helm/crds/workloads.kubeblocks.io_instancesets.yaml
+++ b/deploy/helm/crds/workloads.kubeblocks.io_instancesets.yaml
@@ -612,12 +612,16 @@ spec:
                         - type: integer
                         - type: string
                         description: |-
-                          Indicates the number of instances that should be updated during a rolling update.
-                          The remaining instances will remain untouched. This is helpful in defining how many instances
-                          should participate in the update process.
+                          Indicates the maximum number of instances that can be updated concurrently within a single
+                          reconciliation round, controlling the pace of a rolling update. Instances that are already
+                          up to date do not count against this limit, so the rolling update always proceeds, round by
+                          round, until all instances are updated; this field is not a partition-style gate and does not
+                          pause the rollout after a fixed number of instances. To pause a rollout for observation
+                          (e.g., canary-style upgrades), use the OnDelete strategy instead, where instances are updated
+                          only when they are manually deleted.
                           Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
                           Absolute number is calculated from percentage by rounding up.
-                          The default value is ComponentSpec.Replicas (i.e., update all instances).
+                          The default value is ComponentSpec.Replicas (i.e., no concurrency limit beyond maxUnavailable).
                         x-kubernetes-int-or-string: true
                     type: object
                   type:

--- a/docs/developer_docs/api-reference/cluster.md
+++ b/docs/developer_docs/api-reference/cluster.md
@@ -10976,12 +10976,16 @@ Kubernetes api utils intstr.IntOrString
 </td>
 <td>
 <em>(Optional)</em>
-<p>Indicates the number of instances that should be updated during a rolling update.
-The remaining instances will remain untouched. This is helpful in defining how many instances
-should participate in the update process.
+<p>Indicates the maximum number of instances that can be updated concurrently within a single
+reconciliation round, controlling the pace of a rolling update. Instances that are already
+up to date do not count against this limit, so the rolling update always proceeds, round by
+round, until all instances are updated; this field is not a partition-style gate and does not
+pause the rollout after a fixed number of instances. To pause a rollout for observation
+(e.g., canary-style upgrades), use the OnDelete strategy instead, where instances are updated
+only when they are manually deleted.
 Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
 Absolute number is calculated from percentage by rounding up.
-The default value is ComponentSpec.Replicas (i.e., update all instances).</p>
+The default value is ComponentSpec.Replicas (i.e., no concurrency limit beyond maxUnavailable).</p>
 </td>
 </tr>
 <tr>

--- a/pkg/controller/instanceset/reconciler_update_test.go
+++ b/pkg/controller/instanceset/reconciler_update_test.go
@@ -176,7 +176,7 @@ var _ = Describe("update reconciler test", func() {
 			}
 			reconciler = NewUpdateReconciler()
 
-			By("reconcile with default UpdateStrategy(RollingUpdate, no partition, MaxUnavailable=1)")
+			By("reconcile with default UpdateStrategy(RollingUpdate, no per-round update limit, MaxUnavailable=1)")
 			// order: bar-hello-0, bar-foo-1, bar-foo-0, bar-3, bar-2, bar-1, bar-0
 			// expected: bar-hello-0 being deleted
 			defaultTree, err := tree.DeepCopy()
@@ -186,7 +186,7 @@ var _ = Describe("update reconciler test", func() {
 			Expect(res).Should(Equal(kubebuilderx.Continue))
 			expectUpdatedPods(defaultTree, []string{"bar-hello-0"})
 
-			By("reconcile with Partition=50% and MaxUnavailable=2")
+			By("reconcile with per-round update limit Replicas=3 and MaxUnavailable=2")
 			partitionTree, err := tree.DeepCopy()
 			Expect(err).Should(BeNil())
 			root, ok := partitionTree.GetRoot().(*workloads.InstanceSet)


### PR DESCRIPTION
## What this PR does

Doc-only fix. The API doc comment for `InstanceUpdateStrategy.rollingUpdate.replicas` promised partition-style semantics ("The remaining instances will remain untouched"), but the implementation is a per-reconciliation-round pacing cap: already-updated instances take the no-op branch and do not consume the quota, so the rollout always proceeds round by round until all instances are updated (see the analysis in the linked issue; pinned by the existing unit test in `reconciler_update_test.go`).

Changes:
- Rewrite the `replicas` field doc to describe the actual per-round pacing semantics, state explicitly that it is not a partition-style gate, and point users to the `OnDelete` strategy for pause-and-observe (canary) upgrades.
- Fix the misleading "Partition" wording in the update reconciler test `By(...)` descriptions (no assertion changes).
- Regenerate CRDs (`config/crd/bases` + `deploy/helm/crds`) and the API reference.

No behavior change; the update reconciler is untouched.

Fixes #10656