### PR TITLE
fix(dataprotection): label backup workloads for cleanup

### DIFF
--- a/pkg/dataprotection/backup/request_test.go
+++ b/pkg/dataprotection/backup/request_test.go
@@ -69,7 +69,12 @@ func newRequestTestFixture(t *testing.T) (*Request, *corev1.Pod) {
 		Backup: &dpv1alpha1.Backup{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "backup", Namespace: "ns", UID: types.UID("1234567890abcdef"),
-				Labels: map[string]string{dptypes.ClusterUIDLabelKey: "uid", constant.AppInstanceLabelKey: "cluster", constant.KBAppComponentLabelKey: "mysql"},
+				Labels: map[string]string{
+					dptypes.ClusterUIDLabelKey:      "uid",
+					constant.AppInstanceLabelKey:    "cluster",
+					constant.KBAppComponentLabelKey: "mysql",
+					constant.AppManagedByLabelKey:   constant.AppName,
+				},
 			},
 			Spec: dpv1alpha1.BackupSpec{RetentionPeriod: "7d"},
 		},
@@ -122,6 +127,7 @@ func TestRequestBuildActionBranches(t *testing.T) {
 	assert.NoError(t, err)
 	assert.IsType(t, &action.JobAction{}, jobAction)
 	assert.Equal(t, dpv1alpha1.ActionTypeJob, jobAction.Type())
+	assert.Equal(t, dptypes.AppName, jobAction.(*action.JobAction).ObjectMeta.Labels[constant.AppManagedByLabelKey])
 }
 
 func TestRequestBuildBackupDataActions(t *testing.T) {
@@ -130,11 +136,13 @@ func TestRequestBuildBackupDataActions(t *testing.T) {
 	backupDataAction, err := req.buildBackupDataAction(pod, "backup-data")
 	assert.NoError(t, err)
 	assert.IsType(t, &action.JobAction{}, backupDataAction)
+	assert.Equal(t, dptypes.AppName, backupDataAction.(*action.JobAction).ObjectMeta.Labels[constant.AppManagedByLabelKey])
 
 	req.ActionSet.Spec.BackupType = dpv1alpha1.BackupTypeContinuous
 	backupDataAction, err = req.buildBackupDataAction(pod, "continuous")
 	assert.NoError(t, err)
 	assert.IsType(t, &action.StatefulSetAction{}, backupDataAction)
+	assert.Equal(t, dptypes.AppName, backupDataAction.(*action.StatefulSetAction).ObjectMeta.Labels[constant.AppManagedByLabelKey])
 	assert.Contains(t, req.buildContinuousSyncProgressCommand(), "retryTimes")
 
 	req.ActionSet.Spec.BackupType = dpv1alpha1.BackupType("Unknown")

--- a/pkg/dataprotection/backup/utils.go
+++ b/pkg/dataprotection/backup/utils.go
@@ -142,6 +142,7 @@ func BuildBackupWorkloadLabels(backup *dpv1alpha1.Backup) map[string]string {
 		labels[k] = v
 	}
 	labels[types.BackupNameLabelKey] = backup.Name
+	labels[constant.AppManagedByLabelKey] = types.AppName
 	return labels
 }
 

--- a/pkg/dataprotection/backup/utils_test.go
+++ b/pkg/dataprotection/backup/utils_test.go
@@ -245,6 +245,7 @@ func TestBackupNameAndPathHelpers(t *testing.T) {
 			UID:       types.UID("1234567890abcdef"),
 			Labels: map[string]string{
 				constant.KBAppComponentLabelKey: "excluded",
+				constant.AppManagedByLabelKey:   constant.AppName,
 				"keep":                          "value",
 			},
 		},
@@ -255,6 +256,12 @@ func TestBackupNameAndPathHelpers(t *testing.T) {
 	assert.Equal(t, "value", labels["keep"])
 	assert.NotContains(t, labels, constant.KBAppComponentLabelKey)
 	assert.Equal(t, backup.Name, labels[dptypes.BackupNameLabelKey])
+	assert.Equal(t, dptypes.AppName, labels[constant.AppManagedByLabelKey])
+	assert.Equal(t, constant.AppName, backup.Labels[constant.AppManagedByLabelKey])
+	unlabeledBackup := backup.DeepCopy()
+	unlabeledBackup.Labels = nil
+	assert.Equal(t, dptypes.AppName, BuildBackupWorkloadLabels(unlabeledBackup)[constant.AppManagedByLabelKey])
+	assert.Nil(t, unlabeledBackup.Labels)
 
 	assert.Equal(t, "dp-backup-backup-name-12345678", GenerateBackupJobName(backup, "dp-backup"))
 	longName := GenerateBackupJobName(&dpv1alpha1.Backup{ObjectMeta: metav1.ObjectMeta{Name: "very-long-backup-name-that-should-be-trimmed-for-job-label-limits", UID: types.UID("1234567890abcdef")}}, "prefix")


### PR DESCRIPTION
Closes #10675

## What problem does this solve?

Backup-owned Jobs and continuous backup StatefulSets could inherit a non-DataProtection `app.kubernetes.io/managed-by` label from the parent Backup. DataProtection watch and cleanup selectors require `kubeblocks-dataprotection`, so those workloads could be missed.

## What is changed?

- Force `BuildBackupWorkloadLabels` to set `managed-by=kubeblocks-dataprotection` after copying parent labels.
- Keep the parent Backup labels unchanged.
- Keep existing watch and cleanup selectors narrow.
- Cover helper output, parent non-mutation, nil labels, Action Job, BackupData Job, and continuous StatefulSet metadata/template labels.

Existing workloads with the historical wrong label are not migrated by this change.

## Validation

- Focused tests N=3
- Focused race test
- Full `pkg/dataprotection/backup` and `controllers/dataprotection` tests
- `go vet`, lint, generated-file checks, and full `make check-diff`
