### PR TITLE
fix(instanceset): keep pending pods inside rolling window

### DIFF
--- a/pkg/controller/instanceset/reconciler_update.go
+++ b/pkg/controller/instanceset/reconciler_update.go
@@ -120,7 +120,10 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 
 	// treat old and Pending pod as a special case, as they can be updated without a consequence
 	// PodUpdatePolicy is ignored here since in-place update for a pending pod doesn't make much sense.
-	for _, pod := range oldPodList {
+	for i, pod := range oldPodList {
+		if i >= rollingUpdateQuota {
+			break
+		}
 		updatePolicy, _, err := getPodUpdatePolicy(its, pod)
 		if err != nil {
 			return kubebuilderx.Continue, err

--- a/pkg/controller/instanceset/reconciler_update_test.go
+++ b/pkg/controller/instanceset/reconciler_update_test.go
@@ -302,6 +302,44 @@ var _ = Describe("update reconciler test", func() {
 			expectUpdatedPods(tree, []string{lastPod.GetName()})
 		})
 
+		It("keeps a pending pod outside the rolling-update window untouched", func() {
+			tree := kubebuilderx.NewObjectTree()
+			its.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+			its.Spec.InstanceUpdateStrategy = &workloads.InstanceUpdateStrategy{
+				RollingUpdate: &workloads.RollingUpdate{
+					Replicas:       ptr.To(intstr.FromInt32(1)),
+					MaxUnavailable: ptr.To(intstr.FromInt32(2)),
+				},
+			}
+			tree.SetRoot(its)
+
+			prepareForUpdate(tree)
+
+			for _, object := range tree.List(&corev1.Pod{}) {
+				pod, ok := object.(*corev1.Pod)
+				Expect(ok).Should(BeTrue())
+				pod.Labels[appsv1.ControllerRevisionHashLabelKey] = "old-revision"
+				if pod.Name == "bar-0" {
+					pod.Status.Phase = corev1.PodPending
+					continue
+				}
+				pod.Status.Phase = corev1.PodRunning
+				pod.Status.Conditions = append(pod.Status.Conditions, getPodReadyCondition())
+			}
+
+			reconciler = NewUpdateReconciler()
+			res, err := reconciler.Reconcile(tree)
+			Expect(err).Should(BeNil())
+			Expect(res).Should(Equal(kubebuilderx.Continue))
+			expectUpdatedPods(tree, []string{"bar-2"})
+
+			pending := builder.NewPodBuilder(namespace, "bar-0").GetObject()
+			object, err := tree.Get(pending)
+			Expect(err).Should(BeNil())
+			Expect(object).ShouldNot(BeNil())
+			Expect(object.(*corev1.Pod).Status.Phase).Should(Equal(corev1.PodPending))
+		})
+
 		It("respects maxUnavailable with pending pods", func() {
 			// update order: bar-2, bar-1, bar-0
 			tree := kubebuilderx.NewObjectTree()


### PR DESCRIPTION
## What changed

- backport #10664 to `release-1.1`
- keep outdated Pending Pods inside the ordered `rollingUpdate.replicas` window
- leave Pending Pods outside the selected window untouched
- retain the release-1.1 `getPodUpdatePolicy` contract while resolving the main-branch conflict
- add the out-of-window Pending Pod regression test

## Auto-pick verification

The final release-1.1 commit `b5584b3a3` was actually cherry-picked onto the latest `release-1.0` tip `6b94e3298` with no conflicts. The resulting release-1.0 tree passed both validation suites below, so this PR can use the `pick-1.0` auto-pick path and does not need a separate release-1.0 PR.

## Validation

- `go test ./pkg/controller/instanceset -count=1`
- `go test ./controllers/workloads -run TestAPIs -ginkgo.focus='rolling' -count=1`
- repeated both tests against the actual release-1.0 cherry-pick result

Fixes #10641.
