### PR TITLE
fix(dataprotection): observe backup jobs after target errors

### DIFF
--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -31,6 +31,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -323,11 +324,22 @@ func (r *BackupReconciler) handleNewPhase(
 func (r *BackupReconciler) recordBackupStatusTargets(
 	reqCtx intctrlutil.RequestCtx,
 	request *dpbackup.Request) error {
+	prepareTarget := func(target *dpv1alpha1.BackupTarget) error {
+		if err := r.prepareRequestTargetInfo(reqCtx, request, target); err != nil {
+			return err
+		}
+		request.PreparedTargets = append(request.PreparedTargets, dpbackup.PreparedTarget{
+			Target:               target,
+			TargetPods:           request.TargetPods,
+			WorkerServiceAccount: request.WorkerServiceAccount,
+		})
+		return nil
+	}
 	if request.Backup.Status.Target != nil || len(request.Backup.Status.Targets) > 0 {
 		return nil
 	}
 	buildStatusTarget := func(target *dpv1alpha1.BackupTarget) (*dpv1alpha1.BackupStatusTarget, error) {
-		if err := r.prepareRequestTargetInfo(reqCtx, request, target); err != nil {
+		if err := prepareTarget(target); err != nil {
 			return nil, err
 		}
 		var selectedTargetPods []string
@@ -532,21 +544,29 @@ func (r *BackupReconciler) patchBackupStatus(
 	} else if request.BackupPolicy.Spec.EncryptionConfig != nil {
 		request.Status.EncryptionConfig = request.BackupPolicy.Spec.EncryptionConfig
 	}
-	// init action status
-	actions, err := request.BuildActions()
-	if err != nil {
-		return err
-	}
-	for targetPodName, acts := range actions {
-		for _, act := range acts {
-			request.Status.Actions = append(request.Status.Actions, dpv1alpha1.ActionStatus{
-				Name:          act.GetName(),
-				TargetPodName: targetPodName,
-				Phase:         dpv1alpha1.ActionPhaseNew,
-				ActionType:    act.Type(),
-			})
+	var actionStatuses []dpv1alpha1.ActionStatus
+	for i := range request.PreparedTargets {
+		preparedTarget := &request.PreparedTargets[i]
+		request.Target = preparedTarget.Target
+		request.TargetPods = preparedTarget.TargetPods
+		request.WorkerServiceAccount = preparedTarget.WorkerServiceAccount
+		actions, err := request.BuildActions()
+		if err != nil {
+			return err
+		}
+		for targetPodName, acts := range actions {
+			for _, act := range acts {
+				actionStatuses = append(actionStatuses, dpv1alpha1.ActionStatus{
+					Name:          act.GetName(),
+					TargetPodName: targetPodName,
+					Phase:         dpv1alpha1.ActionPhaseNew,
+					ActionType:    act.Type(),
+					ObjectRef:     act.BuildObjectRef(),
+				})
+			}
 		}
 	}
+	request.Status.Actions = actionStatuses
 
 	// update phase to running
 	request.Status.Phase = dpv1alpha1.BackupPhaseRunning
@@ -560,7 +580,7 @@ func (r *BackupReconciler) patchBackupStatus(
 		request.Status.BaseBackupName = request.BaseBackup.Name
 	}
 
-	if err = dpbackup.SetExpirationTime(request.Backup); err != nil {
+	if err := dpbackup.SetExpirationTime(request.Backup); err != nil {
 		return err
 	}
 	return r.Client.Status().Patch(request.Ctx, request.Backup, client.MergeFrom(original))
@@ -594,6 +614,7 @@ func (r *BackupReconciler) handleRunningPhase(
 	if err = r.syncContinuousBackupEncryptionConfig(reqCtx, backup, request.BackupPolicy); err != nil {
 		return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "sync continuous backup encryption config failed")
 	}
+	targets := dputils.GetBackupTargets(request.BackupPolicy, request.BackupMethod)
 	var (
 		existFailedAction bool
 		waiting           bool
@@ -604,11 +625,14 @@ func (r *BackupReconciler) handleRunningPhase(
 			Scheme:           r.Scheme,
 			RestClientConfig: r.RestConfig,
 		}
-		targets = dputils.GetBackupTargets(request.BackupPolicy, request.BackupMethod)
 	)
 	for i := range targets {
 		if err = r.prepareRequestTargetInfo(reqCtx, request, &targets[i]); err != nil {
-			return r.updateStatusIfFailed(reqCtx, backup, request.Backup, err)
+			waiting, existFailedAction, err = r.syncJobActions(reqCtx.Ctx, request.Backup, err)
+			if err != nil {
+				return r.updateStatusIfFailed(reqCtx, backup, request.Backup, err)
+			}
+			break
 		}
 		// there are actions not completed, continue to handle following actions
 		actions, err := request.BuildActions()
@@ -660,20 +684,90 @@ func (r *BackupReconciler) handleRunningPhase(
 		return r.updateStatusIfFailed(reqCtx, backup, request.Backup,
 			fmt.Errorf("there are failed actions, you can obtain the more information in the status.actions"))
 	}
-	// all actions completed, update backup status to completed
-	request.Status.Phase = dpv1alpha1.BackupPhaseCompleted
-	request.Status.CompletionTimestamp = &metav1.Time{Time: r.clock.Now().UTC()}
-	if !request.Status.StartTimestamp.IsZero() {
+	return r.completeBackup(reqCtx, backup, request.Backup)
+}
+
+func (r *BackupReconciler) syncJobActions(ctx context.Context,
+	backup *dpv1alpha1.Backup,
+	targetErr error) (waiting, failed bool, err error) {
+	if len(backup.Status.Actions) == 0 {
+		return false, false, targetErr
+	}
+
+	for i := range backup.Status.Actions {
+		actionStatus := &backup.Status.Actions[i]
+		objectRef := actionStatus.ObjectRef
+		if objectRef == nil || objectRef.APIVersion != batchv1.SchemeGroupVersion.String() ||
+			objectRef.Kind != constant.JobKind || objectRef.Namespace == "" || objectRef.Name == "" {
+			return false, false, targetErr
+		}
+
+		job := &batchv1.Job{}
+		if err := r.Client.Get(ctx, client.ObjectKey{Namespace: objectRef.Namespace, Name: objectRef.Name}, job); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, false, targetErr
+			}
+			return false, false, intctrlutil.NewErrorf(intctrlutil.ErrorTypeRequeue,
+				"sync backup jobs failed: %v", err)
+		}
+		if objectRef.UID != "" && objectRef.UID != job.UID {
+			return false, false, targetErr
+		}
+		if job.Labels[dptypes.BackupNameLabelKey] != backup.Name {
+			return false, false, targetErr
+		}
+
+		_, finishedType, failureReason := dputils.IsJobFinished(job)
+		actionStatus.ActionType = dpv1alpha1.ActionTypeJob
+		actionStatus.StartTimestamp = job.CreationTimestamp.DeepCopy()
+		actionStatus.ObjectRef = &corev1.ObjectReference{
+			APIVersion: batchv1.SchemeGroupVersion.String(),
+			Kind:       constant.JobKind,
+			Namespace:  job.Namespace,
+			Name:       job.Name,
+			UID:        job.UID,
+		}
+		if !strings.HasPrefix(actionStatus.FailureReason, dptypes.LogCollectorOutput) {
+			actionStatus.FailureReason = failureReason
+		}
+
+		switch finishedType {
+		case batchv1.JobComplete:
+			actionStatus.Phase = dpv1alpha1.ActionPhaseCompleted
+		case batchv1.JobFailed:
+			actionStatus.Phase = dpv1alpha1.ActionPhaseFailed
+			failed = true
+		default:
+			actionStatus.Phase = dpv1alpha1.ActionPhaseRunning
+			actionStatus.CompletionTimestamp = nil
+			waiting = true
+			continue
+		}
+		if job.Status.CompletionTime != nil {
+			actionStatus.CompletionTimestamp = job.Status.CompletionTime.DeepCopy()
+		} else {
+			actionStatus.CompletionTimestamp = &metav1.Time{Time: r.clock.Now().UTC()}
+		}
+	}
+	updateBackupStatusByActionStatus(&backup.Status)
+	return waiting, failed, nil
+}
+
+func (r *BackupReconciler) completeBackup(reqCtx intctrlutil.RequestCtx,
+	original *dpv1alpha1.Backup,
+	backup *dpv1alpha1.Backup) (ctrl.Result, error) {
+	backup.Status.Phase = dpv1alpha1.BackupPhaseCompleted
+	backup.Status.CompletionTimestamp = &metav1.Time{Time: r.clock.Now().UTC()}
+	if !backup.Status.StartTimestamp.IsZero() {
 		// round the duration to a multiple of seconds.
-		duration := request.Status.CompletionTimestamp.Sub(request.Status.StartTimestamp.Time).Round(time.Second)
-		request.Status.Duration = &metav1.Duration{Duration: duration}
+		duration := backup.Status.CompletionTimestamp.Sub(backup.Status.StartTimestamp.Time).Round(time.Second)
+		backup.Status.Duration = &metav1.Duration{Duration: duration}
 	}
-	err = dpbackup.SetExpirationTime(request.Backup)
-	if err != nil {
-		return r.updateStatusIfFailed(reqCtx, backup, request.Backup, fmt.Errorf("failed to set expiration time, %v", err))
+	if err := dpbackup.SetExpirationTime(backup); err != nil {
+		return r.updateStatusIfFailed(reqCtx, original, backup, fmt.Errorf("failed to set expiration time, %v", err))
 	}
-	r.Recorder.Event(backup, corev1.EventTypeNormal, "CreatedBackup", "Completed backup")
-	if err = r.Client.Status().Patch(reqCtx.Ctx, request.Backup, client.MergeFrom(backup)); err != nil {
+	r.Recorder.Event(original, corev1.EventTypeNormal, "CreatedBackup", "Completed backup")
+	if err := r.Client.Status().Patch(reqCtx.Ctx, backup, client.MergeFrom(original)); err != nil {
 		return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "")
 	}
 	return intctrlutil.Reconciled()

--- a/controllers/dataprotection/backup_controller_test.go
+++ b/controllers/dataprotection/backup_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"slices"
 	"strconv"
+	"testing"
 	"time"
 
 	vsv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
@@ -33,10 +34,13 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
@@ -52,6 +56,132 @@ import (
 	testk8s "github.com/apecloud/kubeblocks/pkg/testutil/k8s"
 	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
+
+type getErrorClient struct {
+	client.Client
+}
+
+func (c *getErrorClient) Get(context.Context, client.ObjectKey, client.Object, ...client.GetOption) error {
+	return fmt.Errorf("get failed")
+}
+
+func TestSyncJobActions(t *testing.T) {
+	tests := []struct {
+		name           string
+		jobConditions  []batchv1.JobConditionType
+		notApplicable  bool
+		getError       bool
+		waiting        bool
+		failed         bool
+		expectedAction []dpv1alpha1.ActionPhase
+	}{
+		{
+			name:          "no actions",
+			notApplicable: true,
+		},
+		{
+			name:          "job get error",
+			jobConditions: []batchv1.JobConditionType{""},
+			getError:      true,
+		},
+		{
+			name:           "all jobs completed",
+			jobConditions:  []batchv1.JobConditionType{batchv1.JobComplete, batchv1.JobComplete},
+			expectedAction: []dpv1alpha1.ActionPhase{dpv1alpha1.ActionPhaseCompleted, dpv1alpha1.ActionPhaseCompleted},
+		},
+		{
+			name:           "one job still running",
+			jobConditions:  []batchv1.JobConditionType{batchv1.JobComplete, ""},
+			waiting:        true,
+			expectedAction: []dpv1alpha1.ActionPhase{dpv1alpha1.ActionPhaseCompleted, dpv1alpha1.ActionPhaseRunning},
+		},
+		{
+			name:           "job failed",
+			jobConditions:  []batchv1.JobConditionType{batchv1.JobFailed},
+			failed:         true,
+			expectedAction: []dpv1alpha1.ActionPhase{dpv1alpha1.ActionPhaseFailed},
+		},
+		{
+			name:           "one job failed while another is running",
+			jobConditions:  []batchv1.JobConditionType{batchv1.JobFailed, ""},
+			waiting:        true,
+			failed:         true,
+			expectedAction: []dpv1alpha1.ActionPhase{dpv1alpha1.ActionPhaseFailed, dpv1alpha1.ActionPhaseRunning},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			testScheme := runtime.NewScheme()
+			g.Expect(batchv1.AddToScheme(testScheme)).To(Succeed())
+
+			backup := &dpv1alpha1.Backup{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "backup"}}
+			objects := make([]client.Object, 0, len(tt.jobConditions))
+			for i, conditionType := range tt.jobConditions {
+				jobName := fmt.Sprintf("job-%d", i)
+				job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+					Namespace:         backup.Namespace,
+					Name:              jobName,
+					UID:               types.UID(jobName),
+					CreationTimestamp: metav1.Now(),
+					Labels:            map[string]string{dptypes.BackupNameLabelKey: backup.Name},
+				}}
+				if conditionType != "" {
+					job.Status.Conditions = []batchv1.JobCondition{{
+						Type:    conditionType,
+						Status:  corev1.ConditionTrue,
+						Reason:  "reason",
+						Message: "message",
+					}}
+				}
+				objects = append(objects, job)
+				backup.Status.Actions = append(backup.Status.Actions, dpv1alpha1.ActionStatus{
+					Name: jobName,
+					ObjectRef: &corev1.ObjectReference{
+						APIVersion: batchv1.SchemeGroupVersion.String(),
+						Kind:       constant.JobKind,
+						Namespace:  job.Namespace,
+						Name:       job.Name,
+						UID:        job.UID,
+					},
+				})
+			}
+
+			var cli client.Client = fake.NewClientBuilder().WithScheme(testScheme).WithObjects(objects...).Build()
+			if tt.getError {
+				cli = &getErrorClient{Client: cli}
+			}
+			reconciler := &BackupReconciler{
+				Client: cli,
+				clock:  clock.RealClock{},
+			}
+			targetErr := fmt.Errorf("target unavailable")
+			waiting, failed, err := reconciler.syncJobActions(context.Background(), backup, targetErr)
+			if tt.notApplicable {
+				g.Expect(err).To(MatchError(targetErr))
+				return
+			}
+			if tt.getError {
+				g.Expect(intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeRequeue)).To(BeTrue())
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(waiting).To(Equal(tt.waiting))
+			g.Expect(failed).To(Equal(tt.failed))
+			for i := range backup.Status.Actions {
+				actionStatus := backup.Status.Actions[i]
+				g.Expect(actionStatus.Phase).To(Equal(tt.expectedAction[i]))
+				g.Expect(actionStatus.StartTimestamp).NotTo(BeNil())
+				if actionStatus.Phase == dpv1alpha1.ActionPhaseRunning {
+					g.Expect(actionStatus.CompletionTimestamp).To(BeNil())
+				} else {
+					g.Expect(actionStatus.CompletionTimestamp).NotTo(BeNil())
+				}
+			}
+		})
+	}
+}
 
 var _ = Describe("Backup Controller test", func() {
 	cleanEnv := func() {
@@ -187,8 +317,56 @@ var _ = Describe("Backup Controller test", func() {
 				Eventually(testapps.CheckObjExists(&testCtx, getJobKey(), &batchv1.Job{}, false)).Should(Succeed())
 			})
 
+			It("should succeed when the target pod disappears after the job completes", func() {
+				By("wait for the backup job to be created")
+				Eventually(testapps.CheckObjExists(&testCtx, getJobKey(), &batchv1.Job{}, true)).Should(Succeed())
+
+				By("pause backup reconciliation before completing the job")
+				Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
+					if fetched.Annotations == nil {
+						fetched.Annotations = map[string]string{}
+					}
+					fetched.Annotations[dptypes.SkipReconciliationAnnotationKey] = "true"
+				})).Should(Succeed())
+				Consistently(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+					g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseRunning))
+				}), time.Second).Should(Succeed())
+
+				testdp.PatchK8sJobStatus(&testCtx, getJobKey(), batchv1.JobComplete)
+				Consistently(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+					g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseRunning))
+				}), time.Second).Should(Succeed())
+
+				By("delete the selected target pod before the job result is observed")
+				Expect(k8sClient.Delete(ctx, targetPod)).Should(Succeed())
+				Eventually(testapps.CheckObjExists(&testCtx, client.ObjectKeyFromObject(targetPod), &corev1.Pod{}, false)).Should(Succeed())
+
+				By("resume backup reconciliation")
+				Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
+					delete(fetched.Annotations, dptypes.SkipReconciliationAnnotationKey)
+				})).Should(Succeed())
+
+				By("expect the completed job to win over the missing target pod")
+				Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+					g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseCompleted))
+				})).Should(Succeed())
+			})
+
 			It("should fail after job fails", func() {
+				By("wait for the backup job to be created")
+				Eventually(testapps.CheckObjExists(&testCtx, getJobKey(), &batchv1.Job{}, true)).Should(Succeed())
+
+				By("pause backup reconciliation before failing the job")
+				Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
+					if fetched.Annotations == nil {
+						fetched.Annotations = map[string]string{}
+					}
+					fetched.Annotations[dptypes.SkipReconciliationAnnotationKey] = "true"
+				})).Should(Succeed())
+
 				testdp.PatchK8sJobStatus(&testCtx, getJobKey(), batchv1.JobFailed)
