### PR TITLE
fix: resolve restore target metadata at post-ready Job dispatch

### DIFF
--- a/controllers/dataprotection/restore_controller.go
+++ b/controllers/dataprotection/restore_controller.go
@@ -54,16 +54,20 @@ import (
 // RestoreReconciler reconciles a Restore object
 type RestoreReconciler struct {
 	client.Client
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
+	APIReader client.Reader
+	Scheme    *runtime.Scheme
+	Recorder  record.EventRecorder
 }
 
 // +kubebuilder:rbac:groups=dataprotection.kubeblocks.io,resources=restores,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=dataprotection.kubeblocks.io,resources=restores/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=dataprotection.kubeblocks.io,resources=restores/finalizers,verbs=update
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps.kubeblocks.io,resources=clusters;components,verbs=get;list;watch
+// +kubebuilder:rbac:groups=workloads.kubeblocks.io,resources=instances;instancesets,verbs=get;list;watch
 
 func (r *RestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reqCtx := intctrlutil.RequestCtx{
@@ -102,6 +106,9 @@ func (r *RestoreReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *RestoreReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if r.APIReader == nil {
+		r.APIReader = mgr.GetAPIReader()
+	}
 	return intctrlutil.NewControllerManagedBy(mgr).
 		For(&dpv1alpha1.Restore{}).
 		Owns(&batchv1.Job{}).
@@ -498,7 +505,7 @@ func (r *RestoreReconciler) handleBackupActionSet(reqCtx intctrlutil.RequestCtx,
 	case dpv1alpha1.PostReady:
 		if len(jobs) == 0 {
 			// 2. build jobs for postReady action
-			jobs, err = restoreMgr.BuildPostReadyActionJobs(reqCtx, r.Client, backupSet, target, step)
+			jobs, err = restoreMgr.BuildPostReadyActionJobs(reqCtx, r.Client, r.APIReader, backupSet, target, step)
 		}
 	}
 	if err != nil {

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -1344,7 +1344,10 @@ func (r *VolumePopulatorReconciler) buildPostReadyRestore(reqCtx intctrlutil.Req
 	if effectiveTarget != nil {
 		restore.Spec.Backup.SourceTargetName = effectiveTarget.Name
 	}
-	if err = controllerutil.SetOwnerReference(comp, restore, r.Scheme); err != nil {
+	if err = controllerutil.SetControllerReference(comp, restore, r.Scheme); err != nil {
+		return nil, err
+	}
+	if err = dprestore.ValidateInternalPostReadyRestoreComponent(restore, comp); err != nil {
 		return nil, err
 	}
 	return restore, nil
@@ -1362,9 +1365,11 @@ func stripPostReadyTargetEnv(source []corev1.EnvVar) []corev1.EnvVar {
 }
 
 func validatePostReadyRestore(existing, desired *dpv1alpha1.Restore, comp *appsv1.Component) error {
-	if !hasOwnerReference(existing.OwnerReferences, comp.UID) {
-		return intctrlutil.NewFatalError(fmt.Sprintf("postReady restore %s/%s is not owned by component %s/%s",
-			existing.Namespace, existing.Name, comp.Namespace, comp.Name))
+	if err := dprestore.ValidateInternalPostReadyRestoreComponent(existing, comp); err != nil {
+		return err
+	}
+	if err := dprestore.ValidateInternalPostReadyRestoreComponent(desired, comp); err != nil {
+		return err
 	}
 	existingSpec := existing.Spec.DeepCopy()
 	existingSpec.Env = stripPostReadyTargetEnv(existingSpec.Env)
@@ -1375,15 +1380,6 @@ func validatePostReadyRestore(existing, desired *dpv1alpha1.Restore, comp *appsv
 			existing.Namespace, existing.Name))
 	}
 	return nil
-}
-
-func hasOwnerReference(ownerRefs []metav1.OwnerReference, uid types.UID) bool {
-	for _, ownerRef := range ownerRefs {
-		if ownerRef.UID == uid {
-			return true
-		}
-	}
-	return false
 }
 
 func (r *VolumePopulatorReconciler) highestPriorityRoleName(reqCtx intctrlutil.RequestCtx, comp *appsv1.Component) (string, error) {
@@ -1620,8 +1616,9 @@ func postReadyRequiredPolicy(sourceTarget *dpv1alpha1.BackupStatusTarget) *dpv1a
 func postReadyRestoreLabels(pvc *corev1.PersistentVolumeClaim, comp *appsv1.Component) map[string]string {
 	restoreName := postReadyRestoreName(comp.UID)
 	labels := map[string]string{
-		dprestore.DataProtectionRestoreLabelKey:          restoreName,
-		dprestore.DataProtectionRestoreNamespaceLabelKey: pvc.Namespace,
+		dprestore.DataProtectionRestoreLabelKey:           restoreName,
+		dprestore.DataProtectionRestoreNamespaceLabelKey:  pvc.Namespace,
+		dprestore.DataProtectionInternalPostReadyLabelKey: dprestore.DataProtectionInternalPostReadyLabelValue,
 	}
 	for _, key := range []string{
 		constant.AppInstanceLabelKey,

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/component-helpers/storage/volume"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -81,11 +80,6 @@ type pvcRestoreDecision struct {
 	mode          pvcRestoreMode
 	sourceTarget  *dpv1alpha1.BackupStatusTarget
 	skipPostReady bool
-}
-
-type postReadyTargetFacts struct {
-	clusterTopology         string
-	componentServiceVersion string
 }
 
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims/status,verbs=get;update;patch
@@ -1185,11 +1179,7 @@ func (r *VolumePopulatorReconciler) ensurePostReadyRestoreCompleted(reqCtx intct
 		Name:      postReadyRestoreName(comp.UID),
 	}
 	if err = r.Client.Get(reqCtx.Ctx, existingKey, existing); err == nil {
-		targetFacts, factsErr := postReadyTargetFactsFromRestore(existing)
-		if factsErr != nil {
-			return false, factsErr
-		}
-		desired, buildErr := r.buildPostReadyRestore(reqCtx, pvc, restoreMgr, comp, componentName, backupTarget, targetFacts)
+		desired, buildErr := r.buildPostReadyRestore(reqCtx, pvc, restoreMgr, comp, componentName, backupTarget)
 		if buildErr != nil {
 			return false, buildErr
 		}
@@ -1218,20 +1208,19 @@ func (r *VolumePopulatorReconciler) ensurePostReadyRestoreCompleted(reqCtx intct
 		}
 		return false, nil
 	}
-	componentServiceVersion := postReadyComponentServiceVersion(comp)
-	cluster := &appsv1.Cluster{}
-	if err = r.Client.Get(reqCtx.Ctx, types.NamespacedName{Namespace: pvc.Namespace, Name: clusterName}, cluster); err != nil {
-		if apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err) {
-			return false, intctrlutil.NewFatalError(err.Error())
-		}
-		return false, intctrlutil.NewRequeueError(reconcileInterval,
-			fmt.Sprintf("waiting for target cluster %s/%s: %v", pvc.Namespace, clusterName, err))
-	}
 	parameters, err := restoreParametersMapFromPVC(pvc)
 	if err != nil {
 		return false, intctrlutil.NewFatalError(err.Error())
 	}
 	if parameters[dptypes.DeferPostReadyUntilClusterRunningParameterKey] == "true" {
+		cluster := &appsv1.Cluster{}
+		if err = r.Client.Get(reqCtx.Ctx, types.NamespacedName{Namespace: pvc.Namespace, Name: clusterName}, cluster); err != nil {
+			if apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err) {
+				return false, intctrlutil.NewFatalError(err.Error())
+			}
+			return false, intctrlutil.NewRequeueError(reconcileInterval,
+				fmt.Sprintf("waiting for target cluster %s/%s: %v", pvc.Namespace, clusterName, err))
+		}
 		if cluster.Status.Phase != appsv1.RunningClusterPhase {
 			if err = r.updatePVCConditionsIfPopulateNotReleased(reqCtx, pvc, "Waiting for cluster to run before postReady restore"); err != nil {
 				return false, err
@@ -1239,11 +1228,7 @@ func (r *VolumePopulatorReconciler) ensurePostReadyRestoreCompleted(reqCtx intct
 			return false, nil
 		}
 	}
-	postReadyRestore, err := r.buildPostReadyRestore(reqCtx, pvc, restoreMgr, comp, componentName, backupTarget,
-		postReadyTargetFacts{
-			clusterTopology:         cluster.Spec.Topology,
-			componentServiceVersion: componentServiceVersion,
-		})
+	postReadyRestore, err := r.buildPostReadyRestore(reqCtx, pvc, restoreMgr, comp, componentName, backupTarget)
 	if err != nil {
 		return false, err
 	}
@@ -1270,8 +1255,7 @@ func (r *VolumePopulatorReconciler) buildPostReadyRestore(reqCtx intctrlutil.Req
 	restoreMgr *dprestore.RestoreManager,
 	comp *appsv1.Component,
 	targetComponentName string,
-	redirectTarget *dpv1alpha1.BackupStatusTarget,
-	targetFacts postReadyTargetFacts) (*dpv1alpha1.Restore, error) {
+	redirectTarget *dpv1alpha1.BackupStatusTarget) (*dpv1alpha1.Restore, error) {
 	clusterName := pvc.Labels[constant.AppInstanceLabelKey]
 	componentName := targetComponentName
 	if componentName == "" {
@@ -1352,8 +1336,7 @@ func (r *VolumePopulatorReconciler) buildPostReadyRestore(reqCtx intctrlutil.Req
 				Namespace: backupNamespace,
 			},
 			RestoreTime: pvc.Annotations[constant.RestorePITRAnnotationKey],
-			Env: buildPostReadyTargetEnv(restoreMgr.Restore.Spec.Env,
-				targetFacts.clusterTopology, targetFacts.componentServiceVersion),
+			Env:         stripPostReadyTargetEnv(restoreMgr.Restore.Spec.Env),
 			Parameters:  restoreParametersToPairs(restoreActionParameters(parameters)),
 			ReadyConfig: readyConfig,
 		},
@@ -1367,73 +1350,19 @@ func (r *VolumePopulatorReconciler) buildPostReadyRestore(reqCtx intctrlutil.Req
 	return restore, nil
 }
 
-// postReadyComponentServiceVersion returns an empty value when a legal Component
-// has multiple active versions that cannot be represented by this transitional string.
-func postReadyComponentServiceVersion(comp *appsv1.Component) string {
-	componentVersion := comp.Spec.ServiceVersion
-	versions := map[string]struct{}{}
-	remainingDefaultReplicas := comp.Spec.Replicas
-	for i := range comp.Spec.Instances {
-		instance := &comp.Spec.Instances[i]
-		instanceReplicas := ptr.Deref(instance.Replicas, 1)
-		if instanceReplicas == 0 {
-			continue
-		}
-		remainingDefaultReplicas -= instanceReplicas
-		instanceVersion := instance.ServiceVersion
-		if instanceVersion == "" {
-			instanceVersion = componentVersion
-		}
-		versions[instanceVersion] = struct{}{}
-	}
-	if remainingDefaultReplicas > 0 || len(versions) == 0 {
-		versions[componentVersion] = struct{}{}
-	}
-	if len(versions) != 1 {
-		return ""
-	}
-	for version := range versions {
-		return version
-	}
-	return ""
-}
-
-func postReadyTargetFactsFromRestore(restore *dpv1alpha1.Restore) (postReadyTargetFacts, error) {
-	var facts postReadyTargetFacts
-	var topologyCount, serviceVersionCount int
-	for i := range restore.Spec.Env {
-		switch restore.Spec.Env[i].Name {
-		case dptypes.DPTargetClusterTopology:
-			topologyCount++
-			facts.clusterTopology = restore.Spec.Env[i].Value
-		case dptypes.DPTargetComponentServiceVersion:
-			serviceVersionCount++
-			facts.componentServiceVersion = restore.Spec.Env[i].Value
-		}
-	}
-	if topologyCount == 0 && serviceVersionCount == 0 {
-		return facts, nil
-	}
-	if topologyCount != 1 || serviceVersionCount != 1 {
-		return postReadyTargetFacts{}, intctrlutil.NewFatalError(fmt.Sprintf(
-			"postReady restore %s/%s has an invalid target-fact snapshot", restore.Namespace, restore.Name))
-	}
-	return facts, nil
-}
-
-func buildPostReadyTargetEnv(source []corev1.EnvVar, clusterTopology, componentServiceVersion string) []corev1.EnvVar {
-	env := make([]corev1.EnvVar, 0, len(source)+2)
+func stripPostReadyTargetEnv(source []corev1.EnvVar) []corev1.EnvVar {
+	var env []corev1.EnvVar
 	for i := range source {
 		switch source[i].Name {
-		case dptypes.DPTargetClusterTopology, dptypes.DPTargetComponentServiceVersion:
+		case dptypes.DPTargetClusterTopology,
+			dptypes.DPTargetComponentServiceVersion,
+			dptypes.DPTargetComponentServiceVersionSelector:
 			continue
 		default:
 			env = append(env, source[i])
 		}
 	}
-	return append(env,
-		corev1.EnvVar{Name: dptypes.DPTargetClusterTopology, Value: clusterTopology},
-		corev1.EnvVar{Name: dptypes.DPTargetComponentServiceVersion, Value: componentServiceVersion})
+	return env
 }
 
 func validatePostReadyRestore(existing, desired *dpv1alpha1.Restore, comp *appsv1.Component) error {
@@ -1441,31 +1370,15 @@ func validatePostReadyRestore(existing, desired *dpv1alpha1.Restore, comp *appsv
 		return intctrlutil.NewFatalError(fmt.Sprintf("postReady restore %s/%s is not owned by component %s/%s",
 			existing.Namespace, existing.Name, comp.Namespace, comp.Name))
 	}
-	if !reflect.DeepEqual(existing.Spec, desired.Spec) && !legacyPostReadyRestoreMatches(existing, desired) {
+	existingSpec := existing.Spec.DeepCopy()
+	existingSpec.Env = stripPostReadyTargetEnv(existingSpec.Env)
+	desiredSpec := desired.Spec.DeepCopy()
+	desiredSpec.Env = stripPostReadyTargetEnv(desiredSpec.Env)
+	if !reflect.DeepEqual(existingSpec, desiredSpec) {
 		return intctrlutil.NewFatalError(fmt.Sprintf("postReady restore %s/%s spec does not match current restore intent",
 			existing.Namespace, existing.Name))
 	}
 	return nil
-}
-
-func legacyPostReadyRestoreMatches(existing, desired *dpv1alpha1.Restore) bool {
-	for i := range existing.Spec.Env {
-		switch existing.Spec.Env[i].Name {
-		case dptypes.DPTargetClusterTopology, dptypes.DPTargetComponentServiceVersion:
-			return false
-		}
-	}
-	legacyDesired := desired.DeepCopy()
-	legacyDesired.Spec.Env = nil
-	for i := range desired.Spec.Env {
-		switch desired.Spec.Env[i].Name {
-		case dptypes.DPTargetClusterTopology, dptypes.DPTargetComponentServiceVersion:
-			continue
-		default:
-			legacyDesired.Spec.Env = append(legacyDesired.Spec.Env, desired.Spec.Env[i])
-		}
-	}
-	return reflect.DeepEqual(existing.Spec, legacyDesired.Spec)
 }
 
 func hasOwnerReference(ownerRefs []metav1.OwnerReference, uid types.UID) bool {
@@ -1730,8 +1643,7 @@ func postReadyRestoreLabels(pvc *corev1.PersistentVolumeClaim, comp *appsv1.Comp
 }
 
 func postReadyRestoreName(componentUID types.UID) string {
-	// Backup dataSource restore is an initial, single-attempt restore for a Component UID.
-	return constant.ShortenKubeName(fmt.Sprintf("restore-%s-post-ready", componentUID), constant.KubeNameMaxLength)
+	return dprestore.PostReadyRestoreName(componentUID)
 }
 
 func (r *VolumePopulatorReconciler) Cleanup(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim) error {

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/component-helpers/storage/volume"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -82,8 +83,14 @@ type pvcRestoreDecision struct {
 	skipPostReady bool
 }
 
+type postReadyTargetFacts struct {
+	clusterTopology         string
+	componentServiceVersion string
+}
+
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims/finalizers,verbs=update
+// +kubebuilder:rbac:groups=apps.kubeblocks.io,resources=clusters,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps.kubeblocks.io,resources=components,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps.kubeblocks.io,resources=componentdefinitions,verbs=get;list;watch
 
@@ -1172,21 +1179,31 @@ func (r *VolumePopulatorReconciler) ensurePostReadyRestoreCompleted(reqCtx intct
 		}
 		return false, err
 	}
-	if comp.Status.Phase != appsv1.RunningComponentPhase || componentPostProvisionRunning(comp) {
-		if err = r.updatePVCConditionsIfPopulateNotReleased(reqCtx, pvc, "Waiting for component to finish post-provision"); err != nil {
+	if comp.Generation != comp.Status.ObservedGeneration ||
+		comp.Status.Phase != appsv1.RunningComponentPhase || componentPostProvisionRunning(comp) {
+		if err = r.updatePVCConditionsIfPopulateNotReleased(reqCtx, pvc,
+			"Waiting for component to observe the current generation and finish post-provision"); err != nil {
 			return false, err
 		}
 		return false, nil
+	}
+	componentServiceVersion, err := postReadyComponentServiceVersion(comp)
+	if err != nil {
+		return false, err
+	}
+	cluster := &appsv1.Cluster{}
+	if err = r.Client.Get(reqCtx.Ctx, types.NamespacedName{Namespace: pvc.Namespace, Name: clusterName}, cluster); err != nil {
+		if apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err) {
+			return false, intctrlutil.NewFatalError(err.Error())
+		}
+		return false, intctrlutil.NewRequeueError(reconcileInterval,
+			fmt.Sprintf("waiting for target cluster %s/%s: %v", pvc.Namespace, clusterName, err))
 	}
 	parameters, err := restoreParametersMapFromPVC(pvc)
 	if err != nil {
 		return false, intctrlutil.NewFatalError(err.Error())
 	}
 	if parameters[dptypes.DeferPostReadyUntilClusterRunningParameterKey] == "true" {
-		cluster := &appsv1.Cluster{}
-		if err = r.Client.Get(reqCtx.Ctx, types.NamespacedName{Namespace: pvc.Namespace, Name: clusterName}, cluster); err != nil {
-			return false, err
-		}
 		if cluster.Status.Phase != appsv1.RunningClusterPhase {
 			if err = r.updatePVCConditionsIfPopulateNotReleased(reqCtx, pvc, "Waiting for cluster to run before postReady restore"); err != nil {
 				return false, err
@@ -1194,7 +1211,11 @@ func (r *VolumePopulatorReconciler) ensurePostReadyRestoreCompleted(reqCtx intct
 			return false, nil
 		}
 	}
-	postReadyRestore, err := r.buildPostReadyRestore(reqCtx, pvc, restoreMgr, comp, componentName, backupTarget)
+	postReadyRestore, err := r.buildPostReadyRestore(reqCtx, pvc, restoreMgr, comp, componentName, backupTarget,
+		postReadyTargetFacts{
+			clusterTopology:         cluster.Spec.Topology,
+			componentServiceVersion: componentServiceVersion,
+		})
 	if err != nil {
 		return false, err
 	}
@@ -1241,7 +1262,8 @@ func (r *VolumePopulatorReconciler) buildPostReadyRestore(reqCtx intctrlutil.Req
 	restoreMgr *dprestore.RestoreManager,
 	comp *appsv1.Component,
 	targetComponentName string,
-	redirectTarget *dpv1alpha1.BackupStatusTarget) (*dpv1alpha1.Restore, error) {
+	redirectTarget *dpv1alpha1.BackupStatusTarget,
+	targetFacts postReadyTargetFacts) (*dpv1alpha1.Restore, error) {
 	clusterName := pvc.Labels[constant.AppInstanceLabelKey]
 	componentName := targetComponentName
 	if componentName == "" {
@@ -1310,13 +1332,6 @@ func (r *VolumePopulatorReconciler) buildPostReadyRestore(reqCtx intctrlutil.Req
 			readyConfig.JobAction.Target.VolumeMounts = backup.Status.BackupMethod.TargetVolumes.VolumeMounts
 		}
 	}
-	cluster := &appsv1.Cluster{}
-	if err = r.Client.Get(reqCtx.Ctx, types.NamespacedName{
-		Namespace: pvc.Namespace,
-		Name:      clusterName,
-	}, cluster); err != nil {
-		return nil, err
-	}
 	restore := &dpv1alpha1.Restore{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      postReadyRestoreName(comp.UID),
@@ -1330,7 +1345,7 @@ func (r *VolumePopulatorReconciler) buildPostReadyRestore(reqCtx intctrlutil.Req
 			},
 			RestoreTime: pvc.Annotations[constant.RestorePITRAnnotationKey],
 			Env: buildPostReadyTargetEnv(restoreMgr.Restore.Spec.Env,
-				cluster.Spec.Topology, comp.Spec.ServiceVersion),
+				targetFacts.clusterTopology, targetFacts.componentServiceVersion),
 			Parameters:  restoreParametersToPairs(restoreActionParameters(parameters)),
 			ReadyConfig: readyConfig,
 		},
@@ -1342,6 +1357,36 @@ func (r *VolumePopulatorReconciler) buildPostReadyRestore(reqCtx intctrlutil.Req
 		return nil, err
 	}
 	return restore, nil
+}
+
+func postReadyComponentServiceVersion(comp *appsv1.Component) (string, error) {
+	componentVersion := comp.Spec.ServiceVersion
+	versions := map[string]struct{}{}
+	remainingDefaultReplicas := comp.Spec.Replicas
+	for i := range comp.Spec.Instances {
+		instance := &comp.Spec.Instances[i]
+		instanceReplicas := ptr.Deref(instance.Replicas, 1)
+		if instanceReplicas == 0 {
+			continue
+		}
+		remainingDefaultReplicas -= instanceReplicas
+		instanceVersion := instance.ServiceVersion
+		if instanceVersion == "" {
+			instanceVersion = componentVersion
+		}
+		versions[instanceVersion] = struct{}{}
+	}
+	if remainingDefaultReplicas > 0 || len(versions) == 0 {
+		versions[componentVersion] = struct{}{}
+	}
+	if len(versions) != 1 {
+		return "", intctrlutil.NewFatalError(fmt.Sprintf(
+			"component %s/%s has no single serviceVersion across active instances", comp.Namespace, comp.Name))
+	}
+	for version := range versions {
+		return version, nil
+	}
+	return "", nil
 }
 
 func buildPostReadyTargetEnv(source []corev1.EnvVar, clusterTopology, componentServiceVersion string) []corev1.EnvVar {

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -1310,6 +1310,13 @@ func (r *VolumePopulatorReconciler) buildPostReadyRestore(reqCtx intctrlutil.Req
 			readyConfig.JobAction.Target.VolumeMounts = backup.Status.BackupMethod.TargetVolumes.VolumeMounts
 		}
 	}
+	cluster := &appsv1.Cluster{}
+	if err = r.Client.Get(reqCtx.Ctx, types.NamespacedName{
+		Namespace: pvc.Namespace,
+		Name:      clusterName,
+	}, cluster); err != nil {
+		return nil, err
+	}
 	restore := &dpv1alpha1.Restore{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      postReadyRestoreName(comp.UID),
@@ -1322,7 +1329,8 @@ func (r *VolumePopulatorReconciler) buildPostReadyRestore(reqCtx intctrlutil.Req
 				Namespace: backupNamespace,
 			},
 			RestoreTime: pvc.Annotations[constant.RestorePITRAnnotationKey],
-			Env:         restoreMgr.Restore.Spec.Env,
+			Env: buildPostReadyTargetEnv(restoreMgr.Restore.Spec.Env,
+				cluster.Spec.Topology, comp.Spec.ServiceVersion),
 			Parameters:  restoreParametersToPairs(restoreActionParameters(parameters)),
 			ReadyConfig: readyConfig,
 		},
@@ -1336,16 +1344,51 @@ func (r *VolumePopulatorReconciler) buildPostReadyRestore(reqCtx intctrlutil.Req
 	return restore, nil
 }
 
+func buildPostReadyTargetEnv(source []corev1.EnvVar, clusterTopology, componentServiceVersion string) []corev1.EnvVar {
+	env := make([]corev1.EnvVar, 0, len(source)+2)
+	for i := range source {
+		switch source[i].Name {
+		case dptypes.DPTargetClusterTopology, dptypes.DPTargetComponentServiceVersion:
+			continue
+		default:
+			env = append(env, source[i])
+		}
+	}
+	return append(env,
+		corev1.EnvVar{Name: dptypes.DPTargetClusterTopology, Value: clusterTopology},
+		corev1.EnvVar{Name: dptypes.DPTargetComponentServiceVersion, Value: componentServiceVersion})
+}
+
 func validatePostReadyRestore(existing, desired *dpv1alpha1.Restore, comp *appsv1.Component) error {
 	if !hasOwnerReference(existing.OwnerReferences, comp.UID) {
 		return intctrlutil.NewFatalError(fmt.Sprintf("postReady restore %s/%s is not owned by component %s/%s",
 			existing.Namespace, existing.Name, comp.Namespace, comp.Name))
 	}
-	if !reflect.DeepEqual(existing.Spec, desired.Spec) {
+	if !reflect.DeepEqual(existing.Spec, desired.Spec) && !legacyPostReadyRestoreMatches(existing, desired) {
 		return intctrlutil.NewFatalError(fmt.Sprintf("postReady restore %s/%s spec does not match current restore intent",
 			existing.Namespace, existing.Name))
 	}
 	return nil
+}
+
+func legacyPostReadyRestoreMatches(existing, desired *dpv1alpha1.Restore) bool {
+	for i := range existing.Spec.Env {
+		switch existing.Spec.Env[i].Name {
+		case dptypes.DPTargetClusterTopology, dptypes.DPTargetComponentServiceVersion:
+			return false
+		}
+	}
+	legacyDesired := desired.DeepCopy()
+	legacyDesired.Spec.Env = nil
+	for i := range desired.Spec.Env {
+		switch desired.Spec.Env[i].Name {
+		case dptypes.DPTargetClusterTopology, dptypes.DPTargetComponentServiceVersion:
+			continue
+		default:
+			legacyDesired.Spec.Env = append(legacyDesired.Spec.Env, desired.Spec.Env[i])
+		}
+	}
+	return reflect.DeepEqual(existing.Spec, legacyDesired.Spec)
 }
 
 func hasOwnerReference(ownerRefs []metav1.OwnerReference, uid types.UID) bool {

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -1353,14 +1353,10 @@ func (r *VolumePopulatorReconciler) buildPostReadyRestore(reqCtx intctrlutil.Req
 func stripPostReadyTargetEnv(source []corev1.EnvVar) []corev1.EnvVar {
 	var env []corev1.EnvVar
 	for i := range source {
-		switch source[i].Name {
-		case dptypes.DPTargetClusterTopology,
-			dptypes.DPTargetComponentServiceVersion,
-			dptypes.DPTargetComponentServiceVersionSelector:
+		if dptypes.IsPostReadyTargetEnv(source[i].Name) {
 			continue
-		default:
-			env = append(env, source[i])
 		}
+		env = append(env, source[i])
 	}
 	return env
 }

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -1179,6 +1179,37 @@ func (r *VolumePopulatorReconciler) ensurePostReadyRestoreCompleted(reqCtx intct
 		}
 		return false, err
 	}
+	existing := &dpv1alpha1.Restore{}
+	existingKey := types.NamespacedName{
+		Namespace: pvc.Namespace,
+		Name:      postReadyRestoreName(comp.UID),
+	}
+	if err = r.Client.Get(reqCtx.Ctx, existingKey, existing); err == nil {
+		targetFacts, factsErr := postReadyTargetFactsFromRestore(existing)
+		if factsErr != nil {
+			return false, factsErr
+		}
+		desired, buildErr := r.buildPostReadyRestore(reqCtx, pvc, restoreMgr, comp, componentName, backupTarget, targetFacts)
+		if buildErr != nil {
+			return false, buildErr
+		}
+		if validateErr := validatePostReadyRestore(existing, desired, comp); validateErr != nil {
+			return false, validateErr
+		}
+		switch existing.Status.Phase {
+		case dpv1alpha1.RestorePhaseCompleted:
+			return true, nil
+		case dpv1alpha1.RestorePhaseFailed:
+			return false, intctrlutil.NewFatalError(fmt.Sprintf("postReady restore %s/%s failed", existing.Namespace, existing.Name))
+		default:
+			if err = r.updatePVCConditionsIfPopulateNotReleased(reqCtx, pvc, "Waiting for postReady restore to complete"); err != nil {
+				return false, err
+			}
+			return false, nil
+		}
+	} else if !apierrors.IsNotFound(err) {
+		return false, err
+	}
 	if comp.Generation != comp.Status.ObservedGeneration ||
 		comp.Status.Phase != appsv1.RunningComponentPhase || componentPostProvisionRunning(comp) {
 		if err = r.updatePVCConditionsIfPopulateNotReleased(reqCtx, pvc,
@@ -1187,10 +1218,7 @@ func (r *VolumePopulatorReconciler) ensurePostReadyRestoreCompleted(reqCtx intct
 		}
 		return false, nil
 	}
-	componentServiceVersion, err := postReadyComponentServiceVersion(comp)
-	if err != nil {
-		return false, err
-	}
+	componentServiceVersion := postReadyComponentServiceVersion(comp)
 	cluster := &appsv1.Cluster{}
 	if err = r.Client.Get(reqCtx.Ctx, types.NamespacedName{Namespace: pvc.Namespace, Name: clusterName}, cluster); err != nil {
 		if apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err) {
@@ -1219,33 +1247,13 @@ func (r *VolumePopulatorReconciler) ensurePostReadyRestoreCompleted(reqCtx intct
 	if err != nil {
 		return false, err
 	}
-	existing := &dpv1alpha1.Restore{}
-	if err = r.Client.Get(reqCtx.Ctx, client.ObjectKeyFromObject(postReadyRestore), existing); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return false, err
-		}
-		if err = r.Client.Create(reqCtx.Ctx, postReadyRestore); err != nil && !apierrors.IsAlreadyExists(err) {
-			return false, err
-		}
-		if err = r.updatePVCConditionsIfPopulateNotReleased(reqCtx, pvc, "Waiting for postReady restore to complete"); err != nil {
-			return false, err
-		}
-		return false, nil
-	}
-	if err = validatePostReadyRestore(existing, postReadyRestore, comp); err != nil {
+	if err = r.Client.Create(reqCtx.Ctx, postReadyRestore); err != nil && !apierrors.IsAlreadyExists(err) {
 		return false, err
 	}
-	switch existing.Status.Phase {
-	case dpv1alpha1.RestorePhaseCompleted:
-		return true, nil
-	case dpv1alpha1.RestorePhaseFailed:
-		return false, intctrlutil.NewFatalError(fmt.Sprintf("postReady restore %s/%s failed", existing.Namespace, existing.Name))
-	default:
-		if err = r.updatePVCConditionsIfPopulateNotReleased(reqCtx, pvc, "Waiting for postReady restore to complete"); err != nil {
-			return false, err
-		}
-		return false, nil
+	if err = r.updatePVCConditionsIfPopulateNotReleased(reqCtx, pvc, "Waiting for postReady restore to complete"); err != nil {
+		return false, err
 	}
+	return false, nil
 }
 
 func (r *VolumePopulatorReconciler) updatePVCConditionsIfPopulateNotReleased(reqCtx intctrlutil.RequestCtx,
@@ -1359,7 +1367,9 @@ func (r *VolumePopulatorReconciler) buildPostReadyRestore(reqCtx intctrlutil.Req
 	return restore, nil
 }
 
-func postReadyComponentServiceVersion(comp *appsv1.Component) (string, error) {
+// postReadyComponentServiceVersion returns an empty value when a legal Component
+// has multiple active versions that cannot be represented by this transitional string.
+func postReadyComponentServiceVersion(comp *appsv1.Component) string {
 	componentVersion := comp.Spec.ServiceVersion
 	versions := map[string]struct{}{}
 	remainingDefaultReplicas := comp.Spec.Replicas
@@ -1380,13 +1390,35 @@ func postReadyComponentServiceVersion(comp *appsv1.Component) (string, error) {
 		versions[componentVersion] = struct{}{}
 	}
 	if len(versions) != 1 {
-		return "", intctrlutil.NewFatalError(fmt.Sprintf(
-			"component %s/%s has no single serviceVersion across active instances", comp.Namespace, comp.Name))
+		return ""
 	}
 	for version := range versions {
-		return version, nil
+		return version
 	}
-	return "", nil
+	return ""
+}
+
+func postReadyTargetFactsFromRestore(restore *dpv1alpha1.Restore) (postReadyTargetFacts, error) {
+	var facts postReadyTargetFacts
+	var topologyCount, serviceVersionCount int
+	for i := range restore.Spec.Env {
+		switch restore.Spec.Env[i].Name {
+		case dptypes.DPTargetClusterTopology:
+			topologyCount++
+			facts.clusterTopology = restore.Spec.Env[i].Value
+		case dptypes.DPTargetComponentServiceVersion:
+			serviceVersionCount++
+			facts.componentServiceVersion = restore.Spec.Env[i].Value
+		}
+	}
+	if topologyCount == 0 && serviceVersionCount == 0 {
+		return facts, nil
+	}
+	if topologyCount != 1 || serviceVersionCount != 1 {
+		return postReadyTargetFacts{}, intctrlutil.NewFatalError(fmt.Sprintf(
+			"postReady restore %s/%s has an invalid target-fact snapshot", restore.Namespace, restore.Name))
+	}
+	return facts, nil
 }
 
 func buildPostReadyTargetEnv(source []corev1.EnvVar, clusterTopology, componentServiceVersion string) []corev1.EnvVar {

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -1772,7 +1772,7 @@ func TestBuildPostReadyRestoreStripsCallerTargetEnv(t *testing.T) {
 		{Name: dptypes.DPTargetClusterTopology, Value: "caller-value-1"},
 		{Name: dptypes.DPTargetClusterTopology, Value: "caller-value-2"},
 		{Name: dptypes.DPTargetComponentServiceVersion, Value: "caller-version"},
-		{Name: dptypes.DPTargetComponentServiceVersionSelector, Value: "caller-selector"},
+		{Name: "DP_TARGET_COMPONENT_SERVICE_VERSION_SELECTOR", Value: "caller-selector"},
 	}
 	sourceRestore := &dpv1alpha1.Restore{Spec: dpv1alpha1.RestoreSpec{
 		Env: append([]corev1.EnvVar{}, sourceEnv...),
@@ -1791,7 +1791,7 @@ func TestBuildPostReadyRestoreStripsCallerTargetEnv(t *testing.T) {
 	require.Equal(t, "kept", envValue(restore.Spec.Env, "KEEP_ME"))
 	require.Zero(t, envNameCount(restore.Spec.Env, dptypes.DPTargetClusterTopology))
 	require.Zero(t, envNameCount(restore.Spec.Env, dptypes.DPTargetComponentServiceVersion))
-	require.Zero(t, envNameCount(restore.Spec.Env, dptypes.DPTargetComponentServiceVersionSelector))
+	require.Zero(t, envNameCount(restore.Spec.Env, "DP_TARGET_COMPONENT_SERVICE_VERSION_SELECTOR"))
 }
 
 func TestReconcileCreatesPostReadyRestoreWithoutTargetClusterSnapshot(t *testing.T) {
@@ -1877,7 +1877,7 @@ func TestReconcileCreatesPostReadyRestoreWithoutTargetClusterSnapshot(t *testing
 	}, restore))
 	require.Zero(t, envNameCount(restore.Spec.Env, dptypes.DPTargetClusterTopology))
 	require.Zero(t, envNameCount(restore.Spec.Env, dptypes.DPTargetComponentServiceVersion))
-	require.Zero(t, envNameCount(restore.Spec.Env, dptypes.DPTargetComponentServiceVersionSelector))
+	require.Zero(t, envNameCount(restore.Spec.Env, "DP_TARGET_COMPONENT_SERVICE_VERSION_SELECTOR"))
 }
 
 func TestEnsurePostReadyRestoreWaitsForObservedComponentGeneration(t *testing.T) {
@@ -2014,7 +2014,7 @@ func TestValidatePostReadyRestoreTargetEnvCompatibility(t *testing.T) {
 					{Name: "KEEP_ME", Value: "kept"},
 					{Name: dptypes.DPTargetClusterTopology, Value: "caller-topology"},
 					{Name: dptypes.DPTargetComponentServiceVersion, Value: "caller-version"},
-					{Name: dptypes.DPTargetComponentServiceVersionSelector, Value: "caller-selector"},
+					{Name: "DP_TARGET_COMPONENT_SERVICE_VERSION_SELECTOR", Value: "caller-selector"},
 				},
 			},
 		},

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -1725,6 +1725,7 @@ func TestBuildPostReadyRestoreSelectsHighestPriorityRole(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      constant.GenerateClusterComponentName("cluster", "mysql"),
+			UID:       "component-uid",
 		},
 		Spec: kbappsv1.ComponentSpec{CompDef: compDef.Name},
 	}
@@ -1761,6 +1762,7 @@ func TestBuildPostReadyRestoreStripsCallerTargetEnv(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      constant.GenerateClusterComponentName(cluster.Name, "mysql"),
+			UID:       "component-uid",
 		},
 		Spec: kbappsv1.ComponentSpec{ServiceVersion: "3.3.2"},
 	}
@@ -1953,6 +1955,59 @@ func TestEnsurePostReadyRestoreWaitsForObservedComponentGeneration(t *testing.T)
 		Namespace: pvc.Namespace,
 		Name:      postReadyRestoreName(comp.UID),
 	}, restore))
+	require.Equal(t, dprestore.DataProtectionInternalPostReadyLabelValue,
+		restore.Labels[dprestore.DataProtectionInternalPostReadyLabelKey])
+	require.Len(t, restore.OwnerReferences, 1)
+	require.Equal(t, kbappsv1.APIVersion, restore.OwnerReferences[0].APIVersion)
+	require.Equal(t, kbappsv1.ComponentKind, restore.OwnerReferences[0].Kind)
+	require.Equal(t, comp.Name, restore.OwnerReferences[0].Name)
+	require.Equal(t, comp.UID, restore.OwnerReferences[0].UID)
+	require.Equal(t, ptr.To(true), restore.OwnerReferences[0].Controller)
+}
+
+func strictPostReadyRestoreObjectMeta(comp *kbappsv1.Component) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Namespace: comp.Namespace,
+		Name:      postReadyRestoreName(comp.UID),
+		Labels: map[string]string{
+			dprestore.DataProtectionInternalPostReadyLabelKey: dprestore.DataProtectionInternalPostReadyLabelValue,
+		},
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: kbappsv1.APIVersion,
+			Kind:       kbappsv1.ComponentKind,
+			Name:       comp.Name,
+			UID:        comp.UID,
+			Controller: ptr.To(true),
+		}},
+	}
+}
+
+func TestValidatePostReadyRestoreRejectsUIDOnlyNonComponentOwner(t *testing.T) {
+	comp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "cluster-mysql",
+			UID:       "component-uid",
+		},
+	}
+	desired := &dpv1alpha1.Restore{
+		ObjectMeta: strictPostReadyRestoreObjectMeta(comp),
+		Spec: dpv1alpha1.RestoreSpec{
+			Backup: dpv1alpha1.BackupRef{Name: "backup", Namespace: "default"},
+		},
+	}
+	existing := desired.DeepCopy()
+	existing.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: "v1",
+		Kind:       "Secret",
+		Name:       "not-the-component",
+		UID:        comp.UID,
+	}}
+
+	err := validatePostReadyRestore(existing, desired, comp)
+
+	require.Error(t, err)
+	require.True(t, intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal), err.Error())
 }
 
 func TestValidatePostReadyRestoreTargetEnvCompatibility(t *testing.T) {
@@ -1963,20 +2018,17 @@ func TestValidatePostReadyRestoreTargetEnvCompatibility(t *testing.T) {
 			UID:       "component-uid",
 		},
 	}
-	desired := &dpv1alpha1.Restore{Spec: dpv1alpha1.RestoreSpec{
-		Backup: dpv1alpha1.BackupRef{Name: "backup", Namespace: "default"},
-		Env:    []corev1.EnvVar{{Name: "KEEP_ME", Value: "kept"}},
-	}}
+	desired := &dpv1alpha1.Restore{
+		ObjectMeta: strictPostReadyRestoreObjectMeta(comp),
+		Spec: dpv1alpha1.RestoreSpec{
+			Backup: dpv1alpha1.BackupRef{Name: "backup", Namespace: "default"},
+			Env:    []corev1.EnvVar{{Name: "KEEP_ME", Value: "kept"}},
+		},
+	}
 	newExisting := func(spec dpv1alpha1.RestoreSpec) *dpv1alpha1.Restore {
 		return &dpv1alpha1.Restore{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "post-ready",
-				OwnerReferences: []metav1.OwnerReference{{
-					UID: comp.UID,
-				}},
-			},
-			Spec: spec,
+			ObjectMeta: strictPostReadyRestoreObjectMeta(comp),
+			Spec:       spec,
 		}
 	}
 
@@ -2042,19 +2094,20 @@ func TestValidatePostReadyRestoreTargetEnvCompatibility(t *testing.T) {
 
 func TestValidatePostReadyRestoreAllowsLegacyNilEnv(t *testing.T) {
 	comp := &kbappsv1.Component{
-		ObjectMeta: metav1.ObjectMeta{UID: "component-uid"},
-	}
-	desired := &dpv1alpha1.Restore{Spec: dpv1alpha1.RestoreSpec{
-		Backup: dpv1alpha1.BackupRef{Name: "backup", Namespace: "default"},
-	}}
-	existing := &dpv1alpha1.Restore{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
-			Name:      "post-ready",
-			OwnerReferences: []metav1.OwnerReference{{
-				UID: comp.UID,
-			}},
+			Name:      "cluster-mysql",
+			UID:       "component-uid",
 		},
+	}
+	desired := &dpv1alpha1.Restore{
+		ObjectMeta: strictPostReadyRestoreObjectMeta(comp),
+		Spec: dpv1alpha1.RestoreSpec{
+			Backup: dpv1alpha1.BackupRef{Name: "backup", Namespace: "default"},
+		},
+	}
+	existing := &dpv1alpha1.Restore{
+		ObjectMeta: strictPostReadyRestoreObjectMeta(comp),
 		Spec: dpv1alpha1.RestoreSpec{
 			Backup: desired.Spec.Backup,
 			Env:    nil,
@@ -2102,6 +2155,7 @@ func TestBuildPostReadyRestoreUsesInitAccountFromComponentDefinition(t *testing.
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      constant.GenerateClusterComponentName("cluster", "mysql"),
+			UID:       "component-uid",
 		},
 		Spec: kbappsv1.ComponentSpec{CompDef: compDef.Name},
 	}

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -1740,18 +1740,14 @@ func TestBuildPostReadyRestoreSelectsHighestPriorityRole(t *testing.T) {
 	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{}, nil, scheme, reconciler.Client)
 
 	restore, err := reconciler.buildPostReadyRestore(
-		intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp, "", nil, postReadyTargetFacts{})
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp, "", nil)
 
 	require.NoError(t, err)
 	require.Equal(t, "leader", restore.Spec.ReadyConfig.JobAction.Target.PodSelector.LabelSelector.MatchLabels[instanceset.RoleLabelKey])
 	require.NotContains(t, restore.Spec.ReadyConfig.ExecAction.Target.PodSelector.MatchLabels, instanceset.RoleLabelKey)
 }
 
-func TestBuildPostReadyRestoreWritesLiveTargetEnv(t *testing.T) {
-	const (
-		targetClusterTopologyEnv         = "DP_TARGET_CLUSTER_TOPOLOGY"
-		targetComponentServiceVersionEnv = "DP_TARGET_COMPONENT_SERVICE_VERSION"
-	)
+func TestBuildPostReadyRestoreStripsCallerTargetEnv(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 	require.NoError(t, kbappsv1.AddToScheme(scheme))
@@ -1773,9 +1769,10 @@ func TestBuildPostReadyRestoreWritesLiveTargetEnv(t *testing.T) {
 	pvc.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
 	sourceEnv := []corev1.EnvVar{
 		{Name: "KEEP_ME", Value: "kept"},
-		{Name: targetClusterTopologyEnv, Value: "caller-value-1"},
-		{Name: targetClusterTopologyEnv, Value: "caller-value-2"},
-		{Name: targetComponentServiceVersionEnv, Value: "caller-version"},
+		{Name: dptypes.DPTargetClusterTopology, Value: "caller-value-1"},
+		{Name: dptypes.DPTargetClusterTopology, Value: "caller-value-2"},
+		{Name: dptypes.DPTargetComponentServiceVersion, Value: "caller-version"},
+		{Name: dptypes.DPTargetComponentServiceVersionSelector, Value: "caller-selector"},
 	}
 	sourceRestore := &dpv1alpha1.Restore{Spec: dpv1alpha1.RestoreSpec{
 		Env: append([]corev1.EnvVar{}, sourceEnv...),
@@ -1787,19 +1784,17 @@ func TestBuildPostReadyRestoreWritesLiveTargetEnv(t *testing.T) {
 	restoreMgr := dprestore.NewRestoreManager(sourceRestore, nil, scheme, reconciler.Client)
 
 	restore, err := reconciler.buildPostReadyRestore(
-		intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp, "", nil,
-		postReadyTargetFacts{clusterTopology: "shared-nothing", componentServiceVersion: "3.3.2"})
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp, "", nil)
 
 	require.NoError(t, err)
 	require.Equal(t, sourceEnv, sourceRestore.Spec.Env, "building the internal Restore must not mutate the source Restore")
 	require.Equal(t, "kept", envValue(restore.Spec.Env, "KEEP_ME"))
-	require.Equal(t, "shared-nothing", envValue(restore.Spec.Env, targetClusterTopologyEnv))
-	require.Equal(t, "3.3.2", envValue(restore.Spec.Env, targetComponentServiceVersionEnv))
-	require.Equal(t, 1, envNameCount(restore.Spec.Env, targetClusterTopologyEnv))
-	require.Equal(t, 1, envNameCount(restore.Spec.Env, targetComponentServiceVersionEnv))
+	require.Zero(t, envNameCount(restore.Spec.Env, dptypes.DPTargetClusterTopology))
+	require.Zero(t, envNameCount(restore.Spec.Env, dptypes.DPTargetComponentServiceVersion))
+	require.Zero(t, envNameCount(restore.Spec.Env, dptypes.DPTargetComponentServiceVersionSelector))
 }
 
-func TestReconcileRetriesMissingTargetClusterAndPropagatesInstanceVersionOverride(t *testing.T) {
+func TestReconcileCreatesPostReadyRestoreWithoutTargetClusterSnapshot(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 	require.NoError(t, kbappsv1.AddToScheme(scheme))
@@ -1876,22 +1871,13 @@ func TestReconcileRetriesMissingTargetClusterAndPropagatesInstanceVersionOverrid
 	require.NoError(t, err)
 	require.Equal(t, reconcileInterval, result.RequeueAfter)
 	restore := &dpv1alpha1.Restore{}
-	require.True(t, apierrors.IsNotFound(reconciler.Client.Get(context.Background(), client.ObjectKey{
-		Namespace: pvc.Namespace,
-		Name:      postReadyRestoreName(comp.UID),
-	}, restore)))
-	require.NoError(t, reconciler.Client.Create(context.Background(), newClusterForPostReadyTest()))
-
-	result, err = reconciler.Reconcile(context.Background(), req)
-
-	require.NoError(t, err)
-	require.Equal(t, reconcileInterval, result.RequeueAfter)
 	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKey{
 		Namespace: pvc.Namespace,
 		Name:      postReadyRestoreName(comp.UID),
 	}, restore))
-	require.Equal(t, "shared-nothing", envValue(restore.Spec.Env, dptypes.DPTargetClusterTopology))
-	require.Equal(t, "3.4.0", envValue(restore.Spec.Env, dptypes.DPTargetComponentServiceVersion))
+	require.Zero(t, envNameCount(restore.Spec.Env, dptypes.DPTargetClusterTopology))
+	require.Zero(t, envNameCount(restore.Spec.Env, dptypes.DPTargetComponentServiceVersion))
+	require.Zero(t, envNameCount(restore.Spec.Env, dptypes.DPTargetComponentServiceVersionSelector))
 }
 
 func TestEnsurePostReadyRestoreWaitsForObservedComponentGeneration(t *testing.T) {
@@ -1969,58 +1955,6 @@ func TestEnsurePostReadyRestoreWaitsForObservedComponentGeneration(t *testing.T)
 	}, restore))
 }
 
-func TestPostReadyComponentServiceVersionPublishesOnlyOneActiveVersion(t *testing.T) {
-	zero := int32(0)
-	tests := []struct {
-		name      string
-		replicas  int32
-		instances []kbappsv1.InstanceTemplate
-		want      string
-	}{
-		{name: "component default", replicas: 1, want: "3.3.2"},
-		{
-			name:      "matching active override",
-			replicas:  1,
-			instances: []kbappsv1.InstanceTemplate{{Name: "same", ServiceVersion: "3.3.2"}},
-			want:      "3.3.2",
-		},
-		{
-			name:      "different inactive override",
-			replicas:  1,
-			instances: []kbappsv1.InstanceTemplate{{Name: "disabled", ServiceVersion: "3.4.0", Replicas: &zero}},
-			want:      "3.3.2",
-		},
-		{
-			name:      "single active override replaces all default instances",
-			replicas:  1,
-			instances: []kbappsv1.InstanceTemplate{{Name: "only", ServiceVersion: "3.4.0"}},
-			want:      "3.4.0",
-		},
-		{
-			name:      "different active versions",
-			replicas:  2,
-			instances: []kbappsv1.InstanceTemplate{{Name: "canary", ServiceVersion: "3.4.0"}},
-			want:      "",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			comp := &kbappsv1.Component{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster-mysql"},
-				Spec: kbappsv1.ComponentSpec{
-					ServiceVersion: "3.3.2",
-					Replicas:       tt.replicas,
-					Instances:      tt.instances,
-				},
-			}
-
-			got := postReadyComponentServiceVersion(comp)
-
-			require.Equal(t, tt.want, got)
-		})
-	}
-}
-
 func TestValidatePostReadyRestoreTargetEnvCompatibility(t *testing.T) {
 	comp := &kbappsv1.Component{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2031,11 +1965,7 @@ func TestValidatePostReadyRestoreTargetEnvCompatibility(t *testing.T) {
 	}
 	desired := &dpv1alpha1.Restore{Spec: dpv1alpha1.RestoreSpec{
 		Backup: dpv1alpha1.BackupRef{Name: "backup", Namespace: "default"},
-		Env: []corev1.EnvVar{
-			{Name: "KEEP_ME", Value: "kept"},
-			{Name: dptypes.DPTargetClusterTopology, Value: "shared-nothing"},
-			{Name: dptypes.DPTargetComponentServiceVersion, Value: "3.3.2"},
-		},
+		Env:    []corev1.EnvVar{{Name: "KEEP_ME", Value: "kept"}},
 	}}
 	newExisting := func(spec dpv1alpha1.RestoreSpec) *dpv1alpha1.Restore {
 		return &dpv1alpha1.Restore{
@@ -2060,7 +1990,7 @@ func TestValidatePostReadyRestoreTargetEnvCompatibility(t *testing.T) {
 			spec: *desired.Spec.DeepCopy(),
 		},
 		{
-			name: "legacy restore with both target envs absent",
+			name: "restore without target snapshot",
 			spec: dpv1alpha1.RestoreSpec{
 				Backup: desired.Spec.Backup,
 				Env:    []corev1.EnvVar{{Name: "KEEP_ME", Value: "kept"}},
@@ -2075,7 +2005,6 @@ func TestValidatePostReadyRestoreTargetEnvCompatibility(t *testing.T) {
 					{Name: dptypes.DPTargetClusterTopology, Value: "shared-nothing"},
 				},
 			},
-			wantErr: true,
 		},
 		{
 			name: "caller target env values",
@@ -2085,9 +2014,9 @@ func TestValidatePostReadyRestoreTargetEnvCompatibility(t *testing.T) {
 					{Name: "KEEP_ME", Value: "kept"},
 					{Name: dptypes.DPTargetClusterTopology, Value: "caller-topology"},
 					{Name: dptypes.DPTargetComponentServiceVersion, Value: "caller-version"},
+					{Name: dptypes.DPTargetComponentServiceVersionSelector, Value: "caller-selector"},
 				},
 			},
-			wantErr: true,
 		},
 		{
 			name: "unrelated spec mismatch",
@@ -2111,75 +2040,12 @@ func TestValidatePostReadyRestoreTargetEnvCompatibility(t *testing.T) {
 	}
 }
 
-func TestPostReadyTargetFactsFromRestoreRequiresOneCompleteSnapshot(t *testing.T) {
-	tests := []struct {
-		name    string
-		env     []corev1.EnvVar
-		want    postReadyTargetFacts
-		wantErr bool
-	}{
-		{name: "legacy snapshot absent"},
-		{
-			name: "complete snapshot",
-			env: []corev1.EnvVar{
-				{Name: dptypes.DPTargetClusterTopology, Value: "shared-nothing"},
-				{Name: dptypes.DPTargetComponentServiceVersion, Value: "3.3.2"},
-			},
-			want: postReadyTargetFacts{clusterTopology: "shared-nothing", componentServiceVersion: "3.3.2"},
-		},
-		{
-			name: "heterogeneous version snapshot is explicitly empty",
-			env: []corev1.EnvVar{
-				{Name: dptypes.DPTargetClusterTopology, Value: "shared-nothing"},
-				{Name: dptypes.DPTargetComponentServiceVersion, Value: ""},
-			},
-			want: postReadyTargetFacts{clusterTopology: "shared-nothing"},
-		},
-		{
-			name:    "partial snapshot",
-			env:     []corev1.EnvVar{{Name: dptypes.DPTargetClusterTopology, Value: "shared-nothing"}},
-			wantErr: true,
-		},
-		{
-			name: "duplicate snapshot key",
-			env: []corev1.EnvVar{
-				{Name: dptypes.DPTargetClusterTopology, Value: "shared-nothing"},
-				{Name: dptypes.DPTargetClusterTopology, Value: "shared-data"},
-				{Name: dptypes.DPTargetComponentServiceVersion, Value: "3.3.2"},
-			},
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			restore := &dpv1alpha1.Restore{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "post-ready"},
-				Spec:       dpv1alpha1.RestoreSpec{Env: tt.env},
-			}
-
-			got, err := postReadyTargetFactsFromRestore(restore)
-
-			if tt.wantErr {
-				require.Error(t, err)
-				require.True(t, intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal), err.Error())
-				return
-			}
-			require.NoError(t, err)
-			require.Equal(t, tt.want, got)
-		})
-	}
-}
-
 func TestValidatePostReadyRestoreAllowsLegacyNilEnv(t *testing.T) {
 	comp := &kbappsv1.Component{
 		ObjectMeta: metav1.ObjectMeta{UID: "component-uid"},
 	}
 	desired := &dpv1alpha1.Restore{Spec: dpv1alpha1.RestoreSpec{
 		Backup: dpv1alpha1.BackupRef{Name: "backup", Namespace: "default"},
-		Env: []corev1.EnvVar{
-			{Name: dptypes.DPTargetClusterTopology, Value: "shared-nothing"},
-			{Name: dptypes.DPTargetComponentServiceVersion, Value: "3.3.2"},
-		},
 	}}
 	existing := &dpv1alpha1.Restore{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2251,7 +2117,7 @@ func TestBuildPostReadyRestoreUsesInitAccountFromComponentDefinition(t *testing.
 	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{}, nil, scheme, reconciler.Client)
 
 	restore, err := reconciler.buildPostReadyRestore(
-		intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp, "", nil, postReadyTargetFacts{})
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp, "", nil)
 
 	require.NoError(t, err)
 	require.NotNil(t, restore.Spec.ReadyConfig.ConnectionCredential)
@@ -2553,7 +2419,7 @@ func TestCompleteBoundPVCContinuesPostReadyAfterPopulateReleased(t *testing.T) {
 	require.Nil(t, restoreCondition)
 }
 
-func TestCompleteBoundPVCUsesFrozenTargetFactsAfterPostReadyCompleted(t *testing.T) {
+func TestCompleteBoundPVCUsesTerminalPostReadyResultAfterComponentChanges(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 	require.NoError(t, batchv1.AddToScheme(scheme))
@@ -2612,7 +2478,6 @@ func TestCompleteBoundPVCUsesFrozenTargetFactsAfterPostReadyCompleted(t *testing
 		creationComp,
 		"",
 		nil,
-		postReadyTargetFacts{clusterTopology: "shared-nothing", componentServiceVersion: "3.3.2"},
 	)
 	require.NoError(t, err)
 	postReadyRestore.Status.Phase = dpv1alpha1.RestorePhaseCompleted

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -1731,7 +1731,9 @@ func TestBuildPostReadyRestoreSelectsHighestPriorityRole(t *testing.T) {
 	pvc.Spec.DataSourceRef = &corev1.TypedObjectReference{Name: backup.Name}
 	pvc.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
 	reconciler := &VolumePopulatorReconciler{
-		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(backup, compDef).Build(),
+		Client: fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(backup, compDef, newClusterForPostReadyTest()).
+			Build(),
 		Scheme: scheme,
 	}
 	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{}, nil, scheme, reconciler.Client)
@@ -1741,6 +1743,223 @@ func TestBuildPostReadyRestoreSelectsHighestPriorityRole(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "leader", restore.Spec.ReadyConfig.JobAction.Target.PodSelector.LabelSelector.MatchLabels[instanceset.RoleLabelKey])
 	require.NotContains(t, restore.Spec.ReadyConfig.ExecAction.Target.PodSelector.MatchLabels, instanceset.RoleLabelKey)
+}
+
+func TestBuildPostReadyRestoreWritesLiveTargetEnv(t *testing.T) {
+	const (
+		targetClusterTopologyEnv         = "DP_TARGET_CLUSTER_TOPOLOGY"
+		targetComponentServiceVersionEnv = "DP_TARGET_COMPONENT_SERVICE_VERSION"
+	)
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, kbappsv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	backup := newBackupForRestoreDecision([]string{"data"}, nil)
+	cluster := &kbappsv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster"},
+		Spec:       kbappsv1.ClusterSpec{Topology: "shared-nothing"},
+	}
+	comp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName(cluster.Name, "mysql"),
+		},
+		Spec: kbappsv1.ComponentSpec{ServiceVersion: "3.3.2"},
+	}
+	pvc := newPVCForRestoreDecision("data", "mysql", "")
+	pvc.Spec.DataSourceRef = &corev1.TypedObjectReference{Name: backup.Name}
+	pvc.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+	sourceEnv := []corev1.EnvVar{
+		{Name: "KEEP_ME", Value: "kept"},
+		{Name: targetClusterTopologyEnv, Value: "caller-value-1"},
+		{Name: targetClusterTopologyEnv, Value: "caller-value-2"},
+		{Name: targetComponentServiceVersionEnv, Value: "caller-version"},
+	}
+	sourceRestore := &dpv1alpha1.Restore{Spec: dpv1alpha1.RestoreSpec{
+		Env: append([]corev1.EnvVar{}, sourceEnv...),
+	}}
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(backup, cluster).Build(),
+		Scheme: scheme,
+	}
+	restoreMgr := dprestore.NewRestoreManager(sourceRestore, nil, scheme, reconciler.Client)
+
+	restore, err := reconciler.buildPostReadyRestore(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp, "", nil)
+
+	require.NoError(t, err)
+	require.Equal(t, sourceEnv, sourceRestore.Spec.Env, "building the internal Restore must not mutate the source Restore")
+	require.Equal(t, "kept", envValue(restore.Spec.Env, "KEEP_ME"))
+	require.Equal(t, "shared-nothing", envValue(restore.Spec.Env, targetClusterTopologyEnv))
+	require.Equal(t, "3.3.2", envValue(restore.Spec.Env, targetComponentServiceVersionEnv))
+	require.Equal(t, 1, envNameCount(restore.Spec.Env, targetClusterTopologyEnv))
+	require.Equal(t, 1, envNameCount(restore.Spec.Env, targetComponentServiceVersionEnv))
+}
+
+func TestBuildPostReadyRestoreRequiresTargetCluster(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, kbappsv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	backup := newBackupForRestoreDecision([]string{"data"}, nil)
+	comp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      constant.GenerateClusterComponentName("cluster", "mysql"),
+		},
+	}
+	pvc := newPVCForRestoreDecision("data", "mysql", "")
+	pvc.Spec.DataSourceRef = &corev1.TypedObjectReference{Name: backup.Name}
+	pvc.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(backup).Build(),
+		Scheme: scheme,
+	}
+	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{}, nil, scheme, reconciler.Client)
+
+	restore, err := reconciler.buildPostReadyRestore(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp, "", nil)
+
+	require.Error(t, err)
+	require.Nil(t, restore)
+	require.True(t, apierrors.IsNotFound(err), err.Error())
+}
+
+func TestValidatePostReadyRestoreTargetEnvCompatibility(t *testing.T) {
+	comp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "cluster-mysql",
+			UID:       "component-uid",
+		},
+	}
+	desired := &dpv1alpha1.Restore{Spec: dpv1alpha1.RestoreSpec{
+		Backup: dpv1alpha1.BackupRef{Name: "backup", Namespace: "default"},
+		Env: []corev1.EnvVar{
+			{Name: "KEEP_ME", Value: "kept"},
+			{Name: dptypes.DPTargetClusterTopology, Value: "shared-nothing"},
+			{Name: dptypes.DPTargetComponentServiceVersion, Value: "3.3.2"},
+		},
+	}}
+	newExisting := func(spec dpv1alpha1.RestoreSpec) *dpv1alpha1.Restore {
+		return &dpv1alpha1.Restore{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "post-ready",
+				OwnerReferences: []metav1.OwnerReference{{
+					UID: comp.UID,
+				}},
+			},
+			Spec: spec,
+		}
+	}
+
+	tests := []struct {
+		name    string
+		spec    dpv1alpha1.RestoreSpec
+		wantErr bool
+	}{
+		{
+			name: "exact current restore",
+			spec: *desired.Spec.DeepCopy(),
+		},
+		{
+			name: "legacy restore with both target envs absent",
+			spec: dpv1alpha1.RestoreSpec{
+				Backup: desired.Spec.Backup,
+				Env:    []corev1.EnvVar{{Name: "KEEP_ME", Value: "kept"}},
+			},
+		},
+		{
+			name: "partial target env",
+			spec: dpv1alpha1.RestoreSpec{
+				Backup: desired.Spec.Backup,
+				Env: []corev1.EnvVar{
+					{Name: "KEEP_ME", Value: "kept"},
+					{Name: dptypes.DPTargetClusterTopology, Value: "shared-nothing"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "caller target env values",
+			spec: dpv1alpha1.RestoreSpec{
+				Backup: desired.Spec.Backup,
+				Env: []corev1.EnvVar{
+					{Name: "KEEP_ME", Value: "kept"},
+					{Name: dptypes.DPTargetClusterTopology, Value: "caller-topology"},
+					{Name: dptypes.DPTargetComponentServiceVersion, Value: "caller-version"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "unrelated spec mismatch",
+			spec: dpv1alpha1.RestoreSpec{
+				Backup: dpv1alpha1.BackupRef{Name: "other", Namespace: "default"},
+				Env:    []corev1.EnvVar{{Name: "KEEP_ME", Value: "kept"}},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePostReadyRestore(newExisting(tt.spec), desired, comp)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.True(t, intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal), err.Error())
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestValidatePostReadyRestoreAllowsLegacyNilEnv(t *testing.T) {
+	comp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{UID: "component-uid"},
+	}
+	desired := &dpv1alpha1.Restore{Spec: dpv1alpha1.RestoreSpec{
+		Backup: dpv1alpha1.BackupRef{Name: "backup", Namespace: "default"},
+		Env: []corev1.EnvVar{
+			{Name: dptypes.DPTargetClusterTopology, Value: "shared-nothing"},
+			{Name: dptypes.DPTargetComponentServiceVersion, Value: "3.3.2"},
+		},
+	}}
+	existing := &dpv1alpha1.Restore{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "post-ready",
+			OwnerReferences: []metav1.OwnerReference{{
+				UID: comp.UID,
+			}},
+		},
+		Spec: dpv1alpha1.RestoreSpec{
+			Backup: desired.Spec.Backup,
+			Env:    nil,
+		},
+	}
+
+	require.NoError(t, validatePostReadyRestore(existing, desired, comp))
+}
+
+func envValue(env []corev1.EnvVar, name string) string {
+	for i := range env {
+		if env[i].Name == name {
+			return env[i].Value
+		}
+	}
+	return ""
+}
+
+func envNameCount(env []corev1.EnvVar, name string) int {
+	count := 0
+	for i := range env {
+		if env[i].Name == name {
+			count++
+		}
+	}
+	return count
 }
 
 func TestBuildPostReadyRestoreUsesInitAccountFromComponentDefinition(t *testing.T) {
@@ -1769,7 +1988,9 @@ func TestBuildPostReadyRestoreUsesInitAccountFromComponentDefinition(t *testing.
 	pvc.Spec.DataSourceRef = &corev1.TypedObjectReference{Name: backup.Name}
 	pvc.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
 	reconciler := &VolumePopulatorReconciler{
-		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(backup, compDef).Build(),
+		Client: fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(backup, compDef, newClusterForPostReadyTest()).
+			Build(),
 		Scheme: scheme,
 	}
 	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{}, nil, scheme, reconciler.Client)
@@ -1820,7 +2041,7 @@ func TestEnsurePostReadyRestoreCompletedDoesNotReuseStaleRestore(t *testing.T) {
 	reconciler := &VolumePopulatorReconciler{
 		Client: fake.NewClientBuilder().WithScheme(scheme).
 			WithStatusSubresource(pvc).
-			WithObjects(backup, pvc, comp, staleRestore).
+			WithObjects(backup, pvc, comp, staleRestore, newClusterForPostReadyTest()).
 			Build(),
 		Scheme:   scheme,
 		Recorder: record.NewFakeRecorder(10),
@@ -1881,7 +2102,7 @@ func TestEnsurePostReadyRestoreCompletedUsesOneRestorePerComponent(t *testing.T)
 	reconciler := &VolumePopulatorReconciler{
 		Client: fake.NewClientBuilder().WithScheme(scheme).
 			WithStatusSubresource(pvc1, pvc2).
-			WithObjects(backup, pvc1, pvc2, comp).
+			WithObjects(backup, pvc1, pvc2, comp, newClusterForPostReadyTest()).
 			Build(),
 		Scheme:   scheme,
 		Recorder: record.NewFakeRecorder(10),
@@ -2045,7 +2266,7 @@ func TestCompleteBoundPVCContinuesPostReadyAfterPopulateReleased(t *testing.T) {
 	reconciler := &VolumePopulatorReconciler{
 		Client: fake.NewClientBuilder().WithScheme(scheme).
 			WithStatusSubresource(pvc).
-			WithObjects(backup, pvc, comp).
+			WithObjects(backup, pvc, comp, newClusterForPostReadyTest()).
 			Build(),
 		Scheme:   scheme,
 		Recorder: record.NewFakeRecorder(10),
@@ -2110,7 +2331,7 @@ func TestCompleteBoundPVCMarksRestoreSucceededAfterPostReadyCompleted(t *testing
 	reconciler := &VolumePopulatorReconciler{
 		Client: fake.NewClientBuilder().WithScheme(scheme).
 			WithStatusSubresource(pvc).
-			WithObjects(backup, pvc, comp).
+			WithObjects(backup, pvc, comp, newClusterForPostReadyTest()).
 			Build(),
 		Scheme:   scheme,
 		Recorder: record.NewFakeRecorder(10),
@@ -2193,7 +2414,7 @@ func TestEnsurePostReadyRestoreCompletedRejectsMismatchedExistingRestore(t *test
 	reconciler := &VolumePopulatorReconciler{
 		Client: fake.NewClientBuilder().WithScheme(scheme).
 			WithStatusSubresource(pvc).
-			WithObjects(backup, pvc, comp, existing).
+			WithObjects(backup, pvc, comp, existing, newClusterForPostReadyTest()).
 			Build(),
 		Scheme:   scheme,
 		Recorder: record.NewFakeRecorder(10),
@@ -2412,6 +2633,13 @@ func newPVCForRestoreDecision(volumeName, componentName, shardingName string) *c
 		pvc.Labels[constant.KBAppShardingNameLabelKey] = shardingName
 	}
 	return pvc
+}
+
+func newClusterForPostReadyTest() *kbappsv1.Cluster {
+	return &kbappsv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster"},
+		Spec:       kbappsv1.ClusterSpec{Topology: "shared-nothing"},
+	}
 }
 
 func newClusterForShardingDecision(shards int32) *kbappsv1.Cluster {
@@ -2737,7 +2965,7 @@ func TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_ShouldNotSilentlySk
 	reconciler := &VolumePopulatorReconciler{
 		Client: fake.NewClientBuilder().WithScheme(scheme).
 			WithStatusSubresource(pdPVC, tikvPVC).
-			WithObjects(backup, pdPVC, tikvPVC, pdComp, tikvComp, tidbComp).
+			WithObjects(backup, pdPVC, tikvPVC, pdComp, tikvComp, tidbComp, newClusterForPostReadyTest()).
 			Build(),
 		Scheme:   scheme,
 		Recorder: record.NewFakeRecorder(10),
@@ -2871,7 +3099,7 @@ func TestEnsurePostReadyRestore_MultiComponent_PrepareDataAndPostReady_Redirects
 	reconciler := &VolumePopulatorReconciler{
 		Client: fake.NewClientBuilder().WithScheme(scheme).
 			WithStatusSubresource(pdPVC).
-			WithObjects(backup, pdPVC, pdComp, tidbComp).
+			WithObjects(backup, pdPVC, pdComp, tidbComp, newClusterForPostReadyTest()).
 			Build(),
 		Scheme:   scheme,
 		Recorder: record.NewFakeRecorder(10),
@@ -3092,7 +3320,7 @@ func TestEnsurePostReadyRestore_MultiComponent_PostReadyRedirectPreservesTargetE
 	reconciler := &VolumePopulatorReconciler{
 		Client: fake.NewClientBuilder().WithScheme(scheme).
 			WithStatusSubresource(pdPVC).
-			WithObjects(backup, pdPVC, pdComp, tidbComp).
+			WithObjects(backup, pdPVC, pdComp, tidbComp, newClusterForPostReadyTest()).
 			Build(),
 		Scheme:   scheme,
 		Recorder: record.NewFakeRecorder(10),
@@ -3424,7 +3652,7 @@ func TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_TargetsSlice(t *tes
 	reconciler := &VolumePopulatorReconciler{
 		Client: fake.NewClientBuilder().WithScheme(scheme).
 			WithStatusSubresource(pdPVC).
-			WithObjects(backup, pdPVC, pdComp, tidbComp).
+			WithObjects(backup, pdPVC, pdComp, tidbComp, newClusterForPostReadyTest()).
 			Build(),
 		Scheme:   scheme,
 		Recorder: record.NewFakeRecorder(10),

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -1799,7 +1799,7 @@ func TestBuildPostReadyRestoreWritesLiveTargetEnv(t *testing.T) {
 	require.Equal(t, 1, envNameCount(restore.Spec.Env, targetComponentServiceVersionEnv))
 }
 
-func TestReconcileRetriesMissingTargetClusterAndCreatesPostReadyRestore(t *testing.T) {
+func TestReconcileRetriesMissingTargetClusterAndPropagatesInstanceVersionOverride(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 	require.NoError(t, kbappsv1.AddToScheme(scheme))
@@ -1832,7 +1832,14 @@ func TestReconcileRetriesMissingTargetClusterAndCreatesPostReadyRestore(t *testi
 			Name:      constant.GenerateClusterComponentName("cluster", "mysql"),
 			UID:       "component-uid",
 		},
-		Spec: kbappsv1.ComponentSpec{ServiceVersion: "3.3.2"},
+		Spec: kbappsv1.ComponentSpec{
+			ServiceVersion: "3.3.2",
+			Replicas:       1,
+			Instances: []kbappsv1.InstanceTemplate{{
+				Name:           "replacement",
+				ServiceVersion: "3.4.0",
+			}},
+		},
 		Status: kbappsv1.ComponentStatus{
 			Phase: kbappsv1.RunningComponentPhase,
 		},
@@ -1884,7 +1891,7 @@ func TestReconcileRetriesMissingTargetClusterAndCreatesPostReadyRestore(t *testi
 		Name:      postReadyRestoreName(comp.UID),
 	}, restore))
 	require.Equal(t, "shared-nothing", envValue(restore.Spec.Env, dptypes.DPTargetClusterTopology))
-	require.Equal(t, "3.3.2", envValue(restore.Spec.Env, dptypes.DPTargetComponentServiceVersion))
+	require.Equal(t, "3.4.0", envValue(restore.Spec.Env, dptypes.DPTargetComponentServiceVersion))
 }
 
 func TestEnsurePostReadyRestoreWaitsForObservedComponentGeneration(t *testing.T) {
@@ -1962,14 +1969,13 @@ func TestEnsurePostReadyRestoreWaitsForObservedComponentGeneration(t *testing.T)
 	}, restore))
 }
 
-func TestPostReadyComponentServiceVersionRequiresOneActiveVersion(t *testing.T) {
+func TestPostReadyComponentServiceVersionPublishesOnlyOneActiveVersion(t *testing.T) {
 	zero := int32(0)
 	tests := []struct {
 		name      string
 		replicas  int32
 		instances []kbappsv1.InstanceTemplate
 		want      string
-		wantFatal bool
 	}{
 		{name: "component default", replicas: 1, want: "3.3.2"},
 		{
@@ -1994,7 +2000,7 @@ func TestPostReadyComponentServiceVersionRequiresOneActiveVersion(t *testing.T) 
 			name:      "different active versions",
 			replicas:  2,
 			instances: []kbappsv1.InstanceTemplate{{Name: "canary", ServiceVersion: "3.4.0"}},
-			wantFatal: true,
+			want:      "",
 		},
 	}
 	for _, tt := range tests {
@@ -2008,14 +2014,8 @@ func TestPostReadyComponentServiceVersionRequiresOneActiveVersion(t *testing.T) 
 				},
 			}
 
-			got, err := postReadyComponentServiceVersion(comp)
+			got := postReadyComponentServiceVersion(comp)
 
-			if tt.wantFatal {
-				require.Error(t, err)
-				require.True(t, intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal), err.Error())
-				return
-			}
-			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
 		})
 	}
@@ -2107,6 +2107,65 @@ func TestValidatePostReadyRestoreTargetEnvCompatibility(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
+		})
+	}
+}
+
+func TestPostReadyTargetFactsFromRestoreRequiresOneCompleteSnapshot(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     []corev1.EnvVar
+		want    postReadyTargetFacts
+		wantErr bool
+	}{
+		{name: "legacy snapshot absent"},
+		{
+			name: "complete snapshot",
+			env: []corev1.EnvVar{
+				{Name: dptypes.DPTargetClusterTopology, Value: "shared-nothing"},
+				{Name: dptypes.DPTargetComponentServiceVersion, Value: "3.3.2"},
+			},
+			want: postReadyTargetFacts{clusterTopology: "shared-nothing", componentServiceVersion: "3.3.2"},
+		},
+		{
+			name: "heterogeneous version snapshot is explicitly empty",
+			env: []corev1.EnvVar{
+				{Name: dptypes.DPTargetClusterTopology, Value: "shared-nothing"},
+				{Name: dptypes.DPTargetComponentServiceVersion, Value: ""},
+			},
+			want: postReadyTargetFacts{clusterTopology: "shared-nothing"},
+		},
+		{
+			name:    "partial snapshot",
+			env:     []corev1.EnvVar{{Name: dptypes.DPTargetClusterTopology, Value: "shared-nothing"}},
+			wantErr: true,
+		},
+		{
+			name: "duplicate snapshot key",
+			env: []corev1.EnvVar{
+				{Name: dptypes.DPTargetClusterTopology, Value: "shared-nothing"},
+				{Name: dptypes.DPTargetClusterTopology, Value: "shared-data"},
+				{Name: dptypes.DPTargetComponentServiceVersion, Value: "3.3.2"},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			restore := &dpv1alpha1.Restore{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "post-ready"},
+				Spec:       dpv1alpha1.RestoreSpec{Env: tt.env},
+			}
+
+			got, err := postReadyTargetFactsFromRestore(restore)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.True(t, intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal), err.Error())
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -2494,7 +2553,7 @@ func TestCompleteBoundPVCContinuesPostReadyAfterPopulateReleased(t *testing.T) {
 	require.Nil(t, restoreCondition)
 }
 
-func TestCompleteBoundPVCMarksRestoreSucceededAfterPostReadyCompleted(t *testing.T) {
+func TestCompleteBoundPVCUsesFrozenTargetFactsAfterPostReadyCompleted(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 	require.NoError(t, batchv1.AddToScheme(scheme))
@@ -2519,11 +2578,16 @@ func TestCompleteBoundPVCMarksRestoreSucceededAfterPostReadyCompleted(t *testing
 	}}
 	comp := &kbappsv1.Component{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      constant.GenerateClusterComponentName("cluster", "mysql"),
-			UID:       "component-uid",
+			Namespace:  "default",
+			Name:       constant.GenerateClusterComponentName("cluster", "mysql"),
+			UID:        "component-uid",
+			Generation: 2,
 		},
-		Status: kbappsv1.ComponentStatus{Phase: kbappsv1.RunningComponentPhase},
+		Spec: kbappsv1.ComponentSpec{ServiceVersion: "3.4.0"},
+		Status: kbappsv1.ComponentStatus{
+			ObservedGeneration: 1,
+			Phase:              kbappsv1.RunningComponentPhase,
+		},
 	}
 	reconciler := &VolumePopulatorReconciler{
 		Client: fake.NewClientBuilder().WithScheme(scheme).
@@ -2537,14 +2601,18 @@ func TestCompleteBoundPVCMarksRestoreSucceededAfterPostReadyCompleted(t *testing
 		Spec: dpv1alpha1.RestoreSpec{Backup: dpv1alpha1.BackupRef{Name: backup.Name, Namespace: backup.Namespace}},
 	}, nil, scheme, reconciler.Client)
 	restoreMgr.PostReadyBackupSets = []dprestore.BackupActionSet{{Backup: backup}}
+	creationComp := comp.DeepCopy()
+	creationComp.Generation = 1
+	creationComp.Spec.ServiceVersion = "3.3.2"
+	creationComp.Status.ObservedGeneration = 1
 	postReadyRestore, err := reconciler.buildPostReadyRestore(
 		intctrlutil.RequestCtx{Ctx: context.Background()},
 		pvc,
 		restoreMgr,
-		comp,
+		creationComp,
 		"",
 		nil,
-		postReadyTargetFacts{clusterTopology: "shared-nothing", componentServiceVersion: comp.Spec.ServiceVersion},
+		postReadyTargetFacts{clusterTopology: "shared-nothing", componentServiceVersion: "3.3.2"},
 	)
 	require.NoError(t, err)
 	postReadyRestore.Status.Phase = dpv1alpha1.RestorePhaseCompleted

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -1738,7 +1739,8 @@ func TestBuildPostReadyRestoreSelectsHighestPriorityRole(t *testing.T) {
 	}
 	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{}, nil, scheme, reconciler.Client)
 
-	restore, err := reconciler.buildPostReadyRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp, "", nil)
+	restore, err := reconciler.buildPostReadyRestore(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp, "", nil, postReadyTargetFacts{})
 
 	require.NoError(t, err)
 	require.Equal(t, "leader", restore.Spec.ReadyConfig.JobAction.Target.PodSelector.LabelSelector.MatchLabels[instanceset.RoleLabelKey])
@@ -1785,7 +1787,8 @@ func TestBuildPostReadyRestoreWritesLiveTargetEnv(t *testing.T) {
 	restoreMgr := dprestore.NewRestoreManager(sourceRestore, nil, scheme, reconciler.Client)
 
 	restore, err := reconciler.buildPostReadyRestore(
-		intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp, "", nil)
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp, "", nil,
+		postReadyTargetFacts{clusterTopology: "shared-nothing", componentServiceVersion: "3.3.2"})
 
 	require.NoError(t, err)
 	require.Equal(t, sourceEnv, sourceRestore.Spec.Env, "building the internal Restore must not mutate the source Restore")
@@ -1796,33 +1799,226 @@ func TestBuildPostReadyRestoreWritesLiveTargetEnv(t *testing.T) {
 	require.Equal(t, 1, envNameCount(restore.Spec.Env, targetComponentServiceVersionEnv))
 }
 
-func TestBuildPostReadyRestoreRequiresTargetCluster(t *testing.T) {
+func TestReconcileRetriesMissingTargetClusterAndCreatesPostReadyRestore(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 	require.NoError(t, kbappsv1.AddToScheme(scheme))
 	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	oldSAName := viper.GetString(dptypes.CfgKeyWorkerServiceAccountName)
+	oldClusterRoleName := viper.GetString(dptypes.CfgKeyWorkerClusterRoleName)
+	viper.Set(dptypes.CfgKeyWorkerServiceAccountName, "worker")
+	viper.Set(dptypes.CfgKeyWorkerClusterRoleName, "worker-role")
+	defer func() {
+		viper.Set(dptypes.CfgKeyWorkerServiceAccountName, oldSAName)
+		viper.Set(dptypes.CfgKeyWorkerClusterRoleName, oldClusterRoleName)
+	}()
+	actionSet := &dpv1alpha1.ActionSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "post-ready"},
+		Spec: dpv1alpha1.ActionSetSpec{
+			BackupType: dpv1alpha1.BackupTypeFull,
+			Restore: &dpv1alpha1.RestoreActionSpec{
+				PostReady: []dpv1alpha1.ActionSpec{{
+					Exec: &dpv1alpha1.ExecActionSpec{Command: []string{"true"}},
+				}},
+			},
+		},
+	}
 	backup := newBackupForRestoreDecision([]string{"data"}, nil)
+	backup.Status.Phase = dpv1alpha1.BackupPhaseCompleted
+	backup.Status.BackupMethod.ActionSetName = actionSet.Name
 	comp := &kbappsv1.Component{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      constant.GenerateClusterComponentName("cluster", "mysql"),
+			UID:       "component-uid",
+		},
+		Spec: kbappsv1.ComponentSpec{ServiceVersion: "3.3.2"},
+		Status: kbappsv1.ComponentStatus{
+			Phase: kbappsv1.RunningComponentPhase,
 		},
 	}
 	pvc := newPVCForRestoreDecision("data", "mysql", "")
-	pvc.Spec.DataSourceRef = &corev1.TypedObjectReference{Name: backup.Name}
-	pvc.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
-	reconciler := &VolumePopulatorReconciler{
-		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(backup).Build(),
-		Scheme: scheme,
+	pvc.UID = "pvc-uid"
+	pvc.Spec.VolumeName = "target-pv"
+	apiGroup := dptypes.DataprotectionAPIGroup
+	pvc.Spec.DataSourceRef = &corev1.TypedObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     dptypes.BackupKind,
+		Name:     backup.Name,
 	}
-	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{}, nil, scheme, reconciler.Client)
+	pvc.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
+	pvc.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+	pvc.Status.Conditions = []corev1.PersistentVolumeClaimCondition{{
+		Type:   PersistentVolumeClaimPopulating,
+		Status: corev1.ConditionTrue,
+		Reason: ReasonPopulatingSucceed,
+	}}
+	workerSA := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: pvc.Namespace, Name: "worker"}}
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).
+			WithStatusSubresource(pvc).
+			WithObjects(actionSet, backup, comp, pvc, workerSA).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
 
-	restore, err := reconciler.buildPostReadyRestore(
-		intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp, "", nil)
+	req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(pvc)}
+	result, err := reconciler.Reconcile(context.Background(), req)
 
-	require.Error(t, err)
-	require.Nil(t, restore)
-	require.True(t, apierrors.IsNotFound(err), err.Error())
+	require.NoError(t, err)
+	require.Equal(t, reconcileInterval, result.RequeueAfter)
+	restore := &dpv1alpha1.Restore{}
+	require.True(t, apierrors.IsNotFound(reconciler.Client.Get(context.Background(), client.ObjectKey{
+		Namespace: pvc.Namespace,
+		Name:      postReadyRestoreName(comp.UID),
+	}, restore)))
+	require.NoError(t, reconciler.Client.Create(context.Background(), newClusterForPostReadyTest()))
+
+	result, err = reconciler.Reconcile(context.Background(), req)
+
+	require.NoError(t, err)
+	require.Equal(t, reconcileInterval, result.RequeueAfter)
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKey{
+		Namespace: pvc.Namespace,
+		Name:      postReadyRestoreName(comp.UID),
+	}, restore))
+	require.Equal(t, "shared-nothing", envValue(restore.Spec.Env, dptypes.DPTargetClusterTopology))
+	require.Equal(t, "3.3.2", envValue(restore.Spec.Env, dptypes.DPTargetComponentServiceVersion))
+}
+
+func TestEnsurePostReadyRestoreWaitsForObservedComponentGeneration(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, kbappsv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	apiGroup := dptypes.DataprotectionAPIGroup
+	backup := newBackupForRestoreDecision([]string{"data"}, nil)
+	pvc := newPVCForRestoreDecision("data", "mysql", "")
+	pvc.UID = "pvc-uid"
+	pvc.Spec.VolumeName = "target-pv"
+	pvc.Spec.DataSourceRef = &corev1.TypedObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     dptypes.BackupKind,
+		Name:     backup.Name,
+	}
+	pvc.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
+	pvc.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+	pvc.Status.Conditions = []corev1.PersistentVolumeClaimCondition{{
+		Type:   PersistentVolumeClaimPopulating,
+		Status: corev1.ConditionTrue,
+		Reason: ReasonPopulatingSucceed,
+	}}
+	comp := &kbappsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  pvc.Namespace,
+			Name:       constant.GenerateClusterComponentName("cluster", "mysql"),
+			UID:        "component-uid",
+			Generation: 2,
+		},
+		Spec: kbappsv1.ComponentSpec{ServiceVersion: "3.3.2"},
+		Status: kbappsv1.ComponentStatus{
+			ObservedGeneration: 1,
+			Phase:              kbappsv1.RunningComponentPhase,
+		},
+	}
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).
+			WithStatusSubresource(pvc, comp).
+			WithObjects(backup, pvc, comp, newClusterForPostReadyTest()).
+			Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{
+		Spec: dpv1alpha1.RestoreSpec{Backup: dpv1alpha1.BackupRef{Name: backup.Name, Namespace: backup.Namespace}},
+	}, nil, scheme, reconciler.Client)
+	restoreMgr.PostReadyBackupSets = []dprestore.BackupActionSet{{Backup: backup}}
+	restoreCtx := &pvcRestoreContext{restoreMgr: restoreMgr, mode: pvcRestoreModeRestoreData}
+
+	completed, err := reconciler.ensurePostReadyRestoreCompleted(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreCtx)
+
+	require.NoError(t, err)
+	require.False(t, completed)
+	restore := &dpv1alpha1.Restore{}
+	require.True(t, apierrors.IsNotFound(reconciler.Client.Get(context.Background(), client.ObjectKey{
+		Namespace: pvc.Namespace,
+		Name:      postReadyRestoreName(comp.UID),
+	}, restore)))
+	currentComp := &kbappsv1.Component{}
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(comp), currentComp))
+	currentComp.Status.ObservedGeneration = currentComp.Generation
+	require.NoError(t, reconciler.Client.Status().Update(context.Background(), currentComp))
+
+	completed, err = reconciler.ensurePostReadyRestoreCompleted(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreCtx)
+
+	require.NoError(t, err)
+	require.False(t, completed)
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKey{
+		Namespace: pvc.Namespace,
+		Name:      postReadyRestoreName(comp.UID),
+	}, restore))
+}
+
+func TestPostReadyComponentServiceVersionRequiresOneActiveVersion(t *testing.T) {
+	zero := int32(0)
+	tests := []struct {
+		name      string
+		replicas  int32
+		instances []kbappsv1.InstanceTemplate
+		want      string
+		wantFatal bool
+	}{
+		{name: "component default", replicas: 1, want: "3.3.2"},
+		{
+			name:      "matching active override",
+			replicas:  1,
+			instances: []kbappsv1.InstanceTemplate{{Name: "same", ServiceVersion: "3.3.2"}},
+			want:      "3.3.2",
+		},
+		{
+			name:      "different inactive override",
+			replicas:  1,
+			instances: []kbappsv1.InstanceTemplate{{Name: "disabled", ServiceVersion: "3.4.0", Replicas: &zero}},
+			want:      "3.3.2",
+		},
+		{
+			name:      "single active override replaces all default instances",
+			replicas:  1,
+			instances: []kbappsv1.InstanceTemplate{{Name: "only", ServiceVersion: "3.4.0"}},
+			want:      "3.4.0",
+		},
+		{
+			name:      "different active versions",
+			replicas:  2,
+			instances: []kbappsv1.InstanceTemplate{{Name: "canary", ServiceVersion: "3.4.0"}},
+			wantFatal: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			comp := &kbappsv1.Component{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster-mysql"},
+				Spec: kbappsv1.ComponentSpec{
+					ServiceVersion: "3.3.2",
+					Replicas:       tt.replicas,
+					Instances:      tt.instances,
+				},
+			}
+
+			got, err := postReadyComponentServiceVersion(comp)
+
+			if tt.wantFatal {
+				require.Error(t, err)
+				require.True(t, intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal), err.Error())
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestValidatePostReadyRestoreTargetEnvCompatibility(t *testing.T) {
@@ -1995,7 +2191,8 @@ func TestBuildPostReadyRestoreUsesInitAccountFromComponentDefinition(t *testing.
 	}
 	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{}, nil, scheme, reconciler.Client)
 
-	restore, err := reconciler.buildPostReadyRestore(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp, "", nil)
+	restore, err := reconciler.buildPostReadyRestore(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, restoreMgr, comp, "", nil, postReadyTargetFacts{})
 
 	require.NoError(t, err)
 	require.NotNil(t, restore.Spec.ReadyConfig.ConnectionCredential)
@@ -2347,6 +2544,7 @@ func TestCompleteBoundPVCMarksRestoreSucceededAfterPostReadyCompleted(t *testing
 		comp,
 		"",
 		nil,
+		postReadyTargetFacts{clusterTopology: "shared-nothing", componentServiceVersion: comp.Spec.ServiceVersion},
 	)
 	require.NoError(t, err)
 	postReadyRestore.Status.Phase = dpv1alpha1.RestorePhaseCompleted

--- a/pkg/dataprotection/restore/builder.go
+++ b/pkg/dataprotection/restore/builder.go
@@ -310,22 +310,13 @@ func (r *restoreJobBuilder) addTargetPodAndCredentialEnv(pod *corev1.Pod,
 	return r
 }
 
-func (r *restoreJobBuilder) overridePostReadyTargetEnv() *restoreJobBuilder {
-	var targetEnv []corev1.EnvVar
-	for i := range r.restore.Spec.Env {
-		switch r.restore.Spec.Env[i].Name {
-		case dptypes.DPTargetClusterTopology, dptypes.DPTargetComponentServiceVersion:
-			targetEnv = utils.MergeEnv(targetEnv, []corev1.EnvVar{r.restore.Spec.Env[i]})
-		}
-	}
-	if len(targetEnv) == 0 {
-		return r
-	}
-
+func (r *restoreJobBuilder) overridePostReadyTargetEnv(targetEnv []corev1.EnvVar) *restoreJobBuilder {
 	env := make([]corev1.EnvVar, 0, len(r.env))
 	for i := range r.env {
 		switch r.env[i].Name {
-		case dptypes.DPTargetClusterTopology, dptypes.DPTargetComponentServiceVersion:
+		case dptypes.DPTargetClusterTopology,
+			dptypes.DPTargetComponentServiceVersion,
+			dptypes.DPTargetComponentServiceVersionSelector:
 			continue
 		default:
 			env = append(env, r.env[i])

--- a/pkg/dataprotection/restore/builder.go
+++ b/pkg/dataprotection/restore/builder.go
@@ -313,14 +313,10 @@ func (r *restoreJobBuilder) addTargetPodAndCredentialEnv(pod *corev1.Pod,
 func (r *restoreJobBuilder) overridePostReadyTargetEnv(targetEnv []corev1.EnvVar) *restoreJobBuilder {
 	env := make([]corev1.EnvVar, 0, len(r.env))
 	for i := range r.env {
-		switch r.env[i].Name {
-		case dptypes.DPTargetClusterTopology,
-			dptypes.DPTargetComponentServiceVersion,
-			dptypes.DPTargetComponentServiceVersionSelector:
+		if dptypes.IsPostReadyTargetEnv(r.env[i].Name) {
 			continue
-		default:
-			env = append(env, r.env[i])
 		}
+		env = append(env, r.env[i])
 	}
 	env = append(env, targetEnv...)
 	r.env = env

--- a/pkg/dataprotection/restore/builder.go
+++ b/pkg/dataprotection/restore/builder.go
@@ -310,6 +310,32 @@ func (r *restoreJobBuilder) addTargetPodAndCredentialEnv(pod *corev1.Pod,
 	return r
 }
 
+func (r *restoreJobBuilder) overridePostReadyTargetEnv() *restoreJobBuilder {
+	var targetEnv []corev1.EnvVar
+	for i := range r.restore.Spec.Env {
+		switch r.restore.Spec.Env[i].Name {
+		case dptypes.DPTargetClusterTopology, dptypes.DPTargetComponentServiceVersion:
+			targetEnv = utils.MergeEnv(targetEnv, []corev1.EnvVar{r.restore.Spec.Env[i]})
+		}
+	}
+	if len(targetEnv) == 0 {
+		return r
+	}
+
+	env := make([]corev1.EnvVar, 0, len(r.env))
+	for i := range r.env {
+		switch r.env[i].Name {
+		case dptypes.DPTargetClusterTopology, dptypes.DPTargetComponentServiceVersion:
+			continue
+		default:
+			env = append(env, r.env[i])
+		}
+	}
+	env = append(env, targetEnv...)
+	r.env = env
+	return r
+}
+
 // builderRestoreJobName builds restore job name.
 func (r *restoreJobBuilder) builderRestoreJobName(jobIndex int) string {
 	jobName := fmt.Sprintf("restore-%s-%s-%s-%d", strings.ToLower(string(r.stage)), r.restore.UID[:8], r.backupSet.Backup.Name, jobIndex)

--- a/pkg/dataprotection/restore/internal_post_ready.go
+++ b/pkg/dataprotection/restore/internal_post_ready.go
@@ -1,0 +1,129 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package restore
+
+import (
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+)
+
+func internalPostReadyRestoreNameCandidate(name string) bool {
+	const (
+		prefix = "restore-"
+		suffix = "-post-ready"
+	)
+	return strings.HasPrefix(name, prefix) &&
+		strings.HasSuffix(name, suffix) &&
+		len(name) > len(prefix)+len(suffix)
+}
+
+// InternalPostReadyRestoreComponentOwner validates the durable identity of an
+// internal postReady Restore. The boolean is false only for an external Restore
+// that carries neither the reserved name shape nor the internal marker.
+func InternalPostReadyRestoreComponentOwner(
+	restore *dpv1alpha1.Restore,
+) (*metav1.OwnerReference, bool, error) {
+	if restore == nil {
+		return nil, false, nil
+	}
+	marker, markerExists := restore.Labels[DataProtectionInternalPostReadyLabelKey]
+	if !markerExists && !internalPostReadyRestoreNameCandidate(restore.Name) {
+		return nil, false, nil
+	}
+	identityError := func(detail string) (*metav1.OwnerReference, bool, error) {
+		return nil, true, intctrlutil.NewFatalError(fmt.Sprintf(
+			"internal postReady restore %s/%s has invalid identity: %s",
+			restore.Namespace, restore.Name, detail))
+	}
+	if marker != DataProtectionInternalPostReadyLabelValue {
+		return identityError(fmt.Sprintf(
+			"label %s must be %q",
+			DataProtectionInternalPostReadyLabelKey,
+			DataProtectionInternalPostReadyLabelValue))
+	}
+	if len(restore.OwnerReferences) != 1 {
+		return identityError(fmt.Sprintf(
+			"expected exactly one Component controller owner, got %d",
+			len(restore.OwnerReferences)))
+	}
+	ref := &restore.OwnerReferences[0]
+	if ref.APIVersion != appsv1.APIVersion {
+		return identityError(fmt.Sprintf(
+			"owner apiVersion must be %q, got %q", appsv1.APIVersion, ref.APIVersion))
+	}
+	if ref.Kind != appsv1.ComponentKind {
+		return identityError(fmt.Sprintf(
+			"owner kind must be %q, got %q", appsv1.ComponentKind, ref.Kind))
+	}
+	if ref.Controller == nil || !*ref.Controller {
+		return identityError("Component owner must be the controller")
+	}
+	if ref.Name == "" {
+		return identityError("Component owner name is empty")
+	}
+	if ref.UID == "" {
+		return identityError("Component owner UID is empty")
+	}
+	if expectedName := PostReadyRestoreName(ref.UID); restore.Name != expectedName {
+		return identityError(fmt.Sprintf(
+			"name must be %q for Component UID %s", expectedName, ref.UID))
+	}
+	return ref, true, nil
+}
+
+// ValidateInternalPostReadyRestoreComponent validates the Restore identity
+// against the Component expected by the VolumePopulator.
+func ValidateInternalPostReadyRestoreComponent(
+	restore *dpv1alpha1.Restore,
+	component *appsv1.Component,
+) error {
+	if restore == nil {
+		return intctrlutil.NewFatalError("internal postReady Restore is nil")
+	}
+	ref, internal, err := InternalPostReadyRestoreComponentOwner(restore)
+	if err != nil {
+		return err
+	}
+	if !internal {
+		return intctrlutil.NewFatalError(fmt.Sprintf(
+			"postReady restore %s/%s is missing its internal identity",
+			restore.Namespace, restore.Name))
+	}
+	if component == nil {
+		return intctrlutil.NewFatalError(fmt.Sprintf(
+			"internal postReady restore %s/%s has no expected Component",
+			restore.Namespace, restore.Name))
+	}
+	if restore.Namespace != component.Namespace ||
+		ref.Name != component.Name ||
+		ref.UID != component.UID {
+		return intctrlutil.NewFatalError(fmt.Sprintf(
+			"internal postReady restore %s/%s owner does not match Component %s/%s UID %s",
+			restore.Namespace, restore.Name,
+			component.Namespace, component.Name, component.UID))
+	}
+	return nil
+}

--- a/pkg/dataprotection/restore/internal_post_ready_test.go
+++ b/pkg/dataprotection/restore/internal_post_ready_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package restore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+)
+
+func validInternalPostReadyRestore(component *appsv1.Component) *dpv1alpha1.Restore {
+	return &dpv1alpha1.Restore{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: component.Namespace,
+			Name:      PostReadyRestoreName(component.UID),
+			Labels: map[string]string{
+				DataProtectionInternalPostReadyLabelKey: DataProtectionInternalPostReadyLabelValue,
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: appsv1.APIVersion,
+				Kind:       appsv1.ComponentKind,
+				Name:       component.Name,
+				UID:        component.UID,
+				Controller: ptr.To(true),
+			}},
+		},
+	}
+}
+
+func TestInternalPostReadyRestoreComponentOwnerClassification(t *testing.T) {
+	component := &appsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "cluster-mysql",
+			UID:       types.UID("component-uid"),
+		},
+	}
+
+	t.Run("ordinary external restore", func(t *testing.T) {
+		ref, internal, err := InternalPostReadyRestoreComponentOwner(&dpv1alpha1.Restore{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "user-restore"},
+		})
+		require.NoError(t, err)
+		require.False(t, internal)
+		require.Nil(t, ref)
+	})
+
+	t.Run("valid internal restore", func(t *testing.T) {
+		ref, internal, err := InternalPostReadyRestoreComponentOwner(validInternalPostReadyRestore(component))
+		require.NoError(t, err)
+		require.True(t, internal)
+		require.NotNil(t, ref)
+		require.Equal(t, component.Name, ref.Name)
+		require.Equal(t, component.UID, ref.UID)
+	})
+
+	t.Run("marker on non-deterministic name", func(t *testing.T) {
+		restore := validInternalPostReadyRestore(component)
+		restore.Name = "user-restore"
+
+		ref, internal, err := InternalPostReadyRestoreComponentOwner(restore)
+		require.Error(t, err)
+		require.True(t, internal)
+		require.True(t, intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal), err.Error())
+		require.Nil(t, ref)
+	})
+}
+
+func TestValidateInternalPostReadyRestoreComponentRejectsExpectedComponentMismatch(t *testing.T) {
+	component := &appsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "cluster-mysql",
+			UID:       types.UID("component-uid"),
+		},
+	}
+	tests := []struct {
+		name   string
+		mutate func(*appsv1.Component)
+	}{
+		{
+			name: "namespace",
+			mutate: func(actual *appsv1.Component) {
+				actual.Namespace = "other"
+			},
+		},
+		{
+			name: "name",
+			mutate: func(actual *appsv1.Component) {
+				actual.Name = "other"
+			},
+		},
+		{
+			name: "uid",
+			mutate: func(actual *appsv1.Component) {
+				actual.UID = "other"
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := component.DeepCopy()
+			tt.mutate(actual)
+
+			err := ValidateInternalPostReadyRestoreComponent(
+				validInternalPostReadyRestore(component),
+				actual,
+			)
+
+			require.Error(t, err)
+			require.True(t, intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal), err.Error())
+		})
+	}
+}
+
+func TestValidateInternalPostReadyRestoreComponentRejectsNilInputs(t *testing.T) {
+	component := &appsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "cluster-mysql",
+			UID:       types.UID("component-uid"),
+		},
+	}
+
+	err := ValidateInternalPostReadyRestoreComponent(nil, component)
+	require.Error(t, err)
+	require.True(t, intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal), err.Error())
+
+	err = ValidateInternalPostReadyRestoreComponent(validInternalPostReadyRestore(component), nil)
+	require.Error(t, err)
+	require.True(t, intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal), err.Error())
+}

