### PR TITLE
fix(dataprotection): surface terminating namespace cleanup blocker

### DIFF
--- a/apis/dataprotection/v1alpha1/backup_types.go
+++ b/apis/dataprotection/v1alpha1/backup_types.go
@@ -136,6 +136,13 @@ type BackupStatus struct {
 	// +optional
 	FailureReason string `json:"failureReason,omitempty"`
 
+	// Any error or blocker encountered while deleting the Backup and its data.
+	// This field does not replace FailureReason, which records a failure of the
+	// backup operation itself.
+	//
+	// +optional
+	DeletionFailureReason string `json:"deletionFailureReason,omitempty"`
+
 	// The name of the backup repository.
 	//
 	// +optional

--- a/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
+++ b/config/crd/bases/dataprotection.kubeblocks.io_backups.yaml
@@ -1039,6 +1039,12 @@ spec:
                   The server's time is used for this timestamp.
                 format: date-time
                 type: string
+              deletionFailureReason:
+                description: |-
+                  Any error or blocker encountered while deleting the Backup and its data.
+                  This field does not replace FailureReason, which records a failure of the
+                  backup operation itself.
+                type: string
               duration:
                 description: |-
                   Records the duration of the backup operation.

--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -21,6 +21,7 @@ package dataprotection
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -69,6 +70,14 @@ type BackupReconciler struct {
 	Recorder   record.EventRecorder
 	RestConfig *rest.Config
 	clock      clock.RealClock
+}
+
+type backupNamespaceTerminatingError struct {
+	namespace string
+}
+
+func (e *backupNamespaceTerminatingError) Error() string {
+	return fmt.Sprintf("backup namespace %q is terminating; cannot create worker resources to delete backup files, delete the Backup and wait until it is gone before deleting the namespace", e.namespace)
 }
 
 // +kubebuilder:rbac:groups=dataprotection.kubeblocks.io,resources=backups,verbs=get;list;watch;create;update;patch;delete
@@ -248,7 +257,29 @@ func (r *BackupReconciler) deleteBackupFiles(reqCtx intctrlutil.RequestCtx, back
 	case dpbackup.DeletionStatusDeleting,
 		dpbackup.DeletionStatusUnknown:
 		// wait for the deletion job completed
+		return r.recordBackupDeletionBlocker(reqCtx, backup, err)
+	}
+	return err
+}
+
+func (r *BackupReconciler) recordBackupDeletionBlocker(
+	reqCtx intctrlutil.RequestCtx,
+	backup *dpv1alpha1.Backup,
+	err error,
+) error {
+	var terminatingErr *backupNamespaceTerminatingError
+	if !errors.As(err, &terminatingErr) {
 		return err
+	}
+
+	failureReason := err.Error()
+	if backup.Status.FailureReason == failureReason {
+		return err
+	}
+	backupPatch := client.MergeFrom(backup.DeepCopy())
+	backup.Status.FailureReason = failureReason
+	if patchErr := r.Status().Patch(reqCtx.Ctx, backup, backupPatch); patchErr != nil {
+		return patchErr
 	}
 	return err
 }
@@ -259,7 +290,7 @@ func (r *BackupReconciler) ensureWorkerServiceAccountForBackupDeletion(reqCtx in
 		return "", fmt.Errorf("failed to get backup namespace %q before deleting backup files: %w", namespace, err)
 	}
 	if !ns.DeletionTimestamp.IsZero() {
-		return "", fmt.Errorf("backup namespace %q is terminating; cannot create worker resources to delete backup files, delete the Backup and wait until it is gone before deleting the namespace", namespace)
+		return "", &backupNamespaceTerminatingError{namespace: namespace}
 	}
 	// TODO: update the mcMgr param
 	return EnsureWorkerServiceAccount(reqCtx, r.Client, namespace, nil)

