### PR TITLE
fix(instanceset): keep rolling update participants stable

### DIFF
--- a/pkg/controller/instanceset/reconciler_update.go
+++ b/pkg/controller/instanceset/reconciler_update.go
@@ -118,38 +118,36 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 	priorities := ComposeRolePriorityMap(its.Spec.Roles)
 	sortObjects(oldPodList, priorities, false)
 
-	// treat old and Pending pod as a special case, as they can be updated without a consequence
-	// PodUpdatePolicy is ignored here since in-place update for a pending pod doesn't make much sense.
-	for _, pod := range oldPodList {
-		updatePolicy, _, _, err := getPodUpdatePolicy(its, pod)
-		if err != nil {
-			return kubebuilderx.Continue, err
-		}
-		if isPodPending(pod) && updatePolicy != noOpsPolicy {
-			err = tree.Delete(pod)
-			// wait another reconciliation, so that the following update process won't be confused
-			return kubebuilderx.Continue, err
-		}
-	}
-
 	updatingPods := 0
 	isBlocked := false
 	needRetry := false
 	for _, pod := range oldPodList {
-		if updatingPods >= rollingUpdateQuota || updatingPods >= unavailableQuota {
+		if updatingPods >= rollingUpdateQuota {
 			break
 		}
 		if updatingPods >= memberUpdateQuota {
-			break
-		}
-		if canBeUpdated, retry := r.isPodCanBeUpdated(tree, its, pod); !canBeUpdated {
-			needRetry = retry
 			break
 		}
 
 		updatePolicy, specUpdatePolicy, recreateReason, err := getPodUpdatePolicy(its, pod)
 		if err != nil {
 			return kubebuilderx.Continue, err
+		}
+		if isPodPending(pod) && updatePolicy != noOpsPolicy {
+			// PodUpdatePolicy is ignored here since in-place update for a pending pod
+			// does not make much sense. The pod still consumes the rolling window,
+			// but it keeps the historical maxUnavailable bypass because it is
+			// already unavailable.
+			err = tree.Delete(pod)
+			// wait another reconciliation, so that the following update process won't be confused
+			return kubebuilderx.Continue, err
+		}
+		if updatingPods >= unavailableQuota {
+			break
+		}
+		if canBeUpdated, retry := r.isPodCanBeUpdated(tree, its, pod); !canBeUpdated {
+			needRetry = retry
+			break
 		}
 		if updatePolicy == recreatePolicy && specUpdatePolicy == kbappsv1.StrictInPlacePodUpdatePolicyType {
 			message := fmt.Sprintf("InstanceSet %s/%s blocks on update as the PodUpdatePolicy is %s and the pod %s can not inplace update",
@@ -233,10 +231,22 @@ func (r *updateReconciler) rollingUpdateQuota(its *workloads.InstanceSet, podLis
 		return -1, -1, err
 	}
 	currentUnavailable := 0
+	updatedReplicas := 0
 	for _, pod := range podList {
 		if !intctrlutil.IsPodAvailable(pod, its.Spec.MinReadySeconds) {
 			currentUnavailable++
 		}
+		updated, err := r.isInstUpdated(its, pod)
+		if err != nil {
+			return -1, -1, err
+		}
+		if updated {
+			updatedReplicas++
+		}
+	}
+	replicas -= updatedReplicas
+	if replicas < 0 {
+		replicas = 0
 	}
 	unavailable := maxUnavailable - currentUnavailable
 	return replicas, unavailable, nil

--- a/pkg/controller/instanceset/reconciler_update_test.go
+++ b/pkg/controller/instanceset/reconciler_update_test.go
@@ -228,7 +228,9 @@ var _ = Describe("update reconciler test", func() {
 			res, err = reconciler.Reconcile(partitionTree)
 			Expect(err).Should(BeNil())
 			Expect(res).Should(Equal(kubebuilderx.Continue))
-			expectUpdatedPods(partitionTree, []string{"bar-foo-0", "bar-3"})
+			// The first two pods already occupy two positions in the rolling-update
+			// window, so only one more pod can be updated.
+			expectUpdatedPods(partitionTree, []string{"bar-foo-0"})
 
 			By("reconcile with UpdateStrategy='OnDelete'")
 			onDeleteTree, err := tree.DeepCopy()
@@ -370,6 +372,104 @@ var _ = Describe("update reconciler test", func() {
 			Expect(err).Should(BeNil())
 			Expect(res).Should(Equal(kubebuilderx.Continue))
 			expectUpdatedPods(tree, []string{"bar-1"})
+		})
+
+		It("keeps pending pods outside the rolling-update replicas window", func() {
+			tree := kubebuilderx.NewObjectTree()
+			its.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+			updateReplicas := intstr.FromInt32(1)
+			maxUnavailable := intstr.FromInt32(2)
+			its.Spec.InstanceUpdateStrategy = &workloads.InstanceUpdateStrategy{
+				RollingUpdate: &workloads.RollingUpdate{
+					Replicas:       &updateReplicas,
+					MaxUnavailable: &maxUnavailable,
+				},
+			}
+			tree.SetRoot(its)
+
+			prepareForUpdate(tree)
+			updateRevisions, err := GetRevisions(its.Status.UpdateRevisions)
+			Expect(err).Should(BeNil())
+
+			for _, object := range tree.List(&corev1.Pod{}) {
+				pod, ok := object.(*corev1.Pod)
+				Expect(ok).Should(BeTrue())
+				pod.Status.Conditions = append(pod.Status.Conditions, getPodReadyCondition())
+				switch pod.Name {
+				case "bar-2":
+					pod.Labels[appsv1.ControllerRevisionHashLabelKey] = updateRevisions[pod.Name]
+					pod.Status.Phase = corev1.PodRunning
+				case "bar-0":
+					pod.Labels[appsv1.ControllerRevisionHashLabelKey] = oldRevisionStr
+					pod.Status.Phase = corev1.PodPending
+				default:
+					pod.Labels[appsv1.ControllerRevisionHashLabelKey] = oldRevisionStr
+					pod.Status.Phase = corev1.PodRunning
+				}
+			}
+
+			reconciler = NewUpdateReconciler()
+			res, err := reconciler.Reconcile(tree)
+			Expect(err).Should(BeNil())
+			Expect(res).Should(Equal(kubebuilderx.Continue))
+			expectUpdatedPods(tree, []string{})
+		})
+
+		It("does not admit a new pod after role changes move the updated pod outside the rolling-update window", func() {
+			tree := kubebuilderx.NewObjectTree()
+			its.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+			its.Spec.Roles = []workloads.ReplicaRole{
+				{
+					Name:                 "follower",
+					UpdatePriority:       1,
+					ParticipatesInQuorum: true,
+				},
+				{
+					Name:                 "leader",
+					UpdatePriority:       2,
+					ParticipatesInQuorum: true,
+				},
+			}
+			updateReplicas := intstr.FromInt32(1)
+			maxUnavailable := intstr.FromInt32(2)
+			its.Spec.InstanceUpdateStrategy = &workloads.InstanceUpdateStrategy{
+				RollingUpdate: &workloads.RollingUpdate{
+					Replicas:       &updateReplicas,
+					MaxUnavailable: &maxUnavailable,
+				},
+			}
+			tree.SetRoot(its)
+
+			prepareForUpdate(tree)
+			updateRevisions, err := GetRevisions(its.Status.UpdateRevisions)
+			Expect(err).Should(BeNil())
+
+			for _, object := range tree.List(&corev1.Pod{}) {
+				pod, ok := object.(*corev1.Pod)
+				Expect(ok).Should(BeTrue())
+				pod.Status.Phase = corev1.PodRunning
+				pod.Status.Conditions = append(pod.Status.Conditions, getPodReadyCondition())
+				if pod.Labels == nil {
+					pod.Labels = map[string]string{}
+				}
+				switch pod.Name {
+				case "bar-2":
+					pod.Labels[appsv1.ControllerRevisionHashLabelKey] = updateRevisions[pod.Name]
+					pod.Labels[constant.RoleLabelKey] = "leader"
+				case "bar-1":
+					pod.Labels[appsv1.ControllerRevisionHashLabelKey] = oldRevisionStr
+					pod.Labels[constant.RoleLabelKey] = "follower"
+				default:
+					pod.Labels[appsv1.ControllerRevisionHashLabelKey] = oldRevisionStr
+					pod.Labels[constant.RoleLabelKey] = "leader"
+				}
+			}
+
+			reconciler = NewUpdateReconciler()
+			res, err := reconciler.Reconcile(tree)
+			Expect(err).Should(BeNil())
+			Expect(res).Should(Equal(kubebuilderx.Continue))
+			expectUpdatedPods(tree, []string{})
 		})
 
 		testInplacePodVerticalScaling := func(useSubResource bool) {

--- a/pkg/controller/instanceset2/reconciler_update.go
+++ b/pkg/controller/instanceset2/reconciler_update.go
@@ -100,10 +100,18 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 		return kubebuilderx.Continue, err
 	}
 	currentUnavailable := 0
+	updatedInstances := 0
 	for _, inst := range oldInstanceList {
 		if !intctrlutil.IsInstanceAvailable(inst) {
 			currentUnavailable++
 		}
+		if isInstanceUpdated(its, inst) {
+			updatedInstances++
+		}
+	}
+	replicas -= updatedInstances
+	if replicas < 0 {
+		replicas = 0
 	}
 	unavailable := maxUnavailable - currentUnavailable
 


### PR DESCRIPTION
## Summary

- Keep already-updated instances counted against `rollingUpdate.replicas` so role changes cannot admit extra participants.
- Move the legacy Pending Pod recreate shortcut behind the rolling participants gate while preserving its `maxUnavailable` bypass.
- Add focused regressions for Pending Pods outside the rolling window and role-order drift after a participant has already updated.

## Root Cause

`rollingUpdate.replicas` was enforced only against updates admitted in the current reconciliation. That allowed a previously updated participant to stop counting against the configured window on later reconciliations, especially after role-order changes moved it out of the current update prefix.

The legacy Pending Pod shortcut also ran before the rolling-update quota checks, so an outdated Pending Pod outside the selected participants could be recreated with the new revision.

## Tests

- `GOCACHE=/tmp/go-cache go test ./pkg/controller/instanceset -run 'TestAPIs/update_reconciler_test/PreCondition_&_Reconcile' -count=1`
- `GOCACHE=/tmp/go-cache go test ./pkg/controller/instanceset2 -count=1`
- `git diff --check`

Follow-up for https://github.com/apecloud/kubeblocks/issues/10641.
