### PR TITLE
chore(operations): roll back timed out horizontal scaling on release-1.1

### DIFF
--- a/controllers/operations/opsrequest_controller_test.go
+++ b/controllers/operations/opsrequest_controller_test.go
@@ -762,6 +762,9 @@ var _ = Describe("OpsRequest Controller", func() {
 			}
 			testops.CreateOpsRequest(ctx, testCtx, ops)
 			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(ops))).Should(Equal(opsv1alpha1.OpsRunningPhase))
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(clusterObj), func(g Gomega, cluster *appsv1.Cluster) {
+				g.Expect(cluster.Spec.ComponentSpecs[0].Replicas).Should(Equal(int32(4)))
+			})).Should(Succeed())
 
 			By("create a next opsRequest")
 			ops1 := createRestartOps(clusterObj.Name, 2, true)
@@ -770,6 +773,9 @@ var _ = Describe("OpsRequest Controller", func() {
 			By("mock timeout")
 			time.Sleep(time.Second)
 			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(ops))).Should(Equal(opsv1alpha1.OpsAbortedPhase))
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(clusterObj), func(g Gomega, cluster *appsv1.Cluster) {
+				g.Expect(cluster.Spec.ComponentSpecs[0].Replicas).Should(Equal(replicas))
+			})).Should(Succeed())
 
 			By("expect for the next ops is running")
 			Eventually(testops.GetOpsRequestPhase(&testCtx, client.ObjectKeyFromObject(ops1))).ShouldNot(Equal(opsv1alpha1.OpsPendingPhase))

--- a/pkg/operations/horizontal_scaling.go
+++ b/pkg/operations/horizontal_scaling.go
@@ -57,6 +57,7 @@ func init() {
 		QueueByCluster:    true,
 		OpsHandler:        hsHandler,
 		CancelFunc:        hsHandler.Cancel,
+		RollbackOnTimeout: true,
 	}
 	opsMgr := GetOpsManager()
 	opsMgr.RegisterOps(opsv1alpha1.HorizontalScalingType, horizontalScalingBehaviour)

--- a/pkg/operations/ops_manager.go
+++ b/pkg/operations/ops_manager.go
@@ -192,7 +192,7 @@ func (opsMgr *OpsManager) Reconcile(reqCtx intctrlutil.RequestCtx, cli client.Cl
 		return 0, opsMgr.handleOpsCompleted(reqCtx, cli, opsRes, opsRequestPhase,
 			opsv1alpha1.NewCancelFailedCondition(opsRequest, err), opsv1alpha1.NewFailedCondition(opsRequest, err))
 	default:
-		return opsMgr.checkAndHandleOpsTimeout(reqCtx, cli, opsRes, requeueAfter)
+		return opsMgr.checkAndHandleOpsTimeout(reqCtx, cli, opsRes, opsBehaviour, requeueAfter)
 	}
 }
 