--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -247,11 +247,11 @@ func (r *BackupReconciler) deleteBackupFiles(reqCtx intctrlutil.RequestCtx, back
 		return deleteBackup()
 	case dpbackup.DeletionStatusFailed:
 		failureReason := err.Error()
-		if backup.Status.FailureReason == failureReason {
+		if backup.Status.DeletionFailureReason == failureReason {
 			return nil
 		}
 		backupPatch := client.MergeFrom(backup.DeepCopy())
-		backup.Status.FailureReason = failureReason
+		backup.Status.DeletionFailureReason = failureReason
 		r.Recorder.Event(backup, corev1.EventTypeWarning, "DeleteBackupFilesFailed", failureReason)
 		return r.Status().Patch(reqCtx.Ctx, backup, backupPatch)
 	case dpbackup.DeletionStatusDeleting,
@@ -272,12 +272,12 @@ func (r *BackupReconciler) recordBackupDeletionBlocker(
 		return err
 	}
 
-	failureReason := err.Error()
-	if backup.Status.FailureReason == failureReason {
+	deletionFailureReason := err.Error()
+	if backup.Status.DeletionFailureReason == deletionFailureReason {
 		return err
 	}
 	backupPatch := client.MergeFrom(backup.DeepCopy())
-	backup.Status.FailureReason = failureReason
+	backup.Status.DeletionFailureReason = deletionFailureReason
 	if patchErr := r.Status().Patch(reqCtx.Ctx, backup, backupPatch); patchErr != nil {
 		return patchErr
 	}

--- a/controllers/dataprotection/backup_controller_test.go
+++ b/controllers/dataprotection/backup_controller_test.go
@@ -131,6 +131,7 @@ func TestDeleteBackupFilesRecordsTerminatingNamespaceBlockerWithoutStoppingRetry
 		Spec: dpv1alpha1.BackupSpec{DeletionPolicy: dpv1alpha1.BackupDeletionPolicyDelete},
 		Status: dpv1alpha1.BackupStatus{
 			Phase:          dpv1alpha1.BackupPhaseDeleting,
+			FailureReason:  "backup execution failed",
 			BackupRepoName: "repo",
 			Path:           "/backups/backup",
 		},
@@ -153,7 +154,8 @@ func TestDeleteBackupFilesRecordsTerminatingNamespaceBlockerWithoutStoppingRetry
 
 	stored := &dpv1alpha1.Backup{}
 	g.Expect(baseClient.Get(reqCtx.Ctx, client.ObjectKeyFromObject(backup), stored)).To(Succeed())
-	g.Expect(stored.Status.FailureReason).To(Equal(err.Error()))
+	g.Expect(stored.Status.FailureReason).To(Equal("backup execution failed"))
+	g.Expect(stored.Status.DeletionFailureReason).To(Equal(err.Error()))
 	g.Expect(controllerutil.ContainsFinalizer(stored, dptypes.DataProtectionFinalizerName)).To(BeTrue())
 
 	jobs := &batchv1.JobList{}
@@ -198,6 +200,7 @@ func TestDeleteBackupFilesDoesNotRecordOrdinaryDeletingError(t *testing.T) {
 	g.Expect(err).To(MatchError("get failed"))
 	g.Expect(countingClient.statusPatchCount).To(Equal(0))
 	g.Expect(backup.Status.FailureReason).To(BeEmpty())
+	g.Expect(backup.Status.DeletionFailureReason).To(BeEmpty())
 }
 
 func TestDeleteBackupFilesReturnsStatusPatchError(t *testing.T) {
@@ -243,6 +246,7 @@ func TestDeleteBackupFilesReturnsStatusPatchError(t *testing.T) {
 	stored := &dpv1alpha1.Backup{}
 	g.Expect(baseClient.Get(context.Background(), client.ObjectKeyFromObject(backup), stored)).To(Succeed())
 	g.Expect(stored.Status.FailureReason).To(BeEmpty())
+	g.Expect(stored.Status.DeletionFailureReason).To(BeEmpty())
 }
 
 func TestSyncJobActions(t *testing.T) {

--- a/controllers/dataprotection/backup_controller_test.go
+++ b/controllers/dataprotection/backup_controller_test.go
@@ -22,6 +22,7 @@ package dataprotection
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"strconv"
@@ -35,6 +36,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,6 +48,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
@@ -68,6 +71,178 @@ type getErrorClient struct {
 
 func (c *getErrorClient) Get(context.Context, client.ObjectKey, client.Object, ...client.GetOption) error {
 	return fmt.Errorf("get failed")
+}
+
+type statusPatchCountingClient struct {
+	client.Client
+	statusPatchCount int
+	statusPatchErr   error
+}
+
+func (c *statusPatchCountingClient) Status() client.SubResourceWriter {
+	return &statusPatchCountingWriter{
+		SubResourceWriter: c.Client.Status(),
+		count:             &c.statusPatchCount,
+		patchErr:          c.statusPatchErr,
+	}
+}
+
+type statusPatchCountingWriter struct {
+	client.SubResourceWriter
+	count    *int
+	patchErr error
+}
+
+func (w *statusPatchCountingWriter) Patch(
+	ctx context.Context,
+	obj client.Object,
+	patch client.Patch,
+	opts ...client.SubResourcePatchOption,
+) error {
+	*w.count = *w.count + 1
+	if w.patchErr != nil {
+		return w.patchErr
+	}
+	return w.SubResourceWriter.Patch(ctx, obj, patch, opts...)
+}
+
+func TestDeleteBackupFilesRecordsTerminatingNamespaceBlockerWithoutStoppingRetry(t *testing.T) {
+	g := NewWithT(t)
+	scheme := runtime.NewScheme()
+	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(batchv1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(rbacv1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(dpv1alpha1.AddToScheme(scheme)).To(Succeed())
+
+	now := metav1.Now()
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:              "terminating-backup",
+		DeletionTimestamp: &now,
+		Finalizers:        []string{"test.kubeblocks.io/finalizer"},
+	}}
+	backup := &dpv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "backup",
+			Namespace:         namespace.Name,
+			UID:               types.UID("backup-uid"),
+			DeletionTimestamp: &now,
+			Finalizers:        []string{dptypes.DataProtectionFinalizerName},
+		},
+		Spec: dpv1alpha1.BackupSpec{DeletionPolicy: dpv1alpha1.BackupDeletionPolicyDelete},
+		Status: dpv1alpha1.BackupStatus{
+			Phase:          dpv1alpha1.BackupPhaseDeleting,
+			BackupRepoName: "repo",
+			Path:           "/backups/backup",
+		},
+	}
+	repo := &dpv1alpha1.BackupRepo{ObjectMeta: metav1.ObjectMeta{Name: backup.Status.BackupRepoName}}
+	baseClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&dpv1alpha1.Backup{}).
+		WithObjects(namespace, backup, repo).
+		Build()
+	countingClient := &statusPatchCountingClient{Client: baseClient}
+	reconciler := &BackupReconciler{Client: countingClient, Scheme: scheme}
+	reqCtx := intctrlutil.RequestCtx{Ctx: context.Background()}
+
+	err := reconciler.deleteBackupFiles(reqCtx, backup.DeepCopy())
+	var terminatingErr *backupNamespaceTerminatingError
+	g.Expect(errors.As(err, &terminatingErr)).To(BeTrue())
+	g.Expect(err.Error()).To(ContainSubstring("is terminating; cannot create worker resources to delete backup files"))
+	g.Expect(countingClient.statusPatchCount).To(Equal(1))
+
+	stored := &dpv1alpha1.Backup{}
+	g.Expect(baseClient.Get(reqCtx.Ctx, client.ObjectKeyFromObject(backup), stored)).To(Succeed())
+	g.Expect(stored.Status.FailureReason).To(Equal(err.Error()))
+	g.Expect(controllerutil.ContainsFinalizer(stored, dptypes.DataProtectionFinalizerName)).To(BeTrue())
+
+	jobs := &batchv1.JobList{}
+	g.Expect(baseClient.List(reqCtx.Ctx, jobs, client.InNamespace(namespace.Name))).To(Succeed())
+	g.Expect(jobs.Items).To(BeEmpty())
+	serviceAccounts := &corev1.ServiceAccountList{}
+	g.Expect(baseClient.List(reqCtx.Ctx, serviceAccounts, client.InNamespace(namespace.Name))).To(Succeed())
+	g.Expect(serviceAccounts.Items).To(BeEmpty())
+	roleBindings := &rbacv1.RoleBindingList{}
+	g.Expect(baseClient.List(reqCtx.Ctx, roleBindings, client.InNamespace(namespace.Name))).To(Succeed())
+	g.Expect(roleBindings.Items).To(BeEmpty())
+
+	err = reconciler.deleteBackupFiles(reqCtx, stored.DeepCopy())
+	g.Expect(errors.As(err, &terminatingErr)).To(BeTrue())
+	g.Expect(countingClient.statusPatchCount).To(Equal(1))
+}
+
+func TestDeleteBackupFilesDoesNotRecordOrdinaryDeletingError(t *testing.T) {
+	g := NewWithT(t)
+	scheme := runtime.NewScheme()
+	g.Expect(batchv1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(dpv1alpha1.AddToScheme(scheme)).To(Succeed())
+
+	backup := &dpv1alpha1.Backup{ObjectMeta: metav1.ObjectMeta{
+		Name:       "backup",
+		Namespace:  "default",
+		UID:        types.UID("backup-uid"),
+		Finalizers: []string{dptypes.DataProtectionFinalizerName},
+	}}
+	baseClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&dpv1alpha1.Backup{}).
+		WithObjects(backup).
+		Build()
+	countingClient := &statusPatchCountingClient{Client: baseClient}
+	reconciler := &BackupReconciler{
+		Client: &getErrorClient{Client: countingClient},
+		Scheme: scheme,
+	}
+
+	err := reconciler.deleteBackupFiles(intctrlutil.RequestCtx{Ctx: context.Background()}, backup.DeepCopy())
+	g.Expect(err).To(MatchError("get failed"))
+	g.Expect(countingClient.statusPatchCount).To(Equal(0))
+	g.Expect(backup.Status.FailureReason).To(BeEmpty())
+}
+
+func TestDeleteBackupFilesReturnsStatusPatchError(t *testing.T) {
+	g := NewWithT(t)
+	scheme := runtime.NewScheme()
+	g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(batchv1.AddToScheme(scheme)).To(Succeed())
+	g.Expect(dpv1alpha1.AddToScheme(scheme)).To(Succeed())
+
+	now := metav1.Now()
+	namespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:              "terminating-backup",
+		DeletionTimestamp: &now,
+		Finalizers:        []string{"test.kubeblocks.io/finalizer"},
+	}}
+	backup := &dpv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "backup",
+			Namespace:  namespace.Name,
+			UID:        types.UID("backup-uid"),
+			Finalizers: []string{dptypes.DataProtectionFinalizerName},
+		},
+		Status: dpv1alpha1.BackupStatus{
+			Phase:          dpv1alpha1.BackupPhaseDeleting,
+			BackupRepoName: "repo",
+			Path:           "/backups/backup",
+		},
+	}
+	repo := &dpv1alpha1.BackupRepo{ObjectMeta: metav1.ObjectMeta{Name: backup.Status.BackupRepoName}}
+	baseClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&dpv1alpha1.Backup{}).
+		WithObjects(namespace, backup, repo).
+		Build()
+	patchErr := errors.New("status patch failed")
+	countingClient := &statusPatchCountingClient{Client: baseClient, statusPatchErr: patchErr}
+	reconciler := &BackupReconciler{Client: countingClient, Scheme: scheme}
+
+	err := reconciler.deleteBackupFiles(intctrlutil.RequestCtx{Ctx: context.Background()}, backup.DeepCopy())
+	g.Expect(err).To(MatchError(patchErr))
+	g.Expect(countingClient.statusPatchCount).To(Equal(1))
+
+	stored := &dpv1alpha1.Backup{}
+	g.Expect(baseClient.Get(context.Background(), client.ObjectKeyFromObject(backup), stored)).To(Succeed())
+	g.Expect(stored.Status.FailureReason).To(BeEmpty())
 }
 
 func TestSyncJobActions(t *testing.T) {

--- a/controllers/dataprotection/backup_controller_test.go
+++ b/controllers/dataprotection/backup_controller_test.go
@@ -99,7 +99,7 @@ func (w *statusPatchCountingWriter) Patch(
 	patch client.Patch,
 	opts ...client.SubResourcePatchOption,
 ) error {
-	*w.count = *w.count + 1
+	(*w.count)++
 	if w.patchErr != nil {
 		return w.patchErr
 	}

--- a/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
+++ b/deploy/helm/crds/dataprotection.kubeblocks.io_backups.yaml
@@ -1039,6 +1039,12 @@ spec:
                   The server's time is used for this timestamp.
                 format: date-time
                 type: string
+              deletionFailureReason:
+                description: |-
+                  Any error or blocker encountered while deleting the Backup and its data.
+                  This field does not replace FailureReason, which records a failure of the
+                  backup operation itself.
+                type: string
               duration:
                 description: |-
                   Records the duration of the backup operation.

--- a/docs/developer_docs/api-reference/dataprotection.md
+++ b/docs/developer_docs/api-reference/dataprotection.md
@@ -3508,6 +3508,20 @@ string
 </tr>
 <tr>
 <td>
+<code>deletionFailureReason</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Any error or blocker encountered while deleting the Backup and its data.
+This field does not replace FailureReason, which records a failure of the
+backup operation itself.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>backupRepoName</code><br/>
 <em>
 string


### PR DESCRIPTION
### What problem does this PR solve?

When a Backup with `deletionPolicy: Delete` is deleted after its namespace has entered Terminating, DataProtection cannot create the worker resources needed to delete the backup files. The controller intentionally retains the finalizer and retries, but the Backup API has no durable indication of why deletion is blocked; the reason is visible only in controller logs.

Fixes #10694.

### What is changed and how does it work?

- return a dedicated internal error when the backup namespace is Terminating
- persist that exact cleanup-order blocker in `Backup.status.failureReason`
- avoid duplicate status patches for the same reason while continuing to return the original error so reconciliation keeps retrying
- leave other Deleting/Unknown errors, finalizer behavior, worker-resource creation, and deletion semantics unchanged
- do not emit a namespaced Event because Event creation is not reliable after namespace termination begins

### Tests

- `go test ./controllers/dataprotection -run 'TestDeleteBackupFiles(RecordsTerminatingNamespaceBlockerWithoutStoppingRetry|DoesNotRecordOrdinaryDeletingError|ReturnsStatusPatchError)$' -count=3`
- `KUBEBUILDER_ASSETS=... go test ./controllers/dataprotection -run TestAPIs -ginkgo.focus 'should not create worker resources when backup namespace is terminating' -count=1`
- `KUBEBUILDER_ASSETS=... go test ./controllers/dataprotection -count=1`
- `KUBEBUILDER_ASSETS=... go test ./pkg/dataprotection/backup -count=1`
- `go vet ./controllers/dataprotection`
- `make test-go-generate`
