### PR TITLE
fix(instanceset): keep pending pods inside rolling window

### DIFF
--- a/pkg/controller/instanceset/reconciler_update.go
+++ b/pkg/controller/instanceset/reconciler_update.go
@@ -120,7 +120,10 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 
 	// treat old and Pending pod as a special case, as they can be updated without a consequence
 	// PodUpdatePolicy is ignored here since in-place update for a pending pod doesn't make much sense.
-	for _, pod := range oldPodList {
+	for i, pod := range oldPodList {
+		if i >= rollingUpdateQuota {
+			break
+		}
 		updatePolicy, _, _, err := getPodUpdatePolicy(its, pod)
 		if err != nil {
 			return kubebuilderx.Continue, err

--- a/pkg/controller/instanceset/reconciler_update_test.go
+++ b/pkg/controller/instanceset/reconciler_update_test.go
@@ -315,6 +315,44 @@ var _ = Describe("update reconciler test", func() {
 			expectUpdatedPods(tree, []string{lastPod.GetName()})
 		})
 
+		It("keeps a pending pod outside the rolling-update window untouched", func() {
+			tree := kubebuilderx.NewObjectTree()
+			its.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+			its.Spec.InstanceUpdateStrategy = &workloads.InstanceUpdateStrategy{
+				RollingUpdate: &workloads.RollingUpdate{
+					Replicas:       ptr.To(intstr.FromInt32(1)),
+					MaxUnavailable: ptr.To(intstr.FromInt32(2)),
+				},
+			}
+			tree.SetRoot(its)
+
+			prepareForUpdate(tree)
+
+			for _, object := range tree.List(&corev1.Pod{}) {
+				pod, ok := object.(*corev1.Pod)
+				Expect(ok).Should(BeTrue())
+				pod.Labels[appsv1.ControllerRevisionHashLabelKey] = "old-revision"
+				if pod.Name == "bar-0" {
+					pod.Status.Phase = corev1.PodPending
+					continue
+				}
+				pod.Status.Phase = corev1.PodRunning
+				pod.Status.Conditions = append(pod.Status.Conditions, getPodReadyCondition())
+			}
+
+			reconciler = NewUpdateReconciler()
+			res, err := reconciler.Reconcile(tree)
+			Expect(err).Should(BeNil())
+			Expect(res).Should(Equal(kubebuilderx.Continue))
+			expectUpdatedPods(tree, []string{"bar-2"})
+
+			pending := builder.NewPodBuilder(namespace, "bar-0").GetObject()
+			object, err := tree.Get(pending)
+			Expect(err).Should(BeNil())
+			Expect(object).ShouldNot(BeNil())
+			Expect(object.(*corev1.Pod).Status.Phase).Should(Equal(corev1.PodPending))
+		})
+
 		It("respects maxUnavailable with pending pods", func() {
 			// update order: bar-2, bar-1, bar-0
 			tree := kubebuilderx.NewObjectTree()


### PR DESCRIPTION
## Summary

- keep outdated Pending Pods subject to the same ordered `rollingUpdate.replicas` window as normal updates
- leave Pending Pods outside the selected window untouched
- add a regression test for an out-of-window Pending Pod

This is a follow-up to #10658 and addresses the Pending-Pod behavior recorded in #10641. The behavior predates #9807 and is intentionally separated from the replicas semantics fix.

## Tests

- `go test -mod=mod ./pkg/controller/instanceset -count=1`
- `go test -mod=mod ./controllers/workloads -run TestAPIs -ginkgo.focus='rolling' -count=1`

Fixes #10641