@@ -258,6 +258,7 @@ func (opsMgr *OpsManager) validateDependOnSuccessfulOps(reqCtx intctrlutil.Reque
 func (opsMgr *OpsManager) checkAndHandleOpsTimeout(reqCtx intctrlutil.RequestCtx,
 	cli client.Client,
 	opsRes *OpsResource,
+	opsBehaviour OpsBehaviour,
 	requeueAfter time.Duration) (time.Duration, error) {
 	timeoutSeconds := opsRes.OpsRequest.Spec.TimeoutSeconds
 	if timeoutSeconds == nil || *timeoutSeconds == 0 {
@@ -265,8 +266,20 @@ func (opsMgr *OpsManager) checkAndHandleOpsTimeout(reqCtx intctrlutil.RequestCtx
 	}
 	timeoutPoint := opsRes.OpsRequest.Status.StartTimestamp.Add(time.Duration(*timeoutSeconds) * time.Second)
 	if !time.Now().Before(timeoutPoint) {
+		rolledBack := false
+		if opsBehaviour.RollbackOnTimeout && opsBehaviour.CancelFunc != nil {
+			err := opsBehaviour.CancelFunc(reqCtx, cli, opsRes)
+			if err != nil && !intctrlutil.IsTargetError(err, intctrlutil.ErrorIgnoreCancel) {
+				return 0, err
+			}
+			rolledBack = err == nil
+		}
+		message := "Aborted due to exceeding the specified timeout period (timeoutSeconds)"
+		if rolledBack {
+			message += "; the original desired configuration has been restored"
+		}
 		return 0, PatchOpsStatus(reqCtx.Ctx, cli, opsRes, opsv1alpha1.OpsAbortedPhase,
-			opsv1alpha1.NewAbortedCondition("Aborted due to exceeding the specified timeout period (timeoutSeconds)"))
+			opsv1alpha1.NewAbortedCondition(message))
 	}
 	if requeueAfter != 0 {
 		return requeueAfter, nil

--- a/pkg/operations/ops_manager_timeout_test.go
+++ b/pkg/operations/ops_manager_timeout_test.go
@@ -1,0 +1,265 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package operations
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	opsv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+)
+
+type failClusterUpdateClient struct {
+	client.Client
+	fail bool
+}
+
+func (c *failClusterUpdateClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if _, ok := obj.(*appsv1.Cluster); ok && c.fail {
+		c.fail = false
+		return apierrors.NewConflict(schema.GroupResource{Group: appsv1.GroupVersion.Group, Resource: "clusters"}, obj.GetName(), errors.New("conflict"))
+	}
+	return c.Client.Update(ctx, obj, opts...)
+}
+
+type failStatusPatchClient struct {
+	client.Client
+	fail bool
+}
+
+func (c *failStatusPatchClient) Status() client.StatusWriter {
+	return &failStatusPatchWriter{StatusWriter: c.Client.Status(), client: c}
+}
+
+type failStatusPatchWriter struct {
+	client.StatusWriter
+	client *failStatusPatchClient
+}
+
+func (w *failStatusPatchWriter) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+	if w.client.fail {
+		w.client.fail = false
+		return apierrors.NewConflict(schema.GroupResource{Group: opsv1alpha1.GroupVersion.Group, Resource: "opsrequests/status"}, obj.GetName(), errors.New("conflict"))
+	}
+	return w.StatusWriter.Patch(ctx, obj, patch, opts...)
+}
+
+func TestCheckAndHandleOpsTimeoutRollsBackHorizontalScaling(t *testing.T) {
+	opsRes, cli := newTimedOutHorizontalScalingOpsResource(t)
+	behaviour := OpsBehaviour{
+		CancelFunc:        horizontalScalingOpsHandler{}.Cancel,
+		RollbackOnTimeout: true,
+	}
+
+	requeueAfter, err := GetOpsManager().checkAndHandleOpsTimeout(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, cli, opsRes, behaviour, 0)
+	require.NoError(t, err)
+	require.Zero(t, requeueAfter)
+
+	cluster := &appsv1.Cluster{}
+	require.NoError(t, cli.Get(context.Background(), client.ObjectKeyFromObject(opsRes.Cluster), cluster))
+	require.Equal(t, int32(3), cluster.Spec.ComponentSpecs[0].Replicas)
+
+	opsRequest := &opsv1alpha1.OpsRequest{}
+	require.NoError(t, cli.Get(context.Background(), client.ObjectKeyFromObject(opsRes.OpsRequest), opsRequest))
+	require.Equal(t, opsv1alpha1.OpsAbortedPhase, opsRequest.Status.Phase)
+	require.Condition(t, func() bool {
+		for _, condition := range opsRequest.Status.Conditions {
+			if strings.Contains(condition.Message, "original desired configuration has been restored") {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func TestCheckAndHandleOpsTimeoutRetriesRollbackBeforeAborting(t *testing.T) {
+	opsRes, baseClient := newTimedOutHorizontalScalingOpsResource(t)
+	cli := &failClusterUpdateClient{Client: baseClient, fail: true}
+	behaviour := OpsBehaviour{
+		CancelFunc:        horizontalScalingOpsHandler{}.Cancel,
+		RollbackOnTimeout: true,
+	}
+
+	_, err := GetOpsManager().checkAndHandleOpsTimeout(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, cli, opsRes, behaviour, 0)
+	require.True(t, apierrors.IsConflict(err))
+
+	cluster := &appsv1.Cluster{}
+	require.NoError(t, baseClient.Get(context.Background(), client.ObjectKeyFromObject(opsRes.Cluster), cluster))
+	require.Equal(t, int32(4), cluster.Spec.ComponentSpecs[0].Replicas)
+	opsRequest := &opsv1alpha1.OpsRequest{}
+	require.NoError(t, baseClient.Get(context.Background(), client.ObjectKeyFromObject(opsRes.OpsRequest), opsRequest))
+	require.Equal(t, opsv1alpha1.OpsRunningPhase, opsRequest.Status.Phase)
+
+	retryRes := &OpsResource{Cluster: cluster, OpsRequest: opsRequest, Recorder: record.NewFakeRecorder(10)}
+	_, err = GetOpsManager().checkAndHandleOpsTimeout(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, cli, retryRes, behaviour, 0)
+	require.NoError(t, err)
+
+	require.NoError(t, baseClient.Get(context.Background(), client.ObjectKeyFromObject(cluster), cluster))
+	require.Equal(t, int32(3), cluster.Spec.ComponentSpecs[0].Replicas)
+	require.NoError(t, baseClient.Get(context.Background(), client.ObjectKeyFromObject(opsRequest), opsRequest))
+	require.Equal(t, opsv1alpha1.OpsAbortedPhase, opsRequest.Status.Phase)
+}
+
+func TestCheckAndHandleOpsTimeoutRetriesStatusCommitAfterRollback(t *testing.T) {
+	opsRes, baseClient := newTimedOutHorizontalScalingOpsResource(t)
+	cli := &failStatusPatchClient{Client: baseClient, fail: true}
+	behaviour := OpsBehaviour{
+		CancelFunc:        horizontalScalingOpsHandler{}.Cancel,
+		RollbackOnTimeout: true,
+	}
+
+	_, err := GetOpsManager().checkAndHandleOpsTimeout(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, cli, opsRes, behaviour, 0)
+	require.True(t, apierrors.IsConflict(err))
+
+	cluster := &appsv1.Cluster{}
+	require.NoError(t, baseClient.Get(context.Background(), client.ObjectKeyFromObject(opsRes.Cluster), cluster))
+	require.Equal(t, int32(3), cluster.Spec.ComponentSpecs[0].Replicas)
+	opsRequest := &opsv1alpha1.OpsRequest{}
+	require.NoError(t, baseClient.Get(context.Background(), client.ObjectKeyFromObject(opsRes.OpsRequest), opsRequest))
+	require.Equal(t, opsv1alpha1.OpsRunningPhase, opsRequest.Status.Phase)
+
+	retryRes := &OpsResource{Cluster: cluster, OpsRequest: opsRequest, Recorder: record.NewFakeRecorder(10)}
+	_, err = GetOpsManager().checkAndHandleOpsTimeout(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, cli, retryRes, behaviour, 0)
+	require.NoError(t, err)
+
+	require.NoError(t, baseClient.Get(context.Background(), client.ObjectKeyFromObject(cluster), cluster))
+	require.Equal(t, int32(3), cluster.Spec.ComponentSpecs[0].Replicas)
+	require.NoError(t, baseClient.Get(context.Background(), client.ObjectKeyFromObject(opsRequest), opsRequest))
+	require.Equal(t, opsv1alpha1.OpsAbortedPhase, opsRequest.Status.Phase)
+}
+
+func TestCheckAndHandleOpsTimeoutPreservesUnsupportedRollbackBehavior(t *testing.T) {
+	opsRes, cli := newTimedOutHorizontalScalingOpsResource(t)
+	behaviour := OpsBehaviour{
+		CancelFunc: func(intctrlutil.RequestCtx, client.Client, *OpsResource) error {
+			return intctrlutil.NewErrorf(intctrlutil.ErrorIgnoreCancel, "rollback is not supported")
+		},
+		RollbackOnTimeout: true,
+	}
+
+	_, err := GetOpsManager().checkAndHandleOpsTimeout(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, cli, opsRes, behaviour, 0)
+	require.NoError(t, err)
+
+	cluster := &appsv1.Cluster{}
+	require.NoError(t, cli.Get(context.Background(), client.ObjectKeyFromObject(opsRes.Cluster), cluster))
+	require.Equal(t, int32(4), cluster.Spec.ComponentSpecs[0].Replicas)
+	opsRequest := &opsv1alpha1.OpsRequest{}
+	require.NoError(t, cli.Get(context.Background(), client.ObjectKeyFromObject(opsRes.OpsRequest), opsRequest))
+	require.Equal(t, opsv1alpha1.OpsAbortedPhase, opsRequest.Status.Phase)
+	for _, condition := range opsRequest.Status.Conditions {
+		require.NotContains(t, condition.Message, "original desired configuration has been restored")
+	}
+}
+
+func TestCheckAndHandleOpsTimeoutDoesNotRollbackByDefault(t *testing.T) {
+	opsRes, cli := newTimedOutHorizontalScalingOpsResource(t)
+	called := false
+	behaviour := OpsBehaviour{
+		CancelFunc: func(intctrlutil.RequestCtx, client.Client, *OpsResource) error {
+			called = true
+			return nil
+		},
+	}
+
+	_, err := GetOpsManager().checkAndHandleOpsTimeout(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, cli, opsRes, behaviour, 0)
+	require.NoError(t, err)
+	require.False(t, called)
+
+	cluster := &appsv1.Cluster{}
+	require.NoError(t, cli.Get(context.Background(), client.ObjectKeyFromObject(opsRes.Cluster), cluster))
+	require.Equal(t, int32(4), cluster.Spec.ComponentSpecs[0].Replicas)
+	opsRequest := &opsv1alpha1.OpsRequest{}
+	require.NoError(t, cli.Get(context.Background(), client.ObjectKeyFromObject(opsRes.OpsRequest), opsRequest))
+	require.Equal(t, opsv1alpha1.OpsAbortedPhase, opsRequest.Status.Phase)
+}
+
+func newTimedOutHorizontalScalingOpsResource(t *testing.T) (*OpsResource, client.Client) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, opsv1alpha1.AddToScheme(scheme))
+
+	cluster := &appsv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "default"},
+		Spec: appsv1.ClusterSpec{ComponentSpecs: []appsv1.ClusterComponentSpec{{
+			Name:     "component",
+			Replicas: 4,
+		}}},
+	}
+	timeoutSeconds := int32(1)
+	opsRequest := &opsv1alpha1.OpsRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "ops", Namespace: "default"},
+		Spec: opsv1alpha1.OpsRequestSpec{
+			ClusterName:    cluster.Name,
+			Type:           opsv1alpha1.HorizontalScalingType,
+			TimeoutSeconds: &timeoutSeconds,
+			SpecificOpsRequest: opsv1alpha1.SpecificOpsRequest{
+				HorizontalScalingList: []opsv1alpha1.HorizontalScaling{{
+					ComponentOps: opsv1alpha1.ComponentOps{ComponentName: "component"},
+					ScaleOut:     &opsv1alpha1.ScaleOut{ReplicaChanger: opsv1alpha1.ReplicaChanger{ReplicaChanges: pointer.Int32(1)}},
+				}},
+			},
+		},
+		Status: opsv1alpha1.OpsRequestStatus{
+			Phase:          opsv1alpha1.OpsRunningPhase,
+			StartTimestamp: metav1.NewTime(time.Now().Add(-2 * time.Second)),
+			LastConfiguration: opsv1alpha1.LastConfiguration{Components: map[string]opsv1alpha1.LastComponentConfiguration{
+				"component": {Replicas: pointer.Int32(3)},
+			}},
+		},
+	}
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&opsv1alpha1.OpsRequest{}).
+		WithObjects(cluster, opsRequest).
+		Build()
+
+	storedCluster := &appsv1.Cluster{}
+	require.NoError(t, cli.Get(context.Background(), client.ObjectKeyFromObject(cluster), storedCluster))
+	storedOpsRequest := &opsv1alpha1.OpsRequest{}
+	require.NoError(t, cli.Get(context.Background(), client.ObjectKeyFromObject(opsRequest), storedOpsRequest))
+	return &OpsResource{
+		Cluster:    storedCluster,
+		OpsRequest: storedOpsRequest,
+		Recorder:   record.NewFakeRecorder(10),
+	}, cli
+}

