### PR TITLE
fix(instanceset): normalize planner role priorities

### DIFF
--- a/pkg/controller/instanceset/instance_util.go
+++ b/pkg/controller/instanceset/instance_util.go
@@ -107,8 +107,7 @@ func ParseParentNameAndOrdinal(s string) (string, int) {
 // reverse it if reverse==true
 func sortObjects[T client.Object](objects []T, rolePriorityMap map[string]int, reverse bool) {
 	getRolePriorityFunc := func(i int) int {
-		role := strings.ToLower(objects[i].GetLabels()[constant.RoleLabelKey])
-		return rolePriorityMap[role]
+		return getRolePriority(rolePriorityMap, objects[i].GetLabels()[constant.RoleLabelKey])
 	}
 
 	// cache the parent names and ordinals to accelerate the parsing process when there is a massive number of Pods.

--- a/pkg/controller/instanceset/reconciler_status.go
+++ b/pkg/controller/instanceset/reconciler_status.go
@@ -322,8 +322,7 @@ func setMembersStatus(its *workloads.InstanceSet, pods []*corev1.Pod) {
 
 func sortMembersStatus(membersStatus []workloads.MemberStatus, rolePriorityMap map[string]int) {
 	getRolePriorityFunc := func(i int) int {
-		role := membersStatus[i].ReplicaRole.Name
-		return rolePriorityMap[role]
+		return getRolePriority(rolePriorityMap, membersStatus[i].ReplicaRole.Name)
 	}
 	getNameNOrdinalFunc := func(i int) (string, int) {
 		return ParseParentNameAndOrdinal(membersStatus[i].PodName)

--- a/pkg/controller/instanceset/reconciler_status_test.go
+++ b/pkg/controller/instanceset/reconciler_status_test.go
@@ -441,5 +441,20 @@ var _ = Describe("status reconciler test", func() {
 				Expect(status.PodName).Should(Equal(expectedOrder[i]))
 			}
 		})
+
+		It("should normalize mixed-case role names", func() {
+			membersStatus := []workloads.MemberStatus{
+				{PodName: "pod-0", ReplicaRole: &workloads.ReplicaRole{Name: "Follower"}},
+				{PodName: "pod-1", ReplicaRole: &workloads.ReplicaRole{Name: "Leader"}},
+			}
+			mixedCasePriorityMap := ComposeRolePriorityMap([]workloads.ReplicaRole{
+				{Name: "Follower", UpdatePriority: 1},
+				{Name: "Leader", UpdatePriority: 2},
+			})
+
+			sortMembersStatus(membersStatus, mixedCasePriorityMap)
+			Expect(membersStatus[0].PodName).Should(Equal("pod-1"))
+			Expect(membersStatus[1].PodName).Should(Equal("pod-0"))
+		})
 	})
 })

