### PR TITLE
fix(instanceset): normalize observed role names

### DIFF
--- a/pkg/controller/instanceset2/instance_util.go
+++ b/pkg/controller/instanceset2/instance_util.go
@@ -65,8 +65,7 @@ func parseParentNameAndOrdinal(s string) (string, int) {
 // reverse it if reverse==true
 func sortObjects[T client.Object](objects []T, rolePriorityMap map[string]int, reverse bool) {
 	getRolePriorityFunc := func(i int) int {
-		role := strings.ToLower(objects[i].GetLabels()[constant.RoleLabelKey])
-		return rolePriorityMap[role]
+		return getRolePriority(rolePriorityMap, objects[i].GetLabels()[constant.RoleLabelKey])
 	}
 
 	// cache the parent names and ordinals to accelerate the parsing process when there is a massive number of Pods.

--- a/pkg/controller/instanceset2/update_plan.go
+++ b/pkg/controller/instanceset2/update_plan.go
@@ -144,11 +144,12 @@ func (p *realUpdatePlan) buildBestEffortParallelUpdatePlan(rolePriorityMap map[s
 	quorumPriority := math.MaxInt32
 	leaderPriority := 0
 	for _, role := range p.its.Spec.Roles {
-		if rolePriorityMap[role.Name] > leaderPriority {
-			leaderPriority = rolePriorityMap[role.Name]
+		rolePriority := getRolePriority(rolePriorityMap, role.Name)
+		if rolePriority > leaderPriority {
+			leaderPriority = rolePriority
 		}
-		if role.ParticipatesInQuorum && quorumPriority > rolePriorityMap[role.Name] {
-			quorumPriority = rolePriorityMap[role.Name]
+		if role.ParticipatesInQuorum && quorumPriority > rolePriority {
+			quorumPriority = rolePriority
 		}
 	}
 
@@ -157,7 +158,7 @@ func (p *realUpdatePlan) buildBestEffortParallelUpdatePlan(rolePriorityMap map[s
 	instanceList := p.instances
 	for i, inst := range instanceList {
 		roleName := getInstanceRoleName(&inst)
-		if rolePriorityMap[roleName] < quorumPriority {
+		if getRolePriority(rolePriorityMap, roleName) < quorumPriority {
 			vertex := &model.ObjectVertex{Obj: &instanceList[i]}
 			p.dag.AddConnect(preVertex, vertex)
 			currentVertex = vertex
@@ -171,7 +172,7 @@ func (p *realUpdatePlan) buildBestEffortParallelUpdatePlan(rolePriorityMap map[s
 	followerCount := 0
 	for _, inst := range instanceList {
 		roleName := getInstanceRoleName(&inst)
-		if rolePriorityMap[roleName] < leaderPriority {
+		if getRolePriority(rolePriorityMap, roleName) < leaderPriority {
 			followerCount++
 		}
 	}

--- a/pkg/controller/instanceset2/update_plan_test.go
+++ b/pkg/controller/instanceset2/update_plan_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package instanceset2
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/controller/revisionmap"
+)
+
+func TestBestEffortParallelUpdatePlanNormalizesMixedCaseRoles(t *testing.T) {
+	roles := []workloads.ReplicaRole{
+		{Name: "Follower", ParticipatesInQuorum: true, UpdatePriority: 1},
+		{Name: "Leader", ParticipatesInQuorum: true, UpdatePriority: 2},
+	}
+	instances := []*workloads.Instance{
+		newUpdatePlanTestInstance("mysql-0", "Follower", roles),
+		newUpdatePlanTestInstance("mysql-1", "Follower", roles),
+		newUpdatePlanTestInstance("mysql-2", "Follower", roles),
+		newUpdatePlanTestInstance("mysql-3", "Follower", roles),
+		newUpdatePlanTestInstance("mysql-4", "Leader", roles),
+	}
+	updateRevisions := make(map[string]string, len(instances))
+	for _, inst := range instances {
+		updateRevisions[inst.Name] = "new-revision"
+	}
+	encodedRevisions, err := revisionmap.Encode(updateRevisions)
+	if err != nil {
+		t.Fatalf("encode update revisions: %v", err)
+	}
+	its := workloads.InstanceSet{
+		Spec: workloads.InstanceSetSpec{
+			Roles:                roles,
+			MemberUpdateStrategy: ptr.To(workloads.BestEffortParallelUpdateStrategy),
+		},
+		Status: workloads.InstanceSetStatus{UpdateRevisions: encodedRevisions},
+	}
+
+	expectedLayers := [][]string{
+		{"mysql-2", "mysql-3"},
+		{"mysql-0", "mysql-1"},
+		{"mysql-4"},
+	}
+	for _, expected := range expectedLayers {
+		updated, err := newUpdatePlan(its, instances).Execute()
+		if err != nil {
+			t.Fatalf("execute update plan: %v", err)
+		}
+		if got := sortedInstanceNames(updated); !reflect.DeepEqual(got, expected) {
+			t.Fatalf("updated instances = %v, want %v", got, expected)
+		}
+		for _, updatedInst := range updated {
+			for _, inst := range instances {
+				if inst.Name == updatedInst.Name {
+					inst.Annotations[instanceSetRevisionAnnotationKey] = "new-revision"
+					break
+				}
+			}
+		}
+	}
+}
+
+func newUpdatePlanTestInstance(name, role string, roles []workloads.ReplicaRole) *workloads.Instance {
+	return &workloads.Instance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Generation:  1,
+			Annotations: map[string]string{instanceSetRevisionAnnotationKey: "old-revision"},
+		},
+		Spec: workloads.InstanceSpec{Roles: roles},
+		Status: workloads.InstanceStatus2{
+			ObservedGeneration: 1,
+			UpToDate:           true,
+			Role:               role,
+			Conditions: []metav1.Condition{
+				{Type: string(workloads.InstanceReady), Status: metav1.ConditionTrue},
+			},
+		},
+	}
+}
+
+func sortedInstanceNames(instances []*workloads.Instance) []string {
+	names := make([]string, 0, len(instances))
+	for _, inst := range instances {
+		names = append(names, inst.Name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/pkg/controller/instanceset2/utils.go
+++ b/pkg/controller/instanceset2/utils.go
@@ -43,6 +43,10 @@ func composeRolePriorityMap(roles []workloads.ReplicaRole) map[string]int {
 	return rolePriorityMap
 }
 
+func getRolePriority(rolePriorityMap map[string]int, roleName string) int {
+	return rolePriorityMap[strings.ToLower(roleName)]
+}
+
 // sortInstances sorts instances by their role priority
 // e.g.: unknown -> empty -> learner -> follower1 -> follower2 -> leader, with follower1.Name > follower2.Name
 // reverse it if reverse==true
@@ -61,8 +65,7 @@ func sortInstanceObjects(instances []*workloads.Instance, rolePriorityMap map[st
 func sortInstancesByRole[T any](instances []T, instanceAt func(int) *workloads.Instance,
 	rolePriorityMap map[string]int, reverse bool) {
 	getRolePriorityFunc := func(i int) int {
-		role := getInstanceRoleName(instanceAt(i))
-		return rolePriorityMap[role]
+		return getRolePriority(rolePriorityMap, getInstanceRoleName(instanceAt(i)))
 	}
 	getNameNOrdinalFunc := func(i int) (string, int) {
 		return parseParentNameAndOrdinal(instanceAt(i).GetName())
@@ -71,7 +74,7 @@ func sortInstancesByRole[T any](instances []T, instanceAt func(int) *workloads.I
 }
 
 func getInstanceRoleName(inst *workloads.Instance) string {
-	return inst.Status.Role
+	return strings.ToLower(inst.Status.Role)
 }
 
 func composeRoleMap(its workloads.InstanceSet) map[string]workloads.ReplicaRole {


### PR DESCRIPTION
## What changed

- manually backport #10677 to release-1.1
- normalize observed Instance role names before building and looking up ITS2 role priorities
- keep BestEffortParallel update layers correct when role names use mixed case
- add a planner regression test for the mixed-case role scenario

## Why

The automatic pick failed because release-1.1 deleted pkg/controller/instanceset2/instance_util_test.go in #10469, while #10677 modifies that file. The ITS2 production code still exists on release-1.1 and needs the role normalization fix.

This manual backport preserves the test-file deletion from release-1.1 and ports the production changes plus the new planner regression test.

## Impact

BestEffortParallel rolling updates no longer assign priority 0 to valid mixed-case observed roles, avoiding selection of the wrong update members when replicas is less than total.

## Validation

- go test -mod=mod ./pkg/controller/instanceset2 -run TestBestEffortParallelUpdatePlanNormalizesMixedCaseRoles -count=1
- go test -mod=mod ./pkg/controller/instanceset2 -count=1

Fixes #10641.