--- a/pkg/operations/type.go
+++ b/pkg/operations/type.go
@@ -60,6 +60,9 @@ type OpsBehaviour struct {
 	// only update the opsRequest object, then opsRequest controller will update uniformly.
 	CancelFunc func(reqCtx intctrlutil.RequestCtx, cli client.Client, opsResource *OpsResource) error
 
+	// RollbackOnTimeout restores the last saved configuration before publishing the Aborted phase.
+	RollbackOnTimeout bool
+
 	// IsClusterCreation indicates whether the opsRequest will create a new cluster.
 	IsClusterCreation bool
 


### PR DESCRIPTION
## What type of PR is this?

/kind bug

## What this PR does / why we need it

HorizontalScaling updates `Cluster.spec` before the workload has converged. The generic timeout path previously published `Aborted` without restoring the saved desired component configuration, leaving a terminal OpsRequest while the Cluster continued toward an incomplete scaling target.

This change lets HorizontalScaling opt in to timeout rollback. The existing cancel handler restores replicas, instances, and offlineInstances from `status.lastConfiguration` before `Aborted` is committed. Rollback errors keep the OpsRequest non-terminal so reconciliation can retry. Unsupported shard-count cancellation and other Ops types keep their existing behavior.

Fixes #10673.

## Tests

- timeout controller envtest: RED before the fix, GREEN N=3 after the fix
- rollback success, Cluster update conflict retry, Ops status conflict retry, unsupported rollback, default non-opt-in behavior
- `go test ./pkg/operations -count=1`
- `go test ./controllers/operations -count=1`
- focused race test
- scoped `go vet`

Runtime validation against a patched controller image is still pending.

