### PR TITLE
fix: restore rolling update replicas limit

### DIFF
--- a/controllers/workloads/instanceset_controller_2_test.go
+++ b/controllers/workloads/instanceset_controller_2_test.go
@@ -371,6 +371,61 @@ var _ = Describe("InstanceSet Controller 2", func() {
 			}).Should(Succeed())
 		})
 
+		It("uses status role order for a roleful rolling-update window", func() {
+			createITSObj(itsName, func(f *testapps.MockInstanceSetFactory) {
+				f.SetRoles([]workloads.ReplicaRole{
+					{
+						Name:                 "follower",
+						UpdatePriority:       1,
+						ParticipatesInQuorum: true,
+					},
+					{
+						Name:                 "leader",
+						UpdatePriority:       2,
+						ParticipatesInQuorum: true,
+					},
+				}).SetInstanceUpdateStrategy(&workloads.InstanceUpdateStrategy{
+					Type: kbappsv1.RollingUpdateStrategyType,
+					RollingUpdate: &workloads.RollingUpdate{
+						Replicas:       ptr.To(intstr.FromInt32(1)),
+						MaxUnavailable: ptr.To(intstr.FromInt32(1)),
+					},
+				})
+			})
+
+			// The follower has the lowest name but the highest update precedence.
+			mockPodReadyNAvailableWithRole(itsObj.Namespace, podName(0), "follower", 0)
+			for i := int32(1); i < replicas; i++ {
+				mockPodReadyNAvailableWithRole(itsObj.Namespace, podName(i), "leader", 0)
+			}
+
+			By("check its ready with observed roles")
+			Eventually(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
+				g.Expect(its.IsInstanceSetReady()).Should(BeTrue())
+			})).Should(Succeed())
+
+			By("update its spec")
+			Expect(testapps.GetAndChangeObj(&testCtx, itsKey, func(its *workloads.InstanceSet) {
+				its.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
+			})()).ShouldNot(HaveOccurred())
+
+			followerKey := types.NamespacedName{Namespace: itsObj.Namespace, Name: podName(0)}
+			By("update the follower inside the role-ordered window")
+			Eventually(testapps.CheckObj(&testCtx, followerKey, func(g Gomega, inst *workloads.Instance) {
+				g.Expect(inst.Spec.Template.Spec.DNSPolicy).Should(Equal(corev1.DNSClusterFirstWithHostNet))
+			})).Should(Succeed())
+
+			By("keep leaders outside the rolling-update window")
+			Consistently(func(g Gomega) {
+				for i := int32(1); i < replicas; i++ {
+					inst := &workloads.Instance{}
+					key := types.NamespacedName{Namespace: itsObj.Namespace, Name: podName(i)}
+					g.Expect(testCtx.Cli.Get(testCtx.Ctx, key, inst)).Should(Succeed())
+					g.Expect(inst.Spec.Template.Spec.DNSPolicy).ShouldNot(Equal(corev1.DNSClusterFirstWithHostNet))
+				}
+			}).Should(Succeed())
+		})
+
 		It("scale-in", func() {
 			createITSObj(itsName)
 

--- a/controllers/workloads/instanceset_controller_2_test.go
+++ b/controllers/workloads/instanceset_controller_2_test.go
@@ -258,7 +258,7 @@ var _ = Describe("InstanceSet Controller 2", func() {
 				f.SetInstanceUpdateStrategy(&workloads.InstanceUpdateStrategy{
 					Type: kbappsv1.RollingUpdateStrategyType,
 					RollingUpdate: &workloads.RollingUpdate{
-						Replicas: &intstr.IntOrString{
+						MaxUnavailable: &intstr.IntOrString{
 							Type:   intstr.Int,
 							IntVal: 1, // one instance at a time
 						},
@@ -315,6 +315,60 @@ var _ = Describe("InstanceSet Controller 2", func() {
 			Eventually(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
 				g.Expect(its.IsInstanceSetReady()).Should(BeTrue())
 			})).Should(Succeed())
+		})
+
+		It("limits rolling update to replicas", func() {
+			createITSObj(itsName, func(f *testapps.MockInstanceSetFactory) {
+				f.SetInstanceUpdateStrategy(&workloads.InstanceUpdateStrategy{
+					Type: kbappsv1.RollingUpdateStrategyType,
+					RollingUpdate: &workloads.RollingUpdate{
+						Replicas:       ptr.To(intstr.FromInt32(1)),
+						MaxUnavailable: ptr.To(intstr.FromInt32(2)),
+					},
+				})
+			})
+
+			mockPodsReady()
+
+			By("check its ready")
+			Eventually(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
+				g.Expect(its.IsInstanceSetReady()).Should(BeTrue())
+			})).Should(Succeed())
+
+			By("update its spec")
+			beforeUpdate := time.Now()
+			time.Sleep(1 * time.Second)
+			Expect(testapps.GetAndChangeObj(&testCtx, itsKey, func(its *workloads.InstanceSet) {
+				its.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
+			})()).ShouldNot(HaveOccurred())
+
+			updatedInstanceKey := types.NamespacedName{
+				Namespace: itsObj.Namespace,
+				Name:      podName(replicas - 1),
+			}
+			By("check the first instance updated")
+			Eventually(testapps.CheckObj(&testCtx, updatedInstanceKey, func(g Gomega, inst *workloads.Instance) {
+				g.Expect(inst.Spec.Template.Spec.DNSPolicy).Should(Equal(corev1.DNSClusterFirstWithHostNet))
+			})).Should(Succeed())
+
+			By("wait for its new pod and mock it ready")
+			Eventually(testapps.CheckObj(&testCtx, updatedInstanceKey, func(g Gomega, pod *corev1.Pod) {
+				g.Expect(pod.CreationTimestamp.After(beforeUpdate)).Should(BeTrue())
+			})).Should(Succeed())
+			mockPodReady(itsObj.Namespace, updatedInstanceKey.Name)
+			Eventually(testapps.CheckObj(&testCtx, updatedInstanceKey, func(g Gomega, inst *workloads.Instance) {
+				g.Expect(intctrlutil.IsInstanceReady(inst)).Should(BeTrue())
+			})).Should(Succeed())
+
+			By("keep the remaining instances outside the rolling-update window")
+			Consistently(func(g Gomega) {
+				for i := int32(0); i < replicas-1; i++ {
+					inst := &workloads.Instance{}
+					key := types.NamespacedName{Namespace: itsObj.Namespace, Name: podName(i)}
+					g.Expect(testCtx.Cli.Get(testCtx.Ctx, key, inst)).Should(Succeed())
+					g.Expect(inst.Spec.Template.Spec.DNSPolicy).ShouldNot(Equal(corev1.DNSClusterFirstWithHostNet))
+				}
+			}).Should(Succeed())
 		})
 
 		It("scale-in", func() {

--- a/controllers/workloads/instanceset_controller_test.go
+++ b/controllers/workloads/instanceset_controller_test.go
@@ -191,7 +191,7 @@ var _ = Describe("InstanceSet Controller", func() {
 					SetInstanceUpdateStrategy(&workloads.InstanceUpdateStrategy{
 						Type: kbappsv1.RollingUpdateStrategyType,
 						RollingUpdate: &workloads.RollingUpdate{
-							Replicas: &intstr.IntOrString{
+							MaxUnavailable: &intstr.IntOrString{
 								Type:   intstr.Int,
 								IntVal: 1, // one instance at a time
 							},

--- a/pkg/controller/instanceset/reconciler_update.go
+++ b/pkg/controller/instanceset/reconciler_update.go
@@ -132,11 +132,17 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 		}
 	}
 
+	// updatedPods tracks the positions already covered by the rolling-update
+	// window, while updatingPods tracks actual updates admitted in this round.
+	updatedPods := 0
 	updatingPods := 0
 	isBlocked := false
 	needRetry := false
 	for _, pod := range oldPodList {
-		if updatingPods >= rollingUpdateQuota || updatingPods >= unavailableQuota {
+		if updatedPods >= rollingUpdateQuota {
+			break
+		}
+		if updatingPods >= unavailableQuota {
 			break
 		}
 		if updatingPods >= memberUpdateQuota {
@@ -215,6 +221,7 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 			}
 			updatingPods++
 		}
+		updatedPods++
 	}
 
 	if !isBlocked {

--- a/pkg/controller/instanceset/reconciler_update_test.go
+++ b/pkg/controller/instanceset/reconciler_update_test.go
@@ -186,7 +186,7 @@ var _ = Describe("update reconciler test", func() {
 			Expect(res).Should(Equal(kubebuilderx.Continue))
 			expectUpdatedPods(defaultTree, []string{"bar-hello-0"})
 
-			By("reconcile with Partition=50% and MaxUnavailable=2")
+			By("reconcile with Replicas=3 and MaxUnavailable=2")
 			partitionTree, err := tree.DeepCopy()
 			Expect(err).Should(BeNil())
 			root, ok := partitionTree.GetRoot().(*workloads.InstanceSet)
@@ -228,7 +228,9 @@ var _ = Describe("update reconciler test", func() {
 			res, err = reconciler.Reconcile(partitionTree)
 			Expect(err).Should(BeNil())
 			Expect(res).Should(Equal(kubebuilderx.Continue))
-			expectUpdatedPods(partitionTree, []string{"bar-foo-0", "bar-3"})
+			// The first two pods already occupy two positions in the rolling-update
+			// window, so only one more pod can be updated.
+			expectUpdatedPods(partitionTree, []string{"bar-foo-0"})
 
 			By("reconcile with UpdateStrategy='OnDelete'")
 			onDeleteTree, err := tree.DeepCopy()

--- a/pkg/controller/instanceset2/reconciler_update.go
+++ b/pkg/controller/instanceset2/reconciler_update.go
@@ -123,7 +123,7 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 	updatedInstances := 0
 	updatingInstances := 0
 	priorities := composeRolePriorityMap(its.Spec.Roles)
-	sortObjects(oldInstanceList, priorities, false)
+	sortInstanceObjects(oldInstanceList, priorities, false)
 
 	canBeUpdated := func(inst *workloads.Instance) bool {
 		if !intctrlutil.IsInstanceReady(inst) {

--- a/pkg/controller/instanceset2/reconciler_update.go
+++ b/pkg/controller/instanceset2/reconciler_update.go
@@ -118,6 +118,9 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 		updateCount = len(instancesToBeUpdated)
 	}
 
+	// updatedInstances tracks the positions already covered by the rolling-update
+	// window, while updatingInstances tracks actual updates admitted in this round.
+	updatedInstances := 0
 	updatingInstances := 0
 	priorities := composeRolePriorityMap(its.Spec.Roles)
 	sortObjects(oldInstanceList, priorities, false)
@@ -139,7 +142,10 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 	}
 
 	for _, inst := range oldInstanceList {
-		if updatingInstances >= min(replicas, unavailable, updateCount) {
+		if updatedInstances >= replicas {
+			break
+		}
+		if updatingInstances >= min(unavailable, updateCount) {
 			break
 		}
 
@@ -159,6 +165,7 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 			}
 			updatingInstances++
 		}
+		updatedInstances++
 	}
 	return kubebuilderx.Continue, nil
 }

--- a/pkg/controller/instanceset2/utils.go
+++ b/pkg/controller/instanceset2/utils.go
@@ -47,12 +47,25 @@ func composeRolePriorityMap(roles []workloads.ReplicaRole) map[string]int {
 // e.g.: unknown -> empty -> learner -> follower1 -> follower2 -> leader, with follower1.Name > follower2.Name
 // reverse it if reverse==true
 func sortInstances(instances []workloads.Instance, rolePriorityMap map[string]int, reverse bool) {
+	sortInstancesByRole(instances, func(i int) *workloads.Instance {
+		return &instances[i]
+	}, rolePriorityMap, reverse)
+}
+
+func sortInstanceObjects(instances []*workloads.Instance, rolePriorityMap map[string]int, reverse bool) {
+	sortInstancesByRole(instances, func(i int) *workloads.Instance {
+		return instances[i]
+	}, rolePriorityMap, reverse)
+}
+
+func sortInstancesByRole[T any](instances []T, instanceAt func(int) *workloads.Instance,
+	rolePriorityMap map[string]int, reverse bool) {
 	getRolePriorityFunc := func(i int) int {
-		role := getInstanceRoleName(&instances[i])
+		role := getInstanceRoleName(instanceAt(i))
 		return rolePriorityMap[role]
 	}
 	getNameNOrdinalFunc := func(i int) (string, int) {
-		return parseParentNameAndOrdinal(instances[i].GetName())
+		return parseParentNameAndOrdinal(instanceAt(i).GetName())
 	}
 	baseSort(instances, getNameNOrdinalFunc, getRolePriorityFunc, reverse)
 }


### PR DESCRIPTION
## Summary

- restore rollingUpdate.replicas as the total ordered update window
- keep maxUnavailable and member update quotas scoped to actual updates in each reconciliation
- cover both the direct Pod path and the Instance API path with regression tests
- update the existing sequential rollout test to use maxUnavailable for concurrency

## Tests

- go test -mod=mod -overlay=/private/tmp/kubeblocks-rolling-update-test-overlay.json ./pkg/controller/instanceset -run TestAPIs -ginkgo.focus='update reconciler test' -count=1
- go test -mod=mod ./pkg/controller/instanceset2 -count=1
- go test -mod=mod ./controllers/workloads -run TestAPIs -ginkgo.focus='InstanceSet Controller 2.*(rolling|limits rolling update)' -count=1

Regression introduced by #9807.

Fixes #10641