+				Expect(k8sClient.Delete(ctx, targetPod)).Should(Succeed())
+				Eventually(testapps.CheckObjExists(&testCtx, client.ObjectKeyFromObject(targetPod), &corev1.Pod{}, false)).Should(Succeed())
 
 				By("check backup job failed")
 				Eventually(testapps.CheckObj(&testCtx, getJobKey(), func(g Gomega, fetched *batchv1.Job) {
@@ -196,9 +374,16 @@ var _ = Describe("Backup Controller test", func() {
 					g.Expect(finishedType).To(Equal(batchv1.JobFailed))
 				})).Should(Succeed())
 
-				By("check backup failed")
+				By("resume reconciliation without the target pod")
+				Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
+					delete(fetched.Annotations, dptypes.SkipReconciliationAnnotationKey)
+				})).Should(Succeed())
+
+				By("check backup failed from the persisted job status")
 				Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
 					g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseFailed))
+					g.Expect(fetched.Status.Actions).To(HaveLen(1))
+					g.Expect(fetched.Status.Actions[0].Phase).To(Equal(dpv1alpha1.ActionPhaseFailed))
 				})).Should(Succeed())
 			})
 
@@ -375,17 +560,178 @@ var _ = Describe("Backup Controller test", func() {
 			Expect(targetPods).Should(HaveLen(1))
 			By("create a backup")
 			backup := testdp.NewFakeBackup(&testCtx, nil)
+			backupKey := client.ObjectKeyFromObject(backup)
 			getJobKey := func(targetName string) client.ObjectKey {
 				return client.ObjectKey{
 					Name:      dpbackup.GenerateBackupJobName(backup, fmt.Sprintf("%s-%s-0", dpbackup.BackupDataJobNamePrefix, targetName)),
 					Namespace: backup.Namespace,
 				}
 			}
+			By("check the complete action plan is persisted")
+			Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+				g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseRunning))
+				g.Expect(fetched.Status.Actions).To(HaveLen(2))
+				g.Expect([]string{fetched.Status.Actions[0].Name, fetched.Status.Actions[1].Name}).To(ConsistOf(
+					fmt.Sprintf("%s-%s-0", dpbackup.BackupDataJobNamePrefix, targets[0].Name),
+					fmt.Sprintf("%s-%s-0", dpbackup.BackupDataJobNamePrefix, targets[1].Name),
+				))
+				for _, actionStatus := range fetched.Status.Actions {
+					g.Expect(actionStatus.ObjectRef).ShouldNot(BeNil())
+					g.Expect(actionStatus.ObjectRef.APIVersion).Should(Equal(batchv1.SchemeGroupVersion.String()))
+					g.Expect(actionStatus.ObjectRef.Kind).Should(Equal(constant.JobKind))
+					g.Expect(actionStatus.ObjectRef.Namespace).Should(Equal(backup.Namespace))
+					g.Expect(actionStatus.ObjectRef.Name).Should(Equal(dpbackup.GenerateBackupJobName(backup, actionStatus.Name)))
+				}
+			})).Should(Succeed())
 			By("mock backup jobs to completed and backup should be completed")
 			testdp.PatchK8sJobStatus(&testCtx, getJobKey(targets[0].Name), batchv1.JobComplete)
 			testdp.PatchK8sJobStatus(&testCtx, getJobKey(targets[1].Name), batchv1.JobComplete)
