### PR TITLE
fix: restore rolling update replicas limit

### DIFF
--- a/controllers/workloads/instanceset_controller_test.go
+++ b/controllers/workloads/instanceset_controller_test.go
@@ -187,7 +187,7 @@ var _ = Describe("InstanceSet Controller", func() {
 					SetInstanceUpdateStrategy(&workloads.InstanceUpdateStrategy{
 						Type: kbappsv1.RollingUpdateStrategyType,
 						RollingUpdate: &workloads.RollingUpdate{
-							Replicas: &intstr.IntOrString{
+							MaxUnavailable: &intstr.IntOrString{
 								Type:   intstr.Int,
 								IntVal: 1, // one instance at a time
 							},

--- a/pkg/controller/instanceset/reconciler_update.go
+++ b/pkg/controller/instanceset/reconciler_update.go
@@ -132,11 +132,17 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 		}
 	}
 
+	// updatedPods tracks the positions already covered by the rolling-update
+	// window, while updatingPods tracks actual updates admitted in this round.
+	updatedPods := 0
 	updatingPods := 0
 	isBlocked := false
 	needRetry := false
 	for _, pod := range oldPodList {
-		if updatingPods >= rollingUpdateQuota || updatingPods >= unavailableQuota {
+		if updatedPods >= rollingUpdateQuota {
+			break
+		}
+		if updatingPods >= unavailableQuota {
 			break
 		}
 		if updatingPods >= memberUpdateQuota {
@@ -213,6 +219,7 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 				updatingPods++
 			}
 		}
+		updatedPods++
 	}
 
 	if !isBlocked {

--- a/pkg/controller/instanceset/reconciler_update_test.go
+++ b/pkg/controller/instanceset/reconciler_update_test.go
@@ -173,7 +173,7 @@ var _ = Describe("update reconciler test", func() {
 			Expect(res).Should(Equal(kubebuilderx.Continue))
 			expectUpdatedPods(defaultTree, []string{"bar-hello-0"})
 
-			By("reconcile with Partition=50% and MaxUnavailable=2")
+			By("reconcile with Replicas=3 and MaxUnavailable=2")
 			partitionTree, err := tree.DeepCopy()
 			Expect(err).Should(BeNil())
 			root, ok := partitionTree.GetRoot().(*workloads.InstanceSet)
@@ -215,7 +215,9 @@ var _ = Describe("update reconciler test", func() {
 			res, err = reconciler.Reconcile(partitionTree)
 			Expect(err).Should(BeNil())
 			Expect(res).Should(Equal(kubebuilderx.Continue))
-			expectUpdatedPods(partitionTree, []string{"bar-foo-0", "bar-3"})
+			// The first two pods already occupy two positions in the rolling-update
+			// window, so only one more pod can be updated.
+			expectUpdatedPods(partitionTree, []string{"bar-foo-0"})
 
 			By("reconcile with UpdateStrategy='OnDelete'")
 			onDeleteTree, err := tree.DeepCopy()


### PR DESCRIPTION
## Summary

- restore rollingUpdate.replicas as the total ordered update window on release-1.0
- keep maxUnavailable and member update quotas scoped to actual updates in each reconciliation
- update the existing regression test so completed Pods continue to occupy the replicas window
- keep the backport scoped to the legacy Pod-based InstanceSet path available on release-1.0

## Tests

- go test -mod=mod ./pkg/controller/instanceset -run TestAPIs -ginkgo.focus='update reconciler test' -count=1
- go test -mod=mod ./pkg/controller/instanceset -count=1
- go test -mod=mod ./controllers/workloads -run TestAPIs -ginkgo.focus='rolling' -count=1

Fixes #10641.

release-1.0 counterpart of #10658; regression introduced by #9810.