### PR TITLE
fix(workloads): match image index platform digests

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -46,15 +46,9 @@ rules:
   - ""
   resources:
   - namespaces
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - nodes
   verbs:
+  - get
   - list
   - watch
 - apiGroups:

--- a/controllers/workloads/instance_controller.go
+++ b/controllers/workloads/instance_controller.go
@@ -53,6 +53,7 @@ type InstanceReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=pods/status,verbs=get
 // +kubebuilder:rbac:groups=core,resources=pods/finalizers,verbs=update
+// +kubebuilder:rbac:groups=core,resources=nodes,verbs=get
 
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims/status,verbs=get
@@ -94,11 +95,11 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		Do(instance.NewFixMetaReconciler()).
 		Do(instance.NewDeletionReconciler(r.Client)).
 		Do(instance.NewRevisionUpdateReconciler()).
-		Do(instance.NewStatusReconciler()).
+		Do(instance.NewStatusReconciler(r.Client)).
 		// Do(instance.NewRevisionUpdateReconciler()).
 		Do(instance.NewAssistantObjectReconciler()).
 		Do(instance.NewAlignmentReconciler()).
-		Do(instance.NewUpdateReconciler()).
+		Do(instance.NewUpdateReconciler(r.Client)).
 		Commit()
 }
 

--- a/controllers/workloads/instanceset_controller.go
+++ b/controllers/workloads/instanceset_controller.go
@@ -53,6 +53,7 @@ type InstanceSetReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=pods/status,verbs=get
 // +kubebuilder:rbac:groups=core,resources=pods/finalizers,verbs=update
 // +kubebuilder:rbac:groups=core,resources=pods/resize,verbs=update
+// +kubebuilder:rbac:groups=core,resources=nodes,verbs=get
 
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims/status,verbs=get
@@ -83,11 +84,11 @@ func (r *InstanceSetReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		Do(instanceset.NewFixMetaReconciler()).
 		Do(instanceset.NewDeletionReconciler()).
 		Do(instanceset.NewValidationReconciler()).
-		Do(instanceset.NewStatusReconciler()).
+		Do(instanceset.NewStatusReconciler(r.Client)).
 		Do(instanceset.NewRevisionUpdateReconciler()).
 		Do(instanceset.NewAssistantObjectReconciler()).
 		Do(instanceset.NewReplicasAlignmentReconciler()).
-		Do(instanceset.NewUpdateReconciler()).
+		Do(instanceset.NewUpdateReconciler(r.Client)).
 		Commit()
 
 	// TODO(free6om): handle error based on ErrorCode (after defined)

--- a/deploy/helm/config/rbac/role.yaml
+++ b/deploy/helm/config/rbac/role.yaml
@@ -46,15 +46,9 @@ rules:
   - ""
   resources:
   - namespaces
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - nodes
   verbs:
+  - get
   - list
   - watch
 - apiGroups:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -321,6 +321,12 @@ affinity:
 # registryConfig:
 #   defaultRegistry: apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com
 #   defaultNamespace: apecloud
+#   # Optional offline proof for runtimes that report an OCI/Docker index digest
+#   # instead of the platform manifest digest pinned in a PodSpec (or vice versa).
+#   # indexBase64 must contain the exact raw index bytes whose digest is indexDigest.
+#   imageIndexProofs:
+#   - indexDigest: sha256:<index-digest>
+#     indexBase64: <base64-exact-raw-index-bytes>
 registryConfig: {}
 
 # Add extra pod labels to KubeBlocks Deployment

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,8 @@ require (
 	github.com/magiconair/properties v1.8.7
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.36.3
+	github.com/opencontainers/go-digest v1.0.0
+	github.com/opencontainers/image-spec v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.19.0
 	github.com/sethvargo/go-password v0.2.0
@@ -115,8 +117,6 @@ require (
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/pkg/controller/instance/image_index_proof_reconciler_test.go
+++ b/pkg/controller/instance/image_index_proof_reconciler_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package instance
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"strings"
+	"testing"
+
+	digest "github.com/opencontainers/go-digest"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/kubebuilderx"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
+)
+
+const instanceProofChild = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+type instanceProofReader struct {
+	node *corev1.Node
+	err  error
+}
+
+func (r *instanceProofReader) Get(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+	if r.err != nil {
+		return r.err
+	}
+	r.node.DeepCopyInto(obj.(*corev1.Node))
+	return nil
+}
+
+func (r *instanceProofReader) List(context.Context, client.ObjectList, ...client.ListOption) error {
+	return errors.New("unexpected List")
+}
+
+func instanceProofConfig() (string, map[string]any) {
+	raw := []byte(`{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"` + instanceProofChild + `","size":100,"platform":{"architecture":"amd64","os":"linux"}}]}`)
+	parent := digest.FromBytes(raw).String()
+	return parent, map[string]any{
+		"imageIndexProofs": []map[string]any{{
+			"indexDigest": parent,
+			"indexBase64": base64.StdEncoding.EncodeToString(raw),
+		}},
+	}
+}
+
+func instanceProofPod(parent string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			NodeName: "node-1",
+			Containers: []corev1.Container{{
+				Name:  "kbagent",
+				Image: "example/tools@" + instanceProofChild,
+			}},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{
+				Type:               corev1.PodReady,
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+			}},
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:    "kbagent",
+				Image:   "example/tools:tag",
+				ImageID: "example/tools@" + parent,
+			}},
+		},
+	}
+}
+
+func TestImageIndexProofReconcilerPropagation(t *testing.T) {
+	oldRegistries := viper.Get(constant.CfgRegistries)
+	parent, config := instanceProofConfig()
+	viper.Set(constant.CfgRegistries, config)
+	if err := intctrlutil.LoadRegistryConfig(); err != nil {
+		t.Fatalf("LoadRegistryConfig() error = %v", err)
+	}
+	defer func() {
+		viper.Set(constant.CfgRegistries, oldRegistries)
+		if err := intctrlutil.LoadRegistryConfig(); err != nil {
+			t.Errorf("restore LoadRegistryConfig() error = %v", err)
+		}
+	}()
+
+	newTree := func() (*kubebuilderx.ObjectTree, *workloads.Instance, *corev1.Pod) {
+		inst := &workloads.Instance{ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"}}
+		pod := instanceProofPod(parent)
+		tree := kubebuilderx.NewObjectTree()
+		tree.Context = context.Background()
+		tree.SetRoot(inst)
+		if err := tree.Add(pod); err != nil {
+			t.Fatalf("tree.Add() error = %v", err)
+		}
+		return tree, inst, pod
+	}
+
+	t.Run("status returns transient Node errors", func(t *testing.T) {
+		tree, _, _ := newTree()
+		_, err := NewStatusReconciler(&instanceProofReader{err: errors.New("temporary Node read")}).Reconcile(tree)
+		if err == nil || !strings.Contains(err.Error(), "temporary Node read") {
+			t.Fatalf("status Reconcile() error = %v, want temporary Node read", err)
+		}
+	})
+
+	t.Run("update gate returns transient Node errors", func(t *testing.T) {
+		tree, inst, pod := newTree()
+		matched, retry, err := (&updateReconciler{reader: &instanceProofReader{
+			err: errors.New("temporary Node read"),
+		}}).isPodCanBeUpdated(tree, inst, pod)
+		if matched || retry || err == nil || !strings.Contains(err.Error(), "temporary Node read") {
+			t.Fatalf("isPodCanBeUpdated() = (%v, %v, %v), want (false, false, temporary error)", matched, retry, err)
+		}
+	})
+
+	t.Run("update gate accepts the exact Node platform relation", func(t *testing.T) {
+		tree, inst, pod := newTree()
+		reader := &instanceProofReader{node: &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+			Status: corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{
+				OperatingSystem: "linux",
+				Architecture:    "amd64",
+			}},
+		}}
+		matched, retry, err := (&updateReconciler{reader: reader}).isPodCanBeUpdated(tree, inst, pod)
+		if err != nil || !matched || retry {
+			t.Fatalf("isPodCanBeUpdated() = (%v, %v, %v), want (true, false, nil)", matched, retry, err)
+		}
+	})
+}

--- a/pkg/controller/instance/reconciler_status.go
+++ b/pkg/controller/instance/reconciler_status.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
@@ -35,11 +36,17 @@ import (
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 )
 