--- a/pkg/controller/instanceset/update_plan.go
+++ b/pkg/controller/instanceset/update_plan.go
@@ -147,11 +147,12 @@ func (p *realUpdatePlan) buildBestEffortParallelUpdatePlan(rolePriorityMap map[s
 	quorumPriority := math.MaxInt32
 	leaderPriority := 0
 	for _, role := range p.its.Spec.Roles {
-		if rolePriorityMap[role.Name] > leaderPriority {
-			leaderPriority = rolePriorityMap[role.Name]
+		rolePriority := getRolePriority(rolePriorityMap, role.Name)
+		if rolePriority > leaderPriority {
+			leaderPriority = rolePriority
 		}
-		if role.ParticipatesInQuorum && quorumPriority > rolePriorityMap[role.Name] {
-			quorumPriority = rolePriorityMap[role.Name]
+		if role.ParticipatesInQuorum && quorumPriority > rolePriority {
+			quorumPriority = rolePriority
 		}
 	}
 
@@ -160,7 +161,7 @@ func (p *realUpdatePlan) buildBestEffortParallelUpdatePlan(rolePriorityMap map[s
 	podList := p.pods
 	for i, pod := range podList {
 		roleName := getRoleName(&pod)
-		if rolePriorityMap[roleName] < quorumPriority {
+		if getRolePriority(rolePriorityMap, roleName) < quorumPriority {
 			vertex := &model.ObjectVertex{Obj: &podList[i]}
 			p.dag.AddConnect(preVertex, vertex)
 			currentVertex = vertex
@@ -174,7 +175,7 @@ func (p *realUpdatePlan) buildBestEffortParallelUpdatePlan(rolePriorityMap map[s
 	followerCount := 0
 	for _, pod := range podList {
 		roleName := getRoleName(&pod)
-		if rolePriorityMap[roleName] < leaderPriority {
+		if getRolePriority(rolePriorityMap, roleName) < leaderPriority {
 			followerCount++
 		}
 	}

--- a/pkg/controller/instanceset/update_plan_test.go
+++ b/pkg/controller/instanceset/update_plan_test.go
@@ -170,6 +170,26 @@ var _ = Describe("update plan test.", func() {
 			checkPlan(expectedPlan, true)
 		})
 
+		It("should preserve best effort parallel layers with mixed-case roles", func() {
+			its.Spec.MemberUpdateStrategy = ptr.To(workloads.BestEffortParallelUpdateStrategy)
+			its.Spec.Roles = []workloads.ReplicaRole{
+				{Name: "Follower", ParticipatesInQuorum: true, UpdatePriority: 1},
+				{Name: "Leader", ParticipatesInQuorum: true, UpdatePriority: 2},
+			}
+			for _, pod := range []*corev1.Pod{pod0, pod3, pod6} {
+				pod.Labels[RoleLabelKey] = "Follower"
+			}
+			pod5.Labels[RoleLabelKey] = "Leader"
+
+			expectedPlan := [][]*corev1.Pod{
+				{pod4, pod2, pod1},
+				{pod6},
+				{pod3, pod0},
+				{pod5},
+			}
+			checkPlan(expectedPlan, true)
+		})
+
 		It("should work well with role-less and heterogeneous pods", func() {
 			By("build a serial plan with role-less and heterogeneous pods")
 			its.Spec.MemberUpdateStrategy = ptr.To(workloads.SerialUpdateStrategy)

--- a/pkg/controller/instanceset/utils.go
+++ b/pkg/controller/instanceset/utils.go
@@ -49,13 +49,16 @@ func ComposeRolePriorityMap(roles []workloads.ReplicaRole) map[string]int {
 	return rolePriorityMap
 }
 
+func getRolePriority(rolePriorityMap map[string]int, roleName string) int {
+	return rolePriorityMap[strings.ToLower(roleName)]
+}
+
 // SortPods sorts pods by their role priority
 // e.g.: unknown -> empty -> learner -> follower1 -> follower2 -> leader, with follower1.Name > follower2.Name
 // reverse it if reverse==true
 func SortPods(pods []corev1.Pod, rolePriorityMap map[string]int, reverse bool) {
 	getRolePriorityFunc := func(i int) int {
-		role := getRoleName(&pods[i])
-		return rolePriorityMap[role]
+		return getRolePriority(rolePriorityMap, getRoleName(&pods[i]))
 	}
 	getNameNOrdinalFunc := func(i int) (string, int) {
 		return ParseParentNameAndOrdinal(pods[i].GetName())


### PR DESCRIPTION
## What changed

- backport the InstanceSet role-priority normalization from #10700
- preserve `BestEffortParallel` quorum layers for mixed-case `ReplicaRole.Name` values
- normalize the release-1.0-only `MembersStatus` sorting path as well
- add regression coverage for planner concurrency and member-status ordering

## Why

The priority map stores role names in lower case, while several consumers queried it with the original API role name. Mixed-case names such as `Follower` and `Leader` could therefore collapse to the default priority, allowing quorum members into the same update layer and producing incorrect member ordering.

No data migration or feature gate is required.

## Validation

`go test ./pkg/controller/instanceset -count=1`

Fixes #10641.