-			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(backup), func(g Gomega, fetched *dpv1alpha1.Backup) {
+			Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
 				g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseCompleted))
+			})).Should(Succeed())
+		})
+
+		It("completes a multi-target backup from persisted job object refs", func() {
+			By("Set backupMethod's targets")
+			Expect(testapps.ChangeObj(&testCtx, backupPolicy, func(bp *dpv1alpha1.BackupPolicy) {
+				podSelector := &dpv1alpha1.PodSelector{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							constant.AppInstanceLabelKey:    testdp.ClusterName,
+							constant.KBAppComponentLabelKey: testdp.ComponentName,
+						},
+					},
+					Strategy: dpv1alpha1.PodSelectionStrategyAll,
+				}
+				backupPolicy.Spec.BackupMethods[0].Targets = []dpv1alpha1.BackupTarget{
+					{Name: testdp.ComponentName + "-0", PodSelector: podSelector},
+					{Name: testdp.ComponentName + "-1", PodSelector: podSelector},
+				}
+			})).Should(Succeed())
+			backup := testdp.NewFakeBackup(&testCtx, nil)
+			backupKey := client.ObjectKeyFromObject(backup)
+
+			By("wait for all target jobs to be recorded and created")
+			var jobKeys []client.ObjectKey
+			Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+				g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseRunning))
+				g.Expect(fetched.Status.Actions).To(HaveLen(4))
+				jobKeys = jobKeys[:0]
+				for _, actionStatus := range fetched.Status.Actions {
+					g.Expect(actionStatus.ObjectRef).NotTo(BeNil())
+					jobKeys = append(jobKeys, client.ObjectKey{
+						Namespace: actionStatus.ObjectRef.Namespace,
+						Name:      actionStatus.ObjectRef.Name,
+					})
+				}
+			})).Should(Succeed())
+			for _, jobKey := range jobKeys {
+				Eventually(testapps.CheckObjExists(&testCtx, jobKey, &batchv1.Job{}, true)).Should(Succeed())
+			}
+
+			By("pause reconciliation")
+			Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
+				if fetched.Annotations == nil {
+					fetched.Annotations = map[string]string{}
+				}
+				fetched.Annotations[dptypes.SkipReconciliationAnnotationKey] = "true"
+			})).Should(Succeed())
+			Consistently(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+				g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseRunning))
+			}), time.Second).Should(Succeed())
+
+			for _, jobKey := range jobKeys {
+				testdp.PatchK8sJobStatus(&testCtx, jobKey, batchv1.JobComplete)
+			}
+			Expect(k8sClient.Delete(ctx, targetPod)).Should(Succeed())
+			Eventually(testapps.CheckObjExists(&testCtx, client.ObjectKeyFromObject(targetPod), &corev1.Pod{}, false)).Should(Succeed())
+
+			By("resume reconciliation and fall back to the persisted job refs")
+			Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
+				delete(fetched.Annotations, dptypes.SkipReconciliationAnnotationKey)
+			})).Should(Succeed())
+			Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+				g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseCompleted))
+				g.Expect(fetched.Status.Actions).To(HaveLen(len(jobKeys)))
+				for _, actionStatus := range fetched.Status.Actions {
+					g.Expect(actionStatus.Phase).To(Equal(dpv1alpha1.ActionPhaseCompleted))
+				}
+			})).Should(Succeed())
+		})
+
+		It("keeps reconciling a multi-target backup while a referenced job is incomplete", func() {
+			By("Set backupMethod's targets")
+			Expect(testapps.ChangeObj(&testCtx, backupPolicy, func(bp *dpv1alpha1.BackupPolicy) {
+				podSelector := &dpv1alpha1.PodSelector{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							constant.AppInstanceLabelKey:    testdp.ClusterName,
+							constant.KBAppComponentLabelKey: testdp.ComponentName,
+						},
+					},
+					Strategy: dpv1alpha1.PodSelectionStrategyAny,
+				}
+				backupPolicy.Spec.BackupMethods[0].Targets = []dpv1alpha1.BackupTarget{
+					{Name: testdp.ComponentName + "-0", PodSelector: podSelector},
+					{Name: testdp.ComponentName + "-1", PodSelector: podSelector},
+				}
+			})).Should(Succeed())
+			targets := backupPolicy.Spec.BackupMethods[0].Targets
+			backup := testdp.NewFakeBackup(&testCtx, nil)
+			backupKey := client.ObjectKeyFromObject(backup)
+			getJobKey := func(targetName string) client.ObjectKey {
+				return client.ObjectKey{
+					Name:      dpbackup.GenerateBackupJobName(backup, fmt.Sprintf("%s-%s-0", dpbackup.BackupDataJobNamePrefix, targetName)),
+					Namespace: backup.Namespace,
+				}
+			}
+
+			By("wait for both target jobs to be created")
+			Eventually(testapps.CheckObjExists(&testCtx, getJobKey(targets[0].Name), &batchv1.Job{}, true)).Should(Succeed())
+			Eventually(testapps.CheckObjExists(&testCtx, getJobKey(targets[1].Name), &batchv1.Job{}, true)).Should(Succeed())
+
+			By("pause reconciliation")
+			Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
+				if fetched.Annotations == nil {
+					fetched.Annotations = map[string]string{}
+				}
+				fetched.Annotations[dptypes.SkipReconciliationAnnotationKey] = "true"
+			})).Should(Succeed())
+			Consistently(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+				g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseRunning))
+			}), time.Second).Should(Succeed())
+
+			completedJobKey := getJobKey(targets[0].Name)
+			testdp.PatchK8sJobStatus(&testCtx, completedJobKey, batchv1.JobComplete)
+			Expect(k8sClient.Delete(ctx, targetPod)).Should(Succeed())
+			Eventually(testapps.CheckObjExists(&testCtx, client.ObjectKeyFromObject(targetPod), &corev1.Pod{}, false)).Should(Succeed())
+
+			By("resume reconciliation and expect the backup to keep running")
+			Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
+				delete(fetched.Annotations, dptypes.SkipReconciliationAnnotationKey)
+			})).Should(Succeed())
+			Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+				g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseRunning))
+				g.Expect(fetched.Status.Actions).To(HaveLen(2))
+				completedActionFound := false
+				for _, actionStatus := range fetched.Status.Actions {
+					if actionStatus.ObjectRef.Name == completedJobKey.Name {
+						completedActionFound = true
+						g.Expect(actionStatus.Phase).To(Equal(dpv1alpha1.ActionPhaseCompleted))
+					} else {
+						g.Expect(actionStatus.Phase).NotTo(Equal(dpv1alpha1.ActionPhaseCompleted))
+					}
+				}
+				g.Expect(completedActionFound).To(BeTrue())
+			})).Should(Succeed())
+
+			By("complete the remaining job and expect the backup to complete")
+			testdp.PatchK8sJobStatus(&testCtx, getJobKey(targets[1].Name), batchv1.JobComplete)
+			Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+				g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseCompleted))
+				for _, actionStatus := range fetched.Status.Actions {
+					g.Expect(actionStatus.Phase).To(Equal(dpv1alpha1.ActionPhaseCompleted))
+				}
 			})).Should(Succeed())
 		})
 