--- a/pkg/dataprotection/restore/manager.go
+++ b/pkg/dataprotection/restore/manager.go
@@ -703,6 +703,7 @@ func (r *RestoreManager) BuildPostReadyActionJobs(reqCtx intctrlutil.RequestCtx,
 				setCommand(actionSpec.Job.Command).
 				setToleration(targetPod.Spec.Tolerations).
 				addTargetPodAndCredentialEnv(targetPod, readyConfig.ConnectionCredential, &target.BackupTarget).
+				overridePostReadyTargetEnv().
 				setServiceAccount(r.WorkerServiceAccount).
 				build()
 		}

--- a/pkg/dataprotection/restore/manager.go
+++ b/pkg/dataprotection/restore/manager.go
@@ -34,10 +34,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	workloadsv1 "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/instanceset"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
@@ -50,6 +53,12 @@ import (
 const (
 	restoreManagerContainerName = "restore-manager"
 )
+
+// PostReadyRestoreName returns the deterministic name of the internal postReady
+// Restore owned by one Component UID.
+func PostReadyRestoreName(componentUID types.UID) string {
+	return constant.ShortenKubeName(fmt.Sprintf("restore-%s-post-ready", componentUID), constant.KubeNameMaxLength)
+}
 
 type BackupActionSet struct {
 	Backup *dpv1alpha1.Backup
@@ -638,8 +647,252 @@ func (r *RestoreManager) isJobForRestoreAction(job *batchv1.Job) bool {
 	return restoreNamespace == "" || restoreNamespace == r.Restore.Namespace
 }
 
+func targetFactReadError(kind string, key types.NamespacedName, err error) error {
+	if apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err) {
+		return intctrlutil.NewFatalError(fmt.Sprintf("can not read target %s %s: %v", kind, key, err))
+	}
+	return intctrlutil.NewRequeueError(time.Second,
+		fmt.Sprintf("waiting to read target %s %s: %v", kind, key, err))
+}
+
+func controllerReferenceMatches(obj metav1.Object, apiVersion, kind string, uid types.UID) bool {
+	ref := metav1.GetControllerOf(obj)
+	return ref != nil && ref.APIVersion == apiVersion && ref.Kind == kind && ref.UID == uid
+}
+
+func (r *RestoreManager) internalPostReadyComponent(
+	reqCtx intctrlutil.RequestCtx,
+	reader client.Reader) (*appsv1.Component, bool, error) {
+	var componentRef *metav1.OwnerReference
+	for i := range r.Restore.OwnerReferences {
+		ref := &r.Restore.OwnerReferences[i]
+		if ref.APIVersion != appsv1.APIVersion ||
+			ref.Kind != appsv1.ComponentKind ||
+			r.Restore.Name != PostReadyRestoreName(ref.UID) {
+			continue
+		}
+		if componentRef != nil {
+			return nil, true, intctrlutil.NewFatalError(fmt.Sprintf(
+				"internal postReady restore %s/%s has multiple Component owners",
+				r.Restore.Namespace, r.Restore.Name))
+		}
+		componentRef = ref
+	}
+	if componentRef == nil {
+		return nil, false, nil
+	}
+
+	componentKey := types.NamespacedName{Namespace: r.Restore.Namespace, Name: componentRef.Name}
+	component := &appsv1.Component{}
+	if err := reader.Get(reqCtx.Ctx, componentKey, component); err != nil {
+		return nil, true, targetFactReadError("Component", componentKey, err)
+	}
+	if component.UID != componentRef.UID {
+		return nil, true, intctrlutil.NewFatalError(fmt.Sprintf(
+			"internal postReady restore %s/%s Component identity changed: expected UID %s, got %s",
+			r.Restore.Namespace, r.Restore.Name, componentRef.UID, component.UID))
+	}
+	if !component.DeletionTimestamp.IsZero() {
+		return nil, true, intctrlutil.NewFatalError(fmt.Sprintf(
+			"target Component %s/%s is terminating", component.Namespace, component.Name))
+	}
+	return component, true, nil
+}
+
+func validateTargetPodOwnership(
+	reqCtx intctrlutil.RequestCtx,
+	reader client.Reader,
+	pod *corev1.Pod,
+	component *appsv1.Component) error {
+	owner := metav1.GetControllerOf(pod)
+	if owner == nil || owner.APIVersion != workloadsv1.GroupVersion.String() {
+		return intctrlutil.NewFatalError(fmt.Sprintf(
+			"target Pod %s/%s is not controlled by a KubeBlocks workload", pod.Namespace, pod.Name))
+	}
+
+	instanceSet := &workloadsv1.InstanceSet{}
+	switch owner.Kind {
+	case workloadsv1.InstanceSetKind:
+		key := types.NamespacedName{Namespace: pod.Namespace, Name: owner.Name}
+		if err := reader.Get(reqCtx.Ctx, key, instanceSet); err != nil {
+			return targetFactReadError(workloadsv1.InstanceSetKind, key, err)
+		}
+		if instanceSet.UID != owner.UID {
+			return intctrlutil.NewFatalError(fmt.Sprintf(
+				"target Pod %s/%s InstanceSet identity changed", pod.Namespace, pod.Name))
+		}
+	case "Instance":
+		instanceKey := types.NamespacedName{Namespace: pod.Namespace, Name: owner.Name}
+		instance := &workloadsv1.Instance{}
+		if err := reader.Get(reqCtx.Ctx, instanceKey, instance); err != nil {
+			return targetFactReadError("Instance", instanceKey, err)
+		}
+		if instance.UID != owner.UID {
+			return intctrlutil.NewFatalError(fmt.Sprintf(
+				"target Pod %s/%s Instance identity changed", pod.Namespace, pod.Name))
+		}
+		instanceSetOwner := metav1.GetControllerOf(instance)
+		if instanceSetOwner == nil ||
+			instanceSetOwner.APIVersion != workloadsv1.GroupVersion.String() ||
+			instanceSetOwner.Kind != workloadsv1.InstanceSetKind {
+			return intctrlutil.NewFatalError(fmt.Sprintf(
+				"target Instance %s/%s is not controlled by an InstanceSet", instance.Namespace, instance.Name))
+		}
+		instanceSetKey := types.NamespacedName{Namespace: instance.Namespace, Name: instanceSetOwner.Name}
+		if err := reader.Get(reqCtx.Ctx, instanceSetKey, instanceSet); err != nil {
+			return targetFactReadError(workloadsv1.InstanceSetKind, instanceSetKey, err)
+		}
+		if instanceSet.UID != instanceSetOwner.UID {
+			return intctrlutil.NewFatalError(fmt.Sprintf(
+				"target Instance %s/%s InstanceSet identity changed", instance.Namespace, instance.Name))
+		}
+	default:
+		return intctrlutil.NewFatalError(fmt.Sprintf(
+			"target Pod %s/%s has unsupported controller kind %q", pod.Namespace, pod.Name, owner.Kind))
+	}
+
+	if !controllerReferenceMatches(instanceSet, appsv1.APIVersion, appsv1.ComponentKind, component.UID) {
+		return intctrlutil.NewFatalError(fmt.Sprintf(
+			"target Pod %s/%s workload is not controlled by Component %s/%s",
+			pod.Namespace, pod.Name, component.Namespace, component.Name))
+	}
+	return nil
+}
+
+func targetPodServiceVersionSelector(component *appsv1.Component, pod *corev1.Pod) (string, error) {
+	templateName, ok := pod.Labels[constant.KBAppInstanceTemplateLabelKey]
+	if !ok {
+		return "", intctrlutil.NewFatalError(fmt.Sprintf(
+			"target Pod %s/%s is missing label %s",
+			pod.Namespace, pod.Name, constant.KBAppInstanceTemplateLabelKey))
+	}
+
+	if templateName != "" {
+		for i := range component.Spec.Instances {
+			instance := &component.Spec.Instances[i]
+			if instance.Name != templateName {
+				continue
+			}
+			if ptr.Deref(instance.Replicas, int32(1)) <= 0 {
+				return "", intctrlutil.NewFatalError(fmt.Sprintf(
+					"target Pod %s/%s references inactive instance template %q",
+					pod.Namespace, pod.Name, templateName))
+			}
+			if instance.ServiceVersion != "" {
+				return instance.ServiceVersion, nil
+			}
+			return component.Spec.ServiceVersion, nil
+		}
+		return "", intctrlutil.NewFatalError(fmt.Sprintf(
+			"target Pod %s/%s references unknown instance template %q",
+			pod.Namespace, pod.Name, templateName))
+	}
+
+	remainingDefaultReplicas := component.Spec.Replicas
+	for i := range component.Spec.Instances {
+		remainingDefaultReplicas -= ptr.Deref(component.Spec.Instances[i].Replicas, int32(1))
+	}
+	if remainingDefaultReplicas <= 0 {
+		return "", intctrlutil.NewFatalError(fmt.Sprintf(
+			"target Pod %s/%s has an empty instance-template label but Component has no default instances",
+			pod.Namespace, pod.Name))
+	}
+	return component.Spec.ServiceVersion, nil
+}
+
+func (r *RestoreManager) postReadyTargetEnv(
+	reqCtx intctrlutil.RequestCtx,
+	reader client.Reader,
+	component *appsv1.Component,
+	targetPod *corev1.Pod) ([]corev1.EnvVar, error) {
+	componentKey := client.ObjectKeyFromObject(component)
+	liveComponent := &appsv1.Component{}
+	if err := reader.Get(reqCtx.Ctx, componentKey, liveComponent); err != nil {
+		return nil, targetFactReadError("Component", componentKey, err)
+	}
+	if liveComponent.UID != component.UID {
+		return nil, intctrlutil.NewFatalError(fmt.Sprintf(
+			"target Component %s changed identity before postReady dispatch", componentKey))
+	}
+	if !liveComponent.DeletionTimestamp.IsZero() {
+		return nil, intctrlutil.NewFatalError(fmt.Sprintf(
+			"target Component %s/%s is terminating", liveComponent.Namespace, liveComponent.Name))
+	}
+
+	podKey := client.ObjectKeyFromObject(targetPod)
+	livePod := &corev1.Pod{}
+	if err := reader.Get(reqCtx.Ctx, podKey, livePod); err != nil {
+		return nil, targetFactReadError("Pod", podKey, err)
+	}
+	if targetPod.UID == "" || livePod.UID != targetPod.UID {
+		return nil, intctrlutil.NewRequeueError(time.Second,
+			fmt.Sprintf("target Pod %s changed identity before postReady dispatch", podKey))
+	}
+	if !intctrlutil.IsPodAvailable(livePod, 0) {
+		return nil, intctrlutil.NewRequeueError(time.Second,
+			fmt.Sprintf("target Pod %s is not stably Ready", podKey))
+	}
+	if err := validateTargetPodOwnership(reqCtx, reader, livePod, liveComponent); err != nil {
+		return nil, err
+	}
+
+	clusterName, clusterNameOK := livePod.Labels[constant.AppInstanceLabelKey]
+	componentName, componentNameOK := livePod.Labels[constant.KBAppComponentLabelKey]
+	if !clusterNameOK || clusterName == "" || !componentNameOK || componentName == "" {
+		return nil, intctrlutil.NewFatalError(fmt.Sprintf(
+			"target Pod %s/%s is missing cluster/component identity labels", livePod.Namespace, livePod.Name))
+	}
+	if constant.GenerateClusterComponentName(clusterName, componentName) != liveComponent.Name {
+		return nil, intctrlutil.NewFatalError(fmt.Sprintf(
+			"target Pod %s/%s does not identify Component %s/%s",
+			livePod.Namespace, livePod.Name, liveComponent.Namespace, liveComponent.Name))
+	}
+	if liveComponent.Labels[constant.AppInstanceLabelKey] != clusterName ||
+		liveComponent.Labels[constant.KBAppComponentLabelKey] != componentName {
+		return nil, intctrlutil.NewFatalError(fmt.Sprintf(
+			"target Component %s/%s identity labels do not match target Pod %s/%s",
+			liveComponent.Namespace, liveComponent.Name, livePod.Namespace, livePod.Name))
+	}
+	if liveComponent.Generation != liveComponent.Status.ObservedGeneration ||
+		liveComponent.Status.Phase != appsv1.RunningComponentPhase {
+		return nil, intctrlutil.NewRequeueError(time.Second, fmt.Sprintf(
+			"waiting for target Component %s/%s to observe generation %d and become Running",
+			liveComponent.Namespace, liveComponent.Name, liveComponent.Generation))
+	}
+
+	clusterKey := types.NamespacedName{Namespace: livePod.Namespace, Name: clusterName}
+	cluster := &appsv1.Cluster{}
+	if err := reader.Get(reqCtx.Ctx, clusterKey, cluster); err != nil {
+		return nil, targetFactReadError("Cluster", clusterKey, err)
+	}
+	if !cluster.DeletionTimestamp.IsZero() {
+		return nil, intctrlutil.NewFatalError(fmt.Sprintf(
+			"target Cluster %s/%s is terminating", cluster.Namespace, cluster.Name))
+	}
+	if liveComponent.Annotations[constant.KBAppClusterUIDKey] != string(cluster.UID) {
+		return nil, intctrlutil.NewFatalError(fmt.Sprintf(
+			"target Component %s/%s does not belong to Cluster %s/%s",
+			liveComponent.Namespace, liveComponent.Name, cluster.Namespace, cluster.Name))
+	}
+
+	serviceVersionSelector, err := targetPodServiceVersionSelector(liveComponent, livePod)
+	if err != nil {
+		return nil, err
+	}
+	return []corev1.EnvVar{
+		{Name: dptypes.DPTargetClusterTopology, Value: cluster.Spec.Topology},
+		{Name: dptypes.DPTargetComponentServiceVersionSelector, Value: serviceVersionSelector},
+	}, nil
+}
+
 // BuildPostReadyActionJobs builds the post ready jobs.
-func (r *RestoreManager) BuildPostReadyActionJobs(reqCtx intctrlutil.RequestCtx, cli client.Client, backupSet BackupActionSet, target *dpv1alpha1.BackupStatusTarget, step int) ([]*batchv1.Job, error) {
+func (r *RestoreManager) BuildPostReadyActionJobs(
+	reqCtx intctrlutil.RequestCtx,
+	cli client.Client,
+	reader client.Reader,
+	backupSet BackupActionSet,
+	target *dpv1alpha1.BackupStatusTarget,
+	step int) ([]*batchv1.Job, error) {
 	readyConfig := r.Restore.Spec.ReadyConfig
 	if readyConfig == nil {
 		return nil, nil
@@ -647,14 +900,31 @@ func (r *RestoreManager) BuildPostReadyActionJobs(reqCtx intctrlutil.RequestCtx,
 	if !backupSet.ActionSet.HasPostReadyStage() {
 		return nil, nil
 	}
+	if reader == nil {
+		reader = cli
+	}
+	internalComponent, internalPostReady, err := r.internalPostReadyComponent(reqCtx, reader)
+	if err != nil {
+		return nil, err
+	}
 	backupRepo, err := r.prepareBackupRepo(reqCtx, cli, backupSet)
 	if err != nil {
 		return nil, err
 	}
 	actionSpec := backupSet.ActionSet.Spec.Restore.PostReady[step]
 	getTargetPodList := func(labelSelector metav1.LabelSelector, msgKey string) (*corev1.PodList, error) {
-		targetPodList, err := utils.GetPodListByLabelSelector(reqCtx, cli, &labelSelector)
+		selector, err := metav1.LabelSelectorAsSelector(&labelSelector)
 		if err != nil {
+			return nil, err
+		}
+		targetPodList := &corev1.PodList{}
+		targetReader := client.Reader(cli)
+		if internalPostReady {
+			targetReader = reader
+		}
+		if err = targetReader.List(reqCtx.Ctx, targetPodList,
+			client.InNamespace(r.Restore.Namespace),
+			client.MatchingLabelsSelector{Selector: selector}); err != nil {
 			return nil, err
 		}
 		if len(targetPodList.Items) == 0 {
@@ -682,7 +952,7 @@ func (r *RestoreManager) BuildPostReadyActionJobs(reqCtx intctrlutil.RequestCtx,
 			return nil, err
 		}
 		sort.Sort(intctrlutil.ByPodName(targetPodList.Items))
-		buildJob := func(targetPod *corev1.Pod, sourceTargetPodName string, index int) *batchv1.Job {
+		buildJob := func(targetPod *corev1.Pod, sourceTargetPodName string, index int, targetEnv []corev1.EnvVar) *batchv1.Job {
 			if boolptr.IsSetToTrue(actionSpec.Job.RunOnTargetPodNode) {
 				jobBuilder.resetSpecificVolumesAndMounts()
 				jobBuilder.setNodeNameToNodeSelector(targetPod.Spec.NodeName)
@@ -703,7 +973,7 @@ func (r *RestoreManager) BuildPostReadyActionJobs(reqCtx intctrlutil.RequestCtx,
 				setCommand(actionSpec.Job.Command).
 				setToleration(targetPod.Spec.Tolerations).
 				addTargetPodAndCredentialEnv(targetPod, readyConfig.ConnectionCredential, &target.BackupTarget).
-				overridePostReadyTargetEnv().
+				overridePostReadyTargetEnv(targetEnv).
 				setServiceAccount(r.WorkerServiceAccount).
 				build()
 		}
@@ -725,7 +995,14 @@ func (r *RestoreManager) BuildPostReadyActionJobs(reqCtx intctrlutil.RequestCtx,
 				// no need to recover the volume when the pod selection policy is 'All' and sourceTargetPodName is not found.
 				continue
 			}
-			jobs = append(jobs, buildJob(&targetPodList.Items[i], sourceTargetPodName, i))
+			var targetEnv []corev1.EnvVar
+			if internalPostReady {
+				targetEnv, err = r.postReadyTargetEnv(reqCtx, reader, internalComponent, &targetPodList.Items[i])
+				if err != nil {
+					return nil, err
+				}
+			}
+			jobs = append(jobs, buildJob(&targetPodList.Items[i], sourceTargetPodName, i, targetEnv))
 		}
 		return jobs, nil
 	}

--- a/pkg/dataprotection/restore/manager.go
+++ b/pkg/dataprotection/restore/manager.go
@@ -663,20 +663,9 @@ func controllerReferenceMatches(obj metav1.Object, apiVersion, kind string, uid 
 func (r *RestoreManager) internalPostReadyComponent(
 	reqCtx intctrlutil.RequestCtx,
 	reader client.Reader) (*appsv1.Component, bool, error) {
-	var componentRef *metav1.OwnerReference
-	for i := range r.Restore.OwnerReferences {
-		ref := &r.Restore.OwnerReferences[i]
-		if ref.APIVersion != appsv1.APIVersion ||
-			ref.Kind != appsv1.ComponentKind ||
-			r.Restore.Name != PostReadyRestoreName(ref.UID) {
-			continue
-		}
-		if componentRef != nil {
-			return nil, true, intctrlutil.NewFatalError(fmt.Sprintf(
-				"internal postReady restore %s/%s has multiple Component owners",
-				r.Restore.Namespace, r.Restore.Name))
-		}
-		componentRef = ref
+	componentRef, internal, err := InternalPostReadyRestoreComponentOwner(r.Restore)
+	if err != nil || !internal {
+		return nil, internal, err
 	}
 	if componentRef == nil {
 		return nil, false, nil
@@ -685,12 +674,15 @@ func (r *RestoreManager) internalPostReadyComponent(
 	componentKey := types.NamespacedName{Namespace: r.Restore.Namespace, Name: componentRef.Name}
 	component := &appsv1.Component{}
 	if err := reader.Get(reqCtx.Ctx, componentKey, component); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, true, intctrlutil.NewFatalError(fmt.Sprintf(
+				"internal postReady restore %s/%s references missing Component %s",
+				r.Restore.Namespace, r.Restore.Name, componentKey))
+		}
 		return nil, true, targetFactReadError("Component", componentKey, err)
 	}
-	if component.UID != componentRef.UID {
-		return nil, true, intctrlutil.NewFatalError(fmt.Sprintf(
-			"internal postReady restore %s/%s Component identity changed: expected UID %s, got %s",
-			r.Restore.Namespace, r.Restore.Name, componentRef.UID, component.UID))
+	if err := ValidateInternalPostReadyRestoreComponent(r.Restore, component); err != nil {
+		return nil, true, err
 	}
 	if !component.DeletionTimestamp.IsZero() {
 		return nil, true, intctrlutil.NewFatalError(fmt.Sprintf(

--- a/pkg/dataprotection/restore/manager.go
+++ b/pkg/dataprotection/restore/manager.go
@@ -703,80 +703,97 @@ func validateTargetPodOwnership(
 	reqCtx intctrlutil.RequestCtx,
 	reader client.Reader,
 	pod *corev1.Pod,
-	component *appsv1.Component) error {
+	component *appsv1.Component) (string, error) {
 	owner := metav1.GetControllerOf(pod)
 	if owner == nil || owner.APIVersion != workloadsv1.GroupVersion.String() {
-		return intctrlutil.NewFatalError(fmt.Sprintf(
+		return "", intctrlutil.NewFatalError(fmt.Sprintf(
 			"target Pod %s/%s is not controlled by a KubeBlocks workload", pod.Namespace, pod.Name))
 	}
 
 	instanceSet := &workloadsv1.InstanceSet{}
+	instanceTemplateName := ""
 	switch owner.Kind {
 	case workloadsv1.InstanceSetKind:
 		key := types.NamespacedName{Namespace: pod.Namespace, Name: owner.Name}
 		if err := reader.Get(reqCtx.Ctx, key, instanceSet); err != nil {
-			return targetFactReadError(workloadsv1.InstanceSetKind, key, err)
+			return "", targetFactReadError(workloadsv1.InstanceSetKind, key, err)
 		}
 		if instanceSet.UID != owner.UID {
-			return intctrlutil.NewFatalError(fmt.Sprintf(
+			return "", intctrlutil.NewFatalError(fmt.Sprintf(
 				"target Pod %s/%s InstanceSet identity changed", pod.Namespace, pod.Name))
+		}
+		if !instanceSet.DeletionTimestamp.IsZero() {
+			return "", intctrlutil.NewRequeueError(time.Second, fmt.Sprintf(
+				"target InstanceSet %s/%s is terminating", instanceSet.Namespace, instanceSet.Name))
+		}
+		var ok bool
+		instanceTemplateName, ok = pod.Labels[constant.KBAppInstanceTemplateLabelKey]
+		if !ok {
+			return "", intctrlutil.NewFatalError(fmt.Sprintf(
+				"target Pod %s/%s is missing label %s",
+				pod.Namespace, pod.Name, constant.KBAppInstanceTemplateLabelKey))
 		}
 	case "Instance":
 		instanceKey := types.NamespacedName{Namespace: pod.Namespace, Name: owner.Name}
 		instance := &workloadsv1.Instance{}
 		if err := reader.Get(reqCtx.Ctx, instanceKey, instance); err != nil {
-			return targetFactReadError("Instance", instanceKey, err)
+			return "", targetFactReadError("Instance", instanceKey, err)
 		}
 		if instance.UID != owner.UID {
-			return intctrlutil.NewFatalError(fmt.Sprintf(
+			return "", intctrlutil.NewFatalError(fmt.Sprintf(
 				"target Pod %s/%s Instance identity changed", pod.Namespace, pod.Name))
 		}
+		if !instance.DeletionTimestamp.IsZero() {
+			return "", intctrlutil.NewRequeueError(time.Second, fmt.Sprintf(
+				"target Instance %s/%s is terminating", instance.Namespace, instance.Name))
+		}
+		instanceTemplateName = instance.Spec.InstanceTemplateName
 		instanceSetOwner := metav1.GetControllerOf(instance)
 		if instanceSetOwner == nil ||
 			instanceSetOwner.APIVersion != workloadsv1.GroupVersion.String() ||
 			instanceSetOwner.Kind != workloadsv1.InstanceSetKind {
-			return intctrlutil.NewFatalError(fmt.Sprintf(
+			return "", intctrlutil.NewFatalError(fmt.Sprintf(
 				"target Instance %s/%s is not controlled by an InstanceSet", instance.Namespace, instance.Name))
 		}
 		instanceSetKey := types.NamespacedName{Namespace: instance.Namespace, Name: instanceSetOwner.Name}
 		if err := reader.Get(reqCtx.Ctx, instanceSetKey, instanceSet); err != nil {
-			return targetFactReadError(workloadsv1.InstanceSetKind, instanceSetKey, err)
+			return "", targetFactReadError(workloadsv1.InstanceSetKind, instanceSetKey, err)
 		}
 		if instanceSet.UID != instanceSetOwner.UID {
-			return intctrlutil.NewFatalError(fmt.Sprintf(
+			return "", intctrlutil.NewFatalError(fmt.Sprintf(
 				"target Instance %s/%s InstanceSet identity changed", instance.Namespace, instance.Name))
 		}
+		if !instanceSet.DeletionTimestamp.IsZero() {
+			return "", intctrlutil.NewRequeueError(time.Second, fmt.Sprintf(
+				"target InstanceSet %s/%s is terminating", instanceSet.Namespace, instanceSet.Name))
+		}
 	default:
-		return intctrlutil.NewFatalError(fmt.Sprintf(
+		return "", intctrlutil.NewFatalError(fmt.Sprintf(
 			"target Pod %s/%s has unsupported controller kind %q", pod.Namespace, pod.Name, owner.Kind))
 	}
 
 	if !controllerReferenceMatches(instanceSet, appsv1.APIVersion, appsv1.ComponentKind, component.UID) {
-		return intctrlutil.NewFatalError(fmt.Sprintf(
+		return "", intctrlutil.NewFatalError(fmt.Sprintf(
 			"target Pod %s/%s workload is not controlled by Component %s/%s",
 			pod.Namespace, pod.Name, component.Namespace, component.Name))
 	}
-	return nil
+	return instanceTemplateName, nil
 }
 
-func targetPodServiceVersionSelector(component *appsv1.Component, pod *corev1.Pod) (string, error) {
-	templateName, ok := pod.Labels[constant.KBAppInstanceTemplateLabelKey]
-	if !ok {
-		return "", intctrlutil.NewFatalError(fmt.Sprintf(
-			"target Pod %s/%s is missing label %s",
-			pod.Namespace, pod.Name, constant.KBAppInstanceTemplateLabelKey))
-	}
-
-	if templateName != "" {
+func targetPodExpectedServiceVersion(
+	component *appsv1.Component,
+	pod *corev1.Pod,
+	instanceTemplateName string) (string, error) {
+	if instanceTemplateName != "" {
 		for i := range component.Spec.Instances {
 			instance := &component.Spec.Instances[i]
-			if instance.Name != templateName {
+			if instance.Name != instanceTemplateName {
 				continue
 			}
 			if ptr.Deref(instance.Replicas, int32(1)) <= 0 {
 				return "", intctrlutil.NewFatalError(fmt.Sprintf(
 					"target Pod %s/%s references inactive instance template %q",
-					pod.Namespace, pod.Name, templateName))
+					pod.Namespace, pod.Name, instanceTemplateName))
 			}
 			if instance.ServiceVersion != "" {
 				return instance.ServiceVersion, nil
@@ -785,7 +802,7 @@ func targetPodServiceVersionSelector(component *appsv1.Component, pod *corev1.Po
 		}
 		return "", intctrlutil.NewFatalError(fmt.Sprintf(
 			"target Pod %s/%s references unknown instance template %q",
-			pod.Namespace, pod.Name, templateName))
+			pod.Namespace, pod.Name, instanceTemplateName))
 	}
 
 	remainingDefaultReplicas := component.Spec.Replicas
@@ -794,7 +811,7 @@ func targetPodServiceVersionSelector(component *appsv1.Component, pod *corev1.Po
 	}
 	if remainingDefaultReplicas <= 0 {
 		return "", intctrlutil.NewFatalError(fmt.Sprintf(
-			"target Pod %s/%s has an empty instance-template label but Component has no default instances",
+			"target Pod %s/%s resolves to the default instance template but Component has no default instances",
 			pod.Namespace, pod.Name))
 	}
 	return component.Spec.ServiceVersion, nil
@@ -832,7 +849,8 @@ func (r *RestoreManager) postReadyTargetEnv(
 		return nil, intctrlutil.NewRequeueError(time.Second,
 			fmt.Sprintf("target Pod %s is not stably Ready", podKey))
 	}
-	if err := validateTargetPodOwnership(reqCtx, reader, livePod, liveComponent); err != nil {
+	instanceTemplateName, err := validateTargetPodOwnership(reqCtx, reader, livePod, liveComponent)
+	if err != nil {
 		return nil, err
 	}
 
@@ -875,13 +893,13 @@ func (r *RestoreManager) postReadyTargetEnv(
 			liveComponent.Namespace, liveComponent.Name, cluster.Namespace, cluster.Name))
 	}
 
-	serviceVersionSelector, err := targetPodServiceVersionSelector(liveComponent, livePod)
+	expectedServiceVersion, err := targetPodExpectedServiceVersion(liveComponent, livePod, instanceTemplateName)
 	if err != nil {
 		return nil, err
 	}
 	return []corev1.EnvVar{
 		{Name: dptypes.DPTargetClusterTopology, Value: cluster.Spec.Topology},
-		{Name: dptypes.DPTargetComponentServiceVersionSelector, Value: serviceVersionSelector},
+		{Name: dptypes.DPTargetComponentServiceVersion, Value: expectedServiceVersion},
 	}, nil
 }
 

--- a/pkg/dataprotection/restore/manager_target_env_test.go
+++ b/pkg/dataprotection/restore/manager_target_env_test.go
@@ -153,12 +153,11 @@ func newPostReadyTargetEnvFixture(t *testing.T) postReadyTargetEnvFixture {
 			Namespace: namespace,
 			Name:      PostReadyRestoreName(component.UID),
 			UID:       "restore-uid-1234",
-			OwnerReferences: []metav1.OwnerReference{{
-				APIVersion: appsv1.APIVersion,
-				Kind:       appsv1.ComponentKind,
-				Name:       component.Name,
-				UID:        component.UID,
-			}},
+			Labels: map[string]string{
+				DataProtectionInternalPostReadyLabelKey: DataProtectionInternalPostReadyLabelValue,
+			},
+			OwnerReferences: []metav1.OwnerReference{postReadyControllerRef(
+				appsv1.APIVersion, appsv1.ComponentKind, component.Name, component.UID)},
 		},
 		Spec: dpv1alpha1.RestoreSpec{
 			Backup: dpv1alpha1.BackupRef{Name: "backup", Namespace: namespace},
@@ -271,6 +270,100 @@ func TestBuildPostReadyActionJobsResolvesTargetFactsAtDispatch(t *testing.T) {
 	require.Equal(t, []string{"shared-nothing"}, postReadyJobEnvValues(env, dptypes.DPTargetClusterTopology))
 	require.Equal(t, []string{"3.5.0"}, postReadyJobEnvValues(env, dptypes.DPTargetComponentServiceVersion))
 	require.Empty(t, postReadyJobEnvValues(env, deprecatedTargetComponentServiceVersionSelectorEnvName))
+}
+
+func TestBuildPostReadyActionJobsFailsClosedWhenInternalRestoreOwnerIsMissing(t *testing.T) {
+	fixture := newPostReadyTargetEnvFixture(t)
+	fixture.manager.Restore.OwnerReferences = nil
+
+	jobs, err := fixture.manager.BuildPostReadyActionJobs(
+		intctrlutil.RequestCtx{Ctx: context.Background()},
+		fixture.client,
+		fixture.client,
+		fixture.backupSet,
+		fixture.target,
+		0)
+
+	require.Error(t, err)
+	require.True(t, intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal), err.Error())
+	require.Empty(t, jobs)
+}
+
+func TestBuildPostReadyActionJobsRejectsInvalidInternalRestoreIdentity(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*dpv1alpha1.Restore)
+	}{
+		{
+			name: "marker missing",
+			mutate: func(restore *dpv1alpha1.Restore) {
+				delete(restore.Labels, DataProtectionInternalPostReadyLabelKey)
+			},
+		},
+		{
+			name: "marker conflict",
+			mutate: func(restore *dpv1alpha1.Restore) {
+				restore.Labels[DataProtectionInternalPostReadyLabelKey] = "false"
+			},
+		},
+		{
+			name: "marker and owner missing",
+			mutate: func(restore *dpv1alpha1.Restore) {
+				delete(restore.Labels, DataProtectionInternalPostReadyLabelKey)
+				restore.OwnerReferences = nil
+			},
+		},
+		{
+			name: "wrong owner apiVersion",
+			mutate: func(restore *dpv1alpha1.Restore) {
+				restore.OwnerReferences[0].APIVersion = "v1"
+			},
+		},
+		{
+			name: "wrong owner kind",
+			mutate: func(restore *dpv1alpha1.Restore) {
+				restore.OwnerReferences[0].Kind = "Secret"
+			},
+		},
+		{
+			name: "wrong owner name",
+			mutate: func(restore *dpv1alpha1.Restore) {
+				restore.OwnerReferences[0].Name = "not-the-component"
+			},
+		},
+		{
+			name: "owner is not controller",
+			mutate: func(restore *dpv1alpha1.Restore) {
+				restore.OwnerReferences[0].Controller = nil
+			},
+		},
+		{
+			name: "wrong owner uid",
+			mutate: func(restore *dpv1alpha1.Restore) {
+				restore.OwnerReferences[0].UID = "wrong-component-uid"
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := newPostReadyTargetEnvFixture(t)
+			tt.mutate(fixture.manager.Restore)
+
+			jobs, err := fixture.manager.BuildPostReadyActionJobs(
+				intctrlutil.RequestCtx{Ctx: context.Background()},
+				fixture.client,
+				fixture.client,
+				fixture.backupSet,
+				fixture.target,
+				0,
+			)
+
+			require.Error(t, err)
+			require.True(t, intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal), err.Error())
+			require.Empty(t, jobs)
+		})
+	}
 }
 
 func TestBuildPostReadyActionJobsIgnoresMutatedRestoreTargetEnv(t *testing.T) {

--- a/pkg/dataprotection/restore/manager_target_env_test.go
+++ b/pkg/dataprotection/restore/manager_target_env_test.go
@@ -28,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -39,6 +38,8 @@ import (
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 )
+
+const deprecatedTargetComponentServiceVersionSelectorEnvName = "DP_TARGET_COMPONENT_SERVICE_VERSION_SELECTOR"
 
 type postReadyTargetEnvFixture struct {
 	manager   *RestoreManager
@@ -133,8 +134,8 @@ func newPostReadyTargetEnvFixture(t *testing.T) postReadyTargetEnvFixture {
 			Name: "database",
 			Env: []corev1.EnvVar{
 				{Name: dptypes.DPTargetClusterTopology, Value: "spoofed-pod-topology"},
-				{Name: dptypes.DPTargetComponentServiceVersion, Value: "spoofed-legacy-version"},
-				{Name: dptypes.DPTargetComponentServiceVersionSelector, Value: "spoofed-pod-selector"},
+				{Name: dptypes.DPTargetComponentServiceVersion, Value: "spoofed-pod-version"},
+				{Name: deprecatedTargetComponentServiceVersionSelectorEnvName, Value: "spoofed-pod-selector"},
 			},
 		}}},
 		Status: corev1.PodStatus{
@@ -200,6 +201,48 @@ func postReadyJobEnvValues(env []corev1.EnvVar, name string) []string {
 	return values
 }
 
+func useInstanceTargetOwnership(
+	t *testing.T,
+	fixture postReadyTargetEnvFixture,
+	instanceTemplateName,
+	podTemplateLabel string) {
+	t.Helper()
+	ctx := context.Background()
+	instanceSet := &workloadsv1.InstanceSet{}
+	require.NoError(t, fixture.client.Get(ctx, fixture.component, instanceSet))
+	podKey := types.NamespacedName{Namespace: fixture.component.Namespace, Name: fixture.component.Name + "-0"}
+	pod := &corev1.Pod{}
+	require.NoError(t, fixture.client.Get(ctx, podKey, pod))
+	instance := &workloadsv1.Instance{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: pod.Namespace,
+			Name:      pod.Name,
+			UID:       "instance-uid",
+			OwnerReferences: []metav1.OwnerReference{postReadyControllerRef(
+				workloadsv1.GroupVersion.String(), workloadsv1.InstanceSetKind, instanceSet.Name, instanceSet.UID)},
+		},
+		Spec: workloadsv1.InstanceSpec{InstanceTemplateName: instanceTemplateName},
+	}
+	require.NoError(t, fixture.client.Create(ctx, instance))
+	pod.OwnerReferences = []metav1.OwnerReference{postReadyControllerRef(
+		workloadsv1.GroupVersion.String(), "Instance", instance.Name, instance.UID)}
+	pod.Labels[constant.KBAppInstanceTemplateLabelKey] = podTemplateLabel
+	require.NoError(t, fixture.client.Update(ctx, pod))
+}
+
+func markPostReadyTargetOwnerTerminating(
+	t *testing.T,
+	fixture postReadyTargetEnvFixture,
+	object client.Object) {
+	t.Helper()
+	ctx := context.Background()
+	object.SetFinalizers(append(object.GetFinalizers(), "test.kubeblocks.io/finalizer"))
+	require.NoError(t, fixture.client.Update(ctx, object))
+	require.NoError(t, fixture.client.Delete(ctx, object))
+	require.NoError(t, fixture.client.Get(ctx, client.ObjectKeyFromObject(object), object))
+	require.False(t, object.GetDeletionTimestamp().IsZero())
+}
+
 func TestBuildPostReadyActionJobsResolvesTargetFactsAtDispatch(t *testing.T) {
 	fixture := newPostReadyTargetEnvFixture(t)
 	reqCtx := intctrlutil.RequestCtx{Ctx: context.Background()}
@@ -214,8 +257,8 @@ func TestBuildPostReadyActionJobsResolvesTargetFactsAtDispatch(t *testing.T) {
 
 	env := build()
 	require.Equal(t, []string{"shared-nothing"}, postReadyJobEnvValues(env, dptypes.DPTargetClusterTopology))
-	require.Equal(t, []string{"3.4.0"}, postReadyJobEnvValues(env, dptypes.DPTargetComponentServiceVersionSelector))
-	require.Empty(t, postReadyJobEnvValues(env, dptypes.DPTargetComponentServiceVersion))
+	require.Equal(t, []string{"3.4.0"}, postReadyJobEnvValues(env, dptypes.DPTargetComponentServiceVersion))
+	require.Empty(t, postReadyJobEnvValues(env, deprecatedTargetComponentServiceVersionSelectorEnvName))
 
 	component := &appsv1.Component{}
 	require.NoError(t, fixture.client.Get(context.Background(), fixture.component, component))
@@ -226,8 +269,8 @@ func TestBuildPostReadyActionJobsResolvesTargetFactsAtDispatch(t *testing.T) {
 
 	env = build()
 	require.Equal(t, []string{"shared-nothing"}, postReadyJobEnvValues(env, dptypes.DPTargetClusterTopology))
-	require.Equal(t, []string{"3.5.0"}, postReadyJobEnvValues(env, dptypes.DPTargetComponentServiceVersionSelector))
-	require.Empty(t, postReadyJobEnvValues(env, dptypes.DPTargetComponentServiceVersion))
+	require.Equal(t, []string{"3.5.0"}, postReadyJobEnvValues(env, dptypes.DPTargetComponentServiceVersion))
+	require.Empty(t, postReadyJobEnvValues(env, deprecatedTargetComponentServiceVersionSelectorEnvName))
 }
 
 func TestBuildPostReadyActionJobsIgnoresMutatedRestoreTargetEnv(t *testing.T) {
@@ -236,7 +279,7 @@ func TestBuildPostReadyActionJobsIgnoresMutatedRestoreTargetEnv(t *testing.T) {
 		{Name: "KEEP_RESTORE_ENV", Value: "kept"},
 		{Name: dptypes.DPTargetClusterTopology, Value: "mutated-restore-topology"},
 		{Name: dptypes.DPTargetComponentServiceVersion, Value: "mutated-restore-version"},
-		{Name: dptypes.DPTargetComponentServiceVersionSelector, Value: "mutated-restore-selector"},
+		{Name: deprecatedTargetComponentServiceVersionSelectorEnvName, Value: "mutated-restore-selector"},
 	}
 
 	jobs, err := fixture.manager.BuildPostReadyActionJobs(
@@ -252,12 +295,12 @@ func TestBuildPostReadyActionJobsIgnoresMutatedRestoreTargetEnv(t *testing.T) {
 	require.Len(t, jobs, 1)
 	env := jobs[0].Spec.Template.Spec.Containers[0].Env
 	require.Equal(t, []string{"shared-nothing"}, postReadyJobEnvValues(env, dptypes.DPTargetClusterTopology))
-	require.Equal(t, []string{"3.4.0"}, postReadyJobEnvValues(env, dptypes.DPTargetComponentServiceVersionSelector))
-	require.Empty(t, postReadyJobEnvValues(env, dptypes.DPTargetComponentServiceVersion))
+	require.Equal(t, []string{"3.4.0"}, postReadyJobEnvValues(env, dptypes.DPTargetComponentServiceVersion))
+	require.Empty(t, postReadyJobEnvValues(env, deprecatedTargetComponentServiceVersionSelectorEnvName))
 	require.Equal(t, []string{"kept"}, postReadyJobEnvValues(env, "KEEP_RESTORE_ENV"))
 }
 
-func TestBuildPostReadyActionJobsPublishesEmptyDeclaredSelectorWhenAppsHasNone(t *testing.T) {
+func TestBuildPostReadyActionJobsPublishesEmptyExpectedServiceVersionWhenAppsHasNone(t *testing.T) {
 	fixture := newPostReadyTargetEnvFixture(t)
 	component := &appsv1.Component{}
 	require.NoError(t, fixture.client.Get(context.Background(), fixture.component, component))
@@ -279,7 +322,148 @@ func TestBuildPostReadyActionJobsPublishesEmptyDeclaredSelectorWhenAppsHasNone(t
 	require.NoError(t, err)
 	require.Len(t, jobs, 1)
 	env := jobs[0].Spec.Template.Spec.Containers[0].Env
-	require.Equal(t, []string{""}, postReadyJobEnvValues(env, dptypes.DPTargetComponentServiceVersionSelector))
+	require.Equal(t, []string{""}, postReadyJobEnvValues(env, dptypes.DPTargetComponentServiceVersion))
+}
+
+func TestBuildPostReadyActionJobsUsesInstanceAPITemplateName(t *testing.T) {
+	fixture := newPostReadyTargetEnvFixture(t)
+	// The label is controller-owned implementation detail and intentionally conflicts
+	// with the authoritative public Instance API value.
+	useInstanceTargetOwnership(t, fixture, "canary", "unknown")
+
+	jobs, err := fixture.manager.BuildPostReadyActionJobs(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, fixture.client, fixture.client, fixture.backupSet, fixture.target, 0)
+
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+	env := jobs[0].Spec.Template.Spec.Containers[0].Env
+	require.Equal(t, []string{"3.4.0"}, postReadyJobEnvValues(env, dptypes.DPTargetComponentServiceVersion))
+}
+
+func TestBuildPostReadyActionJobsDoesNotFallbackFromEmptyInstanceAPITemplateName(t *testing.T) {
+	fixture := newPostReadyTargetEnvFixture(t)
+	// Empty is the authoritative default-instance sentinel. The spoofed Pod label
+	// must not redirect this target to the canary instance template.
+	useInstanceTargetOwnership(t, fixture, "", "canary")
+
+	jobs, err := fixture.manager.BuildPostReadyActionJobs(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, fixture.client, fixture.client, fixture.backupSet, fixture.target, 0)
+
+	require.Error(t, err)
+	require.True(t, intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal), err)
+	require.Empty(t, jobs)
+}
+
+func TestBuildPostReadyActionJobsUsesDefaultFromEmptyInstanceAPITemplateName(t *testing.T) {
+	fixture := newPostReadyTargetEnvFixture(t)
+	ctx := context.Background()
+	component := &appsv1.Component{}
+	require.NoError(t, fixture.client.Get(ctx, fixture.component, component))
+	component.Spec.Replicas = 2
+	component.Generation++
+	component.Status.ObservedGeneration = component.Generation
+	require.NoError(t, fixture.client.Update(ctx, component))
+	// The public Instance API selects the default instance even though the Pod
+	// label tries to redirect dispatch to the canary override.
+	useInstanceTargetOwnership(t, fixture, "", "canary")
+
+	jobs, err := fixture.manager.BuildPostReadyActionJobs(
+		intctrlutil.RequestCtx{Ctx: ctx}, fixture.client, fixture.client, fixture.backupSet, fixture.target, 0)
+
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+	env := jobs[0].Spec.Template.Spec.Containers[0].Env
+	require.Equal(t, []string{"3.3.2"}, postReadyJobEnvValues(env, dptypes.DPTargetComponentServiceVersion))
+}
+
+func TestBuildPostReadyActionJobsWaitsForTerminatingInstanceSet(t *testing.T) {
+	fixture := newPostReadyTargetEnvFixture(t)
+	instanceSet := &workloadsv1.InstanceSet{}
+	require.NoError(t, fixture.client.Get(context.Background(), fixture.component, instanceSet))
+	markPostReadyTargetOwnerTerminating(t, fixture, instanceSet)
+
+	jobs, err := fixture.manager.BuildPostReadyActionJobs(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, fixture.client, fixture.client, fixture.backupSet, fixture.target, 0)
+
+	require.Error(t, err)
+	require.True(t, intctrlutil.IsRequeueError(err), err)
+	require.ErrorContains(t, err, "target InstanceSet "+fixture.component.String()+" is terminating")
+	require.Empty(t, jobs)
+}
+
+func TestBuildPostReadyActionJobsWaitsForTerminatingInstance(t *testing.T) {
+	fixture := newPostReadyTargetEnvFixture(t)
+	useInstanceTargetOwnership(t, fixture, "canary", "canary")
+	instanceKey := types.NamespacedName{Namespace: fixture.component.Namespace, Name: fixture.component.Name + "-0"}
+	instance := &workloadsv1.Instance{}
+	require.NoError(t, fixture.client.Get(context.Background(), instanceKey, instance))
+	markPostReadyTargetOwnerTerminating(t, fixture, instance)
+
+	jobs, err := fixture.manager.BuildPostReadyActionJobs(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, fixture.client, fixture.client, fixture.backupSet, fixture.target, 0)
+
+	require.Error(t, err)
+	require.True(t, intctrlutil.IsRequeueError(err), err)
+	require.ErrorContains(t, err, "target Instance "+instanceKey.String()+" is terminating")
+	require.Empty(t, jobs)
+}
+
+func TestBuildPostReadyActionJobsWaitsForTerminatingParentInstanceSet(t *testing.T) {
+	fixture := newPostReadyTargetEnvFixture(t)
+	useInstanceTargetOwnership(t, fixture, "canary", "canary")
+	instanceSet := &workloadsv1.InstanceSet{}
+	require.NoError(t, fixture.client.Get(context.Background(), fixture.component, instanceSet))
+	markPostReadyTargetOwnerTerminating(t, fixture, instanceSet)
+
+	jobs, err := fixture.manager.BuildPostReadyActionJobs(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, fixture.client, fixture.client, fixture.backupSet, fixture.target, 0)
+
+	require.Error(t, err)
+	require.True(t, intctrlutil.IsRequeueError(err), err)
+	require.ErrorContains(t, err, "target InstanceSet "+fixture.component.String()+" is terminating")
+	require.Empty(t, jobs)
+}
+
+func TestValidateTargetPodOwnershipKeepsInstanceSetLabelContract(t *testing.T) {
+	canary := "canary"
+	empty := ""
+	tests := []struct {
+		name      string
+		label     *string
+		want      string
+		wantFatal bool
+	}{
+		{name: "override", label: &canary, want: "canary"},
+		{name: "default", label: &empty},
+		{name: "missing", wantFatal: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := newPostReadyTargetEnvFixture(t)
+			ctx := context.Background()
+			component := &appsv1.Component{}
+			require.NoError(t, fixture.client.Get(ctx, fixture.component, component))
+			podKey := types.NamespacedName{Namespace: fixture.component.Namespace, Name: fixture.component.Name + "-0"}
+			pod := &corev1.Pod{}
+			require.NoError(t, fixture.client.Get(ctx, podKey, pod))
+			if tt.label == nil {
+				delete(pod.Labels, constant.KBAppInstanceTemplateLabelKey)
+			} else {
+				pod.Labels[constant.KBAppInstanceTemplateLabelKey] = *tt.label
+			}
+
+			got, err := validateTargetPodOwnership(
+				intctrlutil.RequestCtx{Ctx: ctx}, fixture.client, pod, component)
+
+			if tt.wantFatal {
+				require.Error(t, err)
+				require.True(t, intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal), err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestBuildPostReadyActionJobsWaitsForObservedTargetComponentGeneration(t *testing.T) {
@@ -304,71 +488,60 @@ func TestBuildPostReadyActionJobsWaitsForObservedTargetComponentGeneration(t *te
 	require.Empty(t, jobs)
 }
 
-func TestTargetPodServiceVersionSelector(t *testing.T) {
+func TestTargetPodExpectedServiceVersion(t *testing.T) {
 	zero := int32(0)
 	tests := []struct {
-		name          string
-		component     appsv1.ComponentSpec
-		templateLabel *string
-		want          string
-		wantFatal     bool
+		name                 string
+		component            appsv1.ComponentSpec
+		instanceTemplateName string
+		want                 string
+		wantFatal            bool
 	}{
 		{
-			name:          "instance override",
-			component:     appsv1.ComponentSpec{ServiceVersion: "3.3.2", Replicas: 1, Instances: []appsv1.InstanceTemplate{{Name: "canary", ServiceVersion: "3.4.0"}}},
-			templateLabel: ptr.To("canary"),
-			want:          "3.4.0",
+			name:                 "instance override",
+			component:            appsv1.ComponentSpec{ServiceVersion: "3.3.2", Replicas: 1, Instances: []appsv1.InstanceTemplate{{Name: "canary", ServiceVersion: "3.4.0"}}},
+			instanceTemplateName: "canary",
+			want:                 "3.4.0",
 		},
 		{
-			name:          "instance inherits component selector",
-			component:     appsv1.ComponentSpec{ServiceVersion: "3.3.2", Replicas: 1, Instances: []appsv1.InstanceTemplate{{Name: "canary"}}},
-			templateLabel: ptr.To("canary"),
-			want:          "3.3.2",
+			name:                 "instance inherits component service version",
+			component:            appsv1.ComponentSpec{ServiceVersion: "3.3.2", Replicas: 1, Instances: []appsv1.InstanceTemplate{{Name: "canary"}}},
+			instanceTemplateName: "canary",
+			want:                 "3.3.2",
 		},
 		{
-			name:          "default instance",
-			component:     appsv1.ComponentSpec{ServiceVersion: "3.3.2", Replicas: 2, Instances: []appsv1.InstanceTemplate{{Name: "canary", ServiceVersion: "3.4.0"}}},
-			templateLabel: ptr.To(""),
-			want:          "3.3.2",
+			name:      "default instance",
+			component: appsv1.ComponentSpec{ServiceVersion: "3.3.2", Replicas: 2, Instances: []appsv1.InstanceTemplate{{Name: "canary", ServiceVersion: "3.4.0"}}},
+			want:      "3.3.2",
 		},
 		{
-			name:          "declared selector absent",
-			component:     appsv1.ComponentSpec{Replicas: 1},
-			templateLabel: ptr.To(""),
-		},
-		{
-			name:          "inactive instance template",
-			component:     appsv1.ComponentSpec{Replicas: 1, Instances: []appsv1.InstanceTemplate{{Name: "canary", Replicas: &zero}}},
-			templateLabel: ptr.To("canary"),
-			wantFatal:     true,
-		},
-		{
-			name:          "unknown instance template",
-			component:     appsv1.ComponentSpec{Replicas: 1},
-			templateLabel: ptr.To("unknown"),
-			wantFatal:     true,
-		},
-		{
-			name:          "no default instances",
-			component:     appsv1.ComponentSpec{Replicas: 1, Instances: []appsv1.InstanceTemplate{{Name: "canary"}}},
-			templateLabel: ptr.To(""),
-			wantFatal:     true,
-		},
-		{
-			name:      "label missing",
+			name:      "expected service version absent",
 			component: appsv1.ComponentSpec{Replicas: 1},
+		},
+		{
+			name:                 "inactive instance template",
+			component:            appsv1.ComponentSpec{Replicas: 1, Instances: []appsv1.InstanceTemplate{{Name: "canary", Replicas: &zero}}},
+			instanceTemplateName: "canary",
+			wantFatal:            true,
+		},
+		{
+			name:                 "unknown instance template",
+			component:            appsv1.ComponentSpec{Replicas: 1},
+			instanceTemplateName: "unknown",
+			wantFatal:            true,
+		},
+		{
+			name:      "no default instances",
+			component: appsv1.ComponentSpec{Replicas: 1, Instances: []appsv1.InstanceTemplate{{Name: "canary"}}},
 			wantFatal: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "target"}}
-			if tt.templateLabel != nil {
-				pod.Labels = map[string]string{constant.KBAppInstanceTemplateLabelKey: *tt.templateLabel}
-			}
 			component := &appsv1.Component{Spec: tt.component}
 
-			got, err := targetPodServiceVersionSelector(component, pod)
+			got, err := targetPodExpectedServiceVersion(component, pod, tt.instanceTemplateName)
 
 			if tt.wantFatal {
 				require.Error(t, err)

--- a/pkg/dataprotection/restore/manager_target_env_test.go
+++ b/pkg/dataprotection/restore/manager_target_env_test.go
@@ -1,0 +1,382 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package restore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	workloadsv1 "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
+)
+
+type postReadyTargetEnvFixture struct {
+	manager   *RestoreManager
+	client    client.Client
+	backupSet BackupActionSet
+	target    *dpv1alpha1.BackupStatusTarget
+	component types.NamespacedName
+}
+
+func postReadyControllerRef(apiVersion, kind, name string, uid types.UID) metav1.OwnerReference {
+	controller := true
+	return metav1.OwnerReference{
+		APIVersion: apiVersion,
+		Kind:       kind,
+		Name:       name,
+		UID:        uid,
+		Controller: &controller,
+	}
+}
+
+func newPostReadyTargetEnvFixture(t *testing.T) postReadyTargetEnvFixture {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	require.NoError(t, workloadsv1.AddToScheme(scheme))
+
+	const (
+		namespace     = "default"
+		clusterName   = "target"
+		componentName = "mysql"
+	)
+	clusterUID := types.UID("cluster-uid")
+	componentUID := types.UID("component-uid")
+	instanceSetUID := types.UID("instanceset-uid")
+	componentObjectName := constant.GenerateClusterComponentName(clusterName, componentName)
+
+	cluster := &appsv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: clusterName, UID: clusterUID},
+		Spec:       appsv1.ClusterSpec{Topology: "shared-nothing"},
+	}
+	component := &appsv1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  namespace,
+			Name:       componentObjectName,
+			UID:        componentUID,
+			Generation: 1,
+			Labels: map[string]string{
+				constant.AppInstanceLabelKey:    clusterName,
+				constant.KBAppComponentLabelKey: componentName,
+			},
+			Annotations: map[string]string{constant.KBAppClusterUIDKey: string(clusterUID)},
+		},
+		Spec: appsv1.ComponentSpec{
+			ServiceVersion: "3.3.2",
+			Replicas:       1,
+			Instances: []appsv1.InstanceTemplate{{
+				Name:           "canary",
+				ServiceVersion: "3.4.0",
+			}},
+		},
+		Status: appsv1.ComponentStatus{
+			ObservedGeneration: 1,
+			Phase:              appsv1.RunningComponentPhase,
+		},
+	}
+	instanceSet := &workloadsv1.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      componentObjectName,
+			UID:       instanceSetUID,
+			OwnerReferences: []metav1.OwnerReference{postReadyControllerRef(
+				appsv1.APIVersion, appsv1.ComponentKind, component.Name, component.UID)},
+		},
+	}
+	targetLabels := map[string]string{
+		"restore-target":                       "true",
+		constant.AppInstanceLabelKey:           clusterName,
+		constant.KBAppComponentLabelKey:        componentName,
+		constant.KBAppInstanceTemplateLabelKey: "canary",
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       namespace,
+			Name:            componentObjectName + "-0",
+			UID:             "pod-uid",
+			Labels:          targetLabels,
+			OwnerReferences: []metav1.OwnerReference{postReadyControllerRef(workloadsv1.GroupVersion.String(), workloadsv1.InstanceSetKind, instanceSet.Name, instanceSet.UID)},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{
+			Name: "database",
+			Env: []corev1.EnvVar{
+				{Name: dptypes.DPTargetClusterTopology, Value: "spoofed-pod-topology"},
+				{Name: dptypes.DPTargetComponentServiceVersion, Value: "spoofed-legacy-version"},
+				{Name: dptypes.DPTargetComponentServiceVersionSelector, Value: "spoofed-pod-selector"},
+			},
+		}}},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodReady,
+				Status: corev1.ConditionTrue,
+			}},
+		},
+	}
+	k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster, component, instanceSet, pod).Build()
+
+	restore := &dpv1alpha1.Restore{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      PostReadyRestoreName(component.UID),
+			UID:       "restore-uid-1234",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: appsv1.APIVersion,
+				Kind:       appsv1.ComponentKind,
+				Name:       component.Name,
+				UID:        component.UID,
+			}},
+		},
+		Spec: dpv1alpha1.RestoreSpec{
+			Backup: dpv1alpha1.BackupRef{Name: "backup", Namespace: namespace},
+			Env:    []corev1.EnvVar{{Name: "KEEP_RESTORE_ENV", Value: "kept"}},
+			ReadyConfig: &dpv1alpha1.ReadyConfig{JobAction: &dpv1alpha1.JobAction{
+				Target: dpv1alpha1.JobActionTarget{PodSelector: dpv1alpha1.PodSelector{
+					LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"restore-target": "true"}},
+					Strategy:      dpv1alpha1.PodSelectionStrategyAny,
+				}},
+			}},
+		},
+	}
+	backup := &dpv1alpha1.Backup{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "backup"}}
+	actionSet := &dpv1alpha1.ActionSet{Spec: dpv1alpha1.ActionSetSpec{
+		Restore: &dpv1alpha1.RestoreActionSpec{PostReady: []dpv1alpha1.ActionSpec{{
+			Job: &dpv1alpha1.JobActionSpec{BaseJobActionSpec: dpv1alpha1.BaseJobActionSpec{
+				Image: "restore:latest", Command: []string{"restore"},
+			}},
+		}}},
+	}}
+	target := &dpv1alpha1.BackupStatusTarget{BackupTarget: dpv1alpha1.BackupTarget{
+		PodSelector: &dpv1alpha1.PodSelector{Strategy: dpv1alpha1.PodSelectionStrategyAny},
+	}}
+	return postReadyTargetEnvFixture{
+		manager:   NewRestoreManager(restore, nil, scheme, k8sClient),
+		client:    k8sClient,
+		backupSet: BackupActionSet{Backup: backup, ActionSet: actionSet},
+		target:    target,
+		component: client.ObjectKeyFromObject(component),
+	}
+}
+
+func postReadyJobEnvValues(env []corev1.EnvVar, name string) []string {
+	var values []string
+	for i := range env {
+		if env[i].Name == name {
+			values = append(values, env[i].Value)
+		}
+	}
+	return values
+}
+
+func TestBuildPostReadyActionJobsResolvesTargetFactsAtDispatch(t *testing.T) {
+	fixture := newPostReadyTargetEnvFixture(t)
+	reqCtx := intctrlutil.RequestCtx{Ctx: context.Background()}
+
+	build := func() []corev1.EnvVar {
+		jobs, err := fixture.manager.BuildPostReadyActionJobs(
+			reqCtx, fixture.client, fixture.client, fixture.backupSet, fixture.target, 0)
+		require.NoError(t, err)
+		require.Len(t, jobs, 1)
+		return jobs[0].Spec.Template.Spec.Containers[0].Env
+	}
+
+	env := build()
+	require.Equal(t, []string{"shared-nothing"}, postReadyJobEnvValues(env, dptypes.DPTargetClusterTopology))
+	require.Equal(t, []string{"3.4.0"}, postReadyJobEnvValues(env, dptypes.DPTargetComponentServiceVersionSelector))
+	require.Empty(t, postReadyJobEnvValues(env, dptypes.DPTargetComponentServiceVersion))
+
+	component := &appsv1.Component{}
+	require.NoError(t, fixture.client.Get(context.Background(), fixture.component, component))
+	component.Spec.Instances[0].ServiceVersion = "3.5.0"
+	component.Generation++
+	component.Status.ObservedGeneration = component.Generation
+	require.NoError(t, fixture.client.Update(context.Background(), component))
+
+	env = build()
+	require.Equal(t, []string{"shared-nothing"}, postReadyJobEnvValues(env, dptypes.DPTargetClusterTopology))
+	require.Equal(t, []string{"3.5.0"}, postReadyJobEnvValues(env, dptypes.DPTargetComponentServiceVersionSelector))
+	require.Empty(t, postReadyJobEnvValues(env, dptypes.DPTargetComponentServiceVersion))
+}
+
+func TestBuildPostReadyActionJobsIgnoresMutatedRestoreTargetEnv(t *testing.T) {
+	fixture := newPostReadyTargetEnvFixture(t)
+	fixture.manager.Restore.Spec.Env = []corev1.EnvVar{
+		{Name: "KEEP_RESTORE_ENV", Value: "kept"},
+		{Name: dptypes.DPTargetClusterTopology, Value: "mutated-restore-topology"},
+		{Name: dptypes.DPTargetComponentServiceVersion, Value: "mutated-restore-version"},
+		{Name: dptypes.DPTargetComponentServiceVersionSelector, Value: "mutated-restore-selector"},
+	}
+
+	jobs, err := fixture.manager.BuildPostReadyActionJobs(
+		intctrlutil.RequestCtx{Ctx: context.Background()},
+		fixture.client,
+		fixture.client,
+		fixture.backupSet,
+		fixture.target,
+		0,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+	env := jobs[0].Spec.Template.Spec.Containers[0].Env
+	require.Equal(t, []string{"shared-nothing"}, postReadyJobEnvValues(env, dptypes.DPTargetClusterTopology))
+	require.Equal(t, []string{"3.4.0"}, postReadyJobEnvValues(env, dptypes.DPTargetComponentServiceVersionSelector))
+	require.Empty(t, postReadyJobEnvValues(env, dptypes.DPTargetComponentServiceVersion))
+	require.Equal(t, []string{"kept"}, postReadyJobEnvValues(env, "KEEP_RESTORE_ENV"))
+}
+
+func TestBuildPostReadyActionJobsPublishesEmptyDeclaredSelectorWhenAppsHasNone(t *testing.T) {
+	fixture := newPostReadyTargetEnvFixture(t)
+	component := &appsv1.Component{}
+	require.NoError(t, fixture.client.Get(context.Background(), fixture.component, component))
+	component.Spec.ServiceVersion = ""
+	component.Spec.Instances[0].ServiceVersion = ""
+	component.Generation++
+	component.Status.ObservedGeneration = component.Generation
+	require.NoError(t, fixture.client.Update(context.Background(), component))
+
+	jobs, err := fixture.manager.BuildPostReadyActionJobs(
+		intctrlutil.RequestCtx{Ctx: context.Background()},
+		fixture.client,
+		fixture.client,
+		fixture.backupSet,
+		fixture.target,
+		0,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+	env := jobs[0].Spec.Template.Spec.Containers[0].Env
+	require.Equal(t, []string{""}, postReadyJobEnvValues(env, dptypes.DPTargetComponentServiceVersionSelector))
+}
+
+func TestBuildPostReadyActionJobsWaitsForObservedTargetComponentGeneration(t *testing.T) {
+	fixture := newPostReadyTargetEnvFixture(t)
+	component := &appsv1.Component{}
+	require.NoError(t, fixture.client.Get(context.Background(), fixture.component, component))
+	component.Spec.Instances[0].ServiceVersion = "3.5.0"
+	component.Generation++
+	require.NoError(t, fixture.client.Update(context.Background(), component))
+
+	jobs, err := fixture.manager.BuildPostReadyActionJobs(
+		intctrlutil.RequestCtx{Ctx: context.Background()},
+		fixture.client,
+		fixture.client,
+		fixture.backupSet,
+		fixture.target,
+		0,
+	)
+
+	require.Error(t, err)
+	require.True(t, intctrlutil.IsRequeueError(err), err)
+	require.Empty(t, jobs)
+}
+
+func TestTargetPodServiceVersionSelector(t *testing.T) {
+	zero := int32(0)
+	tests := []struct {
+		name          string
+		component     appsv1.ComponentSpec
+		templateLabel *string
+		want          string
+		wantFatal     bool
+	}{
+		{
+			name:          "instance override",
+			component:     appsv1.ComponentSpec{ServiceVersion: "3.3.2", Replicas: 1, Instances: []appsv1.InstanceTemplate{{Name: "canary", ServiceVersion: "3.4.0"}}},
+			templateLabel: ptr.To("canary"),
+			want:          "3.4.0",
+		},
+		{
+			name:          "instance inherits component selector",
+			component:     appsv1.ComponentSpec{ServiceVersion: "3.3.2", Replicas: 1, Instances: []appsv1.InstanceTemplate{{Name: "canary"}}},
+			templateLabel: ptr.To("canary"),
+			want:          "3.3.2",
+		},
+		{
+			name:          "default instance",
+			component:     appsv1.ComponentSpec{ServiceVersion: "3.3.2", Replicas: 2, Instances: []appsv1.InstanceTemplate{{Name: "canary", ServiceVersion: "3.4.0"}}},
+			templateLabel: ptr.To(""),
+			want:          "3.3.2",
+		},
+		{
+			name:          "declared selector absent",
+			component:     appsv1.ComponentSpec{Replicas: 1},
+			templateLabel: ptr.To(""),
+		},
+		{
+			name:          "inactive instance template",
+			component:     appsv1.ComponentSpec{Replicas: 1, Instances: []appsv1.InstanceTemplate{{Name: "canary", Replicas: &zero}}},
+			templateLabel: ptr.To("canary"),
+			wantFatal:     true,
+		},
+		{
+			name:          "unknown instance template",
+			component:     appsv1.ComponentSpec{Replicas: 1},
+			templateLabel: ptr.To("unknown"),
+			wantFatal:     true,
+		},
+		{
+			name:          "no default instances",
+			component:     appsv1.ComponentSpec{Replicas: 1, Instances: []appsv1.InstanceTemplate{{Name: "canary"}}},
+			templateLabel: ptr.To(""),
+			wantFatal:     true,
+		},
+		{
+			name:      "label missing",
+			component: appsv1.ComponentSpec{Replicas: 1},
+			wantFatal: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "target"}}
+			if tt.templateLabel != nil {
+				pod.Labels = map[string]string{constant.KBAppInstanceTemplateLabelKey: *tt.templateLabel}
+			}
+			component := &appsv1.Component{Spec: tt.component}
+
+			got, err := targetPodServiceVersionSelector(component, pod)
+
+			if tt.wantFatal {
+				require.Error(t, err)
+				require.True(t, intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal), err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/dataprotection/restore/manager_test.go
+++ b/pkg/dataprotection/restore/manager_test.go
@@ -512,7 +512,7 @@ var _ = Describe("RestoreManager Test", func() {
 			}
 			Expect(envValues(dptypes.DPTargetClusterTopology)).Should(BeEmpty())
 			Expect(envValues(dptypes.DPTargetComponentServiceVersion)).Should(BeEmpty())
-			Expect(envValues(dptypes.DPTargetComponentServiceVersionSelector)).Should(BeEmpty())
+			Expect(envValues(deprecatedTargetComponentServiceVersionSelectorEnvName)).Should(BeEmpty())
 			Expect(envValues("KEEP_POD_ENV")).Should(Equal([]corev1.EnvVar{{Name: "KEEP_POD_ENV", Value: "kept"}}))
 			Expect(envValues(dptypes.DPDBUser)).Should(HaveLen(1))
 			Expect(envValues(dptypes.DPDBPassword)).Should(HaveLen(1))

--- a/pkg/dataprotection/restore/manager_test.go
+++ b/pkg/dataprotection/restore/manager_test.go
@@ -487,7 +487,7 @@ var _ = Describe("RestoreManager Test", func() {
 			By("test with execAction and expect for creating 2 exec job")
 			target := utils.GetBackupStatusTarget(backupSet.Backup, restoreMGR.Restore.Spec.Backup.SourceTargetName)
 			// step 0 is the execAction in actionSet
-			jobs, err := restoreMGR.BuildPostReadyActionJobs(reqCtx, k8sClient, *backupSet, target, 0)
+			jobs, err := restoreMGR.BuildPostReadyActionJobs(reqCtx, k8sClient, k8sClient, *backupSet, target, 0)
 			Expect(err).ShouldNot(HaveOccurred())
 			// the count of exec jobs should equal to the pods count of cluster
 			Expect(len(jobs)).Should(Equal(2))
@@ -496,7 +496,7 @@ var _ = Describe("RestoreManager Test", func() {
 
 			By("test with jobAction and expect for creating 1 job")
 			// step 0 is the execAction in actionSet
-			jobs, err = restoreMGR.BuildPostReadyActionJobs(reqCtx, k8sClient, *backupSet, target, 1)
+			jobs, err = restoreMGR.BuildPostReadyActionJobs(reqCtx, k8sClient, k8sClient, *backupSet, target, 1)
 			Expect(err).ShouldNot(HaveOccurred())
 			// count of job should equal to 1
 			Expect(len(jobs)).Should(Equal(1))
@@ -510,12 +510,9 @@ var _ = Describe("RestoreManager Test", func() {
 				}
 				return values
 			}
-			Expect(envValues(dptypes.DPTargetClusterTopology)).Should(Equal([]corev1.EnvVar{{
-				Name: dptypes.DPTargetClusterTopology, Value: "shared-nothing",
-			}}))
-			Expect(envValues(dptypes.DPTargetComponentServiceVersion)).Should(Equal([]corev1.EnvVar{{
-				Name: dptypes.DPTargetComponentServiceVersion, Value: "3.3.2",
-			}}))
+			Expect(envValues(dptypes.DPTargetClusterTopology)).Should(BeEmpty())
+			Expect(envValues(dptypes.DPTargetComponentServiceVersion)).Should(BeEmpty())
+			Expect(envValues(dptypes.DPTargetComponentServiceVersionSelector)).Should(BeEmpty())
 			Expect(envValues("KEEP_POD_ENV")).Should(Equal([]corev1.EnvVar{{Name: "KEEP_POD_ENV", Value: "kept"}}))
 			Expect(envValues(dptypes.DPDBUser)).Should(HaveLen(1))
 			Expect(envValues(dptypes.DPDBPassword)).Should(HaveLen(1))

--- a/pkg/dataprotection/restore/manager_test.go
+++ b/pkg/dataprotection/restore/manager_test.go
@@ -468,11 +468,21 @@ var _ = Describe("RestoreManager Test", func() {
 				constant.AppInstanceLabelKey: testdp.ClusterName,
 			}
 			restoreMGR, backupSet := initResources(reqCtx, 0, false, func(f *testdp.MockRestoreFactory) {
-				f.SetConnectCredential(testdp.ClusterName).SetJobActionConfig(matchLabels).SetExecActionConfig(matchLabels)
+				f.SetConnectCredential(testdp.ClusterName).
+					SetJobActionConfig(matchLabels).
+					SetExecActionConfig(matchLabels).
+					AddEnv(corev1.EnvVar{Name: dptypes.DPTargetClusterTopology, Value: "shared-nothing"}).
+					AddEnv(corev1.EnvVar{Name: dptypes.DPTargetComponentServiceVersion, Value: "3.3.2"})
 			})
 
 			By("create cluster to restore")
-			testdp.NewFakeCluster(&testCtx)
+			testdp.NewFakeCluster(&testCtx,
+				corev1.EnvVar{Name: "KEEP_POD_ENV", Value: "kept"},
+				corev1.EnvVar{Name: dptypes.DPTargetClusterTopology, Value: "fake-pod-topology-1"},
+				corev1.EnvVar{Name: dptypes.DPTargetClusterTopology, Value: "fake-pod-topology-2"},
+				corev1.EnvVar{Name: dptypes.DPTargetComponentServiceVersion, Value: "fake-pod-service-version-1"},
+				corev1.EnvVar{Name: dptypes.DPTargetComponentServiceVersion, Value: "fake-pod-service-version-2"},
+			)
 
 			By("test with execAction and expect for creating 2 exec job")
 			target := utils.GetBackupStatusTarget(backupSet.Backup, restoreMGR.Restore.Spec.Backup.SourceTargetName)
@@ -490,6 +500,25 @@ var _ = Describe("RestoreManager Test", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			// count of job should equal to 1
 			Expect(len(jobs)).Should(Equal(1))
+			jobEnv := jobs[0].Spec.Template.Spec.Containers[0].Env
+			envValues := func(name string) []corev1.EnvVar {
+				var values []corev1.EnvVar
+				for i := range jobEnv {
+					if jobEnv[i].Name == name {
+						values = append(values, jobEnv[i])
+					}
+				}
+				return values
+			}
+			Expect(envValues(dptypes.DPTargetClusterTopology)).Should(Equal([]corev1.EnvVar{{
+				Name: dptypes.DPTargetClusterTopology, Value: "shared-nothing",
+			}}))
+			Expect(envValues(dptypes.DPTargetComponentServiceVersion)).Should(Equal([]corev1.EnvVar{{
+				Name: dptypes.DPTargetComponentServiceVersion, Value: "3.3.2",
+			}}))
+			Expect(envValues("KEEP_POD_ENV")).Should(Equal([]corev1.EnvVar{{Name: "KEEP_POD_ENV", Value: "kept"}}))
+			Expect(envValues(dptypes.DPDBUser)).Should(HaveLen(1))
+			Expect(envValues(dptypes.DPDBPassword)).Should(HaveLen(1))
 			// test timeZone transform
 			var backupStopTimeEnv string
 			for _, v := range jobs[0].Spec.Template.Spec.Containers[0].Env {

--- a/pkg/dataprotection/restore/types.go
+++ b/pkg/dataprotection/restore/types.go
@@ -47,9 +47,11 @@ const (
 
 // labels key
 const (
-	DataProtectionRestoreLabelKey          = "dataprotection.kubeblocks.io/restore"
-	DataProtectionRestoreNamespaceLabelKey = "dataprotection.kubeblocks.io/restore-namespace"
-	DataProtectionPopulatePVCLabelKey      = "dataprotection.kubeblocks.io/populate-pvc"
+	DataProtectionRestoreLabelKey             = "dataprotection.kubeblocks.io/restore"
+	DataProtectionRestoreNamespaceLabelKey    = "dataprotection.kubeblocks.io/restore-namespace"
+	DataProtectionPopulatePVCLabelKey         = "dataprotection.kubeblocks.io/populate-pvc"
+	DataProtectionInternalPostReadyLabelKey   = "dataprotection.kubeblocks.io/internal-post-ready"
+	DataProtectionInternalPostReadyLabelValue = "true"
 )
 
 // Annotations key

--- a/pkg/dataprotection/types/constant.go
+++ b/pkg/dataprotection/types/constant.go
@@ -122,9 +122,15 @@ const (
 	DPTargetPodRole = "DP_TARGET_POD_ROLE"
 	// DPTargetClusterTopology is the topology of the restore target Cluster.
 	DPTargetClusterTopology = "DP_TARGET_CLUSTER_TOPOLOGY"
-	// DPTargetComponentServiceVersion is the single active service version of the restore target Component.
-	// It is empty when legal active instances use multiple versions that this transitional string cannot represent.
+	// DPTargetComponentServiceVersion is a superseded target version key. It remains
+	// reserved so caller values using the older name are stripped; the controller
+	// never emits it. New jobs use DPTargetComponentServiceVersionSelector.
 	DPTargetComponentServiceVersion = "DP_TARGET_COMPONENT_SERVICE_VERSION"
+	// DPTargetComponentServiceVersionSelector is the serviceVersion selector declared for
+	// the exact target Pod selected when the postReady Job is dispatched. It is empty when
+	// Apps does not expose a declared selector; it is not a claim about a runtime-discovered
+	// database version.
+	DPTargetComponentServiceVersionSelector = "DP_TARGET_COMPONENT_SERVICE_VERSION_SELECTOR"
 	// DPBackupBasePath the base path for backup data in the storage
 	// In a backup action pod, it equals ${DP_BACKUP_ROOT_PATH}/${DP_BACKUP_NAME}/${DP_TARGET_RELATIVE_PATH}
 	DPBackupBasePath = "DP_BACKUP_BASE_PATH"

--- a/pkg/dataprotection/types/constant.go
+++ b/pkg/dataprotection/types/constant.go
@@ -122,7 +122,8 @@ const (
 	DPTargetPodRole = "DP_TARGET_POD_ROLE"
 	// DPTargetClusterTopology is the topology of the restore target Cluster.
 	DPTargetClusterTopology = "DP_TARGET_CLUSTER_TOPOLOGY"
-	// DPTargetComponentServiceVersion is the service version of the restore target Component.
+	// DPTargetComponentServiceVersion is the single active service version of the restore target Component.
+	// It is empty when legal active instances use multiple versions that this transitional string cannot represent.
 	DPTargetComponentServiceVersion = "DP_TARGET_COMPONENT_SERVICE_VERSION"
 	// DPBackupBasePath the base path for backup data in the storage
 	// In a backup action pod, it equals ${DP_BACKUP_ROOT_PATH}/${DP_BACKUP_NAME}/${DP_TARGET_RELATIVE_PATH}

--- a/pkg/dataprotection/types/constant.go
+++ b/pkg/dataprotection/types/constant.go
@@ -120,6 +120,10 @@ const (
 	DPTargetPodName = "DP_TARGET_POD_NAME"
 	// DPTargetPodRole the target pod role
 	DPTargetPodRole = "DP_TARGET_POD_ROLE"
+	// DPTargetClusterTopology is the topology of the restore target Cluster.
+	DPTargetClusterTopology = "DP_TARGET_CLUSTER_TOPOLOGY"
+	// DPTargetComponentServiceVersion is the service version of the restore target Component.
+	DPTargetComponentServiceVersion = "DP_TARGET_COMPONENT_SERVICE_VERSION"
 	// DPBackupBasePath the base path for backup data in the storage
 	// In a backup action pod, it equals ${DP_BACKUP_ROOT_PATH}/${DP_BACKUP_NAME}/${DP_TARGET_RELATIVE_PATH}
 	DPBackupBasePath = "DP_BACKUP_BASE_PATH"

--- a/pkg/dataprotection/types/constant.go
+++ b/pkg/dataprotection/types/constant.go
@@ -122,15 +122,9 @@ const (
 	DPTargetPodRole = "DP_TARGET_POD_ROLE"
 	// DPTargetClusterTopology is the topology of the restore target Cluster.
 	DPTargetClusterTopology = "DP_TARGET_CLUSTER_TOPOLOGY"
-	// DPTargetComponentServiceVersion is a superseded target version key. It remains
-	// reserved so caller values using the older name are stripped; the controller
-	// never emits it. New jobs use DPTargetComponentServiceVersionSelector.
+	// DPTargetComponentServiceVersion is the serviceVersion expected by the owning
+	// Component API for the exact target Pod. It is not a runtime-discovered database version.
 	DPTargetComponentServiceVersion = "DP_TARGET_COMPONENT_SERVICE_VERSION"
-	// DPTargetComponentServiceVersionSelector is the serviceVersion selector declared for
-	// the exact target Pod selected when the postReady Job is dispatched. It is empty when
-	// Apps does not expose a declared selector; it is not a claim about a runtime-discovered
-	// database version.
-	DPTargetComponentServiceVersionSelector = "DP_TARGET_COMPONENT_SERVICE_VERSION_SELECTOR"
 	// DPBackupBasePath the base path for backup data in the storage
 	// In a backup action pod, it equals ${DP_BACKUP_ROOT_PATH}/${DP_BACKUP_NAME}/${DP_TARGET_RELATIVE_PATH}
 	DPBackupBasePath = "DP_BACKUP_BASE_PATH"
@@ -178,6 +172,22 @@ const (
 	DPArchiveInterval      = "DP_ARCHIVE_INTERVAL"
 	DPContinuousTTLSeconds = "DP_TTL_SECONDS"
 )
+
+const deprecatedTargetComponentServiceVersionSelector = "DP_TARGET_COMPONENT_SERVICE_VERSION_SELECTOR"
+
+// IsPostReadyTargetEnv reports whether an environment variable is owned by the
+// controller's postReady dispatch-time target facts. Caller-provided values for
+// these names must be stripped before the controller injects verified values.
+func IsPostReadyTargetEnv(name string) bool {
+	switch name {
+	case DPTargetClusterTopology,
+		DPTargetComponentServiceVersion,
+		deprecatedTargetComponentServiceVersionSelector:
+		return true
+	default:
+		return false
+	}
+}
 
 const (
 	BackupKind             = "Backup"

--- a/pkg/testutil/dataprotection/backup_utils.go
+++ b/pkg/testutil/dataprotection/backup_utils.go
@@ -160,7 +160,7 @@ func NewFakeBackup(testCtx *testutil.TestContext,
 	return backup
 }
 
-func NewFakeCluster(testCtx *testutil.TestContext) *BackupClusterInfo {
+func NewFakeCluster(testCtx *testutil.TestContext, targetEnv ...corev1.EnvVar) *BackupClusterInfo {
 	createPVCAndPV := func(name string) *corev1.PersistentVolumeClaim {
 		pvName := "pv-" + name
 		pvc := testapps.NewPersistentVolumeClaimFactory(
@@ -180,7 +180,11 @@ func NewFakeCluster(testCtx *testutil.TestContext) *BackupClusterInfo {
 		return testapps.NewPodFactory(testCtx.DefaultNamespace, name).
 			AddAppInstanceLabel(ClusterName).
 			AddAppComponentLabel(ComponentName).
-			AddContainer(corev1.Container{Name: ContainerName, Image: testapps.ApeCloudMySQLImage})
+			AddContainer(corev1.Container{
+				Name:  ContainerName,
+				Image: testapps.ApeCloudMySQLImage,
+				Env:   append([]corev1.EnvVar(nil), targetEnv...),
+			})
 	}
 
 	By("mocking a cluster")


### PR DESCRIPTION
Fixes #10679

## Problem observed: StarRocks logical restore BR-R7

In one observed StarRocks Enterprise restore, the source logical backup completed and the target FE/BE restore PVCs became Bound, but the later postReady Job had no trustworthy target topology or target service-version input. The addon checks topology and version compatibility before it creates the repository or runs `RESTORE SNAPSHOT`, so it stopped before changing database state.

This runtime evidence establishes one missing-input case. Runtime validation of this controller fix is still `N=0`.

## Root cause

The existing implementation took target values before the internal Restore was created, stored them in mutable `Restore.spec.env`, and later promoted those same strings into the Job. That contract had three correctness gaps:

1. the mutable Restore authenticated its own supposedly controller-owned values;
2. a creation-time value could be stale when the Restore controller later selected the actual target Pod;
3. the initial dispatch-time implementation read an InstanceSet implementation label even after it had already loaded an authoritative `Instance`, and renamed Apps `serviceVersion` to a selector protocol that the owning API does not define.

A later identity review found a fourth gap: the deterministic postReady Restore name was not enough to keep the object on the internal path. Removing its Component owner made dispatch silently treat it as an external Restore, while an unrelated owner with only a matching UID could pass the VolumePopulator check.

## Before and after

Before this change:

- the internal Restore carried target topology and version as a creation-time snapshot;
- changing those values in `Restore.spec.env` could reach the Job;
- a Component change between Restore creation and Job creation could send a stale value;
- an Instance-owned Pod's mutable template label could select the wrong per-instance expected version;
- a damaged or forged internal Restore identity could fall back to the external path or pass an incomplete owner check.

After this change:

- the internal Restore carries no authoritative target snapshot;
- immediately before each new postReady Job is built, the controller uses the uncached API reader to re-read the exact selected Pod, its workload ownership chain, the current Component, and the current Cluster;
- the selected Pod must keep the same UID and be Ready, each Instance/InstanceSet in its workload ownership chain must be non-terminating and belong to the Component, and the Component must be Running with its current generation observed;
- Component identity labels and the controller-written Cluster UID annotation must match;
- every internal postReady Restore carries `dataprotection.kubeblocks.io/internal-post-ready=true` and exactly one full Component controller owner;
- the producer, existing-object check, and Restore dispatch all use one validator for marker, deterministic name, API group/version, kind, name, controller bit, and UID;
- a reserved deterministic name or internal marker is treated as an internal candidate and fails closed when identity is missing, malformed, conflicting, stale, or the Component is absent;
- an already-created Job remains the durable action record and is not rebuilt from later target state.

The final Job receives each verified value exactly once:

- `DP_TARGET_CLUSTER_TOPOLOGY`: current `Cluster.spec.topology`;
- `DP_TARGET_COMPONENT_SERVICE_VERSION`: the Apps expected `serviceVersion` for the exact selected Pod.

For an Instance-owned Pod, `Instance.spec.instanceTemplateName` is authoritative, including an empty value that selects the default instance lane. A non-empty instance template uses its `serviceVersion` override when present and otherwise inherits `Component.spec.serviceVersion`. The direct legacy InstanceSet-owned Pod lane retains its existing template-label contract because no Instance API object exists in that path.

`DP_TARGET_COMPONENT_SERVICE_VERSION` is not a runtime-discovered database version and does not promise selector or range syntax. It is emitted with an empty value when Apps has no expected `serviceVersion`. The experimental `DP_TARGET_COMPONENT_SERVICE_VERSION_SELECTOR` name is accepted only as a reserved input to strip and is never emitted.

## Implementation

- exports the deterministic internal postReady Restore name so the writer and dispatcher use one identity rule;
- marks internal postReady Restores and sets the Component as their controller owner;
- centralizes strict internal identity validation and uses it before create, for existing objects, and at dispatch;
- removes target facts from internal Restore construction and ignores reserved target keys when validating an existing Restore's remaining intent;
- centralizes stripping of topology, expected-version, and deprecated experimental selector names from Restore, ActionSet, BackupMethod, credential, and target-Pod environment merging;
- injects verified values only for the structurally identified internal postReady Restore;
- returns the authoritative template name while validating workload ownership instead of rereading it from a Pod label;
- requeues before consuming Instance spec or InstanceSet/Pod labels when either workload owner is terminating;
- treats missing target objects and stale readiness/generation as explicit requeues, while identity changes, unsupported ownership, and authorization failures fail closed;
- adds the read-only RBAC declarations needed for Pods, Components, Clusters, Instances, and InstanceSets.

## Rejected alternatives

- Trust values already in `Restore.spec.env`: the carrier is mutable and cannot authenticate itself.
- Freeze values when the Restore is created: dispatch can happen after the target generation changes.
- Identify internal Restores by name alone: the name does not authenticate the controller or target Component.
- Fall back to external behavior when an internal marker or reserved name has incomplete ownership: this turns damaged controller intent into a different execution contract.
- Read the Instance template from its Pod label: the authoritative public `Instance.spec.instanceTemplateName` is already available.
- Rename Apps expected `serviceVersion` to a selector: the Apps API promises expected service version, not selector syntax or actual runtime discovery.
- Read the Pod service-version label as the active database version: the label is mutable, represents the component default, and can be wrong for instance overrides.
- Add a broad public facts API here: API discoverability remains follow-up design work in #10682.

## Compatibility and boundaries

- no CRD field changes;
- ordinary external Restores remain on the external path;
- unrelated internal Restore intent drift is still rejected;
- caller-supplied values under current or experimental reserved names are stripped and cannot reach a new Job;
- generic Restores cannot inject the reserved target names;
- existing in-flight or terminal Jobs are preserved;
- an empty expected service version means only that Apps exposes no expected `serviceVersion`; it makes no claim about the concrete version currently running;
- StarRocks remains responsible for deciding whether topology and expected-version inputs are sufficient for its compatibility policy;
- no fresh StarRocks runtime restore has completed on this head, so this is not a runtime-pass or release-readiness claim.

## Validation

Exact head: `6383fe64e528b951d901c86f1862a26b4599d034`.

- internal marker and full Component controller-owner producer assertions;
- missing/conflicting marker, marker plus owner removal, and wrong owner API version, kind, name, controller bit, or UID all fail with zero Jobs;
- Component namespace, name, UID, NotFound, and terminating cases fail or requeue according to contract;
- ordinary external Restore classification remains unchanged;
- producer, existing-object, and dispatch paths share the same internal identity validator;
- Restore mutation and target-Pod conflict values are stripped; verified topology and expected service version win exactly once;
- dispatch freshness: a Component expected-version change before Job creation reaches the new Job;
- Instance-owned source of truth: API template override beats a conflicting Pod label, and authoritative empty selects only the default lane;
- direct InstanceSet-owned override/default/missing-label compatibility;
- direct InstanceSet, Instance, and parent InstanceSet termination each requeue with no Job;
- stale Component generation requeues and creates no Job;
- full restore and DataProtection controller packages: PASS;
- focused changed-path normal and race tests: PASS;
- restore package full race: PASS;
- scoped `go vet`, `golangci-lint`, and `git diff --check`: PASS.

The full DataProtection controller race run completed all 150 specs on both this head and its exact predecessor, then the race detector reported the same pre-existing race in untouched `controllers/dataprotection/utils.go`. That result is recorded as a predecessor race, not as a pass or failure of this change.