-func NewStatusReconciler() kubebuilderx.Reconciler {
-	return &statusReconciler{}
+func NewStatusReconciler(readers ...client.Reader) kubebuilderx.Reconciler {
+	var reader client.Reader
+	if len(readers) > 0 {
+		reader = readers[0]
+	}
+	return &statusReconciler{reader: reader}
 }
 
-type statusReconciler struct{}
+type statusReconciler struct {
+	reader client.Reader
+}
 
 var _ kubebuilderx.Reconciler = &statusReconciler{}
 
@@ -68,7 +75,11 @@ func (r *statusReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 	if isCreated(pod) {
 		notReadyName = pod.Name
 	}
-	if isImageMatched(pod) && intctrlutil.IsPodReady(pod) {
+	imageMatched, err := isImageMatched(tree.Context, r.reader, pod)
+	if err != nil {
+		return kubebuilderx.Continue, err
+	}
+	if imageMatched && intctrlutil.IsPodReady(pod) {
 		ready = true
 		notReadyName = ""
 		if intctrlutil.IsPodAvailable(pod, inst.Spec.MinReadySeconds) {

--- a/pkg/controller/instance/reconciler_update.go
+++ b/pkg/controller/instance/reconciler_update.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
@@ -38,12 +39,18 @@ import (
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 )
 
-type updateReconciler struct{}
+type updateReconciler struct {
+	reader client.Reader
+}
 
 var _ kubebuilderx.Reconciler = &updateReconciler{}
 
-func NewUpdateReconciler() kubebuilderx.Reconciler {
-	return &updateReconciler{}
+func NewUpdateReconciler(readers ...client.Reader) kubebuilderx.Reconciler {
+	var reader client.Reader
+	if len(readers) > 0 {
+		reader = readers[0]
+	}
+	return &updateReconciler{reader: reader}
 }
 
 func (r *updateReconciler) PreCondition(tree *kubebuilderx.ObjectTree) *kubebuilderx.CheckResult {
@@ -93,30 +100,13 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 
 	needRetry := false
 	isBlocked := false
-	canBeUpdated := func(pod *corev1.Pod) bool {
-		if !isImageMatched(pod) {
-			tree.Logger.Info(fmt.Sprintf("Instance %s/%s blocks on update as the pod %s does not have the same image(s) in the status and in the spec", inst.Namespace, inst.Name, pod.Name))
-			return false
-		}
-		if !intctrlutil.IsPodReady(pod) {
-			tree.Logger.Info(fmt.Sprintf("Instance %s/%s blocks on update as the pod %s is not ready", inst.Namespace, inst.Name, pod.Name))
-			return false
-		}
-		if !intctrlutil.IsPodAvailable(pod, inst.Spec.MinReadySeconds) {
-			tree.Logger.Info(fmt.Sprintf("Instance %s/%s blocks on update as the pod %s is not available", inst.Namespace, inst.Name, pod.Name))
-			// no pod event will trigger the next reconciliation, so retry it
-			needRetry = true
-			return false
-		}
-		if !isRoleReady(pod, inst.Spec.Roles) {
-			tree.Logger.Info(fmt.Sprintf("Instance %s/%s blocks on update as the role of pod %s is not ready", inst.Namespace, inst.Name, pod.Name))
-			return false
-		}
-		return true
-	}
-
 	for _, pod := range oldPodList {
-		if !canBeUpdated(pod) {
+		canUpdate, retry, err := r.isPodCanBeUpdated(tree, inst, pod)
+		if err != nil {
+			return kubebuilderx.Continue, err
+		}
+		if !canUpdate {
+			needRetry = retry
 			break
 		}
 
@@ -191,6 +181,30 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 		return kubebuilderx.RetryAfter(time.Second * time.Duration(inst.Spec.MinReadySeconds)), nil
 	}
 	return kubebuilderx.Continue, nil
+}
+
+func (r *updateReconciler) isPodCanBeUpdated(tree *kubebuilderx.ObjectTree, inst *workloads.Instance, pod *corev1.Pod) (bool, bool, error) {
+	imageMatched, err := isImageMatched(tree.Context, r.reader, pod)
+	if err != nil {
+		return false, false, err
+	}
+	if !imageMatched {
+		tree.Logger.Info(fmt.Sprintf("Instance %s/%s blocks on update as the pod %s does not have the same image(s) in the status and in the spec", inst.Namespace, inst.Name, pod.Name))
+		return false, false, nil
+	}
+	if !intctrlutil.IsPodReady(pod) {
+		tree.Logger.Info(fmt.Sprintf("Instance %s/%s blocks on update as the pod %s is not ready", inst.Namespace, inst.Name, pod.Name))
+		return false, false, nil
+	}
+	if !intctrlutil.IsPodAvailable(pod, inst.Spec.MinReadySeconds) {
+		tree.Logger.Info(fmt.Sprintf("Instance %s/%s blocks on update as the pod %s is not available", inst.Namespace, inst.Name, pod.Name))
+		return false, true, nil
+	}
+	if !isRoleReady(pod, inst.Spec.Roles) {
+		tree.Logger.Info(fmt.Sprintf("Instance %s/%s blocks on update as the role of pod %s is not ready", inst.Namespace, inst.Name, pod.Name))
+		return false, false, nil
+	}
+	return true, false, nil
 }
 
 func (r *updateReconciler) switchover(tree *kubebuilderx.ObjectTree, inst *workloads.Instance, pod *corev1.Pod) error {

--- a/pkg/controller/instance/utils.go
+++ b/pkg/controller/instance/utils.go
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package instance
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
 	"slices"
@@ -125,23 +126,8 @@ func isPodPending(pod *corev1.Pod) bool {
 }
 
 // isImageMatched returns true if all container statuses have same image as defined in pod spec
-func isImageMatched(pod *corev1.Pod) bool {
-	for _, container := range pod.Spec.Containers {
-		index := slices.IndexFunc(pod.Status.ContainerStatuses, func(status corev1.ContainerStatus) bool {
-			return status.Name == container.Name
-		})
-		if index == -1 {
-			continue
-		}
-		specImage := container.Image
-		status := pod.Status.ContainerStatuses[index]
-		// Image in status may not match the image used in the PodSpec.
-		// More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodStatus
-		if !intctrlutil.MatchContainerImageInStatus(specImage, status.Image, status.ImageID) {
-			return false
-		}
-	}
-	return true
+func isImageMatched(ctx context.Context, reader client.Reader, pod *corev1.Pod) (bool, error) {
+	return intctrlutil.MatchPodContainerImages(ctx, reader, pod)
 }
 
 func buildInstancePod(inst *workloads.Instance, revision string) (*corev1.Pod, error) {

--- a/pkg/controller/instance/utils_test.go
+++ b/pkg/controller/instance/utils_test.go
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package instance
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -357,7 +358,15 @@ func TestPodStateHelpers(t *testing.T) {
 }
 
 func TestIsImageMatched(t *testing.T) {
-	if !isImageMatched(&corev1.Pod{
+	matched := func(pod *corev1.Pod) bool {
+		result, err := isImageMatched(context.Background(), nil, pod)
+		if err != nil {
+			t.Fatalf("isImageMatched() error = %v", err)
+		}
+		return result
+	}
+
+	if !matched(&corev1.Pod{
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{{Name: "mysql", Image: "mysql:8.0"}},
 		},
@@ -368,7 +377,7 @@ func TestIsImageMatched(t *testing.T) {
 		t.Fatal("missing matching status should be ignored")
 	}
 
-	if !isImageMatched(&corev1.Pod{
+	if !matched(&corev1.Pod{
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{{Name: "mysql", Image: "docker.io/library/mysql:8.0"}},
 		},
@@ -382,7 +391,7 @@ func TestIsImageMatched(t *testing.T) {
 		t.Fatal("equivalent image references should match")
 	}
 
-	if isImageMatched(&corev1.Pod{
+	if matched(&corev1.Pod{
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{{Name: "mysql", Image: "mysql:8.0"}},
 		},

--- a/pkg/controller/instanceset/image_index_proof_reconciler_test.go
+++ b/pkg/controller/instanceset/image_index_proof_reconciler_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package instanceset
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	digest "github.com/opencontainers/go-digest"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/kubebuilderx"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
+)
+
+const instancesetProofChild = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+type instancesetProofReader struct {
+	node *corev1.Node
+	err  error
+}
+
+func (r *instancesetProofReader) Get(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+	if r.err != nil {
+		return r.err
+	}
+	r.node.DeepCopyInto(obj.(*corev1.Node))
+	return nil
+}
+
+func (r *instancesetProofReader) List(context.Context, client.ObjectList, ...client.ListOption) error {
+	return errors.New("unexpected List")
+}
+
+func instancesetProofConfig() (string, map[string]any) {
+	raw := []byte(`{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"` + instancesetProofChild + `","size":100,"platform":{"architecture":"amd64","os":"linux"}}]}`)
+	parent := digest.FromBytes(raw).String()
+	return parent, map[string]any{
+		"imageIndexProofs": []map[string]any{{
+			"indexDigest": parent,
+			"indexBase64": base64.StdEncoding.EncodeToString(raw),
+		}},
+	}
+}
+
+func instancesetProofPod(parent string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "demo-0", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			NodeName: "node-1",
+			Containers: []corev1.Container{{
+				Name:  "kbagent",
+				Image: "example/tools@" + instancesetProofChild,
+			}},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{
+				Type:               corev1.PodReady,
+				Status:             corev1.ConditionTrue,
+				LastTransitionTime: metav1.Now(),
+			}},
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:    "kbagent",
+				Image:   "example/tools:tag",
+				ImageID: "example/tools@" + parent,
+			}},
+		},
+	}
+}
+
+var _ = Describe("image index proof reconciler propagation", Serial, func() {
+	var oldRegistries any
+	var parent string
+
+	BeforeEach(func() {
+		oldRegistries = viper.Get(constant.CfgRegistries)
+		var config map[string]any
+		parent, config = instancesetProofConfig()
+		viper.Set(constant.CfgRegistries, config)
+		Expect(intctrlutil.LoadRegistryConfig()).To(Succeed())
+	})
+
+	AfterEach(func() {
+		viper.Set(constant.CfgRegistries, oldRegistries)
+		Expect(intctrlutil.LoadRegistryConfig()).To(Succeed())
+	})
+
+	It("returns a transient Node error from the status reconciler", func() {
+		its := &workloads.InstanceSet{ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"}}
+		pod := instancesetProofPod(parent)
+		tree := kubebuilderx.NewObjectTree()
+		tree.Context = context.Background()
+		tree.SetRoot(its)
+		Expect(tree.Add(pod)).To(Succeed())
+
+		_, err := NewStatusReconciler(&instancesetProofReader{err: errors.New("temporary Node read")}).Reconcile(tree)
+		Expect(err).To(MatchError(ContainSubstring("temporary Node read")))
+	})
+
+	It("returns a transient Node error from the update gate", func() {
+		its := &workloads.InstanceSet{ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"}}
+		pod := instancesetProofPod(parent)
+		tree := kubebuilderx.NewObjectTree()
+		tree.Context = context.Background()
+		tree.SetRoot(its)
+
+		matched, retry, err := (&updateReconciler{reader: &instancesetProofReader{
+			err: errors.New("temporary Node read"),
+		}}).isPodCanBeUpdated(tree, its, pod)
+		Expect(matched).To(BeFalse())
+		Expect(retry).To(BeFalse())
+		Expect(err).To(MatchError(ContainSubstring("temporary Node read")))
+	})
+
+	It("allows the update gate only after the exact Node platform match", func() {
+		its := &workloads.InstanceSet{ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"}}
+		pod := instancesetProofPod(parent)
+		tree := kubebuilderx.NewObjectTree()
+		tree.Context = context.Background()
+		tree.SetRoot(its)
+		reader := &instancesetProofReader{node: &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+			Status: corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{
+				OperatingSystem: "linux",
+				Architecture:    "amd64",
+			}},
+		}}
+
+		matched, retry, err := (&updateReconciler{reader: reader}).isPodCanBeUpdated(tree, its, pod)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(matched).To(BeTrue())
+		Expect(retry).To(BeFalse())
+	})
+})

--- a/pkg/controller/instanceset/instance_util.go
+++ b/pkg/controller/instanceset/instance_util.go
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package instanceset
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -149,23 +150,8 @@ func isPodPending(pod *corev1.Pod) bool {
 }
 
 // isImageMatched returns true if all container statuses have same image as defined in pod spec
-func isImageMatched(pod *corev1.Pod) bool {
-	for _, container := range pod.Spec.Containers {
-		index := slices.IndexFunc(pod.Status.ContainerStatuses, func(status corev1.ContainerStatus) bool {
-			return status.Name == container.Name
-		})
-		if index == -1 {
-			continue
-		}
-		specImage := container.Image
-		status := pod.Status.ContainerStatuses[index]
-		// Image in status may not match the image used in the PodSpec.
-		// More info: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodStatus
-		if !intctrlutil.MatchContainerImageInStatus(specImage, status.Image, status.ImageID) {
-			return false
-		}
-	}
-	return true
+func isImageMatched(ctx context.Context, reader client.Reader, pod *corev1.Pod) (bool, error) {
+	return intctrlutil.MatchPodContainerImages(ctx, reader, pod)
 }
 
 // getPodRevision gets the revision of Pod by inspecting the StatefulSetRevisionLabel. If pod has no revision the empty

--- a/pkg/controller/instanceset/instance_util_test.go
+++ b/pkg/controller/instanceset/instance_util_test.go
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package instanceset
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -577,6 +578,12 @@ var _ = Describe("instance util test", func() {
 	})
 
 	Context("isImageMatched", func() {
+		matched := func(pod *corev1.Pod) bool {
+			result, err := isImageMatched(context.Background(), nil, pod)
+			Expect(err).NotTo(HaveOccurred())
+			return result
+		}
+
 		It("should work well", func() {
 			pod := builder.NewPodBuilder(namespace, name).GetObject()
 
@@ -589,35 +596,35 @@ var _ = Describe("instance util test", func() {
 				Name:  name,
 				Image: "docker.io/nginx:latest@0f37a86c04f8",
 			}}
-			Expect(isImageMatched(pod)).Should(BeTrue())
+			Expect(matched(pod)).Should(BeTrue())
 
 			By("exactly match w/o registry and repository")
 			pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
 				Name:  name,
 				Image: "nginx",
 			}}
-			Expect(isImageMatched(pod)).Should(BeTrue())
+			Expect(matched(pod)).Should(BeTrue())
 
 			By("digest not matches")
 			pod.Spec.Containers = []corev1.Container{{
 				Name:  name,
 				Image: "nginx:latest@xxxxxxxxx",
 			}}
-			Expect(isImageMatched(pod)).Should(BeFalse())
+			Expect(matched(pod)).Should(BeFalse())
 
 			By("tag not matches")
 			pod.Spec.Containers = []corev1.Container{{
 				Name:  name,
 				Image: "nginx:xxxx@0f37a86c04f8",
 			}}
-			Expect(isImageMatched(pod)).Should(BeFalse())
+			Expect(matched(pod)).Should(BeFalse())
 
 			By("hostname not matches")
 			pod.Spec.Containers = []corev1.Container{{
 				Name:  name,
 				Image: "apecloud.com/nginx",
 			}}
-			Expect(isImageMatched(pod)).Should(BeTrue())
+			Expect(matched(pod)).Should(BeTrue())
 		})
 	})
 

--- a/pkg/controller/instanceset/reconciler_status.go
+++ b/pkg/controller/instanceset/reconciler_status.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
@@ -40,12 +41,18 @@ import (
 )
 
 // statusReconciler computes the current status
-type statusReconciler struct{}
+type statusReconciler struct {
+	reader client.Reader
+}
 
 var _ kubebuilderx.Reconciler = &statusReconciler{}
 
-func NewStatusReconciler() kubebuilderx.Reconciler {
-	return &statusReconciler{}
+func NewStatusReconciler(readers ...client.Reader) kubebuilderx.Reconciler {
+	var reader client.Reader
+	if len(readers) > 0 {
+		reader = readers[0]
+	}
+	return &statusReconciler{reader: reader}
 }
 
 func (r *statusReconciler) PreCondition(tree *kubebuilderx.ObjectTree) *kubebuilderx.CheckResult {
@@ -104,7 +111,11 @@ func (r *statusReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 			replicas++
 			template2TemplatesStatus[templateName].Replicas++
 		}
-		if isImageMatched(pod) && intctrlutil.IsPodReady(pod) {
+		imageMatched, err := isImageMatched(tree.Context, r.reader, pod)
+		if err != nil {
+			return kubebuilderx.Continue, err
+		}
+		if imageMatched && intctrlutil.IsPodReady(pod) {
 			readyReplicas++
 			template2TemplatesStatus[templateName].ReadyReplicas++
 			notReadyNames.Delete(pod.Name)

--- a/pkg/controller/instanceset/reconciler_update.go
+++ b/pkg/controller/instanceset/reconciler_update.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
@@ -42,12 +43,18 @@ import (
 
 // updateReconciler handles the updates of instances based on the UpdateStrategy.
 // Currently, two update strategies are supported: 'OnDelete' and 'RollingUpdate'.
-type updateReconciler struct{}
+type updateReconciler struct {
+	reader client.Reader
+}
 
 var _ kubebuilderx.Reconciler = &updateReconciler{}
 
-func NewUpdateReconciler() kubebuilderx.Reconciler {
-	return &updateReconciler{}
+func NewUpdateReconciler(readers ...client.Reader) kubebuilderx.Reconciler {
+	var reader client.Reader
+	if len(readers) > 0 {
+		reader = readers[0]
+	}
+	return &updateReconciler{reader: reader}
 }
 
 func (r *updateReconciler) PreCondition(tree *kubebuilderx.ObjectTree) *kubebuilderx.CheckResult {
@@ -148,7 +155,11 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 		if updatingPods >= memberUpdateQuota {
 			break
 		}
-		if canBeUpdated, retry := r.isPodCanBeUpdated(tree, its, pod); !canBeUpdated {
+		canBeUpdated, retry, err := r.isPodCanBeUpdated(tree, its, pod)
+		if err != nil {
+			return kubebuilderx.Continue, err
+		}
+		if !canBeUpdated {
 			needRetry = retry
 			break
 		}
@@ -263,25 +274,29 @@ func (r *updateReconciler) memberUpdateQuota(its *workloads.InstanceSet, podList
 	return updateCount, nil
 }
 
-func (r *updateReconciler) isPodCanBeUpdated(tree *kubebuilderx.ObjectTree, its *workloads.InstanceSet, pod *corev1.Pod) (bool, bool) {
-	if !isImageMatched(pod) {
+func (r *updateReconciler) isPodCanBeUpdated(tree *kubebuilderx.ObjectTree, its *workloads.InstanceSet, pod *corev1.Pod) (bool, bool, error) {
+	imageMatched, err := isImageMatched(tree.Context, r.reader, pod)
+	if err != nil {
+		return false, false, err
+	}
+	if !imageMatched {
 		tree.Logger.Info(fmt.Sprintf("InstanceSet %s/%s blocks on update as the pod %s does not have the same image(s) in the status and in the spec", its.Namespace, its.Name, pod.Name))
-		return false, false
+		return false, false, nil
 	}
 	if !intctrlutil.IsPodReady(pod) {
 		tree.Logger.Info(fmt.Sprintf("InstanceSet %s/%s blocks on update as the pod %s is not ready", its.Namespace, its.Name, pod.Name))
-		return false, false
+		return false, false, nil
 	}
 	if !intctrlutil.IsPodAvailable(pod, its.Spec.MinReadySeconds) {
 		tree.Logger.Info(fmt.Sprintf("InstanceSet %s/%s blocks on update as the pod %s is not available", its.Namespace, its.Name, pod.Name))
 		// no pod event will trigger the next reconciliation, so retry it
-		return false, true
+		return false, true, nil
 	}
 	if !isRoleReady(pod, its.Spec.Roles) {
 		tree.Logger.Info(fmt.Sprintf("InstanceSet %s/%s blocks on update as the role of pod %s is not ready", its.Namespace, its.Name, pod.Name))
-		return false, false
+		return false, false, nil
 	}
-	return true, false
+	return true, false, nil
 }
 
 func (r *updateReconciler) switchover(tree *kubebuilderx.ObjectTree, its *workloads.InstanceSet, pod *corev1.Pod) error {

--- a/pkg/controllerutil/image_index_proof.go
+++ b/pkg/controllerutil/image_index_proof.go
@@ -1,0 +1,181 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package controllerutil
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+const (
+	dockerManifestListMediaType  = "application/vnd.docker.distribution.manifest.list.v2+json"
+	dockerImageManifestMediaType = "application/vnd.docker.distribution.manifest.v2+json"
+)
+
+type imageIndexProofConfig struct {
+	IndexDigest string `mapstructure:"indexDigest"`
+	IndexBase64 string `mapstructure:"indexBase64"`
+}
+
+type imagePlatform struct {
+	operatingSystem string
+	architecture    string
+}
+
+type imageIndexProof struct {
+	children map[imagePlatform]digest.Digest
+}
+
+type imageIndexProofSet map[digest.Digest]imageIndexProof
+
+func compileImageIndexProofs(configs []imageIndexProofConfig) (imageIndexProofSet, error) {
+	proofs := make(imageIndexProofSet, len(configs))
+	for i, config := range configs {
+		parent, proof, err := compileImageIndexProof(config)
+		if err != nil {
+			return nil, fmt.Errorf("imageIndexProofs[%d]: %w", i, err)
+		}
+		if _, ok := proofs[parent]; ok {
+			return nil, fmt.Errorf("imageIndexProofs[%d]: duplicate index digest %q", i, parent)
+		}
+		proofs[parent] = proof
+	}
+	return proofs, nil
+}
+
+func compileImageIndexProof(config imageIndexProofConfig) (digest.Digest, imageIndexProof, error) {
+	if config.IndexDigest == "" {
+		return "", imageIndexProof{}, fmt.Errorf("indexDigest can't be empty")
+	}
+	if config.IndexBase64 == "" {
+		return "", imageIndexProof{}, fmt.Errorf("indexBase64 can't be empty")
+	}
+
+	parent, err := digest.Parse(config.IndexDigest)
+	if err != nil {
+		return "", imageIndexProof{}, fmt.Errorf("invalid indexDigest: %w", err)
+	}
+	if !parent.Algorithm().Available() {
+		return "", imageIndexProof{}, fmt.Errorf("indexDigest algorithm %q is unavailable", parent.Algorithm())
+	}
+	raw, err := base64.StdEncoding.DecodeString(config.IndexBase64)
+	if err != nil {
+		return "", imageIndexProof{}, fmt.Errorf("decode indexBase64: %w", err)
+	}
+	if actual := parent.Algorithm().FromBytes(raw); actual != parent {
+		return "", imageIndexProof{}, fmt.Errorf("raw index digest %q does not match indexDigest %q", actual, parent)
+	}
+
+	var index ocispec.Index
+	if err := json.Unmarshal(raw, &index); err != nil {
+		return "", imageIndexProof{}, fmt.Errorf("decode raw index JSON: %w", err)
+	}
+	if index.SchemaVersion != 2 {
+		return "", imageIndexProof{}, fmt.Errorf("unsupported schemaVersion %d", index.SchemaVersion)
+	}
+	if index.MediaType != ocispec.MediaTypeImageIndex && index.MediaType != dockerManifestListMediaType {
+		return "", imageIndexProof{}, fmt.Errorf("unsupported index mediaType %q", index.MediaType)
+	}
+
+	children := make(map[imagePlatform]digest.Digest)
+	ambiguous := make(map[imagePlatform]struct{})
+	for _, descriptor := range index.Manifests {
+		if descriptor.Platform == nil {
+			continue
+		}
+		platform := imagePlatform{
+			operatingSystem: descriptor.Platform.OS,
+			architecture:    descriptor.Platform.Architecture,
+		}
+		if platform.operatingSystem == "" || platform.architecture == "" ||
+			strings.EqualFold(platform.operatingSystem, "unknown") ||
+			strings.EqualFold(platform.architecture, "unknown") {
+			continue
+		}
+		if _, found := ambiguous[platform]; found {
+			continue
+		}
+
+		unusable := descriptor.Platform.Variant != "" || descriptor.Platform.OSVersion != "" ||
+			len(descriptor.Platform.OSFeatures) != 0 || descriptor.Size <= 0 ||
+			(descriptor.MediaType != ocispec.MediaTypeImageManifest && descriptor.MediaType != dockerImageManifestMediaType)
+		child, digestErr := digest.Parse(descriptor.Digest.String())
+		if digestErr != nil || !child.Algorithm().Available() {
+			unusable = true
+		}
+		if _, found := children[platform]; found {
+			unusable = true
+		}
+		if unusable {
+			delete(children, platform)
+			ambiguous[platform] = struct{}{}
+			continue
+		}
+		children[platform] = child
+	}
+	if len(children) == 0 {
+		return "", imageIndexProof{}, fmt.Errorf("raw index has no uniquely usable OS/architecture platform")
+	}
+	return parent, imageIndexProof{children: children}, nil
+}
+
+func (proofs imageIndexProofSet) matchPair(specDigest, statusDigest, operatingSystem, architecture string) bool {
+	spec, specErr := digest.Parse(specDigest)
+	status, statusErr := digest.Parse(statusDigest)
+	if specErr != nil || statusErr != nil {
+		return false
+	}
+	platform := imagePlatform{operatingSystem: operatingSystem, architecture: architecture}
+	if proof, ok := proofs[spec]; ok && proof.children[platform] == status {
+		return true
+	}
+	if proof, ok := proofs[status]; ok && proof.children[platform] == spec {
+		return true
+	}
+	return false
+}
+
+func (proofs imageIndexProofSet) containsPair(specDigest, statusDigest string) bool {
+	spec, specErr := digest.Parse(specDigest)
+	status, statusErr := digest.Parse(statusDigest)
+	if specErr != nil || statusErr != nil {
+		return false
+	}
+	containsChild := func(proof imageIndexProof, child digest.Digest) bool {
+		for _, candidate := range proof.children {
+			if candidate == child {
+				return true
+			}
+		}
+		return false
+	}
+	if proof, ok := proofs[spec]; ok && containsChild(proof, status) {
+		return true
+	}
+	if proof, ok := proofs[status]; ok && containsChild(proof, spec) {
+		return true
+	}
+	return false
+}

--- a/pkg/controllerutil/image_index_proof_test.go
+++ b/pkg/controllerutil/image_index_proof_test.go
@@ -1,0 +1,489 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package controllerutil
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	digest "github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
+)
+
+const (
+	alpha2IndexDigest = "sha256:3f082e22e2e829c986b5d31099353510e3762a233689254483c04bb84c3c6777"
+	alpha2AMD64Child  = "sha256:8ac42c16a1ff759707b4454d466ef172b0198bd50baac1c4e2526d104f0f9fd7"
+	alpha2ARM64Child  = "sha256:3d1c9bd0c0e452fd87d3959d1ac88f9d7a54bd4dde0a09050af54abb279b81fc"
+	alpha1Direct      = "sha256:67924d0a1b54dcb34bb2fc4401c7c77709f4cb53dc7b9cf44c0db19ba62f0585"
+	alpha2IndexBase64 = "ewogICJzY2hlbWFWZXJzaW9uIjogMiwKICAibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UuaW5kZXgudjEranNvbiIsCiAgIm1hbmlmZXN0cyI6IFsKICAgIHsKICAgICAgIm1lZGlhVHlwZSI6ICJhcHBsaWNhdGlvbi92bmQub2NpLmltYWdlLm1hbmlmZXN0LnYxK2pzb24iLAogICAgICAiZGlnZXN0IjogInNoYTI1Njo4YWM0MmMxNmExZmY3NTk3MDdiNDQ1NGQ0NjZlZjE3MmIwMTk4YmQ1MGJhYWMxYzRlMjUyNmQxMDRmMGY5ZmQ3IiwKICAgICAgInNpemUiOiAxNjI1LAogICAgICAicGxhdGZvcm0iOiB7CiAgICAgICAgImFyY2hpdGVjdHVyZSI6ICJhbWQ2NCIsCiAgICAgICAgIm9zIjogImxpbnV4IgogICAgICB9CiAgICB9LAogICAgewogICAgICAibWVkaWFUeXBlIjogImFwcGxpY2F0aW9uL3ZuZC5vY2kuaW1hZ2UubWFuaWZlc3QudjEranNvbiIsCiAgICAgICJkaWdlc3QiOiAic2hhMjU2OjNkMWM5YmQwYzBlNDUyZmQ4N2QzOTU5ZDFhYzg4ZjlkN2E1NGJkNGRkZTBhMDkwNTBhZjU0YWJiMjc5YjgxZmMiLAogICAgICAic2l6ZSI6IDE2MjUsCiAgICAgICJwbGF0Zm9ybSI6IHsKICAgICAgICAiYXJjaGl0ZWN0dXJlIjogImFybTY0IiwKICAgICAgICAib3MiOiAibGludXgiCiAgICAgIH0KICAgIH0KICBdCn0="
+)
+
+type imageProofReader struct {
+	node *corev1.Node
+	err  error
+	gets int
+}
+
+func (r *imageProofReader) Get(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+	r.gets++
+	if r.err != nil {
+		return r.err
+	}
+	if r.node == nil {
+		return fmt.Errorf("node not found")
+	}
+	r.node.DeepCopyInto(obj.(*corev1.Node))
+	return nil
+}
+
+func (r *imageProofReader) List(context.Context, client.ObjectList, ...client.ListOption) error {
+	return errors.New("unexpected List")
+}
+
+func installImageIndexProofs(configs ...imageIndexProofConfig) error {
+	proofs, err := compileImageIndexProofs(configs)
+	if err != nil {
+		return err
+	}
+	registriesConfigMutex.Lock()
+	registriesConfigInstance = &registriesConfig{
+		ImageIndexProofs:         configs,
+		compiledImageIndexProofs: proofs,
+	}
+	registriesConfigMutex.Unlock()
+	return nil
+}
+
+func syntheticImageIndex(descriptors ...ocispec.Descriptor) imageIndexProofConfig {
+	raw, err := json.Marshal(ocispec.Index{
+		Versioned: ocispec.Index{}.Versioned,
+		MediaType: ocispec.MediaTypeImageIndex,
+		Manifests: descriptors,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	var index map[string]any
+	Expect(json.Unmarshal(raw, &index)).To(Succeed())
+	index["schemaVersion"] = 2
+	raw, err = json.Marshal(index)
+	Expect(err).NotTo(HaveOccurred())
+	return imageIndexProofConfig{
+		IndexDigest: digest.FromBytes(raw).String(),
+		IndexBase64: base64.StdEncoding.EncodeToString(raw),
+	}
+}
+
+func imageDescriptor(child string, operatingSystem string, architecture string) ocispec.Descriptor {
+	return ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    digest.Digest(child),
+		Size:      100,
+		Platform: &ocispec.Platform{
+			OS:           operatingSystem,
+			Architecture: architecture,
+		},
+	}
+}
+
+func alpha2Pod(nodeName string, specDigest string, statusDigest string) *corev1.Pod {
+	return &corev1.Pod{
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
+			Containers: []corev1.Container{{
+				Name:  "kbagent",
+				Image: "apecloud/kubeblocks-tools@" + specDigest,
+			}},
+		},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:    "kbagent",
+				Image:   "apecloud/kubeblocks-tools:1.2.0-alpha.2",
+				ImageID: "apecloud/kubeblocks-tools@" + statusDigest,
+			}},
+		},
+	}
+}
+
+var _ = Describe("image index proof", Serial, func() {
+	BeforeEach(func() {
+		Expect(installImageIndexProofs()).To(Succeed())
+	})
+
+	AfterEach(func() {
+		Expect(installImageIndexProofs()).To(Succeed())
+	})
+
+	It("validates the exact alpha2 raw bytes and matches both digest directions", func() {
+		Expect(installImageIndexProofs(imageIndexProofConfig{
+			IndexDigest: alpha2IndexDigest,
+			IndexBase64: alpha2IndexBase64,
+		})).To(Succeed())
+
+		provider := func() (string, string, error) { return "linux", "amd64", nil }
+		matched, err := MatchContainerImageInStatusWithPlatform(
+			"apecloud/kubeblocks-tools@"+alpha2AMD64Child,
+			"apecloud/kubeblocks-tools:1.2.0-alpha.2",
+			"apecloud/kubeblocks-tools@"+alpha2IndexDigest,
+			provider)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(matched).To(BeTrue())
+
+		matched, err = MatchContainerImageInStatusWithPlatform(
+			"apecloud/kubeblocks-tools@"+alpha2IndexDigest,
+			"apecloud/kubeblocks-tools:1.2.0-alpha.2",
+			"apecloud/kubeblocks-tools@"+alpha2AMD64Child,
+			provider)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(matched).To(BeTrue())
+	})
+
+	It("accepts a Docker manifest list with Docker image manifests", func() {
+		proof := syntheticImageIndex(imageDescriptor(alpha2AMD64Child, "linux", "amd64"))
+		raw, err := base64.StdEncoding.DecodeString(proof.IndexBase64)
+		Expect(err).NotTo(HaveOccurred())
+		var index map[string]any
+		Expect(json.Unmarshal(raw, &index)).To(Succeed())
+		index["mediaType"] = dockerManifestListMediaType
+		manifests := index["manifests"].([]any)
+		manifests[0].(map[string]any)["mediaType"] = dockerImageManifestMediaType
+		raw, err = json.Marshal(index)
+		Expect(err).NotTo(HaveOccurred())
+		proof.IndexDigest = digest.FromBytes(raw).String()
+		proof.IndexBase64 = base64.StdEncoding.EncodeToString(raw)
+		Expect(installImageIndexProofs(proof)).To(Succeed())
+
+		matched, err := MatchContainerImageInStatusWithPlatform(
+			"example/tools@"+alpha2AMD64Child, "example/tools:tag", "example/tools@"+proof.IndexDigest,
+			func() (string, string, error) { return "linux", "amd64", nil })
+		Expect(err).NotTo(HaveOccurred())
+		Expect(matched).To(BeTrue())
+	})
+
+	It("keeps direct digest equality independent of proof and platform reads", func() {
+		providerCalled := false
+		matched, err := MatchContainerImageInStatusWithPlatform(
+			"apecloud/kubeblocks-tools@"+alpha1Direct,
+			"apecloud/kubeblocks-tools:1.2.0-alpha.1",
+			"apecloud/kubeblocks-tools@"+alpha1Direct,
+			func() (string, string, error) {
+				providerCalled = true
+				return "", "", errors.New("must not be called")
+			})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(matched).To(BeTrue())
+		Expect(providerCalled).To(BeFalse())
+	})
+
+	It("fails closed for wrong platform, parent, child, absent proof, and old-child in-place state", func() {
+		Expect(installImageIndexProofs(imageIndexProofConfig{
+			IndexDigest: alpha2IndexDigest,
+			IndexBase64: alpha2IndexBase64,
+		})).To(Succeed())
+
+		cases := []struct {
+			name         string
+			specDigest   string
+			statusDigest string
+			os           string
+			arch         string
+		}{
+			{name: "arm64 child on amd64", specDigest: alpha2ARM64Child, statusDigest: alpha2IndexDigest, os: "linux", arch: "amd64"},
+			{name: "reverse arm64 child on amd64", specDigest: alpha2IndexDigest, statusDigest: alpha2ARM64Child, os: "linux", arch: "amd64"},
+			{name: "wrong parent", specDigest: alpha2AMD64Child, statusDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", os: "linux", arch: "amd64"},
+			{name: "wrong child", specDigest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", statusDigest: alpha2IndexDigest, os: "linux", arch: "amd64"},
+			{name: "new child while old parent is still reported", specDigest: alpha2ARM64Child, statusDigest: alpha2IndexDigest, os: "linux", arch: "amd64"},
+		}
+		for _, tt := range cases {
+			By(tt.name)
+			matched, err := MatchContainerImageInStatusWithPlatform(
+				"example/tools@"+tt.specDigest, "example/tools:tag", "example/tools@"+tt.statusDigest,
+				func() (string, string, error) { return tt.os, tt.arch, nil })
+			Expect(err).NotTo(HaveOccurred())
+			Expect(matched).To(BeFalse())
+		}
+
+		Expect(installImageIndexProofs()).To(Succeed())
+		matched, err := MatchContainerImageInStatusWithPlatform(
+			"example/tools@"+alpha2AMD64Child, "example/tools:tag", "example/tools@"+alpha2IndexDigest,
+			func() (string, string, error) { return "linux", "amd64", nil })
+		Expect(err).NotTo(HaveOccurred())
+		Expect(matched).To(BeFalse())
+	})
+
+	It("propagates platform errors and treats unknown platform as not matched", func() {
+		Expect(installImageIndexProofs(imageIndexProofConfig{
+			IndexDigest: alpha2IndexDigest,
+			IndexBase64: alpha2IndexBase64,
+		})).To(Succeed())
+		temporary := errors.New("temporary Node read")
+		matched, err := MatchContainerImageInStatusWithPlatform(
+			"example/tools@"+alpha2AMD64Child, "example/tools:tag", "example/tools@"+alpha2IndexDigest,
+			func() (string, string, error) { return "", "", temporary })
+		Expect(matched).To(BeFalse())
+		Expect(err).To(MatchError(temporary))
+
+		matched, err = MatchContainerImageInStatusWithPlatform(
+			"example/tools@"+alpha2AMD64Child, "example/tools:tag", "example/tools@"+alpha2IndexDigest,
+			func() (string, string, error) { return "", "", nil })
+		Expect(err).NotTo(HaveOccurred())
+		Expect(matched).To(BeFalse())
+	})
+
+	It("reads the scheduled Node lazily and rejects missing or terminating Nodes", func() {
+		Expect(installImageIndexProofs(imageIndexProofConfig{
+			IndexDigest: alpha2IndexDigest,
+			IndexBase64: alpha2IndexBase64,
+		})).To(Succeed())
+
+		reader := &imageProofReader{node: &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+			Status: corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{
+				OperatingSystem: "linux",
+				Architecture:    "amd64",
+			}},
+		}}
+		matched, err := MatchPodContainerImages(context.Background(), reader,
+			alpha2Pod("node-1", alpha2AMD64Child, alpha2IndexDigest))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(matched).To(BeTrue())
+		Expect(reader.gets).To(Equal(1))
+
+		unscheduled := alpha2Pod("", alpha2AMD64Child, alpha2IndexDigest)
+		matched, err = MatchPodContainerImages(context.Background(), nil, unscheduled)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(matched).To(BeFalse())
+
+		reader = &imageProofReader{err: apierrors.NewNotFound(schema.GroupResource{Resource: "nodes"}, "node-1")}
+		matched, err = MatchPodContainerImages(context.Background(), reader,
+			alpha2Pod("node-1", alpha2AMD64Child, alpha2IndexDigest))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(matched).To(BeFalse())
+
+		terminatingAt := metav1.Now()
+		reader = &imageProofReader{node: &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "node-1", DeletionTimestamp: &terminatingAt},
+			Status: corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{
+				OperatingSystem: "linux",
+				Architecture:    "amd64",
+			}},
+		}}
+		matched, err = MatchPodContainerImages(context.Background(), reader,
+			alpha2Pod("node-1", alpha2AMD64Child, alpha2IndexDigest))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(matched).To(BeFalse())
+	})
+
+	It("propagates transient Node read errors but avoids reads for impossible pairs", func() {
+		Expect(installImageIndexProofs(imageIndexProofConfig{
+			IndexDigest: alpha2IndexDigest,
+			IndexBase64: alpha2IndexBase64,
+		})).To(Succeed())
+
+		reader := &imageProofReader{err: errors.New("temporary")}
+		matched, err := MatchPodContainerImages(context.Background(), reader,
+			alpha2Pod("node-1", alpha2AMD64Child, alpha2IndexDigest))
+		Expect(matched).To(BeFalse())
+		Expect(err).To(MatchError(ContainSubstring("temporary")))
+		Expect(reader.gets).To(Equal(1))
+
+		reader = &imageProofReader{err: errors.New("must not be called")}
+		matched, err = MatchPodContainerImages(context.Background(), reader,
+			alpha2Pod("node-1", "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", alpha2IndexDigest))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(matched).To(BeFalse())
+		Expect(reader.gets).To(BeZero())
+	})
+
+	It("rejects changed raw bytes, invalid JSON, unsupported media type, and duplicate parents", func() {
+		_, err := compileImageIndexProofs([]imageIndexProofConfig{{
+			IndexDigest: alpha2IndexDigest,
+			IndexBase64: "not-base64",
+		}})
+		Expect(err).To(MatchError(ContainSubstring("decode indexBase64")))
+
+		raw, err := base64.StdEncoding.DecodeString(alpha2IndexBase64)
+		Expect(err).NotTo(HaveOccurred())
+		var compacted any
+		Expect(json.Unmarshal(raw, &compacted)).To(Succeed())
+		reformatted, err := json.Marshal(compacted)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = compileImageIndexProofs([]imageIndexProofConfig{{
+			IndexDigest: alpha2IndexDigest,
+			IndexBase64: base64.StdEncoding.EncodeToString(reformatted),
+		}})
+		Expect(err).To(MatchError(ContainSubstring("does not match")))
+
+		invalidJSON := []byte("not-json")
+		_, err = compileImageIndexProofs([]imageIndexProofConfig{{
+			IndexDigest: digest.FromBytes(invalidJSON).String(),
+			IndexBase64: base64.StdEncoding.EncodeToString(invalidJSON),
+		}})
+		Expect(err).To(MatchError(ContainSubstring("decode raw index JSON")))
+
+		wrongMedia := syntheticImageIndex(imageDescriptor(alpha2AMD64Child, "linux", "amd64"))
+		wrongRaw, err := base64.StdEncoding.DecodeString(wrongMedia.IndexBase64)
+		Expect(err).NotTo(HaveOccurred())
+		var wrongIndex map[string]any
+		Expect(json.Unmarshal(wrongRaw, &wrongIndex)).To(Succeed())
+		wrongIndex["mediaType"] = "application/json"
+		wrongRaw, err = json.Marshal(wrongIndex)
+		Expect(err).NotTo(HaveOccurred())
+		wrongMedia.IndexDigest = digest.FromBytes(wrongRaw).String()
+		wrongMedia.IndexBase64 = base64.StdEncoding.EncodeToString(wrongRaw)
+		_, err = compileImageIndexProofs([]imageIndexProofConfig{wrongMedia})
+		Expect(err).To(MatchError(ContainSubstring("unsupported index mediaType")))
+
+		_, err = compileImageIndexProofs([]imageIndexProofConfig{
+			{IndexDigest: alpha2IndexDigest, IndexBase64: alpha2IndexBase64},
+			{IndexDigest: alpha2IndexDigest, IndexBase64: alpha2IndexBase64},
+		})
+		Expect(err).To(MatchError(ContainSubstring("duplicate index digest")))
+	})
+
+	It("isolates an ambiguous platform while retaining another unique platform", func() {
+		proof := syntheticImageIndex(
+			imageDescriptor("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "linux", "amd64"),
+			imageDescriptor("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "linux", "amd64"),
+			imageDescriptor(alpha2ARM64Child, "linux", "arm64"),
+			imageDescriptor("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", "unknown", "unknown"),
+		)
+		Expect(installImageIndexProofs(proof)).To(Succeed())
+
+		matched, err := MatchContainerImageInStatusWithPlatform(
+			"example/tools@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			"example/tools:tag", "example/tools@"+proof.IndexDigest,
+			func() (string, string, error) { return "linux", "amd64", nil })
+		Expect(err).NotTo(HaveOccurred())
+		Expect(matched).To(BeFalse())
+
+		matched, err = MatchContainerImageInStatusWithPlatform(
+			"example/tools@"+proof.IndexDigest,
+			"example/tools:tag", "example/tools@"+alpha2ARM64Child,
+			func() (string, string, error) { return "linux", "arm64", nil })
+		Expect(err).NotTo(HaveOccurred())
+		Expect(matched).To(BeTrue())
+
+		variantAMD64 := imageDescriptor(alpha2AMD64Child, "linux", "amd64")
+		variantAMD64.Platform.Variant = "v3"
+		variantProof := syntheticImageIndex(
+			variantAMD64,
+			imageDescriptor(alpha2ARM64Child, "linux", "arm64"),
+		)
+		Expect(installImageIndexProofs(variantProof)).To(Succeed())
+		matched, err = MatchContainerImageInStatusWithPlatform(
+			"example/tools@"+alpha2AMD64Child,
+			"example/tools:tag", "example/tools@"+variantProof.IndexDigest,
+			func() (string, string, error) { return "linux", "amd64", nil })
+		Expect(err).NotTo(HaveOccurred())
+		Expect(matched).To(BeFalse())
+		matched, err = MatchContainerImageInStatusWithPlatform(
+			"example/tools@"+variantProof.IndexDigest,
+			"example/tools:tag", "example/tools@"+alpha2ARM64Child,
+			func() (string, string, error) { return "linux", "arm64", nil })
+		Expect(err).NotTo(HaveOccurred())
+		Expect(matched).To(BeTrue())
+
+		allAmbiguous := syntheticImageIndex(
+			imageDescriptor("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "linux", "amd64"),
+			imageDescriptor("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", "linux", "amd64"),
+		)
+		Expect(installImageIndexProofs(allAmbiguous)).To(MatchError(ContainSubstring("no uniquely usable")))
+	})
+
+	It("preserves the previous complete snapshot after an invalid hot reload", func() {
+		oldRegistries := viper.Get(constant.CfgRegistries)
+		defer func() {
+			viper.Set(constant.CfgRegistries, oldRegistries)
+			Expect(LoadRegistryConfig()).To(Succeed())
+		}()
+
+		viper.Set(constant.CfgRegistries, map[string]any{
+			"imageIndexProofs": []map[string]any{{
+				"indexDigest": alpha2IndexDigest,
+				"indexBase64": alpha2IndexBase64,
+			}},
+		})
+		Expect(LoadRegistryConfig()).To(Succeed())
+
+		newProof := syntheticImageIndex(imageDescriptor(
+			"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd", "linux", "amd64"))
+		newParent := newProof.IndexDigest
+		newProof.IndexBase64 = base64.StdEncoding.EncodeToString([]byte("invalid"))
+		viper.Set(constant.CfgRegistries, map[string]any{
+			"imageIndexProofs": []map[string]any{{
+				"indexDigest": newProof.IndexDigest,
+				"indexBase64": newProof.IndexBase64,
+			}},
+		})
+		Expect(LoadRegistryConfig()).To(MatchError(ContainSubstring("does not match")))
+
+		matched, err := MatchContainerImageInStatusWithPlatform(
+			"example/tools@"+alpha2AMD64Child, "example/tools:tag", "example/tools@"+alpha2IndexDigest,
+			func() (string, string, error) { return "linux", "amd64", nil })
+		Expect(err).NotTo(HaveOccurred())
+		Expect(matched).To(BeTrue())
+
+		matched, err = MatchContainerImageInStatusWithPlatform(
+			"example/tools@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+			"example/tools:tag", "example/tools@"+newParent,
+			func() (string, string, error) { return "linux", "amd64", nil })
+		Expect(err).NotTo(HaveOccurred())
+		Expect(matched).To(BeFalse())
+	})
+
+	It("validates the newly loaded registry mappings before replacing the snapshot", func() {
+		oldRegistries := viper.Get(constant.CfgRegistries)
+		defer func() {
+			viper.Set(constant.CfgRegistries, oldRegistries)
+			Expect(LoadRegistryConfig()).To(Succeed())
+		}()
+
+		viper.Set(constant.CfgRegistries, map[string]any{
+			"imageIndexProofs": []map[string]any{{
+				"indexDigest": alpha2IndexDigest,
+				"indexBase64": alpha2IndexBase64,
+			}},
+		})
+		Expect(LoadRegistryConfig()).To(Succeed())
+
+		viper.Set(constant.CfgRegistries, map[string]any{
+			"registryConfig": []map[string]any{{"from": "", "to": "mirror.example"}},
+		})
+		Expect(LoadRegistryConfig()).To(MatchError(ContainSubstring("from can't be empty")))
+
+		matched, err := MatchContainerImageInStatusWithPlatform(
+			"example/tools@"+alpha2AMD64Child, "example/tools:tag", "example/tools@"+alpha2IndexDigest,
+			func() (string, string, error) { return "linux", "amd64", nil })
+		Expect(err).NotTo(HaveOccurred())
+		Expect(matched).To(BeTrue())
+	})
+})

--- a/pkg/controllerutil/image_util.go
+++ b/pkg/controllerutil/image_util.go
@@ -21,6 +21,7 @@ package controllerutil
 
 import (
 	//  Import these crypto algorithm so that the image parser can work with digest
+	"context"
 	_ "crypto/sha256"
 	_ "crypto/sha512"
 	"errors"
@@ -31,6 +32,9 @@ import (
 
 	"github.com/distribution/reference"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/apecloud/kubeblocks/pkg/constant"
@@ -61,9 +65,12 @@ type registryConfig struct {
 }
 
 type registriesConfig struct {
-	DefaultRegistry  string           `mapstructure:"defaultRegistry"`
-	DefaultNamespace string           `mapstructure:"defaultNamespace"`
-	RegistryConfig   []registryConfig `mapstructure:"registryConfig"`
+	DefaultRegistry  string                  `mapstructure:"defaultRegistry"`
+	DefaultNamespace string                  `mapstructure:"defaultNamespace"`
+	RegistryConfig   []registryConfig        `mapstructure:"registryConfig"`
+	ImageIndexProofs []imageIndexProofConfig `mapstructure:"imageIndexProofs"`
+
+	compiledImageIndexProofs imageIndexProofSet
 }
 
 // this lock protects r/w to this variable itself,
@@ -81,11 +88,11 @@ func getRegistriesConfig() *registriesConfig {
 
 func LoadRegistryConfig() error {
 	newRegistriesConfig := &registriesConfig{}
-	if err := viper.UnmarshalKey(constant.CfgRegistries, &newRegistriesConfig); err != nil {
+	if err := viper.UnmarshalKey(constant.CfgRegistries, newRegistriesConfig); err != nil {
 		return err
 	}
 
-	for _, registry := range registriesConfigInstance.RegistryConfig {
+	for _, registry := range newRegistriesConfig.RegistryConfig {
 		if len(registry.From) == 0 {
 			return errors.New("registries config invalid: from can't be empty")
 		}
@@ -94,6 +101,11 @@ func LoadRegistryConfig() error {
 			return errors.New("registries config invalid: to can't be empty")
 		}
 	}
+	proofs, err := compileImageIndexProofs(newRegistriesConfig.ImageIndexProofs)
+	if err != nil {
+		return fmt.Errorf("registries config invalid: %w", err)
+	}
+	newRegistriesConfig.compiledImageIndexProofs = proofs
 
 	registriesConfigMutex.Lock()
 	registriesConfigInstance = newRegistriesConfig
@@ -103,7 +115,11 @@ func LoadRegistryConfig() error {
 	// to replace it every time
 	viper.Set(constant.KBToolsImage, ReplaceImageRegistry(viper.GetString(constant.KBToolsImage)))
 
-	imageLogger.Info("registriesConfig reloaded", "registriesConfig", registriesConfigInstance)
+	imageLogger.Info("registriesConfig reloaded",
+		"defaultRegistry", newRegistriesConfig.DefaultRegistry,
+		"defaultNamespace", newRegistriesConfig.DefaultNamespace,
+		"registryMappings", len(newRegistriesConfig.RegistryConfig),
+		"imageIndexProofs", len(newRegistriesConfig.ImageIndexProofs))
 	return nil
 }
 
@@ -222,6 +238,102 @@ func MatchContainerImageInStatus(specImage, statusImage, statusImageID string) b
 		return false
 	}
 	return imageBaseName(specName) == imageBaseName(statusName)
+}
+
+// ImagePlatformProvider returns the operating system and architecture of the
+// Node that is actually running a Pod. It is called only when a configured,
+// self-validated image-index proof contains the observed digest pair.
+type ImagePlatformProvider func() (operatingSystem string, architecture string, err error)
+
+// MatchContainerImageInStatusWithPlatform extends MatchContainerImageInStatus
+// for an explicitly configured OCI/Docker image-index parent and platform child
+// relationship. Direct digest equality and tag matching always take precedence.
+func MatchContainerImageInStatusWithPlatform(
+	specImage, statusImage, statusImageID string,
+	platformProvider ImagePlatformProvider,
+) (bool, error) {
+	if MatchContainerImageInStatus(specImage, statusImage, statusImageID) {
+		return true, nil
+	}
+
+	_, _, specDigest := splitContainerImageRef(specImage)
+	_, _, statusDigest := splitContainerImageRef(statusImageID)
+	proofs := getRegistriesConfig().compiledImageIndexProofs
+	if !proofs.containsPair(specDigest, statusDigest) {
+		return false, nil
+	}
+	if platformProvider == nil {
+		return false, errors.New("image index proof match requires a Node platform provider")
+	}
+	operatingSystem, architecture, err := platformProvider()
+	if err != nil {
+		return false, err
+	}
+	if operatingSystem == "" || architecture == "" {
+		return false, nil
+	}
+	return proofs.matchPair(specDigest, statusDigest, operatingSystem, architecture), nil
+}
+
+// MatchPodContainerImages returns whether every reported container status
+// matches its PodSpec image. A missing status remains ignored for compatibility.
+// Node reads are lazy and cached within this call.
+func MatchPodContainerImages(ctx context.Context, reader client.Reader, pod *corev1.Pod) (bool, error) {
+	var (
+		platformLoaded  bool
+		operatingSystem string
+		architecture    string
+		platformErr     error
+	)
+	platformProvider := func() (string, string, error) {
+		if platformLoaded {
+			return operatingSystem, architecture, platformErr
+		}
+		platformLoaded = true
+		if pod.Spec.NodeName == "" {
+			return "", "", nil
+		}
+		if reader == nil {
+			platformErr = errors.New("image index proof match requires a Kubernetes reader")
+			return "", "", platformErr
+		}
+		node := &corev1.Node{}
+		if err := reader.Get(ctx, types.NamespacedName{Name: pod.Spec.NodeName}, node); err != nil {
+			if apierrors.IsNotFound(err) {
+				return "", "", nil
+			}
+			platformErr = fmt.Errorf("get Node %q for image index proof: %w", pod.Spec.NodeName, err)
+			return "", "", platformErr
+		}
+		if node.DeletionTimestamp != nil {
+			return "", "", nil
+		}
+		operatingSystem = node.Status.NodeInfo.OperatingSystem
+		architecture = node.Status.NodeInfo.Architecture
+		return operatingSystem, architecture, nil
+	}
+
+	for _, container := range pod.Spec.Containers {
+		var status *corev1.ContainerStatus
+		for i := range pod.Status.ContainerStatuses {
+			if pod.Status.ContainerStatuses[i].Name == container.Name {
+				status = &pod.Status.ContainerStatuses[i]
+				break
+			}
+		}
+		if status == nil {
+			continue
+		}
+		matched, err := MatchContainerImageInStatusWithPlatform(
+			container.Image, status.Image, status.ImageID, platformProvider)
+		if err != nil {
+			return false, err
+		}
+		if !matched {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 // EqualContainerImageInSpec returns true if two PodSpec image references point to


### PR DESCRIPTION
## What changed

- add optional offline OCI/Docker image-index proofs under the existing registries configuration
- verify each proof against the exact decoded raw bytes before atomically replacing the active configuration snapshot
- match index-parent and platform-manifest digests in either direction using the scheduled Node OS/architecture
- preserve direct digest equality and existing tag/registry-rewrite behavior
- propagate transient Node reads through InstanceSet and Instance status/update reconcilers
- add the Node `get` permission and document the configuration shape
- validate the candidate registry configuration during hot reload and keep the previous snapshot when the candidate is invalid

## Why

Kubernetes runtimes can report an OCI index digest in `status.containerStatuses[].imageID` while a PodSpec pins the selected platform manifest digest. Strict digest equality then keeps a valid, Ready Pod out of workload ready/available counts and blocks later rolling updates.

The proof is explicit and offline. Missing or invalid proof, wrong parent/child/platform, unscheduled Pods, missing Nodes, and terminating Nodes all fail closed. Reconciliation does not contact a registry or read pull secrets. Pinning the parent index in every artifact pipeline was rejected because runtime reporting direction is not uniform and local sideload pipelines often have only a stable platform-manifest digest.

Proof hashing uses the exact base64-decoded raw index bytes, without JSON reserialization. Descriptors without a platform and `unknown/unknown` attestations are ignored. Because a Kubernetes Node exposes only OS and architecture, descriptors with non-empty `variant`, `os.version`, or `os.features` are deliberately unusable. Multiple descriptors for one OS/architecture make only that platform unusable; other unique platforms remain available. A proof with no usable platform is rejected.

This also corrects an existing hot-reload bug: the loader previously validated the active registry configuration instead of the candidate. An invalid registry mapping update could therefore replace the active snapshot. Invalid candidate updates are now rejected and the previous complete snapshot remains active.

Closes #10689.

## Validation

- current-main focused RED: exact linux/amd64 child vs index parent returned false (`0 passed / 1 failed`)
- `go test -p=1 ./pkg/controllerutil ./pkg/controller/instanceset ./pkg/controller/instance -count=1`
- focused proof and four status/update caller matrices
- `GOFLAGS=-p=1 make test-fast`
- `make manifests`
- `GOTOOLCHAIN=go1.25.10 make lint-fast` (`0 issues`)