--- a/pkg/dataprotection/action/action.go
+++ b/pkg/dataprotection/action/action.go
@@ -22,6 +22,7 @@ package action
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
@@ -39,6 +40,9 @@ type Action interface {
 
 	// Type returns the type of the action.
 	Type() dpv1alpha1.ActionType
+
+	// BuildObjectRef builds the reference to the object managed by the action.
+	BuildObjectRef() *corev1.ObjectReference
 }
 
 type ActionContext struct {

--- a/pkg/dataprotection/action/action_create_vs.go
+++ b/pkg/dataprotection/action/action_create_vs.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 	"github.com/apecloud/kubeblocks/pkg/dataprotection/utils"
@@ -85,6 +86,30 @@ func (c *CreateVolumeSnapshotAction) Type() dpv1alpha1.ActionType {
 	return dpv1alpha1.ActionTypeNone
 }
 
+func (c *CreateVolumeSnapshotAction) BuildObjectRef() *corev1.ObjectReference {
+	if len(c.PersistentVolumeClaimWrappers) != 1 {
+		return nil
+	}
+	key := c.buildVolumeSnapshotObjectKey(&c.PersistentVolumeClaimWrappers[0])
+	return &corev1.ObjectReference{
+		APIVersion: vsv1.SchemeGroupVersion.String(),
+		Kind:       constant.VolumeSnapshotKind,
+		Namespace:  key.Namespace,
+		Name:       key.Name,
+	}
+}
+
+func (c *CreateVolumeSnapshotAction) buildVolumeSnapshotObjectKey(w *PersistentVolumeClaimWrapper) client.ObjectKey {
+	prefix := c.ObjectMeta.Name
+	if c.TargetName != "" {
+		prefix += "-" + c.TargetName
+	}
+	return client.ObjectKey{
+		Namespace: w.PersistentVolumeClaim.Namespace,
+		Name:      utils.GetBackupVolumeSnapshotName(prefix, w.VolumeName, c.Index),
+	}
+}
+
 func (c *CreateVolumeSnapshotAction) Execute(actCtx ActionContext) (*dpv1alpha1.ActionStatus, error) {
 	sb := newStatusBuilder(c)
 	handleErr := func(err error) (*dpv1alpha1.ActionStatus, error) {
@@ -102,16 +127,9 @@ func (c *CreateVolumeSnapshotAction) Execute(actCtx ActionContext) (*dpv1alpha1.
 		snap            *vsv1.VolumeSnapshot
 		totalSize       = &resource.Quantity{}
 		volumeSnapshots []dpv1alpha1.VolumeSnapshotStatus
-		prefix          = c.ObjectMeta.Name
 	)
-	if c.TargetName != "" {
-		prefix += "-" + c.TargetName
-	}
 	for _, w := range c.PersistentVolumeClaimWrappers {
-		key := client.ObjectKey{
-			Namespace: w.PersistentVolumeClaim.Namespace,
-			Name:      utils.GetBackupVolumeSnapshotName(prefix, w.VolumeName, c.Index),
-		}
+		key := c.buildVolumeSnapshotObjectKey(&w)
 		// create volume snapshot
 		if err = c.createVolumeSnapshotIfNotExist(actCtx, &w.PersistentVolumeClaim, key); err != nil {
 			return handleErr(err)

--- a/pkg/dataprotection/action/action_create_vs_test.go
+++ b/pkg/dataprotection/action/action_create_vs_test.go
@@ -91,6 +91,11 @@ var _ = Describe("CreateVolumeSnapshotAction Test", func() {
 					},
 				},
 			}
+			objectRef := act.BuildObjectRef()
+			Expect(objectRef.APIVersion).Should(Equal(vsv1.SchemeGroupVersion.String()))
+			Expect(objectRef.Kind).Should(Equal(constant.VolumeSnapshotKind))
+			Expect(objectRef.Namespace).Should(Equal(testCtx.DefaultNamespace))
+			Expect(objectRef.Name).Should(Equal(dputils.GetBackupVolumeSnapshotName(actionName, volumeName, 0)))
 
 			// mock pv
 			testapps.NewPersistentVolumeFactory(testCtx.DefaultNamespace, volumeName, pvcName).

--- a/pkg/dataprotection/action/action_job.go
+++ b/pkg/dataprotection/action/action_job.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
 	ctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	"github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 	"github.com/apecloud/kubeblocks/pkg/dataprotection/utils"
@@ -58,6 +59,15 @@ func (j *JobAction) GetName() string {
 
 func (j *JobAction) Type() dpv1alpha1.ActionType {
 	return dpv1alpha1.ActionTypeJob
+}
+
+func (j *JobAction) BuildObjectRef() *corev1.ObjectReference {
+	return &corev1.ObjectReference{
+		APIVersion: batchv1.SchemeGroupVersion.String(),
+		Kind:       constant.JobKind,
+		Namespace:  j.ObjectMeta.Namespace,
+		Name:       j.ObjectMeta.Name,
+	}
 }
 
 func (j *JobAction) Execute(actCtx ActionContext) (*dpv1alpha1.ActionStatus, error) {

--- a/pkg/dataprotection/action/action_job_test.go
+++ b/pkg/dataprotection/action/action_job_test.go
@@ -96,6 +96,11 @@ var _ = Describe("JobAction Test", func() {
 				},
 				Owner: testdp.NewFakeBackup(&testCtx, nil),
 			}
+			objectRef := act.BuildObjectRef()
+			Expect(objectRef.APIVersion).Should(Equal(batchv1.SchemeGroupVersion.String()))
+			Expect(objectRef.Kind).Should(Equal(constant.JobKind))
+			Expect(objectRef.Namespace).Should(Equal(testCtx.DefaultNamespace))
+			Expect(objectRef.Name).Should(Equal(actionName))
 
 			By("should success to execute")
 			status, err := act.Execute(buildActionCtx())

--- a/pkg/dataprotection/action/action_stateful.go
+++ b/pkg/dataprotection/action/action_stateful.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 )
@@ -62,6 +63,15 @@ func (s *StatefulSetAction) Type() dpv1alpha1.ActionType {
 	return dpv1alpha1.ActionTypeStatefulSet
 }
 
+func (s *StatefulSetAction) BuildObjectRef() *corev1.ObjectReference {
+	return &corev1.ObjectReference{
+		APIVersion: appsv1.SchemeGroupVersion.String(),
+		Kind:       constant.StatefulSetKind,
+		Namespace:  s.ObjectMeta.Namespace,
+		Name:       s.ObjectMeta.Name,
+	}
+}
+
 func (s *StatefulSetAction) Execute(ctx ActionContext) (actionStatus *dpv1alpha1.ActionStatus, err error) {
 	defer func() {
 		if err != nil {
@@ -88,6 +98,7 @@ func (s *StatefulSetAction) Execute(ctx ActionContext) (actionStatus *dpv1alpha1
 			Name:           s.Name,
 			Phase:          dpv1alpha1.ActionPhaseRunning,
 			ActionType:     s.Type(),
+			ObjectRef:      s.BuildObjectRef(),
 			StartTimestamp: &metav1.Time{Time: time.Now()},
 		}, nil
 	}

--- a/pkg/dataprotection/action/builder_status.go
+++ b/pkg/dataprotection/action/builder_status.go
@@ -36,6 +36,7 @@ func newStatusBuilder(a Action) *statusBuilder {
 			Name:       a.GetName(),
 			ActionType: a.Type(),
 			Phase:      dpv1alpha1.ActionPhaseRunning,
+			ObjectRef:  a.BuildObjectRef(),
 		},
 	}
 	return sb.startTimestamp(nil)

--- a/pkg/dataprotection/backup/request.go
+++ b/pkg/dataprotection/backup/request.go
@@ -59,6 +59,7 @@ type Request struct {
 	BackupMethod         *dpv1alpha1.BackupMethod
 	ActionSet            *dpv1alpha1.ActionSet
 	TargetPods           []*corev1.Pod
+	PreparedTargets      []PreparedTarget
 	BackupRepoPVC        *corev1.PersistentVolumeClaim
 	BackupRepo           *dpv1alpha1.BackupRepo
 	ToolConfigSecret     *corev1.Secret
@@ -67,6 +68,12 @@ type Request struct {
 	Target               *dpv1alpha1.BackupTarget
 	ParentBackup         *dpv1alpha1.Backup
 	BaseBackup           *dpv1alpha1.Backup
+}
+
+type PreparedTarget struct {
+	Target               *dpv1alpha1.BackupTarget
+	TargetPods           []*corev1.Pod
+	WorkerServiceAccount string
 }
 
 func (r *Request) GetBackupType() string {

--- a/pkg/dataprotection/backup/request_test.go
+++ b/pkg/dataprotection/backup/request_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -129,8 +130,15 @@ var _ = Describe("Request Test", func() {
 				request.BackupMethod = &backupPolicy.Spec.BackupMethods[0]
 				request.BackupRepo = backupRepo
 				request.Target = backupPolicy.Spec.Target
-				_, err := request.BuildActions()
+				actions, err := request.BuildActions()
 				Expect(err).NotTo(HaveOccurred())
+				Expect(actions[targetPod.Name]).To(HaveLen(1))
+				objectRef := actions[targetPod.Name][0].BuildObjectRef()
+				Expect(objectRef).NotTo(BeNil())
+				Expect(objectRef.APIVersion).To(Equal(batchv1.SchemeGroupVersion.String()))
+				Expect(objectRef.Kind).To(Equal(constant.JobKind))
+				Expect(objectRef.Namespace).To(Equal(backup.Namespace))
+				Expect(objectRef.Name).To(Equal(GenerateBackupJobName(backup, actions[targetPod.Name][0].GetName())))
 			})
 
 			It("build create volume snapshot action", func() {


### PR DESCRIPTION
## What changed

- Persist the complete backup action inventory and execution object references before entering Running.
- When target preparation fails, observe all persisted Job references before deciding the Backup result.
- Keep the Backup Running while any referenced Job is active, fail when a referenced Job fails, and complete only after all referenced Jobs complete.
- Preserve the original target error when the persisted action inventory cannot safely identify the Jobs.
- Cover single-target and multi-target completion, failure, and waiting paths.

## Why

A backup Job can finish independently after its selected target Pod disappears. Resolving the target Pod first can hide the authoritative Job result and incorrectly fail the Backup.

Backport of #10647 for `release-1.1`. Related to #10643.

## Validation

```bash
GOCACHE=/tmp/kubeblocks-go-cache go test ./controllers/dataprotection -run "^TestSyncJobActions$" -count=1
GOCACHE=/tmp/kubeblocks-go-cache KUBEBUILDER_ASSETS=".../k8s/1.26.1-darwin-arm64" go test ./pkg/dataprotection/action ./pkg/dataprotection/backup -count=1
GOCACHE=/tmp/kubeblocks-go-cache KUBEBUILDER_ASSETS=".../k8s/1.26.1-darwin-arm64" go test ./controllers/dataprotection -run TestAPIs -ginkgo.focus="(should succeed when the target pod disappears after the job completes|should fail after job fails|create a backup with backupMethod and multi targets|completes a multi-target backup from persisted job object refs|keeps reconciling a multi-target backup while a referenced job is incomplete)" -count=1
```