### PR TITLE
fix: serialize restored system account intent

### DIFF
--- a/cmd/dataprotection/main.go
+++ b/cmd/dataprotection/main.go
@@ -320,6 +320,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err = (&dpcontrollers.SystemAccountConflictReceiptLifecycleReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "SystemAccountConflictReceiptLifecycle")
+		os.Exit(1)
+	}
+
 	if err = (&dpcontrollers.BackupPolicyReconciler{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -499,6 +499,14 @@ func main() {
 			os.Exit(1)
 		}
 
+		if err = (&appscontrollers.SystemAccountRestoreLifecycleReconciler{
+			Client: client,
+			Scheme: mgr.GetScheme(),
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "SystemAccountRestoreLifecycle")
+			os.Exit(1)
+		}
+
 		if err = (&appscontrollers.ServiceDescriptorReconciler{
 			Client:   mgr.GetClient(),
 			Scheme:   mgr.GetScheme(),

--- a/controllers/apps/cluster/cluster_plan_builder.go
+++ b/controllers/apps/cluster/cluster_plan_builder.go
@@ -356,6 +356,7 @@ func (c *clusterPlanBuilder) reconcileDeleteObject(ctx context.Context, node *mo
 		deletePropagation := metav1.DeletePropagationBackground
 		deleteOptions := &client.DeleteOptions{
 			PropagationPolicy: &deletePropagation,
+			Preconditions:     node.DeletePreconditions,
 		}
 		if err := c.cli.Delete(ctx, node.Obj, deleteOptions, clientOption(node)); err != nil {
 			return client.IgnoreNotFound(err)

--- a/controllers/apps/cluster/cluster_plan_builder_delete_test.go
+++ b/controllers/apps/cluster/cluster_plan_builder_delete_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/apecloud/kubeblocks/pkg/controller/model"
+)
+
+func TestClusterPlanDeleteKeepsReplacementWithDifferentUID(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	replacement := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "system-account",
+		UID:       "replacement-uid",
+	}}
+	oldUID := types.UID("old-uid")
+	var observedUID *types.UID
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(replacement).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, cli client.WithWatch, obj client.Object,
+				opts ...client.DeleteOption) error {
+				deleteOptions := &client.DeleteOptions{}
+				deleteOptions.ApplyOptions(opts)
+				if deleteOptions.Preconditions == nil || deleteOptions.Preconditions.UID == nil {
+					return fmt.Errorf("delete has no UID precondition")
+				}
+				uid := *deleteOptions.Preconditions.UID
+				observedUID = &uid
+				current := &corev1.ConfigMap{}
+				if err := cli.Get(ctx, client.ObjectKeyFromObject(obj), current); err != nil {
+					return err
+				}
+				if current.UID != uid {
+					return apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"},
+						obj.GetName(), fmt.Errorf("UID precondition %s does not match %s", uid, current.UID))
+				}
+				return cli.Delete(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	builder := &clusterPlanBuilder{
+		cli: cli,
+		transCtx: &clusterTransformContext{
+			Context: context.Background(),
+			Logger:  logr.Discard(),
+		},
+	}
+	stale := replacement.DeepCopy()
+	stale.UID = oldUID
+	err := builder.defaultWalkFunc(&model.ObjectVertex{
+		Obj:                 stale,
+		Action:              model.ActionDeletePtr(),
+		DeletePreconditions: &metav1.Preconditions{UID: &oldUID},
+	})
+	if !apierrors.IsConflict(err) {
+		t.Fatalf("expected UID conflict, got %v", err)
+	}
+	if observedUID == nil || *observedUID != oldUID {
+		t.Fatalf("delete UID precondition = %v, want %s", observedUID, oldUID)
+	}
+	current := &corev1.ConfigMap{}
+	if err := cli.Get(context.Background(), client.ObjectKeyFromObject(replacement), current); err != nil {
+		t.Fatalf("replacement was deleted: %v", err)
+	}
+	if current.UID != replacement.UID {
+		t.Fatalf("replacement UID = %s, want %s", current.UID, replacement.UID)
+	}
+}

--- a/controllers/apps/cluster/transformer_cluster_component.go
+++ b/controllers/apps/cluster/transformer_cluster_component.go
@@ -766,9 +766,7 @@ func (h *clusterComponentHandler) delete(transCtx *clusterTransformContext, dag 
 
 	transCtx.Logger.Info(fmt.Sprintf("deleting component %s", comp.Name))
 	graphCli, _ := transCtx.Client.(model.GraphClient)
-	graphCli.Delete(dag, comp)
-
-	return nil
+	return graphCli.Delete(dag, comp)
 }
 
 func (h *clusterComponentHandler) update(transCtx *clusterTransformContext, dag *graph.DAG, name string) error {

--- a/controllers/apps/cluster/transformer_cluster_deletion.go
+++ b/controllers/apps/cluster/transformer_cluster_deletion.go
@@ -116,13 +116,17 @@ func (t *clusterDeletionTransformer) Transform(ctx graph.TransformContext, dag *
 		if isOwnedByComp(o) || appsutil.IsOwnedByInstanceSet(o) {
 			continue
 		}
-		graphCli.Delete(dag, o)
+		if err := graphCli.Delete(dag, o); err != nil {
+			return err
+		}
 	}
 
 	// set cluster action to status until all the sub-resources deleted
 	if len(delObjs) == 0 {
 		transCtx.Logger.Info(fmt.Sprintf("deleting cluster %v", klog.KObj(cluster)))
-		graphCli.Delete(dag, cluster)
+		if err := graphCli.Delete(dag, cluster); err != nil {
+			return err
+		}
 	} else {
 		transCtx.Logger.Info(fmt.Sprintf("deleting the sub-resource kinds: %v", maps.Keys(delKindMap)))
 		graphCli.Status(dag, cluster, transCtx.Cluster)

--- a/controllers/apps/cluster/transformer_cluster_service.go
+++ b/controllers/apps/cluster/transformer_cluster_service.go
@@ -75,7 +75,9 @@ func (t *clusterServiceTransformer) Transform(ctx graph.TransformContext, dag *g
 		t.updateService(dag, graphCli, services[svc], protoServices[svc])
 	}
 	for svc := range toDeleteServices {
-		graphCli.Delete(dag, services[svc], inDataContext4G())
+		if err := graphCli.Delete(dag, services[svc], inDataContext4G()); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/controllers/apps/cluster/transformer_cluster_sharding_account.go
+++ b/controllers/apps/cluster/transformer_cluster_sharding_account.go
@@ -35,6 +35,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
 	"github.com/apecloud/kubeblocks/pkg/controller/systemaccount"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 )
 
 // clusterShardingAccountTransformer handles shared system accounts for sharding.
@@ -50,7 +51,32 @@ func (t *clusterShardingAccountTransformer) Transform(ctx graph.TransformContext
 
 	graphCli, _ := transCtx.Client.(model.GraphClient)
 	handled, err := systemaccount.ReconcileRestoreRequests(transCtx.Context, graphCli, dag,
-		transCtx.Cluster, constant.DBClusterFinalizerName)
+		transCtx.Cluster, constant.DBClusterFinalizerName,
+		func(intent systemaccount.CredentialIntent) (*corev1.Secret, error) {
+			var sharding *appsv1.ClusterSharding
+			for i := range transCtx.shardings {
+				if transCtx.shardings[i].Name == intent.Target.ShardingName {
+					sharding = transCtx.shardings[i]
+					break
+				}
+			}
+			if sharding == nil {
+				return nil, systemaccount.NewTargetSemanticError(
+					systemaccount.TargetSemanticUnavailableReason,
+					fmt.Errorf("sharding %s is unavailable", intent.Target.ShardingName))
+			}
+			if _, err := t.definedSystemAccount(transCtx, sharding, intent.Target.Account); err != nil {
+				return nil, systemaccount.NewTargetSemanticError(
+					systemaccount.AccountUnavailableReason, err)
+			}
+			password := intent.Credentials[constant.AccountPasswdForSecret]
+			if len(password) == 0 {
+				return nil, systemaccount.NewTargetSemanticError(
+					systemaccount.TargetSemanticUnavailableReason,
+					fmt.Errorf("system account %s credential is unavailable", intent.Target.Account))
+			}
+			return t.newAccountSecretWithPassword(transCtx, sharding, intent.Target.Account, password)
+		})
 	if err != nil {
 		return err
 	}
@@ -189,6 +215,10 @@ func (t *clusterShardingAccountTransformer) newAccountSecretWithPassword(transCt
 		PutData(constant.AccountPasswdForSecret, password).
 		SetImmutable(true).
 		GetObject()
+	if err := intctrlutil.SetOwnership(cluster, secret, model.GetScheme(),
+		constant.DBClusterFinalizerName); err != nil {
+		return nil, err
+	}
 	return secret, nil
 }
 

--- a/controllers/apps/cluster/transformer_cluster_sharding_account.go
+++ b/controllers/apps/cluster/transformer_cluster_sharding_account.go
@@ -34,6 +34,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/builder"
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
+	"github.com/apecloud/kubeblocks/pkg/controller/systemaccount"
 )
 
 // clusterShardingAccountTransformer handles shared system accounts for sharding.
@@ -47,12 +48,20 @@ func (t *clusterShardingAccountTransformer) Transform(ctx graph.TransformContext
 		return nil
 	}
 
+	graphCli, _ := transCtx.Client.(model.GraphClient)
+	handled, err := systemaccount.ReconcileRestoreRequests(transCtx.Context, graphCli, dag,
+		transCtx.Cluster, constant.DBClusterFinalizerName)
+	if err != nil {
+		return err
+	}
+	if handled {
+		return nil
+	}
+
 	if common.IsCompactMode(transCtx.Cluster.Annotations) {
 		transCtx.V(1).Info("Cluster is in compact mode, no need to create account related objects", "cluster", client.ObjectKeyFromObject(transCtx.Cluster))
 		return nil
 	}
-
-	graphCli, _ := transCtx.Client.(model.GraphClient)
 	return t.reconcileShardingAccounts(transCtx, graphCli, dag)
 }
 

--- a/controllers/apps/component/component_plan_builder.go
+++ b/controllers/apps/component/component_plan_builder.go
@@ -232,6 +232,9 @@ func (c *componentPlanBuilder) reconcileDeleteObject(ctx context.Context, vertex
 		if len(vertex.PropagationPolicy) > 0 {
 			opts = append(opts, vertex.PropagationPolicy)
 		}
+		if vertex.DeletePreconditions != nil {
+			opts = append(opts, client.Preconditions(*vertex.DeletePreconditions))
+		}
 		err := c.cli.Delete(ctx, vertex.Obj, opts...)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return err

--- a/controllers/apps/component/component_plan_builder_delete_test.go
+++ b/controllers/apps/component/component_plan_builder_delete_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package component
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/apecloud/kubeblocks/pkg/controller/model"
+)
+
+func TestComponentPlanDeleteKeepsReplacementWithDifferentUID(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	replacement := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "system-account",
+		UID:       "replacement-uid",
+	}}
+	oldUID := types.UID("old-uid")
+	var observedUID *types.UID
+	cli := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(replacement).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, cli client.WithWatch, obj client.Object,
+				opts ...client.DeleteOption) error {
+				deleteOptions := &client.DeleteOptions{}
+				deleteOptions.ApplyOptions(opts)
+				if deleteOptions.Preconditions == nil || deleteOptions.Preconditions.UID == nil {
+					return fmt.Errorf("delete has no UID precondition")
+				}
+				uid := *deleteOptions.Preconditions.UID
+				observedUID = &uid
+				current := &corev1.ConfigMap{}
+				if err := cli.Get(ctx, client.ObjectKeyFromObject(obj), current); err != nil {
+					return err
+				}
+				if current.UID != uid {
+					return apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"},
+						obj.GetName(), fmt.Errorf("UID precondition %s does not match %s", uid, current.UID))
+				}
+				return cli.Delete(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	builder := &componentPlanBuilder{
+		cli: cli,
+		transCtx: &componentTransformContext{
+			Context: context.Background(),
+			Logger:  logr.Discard(),
+		},
+	}
+	stale := replacement.DeepCopy()
+	stale.UID = oldUID
+	err := builder.defaultWalkFunc(&model.ObjectVertex{
+		Obj:                 stale,
+		Action:              model.ActionDeletePtr(),
+		DeletePreconditions: &metav1.Preconditions{UID: &oldUID},
+	})
+	if !apierrors.IsConflict(err) {
+		t.Fatalf("expected UID conflict, got %v", err)
+	}
+	if observedUID == nil || *observedUID != oldUID {
+		t.Fatalf("delete UID precondition = %v, want %s", observedUID, oldUID)
+	}
+	current := &corev1.ConfigMap{}
+	if err := cli.Get(context.Background(), client.ObjectKeyFromObject(replacement), current); err != nil {
+		t.Fatalf("replacement was deleted: %v", err)
+	}
+	if current.UID != replacement.UID {
+		t.Fatalf("replacement UID = %s, want %s", current.UID, replacement.UID)
+	}
+}

--- a/controllers/apps/component/transformer_component_account.go
+++ b/controllers/apps/component/transformer_component_account.go
@@ -64,7 +64,28 @@ func (t *componentAccountTransformer) Transform(ctx graph.TransformContext, dag 
 	}
 	graphCli, _ := transCtx.Client.(model.GraphClient)
 	handled, err := systemaccount.ReconcileRestoreRequests(transCtx.Context, graphCli, dag,
-		transCtx.Component, constant.DBComponentFinalizerName)
+		transCtx.Component, constant.DBComponentFinalizerName,
+		func(intent systemaccount.CredentialIntent) (*corev1.Secret, error) {
+			accounts, err := synthesizeSystemAccounts(transCtx.CompDef.Spec.SystemAccounts,
+				transCtx.Component.Spec.SystemAccounts, false)
+			if err != nil {
+				return nil, systemaccount.NewTargetSemanticError(
+					systemaccount.TargetSemanticUnavailableReason, err)
+			}
+			account, ok := accounts[intent.Target.Account]
+			if !ok {
+				return nil, systemaccount.NewTargetSemanticError(
+					systemaccount.AccountUnavailableReason,
+					fmt.Errorf("system account %s is unavailable", intent.Target.Account))
+			}
+			password := intent.Credentials[constant.AccountPasswdForSecret]
+			if len(password) == 0 {
+				return nil, systemaccount.NewTargetSemanticError(
+					systemaccount.TargetSemanticUnavailableReason,
+					fmt.Errorf("system account %s credential is unavailable", intent.Target.Account))
+			}
+			return t.buildAccountSecretWithPassword(transCtx, account, password)
+		})
 	if err != nil {
 		return err
 	}
@@ -103,7 +124,9 @@ func (t *componentAccountTransformer) Transform(ctx graph.TransformContext, dag 
 	}
 
 	for _, name := range sets.List(deleteSet) {
-		t.deleteAccount(transCtx, dag, graphCli, secrets[name])
+		if err := t.deleteAccount(transCtx, dag, graphCli, secrets[name]); err != nil {
+			return err
+		}
 	}
 
 	for _, name := range sets.List(updateSet) {
@@ -139,8 +162,8 @@ func (t *componentAccountTransformer) createAccount(transCtx *componentTransform
 }
 
 func (t *componentAccountTransformer) deleteAccount(transCtx *componentTransformContext,
-	dag *graph.DAG, graphCli model.GraphClient, secret *corev1.Secret) {
-	graphCli.Delete(dag, secret)
+	dag *graph.DAG, graphCli model.GraphClient, secret *corev1.Secret) error {
+	return graphCli.Delete(dag, secret)
 }
 
 func (t *componentAccountTransformer) updateAccount(transCtx *componentTransformContext,
@@ -160,6 +183,8 @@ func (t *componentAccountTransformer) updateAccount(transCtx *componentTransform
 	}
 	ctrlutil.MergeMetadataMapInplace(secret.Labels, &runningCopy.Labels)
 	ctrlutil.MergeMetadataMapInplace(secret.Annotations, &runningCopy.Annotations)
+	systemaccount.ClearStaleTargetRestoreReceipt(
+		runningCopy, constant.DBComponentFinalizerName)
 	if !reflect.DeepEqual(running, runningCopy) {
 		graphCli.Update(dag, running, runningCopy)
 	}

--- a/controllers/apps/component/transformer_component_account.go
+++ b/controllers/apps/component/transformer_component_account.go
@@ -38,6 +38,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
+	"github.com/apecloud/kubeblocks/pkg/controller/systemaccount"
 	ctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 )
 
@@ -61,13 +62,22 @@ func (t *componentAccountTransformer) Transform(ctx graph.TransformContext, dag 
 	if isCompDeleting(transCtx.ComponentOrig) {
 		return nil
 	}
+	graphCli, _ := transCtx.Client.(model.GraphClient)
+	handled, err := systemaccount.ReconcileRestoreRequests(transCtx.Context, graphCli, dag,
+		transCtx.Component, constant.DBComponentFinalizerName)
+	if err != nil {
+		return err
+	}
+	if handled {
+		return nil
+	}
+
 	if common.IsCompactMode(transCtx.ComponentOrig.Annotations) {
 		transCtx.V(1).Info("Component is in compact mode, no need to create account related objects", "component", client.ObjectKeyFromObject(transCtx.ComponentOrig))
 		return nil
 	}
 
 	synthesizedComp := transCtx.SynthesizeComponent
-	graphCli, _ := transCtx.Client.(model.GraphClient)
 
 	// exist account objects
 	secrets, err := listSystemAccountObjects(ctx, synthesizedComp)

--- a/controllers/apps/component/transformer_component_deletion.go
+++ b/controllers/apps/component/transformer_component_deletion.go
@@ -109,7 +109,9 @@ func (t *componentDeletionTransformer) deleteCompResources(transCtx *componentTr
 	}
 	if len(workloads) > 0 {
 		for _, workload := range workloads {
-			graphCli.Delete(dag, workload)
+			if err := graphCli.Delete(dag, workload); err != nil {
+				return err
+			}
 		}
 		// wait for the workloads to be deleted to trigger the next reconcile
 		transCtx.Logger.Info(fmt.Sprintf("wait for the workloads to be deleted: %v", workloads))
@@ -134,7 +136,9 @@ func (t *componentDeletionTransformer) deleteCompResources(transCtx *componentTr
 					return fmt.Errorf("handle rbac deletion failed: %w", err)
 				}
 			default:
-				graphCli.Delete(dag, object)
+				if err := graphCli.Delete(dag, object); err != nil {
+					return err
+				}
 			}
 		}
 		graphCli.Status(dag, comp, transCtx.Component)
@@ -143,7 +147,9 @@ func (t *componentDeletionTransformer) deleteCompResources(transCtx *componentTr
 		if err = notifyDependents4CompDeletion(transCtx, dag); err != nil {
 			return intctrlutil.NewRequeueError(appsutil.RequeueDuration, fmt.Sprintf("notify dependent components error: %s", err.Error()))
 		}
-		graphCli.Delete(dag, comp)
+		if err := graphCli.Delete(dag, comp); err != nil {
+			return err
+		}
 	}
 
 	// release the allocated host-network ports for the component
@@ -162,8 +168,7 @@ func handleRBACResourceDeletion(obj client.Object, transCtx *componentTransformC
 	// rolebinding and serviceaccount have the same name
 	newName := constant.GenerateDefaultServiceAccountNameNew(comp.Name)
 	if obj.GetName() == newName {
-		graphCli.Delete(dag, obj)
-		return
+		return graphCli.Delete(dag, obj)
 	}
 
 	// orphan a rbac resource so that it can be adopted by another component

--- a/controllers/apps/component/transformer_component_service.go
+++ b/controllers/apps/component/transformer_component_service.go
@@ -98,7 +98,9 @@ func (t *componentServiceTransformer) Transform(ctx graph.TransformContext, dag 
 	}
 
 	for svc := range runningServices {
-		graphCli.Delete(dag, runningServices[svc])
+		if err := graphCli.Delete(dag, runningServices[svc]); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/controllers/apps/component/transformer_component_template.go
+++ b/controllers/apps/component/transformer_component_template.go
@@ -73,7 +73,9 @@ func (t *componentFileTemplateTransformer) Transform(ctx graph.TransformContext,
 
 	toCreate, toDelete, toUpdate := mapDiff(runningObjs, protoObjs)
 
-	t.handleTemplateObjectChanges(transCtx, dag, runningObjs, protoObjs, toCreate, toDelete, toUpdate)
+	if err := t.handleTemplateObjectChanges(transCtx, dag, runningObjs, protoObjs, toCreate, toDelete, toUpdate); err != nil {
+		return err
+	}
 
 	for _, tpl := range transCtx.SynthesizeComponent.FileTemplates {
 		if obj := t.instanceAssistantObject(transCtx, tpl, protoObjs); obj != nil {
@@ -120,13 +122,15 @@ func (t *componentFileTemplateTransformer) precheck(transCtx *componentTransform
 }
 
 func (t *componentFileTemplateTransformer) handleTemplateObjectChanges(transCtx *componentTransformContext,
-	dag *graph.DAG, runningObjs, protoObjs map[string]*corev1.ConfigMap, toCreate, toDelete, toUpdate sets.Set[string]) {
+	dag *graph.DAG, runningObjs, protoObjs map[string]*corev1.ConfigMap, toCreate, toDelete, toUpdate sets.Set[string]) error {
 	graphCli, _ := transCtx.Client.(model.GraphClient)
 	for name := range toCreate {
 		graphCli.Create(dag, protoObjs[name])
 	}
 	for name := range toDelete {
-		graphCli.Delete(dag, runningObjs[name])
+		if err := graphCli.Delete(dag, runningObjs[name]); err != nil {
+			return err
+		}
 	}
 	for name := range toUpdate {
 		runningObj, protoObj := runningObjs[name], protoObjs[name]
@@ -136,6 +140,7 @@ func (t *componentFileTemplateTransformer) handleTemplateObjectChanges(transCtx 
 			graphCli.Update(dag, runningObj, protoObj)
 		}
 	}
+	return nil
 }
 
 func (t *componentFileTemplateTransformer) buildPodVolumes(transCtx *componentTransformContext) error {

--- a/controllers/apps/component/transformer_component_tls.go
+++ b/controllers/apps/component/transformer_component_tls.go
@@ -174,7 +174,7 @@ func (t *componentTLSTransformer) handleDelete(ctx context.Context, cli client.R
 	}
 	if secret != nil {
 		graphCli, _ := cli.(model.GraphClient)
-		graphCli.Delete(dag, secret) // TODO: notify the pods
+		return graphCli.Delete(dag, secret) // TODO: notify the pods
 	}
 	return nil
 }

--- a/controllers/apps/component/transformer_component_workload.go
+++ b/controllers/apps/component/transformer_component_workload.go
@@ -80,7 +80,7 @@ func (t *componentWorkloadTransformer) Transform(ctx graph.TransformContext, dag
 		}
 	} else {
 		if protoITS == nil {
-			graphCli.Delete(dag, runningITS)
+			err = graphCli.Delete(dag, runningITS)
 		} else {
 			err = t.handleUpdate(transCtx, graphCli, dag, synthesizeComp, comp, runningITS, protoITS)
 		}

--- a/controllers/apps/rollout/rollout_plan_builder.go
+++ b/controllers/apps/rollout/rollout_plan_builder.go
@@ -222,6 +222,9 @@ func (c *rolloutPlanBuilder) reconcileDeleteObject(ctx context.Context, vertex *
 		if len(vertex.PropagationPolicy) > 0 {
 			opts = append(opts, vertex.PropagationPolicy)
 		}
+		if vertex.DeletePreconditions != nil {
+			opts = append(opts, client.Preconditions(*vertex.DeletePreconditions))
+		}
 		err := c.cli.Delete(ctx, vertex.Obj, opts...)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return err

--- a/controllers/apps/rollout/rollout_plan_builder_delete_precondition_test.go
+++ b/controllers/apps/rollout/rollout_plan_builder_delete_precondition_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package rollout
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/apecloud/kubeblocks/pkg/controller/model"
+)
+
+func TestRolloutPlanDeleteKeepsReplacementWithDifferentUID(t *testing.T) {
+	replacement := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "system-account",
+		UID:       "replacement-uid",
+	}}
+	oldUID := types.UID("old-uid")
+	var observedUID *types.UID
+	cli := fake.NewClientBuilder().
+		WithScheme(testRolloutPlanBuilderScheme(t)).
+		WithObjects(replacement).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, cli client.WithWatch, obj client.Object,
+				opts ...client.DeleteOption) error {
+				deleteOptions := &client.DeleteOptions{}
+				deleteOptions.ApplyOptions(opts)
+				if deleteOptions.Preconditions == nil || deleteOptions.Preconditions.UID == nil {
+					return fmt.Errorf("delete has no UID precondition")
+				}
+				uid := *deleteOptions.Preconditions.UID
+				observedUID = &uid
+				current := &corev1.ConfigMap{}
+				if err := cli.Get(ctx, client.ObjectKeyFromObject(obj), current); err != nil {
+					return err
+				}
+				if current.UID != uid {
+					return apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"},
+						obj.GetName(), fmt.Errorf("UID precondition %s does not match %s", uid, current.UID))
+				}
+				return cli.Delete(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	builder := &rolloutPlanBuilder{
+		cli: cli,
+		transCtx: &rolloutTransformContext{
+			Context: context.Background(),
+			Logger:  logr.Discard(),
+		},
+	}
+	stale := replacement.DeepCopy()
+	stale.UID = oldUID
+	err := builder.defaultWalkFunc(&model.ObjectVertex{
+		Obj:                 stale,
+		Action:              model.ActionDeletePtr(),
+		DeletePreconditions: &metav1.Preconditions{UID: &oldUID},
+	})
+	if !apierrors.IsConflict(err) {
+		t.Fatalf("expected UID conflict, got %v", err)
+	}
+	if observedUID == nil || *observedUID != oldUID {
+		t.Fatalf("delete UID precondition = %v, want %s", observedUID, oldUID)
+	}
+	current := &corev1.ConfigMap{}
+	if err := cli.Get(context.Background(), client.ObjectKeyFromObject(replacement), current); err != nil {
+		t.Fatalf("replacement was deleted: %v", err)
+	}
+	if current.UID != replacement.UID {
+		t.Fatalf("replacement UID = %s, want %s", current.UID, replacement.UID)
+	}
+}

--- a/controllers/apps/rollout/transformer_rollout_deletion.go
+++ b/controllers/apps/rollout/transformer_rollout_deletion.go
@@ -65,7 +65,5 @@ func (t *rolloutDeletionTransformer) Transform(ctx graph.TransformContext, dag *
 
 	// TODO: rollback if the rollout is not succeed
 
-	graphCli.Delete(dag, rollout)
-
-	return nil
+	return graphCli.Delete(dag, rollout)
 }

--- a/controllers/apps/system_account_restore_controller.go
+++ b/controllers/apps/system_account_restore_controller.go
@@ -1,0 +1,652 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package apps
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"maps"
+	"slices"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/systemaccount"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+)
+
+type restoreOperationState string
+
+const (
+	restoreOperationActive      restoreOperationState = "Active"
+	restoreOperationSucceeded   restoreOperationState = "TerminalSuccess"
+	restoreOperationFailed      restoreOperationState = "TerminalFailure"
+	restoreOperationTerminating restoreOperationState = "Terminating"
+	restoreOperationGone        restoreOperationState = "Gone"
+)
+
+// SystemAccountRestoreLifecycleReconciler keeps request cleanup reachable when
+// Component and Cluster reconcilers return early during owner deletion.
+type SystemAccountRestoreLifecycleReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+func (r *SystemAccountRestoreLifecycleReconciler) Reconcile(
+	ctx context.Context,
+	req controllerruntime.Request,
+) (controllerruntime.Result, error) {
+	request := &corev1.Secret{}
+	if err := r.Client.Get(ctx, req.NamespacedName, request); err != nil {
+		return intctrlutil.CheckedRequeueWithError(err, log.FromContext(ctx), "")
+	}
+	if request.Annotations[systemaccount.RestoreProtocolAnnotationKey] != systemaccount.RestoreProtocolV2 {
+		return controllerruntime.Result{}, nil
+	}
+	intent, err := systemaccount.DecodeRestoreRequestV2(request)
+	if err != nil {
+		return r.reconcileInvalidRequestMetadata(ctx, request, err)
+	}
+	rootState, err := r.restoreOperationState(ctx, intent.Operation)
+	if err != nil {
+		return controllerruntime.Result{}, err
+	}
+	phase := systemaccount.RestoreRequestPhase(
+		request.Annotations[systemaccount.RestoreRequestPhaseAnnotationKey])
+	hasFinalizer := slices.Contains(request.Finalizers, systemaccount.RestoreProtocolFinalizer)
+
+	if !phase.Valid() {
+		updated := request.DeepCopy()
+		if updated.Annotations == nil {
+			updated.Annotations = map[string]string{}
+		}
+		updated.Annotations[systemaccount.RestoreRequestReasonAnnotationKey] =
+			systemaccount.InvalidPhaseReason
+		if rootState != restoreOperationActive {
+			updated.Finalizers = slices.DeleteFunc(updated.Finalizers,
+				func(value string) bool { return value == systemaccount.RestoreProtocolFinalizer })
+		}
+		if err := r.Client.Update(ctx, updated); err != nil {
+			return controllerruntime.Result{}, err
+		}
+		return r.lifecycleRequeue(request), nil
+	}
+
+	if rootState == restoreOperationGone || rootState == restoreOperationTerminating {
+		return r.reconcileUnavailableRoot(ctx, request, phase, rootState)
+	}
+	if rootState == restoreOperationSucceeded || rootState == restoreOperationFailed {
+		return r.reconcileTerminalOperation(ctx, request, phase)
+	}
+	if !request.DeletionTimestamp.IsZero() {
+		if phase == systemaccount.RestoreRequestPhaseClaimed ||
+			phase == systemaccount.RestoreRequestPhaseCommitted {
+			target, exact, err := r.findExactTarget(ctx, request, intent)
+			if err != nil {
+				return controllerruntime.Result{}, err
+			}
+			if exact {
+				if err := r.clearTargetReceipt(ctx, target); err != nil {
+					return controllerruntime.Result{}, err
+				}
+			}
+		}
+		if phase != systemaccount.RestoreRequestPhaseFailed {
+			return r.transitionRequest(ctx, request, systemaccount.RestoreRequestPhaseFailed,
+				systemaccount.RequestDeletionRequestedReason, nil, false)
+		}
+		return r.lifecycleRequeue(request), nil
+	}
+	if !hasFinalizer {
+		return controllerruntime.Result{}, nil
+	}
+
+	ownerLive, err := r.targetOwnerLive(ctx, intent.Target.Owner)
+	if err != nil {
+		return controllerruntime.Result{}, err
+	}
+	if !ownerLive {
+		target, exact, err := r.findExactTarget(ctx, request, intent)
+		if err != nil {
+			return controllerruntime.Result{}, err
+		}
+		reason := systemaccount.TargetOwnerUnavailableReason
+		if phase == systemaccount.RestoreRequestPhaseClaimed && exact {
+			if err := r.clearTargetReceipt(ctx, target); err != nil {
+				return controllerruntime.Result{}, err
+			}
+			reason = systemaccount.PostWriteCancellationReason
+		}
+		if phase != systemaccount.RestoreRequestPhaseFailed {
+			return r.transitionRequest(ctx, request, systemaccount.RestoreRequestPhaseFailed,
+				reason, nil, false)
+		}
+		return r.lifecycleRequeue(request), nil
+	}
+	if phase == systemaccount.RestoreRequestPhaseClaimed {
+		target, exact, err := r.findExactTarget(ctx, request, intent)
+		if err != nil {
+			return controllerruntime.Result{}, err
+		}
+		if exact {
+			revision, err := systemaccount.TargetCommitRevision(target,
+				requiredSystemAccountFinalizer(intent.Target.Scope))
+			if err != nil {
+				return controllerruntime.Result{}, err
+			}
+			return r.transitionRequest(ctx, request, systemaccount.RestoreRequestPhaseCommitted,
+				"", &systemaccount.RestoreCommitReceipt{
+					TargetName:     target.Name,
+					TargetUID:      target.UID,
+					CommitRevision: revision,
+				}, false)
+		}
+	}
+	return r.lifecycleRequeue(request), nil
+}
+
+func (r *SystemAccountRestoreLifecycleReconciler) reconcileInvalidRequestMetadata(
+	ctx context.Context,
+	request *corev1.Secret,
+	validationErr error,
+) (controllerruntime.Result, error) {
+	intent, err := systemaccount.DecodeRestoreIntentEnvelope(request)
+	if err != nil {
+		return controllerruntime.Result{}, validationErr
+	}
+	rootState, err := r.restoreOperationState(ctx, intent.Operation)
+	if err != nil {
+		return controllerruntime.Result{}, err
+	}
+	if rootState != restoreOperationGone && rootState != restoreOperationTerminating {
+		return controllerruntime.Result{}, validationErr
+	}
+	if !slices.Contains(request.Finalizers, systemaccount.RestoreProtocolFinalizer) {
+		return controllerruntime.Result{}, nil
+	}
+	updated := request.DeepCopy()
+	updated.Finalizers = slices.DeleteFunc(updated.Finalizers,
+		func(value string) bool { return value == systemaccount.RestoreProtocolFinalizer })
+	if updated.Annotations == nil {
+		updated.Annotations = map[string]string{}
+	}
+	updated.Annotations[systemaccount.RestoreRequestReasonAnnotationKey] =
+		systemaccount.InvalidPhaseReason
+	if err := r.Client.Update(ctx, updated); err != nil {
+		return controllerruntime.Result{}, err
+	}
+	return controllerruntime.Result{}, nil
+}
+
+func (r *SystemAccountRestoreLifecycleReconciler) reconcileUnavailableRoot(
+	ctx context.Context,
+	request *corev1.Secret,
+	phase systemaccount.RestoreRequestPhase,
+	rootState restoreOperationState,
+) (controllerruntime.Result, error) {
+	intent, _ := systemaccount.DecodeRestoreRequestV2(request)
+	target, exact, err := r.findExactTarget(ctx, request, intent)
+	if err != nil {
+		return controllerruntime.Result{}, err
+	}
+	reason := systemaccount.RootUnavailableReason
+	if !request.DeletionTimestamp.IsZero() {
+		reason = systemaccount.RequestDeletionRequestedReason
+	}
+	if phase == systemaccount.RestoreRequestPhaseClaimed && exact {
+		if err := r.clearTargetReceipt(ctx, target); err != nil {
+			return controllerruntime.Result{}, err
+		}
+		reason = systemaccount.PostWriteCancellationReason
+	}
+	if phase == systemaccount.RestoreRequestPhaseCommitted {
+		receipt := committedReceipt(request)
+		if receipt == nil {
+			return r.releaseProtocolFinalizer(ctx, request)
+		}
+		return r.transitionRequest(ctx, request, phase, "", receipt, true)
+	}
+	if phase != systemaccount.RestoreRequestPhaseFailed {
+		return r.transitionRequest(ctx, request, systemaccount.RestoreRequestPhaseFailed,
+			reason, nil, true)
+	}
+	if slices.Contains(request.Finalizers, systemaccount.RestoreProtocolFinalizer) {
+		storedReason := request.Annotations[systemaccount.RestoreRequestReasonAnnotationKey]
+		if !systemaccount.IsRestoreFailureReason(storedReason) {
+			storedReason = systemaccount.RootUnavailableReason
+		}
+		return r.transitionRequest(ctx, request, phase,
+			storedReason, nil, true)
+	}
+	if rootState == restoreOperationGone && request.DeletionTimestamp.IsZero() {
+		return controllerruntime.Result{}, r.Client.Delete(ctx, request)
+	}
+	return controllerruntime.Result{}, nil
+}
+
+func (r *SystemAccountRestoreLifecycleReconciler) reconcileTerminalOperation(
+	ctx context.Context,
+	request *corev1.Secret,
+	phase systemaccount.RestoreRequestPhase,
+) (controllerruntime.Result, error) {
+	intent, _ := systemaccount.DecodeRestoreRequestV2(request)
+	if phase == systemaccount.RestoreRequestPhaseClaimed {
+		ownerLive, err := r.targetOwnerLive(ctx, intent.Target.Owner)
+		if err != nil {
+			return controllerruntime.Result{}, err
+		}
+		if !ownerLive {
+			return r.transitionRequest(ctx, request, systemaccount.RestoreRequestPhaseFailed,
+				systemaccount.OperationTerminalReason, nil, true)
+		}
+		target, exact, err := r.findExactTarget(ctx, request, intent)
+		if err != nil {
+			return controllerruntime.Result{}, err
+		}
+		if exact {
+			revision, err := systemaccount.TargetCommitRevision(target,
+				requiredSystemAccountFinalizer(intent.Target.Scope))
+			if err != nil {
+				return controllerruntime.Result{}, err
+			}
+			return r.transitionRequest(ctx, request, systemaccount.RestoreRequestPhaseCommitted,
+				"", &systemaccount.RestoreCommitReceipt{
+					TargetName:     target.Name,
+					TargetUID:      target.UID,
+					CommitRevision: revision,
+				}, false)
+		}
+		return r.transitionRequest(ctx, request, systemaccount.RestoreRequestPhaseFailed,
+			systemaccount.OperationTerminalReason, nil, true)
+	}
+	if phase == systemaccount.RestoreRequestPhasePending {
+		return r.transitionRequest(ctx, request, systemaccount.RestoreRequestPhaseFailed,
+			systemaccount.OperationTerminalReason, nil, true)
+	}
+	if slices.Contains(request.Finalizers, systemaccount.RestoreProtocolFinalizer) {
+		receipt := committedReceipt(request)
+		if phase == systemaccount.RestoreRequestPhaseCommitted && receipt == nil {
+			return r.releaseProtocolFinalizer(ctx, request)
+		}
+		reason := request.Annotations[systemaccount.RestoreRequestReasonAnnotationKey]
+		if phase == systemaccount.RestoreRequestPhaseFailed &&
+			!systemaccount.IsRestoreFailureReason(reason) {
+			reason = systemaccount.OperationTerminalReason
+		}
+		return r.transitionRequest(ctx, request, phase, reason, receipt, true)
+	}
+	if request.DeletionTimestamp.IsZero() {
+		return controllerruntime.Result{}, r.Client.Delete(ctx, request)
+	}
+	return controllerruntime.Result{}, nil
+}
+
+func (r *SystemAccountRestoreLifecycleReconciler) transitionRequest(
+	ctx context.Context,
+	request *corev1.Secret,
+	phase systemaccount.RestoreRequestPhase,
+	reason string,
+	receipt *systemaccount.RestoreCommitReceipt,
+	releaseFinalizer bool,
+) (controllerruntime.Result, error) {
+	updated, err := systemaccount.TransitionRestoreRequestV2(
+		request, phase, reason, receipt, releaseFinalizer)
+	if err != nil {
+		return controllerruntime.Result{}, err
+	}
+	if err := r.Client.Update(ctx, updated); err != nil {
+		return controllerruntime.Result{}, err
+	}
+	return r.lifecycleRequeue(updated), nil
+}
+
+func (r *SystemAccountRestoreLifecycleReconciler) releaseProtocolFinalizer(
+	ctx context.Context,
+	request *corev1.Secret,
+) (controllerruntime.Result, error) {
+	updated := request.DeepCopy()
+	updated.Finalizers = slices.DeleteFunc(updated.Finalizers,
+		func(value string) bool { return value == systemaccount.RestoreProtocolFinalizer })
+	if err := r.Client.Update(ctx, updated); err != nil {
+		return controllerruntime.Result{}, err
+	}
+	return controllerruntime.Result{}, nil
+}
+
+func (r *SystemAccountRestoreLifecycleReconciler) restoreOperationState(
+	ctx context.Context,
+	operation systemaccount.RestoreOperationIdentity,
+) (restoreOperationState, error) {
+	cluster := &appsv1.Cluster{}
+	if err := r.Client.Get(ctx, client.ObjectKey{
+		Namespace: operation.Root.Namespace,
+		Name:      operation.Root.Name,
+	}, cluster); err != nil {
+		if apierrors.IsNotFound(err) {
+			return restoreOperationGone, nil
+		}
+		return "", err
+	}
+	if cluster.UID != operation.Root.UID {
+		return restoreOperationGone, nil
+	}
+	if !cluster.DeletionTimestamp.IsZero() {
+		return restoreOperationTerminating, nil
+	}
+	if operation.Profile == systemaccount.RestoreProfileLegacyPVCGroup {
+		return r.legacyRestoreOperationState(ctx, operation)
+	}
+	if cluster.Spec.Restore == nil {
+		return restoreOperationGone, nil
+	}
+	namespace := cluster.Spec.Restore.Source.Namespace
+	if namespace == "" {
+		namespace = cluster.Namespace
+	}
+	current := systemaccount.RestoreOperationIdentity{
+		Protocol: systemaccount.RestoreProtocolV2,
+		Profile:  systemaccount.RestoreProfileInitialCluster,
+		Root:     appsObjectIdentity(cluster),
+		Source: systemaccount.SourceIdentity{
+			APIGroup:  cluster.Spec.Restore.Source.APIGroup,
+			Kind:      cluster.Spec.Restore.Source.Kind,
+			Namespace: namespace,
+			Name:      cluster.Spec.Restore.Source.Name,
+		},
+		PITR:       cluster.Spec.Restore.PITR,
+		Parameters: maps.Clone(cluster.Spec.Restore.Parameters),
+	}
+	currentDigest, err := systemaccount.OperationDigest(current)
+	if err != nil {
+		return "", err
+	}
+	expectedDigest, err := systemaccount.OperationDigest(operation)
+	if err != nil || currentDigest != expectedDigest {
+		return restoreOperationGone, err
+	}
+	condition := meta.FindStatusCondition(cluster.Status.Conditions, appsv1.ConditionTypeRestore)
+	if condition == nil || condition.ObservedGeneration != cluster.Generation ||
+		condition.Status == metav1.ConditionUnknown {
+		return restoreOperationActive, nil
+	}
+	if condition.Status == metav1.ConditionTrue {
+		return restoreOperationSucceeded, nil
+	}
+	return restoreOperationFailed, nil
+}
+
+func (r *SystemAccountRestoreLifecycleReconciler) legacyRestoreOperationState(
+	ctx context.Context,
+	operation systemaccount.RestoreOperationIdentity,
+) (restoreOperationState, error) {
+	pvcs := &corev1.PersistentVolumeClaimList{}
+	if err := r.Client.List(ctx, pvcs, client.InNamespace(operation.Root.Namespace),
+		client.MatchingLabels{constant.AppInstanceLabelKey: operation.Root.Name}); err != nil {
+		return "", err
+	}
+	found := false
+	allSucceeded := true
+	for i := range pvcs.Items {
+		pvc := &pvcs.Items[i]
+		if !legacyPVCMatchesOperation(pvc, operation) ||
+			!r.legacyPVCHasAuthority(ctx, pvc, operation.Root) {
+			continue
+		}
+		found = true
+		condition := findPVCCondition(pvc, appsv1.ConditionTypeRestore)
+		if condition == nil || condition.Status == corev1.ConditionUnknown {
+			allSucceeded = false
+			continue
+		}
+		if condition.Status == corev1.ConditionFalse {
+			return restoreOperationFailed, nil
+		}
+	}
+	if !found {
+		return restoreOperationGone, nil
+	}
+	if allSucceeded {
+		return restoreOperationSucceeded, nil
+	}
+	return restoreOperationActive, nil
+}
+
+func (r *SystemAccountRestoreLifecycleReconciler) legacyPVCHasAuthority(
+	ctx context.Context,
+	pvc *corev1.PersistentVolumeClaim,
+	root systemaccount.ObjectIdentity,
+) bool {
+	ref := metav1.GetControllerOf(pvc)
+	if ref == nil || ref.APIVersion != workloads.GroupVersion.String() {
+		return false
+	}
+	var workload client.Object
+	switch ref.Kind {
+	case workloads.InstanceSetKind:
+		workload = &workloads.InstanceSet{}
+	case "Instance":
+		workload = &workloads.Instance{}
+	default:
+		return false
+	}
+	if err := r.Client.Get(ctx, client.ObjectKey{Namespace: pvc.Namespace, Name: ref.Name}, workload); err != nil ||
+		workload.GetUID() != ref.UID {
+		return false
+	}
+	componentRef := metav1.GetControllerOf(workload)
+	if componentRef == nil || componentRef.APIVersion != appsv1.GroupVersion.String() ||
+		componentRef.Kind != appsv1.ComponentKind {
+		return false
+	}
+	component := &appsv1.Component{}
+	if err := r.Client.Get(ctx, client.ObjectKey{Namespace: pvc.Namespace, Name: componentRef.Name}, component); err != nil ||
+		component.UID != componentRef.UID {
+		return false
+	}
+	clusterRef := metav1.GetControllerOf(component)
+	return clusterRef != nil && clusterRef.APIVersion == appsv1.GroupVersion.String() &&
+		clusterRef.Kind == appsv1.ClusterKind &&
+		clusterRef.Name == root.Name && clusterRef.UID == root.UID
+}
+
+func (r *SystemAccountRestoreLifecycleReconciler) targetOwnerLive(
+	ctx context.Context,
+	identity systemaccount.ObjectIdentity,
+) (bool, error) {
+	if identity.APIVersion != appsv1.GroupVersion.String() {
+		return false, nil
+	}
+	var owner client.Object
+	switch identity.Kind {
+	case appsv1.ComponentKind:
+		owner = &appsv1.Component{}
+	case appsv1.ClusterKind:
+		owner = &appsv1.Cluster{}
+	default:
+		return false, nil
+	}
+	if err := r.Client.Get(ctx, client.ObjectKey{
+		Namespace: identity.Namespace,
+		Name:      identity.Name,
+	}, owner); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return owner.GetUID() == identity.UID && owner.GetDeletionTimestamp().IsZero(), nil
+}
+
+func (r *SystemAccountRestoreLifecycleReconciler) findExactTarget(
+	ctx context.Context,
+	request *corev1.Secret,
+	intent systemaccount.CredentialIntent,
+) (*corev1.Secret, bool, error) {
+	requiredFinalizer := requiredSystemAccountFinalizer(intent.Target.Scope)
+	if name := request.Annotations[systemaccount.TargetSecretNameAnnotationKey]; name != "" {
+		target := &corev1.Secret{}
+		if err := r.Client.Get(ctx, client.ObjectKey{Namespace: request.Namespace, Name: name}, target); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, false, nil
+			}
+			return nil, false, err
+		}
+		return target, systemaccount.TargetReceiptExactV2(target, request, requiredFinalizer), nil
+	}
+	secrets := &corev1.SecretList{}
+	if err := r.Client.List(ctx, secrets, client.InNamespace(request.Namespace)); err != nil {
+		return nil, false, err
+	}
+	var exactTarget *corev1.Secret
+	for i := range secrets.Items {
+		target := &secrets.Items[i]
+		if target.Annotations[systemaccount.RestoreRequestNameAnnotationKey] == request.Name &&
+			target.Annotations[systemaccount.RestoreRequestUIDAnnotationKey] == string(request.UID) &&
+			systemaccount.TargetReceiptExactV2(target, request, requiredFinalizer) {
+			if exactTarget != nil {
+				return nil, false, fmt.Errorf(
+					"multiple exact targets %s/%s and %s/%s link restore request %s/%s",
+					exactTarget.Namespace, exactTarget.Name, target.Namespace, target.Name,
+					request.Namespace, request.Name)
+			}
+			exactTarget = target
+		}
+	}
+	if exactTarget != nil {
+		return exactTarget, true, nil
+	}
+	return nil, false, nil
+}
+
+func (r *SystemAccountRestoreLifecycleReconciler) clearTargetReceipt(
+	ctx context.Context,
+	target *corev1.Secret,
+) error {
+	if target == nil || !target.DeletionTimestamp.IsZero() {
+		return nil
+	}
+	updated := target.DeepCopy()
+	systemaccount.ClearTargetRestoreReceipt(updated)
+	return r.Client.Update(ctx, updated)
+}
+
+func (r *SystemAccountRestoreLifecycleReconciler) lifecycleRequeue(
+	request *corev1.Secret,
+) controllerruntime.Result {
+	if !slices.Contains(request.Finalizers, systemaccount.RestoreProtocolFinalizer) {
+		return controllerruntime.Result{}
+	}
+	hash := fnv.New32a()
+	_, _ = hash.Write([]byte(request.Namespace + "/" + request.Name))
+	return controllerruntime.Result{RequeueAfter: time.Duration(1+hash.Sum32()%30) * time.Second}
+}
+
+func (r *SystemAccountRestoreLifecycleReconciler) SetupWithManager(mgr controllerruntime.Manager) error {
+	return intctrlutil.NewControllerManagedBy(mgr).
+		Named("system-account-restore-lifecycle").
+		For(&corev1.Secret{}, builder.WithPredicates(predicate.NewPredicateFuncs(
+			func(object client.Object) bool {
+				return object.GetAnnotations()[systemaccount.RestoreProtocolAnnotationKey] ==
+					systemaccount.RestoreProtocolV2
+			}))).
+		Complete(r)
+}
+
+func committedReceipt(request *corev1.Secret) *systemaccount.RestoreCommitReceipt {
+	if systemaccount.RestoreRequestPhase(
+		request.Annotations[systemaccount.RestoreRequestPhaseAnnotationKey]) !=
+		systemaccount.RestoreRequestPhaseCommitted {
+		return nil
+	}
+	receipt := &systemaccount.RestoreCommitReceipt{
+		TargetName:     request.Annotations[systemaccount.TargetSecretNameAnnotationKey],
+		TargetUID:      types.UID(request.Annotations[systemaccount.TargetSecretUIDAnnotationKey]),
+		CommitRevision: request.Annotations[systemaccount.TargetCommitRevisionAnnotationKey],
+	}
+	if receipt.TargetName == "" || receipt.TargetUID == "" || receipt.CommitRevision == "" {
+		return nil
+	}
+	return receipt
+}
+
+func requiredSystemAccountFinalizer(scope string) string {
+	if scope == systemaccount.SystemAccountScopeSharding {
+		return constant.DBClusterFinalizerName
+	}
+	return constant.DBComponentFinalizerName
+}
+
+func appsObjectIdentity(object client.Object) systemaccount.ObjectIdentity {
+	kind := appsv1.ClusterKind
+	if _, ok := object.(*appsv1.Component); ok {
+		kind = appsv1.ComponentKind
+	}
+	return systemaccount.ObjectIdentity{
+		APIVersion: appsv1.GroupVersion.String(),
+		Kind:       kind,
+		Namespace:  object.GetNamespace(),
+		Name:       object.GetName(),
+		UID:        object.GetUID(),
+	}
+}
+
+func legacyPVCMatchesOperation(
+	pvc *corev1.PersistentVolumeClaim,
+	operation systemaccount.RestoreOperationIdentity,
+) bool {
+	if pvc.Spec.DataSourceRef == nil || pvc.Spec.DataSourceRef.APIGroup == nil ||
+		*pvc.Spec.DataSourceRef.APIGroup != operation.Source.APIGroup ||
+		pvc.Spec.DataSourceRef.Name != operation.Source.Name ||
+		pvc.Spec.DataSourceRef.Kind != operation.Source.Kind ||
+		pvc.Annotations[constant.RestorePITRAnnotationKey] != operation.PITR {
+		return false
+	}
+	namespace := pvc.Namespace
+	if pvc.Spec.DataSourceRef.Namespace != nil {
+		namespace = *pvc.Spec.DataSourceRef.Namespace
+	}
+	return namespace == operation.Source.Namespace
+}
+
+func findPVCCondition(
+	pvc *corev1.PersistentVolumeClaim,
+	conditionType corev1.PersistentVolumeClaimConditionType,
+) *corev1.PersistentVolumeClaimCondition {
+	for i := range pvc.Status.Conditions {
+		if pvc.Status.Conditions[i].Type == conditionType {
+			return &pvc.Status.Conditions[i]
+		}
+	}
+	return nil
+}

--- a/controllers/apps/system_account_restore_controller_test.go
+++ b/controllers/apps/system_account_restore_controller_test.go
@@ -1,0 +1,551 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package apps
+
+import (
+	"context"
+	"reflect"
+	"slices"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/systemaccount"
+)
+
+func TestSystemAccountRestoreLifecycleReleasesGoneRoot(t *testing.T) {
+	scheme := newSystemAccountLifecycleScheme(t)
+	request := newLifecycleRestoreRequest(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(request).Build()
+	reconciler := &SystemAccountRestoreLifecycleReconciler{Client: cli, Scheme: scheme}
+
+	if _, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: client.ObjectKeyFromObject(request),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	current := &corev1.Secret{}
+	if err := cli.Get(context.Background(), client.ObjectKeyFromObject(request), current); err != nil {
+		t.Fatal(err)
+	}
+	if slices.Contains(current.Finalizers, systemaccount.RestoreProtocolFinalizer) {
+		t.Fatalf("protocol finalizer was not released: %#v", current.Finalizers)
+	}
+	if current.Annotations[systemaccount.RestoreRequestPhaseAnnotationKey] !=
+		string(systemaccount.RestoreRequestPhaseFailed) {
+		t.Fatalf("phase = %q", current.Annotations[systemaccount.RestoreRequestPhaseAnnotationKey])
+	}
+	if current.Annotations[systemaccount.RestoreRequestReasonAnnotationKey] !=
+		systemaccount.RootUnavailableReason {
+		t.Fatalf("reason = %q", current.Annotations[systemaccount.RestoreRequestReasonAnnotationKey])
+	}
+}
+
+func TestSystemAccountRestoreLifecyclePersistsDeletionFailureBeforeRelease(t *testing.T) {
+	scheme := newSystemAccountLifecycleScheme(t)
+	request := newLifecycleRestoreRequest(t)
+	now := metav1.NewTime(time.Now())
+	request.DeletionTimestamp = &now
+	cluster := &appsv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: request.Namespace,
+			Name:      request.Annotations[systemaccount.RootClusterNameAnnotationKey],
+			UID:       types.UID(request.Annotations[systemaccount.RootClusterUIDAnnotationKey]),
+		},
+		Spec: appsv1.ClusterSpec{
+			Restore: &appsv1.ClusterRestore{
+				Source: appsv1.ClusterRestoreSource{
+					APIGroup:  "dataprotection.kubeblocks.io",
+					Kind:      "Backup",
+					Namespace: request.Namespace,
+					Name:      "backup",
+				},
+			},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster, request).Build()
+	reconciler := &SystemAccountRestoreLifecycleReconciler{Client: cli, Scheme: scheme}
+
+	if _, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: client.ObjectKeyFromObject(request),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	current := &corev1.Secret{}
+	if err := cli.Get(context.Background(), client.ObjectKeyFromObject(request), current); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(current.Finalizers, systemaccount.RestoreProtocolFinalizer) {
+		t.Fatalf("protocol finalizer released before failure projection")
+	}
+	if current.Annotations[systemaccount.RestoreRequestReasonAnnotationKey] !=
+		systemaccount.RequestDeletionRequestedReason {
+		t.Fatalf("reason = %q", current.Annotations[systemaccount.RestoreRequestReasonAnnotationKey])
+	}
+}
+
+func TestSystemAccountRestoreLifecycleClearsExactReceiptBeforeDeletionFailure(t *testing.T) {
+	scheme := newSystemAccountLifecycleScheme(t)
+	request := newLifecycleRestoreRequest(t)
+	request.Annotations[systemaccount.RestoreRequestPhaseAnnotationKey] =
+		string(systemaccount.RestoreRequestPhaseClaimed)
+	now := metav1.NewTime(time.Now())
+	request.DeletionTimestamp = &now
+	cluster := newLifecycleActiveCluster(request)
+	component := &appsv1.Component{ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "component",
+		UID:       "component-uid",
+	}}
+	target := newLifecycleExactTarget(t, scheme, request, component)
+	originalData := target.DeepCopy().Data
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(cluster, component, request, target).Build()
+	reconciler := &SystemAccountRestoreLifecycleReconciler{Client: cli, Scheme: scheme}
+
+	if _, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: client.ObjectKeyFromObject(request),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	currentRequest := &corev1.Secret{}
+	if err := cli.Get(context.Background(), client.ObjectKeyFromObject(request), currentRequest); err != nil {
+		t.Fatal(err)
+	}
+	if currentRequest.Annotations[systemaccount.RestoreRequestPhaseAnnotationKey] !=
+		string(systemaccount.RestoreRequestPhaseFailed) {
+		t.Fatalf("phase = %q", currentRequest.Annotations[systemaccount.RestoreRequestPhaseAnnotationKey])
+	}
+	if currentRequest.Annotations[systemaccount.RestoreRequestReasonAnnotationKey] !=
+		systemaccount.RequestDeletionRequestedReason {
+		t.Fatalf("reason = %q", currentRequest.Annotations[systemaccount.RestoreRequestReasonAnnotationKey])
+	}
+	currentTarget := &corev1.Secret{}
+	if err := cli.Get(context.Background(), client.ObjectKeyFromObject(target), currentTarget); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(currentTarget.Data, originalData) {
+		t.Fatal("deleting request changed target credential data")
+	}
+	for _, key := range []string{
+		systemaccount.RestoreOperationDigestAnnotationKey,
+		systemaccount.CredentialIntentRevisionAnnotationKey,
+		systemaccount.TargetCommitRevisionAnnotationKey,
+		systemaccount.RestoreRequestNameAnnotationKey,
+		systemaccount.RestoreRequestUIDAnnotationKey,
+	} {
+		if currentTarget.Annotations[key] != "" {
+			t.Fatalf("target retained protocol receipt %s=%q", key, currentTarget.Annotations[key])
+		}
+	}
+}
+
+func TestSystemAccountRestoreLifecycleReleasesDamagedMetadataAfterRootGone(t *testing.T) {
+	scheme := newSystemAccountLifecycleScheme(t)
+	request := newLifecycleRestoreRequest(t)
+	request.OwnerReferences[0].UID = "replacement-root-uid"
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(request).Build()
+	reconciler := &SystemAccountRestoreLifecycleReconciler{Client: cli, Scheme: scheme}
+
+	if _, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: client.ObjectKeyFromObject(request),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	current := &corev1.Secret{}
+	if err := cli.Get(context.Background(), client.ObjectKeyFromObject(request), current); err != nil {
+		t.Fatal(err)
+	}
+	if slices.Contains(current.Finalizers, systemaccount.RestoreProtocolFinalizer) {
+		t.Fatalf("damaged metadata kept protocol finalizer after root disappeared")
+	}
+	if current.Annotations[systemaccount.RestoreRequestReasonAnnotationKey] !=
+		systemaccount.InvalidPhaseReason {
+		t.Fatalf("reason = %q", current.Annotations[systemaccount.RestoreRequestReasonAnnotationKey])
+	}
+}
+
+func TestSystemAccountRestoreLifecycleFailsClosedForDamagedMetadataWhileRootLive(t *testing.T) {
+	scheme := newSystemAccountLifecycleScheme(t)
+	request := newLifecycleRestoreRequest(t)
+	request.OwnerReferences[0].UID = "replacement-root-uid"
+	cluster := &appsv1.Cluster{ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "cluster",
+		UID:       "cluster-uid",
+	}, Spec: appsv1.ClusterSpec{
+		Restore: &appsv1.ClusterRestore{
+			Source: appsv1.ClusterRestoreSource{
+				APIGroup:  "dataprotection.kubeblocks.io",
+				Kind:      "Backup",
+				Namespace: "default",
+				Name:      "backup",
+			},
+		},
+	}}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster, request).Build()
+	reconciler := &SystemAccountRestoreLifecycleReconciler{Client: cli, Scheme: scheme}
+
+	if _, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: client.ObjectKeyFromObject(request),
+	}); err == nil {
+		t.Fatal("active root accepted damaged request metadata")
+	}
+}
+
+func TestSystemAccountRestoreLifecycleCommitsExactTargetAfterActiveRecheck(t *testing.T) {
+	scheme := newSystemAccountLifecycleScheme(t)
+	request := newLifecycleRestoreRequest(t)
+	request.Annotations[systemaccount.RestoreRequestPhaseAnnotationKey] =
+		string(systemaccount.RestoreRequestPhaseClaimed)
+	cluster := newLifecycleActiveCluster(request)
+	component := &appsv1.Component{ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "component",
+		UID:       "component-uid",
+	}}
+	intent, err := systemaccount.DecodeRestoreRequestV2(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  request.Namespace,
+			Name:       "cluster-component-admin",
+			UID:        "target-uid",
+			Finalizers: []string{constant.DBComponentFinalizerName},
+			Annotations: map[string]string{
+				constant.SystemAccountProvisionedAnnotationKey:      "true",
+				systemaccount.RestoreProtocolAnnotationKey:          systemaccount.RestoreProtocolV2,
+				systemaccount.RestoreOperationDigestAnnotationKey:   request.Annotations[systemaccount.RestoreOperationDigestAnnotationKey],
+				systemaccount.CredentialIntentRevisionAnnotationKey: request.Annotations[systemaccount.CredentialIntentRevisionAnnotationKey],
+				systemaccount.RestoreRequestNameAnnotationKey:       request.Name,
+				systemaccount.RestoreRequestUIDAnnotationKey:        string(request.UID),
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: intent.Credentials,
+	}
+	if err := controllerutil.SetControllerReference(component, target, scheme); err != nil {
+		t.Fatal(err)
+	}
+	revision, err := systemaccount.TargetCommitRevision(target, constant.DBComponentFinalizerName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target.Annotations[systemaccount.TargetCommitRevisionAnnotationKey] = revision
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(cluster, component, request, target).Build()
+	reconciler := &SystemAccountRestoreLifecycleReconciler{Client: cli, Scheme: scheme}
+
+	if _, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: client.ObjectKeyFromObject(request),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	current := &corev1.Secret{}
+	if err := cli.Get(context.Background(), client.ObjectKeyFromObject(request), current); err != nil {
+		t.Fatal(err)
+	}
+	if current.Annotations[systemaccount.RestoreRequestPhaseAnnotationKey] !=
+		string(systemaccount.RestoreRequestPhaseCommitted) {
+		t.Fatalf("phase = %q", current.Annotations[systemaccount.RestoreRequestPhaseAnnotationKey])
+	}
+	if current.Annotations[systemaccount.TargetSecretNameAnnotationKey] != target.Name ||
+		current.Annotations[systemaccount.TargetSecretUIDAnnotationKey] != string(target.UID) ||
+		current.Annotations[systemaccount.TargetCommitRevisionAnnotationKey] != revision {
+		t.Fatalf("committed receipt is incomplete: %#v", current.Annotations)
+	}
+	if !slices.Contains(current.Finalizers, systemaccount.RestoreProtocolFinalizer) {
+		t.Fatal("active operation commit released the protocol finalizer")
+	}
+}
+
+func TestSystemAccountRestoreLifecycleDoesNotCommitTerminalTargetWithUnavailableOwner(t *testing.T) {
+	scheme := newSystemAccountLifecycleScheme(t)
+	request := newLifecycleRestoreRequest(t)
+	request.Annotations[systemaccount.RestoreRequestPhaseAnnotationKey] =
+		string(systemaccount.RestoreRequestPhaseClaimed)
+	cluster := newLifecycleActiveCluster(request)
+	cluster.Status.Conditions = []metav1.Condition{{
+		Type:               appsv1.ConditionTypeRestore,
+		Status:             metav1.ConditionTrue,
+		ObservedGeneration: cluster.Generation,
+	}}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster, request).Build()
+	reconciler := &SystemAccountRestoreLifecycleReconciler{Client: cli, Scheme: scheme}
+
+	if _, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: client.ObjectKeyFromObject(request),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	current := &corev1.Secret{}
+	if err := cli.Get(context.Background(), client.ObjectKeyFromObject(request), current); err != nil {
+		t.Fatal(err)
+	}
+	if current.Annotations[systemaccount.RestoreRequestPhaseAnnotationKey] !=
+		string(systemaccount.RestoreRequestPhaseFailed) {
+		t.Fatalf("phase = %q", current.Annotations[systemaccount.RestoreRequestPhaseAnnotationKey])
+	}
+	if current.Annotations[systemaccount.RestoreRequestReasonAnnotationKey] !=
+		systemaccount.OperationTerminalReason {
+		t.Fatalf("reason = %q", current.Annotations[systemaccount.RestoreRequestReasonAnnotationKey])
+	}
+	if slices.Contains(current.Finalizers, systemaccount.RestoreProtocolFinalizer) {
+		t.Fatal("terminal unavailable-owner request retained the protocol finalizer")
+	}
+}
+
+func TestSystemAccountRestoreLifecycleRequiresExactAppsAuthorityGroup(t *testing.T) {
+	scheme := newSystemAccountLifecycleScheme(t)
+	if err := workloads.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	controller := true
+	cluster := &appsv1.Cluster{ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "cluster",
+		UID:       "cluster-uid",
+	}}
+	component := &appsv1.Component{ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "component",
+		UID:       "component-uid",
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: appsv1.GroupVersion.String(),
+			Kind:       appsv1.ClusterKind,
+			Name:       cluster.Name,
+			UID:        cluster.UID,
+			Controller: &controller,
+		}},
+	}}
+	workload := &workloads.InstanceSet{ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "workload",
+		UID:       "workload-uid",
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: "apps.kubeblocks.io/v1alpha1",
+			Kind:       appsv1.ComponentKind,
+			Name:       component.Name,
+			UID:        component.UID,
+			Controller: &controller,
+		}},
+	}}
+	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "data",
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: workloads.GroupVersion.String(),
+			Kind:       workloads.InstanceSetKind,
+			Name:       workload.Name,
+			UID:        workload.UID,
+			Controller: &controller,
+		}},
+	}}
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(cluster, component, workload, pvc).Build()
+	reconciler := &SystemAccountRestoreLifecycleReconciler{Client: cli, Scheme: scheme}
+
+	live, err := reconciler.targetOwnerLive(context.Background(), systemaccount.ObjectIdentity{
+		APIVersion: "apps.kubeblocks.io/v1alpha1",
+		Kind:       appsv1.ComponentKind,
+		Namespace:  component.Namespace,
+		Name:       component.Name,
+		UID:        component.UID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if live {
+		t.Fatal("target owner with a non-exact API version was accepted")
+	}
+	if reconciler.legacyPVCHasAuthority(context.Background(), pvc, systemaccount.ObjectIdentity{
+		APIVersion: appsv1.GroupVersion.String(),
+		Kind:       appsv1.ClusterKind,
+		Namespace:  cluster.Namespace,
+		Name:       cluster.Name,
+		UID:        cluster.UID,
+	}) {
+		t.Fatal("legacy workload chain with a non-exact Component API version was accepted")
+	}
+
+	workload.OwnerReferences[0].APIVersion = appsv1.GroupVersion.String()
+	if err := cli.Update(context.Background(), workload); err != nil {
+		t.Fatal(err)
+	}
+	component.OwnerReferences[0].APIVersion = "apps.kubeblocks.io/v1alpha1"
+	if err := cli.Update(context.Background(), component); err != nil {
+		t.Fatal(err)
+	}
+	if reconciler.legacyPVCHasAuthority(context.Background(), pvc, systemaccount.ObjectIdentity{
+		APIVersion: appsv1.GroupVersion.String(),
+		Kind:       appsv1.ClusterKind,
+		Namespace:  cluster.Namespace,
+		Name:       cluster.Name,
+		UID:        cluster.UID,
+	}) {
+		t.Fatal("legacy workload chain with a non-exact Cluster API version was accepted")
+	}
+}
+
+func newSystemAccountLifecycleScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	return scheme
+}
+
+func newLifecycleRestoreRequest(t *testing.T) *corev1.Secret {
+	t.Helper()
+	root := systemaccount.ObjectIdentity{
+		APIVersion: appsv1.GroupVersion.String(),
+		Kind:       appsv1.ClusterKind,
+		Namespace:  "default",
+		Name:       "cluster",
+		UID:        "cluster-uid",
+	}
+	request, err := systemaccount.BuildRestoreRequest(systemaccount.CredentialIntent{
+		Operation: systemaccount.RestoreOperationIdentity{
+			Protocol: systemaccount.RestoreProtocolV2,
+			Profile:  systemaccount.RestoreProfileInitialCluster,
+			Root:     root,
+			Source: systemaccount.SourceIdentity{
+				APIGroup:  "dataprotection.kubeblocks.io",
+				Kind:      "Backup",
+				Namespace: "default",
+				Name:      "backup",
+			},
+		},
+		Target: systemaccount.LogicalTargetIdentity{
+			Protocol:  systemaccount.LogicalTargetProtocolV1,
+			Namespace: "default",
+			Root:      root,
+			Owner: systemaccount.ObjectIdentity{
+				APIVersion: appsv1.GroupVersion.String(),
+				Kind:       appsv1.ComponentKind,
+				Namespace:  "default",
+				Name:       "component",
+				UID:        "component-uid",
+			},
+			Scope:   systemaccount.SystemAccountScopeComponent,
+			Account: "admin",
+		},
+		ResolvedSource: systemaccount.ObjectIdentity{
+			APIVersion: "dataprotection.kubeblocks.io/v1alpha1",
+			Kind:       "Backup",
+			Namespace:  "default",
+			Name:       "backup",
+			UID:        "backup-uid",
+		},
+		Credentials: map[string][]byte{
+			constant.AccountNameForSecret:   []byte("admin"),
+			constant.AccountPasswdForSecret: []byte("password"),
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.UID = "request-uid"
+	request.ResourceVersion = "1"
+	return request
+}
+
+func newLifecycleActiveCluster(request *corev1.Secret) *appsv1.Cluster {
+	return &appsv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: request.Namespace,
+			Name:      request.Annotations[systemaccount.RootClusterNameAnnotationKey],
+			UID:       types.UID(request.Annotations[systemaccount.RootClusterUIDAnnotationKey]),
+		},
+		Spec: appsv1.ClusterSpec{
+			Restore: &appsv1.ClusterRestore{
+				Source: appsv1.ClusterRestoreSource{
+					APIGroup:  "dataprotection.kubeblocks.io",
+					Kind:      "Backup",
+					Namespace: request.Namespace,
+					Name:      "backup",
+				},
+			},
+		},
+	}
+}
+
+func newLifecycleExactTarget(
+	t *testing.T,
+	scheme *runtime.Scheme,
+	request *corev1.Secret,
+	component *appsv1.Component,
+) *corev1.Secret {
+	t.Helper()
+	intent, err := systemaccount.DecodeRestoreRequestV2(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  request.Namespace,
+			Name:       "cluster-component-admin",
+			UID:        "target-uid",
+			Finalizers: []string{constant.DBComponentFinalizerName},
+			Annotations: map[string]string{
+				constant.SystemAccountProvisionedAnnotationKey:      "true",
+				systemaccount.RestoreProtocolAnnotationKey:          systemaccount.RestoreProtocolV2,
+				systemaccount.RestoreOperationDigestAnnotationKey:   request.Annotations[systemaccount.RestoreOperationDigestAnnotationKey],
+				systemaccount.CredentialIntentRevisionAnnotationKey: request.Annotations[systemaccount.CredentialIntentRevisionAnnotationKey],
+				systemaccount.RestoreRequestNameAnnotationKey:       request.Name,
+				systemaccount.RestoreRequestUIDAnnotationKey:        string(request.UID),
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: intent.Credentials,
+	}
+	if err := controllerutil.SetControllerReference(component, target, scheme); err != nil {
+		t.Fatal(err)
+	}
+	revision, err := systemaccount.TargetCommitRevision(target, constant.DBComponentFinalizerName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target.Annotations[systemaccount.TargetCommitRevisionAnnotationKey] = revision
+	return target
+}

--- a/controllers/dataprotection/suite_test.go
+++ b/controllers/dataprotection/suite_test.go
@@ -48,6 +48,7 @@ import (
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	workloadsv1 "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 	"github.com/apecloud/kubeblocks/pkg/testutil"
@@ -124,6 +125,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = appsv1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = workloadsv1.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = dpv1alpha1.AddToScheme(scheme)

--- a/controllers/dataprotection/system_account_conflict_lifecycle.go
+++ b/controllers/dataprotection/system_account_conflict_lifecycle.go
@@ -1,0 +1,273 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package dataprotection
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"slices"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/systemaccount"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+)
+
+// SystemAccountConflictReceiptLifecycleReconciler retains loser decisions
+// while their exact root UID is live and releases them when that root starts
+// terminating or is gone.
+type SystemAccountConflictReceiptLifecycleReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+func (r *SystemAccountConflictReceiptLifecycleReconciler) Reconcile(
+	ctx context.Context,
+	req controllerruntime.Request,
+) (controllerruntime.Result, error) {
+	receipt := &corev1.Secret{}
+	if err := r.Client.Get(ctx, req.NamespacedName, receipt); err != nil {
+		return intctrlutil.CheckedRequeueWithError(err, log.FromContext(ctx), "")
+	}
+	if receipt.Annotations[systemaccount.RestoreProtocolAnnotationKey] !=
+		systemaccount.ConflictProtocolV1 {
+		return controllerruntime.Result{}, nil
+	}
+	envelope, err := systemaccount.DecodeAndValidateConflictReceipt(receipt, false)
+	if err != nil {
+		return r.reconcileInvalidConflictMetadata(ctx, receipt, err)
+	}
+	rootGone, rootTerminating, err := r.conflictRootState(ctx, envelope)
+	if err != nil {
+		return controllerruntime.Result{}, err
+	}
+	if !rootGone && !rootTerminating {
+		return conflictReceiptRequeue(receipt), nil
+	}
+
+	if rootTerminating {
+		if projectionErr := r.projectConflictReceipt(ctx, receipt, envelope); projectionErr != nil {
+			log.FromContext(ctx).Error(projectionErr,
+				"bounded loser projection failed before conflict receipt release",
+				"receipt", client.ObjectKeyFromObject(receipt))
+		}
+	}
+	if slices.Contains(receipt.Finalizers, systemaccount.RestoreProtocolFinalizer) {
+		updated := receipt.DeepCopy()
+		updated.Finalizers = slices.DeleteFunc(updated.Finalizers,
+			func(value string) bool { return value == systemaccount.RestoreProtocolFinalizer })
+		if err := r.Client.Update(ctx, updated); err != nil {
+			return controllerruntime.Result{}, err
+		}
+		return controllerruntime.Result{}, nil
+	}
+	if rootGone && receipt.DeletionTimestamp.IsZero() {
+		return controllerruntime.Result{}, r.Client.Delete(ctx, receipt)
+	}
+	return controllerruntime.Result{}, nil
+}
+
+func (r *SystemAccountConflictReceiptLifecycleReconciler) reconcileInvalidConflictMetadata(
+	ctx context.Context,
+	receipt *corev1.Secret,
+	validationErr error,
+) (controllerruntime.Result, error) {
+	if receipt.Immutable == nil || !*receipt.Immutable {
+		return controllerruntime.Result{}, validationErr
+	}
+	envelope, err := systemaccount.DecodeConflictEnvelope(receipt)
+	if err != nil || envelope.Protocol != systemaccount.ConflictProtocolV1 ||
+		envelope.Decision != systemaccount.ConcurrentRestoreIntentReason {
+		return controllerruntime.Result{}, validationErr
+	}
+	rootGone, rootTerminating, err := r.conflictRootState(ctx, envelope)
+	if err != nil {
+		return controllerruntime.Result{}, err
+	}
+	if !rootGone && !rootTerminating {
+		return controllerruntime.Result{}, validationErr
+	}
+	if !slices.Contains(receipt.Finalizers, systemaccount.RestoreProtocolFinalizer) {
+		return controllerruntime.Result{}, nil
+	}
+	updated := receipt.DeepCopy()
+	updated.Finalizers = slices.DeleteFunc(updated.Finalizers,
+		func(value string) bool { return value == systemaccount.RestoreProtocolFinalizer })
+	if err := r.Client.Update(ctx, updated); err != nil {
+		return controllerruntime.Result{}, err
+	}
+	return controllerruntime.Result{}, nil
+}
+
+func (r *SystemAccountConflictReceiptLifecycleReconciler) conflictRootState(
+	ctx context.Context,
+	envelope systemaccount.ConflictEnvelope,
+) (bool, bool, error) {
+	root := &appsv1.Cluster{}
+	rootKey := client.ObjectKey{
+		Namespace: envelope.LoserOperation.Root.Namespace,
+		Name:      envelope.LoserOperation.Root.Name,
+	}
+	err := r.Client.Get(ctx, rootKey, root)
+	rootGone := apierrors.IsNotFound(err)
+	if err != nil && !rootGone {
+		return false, false, err
+	}
+	if !rootGone && root.UID != envelope.LoserOperation.Root.UID {
+		rootGone = true
+	}
+	return rootGone, !rootGone && !root.DeletionTimestamp.IsZero(), nil
+}
+
+func (r *SystemAccountConflictReceiptLifecycleReconciler) projectConflictReceipt(
+	ctx context.Context,
+	receipt *corev1.Secret,
+	envelope systemaccount.ConflictEnvelope,
+) error {
+	pvcs, err := r.participantsForOperation(ctx, envelope.LoserOperation)
+	if err != nil {
+		return err
+	}
+	loserDigest, _ := systemaccount.OperationDigest(envelope.LoserOperation)
+	volumePopulator := &VolumePopulatorReconciler{Client: r.Client, Scheme: r.Scheme}
+	var projectionErrors []error
+	for _, pvc := range pvcs {
+		if err := volumePopulator.projectSystemAccountConflictIdentity(
+			intctrlutil.RequestCtx{Ctx: ctx}, pvc, envelope); err != nil {
+			projectionErrors = append(projectionErrors,
+				fmt.Errorf("project conflict receipt %s identity to PVC %s: %w",
+					client.ObjectKeyFromObject(receipt), client.ObjectKeyFromObject(pvc), err))
+			continue
+		}
+		updated := pvc.DeepCopy()
+		upsertPVCCondition(&updated.Status.Conditions, corev1.PersistentVolumeClaimCondition{
+			Type:               appsv1.ConditionTypeRestore,
+			Status:             corev1.ConditionFalse,
+			LastProbeTime:      metav1.Now(),
+			LastTransitionTime: metav1.Now(),
+			Reason:             systemaccount.ConcurrentRestoreIntentReason,
+			Message: fmt.Sprintf("restore operation %s is blocked by request %s/%s UID %s",
+				loserDigest,
+				envelope.BlockingRequest.Namespace,
+				envelope.BlockingRequest.Name,
+				envelope.BlockingRequest.UID),
+		})
+		if err := r.Client.Status().Update(ctx, updated); err != nil {
+			projectionErrors = append(projectionErrors,
+				fmt.Errorf("project conflict receipt %s to PVC %s: %w",
+					client.ObjectKeyFromObject(receipt), client.ObjectKeyFromObject(pvc), err))
+		}
+	}
+	return errors.Join(projectionErrors...)
+}
+
+func (r *SystemAccountConflictReceiptLifecycleReconciler) participantsForOperation(
+	ctx context.Context,
+	operation systemaccount.RestoreOperationIdentity,
+) ([]*corev1.PersistentVolumeClaim, error) {
+	pvcs := &corev1.PersistentVolumeClaimList{}
+	if err := r.Client.List(ctx, pvcs, client.InNamespace(operation.Root.Namespace),
+		client.MatchingLabels{constant.AppInstanceLabelKey: operation.Root.Name}); err != nil {
+		return nil, err
+	}
+	operationDigest, err := systemaccount.OperationDigest(operation)
+	if err != nil {
+		return nil, err
+	}
+	volumePopulator := &VolumePopulatorReconciler{Client: r.Client, Scheme: r.Scheme}
+	participants := make([]*corev1.PersistentVolumeClaim, 0, len(pvcs.Items))
+	for i := range pvcs.Items {
+		pvc := &pvcs.Items[i]
+		if !pvcReferencesOperationSource(pvc, operation) {
+			continue
+		}
+		backup := &dpv1alpha1.Backup{}
+		if err := r.Client.Get(ctx, client.ObjectKey{
+			Namespace: operation.Source.Namespace,
+			Name:      operation.Source.Name,
+		}, backup); err != nil {
+			continue
+		}
+		authority, err := volumePopulator.resolveSystemAccountRestoreAuthority(
+			intctrlutil.RequestCtx{Ctx: ctx}, pvc, backup, operation.Root.Name)
+		if err != nil {
+			continue
+		}
+		candidateDigest, err := systemaccount.OperationDigest(authority.operation)
+		if err == nil && candidateDigest == operationDigest {
+			participants = append(participants, pvc)
+		}
+	}
+	return participants, nil
+}
+
+func (r *SystemAccountConflictReceiptLifecycleReconciler) SetupWithManager(
+	mgr controllerruntime.Manager,
+) error {
+	return intctrlutil.NewControllerManagedBy(mgr).
+		Named("system-account-conflict-receipt-lifecycle").
+		For(&corev1.Secret{}, builder.WithPredicates(predicate.NewPredicateFuncs(
+			func(object client.Object) bool {
+				return object.GetAnnotations()[systemaccount.RestoreProtocolAnnotationKey] ==
+					systemaccount.ConflictProtocolV1
+			}))).
+		Complete(r)
+}
+
+func conflictReceiptRequeue(receipt *corev1.Secret) controllerruntime.Result {
+	if !slices.Contains(receipt.Finalizers, systemaccount.RestoreProtocolFinalizer) {
+		return controllerruntime.Result{}
+	}
+	hash := fnv.New32a()
+	_, _ = hash.Write([]byte(receipt.Namespace + "/" + receipt.Name))
+	return controllerruntime.Result{RequeueAfter: time.Duration(1+hash.Sum32()%30) * time.Second}
+}
+
+func pvcReferencesOperationSource(
+	pvc *corev1.PersistentVolumeClaim,
+	operation systemaccount.RestoreOperationIdentity,
+) bool {
+	if pvc.Spec.DataSourceRef == nil || pvc.Spec.DataSourceRef.APIGroup == nil ||
+		*pvc.Spec.DataSourceRef.APIGroup != operation.Source.APIGroup ||
+		pvc.Spec.DataSourceRef.Kind != operation.Source.Kind ||
+		pvc.Spec.DataSourceRef.Name != operation.Source.Name ||
+		pvc.Annotations[constant.RestorePITRAnnotationKey] != operation.PITR {
+		return false
+	}
+	namespace := pvc.Namespace
+	if pvc.Spec.DataSourceRef.Namespace != nil {
+		namespace = *pvc.Spec.DataSourceRef.Namespace
+	}
+	return namespace == operation.Source.Namespace
+}

--- a/controllers/dataprotection/system_account_conflict_lifecycle_test.go
+++ b/controllers/dataprotection/system_account_conflict_lifecycle_test.go
@@ -1,0 +1,214 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package dataprotection
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/systemaccount"
+)
+
+func TestConflictReceiptLifecycleReleasesGoneRoot(t *testing.T) {
+	scheme := newConflictLifecycleScheme(t)
+	receipt := newConflictLifecycleReceipt(t)
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(receipt).Build()
+	reconciler := &SystemAccountConflictReceiptLifecycleReconciler{Client: cli, Scheme: scheme}
+
+	if _, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: client.ObjectKeyFromObject(receipt),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	current := &corev1.Secret{}
+	if err := cli.Get(context.Background(), client.ObjectKeyFromObject(receipt), current); err != nil {
+		t.Fatal(err)
+	}
+	if slices.Contains(current.Finalizers, systemaccount.RestoreProtocolFinalizer) {
+		t.Fatalf("protocol finalizer was not released: %#v", current.Finalizers)
+	}
+}
+
+func TestConflictReceiptLifecycleRetainsDeletingReceiptWhileRootLive(t *testing.T) {
+	scheme := newConflictLifecycleScheme(t)
+	receipt := newConflictLifecycleReceipt(t)
+	now := metav1.NewTime(time.Now())
+	receipt.DeletionTimestamp = &now
+	cluster := &appsv1.Cluster{ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "cluster",
+		UID:       "cluster-uid",
+	}}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster, receipt).Build()
+	reconciler := &SystemAccountConflictReceiptLifecycleReconciler{Client: cli, Scheme: scheme}
+
+	if _, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: client.ObjectKeyFromObject(receipt),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	current := &corev1.Secret{}
+	if err := cli.Get(context.Background(), client.ObjectKeyFromObject(receipt), current); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(current.Finalizers, systemaccount.RestoreProtocolFinalizer) {
+		t.Fatal("live-root conflict receipt lost its protocol finalizer")
+	}
+}
+
+func TestConflictReceiptLifecycleReleasesDamagedMetadataAfterRootGone(t *testing.T) {
+	scheme := newConflictLifecycleScheme(t)
+	receipt := newConflictLifecycleReceipt(t)
+	receipt.OwnerReferences[0].UID = "replacement-root-uid"
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(receipt).Build()
+	reconciler := &SystemAccountConflictReceiptLifecycleReconciler{Client: cli, Scheme: scheme}
+
+	if _, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: client.ObjectKeyFromObject(receipt),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	current := &corev1.Secret{}
+	if err := cli.Get(context.Background(), client.ObjectKeyFromObject(receipt), current); err != nil {
+		t.Fatal(err)
+	}
+	if slices.Contains(current.Finalizers, systemaccount.RestoreProtocolFinalizer) {
+		t.Fatalf("damaged metadata kept protocol finalizer after root disappeared")
+	}
+}
+
+func TestConflictReceiptLifecycleFailsClosedForDamagedMetadataWhileRootLive(t *testing.T) {
+	scheme := newConflictLifecycleScheme(t)
+	receipt := newConflictLifecycleReceipt(t)
+	receipt.OwnerReferences[0].UID = "replacement-root-uid"
+	cluster := &appsv1.Cluster{ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "cluster",
+		UID:       "cluster-uid",
+	}}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster, receipt).Build()
+	reconciler := &SystemAccountConflictReceiptLifecycleReconciler{Client: cli, Scheme: scheme}
+
+	if _, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: client.ObjectKeyFromObject(receipt),
+	}); err == nil {
+		t.Fatal("active root accepted damaged receipt metadata")
+	}
+}
+
+func newConflictLifecycleScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	return scheme
+}
+
+func newConflictLifecycleReceipt(t *testing.T) *corev1.Secret {
+	t.Helper()
+	root := systemaccount.ObjectIdentity{
+		APIVersion: appsv1.GroupVersion.String(),
+		Kind:       appsv1.ClusterKind,
+		Namespace:  "default",
+		Name:       "cluster",
+		UID:        "cluster-uid",
+	}
+	target := systemaccount.LogicalTargetIdentity{
+		Protocol:  systemaccount.LogicalTargetProtocolV1,
+		Namespace: "default",
+		Root:      root,
+		Owner: systemaccount.ObjectIdentity{
+			APIVersion: appsv1.GroupVersion.String(),
+			Kind:       appsv1.ComponentKind,
+			Namespace:  "default",
+			Name:       "component",
+			UID:        "component-uid",
+		},
+		Scope:   systemaccount.SystemAccountScopeComponent,
+		Account: "admin",
+	}
+	winner := conflictLifecycleIntent(root, target, "winner", "winner-backup-uid")
+	loser := conflictLifecycleIntent(root, target, "loser", "loser-backup-uid")
+	request, err := systemaccount.BuildRestoreRequest(winner)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.UID = "request-uid"
+	request.ResourceVersion = "7"
+	receipt, err := systemaccount.BuildConflictReceipt(loser, request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt.UID = "receipt-uid"
+	receipt.ResourceVersion = "8"
+	return receipt
+}
+
+func conflictLifecycleIntent(
+	root systemaccount.ObjectIdentity,
+	target systemaccount.LogicalTargetIdentity,
+	backupName string,
+	backupUID types.UID,
+) systemaccount.CredentialIntent {
+	return systemaccount.CredentialIntent{
+		Operation: systemaccount.RestoreOperationIdentity{
+			Protocol: systemaccount.RestoreProtocolV2,
+			Profile:  systemaccount.RestoreProfileLegacyPVCGroup,
+			Root:     root,
+			Source: systemaccount.SourceIdentity{
+				APIGroup:  "dataprotection.kubeblocks.io",
+				Kind:      "Backup",
+				Namespace: "default",
+				Name:      backupName,
+			},
+		},
+		Target: target,
+		ResolvedSource: systemaccount.ObjectIdentity{
+			APIVersion: "dataprotection.kubeblocks.io/v1alpha1",
+			Kind:       "Backup",
+			Namespace:  "default",
+			Name:       backupName,
+			UID:        backupUID,
+		},
+		Credentials: map[string][]byte{
+			constant.AccountNameForSecret:   []byte("admin"),
+			constant.AccountPasswdForSecret: []byte("password"),
+		},
+	}
+}

--- a/controllers/dataprotection/system_account_restore.go
+++ b/controllers/dataprotection/system_account_restore.go
@@ -1,0 +1,531 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package dataprotection
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/systemaccount"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
+)
+
+type systemAccountRestoreAuthority struct {
+	root      *appsv1.Cluster
+	component *appsv1.Component
+	operation systemaccount.RestoreOperationIdentity
+}
+
+type systemAccountRestoreContractError struct {
+	reason string
+	cause  error
+}
+
+func (e *systemAccountRestoreContractError) Error() string {
+	return fmt.Sprintf("%s: %v", e.reason, e.cause)
+}
+
+func (e *systemAccountRestoreContractError) Unwrap() error {
+	return e.cause
+}
+
+func newSystemAccountRestoreContractError(reason string, err error) error {
+	if err == nil {
+		err = errors.New(reason)
+	}
+	return &systemAccountRestoreContractError{reason: reason, cause: err}
+}
+
+func (r *VolumePopulatorReconciler) buildSystemAccountCredentialIntent(
+	reqCtx intctrlutil.RequestCtx,
+	pvc *corev1.PersistentVolumeClaim,
+	backup *dpv1alpha1.Backup,
+	scope systemAccountSecretScope,
+	clusterName, ownerName, accountName string,
+	password []byte,
+) (systemaccount.CredentialIntent, error) {
+	authority, err := r.resolveSystemAccountRestoreAuthority(reqCtx, pvc, backup, clusterName)
+	if err != nil {
+		var contractErr *systemAccountRestoreContractError
+		if !apierrors.IsNotFound(err) && !errors.As(err, &contractErr) {
+			err = newSystemAccountRestoreContractError(
+				systemaccount.UnauthorizedRestoreProducerReason, err)
+		}
+		return systemaccount.CredentialIntent{}, err
+	}
+	targetOwner := objectIdentity(authority.component)
+	shardingName := ""
+	switch scope {
+	case systemAccountSecretScopeComponent:
+		if authority.component.Labels[constant.KBAppComponentLabelKey] != ownerName &&
+			authority.component.Name != constant.GenerateClusterComponentName(clusterName, ownerName) {
+			return systemaccount.CredentialIntent{}, newSystemAccountRestoreContractError(
+				systemaccount.UnauthorizedRestoreProducerReason,
+				fmt.Errorf("PVC %s/%s component identity %q does not match live Component %s/%s",
+					pvc.Namespace, pvc.Name, ownerName, authority.component.Namespace, authority.component.Name))
+		}
+	case systemAccountSecretScopeSharding:
+		if pvc.Labels[constant.KBAppShardingNameLabelKey] != ownerName {
+			return systemaccount.CredentialIntent{}, newSystemAccountRestoreContractError(
+				systemaccount.UnauthorizedRestoreProducerReason,
+				fmt.Errorf("PVC %s/%s sharding identity %q does not match %q",
+					pvc.Namespace, pvc.Name, ownerName, pvc.Labels[constant.KBAppShardingNameLabelKey]))
+		}
+		targetOwner = objectIdentity(authority.root)
+		shardingName = ownerName
+	default:
+		return systemaccount.CredentialIntent{}, newSystemAccountRestoreContractError(
+			systemaccount.TargetSemanticUnavailableReason,
+			fmt.Errorf("unsupported system account scope %q", scope))
+	}
+	rootIdentity := objectIdentity(authority.root)
+	return systemaccount.CredentialIntent{
+		Operation: authority.operation,
+		Target: systemaccount.LogicalTargetIdentity{
+			Protocol:     systemaccount.LogicalTargetProtocolV1,
+			Namespace:    authority.root.Namespace,
+			Root:         rootIdentity,
+			Owner:        targetOwner,
+			Scope:        string(scope),
+			ShardingName: shardingName,
+			Account:      accountName,
+		},
+		ResolvedSource: objectIdentity(backup),
+		Credentials: map[string][]byte{
+			constant.AccountNameForSecret:   []byte(accountName),
+			constant.AccountPasswdForSecret: append([]byte(nil), password...),
+		},
+	}, nil
+}
+
+func (r *VolumePopulatorReconciler) resolveSystemAccountRestoreAuthority(
+	reqCtx intctrlutil.RequestCtx,
+	pvc *corev1.PersistentVolumeClaim,
+	backup *dpv1alpha1.Backup,
+	clusterName string,
+) (*systemAccountRestoreAuthority, error) {
+	if pvc == nil || backup == nil {
+		return nil, fmt.Errorf("PVC and Backup are required")
+	}
+	if pvc.Namespace == "" || pvc.UID == "" {
+		return nil, fmt.Errorf("PVC identity must include namespace and UID")
+	}
+	if !pvc.DeletionTimestamp.IsZero() {
+		return nil, fmt.Errorf("PVC %s/%s is terminating", pvc.Namespace, pvc.Name)
+	}
+	workload, err := r.resolveRestorePVCWorkload(reqCtx, pvc)
+	if err != nil {
+		return nil, err
+	}
+	componentRef := metav1.GetControllerOf(workload)
+	if componentRef == nil || componentRef.APIVersion != appsv1.GroupVersion.String() ||
+		componentRef.Kind != "Component" {
+		return nil, fmt.Errorf("PVC %s/%s workload %s/%s has no Component controller owner",
+			pvc.Namespace, pvc.Name, workload.GetNamespace(), workload.GetName())
+	}
+	component := &appsv1.Component{}
+	if err := r.Client.Get(reqCtx.Ctx, client.ObjectKey{
+		Namespace: pvc.Namespace,
+		Name:      componentRef.Name,
+	}, component); err != nil {
+		return nil, err
+	}
+	if component.UID == "" || component.UID != componentRef.UID {
+		return nil, fmt.Errorf("PVC %s/%s Component owner UID mismatch", pvc.Namespace, pvc.Name)
+	}
+	if !component.DeletionTimestamp.IsZero() {
+		return nil, fmt.Errorf("PVC %s/%s Component owner is terminating", pvc.Namespace, pvc.Name)
+	}
+	clusterRef := metav1.GetControllerOf(component)
+	if clusterRef == nil || clusterRef.APIVersion != appsv1.GroupVersion.String() ||
+		clusterRef.Kind != "Cluster" || clusterRef.Name != clusterName {
+		return nil, fmt.Errorf("component %s/%s has no matching Cluster %q controller owner",
+			component.Namespace, component.Name, clusterName)
+	}
+	cluster := &appsv1.Cluster{}
+	if err := r.Client.Get(reqCtx.Ctx, client.ObjectKey{
+		Namespace: pvc.Namespace,
+		Name:      clusterRef.Name,
+	}, cluster); err != nil {
+		return nil, err
+	}
+	if cluster.UID == "" || cluster.UID != clusterRef.UID {
+		return nil, fmt.Errorf("component %s/%s Cluster owner UID mismatch", component.Namespace, component.Name)
+	}
+	if !cluster.DeletionTimestamp.IsZero() {
+		return nil, fmt.Errorf("component %s/%s Cluster owner is terminating", component.Namespace, component.Name)
+	}
+	if workload.GetLabels()[constant.AppInstanceLabelKey] != cluster.Name ||
+		pvc.Labels[constant.AppInstanceLabelKey] != cluster.Name {
+		return nil, fmt.Errorf("PVC %s/%s workload authority does not match Cluster %s/%s",
+			pvc.Namespace, pvc.Name, cluster.Namespace, cluster.Name)
+	}
+	source := systemaccount.SourceIdentity{
+		APIGroup:  dptypes.DataprotectionAPIGroup,
+		Kind:      dptypes.BackupKind,
+		Namespace: backup.Namespace,
+		Name:      backup.Name,
+	}
+	operation := systemaccount.RestoreOperationIdentity{
+		Protocol: systemaccount.RestoreProtocolV2,
+		Root:     objectIdentity(cluster),
+		Source:   source,
+	}
+	switch {
+	case cluster.Spec.Restore != nil:
+		declared := cluster.Spec.Restore.Source
+		namespace := declared.Namespace
+		if namespace == "" {
+			namespace = cluster.Namespace
+		}
+		if declared.APIGroup != source.APIGroup || declared.Kind != source.Kind ||
+			namespace != source.Namespace || declared.Name != source.Name {
+			return nil, newSystemAccountRestoreContractError(
+				systemaccount.RestoreIntentMismatchReason,
+				fmt.Errorf("cluster %s/%s restore source does not match Backup %s/%s",
+					cluster.Namespace, cluster.Name, backup.Namespace, backup.Name))
+		}
+		operation.Profile = systemaccount.RestoreProfileInitialCluster
+		operation.Source.Namespace = namespace
+		operation.PITR = cluster.Spec.Restore.PITR
+		operation.Parameters = maps.Clone(cluster.Spec.Restore.Parameters)
+	case backup.Namespace != pvc.Namespace:
+		return nil, newSystemAccountRestoreContractError(
+			systemaccount.UnsupportedRestoreSourceReason,
+			fmt.Errorf("PVC %s/%s legacy restore profile does not allow cross-namespace Backup %s/%s",
+				pvc.Namespace, pvc.Name, backup.Namespace, backup.Name))
+	default:
+		operation.Profile = systemaccount.RestoreProfileLegacyPVCGroup
+		operation.PITR = pvc.Annotations[constant.RestorePITRAnnotationKey]
+	}
+	return &systemAccountRestoreAuthority{
+		root:      cluster,
+		component: component,
+		operation: operation,
+	}, nil
+}
+
+func (r *VolumePopulatorReconciler) resolveRestorePVCWorkload(
+	reqCtx intctrlutil.RequestCtx,
+	pvc *corev1.PersistentVolumeClaim,
+) (client.Object, error) {
+	ownerRef := metav1.GetControllerOf(pvc)
+	if ownerRef == nil || ownerRef.APIVersion != workloads.GroupVersion.String() {
+		return nil, fmt.Errorf("PVC %s/%s has no supported workload controller owner", pvc.Namespace, pvc.Name)
+	}
+	var workload client.Object
+	switch ownerRef.Kind {
+	case workloads.InstanceSetKind:
+		workload = &workloads.InstanceSet{}
+	case "Instance":
+		workload = &workloads.Instance{}
+	default:
+		return nil, fmt.Errorf("PVC %s/%s has unsupported workload owner kind %q",
+			pvc.Namespace, pvc.Name, ownerRef.Kind)
+	}
+	if err := r.Client.Get(reqCtx.Ctx, client.ObjectKey{
+		Namespace: pvc.Namespace,
+		Name:      ownerRef.Name,
+	}, workload); err != nil {
+		return nil, err
+	}
+	if workload.GetUID() == "" || workload.GetUID() != ownerRef.UID {
+		return nil, fmt.Errorf("PVC %s/%s workload owner UID mismatch", pvc.Namespace, pvc.Name)
+	}
+	if !workload.GetDeletionTimestamp().IsZero() {
+		return nil, fmt.Errorf("PVC %s/%s workload owner is terminating", pvc.Namespace, pvc.Name)
+	}
+	return workload, nil
+}
+
+func objectIdentity(object client.Object) systemaccount.ObjectIdentity {
+	gvk := object.GetObjectKind().GroupVersionKind()
+	if gvk.Empty() {
+		switch object.(type) {
+		case *appsv1.Cluster:
+			gvk = appsv1.GroupVersion.WithKind("Cluster")
+		case *appsv1.Component:
+			gvk = appsv1.GroupVersion.WithKind("Component")
+		case *dpv1alpha1.Backup:
+			gvk = dpv1alpha1.GroupVersion.WithKind("Backup")
+		}
+	}
+	return systemaccount.ObjectIdentity{
+		APIVersion: gvk.GroupVersion().String(),
+		Kind:       gvk.Kind,
+		Namespace:  object.GetNamespace(),
+		Name:       object.GetName(),
+		UID:        object.GetUID(),
+	}
+}
+
+func (r *VolumePopulatorReconciler) projectSystemAccountConflictIdentity(
+	reqCtx intctrlutil.RequestCtx,
+	pvc *corev1.PersistentVolumeClaim,
+	envelope systemaccount.ConflictEnvelope,
+) error {
+	if pvc == nil || pvc.Namespace == "" || pvc.Name == "" || pvc.UID == "" {
+		return fmt.Errorf("PVC identity must include namespace, name, and UID")
+	}
+	expected, err := systemAccountConflictExpectedIdentity(envelope)
+	if err != nil {
+		return err
+	}
+
+	current := &corev1.PersistentVolumeClaim{}
+	if err := r.Client.Get(reqCtx.Ctx, client.ObjectKeyFromObject(pvc), current); err != nil {
+		return err
+	}
+	if current.UID != pvc.UID {
+		return fmt.Errorf("PVC %s was replaced: expected UID %s, got %s",
+			client.ObjectKeyFromObject(pvc), pvc.UID, current.UID)
+	}
+	if systemAccountConflictIdentityExact(current, expected) {
+		*pvc = *current
+		return nil
+	}
+
+	updated := current.DeepCopy()
+	if updated.Annotations == nil {
+		updated.Annotations = map[string]string{}
+	}
+	for key, value := range expected {
+		updated.Annotations[key] = value
+	}
+	updateErr := r.Client.Update(reqCtx.Ctx, updated)
+	if updateErr == nil {
+		*pvc = *updated
+		return nil
+	}
+
+	// An update response can be lost after the apiserver committed it. Accept
+	// only a fresh read of the same PVC UID with all three receipt identities.
+	fresh := &corev1.PersistentVolumeClaim{}
+	if getErr := r.Client.Get(reqCtx.Ctx, client.ObjectKeyFromObject(pvc), fresh); getErr == nil &&
+		fresh.UID == pvc.UID && systemAccountConflictIdentityExact(fresh, expected) {
+		*pvc = *fresh
+		return nil
+	}
+	return updateErr
+}
+
+func systemAccountConflictExpectedIdentity(
+	envelope systemaccount.ConflictEnvelope,
+) (map[string]string, error) {
+	operationDigest, err := systemaccount.OperationDigest(envelope.LoserOperation)
+	if err != nil {
+		return nil, err
+	}
+	expected := map[string]string{
+		systemaccount.RestoreOperationDigestAnnotationKey: operationDigest,
+		systemaccount.BlockingRequestUIDAnnotationKey:     string(envelope.BlockingRequest.UID),
+		systemaccount.WinnerOperationDigestAnnotationKey:  envelope.BlockingRequest.WinnerOperationDigest,
+	}
+	for key, value := range expected {
+		if value == "" {
+			return nil, fmt.Errorf("conflict projection annotation %q must not be empty", key)
+		}
+	}
+	return expected, nil
+}
+
+func systemAccountConflictIdentityExact(
+	pvc *corev1.PersistentVolumeClaim,
+	expected map[string]string,
+) bool {
+	if pvc == nil || pvc.Annotations == nil {
+		return false
+	}
+	for key, value := range expected {
+		if value == "" || pvc.Annotations[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func systemAccountConflictIdentityPresent(pvc *corev1.PersistentVolumeClaim) bool {
+	if pvc == nil || pvc.Annotations == nil {
+		return false
+	}
+	for _, key := range []string{
+		systemaccount.RestoreOperationDigestAnnotationKey,
+		systemaccount.BlockingRequestUIDAnnotationKey,
+		systemaccount.WinnerOperationDigestAnnotationKey,
+	} {
+		if pvc.Annotations[key] == "" {
+			return false
+		}
+	}
+	return true
+}
+
+func (r *VolumePopulatorReconciler) systemAccountRestoreOperationState(
+	reqCtx intctrlutil.RequestCtx,
+	operation systemaccount.RestoreOperationIdentity,
+) (systemAccountRestoreOperationState, error) {
+	cluster := &appsv1.Cluster{}
+	if err := r.Client.Get(reqCtx.Ctx, client.ObjectKey{
+		Namespace: operation.Root.Namespace,
+		Name:      operation.Root.Name,
+	}, cluster); err != nil {
+		if apierrors.IsNotFound(err) {
+			return systemAccountRestoreOperationGone, nil
+		}
+		return "", err
+	}
+	if cluster.UID != operation.Root.UID {
+		return systemAccountRestoreOperationGone, nil
+	}
+	if !cluster.DeletionTimestamp.IsZero() {
+		return systemAccountRestoreOperationTerminating, nil
+	}
+	if operation.Profile == systemaccount.RestoreProfileInitialCluster {
+		if cluster.Spec.Restore == nil {
+			return systemAccountRestoreOperationGone, nil
+		}
+		current := systemaccount.RestoreOperationIdentity{
+			Protocol: systemaccount.RestoreProtocolV2,
+			Profile:  systemaccount.RestoreProfileInitialCluster,
+			Root:     objectIdentity(cluster),
+			Source: systemaccount.SourceIdentity{
+				APIGroup:  cluster.Spec.Restore.Source.APIGroup,
+				Kind:      cluster.Spec.Restore.Source.Kind,
+				Namespace: cluster.Spec.Restore.Source.Namespace,
+				Name:      cluster.Spec.Restore.Source.Name,
+			},
+			PITR:       cluster.Spec.Restore.PITR,
+			Parameters: maps.Clone(cluster.Spec.Restore.Parameters),
+		}
+		if current.Source.Namespace == "" {
+			current.Source.Namespace = cluster.Namespace
+		}
+		currentDigest, err := systemaccount.OperationDigest(current)
+		if err != nil {
+			return "", err
+		}
+		expectedDigest, err := systemaccount.OperationDigest(operation)
+		if err != nil {
+			return "", err
+		}
+		if currentDigest != expectedDigest {
+			return systemAccountRestoreOperationGone, nil
+		}
+		condition := findClusterCondition(cluster.Status.Conditions, appsv1.ConditionTypeRestore)
+		if condition == nil || condition.ObservedGeneration != cluster.Generation ||
+			condition.Status == metav1.ConditionUnknown {
+			return systemAccountRestoreOperationActive, nil
+		}
+		if condition.Status == metav1.ConditionTrue {
+			return systemAccountRestoreOperationSucceeded, nil
+		}
+		return systemAccountRestoreOperationFailed, nil
+	}
+	return r.legacySystemAccountRestoreOperationState(reqCtx, operation)
+}
+
+type systemAccountRestoreOperationState string
+
+const (
+	systemAccountRestoreOperationActive      systemAccountRestoreOperationState = "Active"
+	systemAccountRestoreOperationSucceeded   systemAccountRestoreOperationState = "Succeeded"
+	systemAccountRestoreOperationFailed      systemAccountRestoreOperationState = "Failed"
+	systemAccountRestoreOperationTerminating systemAccountRestoreOperationState = "Terminating"
+	systemAccountRestoreOperationGone        systemAccountRestoreOperationState = "Gone"
+)
+
+func (r *VolumePopulatorReconciler) legacySystemAccountRestoreOperationState(
+	reqCtx intctrlutil.RequestCtx,
+	operation systemaccount.RestoreOperationIdentity,
+) (systemAccountRestoreOperationState, error) {
+	pvcs := &corev1.PersistentVolumeClaimList{}
+	if err := r.Client.List(reqCtx.Ctx, pvcs,
+		client.InNamespace(operation.Root.Namespace),
+		client.MatchingLabels{constant.AppInstanceLabelKey: operation.Root.Name}); err != nil {
+		return "", err
+	}
+	found := false
+	allSucceeded := true
+	for i := range pvcs.Items {
+		pvc := &pvcs.Items[i]
+		if !pvcReferencesOperationSource(pvc, operation) {
+			continue
+		}
+		namespace, err := backupNamespaceFromPVC(pvc)
+		if err != nil || namespace != operation.Source.Namespace {
+			continue
+		}
+		workload, err := r.resolveRestorePVCWorkload(reqCtx, pvc)
+		if err != nil {
+			continue
+		}
+		componentRef := metav1.GetControllerOf(workload)
+		if componentRef == nil || componentRef.Kind != "Component" {
+			continue
+		}
+		component := &appsv1.Component{}
+		if err := r.Client.Get(reqCtx.Ctx, client.ObjectKey{
+			Namespace: pvc.Namespace,
+			Name:      componentRef.Name,
+		}, component); err != nil || component.UID != componentRef.UID {
+			continue
+		}
+		clusterRef := metav1.GetControllerOf(component)
+		if clusterRef == nil || clusterRef.UID != operation.Root.UID {
+			continue
+		}
+		found = true
+		condition := findPVCConditionByType(pvc, appsv1.ConditionTypeRestore)
+		if condition == nil || condition.Status == corev1.ConditionUnknown {
+			allSucceeded = false
+			continue
+		}
+		if condition.Status == corev1.ConditionFalse {
+			return systemAccountRestoreOperationFailed, nil
+		}
+	}
+	if !found {
+		return systemAccountRestoreOperationGone, nil
+	}
+	if allSucceeded {
+		return systemAccountRestoreOperationSucceeded, nil
+	}
+	return systemAccountRestoreOperationActive, nil
+}
+
+func findClusterCondition(conditions []metav1.Condition, conditionType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == conditionType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -2312,31 +2312,18 @@ func (r *VolumePopulatorReconciler) upsertSystemAccountSecret(reqCtx intctrlutil
 		return r.Client.Create(reqCtx.Ctx, secret)
 	}
 	if secret.Immutable != nil && *secret.Immutable && !systemAccountSecretMatches(secret, accountName, password) {
+		if controllerutil.RemoveFinalizer(secret, constant.DBClusterFinalizerName) {
+			if err := r.Client.Update(reqCtx.Ctx, secret); err != nil && !apierrors.IsNotFound(err) {
+				return err
+			}
+		}
+		if !secret.DeletionTimestamp.IsZero() {
+			return intctrlutil.NewRequeueError(reconcileInterval, fmt.Sprintf("waiting for immutable system account secret %s/%s to be deleted", secret.Namespace, secret.Name))
+		}
 		if err := r.Client.Delete(reqCtx.Ctx, secret); err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
-		secret = &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      secretName,
-				Namespace: pvc.Namespace,
-				Labels:    labels,
-				Annotations: map[string]string{
-					constant.SystemAccountProvisionedAnnotationKey: "true",
-				},
-			},
-			Type: corev1.SecretTypeOpaque,
-			Data: map[string][]byte{
-				constant.AccountNameForSecret:   []byte(accountName),
-				constant.AccountPasswdForSecret: password,
-			},
-		}
-		if err := r.setSystemAccountSecretOwner(reqCtx, pvc.Namespace, secret, scope, clusterName, ownerName); err != nil {
-			return err
-		}
-		if err := r.Client.Create(reqCtx.Ctx, secret); err != nil {
-			return err
-		}
-		return nil
+		return intctrlutil.NewRequeueError(reconcileInterval, fmt.Sprintf("waiting for immutable system account secret %s/%s to be recreated", secret.Namespace, secret.Name))
 	}
 	patch := client.MergeFrom(secret.DeepCopy())
 	if secret.Labels == nil {

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -49,6 +49,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/instanceset"
 	"github.com/apecloud/kubeblocks/pkg/controller/instancetemplate"
+	"github.com/apecloud/kubeblocks/pkg/controller/systemaccount"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	dprestore "github.com/apecloud/kubeblocks/pkg/dataprotection/restore"
 	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
@@ -2285,91 +2286,132 @@ func (r *VolumePopulatorReconciler) upsertSystemAccountSecret(reqCtx intctrlutil
 	password []byte,
 	labels map[string]string) error {
 	secretName := systemAccountSecretName(scope, clusterName, ownerName, accountName)
-	secret := &corev1.Secret{}
 	key := types.NamespacedName{Namespace: pvc.Namespace, Name: secretName}
-	if err := r.Client.Get(reqCtx.Ctx, key, secret); err != nil {
+	request, err := r.newSystemAccountRestoreRequest(reqCtx, pvc.Namespace, secretName, scope,
+		clusterName, ownerName, accountName, password, labels)
+	if err != nil {
+		return newSystemAccountSecretRequeueError("build restore request for", key, err)
+	}
+
+	secret := &corev1.Secret{}
+	if err := r.Client.Get(reqCtx.Ctx, key, secret); err == nil {
+		if systemaccount.RestoreConverged(secret, request, systemAccountSecretFinalizer(scope)) {
+			return nil
+		}
+	} else {
 		if !apierrors.IsNotFound(err) {
-			return err
+			return newSystemAccountSecretRequeueError("get", key, err)
 		}
-		secret = &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      secretName,
-				Namespace: pvc.Namespace,
-				Labels:    labels,
-				Annotations: map[string]string{
-					constant.SystemAccountProvisionedAnnotationKey: "true",
-				},
-			},
-			Type: corev1.SecretTypeOpaque,
-			Data: map[string][]byte{
-				constant.AccountNameForSecret:   []byte(accountName),
-				constant.AccountPasswdForSecret: password,
-			},
+	}
+
+	existing := &corev1.Secret{}
+	requestKey := client.ObjectKeyFromObject(request)
+	if err := r.Client.Get(reqCtx.Ctx, requestKey, existing); err == nil {
+		if validationErr := validateSystemAccountRestoreRequest(existing, request); validationErr != nil {
+			return validationErr
 		}
-		if err := r.setSystemAccountSecretOwner(reqCtx, pvc.Namespace, secret, scope, clusterName, ownerName); err != nil {
-			return err
-		}
-		return r.Client.Create(reqCtx.Ctx, secret)
+		return intctrlutil.NewRequeueError(reconcileInterval,
+			fmt.Sprintf("waiting for system account restore request %s to converge target %s", requestKey, key))
+	} else if !apierrors.IsNotFound(err) {
+		return newSystemAccountSecretRequeueError("get restore request for", key, err)
 	}
-	if secret.Immutable != nil && *secret.Immutable && !systemAccountSecretMatches(secret, accountName, password) {
-		if controllerutil.RemoveFinalizer(secret, constant.DBClusterFinalizerName) {
-			if err := r.Client.Update(reqCtx.Ctx, secret); err != nil && !apierrors.IsNotFound(err) {
-				return err
-			}
-		}
-		if !secret.DeletionTimestamp.IsZero() {
-			return intctrlutil.NewRequeueError(reconcileInterval, fmt.Sprintf("waiting for immutable system account secret %s/%s to be deleted", secret.Namespace, secret.Name))
-		}
-		uid := secret.UID
-		if err := r.Client.Delete(reqCtx.Ctx, secret, client.Preconditions{UID: &uid}); err != nil && !apierrors.IsNotFound(err) {
-			return err
-		}
-		return intctrlutil.NewRequeueError(reconcileInterval, fmt.Sprintf("waiting for immutable system account secret %s/%s to be recreated", secret.Namespace, secret.Name))
+	if err := r.Client.Create(reqCtx.Ctx, request); err != nil {
+		return newSystemAccountSecretRequeueError("create", requestKey, err)
 	}
-	patch := client.MergeFrom(secret.DeepCopy())
-	if secret.Labels == nil {
-		secret.Labels = map[string]string{}
-	}
-	for k, v := range labels {
-		secret.Labels[k] = v
-	}
-	if secret.Annotations == nil {
-		secret.Annotations = map[string]string{}
-	}
-	secret.Annotations[constant.SystemAccountProvisionedAnnotationKey] = "true"
-	if secret.Data == nil {
-		secret.Data = map[string][]byte{}
-	}
-	secret.Data[constant.AccountNameForSecret] = []byte(accountName)
-	secret.Data[constant.AccountPasswdForSecret] = password
-	if err := r.setSystemAccountSecretOwner(reqCtx, pvc.Namespace, secret, scope, clusterName, ownerName); err != nil {
-		return err
-	}
-	return r.Client.Patch(reqCtx.Ctx, secret, patch)
+	return intctrlutil.NewRequeueError(reconcileInterval,
+		fmt.Sprintf("waiting for the Apps owner to converge system account Secret %s", key))
 }
 
-func (r *VolumePopulatorReconciler) setSystemAccountSecretOwner(reqCtx intctrlutil.RequestCtx,
+func (r *VolumePopulatorReconciler) newSystemAccountRestoreRequest(reqCtx intctrlutil.RequestCtx,
+	namespace, targetName string,
+	scope systemAccountSecretScope,
+	clusterName, ownerName, accountName string,
+	password []byte,
+	labels map[string]string) (*corev1.Secret, error) {
+	requestLabels := mapsClone(labels)
+	requestLabels[constant.SystemAccountRestoreRequestLabelKey] = "true"
+	request := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      systemaccount.RestoreRequestName(namespace, targetName),
+			Labels:    requestLabels,
+			Annotations: map[string]string{
+				constant.SystemAccountRestoreTargetAnnotationKey: targetName,
+				constant.SystemAccountProvisionedAnnotationKey:   "true",
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			constant.AccountNameForSecret:   []byte(accountName),
+			constant.AccountPasswdForSecret: slices.Clone(password),
+		},
+	}
+	if scope == systemAccountSecretScopeSharding {
+		immutable := true
+		request.Immutable = &immutable
+	}
+	if err := r.setSystemAccountRestoreRequestOwner(reqCtx, namespace, request, scope, clusterName, ownerName); err != nil {
+		return nil, err
+	}
+	if err := systemaccount.SetRestoreRevision(request); err != nil {
+		return nil, err
+	}
+	return request, nil
+}
+
+func (r *VolumePopulatorReconciler) setSystemAccountRestoreRequestOwner(reqCtx intctrlutil.RequestCtx,
 	namespace string,
-	secret *corev1.Secret,
+	request *corev1.Secret,
 	scope systemAccountSecretScope,
 	clusterName, ownerName string) error {
-	switch scope {
-	case systemAccountSecretScopeSharding:
-		cluster := &appsv1.Cluster{}
-		if err := r.Client.Get(reqCtx.Ctx, types.NamespacedName{Namespace: namespace, Name: clusterName}, cluster); err != nil {
+	var owner client.Object
+	if scope == systemAccountSecretScopeSharding {
+		owner = &appsv1.Cluster{}
+		if err := r.Client.Get(reqCtx.Ctx, types.NamespacedName{Namespace: namespace, Name: clusterName}, owner); err != nil {
 			return err
 		}
-		return controllerutil.SetOwnerReference(cluster, secret, r.Scheme)
-	default:
-		component := &appsv1.Component{}
+	} else {
+		owner = &appsv1.Component{}
 		if err := r.Client.Get(reqCtx.Ctx, types.NamespacedName{
 			Namespace: namespace,
 			Name:      constant.GenerateClusterComponentName(clusterName, ownerName),
-		}, component); err != nil {
+		}, owner); err != nil {
 			return err
 		}
-		return controllerutil.SetOwnerReference(component, secret, r.Scheme)
 	}
+	return controllerutil.SetControllerReference(owner, request, r.Scheme)
+}
+
+func newSystemAccountSecretRequeueError(action string, key client.ObjectKey, err error) error {
+	return intctrlutil.NewRequeueError(reconcileInterval,
+		fmt.Sprintf("failed to %s system account Secret %s: %v", action, key, err))
+}
+
+func validateSystemAccountRestoreRequest(existing, desired *corev1.Secret) error {
+	if err := systemaccount.ValidateRestoreRequest(existing); err != nil {
+		return intctrlutil.NewFatalError(fmt.Sprintf("invalid system account restore request %s: %v",
+			client.ObjectKeyFromObject(existing), err))
+	}
+	existingOwner := metav1.GetControllerOf(existing)
+	desiredOwner := metav1.GetControllerOf(desired)
+	if existing.Annotations[constant.SystemAccountRestoreTargetAnnotationKey] !=
+		desired.Annotations[constant.SystemAccountRestoreTargetAnnotationKey] ||
+		existingOwner == nil || desiredOwner == nil ||
+		existingOwner.APIVersion != desiredOwner.APIVersion ||
+		existingOwner.Kind != desiredOwner.Kind ||
+		existingOwner.Name != desiredOwner.Name {
+		return intctrlutil.NewFatalError(fmt.Sprintf(
+			"system account restore request %s conflicts with desired request owner or target",
+			client.ObjectKeyFromObject(existing)))
+	}
+	return nil
+}
+
+func systemAccountSecretFinalizer(scope systemAccountSecretScope) string {
+	if scope == systemAccountSecretScopeSharding {
+		return constant.DBClusterFinalizerName
+	}
+	return constant.DBComponentFinalizerName
 }
 
 func systemAccountSecretName(scope systemAccountSecretScope, clusterName, ownerName, accountName string) string {
@@ -2377,11 +2419,6 @@ func systemAccountSecretName(scope systemAccountSecretScope, clusterName, ownerN
 		return fmt.Sprintf("%s-%s-%s", clusterName, ownerName, accountName)
 	}
 	return constant.GenerateAccountSecretName(clusterName, ownerName, accountName)
-}
-
-func systemAccountSecretMatches(secret *corev1.Secret, accountName string, password []byte) bool {
-	return string(secret.Data[constant.AccountNameForSecret]) == accountName &&
-		string(secret.Data[constant.AccountPasswdForSecret]) == string(password)
 }
 
 func upsertPVCCondition(conditions *[]corev1.PersistentVolumeClaimCondition, condition corev1.PersistentVolumeClaimCondition) {

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -2320,7 +2320,8 @@ func (r *VolumePopulatorReconciler) upsertSystemAccountSecret(reqCtx intctrlutil
 		if !secret.DeletionTimestamp.IsZero() {
 			return intctrlutil.NewRequeueError(reconcileInterval, fmt.Sprintf("waiting for immutable system account secret %s/%s to be deleted", secret.Namespace, secret.Name))
 		}
-		if err := r.Client.Delete(reqCtx.Ctx, secret); err != nil && !apierrors.IsNotFound(err) {
+		uid := secret.UID
+		if err := r.Client.Delete(reqCtx.Ctx, secret, client.Preconditions{UID: &uid}); err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 		return intctrlutil.NewRequeueError(reconcileInterval, fmt.Sprintf("waiting for immutable system account secret %s/%s to be recreated", secret.Namespace, secret.Name))

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -22,6 +22,7 @@ package dataprotection
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"reflect"
 	"slices"
@@ -39,9 +40,13 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/component-helpers/storage/volume"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
@@ -116,7 +121,16 @@ func (r *VolumePopulatorReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 func (r *VolumePopulatorReconciler) handleSyncPVCError(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim, err error) (ctrl.Result, error) {
 	if intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal) {
 		r.Recorder.Event(pvc, corev1.EventTypeWarning, ReasonVolumePopulateFailed, err.Error())
-		if patchErr := r.UpdatePVCConditions(reqCtx, pvc, ReasonPopulatingFailed, err.Error()); patchErr != nil {
+		reason := systemAccountRestoreFailureReason(err)
+		if reason == "" {
+			reason = ReasonPopulatingFailed
+		}
+		if reason == systemaccount.ConcurrentRestoreIntentReason &&
+			!systemAccountConflictIdentityPresent(pvc) {
+			return intctrlutil.RequeueAfter(reconcileInterval, reqCtx.Log,
+				"waiting for exact system account conflict identity projection")
+		}
+		if patchErr := r.UpdatePVCConditions(reqCtx, pvc, reason, err.Error()); patchErr != nil {
 			return intctrlutil.RequeueWithError(patchErr, reqCtx.Log, "")
 		}
 		return intctrlutil.Reconciled()
@@ -135,7 +149,94 @@ func (r *VolumePopulatorReconciler) handleSyncPVCError(reqCtx intctrlutil.Reques
 func (r *VolumePopulatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return intctrlutil.NewControllerManagedBy(mgr).
 		For(&corev1.PersistentVolumeClaim{}).
+		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.mapSystemAccountProtocolSecret),
+			builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
+				protocol := object.GetAnnotations()[systemaccount.RestoreProtocolAnnotationKey]
+				return protocol == systemaccount.RestoreProtocolV2 ||
+					protocol == systemaccount.ConflictProtocolV1
+			}))).
 		Complete(r)
+}
+
+func (r *VolumePopulatorReconciler) mapSystemAccountProtocolSecret(
+	ctx context.Context,
+	object client.Object,
+) []reconcile.Request {
+	secret, ok := object.(*corev1.Secret)
+	if !ok {
+		return nil
+	}
+	var (
+		operation      systemaccount.RestoreOperationIdentity
+		resolvedSource *systemaccount.ObjectIdentity
+		conflict       *systemaccount.ConflictEnvelope
+	)
+	switch secret.Annotations[systemaccount.RestoreProtocolAnnotationKey] {
+	case systemaccount.RestoreProtocolV2:
+		intent, err := systemaccount.DecodeRestoreRequestV2(secret)
+		if err != nil {
+			log.FromContext(ctx).Error(err, "ignore invalid system account restore request event",
+				"request", client.ObjectKeyFromObject(secret))
+			return nil
+		}
+		operation = intent.Operation
+		resolvedSource = &intent.ResolvedSource
+	case systemaccount.ConflictProtocolV1:
+		envelope, err := systemaccount.DecodeAndValidateConflictReceipt(secret, false)
+		if err != nil {
+			log.FromContext(ctx).Error(err, "ignore invalid system account conflict receipt event",
+				"receipt", client.ObjectKeyFromObject(secret))
+			return nil
+		}
+		operation = envelope.LoserOperation
+		conflict = &envelope
+	default:
+		return nil
+	}
+	lifecycle := &SystemAccountConflictReceiptLifecycleReconciler{
+		Client: r.Client,
+		Scheme: r.Scheme,
+	}
+	pvcs, err := lifecycle.participantsForOperation(ctx, operation)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "map system account protocol Secret to participants",
+			"secret", client.ObjectKeyFromObject(secret))
+		return nil
+	}
+	if resolvedSource != nil {
+		backup := &dpv1alpha1.Backup{}
+		if err := r.Client.Get(ctx, client.ObjectKey{
+			Namespace: resolvedSource.Namespace,
+			Name:      resolvedSource.Name,
+		}, backup); err != nil || backup.UID != resolvedSource.UID {
+			return nil
+		}
+	}
+	var conflictIdentity map[string]string
+	if conflict != nil {
+		conflictIdentity, err = systemAccountConflictExpectedIdentity(*conflict)
+		if err != nil {
+			log.FromContext(ctx).Error(err, "ignore invalid system account conflict projection identity",
+				"receipt", client.ObjectKeyFromObject(secret))
+			return nil
+		}
+	}
+	requests := make([]reconcile.Request, 0, len(pvcs))
+	for _, pvc := range pvcs {
+		condition := findPVCConditionByType(pvc, appsv1.ConditionTypeRestore)
+		if conflict != nil {
+			if condition != nil &&
+				condition.Status == corev1.ConditionFalse &&
+				condition.Reason == systemaccount.ConcurrentRestoreIntentReason &&
+				systemAccountConflictIdentityExact(pvc, conflictIdentity) {
+				continue
+			}
+		} else if condition != nil && condition.Status != corev1.ConditionUnknown {
+			continue
+		}
+		requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(pvc)})
+	}
+	return requests
 }
 
 func (r *VolumePopulatorReconciler) MatchToPopulate(pvc *corev1.PersistentVolumeClaim) (bool, error) {
@@ -1893,6 +1994,10 @@ func (r *VolumePopulatorReconciler) UpdatePVCConditions(reqCtx intctrlutil.Reque
 		restoreCondition.Status = corev1.ConditionTrue
 	case ReasonPopulatingFailed:
 		restoreCondition.Status = corev1.ConditionFalse
+	default:
+		if systemaccount.IsRestoreFailureReason(reason) {
+			restoreCondition.Status = corev1.ConditionFalse
+		}
 	}
 	pvcPatch := client.MergeFrom(pvc.DeepCopy())
 	var existPopulating bool
@@ -2217,24 +2322,14 @@ func (r *VolumePopulatorReconciler) restoreSystemAccountSecrets(reqCtx intctrlut
 	}
 	encryptor := intctrlutil.NewEncryptor(viper.GetString(constant.CfgKeyDPEncryptionKey))
 	if componentName != "" {
-		labels := map[string]string{
-			constant.AppInstanceLabelKey:        clusterName,
-			constant.KBAppComponentLabelKey:     componentName,
-			"apps.kubeblocks.io/system-account": "",
-		}
-		if err := r.restoreSystemAccountSecretSet(reqCtx, pvc, encryptor, accountsByComponent[componentName],
-			systemAccountSecretScopeComponent, clusterName, componentName, labels); err != nil {
+		if err := r.restoreSystemAccountSecretSet(reqCtx, pvc, backup, encryptor, accountsByComponent[componentName],
+			systemAccountSecretScopeComponent, clusterName, componentName); err != nil {
 			return err
 		}
 	}
 	if shardingName := pvc.Labels[constant.KBAppShardingNameLabelKey]; shardingName != "" {
-		labels := map[string]string{
-			constant.AppInstanceLabelKey:        clusterName,
-			constant.KBAppShardingNameLabelKey:  shardingName,
-			"apps.kubeblocks.io/system-account": "",
-		}
-		if err := r.restoreSystemAccountSecretSet(reqCtx, pvc, encryptor, accountsByComponent[shardingName],
-			systemAccountSecretScopeSharding, clusterName, shardingName, labels); err != nil {
+		if err := r.restoreSystemAccountSecretSet(reqCtx, pvc, backup, encryptor, accountsByComponent[shardingName],
+			systemAccountSecretScopeSharding, clusterName, shardingName); err != nil {
 			return err
 		}
 	}
@@ -2250,136 +2345,224 @@ const (
 
 func (r *VolumePopulatorReconciler) restoreSystemAccountSecretSet(reqCtx intctrlutil.RequestCtx,
 	pvc *corev1.PersistentVolumeClaim,
+	backup *dpv1alpha1.Backup,
 	encryptor interface {
 		Decrypt([]byte) (string, error)
 	},
 	accounts map[string]string,
 	scope systemAccountSecretScope,
-	clusterName, ownerName string,
-	labels map[string]string) error {
+	clusterName, ownerName string) error {
 	for accountName, encryptedPassword := range accounts {
 		password, err := encryptor.Decrypt([]byte(encryptedPassword))
 		if err != nil {
 			return intctrlutil.NewFatalError(err.Error())
 		}
-		accountLabels := mapsClone(labels)
-		accountLabels["apps.kubeblocks.io/system-account"] = accountName
-		if err = r.upsertSystemAccountSecret(reqCtx, pvc, scope, clusterName, ownerName, accountName, []byte(password), accountLabels); err != nil {
+		if err = r.upsertSystemAccountSecret(reqCtx, pvc, backup, scope,
+			clusterName, ownerName, accountName, []byte(password)); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func mapsClone(in map[string]string) map[string]string {
-	out := make(map[string]string, len(in))
-	for k, v := range in {
-		out[k] = v
-	}
-	return out
-}
-
 func (r *VolumePopulatorReconciler) upsertSystemAccountSecret(reqCtx intctrlutil.RequestCtx,
 	pvc *corev1.PersistentVolumeClaim,
+	backup *dpv1alpha1.Backup,
 	scope systemAccountSecretScope,
 	clusterName, ownerName, accountName string,
-	password []byte,
-	labels map[string]string) error {
+	password []byte) error {
 	secretName := systemAccountSecretName(scope, clusterName, ownerName, accountName)
 	key := types.NamespacedName{Namespace: pvc.Namespace, Name: secretName}
-	request, err := r.newSystemAccountRestoreRequest(reqCtx, pvc.Namespace, secretName, scope,
-		clusterName, ownerName, accountName, password, labels)
+	request, err := r.newSystemAccountRestoreRequest(reqCtx, pvc, backup, scope,
+		clusterName, ownerName, accountName, password)
 	if err != nil {
+		var contractErr *systemAccountRestoreContractError
+		if errors.As(err, &contractErr) {
+			return intctrlutil.NewFatalError(contractErr.Error())
+		}
 		return newSystemAccountSecretRequeueError("build restore request for", key, err)
 	}
-
-	secret := &corev1.Secret{}
-	if err := r.Client.Get(reqCtx.Ctx, key, secret); err == nil {
-		if systemaccount.RestoreConverged(secret, request, systemAccountSecretFinalizer(scope)) {
-			return nil
-		}
-	} else {
-		if !apierrors.IsNotFound(err) {
-			return newSystemAccountSecretRequeueError("get", key, err)
-		}
+	intent, err := systemaccount.ValidateRestoreRequestV2(request)
+	if err != nil {
+		return intctrlutil.NewFatalError(err.Error())
 	}
-
-	existing := &corev1.Secret{}
-	requestKey := client.ObjectKeyFromObject(request)
-	if err := r.Client.Get(reqCtx.Ctx, requestKey, existing); err == nil {
-		if validationErr := validateSystemAccountRestoreRequest(existing, request); validationErr != nil {
-			return validationErr
+	receiptName, err := systemaccount.ConflictReceiptName(intent.Target, intent.Operation)
+	if err != nil {
+		return intctrlutil.NewFatalError(err.Error())
+	}
+	receipt := &corev1.Secret{}
+	receiptKey := client.ObjectKey{Namespace: request.Namespace, Name: receiptName}
+	if err := r.Client.Get(reqCtx.Ctx, receiptKey, receipt); err == nil {
+		envelope, validationErr := systemaccount.ValidateConflictReceipt(receipt, intent)
+		if validationErr != nil {
+			return intctrlutil.NewFatalError(validationErr.Error())
 		}
-		return intctrlutil.NewRequeueError(reconcileInterval,
-			fmt.Sprintf("waiting for system account restore request %s to converge target %s", requestKey, key))
+		if projectionErr := r.projectSystemAccountConflictIdentity(reqCtx, pvc, envelope); projectionErr != nil {
+			return newSystemAccountSecretRequeueError(
+				"project conflict receipt identity to", client.ObjectKeyFromObject(pvc), projectionErr)
+		}
+		return intctrlutil.NewFatalError(fmt.Sprintf(
+			"%s: restore operation is blocked by request %s/%s",
+			systemaccount.ConcurrentRestoreIntentReason,
+			receipt.Annotations[systemaccount.BlockingRequestNamespaceAnnotationKey],
+			receipt.Annotations[systemaccount.BlockingRequestNameAnnotationKey]))
+	} else if !apierrors.IsNotFound(err) {
+		return newSystemAccountSecretRequeueError("get conflict receipt for", key, err)
+	}
+	requestKey := client.ObjectKeyFromObject(request)
+	existing := &corev1.Secret{}
+	if err := r.Client.Get(reqCtx.Ctx, requestKey, existing); err == nil {
+		return r.arbitrateSystemAccountRestoreRequest(reqCtx, key, pvc, intent, request, existing)
 	} else if !apierrors.IsNotFound(err) {
 		return newSystemAccountSecretRequeueError("get restore request for", key, err)
 	}
+	operationState, err := r.systemAccountRestoreOperationState(reqCtx, intent.Operation)
+	if err != nil {
+		return newSystemAccountSecretRequeueError("read restore operation for", key, err)
+	}
+	if operationState != systemAccountRestoreOperationActive {
+		return nil
+	}
 	if err := r.Client.Create(reqCtx.Ctx, request); err != nil {
-		return newSystemAccountSecretRequeueError("create", requestKey, err)
+		fresh := &corev1.Secret{}
+		if getErr := r.Client.Get(reqCtx.Ctx, requestKey, fresh); getErr != nil {
+			if apierrors.IsNotFound(getErr) {
+				return newSystemAccountSecretRequeueError("create", requestKey, err)
+			}
+			return newSystemAccountSecretRequeueError("fresh-read competing restore request for", key, getErr)
+		}
+		return r.arbitrateSystemAccountRestoreRequest(reqCtx, key, pvc, intent, request, fresh)
 	}
 	return intctrlutil.NewRequeueError(reconcileInterval,
 		fmt.Sprintf("waiting for the Apps owner to converge system account Secret %s", key))
 }
 
-func (r *VolumePopulatorReconciler) newSystemAccountRestoreRequest(reqCtx intctrlutil.RequestCtx,
-	namespace, targetName string,
-	scope systemAccountSecretScope,
-	clusterName, ownerName, accountName string,
-	password []byte,
-	labels map[string]string) (*corev1.Secret, error) {
-	requestLabels := mapsClone(labels)
-	requestLabels[constant.SystemAccountRestoreRequestLabelKey] = "true"
-	request := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      systemaccount.RestoreRequestName(namespace, targetName),
-			Labels:    requestLabels,
-			Annotations: map[string]string{
-				constant.SystemAccountRestoreTargetAnnotationKey: targetName,
-				constant.SystemAccountProvisionedAnnotationKey:   "true",
-			},
-		},
-		Type: corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			constant.AccountNameForSecret:   []byte(accountName),
-			constant.AccountPasswdForSecret: slices.Clone(password),
-		},
+func (r *VolumePopulatorReconciler) arbitrateSystemAccountRestoreRequest(
+	reqCtx intctrlutil.RequestCtx,
+	targetKey client.ObjectKey,
+	pvc *corev1.PersistentVolumeClaim,
+	contender systemaccount.CredentialIntent,
+	desired, existing *corev1.Secret,
+) error {
+	existingIntent, err := systemaccount.DecodeRestoreRequestV2(existing)
+	if err != nil {
+		return intctrlutil.NewFatalError(fmt.Sprintf(
+			"%s: invalid existing request %s: %v",
+			systemaccount.OperationCredentialConflictReason, client.ObjectKeyFromObject(existing), err))
 	}
-	if scope == systemAccountSecretScopeSharding {
-		immutable := true
-		request.Immutable = &immutable
+	existingTargetDigest, _ := systemaccount.LogicalTargetDigest(existingIntent.Target)
+	contenderTargetDigest, _ := systemaccount.LogicalTargetDigest(contender.Target)
+	if existingTargetDigest != contenderTargetDigest {
+		return intctrlutil.NewFatalError(fmt.Sprintf(
+			"%s: request name collision at %s",
+			systemaccount.OperationCredentialConflictReason, client.ObjectKeyFromObject(existing)))
 	}
-	if err := r.setSystemAccountRestoreRequestOwner(reqCtx, namespace, request, scope, clusterName, ownerName); err != nil {
-		return nil, err
+	existingOperationDigest, _ := systemaccount.OperationDigest(existingIntent.Operation)
+	contenderOperationDigest, _ := systemaccount.OperationDigest(contender.Operation)
+	if !existing.DeletionTimestamp.IsZero() {
+		reason := systemaccount.PreviousRestoreIntentFinalizingReason
+		if existingOperationDigest == contenderOperationDigest {
+			reason = systemaccount.RequestDeletionRequestedReason
+		}
+		return intctrlutil.NewRequeueError(reconcileInterval,
+			fmt.Sprintf("%s: waiting for request %s finalization", reason, client.ObjectKeyFromObject(existing)))
 	}
-	if err := systemaccount.SetRestoreRevision(request); err != nil {
-		return nil, err
+	if !slices.Contains(existing.Finalizers, systemaccount.RestoreProtocolFinalizer) {
+		return intctrlutil.NewRequeueError(reconcileInterval,
+			fmt.Sprintf("%s: waiting for request %s lifecycle cleanup",
+				systemaccount.PreviousRestoreIntentFinalizingReason, client.ObjectKeyFromObject(existing)))
 	}
-	return request, nil
+	phase := systemaccount.RestoreRequestPhase(existing.Annotations[systemaccount.RestoreRequestPhaseAnnotationKey])
+	if existingOperationDigest == contenderOperationDigest {
+		if validationErr := validateSystemAccountRestoreRequest(existing, desired); validationErr != nil {
+			return validationErr
+		}
+		if phase == systemaccount.RestoreRequestPhaseFailed {
+			reason := existing.Annotations[systemaccount.RestoreRequestReasonAnnotationKey]
+			if !systemaccount.IsRestoreFailureReason(reason) {
+				reason = systemaccount.OperationCredentialConflictReason
+			}
+			return intctrlutil.NewFatalError(fmt.Sprintf(
+				"%s: restore request %s failed",
+				reason, client.ObjectKeyFromObject(existing)))
+		}
+		target := &corev1.Secret{}
+		if getErr := r.Client.Get(reqCtx.Ctx, targetKey, target); getErr == nil {
+			if systemaccount.RestoreConvergedV2(target, existing, systemAccountSecretFinalizer(
+				systemAccountSecretScope(contender.Target.Scope))) {
+				return nil
+			}
+		} else if !apierrors.IsNotFound(getErr) {
+			return newSystemAccountSecretRequeueError("get", targetKey, getErr)
+		}
+		return intctrlutil.NewRequeueError(reconcileInterval,
+			fmt.Sprintf("waiting for system account restore request %s to converge target %s",
+				client.ObjectKeyFromObject(existing), targetKey))
+	}
+	winnerState, err := r.systemAccountRestoreOperationState(reqCtx, existingIntent.Operation)
+	if err != nil {
+		return newSystemAccountSecretRequeueError("read blocking restore operation for", targetKey, err)
+	}
+	if !phase.Active() || winnerState != systemAccountRestoreOperationActive {
+		return intctrlutil.NewRequeueError(reconcileInterval,
+			fmt.Sprintf("%s: waiting for request %s lifecycle cleanup",
+				systemaccount.PreviousRestoreIntentFinalizingReason, client.ObjectKeyFromObject(existing)))
+	}
+
+	fresh := &corev1.Secret{}
+	if err := r.Client.Get(reqCtx.Ctx, client.ObjectKeyFromObject(existing), fresh); err != nil {
+		return newSystemAccountSecretRequeueError("re-read blocking restore request for", targetKey, err)
+	}
+	if fresh.UID != existing.UID || fresh.ResourceVersion != existing.ResourceVersion ||
+		fresh.Annotations[systemaccount.RestoreRequestPhaseAnnotationKey] != string(phase) {
+		return intctrlutil.NewRequeueError(reconcileInterval,
+			fmt.Sprintf("blocking restore request %s changed during arbitration", client.ObjectKeyFromObject(existing)))
+	}
+	receipt, err := systemaccount.BuildConflictReceipt(contender, fresh)
+	if err != nil {
+		return intctrlutil.NewFatalError(fmt.Sprintf(
+			"%s: %v", systemaccount.OperationCredentialConflictReason, err))
+	}
+	if err := r.Client.Create(reqCtx.Ctx, receipt); err != nil {
+		persisted := &corev1.Secret{}
+		if getErr := r.Client.Get(reqCtx.Ctx, client.ObjectKeyFromObject(receipt), persisted); getErr != nil {
+			if apierrors.IsNotFound(getErr) {
+				return newSystemAccountSecretRequeueError("create conflict receipt for", targetKey, err)
+			}
+			return newSystemAccountSecretRequeueError("fresh-read conflict receipt for", targetKey, getErr)
+		}
+		if _, validationErr := systemaccount.ValidateConflictReceipt(persisted, contender); validationErr != nil {
+			return intctrlutil.NewFatalError(fmt.Sprintf(
+				"%s: %v", systemaccount.OperationCredentialConflictReason, validationErr))
+		}
+		receipt = persisted
+	}
+	envelope, validationErr := systemaccount.ValidateConflictReceipt(receipt, contender)
+	if validationErr != nil {
+		return intctrlutil.NewFatalError(fmt.Sprintf(
+			"%s: %v", systemaccount.OperationCredentialConflictReason, validationErr))
+	}
+	if projectionErr := r.projectSystemAccountConflictIdentity(reqCtx, pvc, envelope); projectionErr != nil {
+		return newSystemAccountSecretRequeueError(
+			"project conflict receipt identity to", client.ObjectKeyFromObject(pvc), projectionErr)
+	}
+	return intctrlutil.NewFatalError(fmt.Sprintf(
+		"%s: restore operation is blocked by request %s",
+		systemaccount.ConcurrentRestoreIntentReason, client.ObjectKeyFromObject(existing)))
 }
 
-func (r *VolumePopulatorReconciler) setSystemAccountRestoreRequestOwner(reqCtx intctrlutil.RequestCtx,
-	namespace string,
-	request *corev1.Secret,
+func (r *VolumePopulatorReconciler) newSystemAccountRestoreRequest(reqCtx intctrlutil.RequestCtx,
+	pvc *corev1.PersistentVolumeClaim,
+	backup *dpv1alpha1.Backup,
 	scope systemAccountSecretScope,
-	clusterName, ownerName string) error {
-	var owner client.Object
-	if scope == systemAccountSecretScopeSharding {
-		owner = &appsv1.Cluster{}
-		if err := r.Client.Get(reqCtx.Ctx, types.NamespacedName{Namespace: namespace, Name: clusterName}, owner); err != nil {
-			return err
-		}
-	} else {
-		owner = &appsv1.Component{}
-		if err := r.Client.Get(reqCtx.Ctx, types.NamespacedName{
-			Namespace: namespace,
-			Name:      constant.GenerateClusterComponentName(clusterName, ownerName),
-		}, owner); err != nil {
-			return err
-		}
+	clusterName, ownerName, accountName string,
+	password []byte) (*corev1.Secret, error) {
+	intent, err := r.buildSystemAccountCredentialIntent(reqCtx, pvc, backup, scope,
+		clusterName, ownerName, accountName, password)
+	if err != nil {
+		return nil, err
 	}
-	return controllerutil.SetControllerReference(owner, request, r.Scheme)
+	return systemaccount.BuildRestoreRequest(intent)
 }
 
 func newSystemAccountSecretRequeueError(action string, key client.ObjectKey, err error) error {
@@ -2388,20 +2571,25 @@ func newSystemAccountSecretRequeueError(action string, key client.ObjectKey, err
 }
 
 func validateSystemAccountRestoreRequest(existing, desired *corev1.Secret) error {
-	if err := systemaccount.ValidateRestoreRequest(existing); err != nil {
+	existingIntent, err := systemaccount.ValidateRestoreRequestV2(existing)
+	if err != nil {
 		return intctrlutil.NewFatalError(fmt.Sprintf("invalid system account restore request %s: %v",
 			client.ObjectKeyFromObject(existing), err))
 	}
-	existingOwner := metav1.GetControllerOf(existing)
-	desiredOwner := metav1.GetControllerOf(desired)
-	if existing.Annotations[constant.SystemAccountRestoreTargetAnnotationKey] !=
-		desired.Annotations[constant.SystemAccountRestoreTargetAnnotationKey] ||
-		existingOwner == nil || desiredOwner == nil ||
-		existingOwner.APIVersion != desiredOwner.APIVersion ||
-		existingOwner.Kind != desiredOwner.Kind ||
-		existingOwner.Name != desiredOwner.Name {
+	desiredIntent, err := systemaccount.ValidateRestoreRequestV2(desired)
+	if err != nil {
+		return intctrlutil.NewFatalError(fmt.Sprintf("invalid desired system account restore request %s: %v",
+			client.ObjectKeyFromObject(desired), err))
+	}
+	existingRevision := existing.Annotations[systemaccount.CredentialIntentRevisionAnnotationKey]
+	desiredRevision := desired.Annotations[systemaccount.CredentialIntentRevisionAnnotationKey]
+	if !reflect.DeepEqual(existingIntent.Operation, desiredIntent.Operation) ||
+		existingIntent.Target != desiredIntent.Target ||
+		existingIntent.ResolvedSource != desiredIntent.ResolvedSource ||
+		existingRevision != desiredRevision {
 		return intctrlutil.NewFatalError(fmt.Sprintf(
-			"system account restore request %s conflicts with desired request owner or target",
+			"%s: system account restore request %s conflicts with desired restore operation or credential intent",
+			systemaccount.OperationCredentialConflictReason,
 			client.ObjectKeyFromObject(existing)))
 	}
 	return nil
@@ -2429,4 +2617,19 @@ func upsertPVCCondition(conditions *[]corev1.PersistentVolumeClaimCondition, con
 		}
 	}
 	*conditions = append(*conditions, condition)
+}
+
+func systemAccountRestoreFailureReason(err error) string {
+	if err == nil {
+		return ""
+	}
+	message := err.Error()
+	if index := strings.IndexByte(message, ':'); index >= 0 {
+		message = message[:index]
+	}
+	message = strings.TrimSpace(message)
+	if systemaccount.IsRestoreFailureReason(message) {
+		return message
+	}
+	return ""
 }

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
@@ -196,13 +197,6 @@ var _ = Describe("Volume Populator Controller test", func() {
 			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
 			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
 
-			component := &kbappsv1.Component{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      constant.GenerateClusterComponentName("cluster", "mysql"),
-					UID:       types.UID("component-uid"),
-				},
-			}
 			mutableSecret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
@@ -229,17 +223,18 @@ var _ = Describe("Volume Populator Controller test", func() {
 					Name:      "data-target-0",
 				},
 			}
+			backup, cluster, component, instanceSet := prepareSystemAccountAuthorityFixture(Default, scheme, pvc)
 			reconciler := &VolumePopulatorReconciler{
 				Client: fake.NewClientBuilder().
 					WithScheme(scheme).
-					WithObjects(component, mutableSecret, immutableSecret).
+					WithObjects(backup, cluster, component, instanceSet, pvc, mutableSecret, immutableSecret).
 					Build(),
 				Scheme: scheme,
 			}
 			reqCtx := intctrlutil.RequestCtx{Ctx: context.Background()}
 
-			err := reconciler.upsertSystemAccountSecret(reqCtx, pvc, systemAccountSecretScopeComponent,
-				"cluster", "mysql", "admin", []byte("new-password"), map[string]string{"role": "admin"})
+			err := reconciler.upsertSystemAccountSecret(reqCtx, pvc, backup, systemAccountSecretScopeComponent,
+				"cluster", "mysql", "admin", []byte("new-password"))
 			Expect(err).To(HaveOccurred())
 			Expect(intctrlutil.IsRequeueError(err)).To(BeTrue(), err.Error())
 			currentMutable := &corev1.Secret{}
@@ -252,8 +247,8 @@ var _ = Describe("Volume Populator Controller test", func() {
 			Expect(currentMutable.Data).To(BeEmpty())
 			Expect(currentMutable.OwnerReferences).To(BeEmpty())
 
-			err = reconciler.upsertSystemAccountSecret(reqCtx, pvc, systemAccountSecretScopeComponent,
-				"cluster", "mysql", "root", []byte("new-root-password"), map[string]string{"role": "root"})
+			err = reconciler.upsertSystemAccountSecret(reqCtx, pvc, backup, systemAccountSecretScopeComponent,
+				"cluster", "mysql", "root", []byte("new-root-password"))
 			Expect(err).To(HaveOccurred())
 			Expect(intctrlutil.IsRequeueError(err)).To(BeTrue(), err.Error())
 			currentImmutable := &corev1.Secret{}
@@ -269,10 +264,10 @@ var _ = Describe("Volume Populator Controller test", func() {
 			Expect(reconciler.Client.List(context.Background(), requests, client.InNamespace("default"))).Should(Succeed())
 			var mutableRequest, immutableRequest *corev1.Secret
 			for i := range requests.Items {
-				switch requests.Items[i].Annotations[constant.SystemAccountRestoreTargetAnnotationKey] {
-				case mutableSecret.Name:
+				switch requests.Items[i].Annotations[systemaccount.SystemAccountAnnotationKey] {
+				case "admin":
 					mutableRequest = &requests.Items[i]
-				case immutableSecret.Name:
+				case "root":
 					immutableRequest = &requests.Items[i]
 				}
 			}
@@ -282,87 +277,282 @@ var _ = Describe("Volume Populator Controller test", func() {
 			Expect(immutableRequest.Data[constant.AccountNameForSecret]).To(Equal([]byte("root")))
 			Expect(immutableRequest.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("new-root-password")))
 			Expect(immutableRequest.OwnerReferences).To(HaveLen(1))
-			Expect(immutableRequest.OwnerReferences[0].Kind).To(Equal("Component"))
+			Expect(immutableRequest.OwnerReferences[0].Kind).To(Equal("Cluster"))
 			Expect(immutableRequest.OwnerReferences[0].Controller).NotTo(BeNil())
-			Expect(*immutableRequest.OwnerReferences[0].Controller).To(BeTrue())
+			Expect(*immutableRequest.OwnerReferences[0].Controller).To(BeFalse())
 			Expect(immutableRequest.Labels[constant.SystemAccountRestoreRequestLabelKey]).To(Equal("true"))
-			Expect(immutableRequest.Annotations[constant.SystemAccountRestoreRevisionAnnotationKey]).NotTo(BeEmpty())
+			Expect(immutableRequest.Annotations[systemaccount.CredentialIntentRevisionAnnotationKey]).NotTo(BeEmpty())
 		})
 
 		It("accepts only the Apps-committed restore revision as converged", func() {
 			scheme := runtime.NewScheme()
 			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
 			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
-			component := &kbappsv1.Component{ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      constant.GenerateClusterComponentName("cluster", "mysql"),
-				UID:       types.UID("component-uid"),
-			}}
 			pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
 				Namespace: "default",
 				Name:      "data-target-0",
 			}}
+			backup, cluster, component, instanceSet := prepareSystemAccountAuthorityFixture(Default, scheme, pvc)
 			reconciler := &VolumePopulatorReconciler{
-				Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(component).Build(),
+				Client: fake.NewClientBuilder().WithScheme(scheme).
+					WithObjects(backup, cluster, component, instanceSet, pvc).Build(),
 				Scheme: scheme,
 			}
 			request, err := reconciler.newSystemAccountRestoreRequest(
-				intctrlutil.RequestCtx{Ctx: context.Background()}, "default",
-				constant.GenerateAccountSecretName("cluster", "mysql", "admin"),
-				systemAccountSecretScopeComponent, "cluster", "mysql", "admin", []byte("restored-password"),
-				map[string]string{"role": "admin"})
+				intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup,
+				systemAccountSecretScopeComponent, "cluster", "mysql", "admin", []byte("restored-password"))
 			Expect(err).ShouldNot(HaveOccurred())
-			target := request.DeepCopy()
-			target.Name = request.Annotations[constant.SystemAccountRestoreTargetAnnotationKey]
-			delete(target.Labels, constant.SystemAccountRestoreRequestLabelKey)
-			delete(target.Annotations, constant.SystemAccountRestoreTargetAnnotationKey)
-			target.Finalizers = []string{constant.DBComponentFinalizerName}
+			request.UID = types.UID("request-uid")
+			Expect(reconciler.Client.Create(context.Background(), request)).Should(Succeed())
+			Expect(reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(request), request)).Should(Succeed())
+			target := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+				Namespace:  "default",
+				Name:       constant.GenerateAccountSecretName("cluster", "mysql", "admin"),
+				UID:        types.UID("target-uid"),
+				Finalizers: []string{constant.DBComponentFinalizerName},
+				Annotations: map[string]string{
+					constant.SystemAccountProvisionedAnnotationKey:      "true",
+					systemaccount.RestoreProtocolAnnotationKey:          systemaccount.RestoreProtocolV2,
+					systemaccount.RestoreOperationDigestAnnotationKey:   request.Annotations[systemaccount.RestoreOperationDigestAnnotationKey],
+					systemaccount.CredentialIntentRevisionAnnotationKey: request.Annotations[systemaccount.CredentialIntentRevisionAnnotationKey],
+					systemaccount.RestoreRequestNameAnnotationKey:       request.Name,
+					systemaccount.RestoreRequestUIDAnnotationKey:        string(request.UID),
+				},
+			}, Type: corev1.SecretTypeOpaque, Data: map[string][]byte{
+				constant.AccountNameForSecret:   []byte("admin"),
+				constant.AccountPasswdForSecret: []byte("restored-password"),
+			}}
+			Expect(controllerutil.SetControllerReference(component, target, scheme)).Should(Succeed())
+			revision, err := systemaccount.TargetCommitRevision(target, constant.DBComponentFinalizerName)
+			Expect(err).ShouldNot(HaveOccurred())
+			target.Annotations[systemaccount.TargetCommitRevisionAnnotationKey] = revision
+			request.Annotations[systemaccount.TargetSecretNameAnnotationKey] = target.Name
+			request.Annotations[systemaccount.TargetSecretUIDAnnotationKey] = string(target.UID)
+			request.Annotations[systemaccount.TargetCommitRevisionAnnotationKey] = revision
 			Expect(reconciler.Client.Create(context.Background(), target)).Should(Succeed())
+			persistedTarget := &corev1.Secret{}
+			Expect(reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(target), persistedTarget)).Should(Succeed())
+			request.Annotations[systemaccount.RestoreRequestPhaseAnnotationKey] =
+				string(systemaccount.RestoreRequestPhaseCommitted)
+			request.Annotations[systemaccount.TargetSecretUIDAnnotationKey] = string(persistedTarget.UID)
+			Expect(reconciler.Client.Update(context.Background(), request)).Should(Succeed())
+			persistedRequest := &corev1.Secret{}
+			Expect(reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(request), persistedRequest)).Should(Succeed())
+			Expect(systemaccount.RestoreConvergedV2(
+				persistedTarget, persistedRequest, constant.DBComponentFinalizerName,
+			)).To(BeTrue())
 
-			err = reconciler.upsertSystemAccountSecret(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc,
-				systemAccountSecretScopeComponent, "cluster", "mysql", "admin", []byte("restored-password"),
-				map[string]string{"role": "admin"})
+			err = reconciler.upsertSystemAccountSecret(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup,
+				systemAccountSecretScopeComponent, "cluster", "mysql", "admin", []byte("restored-password"))
 
 			Expect(err).ShouldNot(HaveOccurred())
 			requests := &corev1.SecretList{}
 			Expect(reconciler.Client.List(context.Background(), requests,
 				client.MatchingLabels{constant.SystemAccountRestoreRequestLabelKey: "true"})).Should(Succeed())
-			Expect(requests.Items).To(BeEmpty())
+			Expect(requests.Items).To(HaveLen(1))
 		})
 
 		It("serializes a new restore behind an older valid request", func() {
 			scheme := runtime.NewScheme()
 			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
 			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
-			component := &kbappsv1.Component{ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      constant.GenerateClusterComponentName("cluster", "mysql"),
-				UID:       types.UID("component-uid"),
-			}}
 			pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
 				Namespace: "default",
 				Name:      "data-target-0",
 			}}
+			backup, cluster, component, instanceSet := prepareSystemAccountAuthorityFixture(Default, scheme, pvc)
 			reconciler := &VolumePopulatorReconciler{
-				Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(component).Build(),
+				Client: fake.NewClientBuilder().WithScheme(scheme).
+					WithObjects(backup, cluster, component, instanceSet, pvc).Build(),
 				Scheme: scheme,
 			}
 			oldRequest, err := reconciler.newSystemAccountRestoreRequest(
-				intctrlutil.RequestCtx{Ctx: context.Background()}, "default",
-				constant.GenerateAccountSecretName("cluster", "mysql", "admin"),
-				systemAccountSecretScopeComponent, "cluster", "mysql", "admin", []byte("old-password"),
-				map[string]string{"role": "admin"})
+				intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup,
+				systemAccountSecretScopeComponent, "cluster", "mysql", "admin", []byte("old-password"))
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(reconciler.Client.Create(context.Background(), oldRequest)).Should(Succeed())
 
-			err = reconciler.upsertSystemAccountSecret(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc,
-				systemAccountSecretScopeComponent, "cluster", "mysql", "admin", []byte("new-password"),
-				map[string]string{"role": "admin"})
+			err = reconciler.upsertSystemAccountSecret(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup,
+				systemAccountSecretScopeComponent, "cluster", "mysql", "admin", []byte("new-password"))
 
-			Expect(intctrlutil.IsRequeueError(err)).To(BeTrue(), err)
+			Expect(intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal)).To(BeTrue(), err)
+			Expect(err).To(MatchError(ContainSubstring("credential intent")))
 			persisted := &corev1.Secret{}
 			Expect(reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(oldRequest), persisted)).Should(Succeed())
 			Expect(persisted.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("old-password")))
+		})
+
+		It("projects an exact conflict receipt identity before the PVC failure condition", func() {
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
+			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
+			pvc := &corev1.PersistentVolumeClaim{}
+			backup, cluster, component, instanceSet :=
+				prepareSystemAccountAuthorityFixture(Default, scheme, pvc)
+			cli := fake.NewClientBuilder().WithScheme(scheme).
+				WithStatusSubresource(pvc).
+				WithObjects(backup, cluster, component, instanceSet, pvc).Build()
+			reconciler := &VolumePopulatorReconciler{
+				Client:   cli,
+				Scheme:   scheme,
+				Recorder: record.NewFakeRecorder(10),
+			}
+			winner, err := reconciler.newSystemAccountRestoreRequest(
+				intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup,
+				systemAccountSecretScopeComponent, "cluster", "mysql", "admin", []byte("winner-password"))
+			Expect(err).ShouldNot(HaveOccurred())
+			winner.UID = "winner-request-uid"
+			Expect(cli.Create(context.Background(), winner)).Should(Succeed())
+			Expect(cli.Get(context.Background(), client.ObjectKeyFromObject(winner), winner)).Should(Succeed())
+
+			loserPVC := &corev1.PersistentVolumeClaim{}
+			Expect(cli.Get(context.Background(), client.ObjectKeyFromObject(pvc), loserPVC)).Should(Succeed())
+			loserPVC.Annotations[constant.RestorePITRAnnotationKey] = "2026-07-23T00:00:00Z"
+			Expect(cli.Update(context.Background(), loserPVC)).Should(Succeed())
+			Expect(cli.Get(context.Background(), client.ObjectKeyFromObject(pvc), loserPVC)).Should(Succeed())
+			loserRequest, err := reconciler.newSystemAccountRestoreRequest(
+				intctrlutil.RequestCtx{Ctx: context.Background()}, loserPVC, backup,
+				systemAccountSecretScopeComponent, "cluster", "mysql", "admin", []byte("loser-password"))
+			Expect(err).ShouldNot(HaveOccurred())
+			loserIntent, err := systemaccount.ValidateRestoreRequestV2(loserRequest)
+			Expect(err).ShouldNot(HaveOccurred())
+			receipt, err := systemaccount.BuildConflictReceipt(loserIntent, winner)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(cli.Create(context.Background(), receipt)).Should(Succeed())
+
+			syncErr := reconciler.upsertSystemAccountSecret(
+				intctrlutil.RequestCtx{Ctx: context.Background()}, loserPVC, backup,
+				systemAccountSecretScopeComponent, "cluster", "mysql", "admin", []byte("loser-password"))
+			Expect(intctrlutil.IsTargetError(syncErr, intctrlutil.ErrorTypeFatal)).To(BeTrue(), syncErr)
+			_, err = reconciler.handleSyncPVCError(
+				intctrlutil.RequestCtx{Ctx: context.Background()}, loserPVC, syncErr)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			projected := &corev1.PersistentVolumeClaim{}
+			Expect(cli.Get(context.Background(), client.ObjectKeyFromObject(pvc), projected)).Should(Succeed())
+			Expect(projected.Annotations[systemaccount.RestoreOperationDigestAnnotationKey]).
+				To(Equal(receipt.Annotations[systemaccount.RestoreOperationDigestAnnotationKey]))
+			Expect(projected.Annotations[systemaccount.BlockingRequestUIDAnnotationKey]).
+				To(Equal(receipt.Annotations[systemaccount.BlockingRequestUIDAnnotationKey]))
+			Expect(projected.Annotations[systemaccount.WinnerOperationDigestAnnotationKey]).
+				To(Equal(receipt.Annotations[systemaccount.WinnerOperationDigestAnnotationKey]))
+			restoreCondition := findPVCConditionByType(projected, kbappsv1.ConditionTypeRestore)
+			Expect(restoreCondition).NotTo(BeNil())
+			Expect(restoreCondition.Status).To(Equal(corev1.ConditionFalse))
+			Expect(restoreCondition.Reason).To(Equal(systemaccount.ConcurrentRestoreIntentReason))
+		})
+
+		It("does not arbitrate or create a receipt past a deleting request", func() {
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
+			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
+			pvc := &corev1.PersistentVolumeClaim{}
+			backup, cluster, component, instanceSet :=
+				prepareSystemAccountAuthorityFixture(Default, scheme, pvc)
+			cli := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(backup, cluster, component, instanceSet, pvc).Build()
+			reconciler := &VolumePopulatorReconciler{Client: cli, Scheme: scheme}
+			oldRequest, err := reconciler.newSystemAccountRestoreRequest(
+				intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup,
+				systemAccountSecretScopeComponent, "cluster", "mysql", "admin", []byte("old-password"))
+			Expect(err).ShouldNot(HaveOccurred())
+			oldRequest.UID = "old-request-uid"
+			Expect(cli.Create(context.Background(), oldRequest)).Should(Succeed())
+			Expect(cli.Delete(context.Background(), oldRequest)).Should(Succeed())
+			deleting := &corev1.Secret{}
+			Expect(cli.Get(context.Background(), client.ObjectKeyFromObject(oldRequest), deleting)).Should(Succeed())
+			Expect(deleting.DeletionTimestamp.IsZero()).To(BeFalse())
+
+			persistedPVC := &corev1.PersistentVolumeClaim{}
+			Expect(cli.Get(context.Background(), client.ObjectKeyFromObject(pvc), persistedPVC)).Should(Succeed())
+			persistedPVC.Annotations[constant.RestorePITRAnnotationKey] = "2026-07-23T00:00:00Z"
+			Expect(cli.Update(context.Background(), persistedPVC)).Should(Succeed())
+
+			err = reconciler.upsertSystemAccountSecret(
+				intctrlutil.RequestCtx{Ctx: context.Background()},
+				persistedPVC, backup, systemAccountSecretScopeComponent,
+				"cluster", "mysql", "admin", []byte("new-password"))
+
+			Expect(intctrlutil.IsRequeueError(err)).To(BeTrue(), err)
+			Expect(err).To(MatchError(ContainSubstring(
+				systemaccount.PreviousRestoreIntentFinalizingReason)))
+			secrets := &corev1.SecretList{}
+			Expect(cli.List(context.Background(), secrets)).Should(Succeed())
+			conflictReceipts := 0
+			for i := range secrets.Items {
+				if secrets.Items[i].Annotations[systemaccount.RestoreProtocolAnnotationKey] ==
+					systemaccount.ConflictProtocolV1 {
+					conflictReceipts++
+				}
+			}
+			Expect(conflictReceipts).To(Equal(0))
+			target := &corev1.Secret{}
+			err = cli.Get(context.Background(), client.ObjectKey{
+				Namespace: "default",
+				Name:      constant.GenerateAccountSecretName("cluster", "mysql", "admin"),
+			}, target)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue(), err)
+		})
+
+		It("preserves a same-operation request failure after the operation becomes terminal", func() {
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
+			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
+			pvc := &corev1.PersistentVolumeClaim{}
+			backup, cluster, component, instanceSet :=
+				prepareSystemAccountAuthorityFixture(Default, scheme, pvc)
+			cluster.Status.Conditions = []metav1.Condition{{
+				Type:               kbappsv1.ConditionTypeRestore,
+				Status:             metav1.ConditionFalse,
+				ObservedGeneration: cluster.Generation,
+			}}
+			cli := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(backup, cluster, component, instanceSet, pvc).Build()
+			reconciler := &VolumePopulatorReconciler{Client: cli, Scheme: scheme}
+			request, err := reconciler.newSystemAccountRestoreRequest(
+				intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup,
+				systemAccountSecretScopeComponent, "cluster", "mysql", "admin", []byte("password"))
+			Expect(err).ShouldNot(HaveOccurred())
+			request.Annotations[systemaccount.RestoreRequestPhaseAnnotationKey] =
+				string(systemaccount.RestoreRequestPhaseFailed)
+			request.Annotations[systemaccount.RestoreRequestReasonAnnotationKey] =
+				systemaccount.AccountUnavailableReason
+			Expect(cli.Create(context.Background(), request)).Should(Succeed())
+
+			err = reconciler.upsertSystemAccountSecret(
+				intctrlutil.RequestCtx{Ctx: context.Background()},
+				pvc, backup, systemAccountSecretScopeComponent,
+				"cluster", "mysql", "admin", []byte("password"))
+
+			Expect(intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal)).To(BeTrue(), err)
+			Expect(err).To(MatchError(ContainSubstring(systemaccount.AccountUnavailableReason)))
+		})
+
+		It("does not reuse a request whose protocol finalizer was already released", func() {
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
+			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
+			pvc := &corev1.PersistentVolumeClaim{}
+			backup, cluster, component, instanceSet :=
+				prepareSystemAccountAuthorityFixture(Default, scheme, pvc)
+			cli := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(backup, cluster, component, instanceSet, pvc).Build()
+			reconciler := &VolumePopulatorReconciler{Client: cli, Scheme: scheme}
+			request, err := reconciler.newSystemAccountRestoreRequest(
+				intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup,
+				systemAccountSecretScopeComponent, "cluster", "mysql", "admin", []byte("password"))
+			Expect(err).ShouldNot(HaveOccurred())
+			request.Finalizers = nil
+			Expect(cli.Create(context.Background(), request)).Should(Succeed())
+
+			err = reconciler.upsertSystemAccountSecret(
+				intctrlutil.RequestCtx{Ctx: context.Background()},
+				pvc, backup, systemAccountSecretScopeComponent,
+				"cluster", "mysql", "admin", []byte("password"))
+
+			Expect(intctrlutil.IsRequeueError(err)).To(BeTrue(), err)
+			Expect(err).To(MatchError(ContainSubstring(
+				systemaccount.PreviousRestoreIntentFinalizingReason)))
 		})
 
 		It("requeues a restore request create race through the full reconciler", func() {
@@ -371,38 +561,23 @@ var _ = Describe("Volume Populator Controller test", func() {
 			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
 			Expect(dpv1alpha1.AddToScheme(scheme)).Should(Succeed())
 
-			apiGroup := dptypes.DataprotectionAPIGroup
-			backup := newBackupForRestoreDecision(nil, nil)
 			encryptor := intctrlutil.NewEncryptor(viper.GetString(constant.CfgKeyDPEncryptionKey))
 			encryptedPassword, err := encryptor.Encrypt([]byte("restored-password"))
 			Expect(err).ShouldNot(HaveOccurred())
-			backup.Annotations = map[string]string{
-				constant.EncryptedSystemAccountsAnnotationKey: fmt.Sprintf(`{"mysql":{"admin":"%s"}}`, encryptedPassword),
-			}
 			pvc := newPVCForRestoreDecision("data", "mysql", "")
-			pvc.UID = types.UID("target-pvc-uid")
-			pvc.Spec.DataSourceRef = &corev1.TypedObjectReference{
-				APIGroup: &apiGroup,
-				Kind:     dptypes.BackupKind,
-				Name:     backup.Name,
-			}
-			pvc.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
-			pvc.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
 			pvc.Status.Conditions = []corev1.PersistentVolumeClaimCondition{{
 				Type:   PersistentVolumeClaimPopulating,
 				Status: corev1.ConditionTrue,
 			}}
-			component := &kbappsv1.Component{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      constant.GenerateClusterComponentName("cluster", "mysql"),
-					UID:       types.UID("component-uid"),
-				},
+			backup, cluster, component, instanceSet := prepareSystemAccountAuthorityFixture(Default, scheme, pvc)
+			backup.Status = newBackupForRestoreDecision(nil, nil).Status
+			backup.Annotations = map[string]string{
+				constant.EncryptedSystemAccountsAnnotationKey: fmt.Sprintf(`{"mysql":{"admin":"%s"}}`, encryptedPassword),
 			}
 			baseClient := fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithStatusSubresource(pvc, backup).
-				WithObjects(component, backup, pvc).
+				WithObjects(cluster, component, instanceSet, backup, pvc).
 				Build()
 			requestCreateAttempts := 0
 			interceptedClient := interceptor.NewClient(baseClient, interceptor.Funcs{
@@ -410,6 +585,9 @@ var _ = Describe("Volume Populator Controller test", func() {
 					if secret, ok := obj.(*corev1.Secret); ok &&
 						secret.Labels[constant.SystemAccountRestoreRequestLabelKey] == "true" {
 						requestCreateAttempts++
+						if err := c.Create(ctx, secret.DeepCopy(), opts...); err != nil {
+							return err
+						}
 						return apierrors.NewAlreadyExists(corev1.Resource("secrets"), secret.Name)
 					}
 					return c.Create(ctx, obj, opts...)
@@ -435,13 +613,6 @@ var _ = Describe("Volume Populator Controller test", func() {
 			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
 			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
 
-			cluster := &kbappsv1.Cluster{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      "cluster",
-					UID:       types.UID("cluster-uid"),
-				},
-			}
 			immutable := true
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -459,20 +630,23 @@ var _ = Describe("Volume Populator Controller test", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Name:      "data-target-0",
+					Labels: map[string]string{
+						constant.KBAppShardingNameLabelKey: "shard",
+					},
 				},
 			}
+			backup, cluster, component, instanceSet := prepareSystemAccountAuthorityFixture(Default, scheme, pvc)
 			reconciler := &VolumePopulatorReconciler{
 				Client: fake.NewClientBuilder().
 					WithScheme(scheme).
-					WithObjects(cluster, secret).
+					WithObjects(backup, cluster, component, instanceSet, pvc, secret).
 					Build(),
 				Scheme: scheme,
 			}
 			reqCtx := intctrlutil.RequestCtx{Ctx: context.Background()}
 
-			err := reconciler.upsertSystemAccountSecret(reqCtx, pvc, systemAccountSecretScopeSharding,
-				"cluster", "shard", "root", []byte("new-password"),
-				map[string]string{constant.KBAppShardingNameLabelKey: "shard"})
+			err := reconciler.upsertSystemAccountSecret(reqCtx, pvc, backup, systemAccountSecretScopeSharding,
+				"cluster", "shard", "root", []byte("new-password"))
 			Expect(err).To(HaveOccurred())
 			Expect(intctrlutil.IsRequeueError(err)).To(BeTrue(), err.Error())
 			current := &corev1.Secret{}
@@ -487,7 +661,9 @@ var _ = Describe("Volume Populator Controller test", func() {
 			Expect(reconciler.Client.List(context.Background(), requests, client.InNamespace("default"))).Should(Succeed())
 			var request *corev1.Secret
 			for i := range requests.Items {
-				if requests.Items[i].Annotations[constant.SystemAccountRestoreTargetAnnotationKey] == secret.Name {
+				if requests.Items[i].Annotations[systemaccount.SystemAccountAnnotationKey] == "root" &&
+					requests.Items[i].Annotations[systemaccount.SystemAccountScopeAnnotationKey] ==
+						systemaccount.SystemAccountScopeSharding {
 					request = &requests.Items[i]
 					break
 				}
@@ -496,7 +672,7 @@ var _ = Describe("Volume Populator Controller test", func() {
 			Expect(request.OwnerReferences).To(HaveLen(1))
 			Expect(request.OwnerReferences[0].Kind).To(Equal("Cluster"))
 			Expect(request.OwnerReferences[0].Controller).NotTo(BeNil())
-			Expect(*request.OwnerReferences[0].Controller).To(BeTrue())
+			Expect(*request.OwnerReferences[0].Controller).To(BeFalse())
 			Expect(request.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("new-password")))
 		})
 
@@ -524,24 +700,22 @@ var _ = Describe("Volume Populator Controller test", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
 					Name:      "data-target-0",
+					Labels: map[string]string{
+						constant.KBAppShardingNameLabelKey: "shard",
+					},
 				},
 			}
-			cluster := &kbappsv1.Cluster{ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "cluster",
-				UID:       types.UID("cluster-uid"),
-			}}
+			backup, cluster, component, instanceSet := prepareSystemAccountAuthorityFixture(Default, scheme, pvc)
 			reconciler := &VolumePopulatorReconciler{
 				Client: fake.NewClientBuilder().
 					WithScheme(scheme).
-					WithObjects(cluster, secret).
+					WithObjects(backup, cluster, component, instanceSet, pvc, secret).
 					Build(),
 				Scheme: scheme,
 			}
 
-			err := reconciler.upsertSystemAccountSecret(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc,
-				systemAccountSecretScopeSharding, "cluster", "shard", "root", []byte("new-password"),
-				map[string]string{constant.KBAppShardingNameLabelKey: "shard"})
+			err := reconciler.upsertSystemAccountSecret(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup,
+				systemAccountSecretScopeSharding, "cluster", "shard", "root", []byte("new-password"))
 			Expect(err).To(HaveOccurred())
 			Expect(intctrlutil.IsRequeueError(err)).To(BeTrue(), err.Error())
 
@@ -557,8 +731,8 @@ var _ = Describe("Volume Populator Controller test", func() {
 			requests := &corev1.SecretList{}
 			Expect(reconciler.Client.List(context.Background(), requests, client.InNamespace("default"))).Should(Succeed())
 			Expect(requests.Items).To(ContainElement(WithTransform(func(item corev1.Secret) string {
-				return item.Annotations[constant.SystemAccountRestoreTargetAnnotationKey]
-			}, Equal(secret.Name))))
+				return item.Annotations[systemaccount.SystemAccountAnnotationKey]
+			}, Equal("root"))))
 		})
 
 		It("validates PVC names against instance volume templates", func() {
@@ -971,7 +1145,7 @@ var _ = Describe("Volume Populator Controller test", func() {
 
 			It("restores system account secrets before volume population", func() {
 				pvc := initResources(storagev1.VolumeBindingWaitForFirstConsumer, false, true)
-				Expect(testCtx.CreateObj(testCtx.Ctx, &kbappsv1.Cluster{
+				cluster := &kbappsv1.Cluster{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: testCtx.DefaultNamespace,
 						Name:      testdp.ClusterName,
@@ -979,19 +1153,57 @@ var _ = Describe("Volume Populator Controller test", func() {
 					Spec: kbappsv1.ClusterSpec{
 						TerminationPolicy: kbappsv1.Delete,
 					},
-				})).Should(Succeed())
-				Expect(testCtx.CreateObj(testCtx.Ctx, &kbappsv1.Component{
+				}
+				Expect(testCtx.CreateObj(testCtx.Ctx, cluster)).Should(Succeed())
+				component := &kbappsv1.Component{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: testCtx.DefaultNamespace,
 						Name:      constant.GenerateClusterComponentName(testdp.ClusterName, testdp.ComponentName),
+						Labels: map[string]string{
+							constant.AppInstanceLabelKey:    testdp.ClusterName,
+							constant.KBAppComponentLabelKey: testdp.ComponentName,
+						},
 					},
 					Spec: kbappsv1.ComponentSpec{
 						TerminationPolicy: kbappsv1.Delete,
 						CompDef:           testdp.ComponentName,
 						Replicas:          1,
 					},
-				})).Should(Succeed())
+				}
+				Expect(controllerutil.SetControllerReference(cluster, component, k8sManager.GetScheme())).Should(Succeed())
+				Expect(testCtx.CreateObj(testCtx.Ctx, component)).Should(Succeed())
+				instanceSet := &workloadsv1.InstanceSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testCtx.DefaultNamespace,
+						Name:      constant.GenerateClusterComponentName(testdp.ClusterName, testdp.ComponentName),
+						Labels: map[string]string{
+							constant.AppInstanceLabelKey:    testdp.ClusterName,
+							constant.KBAppComponentLabelKey: testdp.ComponentName,
+						},
+					},
+					Spec: workloadsv1.InstanceSetSpec{
+						Selector: &metav1.LabelSelector{MatchLabels: map[string]string{
+							constant.AppInstanceLabelKey:    testdp.ClusterName,
+							constant.KBAppComponentLabelKey: testdp.ComponentName,
+						}},
+						Template: corev1.PodTemplateSpec{
+							ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+								constant.AppInstanceLabelKey:    testdp.ClusterName,
+								constant.KBAppComponentLabelKey: testdp.ComponentName,
+							}},
+							Spec: corev1.PodSpec{Containers: []corev1.Container{{
+								Name:  "database",
+								Image: "example.invalid/database:test",
+							}}},
+						},
+					},
+				}
+				Expect(controllerutil.SetControllerReference(component, instanceSet, k8sManager.GetScheme())).Should(Succeed())
+				Expect(testCtx.CreateObj(testCtx.Ctx, instanceSet)).Should(Succeed())
 				pvcKey := client.ObjectKeyFromObject(pvc)
+				Eventually(testapps.GetAndChangeObj(&testCtx, pvcKey, func(claim *corev1.PersistentVolumeClaim) {
+					Expect(controllerutil.SetControllerReference(instanceSet, claim, k8sManager.GetScheme())).Should(Succeed())
+				})).Should(Succeed())
 				backupKey := types.NamespacedName{Namespace: testCtx.DefaultNamespace, Name: pvc.Spec.DataSourceRef.Name}
 				encryptor := intctrlutil.NewEncryptor(viper.GetString(constant.CfgKeyDPEncryptionKey))
 				encryptedPassword, err := encryptor.Encrypt([]byte("restored-password"))
@@ -1014,17 +1226,17 @@ var _ = Describe("Volume Populator Controller test", func() {
 					Namespace: testCtx.DefaultNamespace,
 					Name:      constant.GenerateAccountSecretName(testdp.ClusterName, testdp.ComponentName, "admin"),
 				}
-				requestKey := types.NamespacedName{
-					Namespace: testCtx.DefaultNamespace,
-					Name:      systemaccount.RestoreRequestName(testCtx.DefaultNamespace, secretKey.Name),
-				}
 				request := &corev1.Secret{}
 				Eventually(func(g Gomega) {
-					g.Expect(testCtx.Cli.Get(testCtx.Ctx, requestKey, request)).Should(Succeed())
+					requests := &corev1.SecretList{}
+					g.Expect(testCtx.Cli.List(testCtx.Ctx, requests, client.InNamespace(testCtx.DefaultNamespace),
+						client.MatchingLabels{constant.SystemAccountRestoreRequestLabelKey: "true"})).Should(Succeed())
+					g.Expect(requests.Items).To(HaveLen(1))
+					requests.Items[0].DeepCopyInto(request)
 					g.Expect(request.Data).Should(HaveKeyWithValue(constant.AccountNameForSecret, []byte("admin")))
 					g.Expect(request.Data).Should(HaveKeyWithValue(constant.AccountPasswdForSecret, []byte("restored-password")))
 					g.Expect(request.Labels).Should(HaveKeyWithValue(constant.SystemAccountRestoreRequestLabelKey, "true"))
-					g.Expect(request.Annotations[constant.SystemAccountRestoreRevisionAnnotationKey]).ShouldNot(BeEmpty())
+					g.Expect(request.Annotations[systemaccount.CredentialIntentRevisionAnnotationKey]).ShouldNot(BeEmpty())
 				}).Should(Succeed())
 				Expect(testCtx.Cli.Get(testCtx.Ctx, secretKey, &corev1.Secret{})).Should(Satisfy(apierrors.IsNotFound))
 				Expect(testCtx.Cli.Get(testCtx.Ctx, types.NamespacedName{
@@ -1034,17 +1246,38 @@ var _ = Describe("Volume Populator Controller test", func() {
 
 				// The Apps controller is not installed in this focused DP envtest. Commit
 				// its side of the public request contract before letting DP continue.
-				target := request.DeepCopy()
-				target.Name = secretKey.Name
-				target.ResourceVersion = ""
-				target.UID = ""
-				target.CreationTimestamp = metav1.Time{}
-				target.ManagedFields = nil
-				target.Finalizers = []string{constant.DBComponentFinalizerName}
-				delete(target.Labels, constant.SystemAccountRestoreRequestLabelKey)
-				delete(target.Annotations, constant.SystemAccountRestoreTargetAnnotationKey)
+				target := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:  secretKey.Namespace,
+						Name:       secretKey.Name,
+						Finalizers: []string{constant.DBComponentFinalizerName},
+						Annotations: map[string]string{
+							constant.SystemAccountProvisionedAnnotationKey:      "true",
+							systemaccount.RestoreProtocolAnnotationKey:          systemaccount.RestoreProtocolV2,
+							systemaccount.RestoreOperationDigestAnnotationKey:   request.Annotations[systemaccount.RestoreOperationDigestAnnotationKey],
+							systemaccount.CredentialIntentRevisionAnnotationKey: request.Annotations[systemaccount.CredentialIntentRevisionAnnotationKey],
+							systemaccount.RestoreRequestNameAnnotationKey:       request.Name,
+							systemaccount.RestoreRequestUIDAnnotationKey:        string(request.UID),
+						},
+					},
+					Type: corev1.SecretTypeOpaque,
+					Data: map[string][]byte{
+						constant.AccountNameForSecret:   []byte("admin"),
+						constant.AccountPasswdForSecret: []byte("restored-password"),
+					},
+				}
+				Expect(controllerutil.SetControllerReference(component, target, k8sManager.GetScheme())).Should(Succeed())
+				revision, err := systemaccount.TargetCommitRevision(target, constant.DBComponentFinalizerName)
+				Expect(err).ShouldNot(HaveOccurred())
+				target.Annotations[systemaccount.TargetCommitRevisionAnnotationKey] = revision
 				Expect(testCtx.Cli.Create(testCtx.Ctx, target)).Should(Succeed())
-				Expect(testCtx.Cli.Delete(testCtx.Ctx, request)).Should(Succeed())
+				Expect(testCtx.Cli.Get(testCtx.Ctx, secretKey, target)).Should(Succeed())
+				request.Annotations[systemaccount.RestoreRequestPhaseAnnotationKey] =
+					string(systemaccount.RestoreRequestPhaseCommitted)
+				request.Annotations[systemaccount.TargetSecretNameAnnotationKey] = target.Name
+				request.Annotations[systemaccount.TargetSecretUIDAnnotationKey] = string(target.UID)
+				request.Annotations[systemaccount.TargetCommitRevisionAnnotationKey] = revision
+				Expect(testCtx.Cli.Update(testCtx.Ctx, request)).Should(Succeed())
 
 				Eventually(testapps.CheckObj(&testCtx, secretKey, func(g Gomega, secret *corev1.Secret) {
 					g.Expect(secret.Data).Should(HaveKeyWithValue(constant.AccountNameForSecret, []byte("admin")))
@@ -2847,60 +3080,41 @@ func TestRestoreSystemAccountSecretsRestoresComponentAndShardingSecrets(t *testi
 		},
 	})
 	require.NoError(t, err)
-	backup := &dpv1alpha1.Backup{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "backup",
-			Annotations: map[string]string{
-				constant.EncryptedSystemAccountsAnnotationKey: string(accounts),
-			},
-		},
-	}
-	cluster := &kbappsv1.Cluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "cluster",
-			UID:       types.UID("cluster-uid"),
-		},
-	}
-	component := &kbappsv1.Component{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      constant.GenerateClusterComponentName("cluster", "mysql"),
-			UID:       types.UID("component-uid"),
-		},
-	}
 	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      "data-target-0",
 			Labels: map[string]string{
-				constant.AppInstanceLabelKey:       "cluster",
-				constant.KBAppComponentLabelKey:    "mysql",
 				constant.KBAppShardingNameLabelKey: "shard",
 			},
 		},
-		Spec: corev1.PersistentVolumeClaimSpec{
-			DataSourceRef: &corev1.TypedObjectReference{Name: backup.Name},
-		},
+	}
+	g := NewWithT(t)
+	backup, cluster, component, instanceSet := prepareSystemAccountAuthorityFixture(g, scheme, pvc)
+	backup.Annotations = map[string]string{
+		constant.EncryptedSystemAccountsAnnotationKey: string(accounts),
 	}
 	reconciler := &VolumePopulatorReconciler{
-		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(backup, cluster, component).Build(),
+		Client: fake.NewClientBuilder().WithScheme(scheme).
+			WithObjects(backup, cluster, component, instanceSet, pvc).Build(),
 		Scheme: scheme,
 	}
 
 	err = reconciler.restoreSystemAccountSecrets(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup.Namespace)
 	require.True(t, intctrlutil.IsRequeueError(err), err)
 	componentRequest := getSystemAccountRestoreRequest(t, reconciler.Client,
-		constant.GenerateAccountSecretName("cluster", "mysql", "admin"))
+		"admin", systemaccount.SystemAccountScopeComponent)
 	require.Equal(t, []byte("component-password"), componentRequest.Data[constant.AccountPasswdForSecret])
-	commitSystemAccountRestoreRequest(t, reconciler.Client, componentRequest, constant.DBComponentFinalizerName)
+	commitSystemAccountRestoreRequest(t, reconciler.Client, scheme, componentRequest, component,
+		constant.GenerateAccountSecretName("cluster", "mysql", "admin"), constant.DBComponentFinalizerName)
 
 	err = reconciler.restoreSystemAccountSecrets(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup.Namespace)
 	require.True(t, intctrlutil.IsRequeueError(err), err)
-	shardingRequest := getSystemAccountRestoreRequest(t, reconciler.Client, "cluster-shard-root")
+	shardingRequest := getSystemAccountRestoreRequest(t, reconciler.Client,
+		"root", systemaccount.SystemAccountScopeSharding)
 	require.Equal(t, []byte("sharding-password"), shardingRequest.Data[constant.AccountPasswdForSecret])
-	commitSystemAccountRestoreRequest(t, reconciler.Client, shardingRequest, constant.DBClusterFinalizerName)
+	commitSystemAccountRestoreRequest(t, reconciler.Client, scheme, shardingRequest, cluster,
+		"cluster-shard-root", constant.DBClusterFinalizerName)
 
 	err = reconciler.restoreSystemAccountSecrets(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup.Namespace)
 	require.NoError(t, err)
@@ -2926,34 +3140,429 @@ func TestRestoreSystemAccountSecretsRestoresComponentAndShardingSecrets(t *testi
 	require.Equal(t, cluster.Name, shardingSecret.OwnerReferences[0].Name)
 }
 
-func getSystemAccountRestoreRequest(t *testing.T, cli client.Client, targetName string) *corev1.Secret {
+func getSystemAccountRestoreRequest(t *testing.T, cli client.Client, account, scope string) *corev1.Secret {
 	t.Helper()
 	requests := &corev1.SecretList{}
 	require.NoError(t, cli.List(context.Background(), requests,
 		client.MatchingLabels{constant.SystemAccountRestoreRequestLabelKey: "true"}))
 	for i := range requests.Items {
 		request := &requests.Items[i]
-		if request.Annotations[constant.SystemAccountRestoreTargetAnnotationKey] == targetName {
+		if request.Annotations[systemaccount.SystemAccountAnnotationKey] == account &&
+			request.Annotations[systemaccount.SystemAccountScopeAnnotationKey] == scope {
 			return request.DeepCopy()
 		}
 	}
-	require.FailNow(t, "restore request not found", targetName)
+	require.FailNow(t, "restore request not found", "account=%s scope=%s", account, scope)
 	return nil
 }
 
-func commitSystemAccountRestoreRequest(t *testing.T, cli client.Client, request *corev1.Secret, finalizer string) {
+func commitSystemAccountRestoreRequest(
+	t *testing.T,
+	cli client.Client,
+	scheme *runtime.Scheme,
+	request *corev1.Secret,
+	owner client.Object,
+	targetName, finalizer string,
+) {
 	t.Helper()
-	target := request.DeepCopy()
-	target.Name = request.Annotations[constant.SystemAccountRestoreTargetAnnotationKey]
-	target.ResourceVersion = ""
-	target.UID = ""
-	target.CreationTimestamp = metav1.Time{}
-	target.ManagedFields = nil
-	target.Finalizers = []string{finalizer}
-	delete(target.Labels, constant.SystemAccountRestoreRequestLabelKey)
-	delete(target.Annotations, constant.SystemAccountRestoreTargetAnnotationKey)
+	if request.UID == "" {
+		request.UID = types.UID(request.Name + "-uid")
+		require.NoError(t, cli.Update(context.Background(), request))
+	}
+	intent, err := systemaccount.ValidateRestoreRequestV2(request)
+	require.NoError(t, err)
+	target := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  request.Namespace,
+			Name:       targetName,
+			UID:        types.UID(targetName + "-uid"),
+			Finalizers: []string{finalizer},
+			Annotations: map[string]string{
+				constant.SystemAccountProvisionedAnnotationKey:      "true",
+				systemaccount.RestoreProtocolAnnotationKey:          systemaccount.RestoreProtocolV2,
+				systemaccount.RestoreOperationDigestAnnotationKey:   request.Annotations[systemaccount.RestoreOperationDigestAnnotationKey],
+				systemaccount.CredentialIntentRevisionAnnotationKey: request.Annotations[systemaccount.CredentialIntentRevisionAnnotationKey],
+				systemaccount.RestoreRequestNameAnnotationKey:       request.Name,
+				systemaccount.RestoreRequestUIDAnnotationKey:        string(request.UID),
+			},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			constant.AccountNameForSecret:   append([]byte(nil), intent.Credentials[constant.AccountNameForSecret]...),
+			constant.AccountPasswdForSecret: append([]byte(nil), intent.Credentials[constant.AccountPasswdForSecret]...),
+		},
+	}
+	require.NoError(t, controllerutil.SetControllerReference(owner, target, scheme))
+	revision, err := systemaccount.TargetCommitRevision(target, finalizer)
+	require.NoError(t, err)
+	target.Annotations[systemaccount.TargetCommitRevisionAnnotationKey] = revision
 	require.NoError(t, cli.Create(context.Background(), target))
-	require.NoError(t, cli.Delete(context.Background(), request))
+	request.Annotations[systemaccount.RestoreRequestPhaseAnnotationKey] =
+		string(systemaccount.RestoreRequestPhaseCommitted)
+	request.Annotations[systemaccount.TargetSecretNameAnnotationKey] = target.Name
+	request.Annotations[systemaccount.TargetSecretUIDAnnotationKey] = string(target.UID)
+	request.Annotations[systemaccount.TargetCommitRevisionAnnotationKey] = revision
+	require.NoError(t, cli.Update(context.Background(), request))
+}
+
+func prepareSystemAccountAuthorityFixture(
+	t Gomega,
+	scheme *runtime.Scheme,
+	pvc *corev1.PersistentVolumeClaim,
+) (*dpv1alpha1.Backup, *kbappsv1.Cluster, *kbappsv1.Component, *workloadsv1.InstanceSet) {
+	t.Expect(dpv1alpha1.AddToScheme(scheme)).Should(Succeed())
+	t.Expect(workloadsv1.AddToScheme(scheme)).Should(Succeed())
+	apiGroup := dptypes.DataprotectionAPIGroup
+	if pvc.Namespace == "" {
+		pvc.Namespace = "default"
+	}
+	if pvc.Name == "" {
+		pvc.Name = "data-cluster-mysql-0"
+	}
+	pvc.UID = types.UID("pvc-uid")
+	if pvc.Labels == nil {
+		pvc.Labels = map[string]string{}
+	}
+	pvc.Labels[constant.AppInstanceLabelKey] = "cluster"
+	pvc.Labels[constant.KBAppComponentLabelKey] = "mysql"
+	if pvc.Annotations == nil {
+		pvc.Annotations = map[string]string{}
+	}
+	pvc.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
+	pvc.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = pvc.Namespace
+	backup := &dpv1alpha1.Backup{
+		TypeMeta: metav1.TypeMeta{APIVersion: dpv1alpha1.GroupVersion.String(), Kind: "Backup"},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: pvc.Namespace,
+			Name:      "backup",
+			UID:       types.UID("backup-uid"),
+		},
+	}
+	pvc.Spec.DataSourceRef = &corev1.TypedObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     dptypes.BackupKind,
+		Name:     backup.Name,
+	}
+	cluster := &kbappsv1.Cluster{
+		TypeMeta: metav1.TypeMeta{APIVersion: kbappsv1.GroupVersion.String(), Kind: "Cluster"},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: pvc.Namespace,
+			Name:      "cluster",
+			UID:       types.UID("cluster-uid"),
+		},
+	}
+	component := &kbappsv1.Component{
+		TypeMeta: metav1.TypeMeta{APIVersion: kbappsv1.GroupVersion.String(), Kind: "Component"},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: pvc.Namespace,
+			Name:      constant.GenerateClusterComponentName("cluster", "mysql"),
+			UID:       types.UID("component-uid"),
+			Labels: map[string]string{
+				constant.AppInstanceLabelKey:    "cluster",
+				constant.KBAppComponentLabelKey: "mysql",
+			},
+		},
+	}
+	instanceSet := &workloadsv1.InstanceSet{
+		TypeMeta: metav1.TypeMeta{APIVersion: workloadsv1.GroupVersion.String(), Kind: workloadsv1.InstanceSetKind},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: pvc.Namespace,
+			Name:      "cluster-mysql",
+			UID:       types.UID("instanceset-uid"),
+			Labels: map[string]string{
+				constant.AppInstanceLabelKey:    "cluster",
+				constant.KBAppComponentLabelKey: "mysql",
+			},
+		},
+	}
+	t.Expect(controllerutil.SetControllerReference(cluster, component, scheme)).Should(Succeed())
+	t.Expect(controllerutil.SetControllerReference(component, instanceSet, scheme)).Should(Succeed())
+	t.Expect(controllerutil.SetControllerReference(instanceSet, pvc, scheme)).Should(Succeed())
+	return backup, cluster, component, instanceSet
+}
+
+func TestSystemAccountRestoreAuthorityRejectsForeignIdentityWithoutCreatingRequest(t *testing.T) {
+	testCases := []struct {
+		name       string
+		wantReason string
+		mutate     func(
+			pvc *corev1.PersistentVolumeClaim,
+			backup *dpv1alpha1.Backup,
+			cluster *kbappsv1.Cluster,
+			component *kbappsv1.Component,
+			instanceSet *workloadsv1.InstanceSet,
+		)
+	}{
+		{
+			name:       "workload UID replacement",
+			wantReason: systemaccount.UnauthorizedRestoreProducerReason,
+			mutate: func(pvc *corev1.PersistentVolumeClaim, _ *dpv1alpha1.Backup,
+				_ *kbappsv1.Cluster, _ *kbappsv1.Component, _ *workloadsv1.InstanceSet) {
+				pvc.OwnerReferences[0].UID = "replacement-workload-uid"
+			},
+		},
+		{
+			name:       "Component UID mismatch",
+			wantReason: systemaccount.UnauthorizedRestoreProducerReason,
+			mutate: func(_ *corev1.PersistentVolumeClaim, _ *dpv1alpha1.Backup,
+				_ *kbappsv1.Cluster, _ *kbappsv1.Component, instanceSet *workloadsv1.InstanceSet) {
+				instanceSet.OwnerReferences[0].UID = "replacement-component-uid"
+			},
+		},
+		{
+			name:       "Cluster UID mismatch",
+			wantReason: systemaccount.UnauthorizedRestoreProducerReason,
+			mutate: func(_ *corev1.PersistentVolumeClaim, _ *dpv1alpha1.Backup,
+				_ *kbappsv1.Cluster, component *kbappsv1.Component, _ *workloadsv1.InstanceSet) {
+				component.OwnerReferences[0].UID = "replacement-cluster-uid"
+			},
+		},
+		{
+			name:       "terminating PVC",
+			wantReason: systemaccount.UnauthorizedRestoreProducerReason,
+			mutate: func(pvc *corev1.PersistentVolumeClaim, _ *dpv1alpha1.Backup,
+				_ *kbappsv1.Cluster, _ *kbappsv1.Component, _ *workloadsv1.InstanceSet) {
+				now := metav1.Now()
+				pvc.DeletionTimestamp = &now
+				pvc.Finalizers = []string{"test.kubeblocks.io/hold"}
+			},
+		},
+		{
+			name:       "terminating workload",
+			wantReason: systemaccount.UnauthorizedRestoreProducerReason,
+			mutate: func(_ *corev1.PersistentVolumeClaim, _ *dpv1alpha1.Backup,
+				_ *kbappsv1.Cluster, _ *kbappsv1.Component, instanceSet *workloadsv1.InstanceSet) {
+				now := metav1.Now()
+				instanceSet.DeletionTimestamp = &now
+				instanceSet.Finalizers = []string{"test.kubeblocks.io/hold"}
+			},
+		},
+		{
+			name:       "terminating Component",
+			wantReason: systemaccount.UnauthorizedRestoreProducerReason,
+			mutate: func(_ *corev1.PersistentVolumeClaim, _ *dpv1alpha1.Backup,
+				_ *kbappsv1.Cluster, component *kbappsv1.Component, _ *workloadsv1.InstanceSet) {
+				now := metav1.Now()
+				component.DeletionTimestamp = &now
+				component.Finalizers = []string{"test.kubeblocks.io/hold"}
+			},
+		},
+		{
+			name:       "terminating Cluster",
+			wantReason: systemaccount.UnauthorizedRestoreProducerReason,
+			mutate: func(_ *corev1.PersistentVolumeClaim, _ *dpv1alpha1.Backup,
+				cluster *kbappsv1.Cluster, _ *kbappsv1.Component, _ *workloadsv1.InstanceSet) {
+				now := metav1.Now()
+				cluster.DeletionTimestamp = &now
+				cluster.Finalizers = []string{"test.kubeblocks.io/hold"}
+			},
+		},
+		{
+			name:       "initial restore source mismatch",
+			wantReason: systemaccount.RestoreIntentMismatchReason,
+			mutate: func(_ *corev1.PersistentVolumeClaim, _ *dpv1alpha1.Backup,
+				cluster *kbappsv1.Cluster, _ *kbappsv1.Component, _ *workloadsv1.InstanceSet) {
+				cluster.Spec.Restore = &kbappsv1.ClusterRestore{
+					Source: kbappsv1.ClusterRestoreSource{
+						APIGroup:  dptypes.DataprotectionAPIGroup,
+						Kind:      dptypes.BackupKind,
+						Namespace: "default",
+						Name:      "other-backup",
+					},
+				}
+			},
+		},
+		{
+			name:       "cross namespace legacy source",
+			wantReason: systemaccount.UnsupportedRestoreSourceReason,
+			mutate: func(pvc *corev1.PersistentVolumeClaim, backup *dpv1alpha1.Backup,
+				_ *kbappsv1.Cluster, _ *kbappsv1.Component, _ *workloadsv1.InstanceSet) {
+				namespace := "backup"
+				backup.Namespace = namespace
+				pvc.Spec.DataSourceRef.Namespace = &namespace
+				pvc.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = namespace
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, corev1.AddToScheme(scheme))
+			require.NoError(t, kbappsv1.AddToScheme(scheme))
+			pvc := &corev1.PersistentVolumeClaim{}
+			backup, cluster, component, instanceSet :=
+				prepareSystemAccountAuthorityFixture(NewWithT(t), scheme, pvc)
+			testCase.mutate(pvc, backup, cluster, component, instanceSet)
+			cli := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(pvc, backup, cluster, component, instanceSet).Build()
+			reconciler := &VolumePopulatorReconciler{Client: cli, Scheme: scheme}
+
+			err := reconciler.upsertSystemAccountSecret(
+				intctrlutil.RequestCtx{Ctx: context.Background()},
+				pvc, backup, systemAccountSecretScopeComponent,
+				"cluster", "mysql", "admin", []byte("password"))
+
+			require.True(t, intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal), err)
+			require.ErrorContains(t, err, testCase.wantReason)
+			requests := &corev1.SecretList{}
+			require.NoError(t, cli.List(context.Background(), requests,
+				client.MatchingLabels{constant.SystemAccountRestoreRequestLabelKey: "true"}))
+			require.Empty(t, requests.Items)
+		})
+	}
+}
+
+func TestSystemAccountProtocolMapperRevalidatesReplacementPVCAuthority(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, kbappsv1.AddToScheme(scheme))
+	pvc := &corev1.PersistentVolumeClaim{}
+	backup, cluster, component, instanceSet :=
+		prepareSystemAccountAuthorityFixture(NewWithT(t), scheme, pvc)
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(pvc, backup, cluster, component, instanceSet).Build()
+	reconciler := &VolumePopulatorReconciler{Client: cli, Scheme: scheme}
+	request, err := reconciler.newSystemAccountRestoreRequest(
+		intctrlutil.RequestCtx{Ctx: context.Background()},
+		pvc, backup, systemAccountSecretScopeComponent,
+		"cluster", "mysql", "admin", []byte("password"))
+	require.NoError(t, err)
+
+	mapped := reconciler.mapSystemAccountProtocolSecret(context.Background(), request)
+	require.Equal(t, []ctrl.Request{{
+		NamespacedName: client.ObjectKeyFromObject(pvc),
+	}}, mapped)
+
+	require.NoError(t, cli.Delete(context.Background(), pvc))
+	replacement := pvc.DeepCopy()
+	replacement.ResourceVersion = ""
+	replacement.UID = "replacement-pvc-uid"
+	replacement.OwnerReferences[0].UID = "replacement-workload-uid"
+	require.NoError(t, cli.Create(context.Background(), replacement))
+
+	mapped = reconciler.mapSystemAccountProtocolSecret(context.Background(), request)
+	require.Empty(t, mapped)
+}
+
+func TestConflictReceiptCreateUncertainResponseUsesPersistedReceipt(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, kbappsv1.AddToScheme(scheme))
+	winnerPVC := &corev1.PersistentVolumeClaim{}
+	backup, cluster, component, instanceSet :=
+		prepareSystemAccountAuthorityFixture(NewWithT(t), scheme, winnerPVC)
+	loserPVC := winnerPVC.DeepCopy()
+	loserPVC.Name = "data-loser"
+	loserPVC.UID = "loser-pvc-uid"
+	loserPVC.ResourceVersion = ""
+	loserPVC.Annotations[constant.RestorePITRAnnotationKey] = "2026-07-23T00:00:00Z"
+	baseClient := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(winnerPVC, loserPVC, backup, cluster, component, instanceSet).Build()
+	reconciler := &VolumePopulatorReconciler{Client: baseClient, Scheme: scheme}
+	winner, err := reconciler.newSystemAccountRestoreRequest(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, winnerPVC, backup,
+		systemAccountSecretScopeComponent, "cluster", "mysql", "admin", []byte("winner-password"))
+	require.NoError(t, err)
+	winner.UID = "winner-request-uid"
+	require.NoError(t, baseClient.Create(context.Background(), winner))
+
+	createAttempts := 0
+	interceptedClient := interceptor.NewClient(baseClient, interceptor.Funcs{
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			secret, ok := obj.(*corev1.Secret)
+			if !ok || secret.Annotations[systemaccount.RestoreProtocolAnnotationKey] !=
+				systemaccount.ConflictProtocolV1 {
+				return c.Create(ctx, obj, opts...)
+			}
+			createAttempts++
+			if err := c.Create(ctx, secret.DeepCopy(), opts...); err != nil {
+				return err
+			}
+			return context.DeadlineExceeded
+		},
+	})
+	reconciler.Client = interceptedClient
+
+	err = reconciler.upsertSystemAccountSecret(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, loserPVC, backup,
+		systemAccountSecretScopeComponent, "cluster", "mysql", "admin", []byte("loser-password"))
+
+	require.True(t, intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal), err)
+	require.ErrorContains(t, err, systemaccount.ConcurrentRestoreIntentReason)
+	require.Equal(t, 1, createAttempts)
+	receipts := &corev1.SecretList{}
+	require.NoError(t, baseClient.List(context.Background(), receipts))
+	var receipt *corev1.Secret
+	for i := range receipts.Items {
+		if receipts.Items[i].Annotations[systemaccount.RestoreProtocolAnnotationKey] ==
+			systemaccount.ConflictProtocolV1 {
+			receipt = &receipts.Items[i]
+			break
+		}
+	}
+	require.NotNil(t, receipt)
+	projected := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, baseClient.Get(context.Background(), client.ObjectKeyFromObject(loserPVC), projected))
+	require.Equal(t, receipt.Annotations[systemaccount.RestoreOperationDigestAnnotationKey],
+		projected.Annotations[systemaccount.RestoreOperationDigestAnnotationKey])
+	require.Equal(t, receipt.Annotations[systemaccount.BlockingRequestUIDAnnotationKey],
+		projected.Annotations[systemaccount.BlockingRequestUIDAnnotationKey])
+	require.Equal(t, receipt.Annotations[systemaccount.WinnerOperationDigestAnnotationKey],
+		projected.Annotations[systemaccount.WinnerOperationDigestAnnotationKey])
+}
+
+func TestConflictReceiptMapperRepairsNonExactTerminalProjection(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, kbappsv1.AddToScheme(scheme))
+	pvc := &corev1.PersistentVolumeClaim{}
+	backup, cluster, component, instanceSet :=
+		prepareSystemAccountAuthorityFixture(NewWithT(t), scheme, pvc)
+	cli := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(pvc).
+		WithObjects(pvc, backup, cluster, component, instanceSet).Build()
+	reconciler := &VolumePopulatorReconciler{Client: cli, Scheme: scheme}
+	winner, err := reconciler.newSystemAccountRestoreRequest(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup,
+		systemAccountSecretScopeComponent, "cluster", "mysql", "admin", []byte("winner-password"))
+	require.NoError(t, err)
+	winner.UID = "winner-request-uid"
+	winner.ResourceVersion = "17"
+
+	loserPVC := pvc.DeepCopy()
+	loserPVC.Annotations[constant.RestorePITRAnnotationKey] = "2026-07-23T00:00:00Z"
+	require.NoError(t, cli.Update(context.Background(), loserPVC))
+	require.NoError(t, cli.Get(context.Background(), client.ObjectKeyFromObject(pvc), loserPVC))
+	loserRequest, err := reconciler.newSystemAccountRestoreRequest(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, loserPVC, backup,
+		systemAccountSecretScopeComponent, "cluster", "mysql", "admin", []byte("loser-password"))
+	require.NoError(t, err)
+	loserIntent, err := systemaccount.ValidateRestoreRequestV2(loserRequest)
+	require.NoError(t, err)
+	receipt, err := systemaccount.BuildConflictReceipt(loserIntent, winner)
+	require.NoError(t, err)
+
+	loserPVC.Status.Conditions = []corev1.PersistentVolumeClaimCondition{{
+		Type:   kbappsv1.ConditionTypeRestore,
+		Status: corev1.ConditionFalse,
+		Reason: systemaccount.AccountUnavailableReason,
+	}}
+	require.NoError(t, cli.Status().Update(context.Background(), loserPVC))
+	mapped := reconciler.mapSystemAccountProtocolSecret(context.Background(), receipt)
+	require.Equal(t, []ctrl.Request{{
+		NamespacedName: client.ObjectKeyFromObject(pvc),
+	}}, mapped)
+
+	envelope, err := systemaccount.ValidateConflictReceipt(receipt, loserIntent)
+	require.NoError(t, err)
+	require.NoError(t, reconciler.projectSystemAccountConflictIdentity(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, loserPVC, envelope))
+	loserPVC.Status.Conditions[0].Reason = systemaccount.ConcurrentRestoreIntentReason
+	require.NoError(t, cli.Status().Update(context.Background(), loserPVC))
+
+	mapped = reconciler.mapSystemAccountProtocolSecret(context.Background(), receipt)
+	require.Empty(t, mapped)
 }
 
 func TestRestoreSystemAccountSecretsReturnsFatalForInvalidAccountsPayload(t *testing.T) {

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
@@ -47,6 +48,7 @@ import (
 	workloadsv1 "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/instanceset"
+	"github.com/apecloud/kubeblocks/pkg/controller/systemaccount"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	dprestore "github.com/apecloud/kubeblocks/pkg/dataprotection/restore"
 	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
@@ -189,7 +191,7 @@ var _ = Describe("Volume Populator Controller test", func() {
 	})
 
 	Context("system account secret helpers", func() {
-		It("patches existing mutable secrets and waits before recreating changed immutable secrets", func() {
+		It("hands all target mutations to the Apps owner", func() {
 			scheme := runtime.NewScheme()
 			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
 			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
@@ -211,8 +213,9 @@ var _ = Describe("Volume Populator Controller test", func() {
 			immutable := true
 			immutableSecret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      constant.GenerateAccountSecretName("cluster", "mysql", "root"),
+					Namespace:  "default",
+					Name:       constant.GenerateAccountSecretName("cluster", "mysql", "root"),
+					Finalizers: []string{constant.DBComponentFinalizerName},
 				},
 				Immutable: &immutable,
 				Data: map[string][]byte{
@@ -235,48 +238,160 @@ var _ = Describe("Volume Populator Controller test", func() {
 			}
 			reqCtx := intctrlutil.RequestCtx{Ctx: context.Background()}
 
-			Expect(reconciler.upsertSystemAccountSecret(reqCtx, pvc, systemAccountSecretScopeComponent,
-				"cluster", "mysql", "admin", []byte("new-password"), map[string]string{"role": "admin"})).Should(Succeed())
-			patched := &corev1.Secret{}
+			err := reconciler.upsertSystemAccountSecret(reqCtx, pvc, systemAccountSecretScopeComponent,
+				"cluster", "mysql", "admin", []byte("new-password"), map[string]string{"role": "admin"})
+			Expect(err).To(HaveOccurred())
+			Expect(intctrlutil.IsRequeueError(err)).To(BeTrue(), err.Error())
+			currentMutable := &corev1.Secret{}
 			Expect(reconciler.Client.Get(context.Background(), client.ObjectKey{
 				Namespace: "default",
 				Name:      mutableSecret.Name,
-			}, patched)).Should(Succeed())
-			Expect(patched.Labels["role"]).To(Equal("admin"))
-			Expect(patched.Annotations[constant.SystemAccountProvisionedAnnotationKey]).To(Equal("true"))
-			Expect(patched.Data[constant.AccountNameForSecret]).To(Equal([]byte("admin")))
-			Expect(patched.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("new-password")))
-			Expect(patched.OwnerReferences).To(HaveLen(1))
-			Expect(patched.OwnerReferences[0].Kind).To(Equal("Component"))
+			}, currentMutable)).Should(Succeed())
+			Expect(currentMutable.Labels).To(BeEmpty())
+			Expect(currentMutable.Annotations).To(BeEmpty())
+			Expect(currentMutable.Data).To(BeEmpty())
+			Expect(currentMutable.OwnerReferences).To(BeEmpty())
 
-			err := reconciler.upsertSystemAccountSecret(reqCtx, pvc, systemAccountSecretScopeComponent,
+			err = reconciler.upsertSystemAccountSecret(reqCtx, pvc, systemAccountSecretScopeComponent,
 				"cluster", "mysql", "root", []byte("new-root-password"), map[string]string{"role": "root"})
 			Expect(err).To(HaveOccurred())
 			Expect(intctrlutil.IsRequeueError(err)).To(BeTrue(), err.Error())
+			currentImmutable := &corev1.Secret{}
 			Expect(reconciler.Client.Get(context.Background(), client.ObjectKey{
 				Namespace: "default",
 				Name:      immutableSecret.Name,
-			}, &corev1.Secret{})).To(MatchError(ContainSubstring("not found")))
+			}, currentImmutable)).Should(Succeed())
+			Expect(currentImmutable.DeletionTimestamp.IsZero()).To(BeTrue())
+			Expect(currentImmutable.Finalizers).To(ConsistOf(constant.DBComponentFinalizerName))
+			Expect(currentImmutable.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("old-password")))
 
-			Expect(reconciler.upsertSystemAccountSecret(reqCtx, pvc, systemAccountSecretScopeComponent,
-				"cluster", "mysql", "root", []byte("new-root-password"), map[string]string{"role": "root"})).Should(Succeed())
-			recreated := &corev1.Secret{}
-			Expect(reconciler.Client.Get(context.Background(), client.ObjectKey{
-				Namespace: "default",
-				Name:      immutableSecret.Name,
-			}, recreated)).Should(Succeed())
-			Expect(recreated.Immutable).To(BeNil())
-			Expect(recreated.Labels["role"]).To(Equal("root"))
-			Expect(recreated.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("new-root-password")))
-			Expect(systemAccountSecretMatches(recreated, "root", []byte("new-root-password"))).To(BeTrue())
-			Expect(systemAccountSecretMatches(recreated, "root", []byte("old-password"))).To(BeFalse())
+			requests := &corev1.SecretList{}
+			Expect(reconciler.Client.List(context.Background(), requests, client.InNamespace("default"))).Should(Succeed())
+			var mutableRequest, immutableRequest *corev1.Secret
+			for i := range requests.Items {
+				switch requests.Items[i].Annotations[constant.SystemAccountRestoreTargetAnnotationKey] {
+				case mutableSecret.Name:
+					mutableRequest = &requests.Items[i]
+				case immutableSecret.Name:
+					immutableRequest = &requests.Items[i]
+				}
+			}
+			Expect(mutableRequest).NotTo(BeNil())
+			Expect(mutableRequest.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("new-password")))
+			Expect(immutableRequest).NotTo(BeNil())
+			Expect(immutableRequest.Data[constant.AccountNameForSecret]).To(Equal([]byte("root")))
+			Expect(immutableRequest.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("new-root-password")))
+			Expect(immutableRequest.OwnerReferences).To(HaveLen(1))
+			Expect(immutableRequest.OwnerReferences[0].Kind).To(Equal("Component"))
+			Expect(immutableRequest.OwnerReferences[0].Controller).NotTo(BeNil())
+			Expect(*immutableRequest.OwnerReferences[0].Controller).To(BeTrue())
+			Expect(immutableRequest.Labels[constant.SystemAccountRestoreRequestLabelKey]).To(Equal("true"))
+			Expect(immutableRequest.Annotations[constant.SystemAccountRestoreRevisionAnnotationKey]).NotTo(BeEmpty())
 		})
 
-		It("does not delete a recreated immutable system account secret", func() {
+		It("accepts only the Apps-committed restore revision as converged", func() {
 			scheme := runtime.NewScheme()
 			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
 			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
+			component := &kbappsv1.Component{ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      constant.GenerateClusterComponentName("cluster", "mysql"),
+				UID:       types.UID("component-uid"),
+			}}
+			pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "data-target-0",
+			}}
+			reconciler := &VolumePopulatorReconciler{
+				Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(component).Build(),
+				Scheme: scheme,
+			}
+			request, err := reconciler.newSystemAccountRestoreRequest(
+				intctrlutil.RequestCtx{Ctx: context.Background()}, "default",
+				constant.GenerateAccountSecretName("cluster", "mysql", "admin"),
+				systemAccountSecretScopeComponent, "cluster", "mysql", "admin", []byte("restored-password"),
+				map[string]string{"role": "admin"})
+			Expect(err).ShouldNot(HaveOccurred())
+			target := request.DeepCopy()
+			target.Name = request.Annotations[constant.SystemAccountRestoreTargetAnnotationKey]
+			delete(target.Labels, constant.SystemAccountRestoreRequestLabelKey)
+			delete(target.Annotations, constant.SystemAccountRestoreTargetAnnotationKey)
+			target.Finalizers = []string{constant.DBComponentFinalizerName}
+			Expect(reconciler.Client.Create(context.Background(), target)).Should(Succeed())
 
+			err = reconciler.upsertSystemAccountSecret(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc,
+				systemAccountSecretScopeComponent, "cluster", "mysql", "admin", []byte("restored-password"),
+				map[string]string{"role": "admin"})
+
+			Expect(err).ShouldNot(HaveOccurred())
+			requests := &corev1.SecretList{}
+			Expect(reconciler.Client.List(context.Background(), requests,
+				client.MatchingLabels{constant.SystemAccountRestoreRequestLabelKey: "true"})).Should(Succeed())
+			Expect(requests.Items).To(BeEmpty())
+		})
+
+		It("serializes a new restore behind an older valid request", func() {
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
+			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
+			component := &kbappsv1.Component{ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      constant.GenerateClusterComponentName("cluster", "mysql"),
+				UID:       types.UID("component-uid"),
+			}}
+			pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "data-target-0",
+			}}
+			reconciler := &VolumePopulatorReconciler{
+				Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(component).Build(),
+				Scheme: scheme,
+			}
+			oldRequest, err := reconciler.newSystemAccountRestoreRequest(
+				intctrlutil.RequestCtx{Ctx: context.Background()}, "default",
+				constant.GenerateAccountSecretName("cluster", "mysql", "admin"),
+				systemAccountSecretScopeComponent, "cluster", "mysql", "admin", []byte("old-password"),
+				map[string]string{"role": "admin"})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(reconciler.Client.Create(context.Background(), oldRequest)).Should(Succeed())
+
+			err = reconciler.upsertSystemAccountSecret(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc,
+				systemAccountSecretScopeComponent, "cluster", "mysql", "admin", []byte("new-password"),
+				map[string]string{"role": "admin"})
+
+			Expect(intctrlutil.IsRequeueError(err)).To(BeTrue(), err)
+			persisted := &corev1.Secret{}
+			Expect(reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(oldRequest), persisted)).Should(Succeed())
+			Expect(persisted.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("old-password")))
+		})
+
+		It("requeues a restore request create race through the full reconciler", func() {
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
+			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
+			Expect(dpv1alpha1.AddToScheme(scheme)).Should(Succeed())
+
+			apiGroup := dptypes.DataprotectionAPIGroup
+			backup := newBackupForRestoreDecision(nil, nil)
+			encryptor := intctrlutil.NewEncryptor(viper.GetString(constant.CfgKeyDPEncryptionKey))
+			encryptedPassword, err := encryptor.Encrypt([]byte("restored-password"))
+			Expect(err).ShouldNot(HaveOccurred())
+			backup.Annotations = map[string]string{
+				constant.EncryptedSystemAccountsAnnotationKey: fmt.Sprintf(`{"mysql":{"admin":"%s"}}`, encryptedPassword),
+			}
+			pvc := newPVCForRestoreDecision("data", "mysql", "")
+			pvc.UID = types.UID("target-pvc-uid")
+			pvc.Spec.DataSourceRef = &corev1.TypedObjectReference{
+				APIGroup: &apiGroup,
+				Kind:     dptypes.BackupKind,
+				Name:     backup.Name,
+			}
+			pvc.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
+			pvc.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+			pvc.Status.Conditions = []corev1.PersistentVolumeClaimCondition{{
+				Type:   PersistentVolumeClaimPopulating,
+				Status: corev1.ConditionTrue,
+			}}
 			component := &kbappsv1.Component{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "default",
@@ -284,72 +399,38 @@ var _ = Describe("Volume Populator Controller test", func() {
 					UID:       types.UID("component-uid"),
 				},
 			}
-			immutable := true
-			oldSecret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      constant.GenerateAccountSecretName("cluster", "mysql", "root"),
-					UID:       types.UID("old-secret-uid"),
-				},
-				Immutable: &immutable,
-				Data: map[string][]byte{
-					constant.AccountNameForSecret:   []byte("root"),
-					constant.AccountPasswdForSecret: []byte("old-password"),
-				},
-			}
-			pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
-				Namespace: "default",
-				Name:      "data-target-0",
-			}}
 			baseClient := fake.NewClientBuilder().
 				WithScheme(scheme).
-				WithObjects(component, oldSecret).
+				WithStatusSubresource(pvc, backup).
+				WithObjects(component, backup, pvc).
 				Build()
-			replacementUID := types.UID("replacement-secret-uid")
-			deleteIntercepted := false
+			requestCreateAttempts := 0
 			interceptedClient := interceptor.NewClient(baseClient, interceptor.Funcs{
-				Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
-					if deleteIntercepted {
-						return c.Delete(ctx, obj, opts...)
+				Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+					if secret, ok := obj.(*corev1.Secret); ok &&
+						secret.Labels[constant.SystemAccountRestoreRequestLabelKey] == "true" {
+						requestCreateAttempts++
+						return apierrors.NewAlreadyExists(corev1.Resource("secrets"), secret.Name)
 					}
-					deleteIntercepted = true
-					Expect(c.Delete(ctx, obj)).Should(Succeed())
-					replacement := &corev1.Secret{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: obj.GetNamespace(),
-							Name:      obj.GetName(),
-							UID:       replacementUID,
-						},
-						Data: map[string][]byte{constant.AccountPasswdForSecret: []byte("replacement-password")},
-					}
-					Expect(c.Create(ctx, replacement)).Should(Succeed())
-
-					deleteOptions := &client.DeleteOptions{}
-					deleteOptions.ApplyOptions(opts)
-					if deleteOptions.Preconditions != nil && deleteOptions.Preconditions.UID != nil {
-						current := &corev1.Secret{}
-						Expect(c.Get(ctx, client.ObjectKeyFromObject(replacement), current)).Should(Succeed())
-						if current.UID != *deleteOptions.Preconditions.UID {
-							return apierrors.NewConflict(corev1.Resource("secrets"), current.Name,
-								fmt.Errorf("UID precondition does not match"))
-						}
-					}
-					return c.Delete(ctx, obj, opts...)
+					return c.Create(ctx, obj, opts...)
 				},
 			})
-			reconciler := &VolumePopulatorReconciler{Client: interceptedClient, Scheme: scheme}
+			reconciler := &VolumePopulatorReconciler{
+				Client:   interceptedClient,
+				Scheme:   scheme,
+				Recorder: record.NewFakeRecorder(10),
+			}
 
-			err := reconciler.upsertSystemAccountSecret(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc,
-				systemAccountSecretScopeComponent, "cluster", "mysql", "root", []byte("new-password"), nil)
-			Expect(err).To(HaveOccurred())
-			Expect(apierrors.IsConflict(err)).To(BeTrue(), "expected a UID-precondition conflict, got %v", err)
-			current := &corev1.Secret{}
-			Expect(baseClient.Get(context.Background(), client.ObjectKeyFromObject(oldSecret), current)).Should(Succeed())
-			Expect(current.UID).To(Equal(replacementUID))
-			Expect(current.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("replacement-password")))
+			result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: client.ObjectKeyFromObject(pvc),
+			})
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(reconcileInterval))
+			Expect(requestCreateAttempts).To(Equal(1))
 		})
 
-		It("removes the cluster finalizer before replacing immutable sharding account secrets", func() {
+		It("asks the Cluster owner to replace immutable sharding account secrets", func() {
 			scheme := runtime.NewScheme()
 			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
 			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
@@ -394,26 +475,32 @@ var _ = Describe("Volume Populator Controller test", func() {
 				map[string]string{constant.KBAppShardingNameLabelKey: "shard"})
 			Expect(err).To(HaveOccurred())
 			Expect(intctrlutil.IsRequeueError(err)).To(BeTrue(), err.Error())
+			current := &corev1.Secret{}
 			Expect(reconciler.Client.Get(context.Background(), client.ObjectKey{
 				Namespace: "default",
 				Name:      secret.Name,
-			}, &corev1.Secret{})).To(MatchError(ContainSubstring("not found")))
+			}, current)).Should(Succeed())
+			Expect(current.DeletionTimestamp.IsZero()).To(BeTrue())
+			Expect(current.Finalizers).To(ConsistOf(constant.DBClusterFinalizerName))
 
-			Expect(reconciler.upsertSystemAccountSecret(reqCtx, pvc, systemAccountSecretScopeSharding,
-				"cluster", "shard", "root", []byte("new-password"),
-				map[string]string{constant.KBAppShardingNameLabelKey: "shard"})).Should(Succeed())
-			recreated := &corev1.Secret{}
-			Expect(reconciler.Client.Get(context.Background(), client.ObjectKey{
-				Namespace: "default",
-				Name:      secret.Name,
-			}, recreated)).Should(Succeed())
-			Expect(recreated.Finalizers).To(BeEmpty())
-			Expect(recreated.OwnerReferences).To(HaveLen(1))
-			Expect(recreated.OwnerReferences[0].Kind).To(Equal("Cluster"))
-			Expect(recreated.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("new-password")))
+			requests := &corev1.SecretList{}
+			Expect(reconciler.Client.List(context.Background(), requests, client.InNamespace("default"))).Should(Succeed())
+			var request *corev1.Secret
+			for i := range requests.Items {
+				if requests.Items[i].Annotations[constant.SystemAccountRestoreTargetAnnotationKey] == secret.Name {
+					request = &requests.Items[i]
+					break
+				}
+			}
+			Expect(request).NotTo(BeNil())
+			Expect(request.OwnerReferences).To(HaveLen(1))
+			Expect(request.OwnerReferences[0].Kind).To(Equal("Cluster"))
+			Expect(request.OwnerReferences[0].Controller).NotTo(BeNil())
+			Expect(*request.OwnerReferences[0].Controller).To(BeTrue())
+			Expect(request.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("new-password")))
 		})
 
-		It("removes the cluster finalizer from deletion-stamped immutable sharding account secrets", func() {
+		It("does not remove the Cluster finalizer from deletion-stamped account secrets", func() {
 			scheme := runtime.NewScheme()
 			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
 			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
@@ -439,10 +526,15 @@ var _ = Describe("Volume Populator Controller test", func() {
 					Name:      "data-target-0",
 				},
 			}
+			cluster := &kbappsv1.Cluster{ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "cluster",
+				UID:       types.UID("cluster-uid"),
+			}}
 			reconciler := &VolumePopulatorReconciler{
 				Client: fake.NewClientBuilder().
 					WithScheme(scheme).
-					WithObjects(secret).
+					WithObjects(cluster, secret).
 					Build(),
 				Scheme: scheme,
 			}
@@ -458,12 +550,15 @@ var _ = Describe("Volume Populator Controller test", func() {
 				Namespace: "default",
 				Name:      secret.Name,
 			}, patched)
-			if apierrors.IsNotFound(err) {
-				return
-			}
 			Expect(err).Should(Succeed())
-			Expect(patched.Finalizers).To(BeEmpty())
+			Expect(patched.Finalizers).To(ConsistOf(constant.DBClusterFinalizerName))
 			Expect(patched.DeletionTimestamp).NotTo(BeNil())
+
+			requests := &corev1.SecretList{}
+			Expect(reconciler.Client.List(context.Background(), requests, client.InNamespace("default"))).Should(Succeed())
+			Expect(requests.Items).To(ContainElement(WithTransform(func(item corev1.Secret) string {
+				return item.Annotations[constant.SystemAccountRestoreTargetAnnotationKey]
+			}, Equal(secret.Name))))
 		})
 
 		It("validates PVC names against instance volume templates", func() {
@@ -919,6 +1014,38 @@ var _ = Describe("Volume Populator Controller test", func() {
 					Namespace: testCtx.DefaultNamespace,
 					Name:      constant.GenerateAccountSecretName(testdp.ClusterName, testdp.ComponentName, "admin"),
 				}
+				requestKey := types.NamespacedName{
+					Namespace: testCtx.DefaultNamespace,
+					Name:      systemaccount.RestoreRequestName(testCtx.DefaultNamespace, secretKey.Name),
+				}
+				request := &corev1.Secret{}
+				Eventually(func(g Gomega) {
+					g.Expect(testCtx.Cli.Get(testCtx.Ctx, requestKey, request)).Should(Succeed())
+					g.Expect(request.Data).Should(HaveKeyWithValue(constant.AccountNameForSecret, []byte("admin")))
+					g.Expect(request.Data).Should(HaveKeyWithValue(constant.AccountPasswdForSecret, []byte("restored-password")))
+					g.Expect(request.Labels).Should(HaveKeyWithValue(constant.SystemAccountRestoreRequestLabelKey, "true"))
+					g.Expect(request.Annotations[constant.SystemAccountRestoreRevisionAnnotationKey]).ShouldNot(BeEmpty())
+				}).Should(Succeed())
+				Expect(testCtx.Cli.Get(testCtx.Ctx, secretKey, &corev1.Secret{})).Should(Satisfy(apierrors.IsNotFound))
+				Expect(testCtx.Cli.Get(testCtx.Ctx, types.NamespacedName{
+					Namespace: testCtx.DefaultNamespace,
+					Name:      getPopulatePVCName(pvc.UID),
+				}, &dpv1alpha1.Restore{})).Should(Satisfy(apierrors.IsNotFound))
+
+				// The Apps controller is not installed in this focused DP envtest. Commit
+				// its side of the public request contract before letting DP continue.
+				target := request.DeepCopy()
+				target.Name = secretKey.Name
+				target.ResourceVersion = ""
+				target.UID = ""
+				target.CreationTimestamp = metav1.Time{}
+				target.ManagedFields = nil
+				target.Finalizers = []string{constant.DBComponentFinalizerName}
+				delete(target.Labels, constant.SystemAccountRestoreRequestLabelKey)
+				delete(target.Annotations, constant.SystemAccountRestoreTargetAnnotationKey)
+				Expect(testCtx.Cli.Create(testCtx.Ctx, target)).Should(Succeed())
+				Expect(testCtx.Cli.Delete(testCtx.Ctx, request)).Should(Succeed())
+
 				Eventually(testapps.CheckObj(&testCtx, secretKey, func(g Gomega, secret *corev1.Secret) {
 					g.Expect(secret.Data).Should(HaveKeyWithValue(constant.AccountNameForSecret, []byte("admin")))
 					g.Expect(secret.Data).Should(HaveKeyWithValue(constant.AccountPasswdForSecret, []byte("restored-password")))
@@ -2763,6 +2890,19 @@ func TestRestoreSystemAccountSecretsRestoresComponentAndShardingSecrets(t *testi
 	}
 
 	err = reconciler.restoreSystemAccountSecrets(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup.Namespace)
+	require.True(t, intctrlutil.IsRequeueError(err), err)
+	componentRequest := getSystemAccountRestoreRequest(t, reconciler.Client,
+		constant.GenerateAccountSecretName("cluster", "mysql", "admin"))
+	require.Equal(t, []byte("component-password"), componentRequest.Data[constant.AccountPasswdForSecret])
+	commitSystemAccountRestoreRequest(t, reconciler.Client, componentRequest, constant.DBComponentFinalizerName)
+
+	err = reconciler.restoreSystemAccountSecrets(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup.Namespace)
+	require.True(t, intctrlutil.IsRequeueError(err), err)
+	shardingRequest := getSystemAccountRestoreRequest(t, reconciler.Client, "cluster-shard-root")
+	require.Equal(t, []byte("sharding-password"), shardingRequest.Data[constant.AccountPasswdForSecret])
+	commitSystemAccountRestoreRequest(t, reconciler.Client, shardingRequest, constant.DBClusterFinalizerName)
+
+	err = reconciler.restoreSystemAccountSecrets(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, backup.Namespace)
 	require.NoError(t, err)
 
 	componentSecret := &corev1.Secret{}
@@ -2784,6 +2924,36 @@ func TestRestoreSystemAccountSecretsRestoresComponentAndShardingSecrets(t *testi
 	require.Len(t, shardingSecret.OwnerReferences, 1)
 	require.Equal(t, "Cluster", shardingSecret.OwnerReferences[0].Kind)
 	require.Equal(t, cluster.Name, shardingSecret.OwnerReferences[0].Name)
+}
+
+func getSystemAccountRestoreRequest(t *testing.T, cli client.Client, targetName string) *corev1.Secret {
+	t.Helper()
+	requests := &corev1.SecretList{}
+	require.NoError(t, cli.List(context.Background(), requests,
+		client.MatchingLabels{constant.SystemAccountRestoreRequestLabelKey: "true"}))
+	for i := range requests.Items {
+		request := &requests.Items[i]
+		if request.Annotations[constant.SystemAccountRestoreTargetAnnotationKey] == targetName {
+			return request.DeepCopy()
+		}
+	}
+	require.FailNow(t, "restore request not found", targetName)
+	return nil
+}
+
+func commitSystemAccountRestoreRequest(t *testing.T, cli client.Client, request *corev1.Secret, finalizer string) {
+	t.Helper()
+	target := request.DeepCopy()
+	target.Name = request.Annotations[constant.SystemAccountRestoreTargetAnnotationKey]
+	target.ResourceVersion = ""
+	target.UID = ""
+	target.CreationTimestamp = metav1.Time{}
+	target.ManagedFields = nil
+	target.Finalizers = []string{finalizer}
+	delete(target.Labels, constant.SystemAccountRestoreRequestLabelKey)
+	delete(target.Annotations, constant.SystemAccountRestoreTargetAnnotationKey)
+	require.NoError(t, cli.Create(context.Background(), target))
+	require.NoError(t, cli.Delete(context.Background(), request))
 }
 
 func TestRestoreSystemAccountSecretsReturnsFatalForInvalidAccountsPayload(t *testing.T) {

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
@@ -269,6 +270,83 @@ var _ = Describe("Volume Populator Controller test", func() {
 			Expect(recreated.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("new-root-password")))
 			Expect(systemAccountSecretMatches(recreated, "root", []byte("new-root-password"))).To(BeTrue())
 			Expect(systemAccountSecretMatches(recreated, "root", []byte("old-password"))).To(BeFalse())
+		})
+
+		It("does not delete a recreated immutable system account secret", func() {
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
+			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
+
+			component := &kbappsv1.Component{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      constant.GenerateClusterComponentName("cluster", "mysql"),
+					UID:       types.UID("component-uid"),
+				},
+			}
+			immutable := true
+			oldSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      constant.GenerateAccountSecretName("cluster", "mysql", "root"),
+					UID:       types.UID("old-secret-uid"),
+				},
+				Immutable: &immutable,
+				Data: map[string][]byte{
+					constant.AccountNameForSecret:   []byte("root"),
+					constant.AccountPasswdForSecret: []byte("old-password"),
+				},
+			}
+			pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+				Namespace: "default",
+				Name:      "data-target-0",
+			}}
+			baseClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(component, oldSecret).
+				Build()
+			replacementUID := types.UID("replacement-secret-uid")
+			deleteIntercepted := false
+			interceptedClient := interceptor.NewClient(baseClient, interceptor.Funcs{
+				Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					if deleteIntercepted {
+						return c.Delete(ctx, obj, opts...)
+					}
+					deleteIntercepted = true
+					Expect(c.Delete(ctx, obj)).Should(Succeed())
+					replacement := &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: obj.GetNamespace(),
+							Name:      obj.GetName(),
+							UID:       replacementUID,
+						},
+						Data: map[string][]byte{constant.AccountPasswdForSecret: []byte("replacement-password")},
+					}
+					Expect(c.Create(ctx, replacement)).Should(Succeed())
+
+					deleteOptions := &client.DeleteOptions{}
+					deleteOptions.ApplyOptions(opts)
+					if deleteOptions.Preconditions != nil && deleteOptions.Preconditions.UID != nil {
+						current := &corev1.Secret{}
+						Expect(c.Get(ctx, client.ObjectKeyFromObject(replacement), current)).Should(Succeed())
+						if current.UID != *deleteOptions.Preconditions.UID {
+							return apierrors.NewConflict(corev1.Resource("secrets"), current.Name,
+								fmt.Errorf("UID precondition does not match"))
+						}
+					}
+					return c.Delete(ctx, obj, opts...)
+				},
+			})
+			reconciler := &VolumePopulatorReconciler{Client: interceptedClient, Scheme: scheme}
+
+			err := reconciler.upsertSystemAccountSecret(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc,
+				systemAccountSecretScopeComponent, "cluster", "mysql", "root", []byte("new-password"), nil)
+			Expect(err).To(HaveOccurred())
+			Expect(apierrors.IsConflict(err)).To(BeTrue(), "expected a UID-precondition conflict, got %v", err)
+			current := &corev1.Secret{}
+			Expect(baseClient.Get(context.Background(), client.ObjectKeyFromObject(oldSecret), current)).Should(Succeed())
+			Expect(current.UID).To(Equal(replacementUID))
+			Expect(current.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("replacement-password")))
 		})
 
 		It("removes the cluster finalizer before replacing immutable sharding account secrets", func() {

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -376,10 +376,14 @@ var _ = Describe("Volume Populator Controller test", func() {
 			Expect(intctrlutil.IsRequeueError(err)).To(BeTrue(), err.Error())
 
 			patched := &corev1.Secret{}
-			Expect(reconciler.Client.Get(context.Background(), client.ObjectKey{
+			err = reconciler.Client.Get(context.Background(), client.ObjectKey{
 				Namespace: "default",
 				Name:      secret.Name,
-			}, patched)).Should(Succeed())
+			}, patched)
+			if apierrors.IsNotFound(err) {
+				return
+			}
+			Expect(err).Should(Succeed())
 			Expect(patched.Finalizers).To(BeEmpty())
 			Expect(patched.DeletionTimestamp).NotTo(BeNil())
 		})

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -188,7 +188,7 @@ var _ = Describe("Volume Populator Controller test", func() {
 	})
 
 	Context("system account secret helpers", func() {
-		It("patches existing mutable secrets and recreates changed immutable secrets", func() {
+		It("patches existing mutable secrets and waits before recreating changed immutable secrets", func() {
 			scheme := runtime.NewScheme()
 			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
 			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
@@ -248,6 +248,15 @@ var _ = Describe("Volume Populator Controller test", func() {
 			Expect(patched.OwnerReferences).To(HaveLen(1))
 			Expect(patched.OwnerReferences[0].Kind).To(Equal("Component"))
 
+			err := reconciler.upsertSystemAccountSecret(reqCtx, pvc, systemAccountSecretScopeComponent,
+				"cluster", "mysql", "root", []byte("new-root-password"), map[string]string{"role": "root"})
+			Expect(err).To(HaveOccurred())
+			Expect(intctrlutil.IsRequeueError(err)).To(BeTrue(), err.Error())
+			Expect(reconciler.Client.Get(context.Background(), client.ObjectKey{
+				Namespace: "default",
+				Name:      immutableSecret.Name,
+			}, &corev1.Secret{})).To(MatchError(ContainSubstring("not found")))
+
 			Expect(reconciler.upsertSystemAccountSecret(reqCtx, pvc, systemAccountSecretScopeComponent,
 				"cluster", "mysql", "root", []byte("new-root-password"), map[string]string{"role": "root"})).Should(Succeed())
 			recreated := &corev1.Secret{}
@@ -260,6 +269,119 @@ var _ = Describe("Volume Populator Controller test", func() {
 			Expect(recreated.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("new-root-password")))
 			Expect(systemAccountSecretMatches(recreated, "root", []byte("new-root-password"))).To(BeTrue())
 			Expect(systemAccountSecretMatches(recreated, "root", []byte("old-password"))).To(BeFalse())
+		})
+
+		It("removes the cluster finalizer before replacing immutable sharding account secrets", func() {
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
+			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
+
+			cluster := &kbappsv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "cluster",
+					UID:       types.UID("cluster-uid"),
+				},
+			}
+			immutable := true
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:  "default",
+					Name:       "cluster-shard-root",
+					Finalizers: []string{constant.DBClusterFinalizerName},
+				},
+				Immutable: &immutable,
+				Data: map[string][]byte{
+					constant.AccountNameForSecret:   []byte("root"),
+					constant.AccountPasswdForSecret: []byte("old-password"),
+				},
+			}
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "data-target-0",
+				},
+			}
+			reconciler := &VolumePopulatorReconciler{
+				Client: fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(cluster, secret).
+					Build(),
+				Scheme: scheme,
+			}
+			reqCtx := intctrlutil.RequestCtx{Ctx: context.Background()}
+
+			err := reconciler.upsertSystemAccountSecret(reqCtx, pvc, systemAccountSecretScopeSharding,
+				"cluster", "shard", "root", []byte("new-password"),
+				map[string]string{constant.KBAppShardingNameLabelKey: "shard"})
+			Expect(err).To(HaveOccurred())
+			Expect(intctrlutil.IsRequeueError(err)).To(BeTrue(), err.Error())
+			Expect(reconciler.Client.Get(context.Background(), client.ObjectKey{
+				Namespace: "default",
+				Name:      secret.Name,
+			}, &corev1.Secret{})).To(MatchError(ContainSubstring("not found")))
+
+			Expect(reconciler.upsertSystemAccountSecret(reqCtx, pvc, systemAccountSecretScopeSharding,
+				"cluster", "shard", "root", []byte("new-password"),
+				map[string]string{constant.KBAppShardingNameLabelKey: "shard"})).Should(Succeed())
+			recreated := &corev1.Secret{}
+			Expect(reconciler.Client.Get(context.Background(), client.ObjectKey{
+				Namespace: "default",
+				Name:      secret.Name,
+			}, recreated)).Should(Succeed())
+			Expect(recreated.Finalizers).To(BeEmpty())
+			Expect(recreated.OwnerReferences).To(HaveLen(1))
+			Expect(recreated.OwnerReferences[0].Kind).To(Equal("Cluster"))
+			Expect(recreated.Data[constant.AccountPasswdForSecret]).To(Equal([]byte("new-password")))
+		})
+
+		It("removes the cluster finalizer from deletion-stamped immutable sharding account secrets", func() {
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).Should(Succeed())
+			Expect(kbappsv1.AddToScheme(scheme)).Should(Succeed())
+
+			deletionTime := metav1.Now()
+			immutable := true
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:         "default",
+					Name:              "cluster-shard-root",
+					DeletionTimestamp: &deletionTime,
+					Finalizers:        []string{constant.DBClusterFinalizerName},
+				},
+				Immutable: &immutable,
+				Data: map[string][]byte{
+					constant.AccountNameForSecret:   []byte("root"),
+					constant.AccountPasswdForSecret: []byte("old-password"),
+				},
+			}
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "data-target-0",
+				},
+			}
+			reconciler := &VolumePopulatorReconciler{
+				Client: fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(secret).
+					Build(),
+				Scheme: scheme,
+			}
+
+			err := reconciler.upsertSystemAccountSecret(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc,
+				systemAccountSecretScopeSharding, "cluster", "shard", "root", []byte("new-password"),
+				map[string]string{constant.KBAppShardingNameLabelKey: "shard"})
+			Expect(err).To(HaveOccurred())
+			Expect(intctrlutil.IsRequeueError(err)).To(BeTrue(), err.Error())
+
+			patched := &corev1.Secret{}
+			Expect(reconciler.Client.Get(context.Background(), client.ObjectKey{
+				Namespace: "default",
+				Name:      secret.Name,
+			}, patched)).Should(Succeed())
+			Expect(patched.Finalizers).To(BeEmpty())
+			Expect(patched.DeletionTimestamp).NotTo(BeNil())
 		})
 
 		It("validates PVC names against instance volume templates", func() {

--- a/pkg/constant/annotations.go
+++ b/pkg/constant/annotations.go
@@ -46,6 +46,14 @@ const (
 
 	// SystemAccountProvisionedAnnotationKey marks a system account secret whose account has already been prepared externally.
 	SystemAccountProvisionedAnnotationKey = "apps.kubeblocks.io/system-account-provisioned"
+	// SystemAccountRestoreTargetAnnotationKey names the system account Secret
+	// that an Apps-owned temporary request must converge. DataProtection writes
+	// the request; the Component or Cluster owner is the only controller allowed
+	// to mutate/delete/recreate the target or release its finalizer.
+	SystemAccountRestoreTargetAnnotationKey = "apps.kubeblocks.io/system-account-restore-target"
+	// SystemAccountRestoreRevisionAnnotationKey is the content-addressed
+	// revision that Apps copies from a restore request to the converged target.
+	SystemAccountRestoreRevisionAnnotationKey = "apps.kubeblocks.io/system-account-restore-revision"
 
 	// SkipPreTerminateAnnotationKey specifies to skip the pre-terminate action for a component.
 	SkipPreTerminateAnnotationKey = "apps.kubeblocks.io/skip-pre-terminate"

--- a/pkg/constant/labels.go
+++ b/pkg/constant/labels.go
@@ -48,6 +48,9 @@ const (
 	KBAppInstanceTemplateLabelKey   = "apps.kubeblocks.io/instance-template"
 	KBAppPodNameLabelKey            = "apps.kubeblocks.io/pod-name"
 	VolumeClaimTemplateNameLabelKey = "apps.kubeblocks.io/vct-name"
+	// SystemAccountRestoreRequestLabelKey selects temporary credential
+	// requests that must be reconciled by their Apps controller owner.
+	SystemAccountRestoreRequestLabelKey = "apps.kubeblocks.io/system-account-restore-request"
 
 	KBAppServiceVersionKey = "apps.kubeblocks.io/service-version"
 	KBAppReleasePhaseKey   = "apps.kubeblocks.io/release-phase" // TODO: release or service phase?

--- a/pkg/controller/model/graph_client.go
+++ b/pkg/controller/model/graph_client.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
@@ -36,7 +37,7 @@ type GraphWriter interface {
 	Create(dag *graph.DAG, obj client.Object, opts ...GraphOption)
 
 	// Delete deletes the given obj from the underlying DAG.
-	Delete(dag *graph.DAG, obj client.Object, opts ...GraphOption)
+	Delete(dag *graph.DAG, obj client.Object, opts ...GraphOption) error
 
 	// Update updates the given obj in the underlying DAG.
 	Update(dag *graph.DAG, objOld, objNew client.Object, opts ...GraphOption)
@@ -73,6 +74,23 @@ type GraphClient interface {
 	GraphWriter
 }
 
+// DeleteUIDConflict reports an invalid or conflicting UID-bound delete plan.
+// Callers can use errors.As to distinguish this fail-closed contract from
+// ordinary plan construction errors.
+type DeleteUIDConflict struct {
+	ObjectType   string
+	Namespace    string
+	Name         string
+	ExistingUID  string
+	RequestedUID string
+	Reason       string
+}
+
+func (e *DeleteUIDConflict) Error() string {
+	return fmt.Sprintf("delete UID conflict for %s %s/%s: %s (existing UID %q, requested UID %q)",
+		e.ObjectType, e.Namespace, e.Name, e.Reason, e.ExistingUID, e.RequestedUID)
+}
+
 // TODO(free6om): make DAG a member of realGraphClient
 type realGraphClient struct {
 	client.Reader
@@ -101,23 +119,23 @@ func (r *realGraphClient) Root(dag *graph.DAG, objOld, objNew client.Object, act
 }
 
 func (r *realGraphClient) Create(dag *graph.DAG, obj client.Object, opts ...GraphOption) {
-	r.doWrite(dag, nil, obj, ActionCreatePtr(), opts...)
+	_ = r.doWrite(dag, nil, obj, ActionCreatePtr(), opts...)
 }
 
 func (r *realGraphClient) Update(dag *graph.DAG, objOld, objNew client.Object, opts ...GraphOption) {
-	r.doWrite(dag, objOld, objNew, ActionUpdatePtr(), opts...)
+	_ = r.doWrite(dag, objOld, objNew, ActionUpdatePtr(), opts...)
 }
 
 func (r *realGraphClient) Patch(dag *graph.DAG, objOld, objNew client.Object, opts ...GraphOption) {
-	r.doWrite(dag, objOld, objNew, ActionPatchPtr(), opts...)
+	_ = r.doWrite(dag, objOld, objNew, ActionPatchPtr(), opts...)
 }
 
-func (r *realGraphClient) Delete(dag *graph.DAG, obj client.Object, opts ...GraphOption) {
-	r.doWrite(dag, nil, obj, ActionDeletePtr(), opts...)
+func (r *realGraphClient) Delete(dag *graph.DAG, obj client.Object, opts ...GraphOption) error {
+	return r.doWrite(dag, nil, obj, ActionDeletePtr(), opts...)
 }
 
 func (r *realGraphClient) Status(dag *graph.DAG, objOld, objNew client.Object, opts ...GraphOption) {
-	r.doWrite(dag, objOld, objNew, ActionStatusPtr(), opts...)
+	_ = r.doWrite(dag, objOld, objNew, ActionStatusPtr(), opts...)
 }
 
 func (r *realGraphClient) Do(dag *graph.DAG, objOld, objNew client.Object, action *Action, parent *ObjectVertex, opts ...GraphOption) *ObjectVertex {
@@ -131,11 +149,12 @@ func (r *realGraphClient) Do(dag *graph.DAG, objOld, objNew client.Object, actio
 	}
 
 	vertex := &ObjectVertex{
-		OriObj:            objOld,
-		Obj:               objNew,
-		Action:            action,
-		ClientOpt:         graphOpts.clientOpt,
-		PropagationPolicy: graphOpts.propagationPolicy,
+		OriObj:              objOld,
+		Obj:                 objNew,
+		Action:              action,
+		ClientOpt:           graphOpts.clientOpt,
+		PropagationPolicy:   graphOpts.propagationPolicy,
+		DeletePreconditions: graphOpts.deletePreconditions,
 	}
 	switch parent {
 	case nil:
@@ -206,30 +225,92 @@ func (r *realGraphClient) FindAll(dag *graph.DAG, obj interface{}, opts ...Graph
 	return objects
 }
 
-func (r *realGraphClient) doWrite(dag *graph.DAG, objOld, objNew client.Object, action *Action, opts ...GraphOption) {
+func (r *realGraphClient) doWrite(dag *graph.DAG, objOld, objNew client.Object, action *Action, opts ...GraphOption) error {
 	graphOpts := &GraphOptions{}
 	for _, opt := range opts {
 		opt.ApplyTo(graphOpts)
 	}
 
 	vertex := r.FindMatchedVertex(dag, objNew)
+	if *action == DELETE {
+		if graphOpts.deletePreconditions == nil && vertex != nil {
+			existing := vertex.(*ObjectVertex)
+			if existing.DeletePreconditions != nil {
+				graphOpts.deletePreconditions = existing.DeletePreconditions.DeepCopy()
+			}
+		}
+		if err := validateDeletePreconditions(vertex, objNew, graphOpts); err != nil {
+			return err
+		}
+	} else {
+		graphOpts.deletePreconditions = nil
+	}
 	switch {
 	case vertex != nil:
 		objVertex, _ := vertex.(*ObjectVertex)
 		objVertex.Action = action
+		objVertex.DeletePreconditions = graphOpts.deletePreconditions
 		if graphOpts.replaceIfExisting {
 			objVertex.Obj = objNew
 			objVertex.OriObj = objOld
 		}
 	default:
 		vertex = &ObjectVertex{
-			Obj:       objNew,
-			OriObj:    objOld,
-			Action:    action,
-			ClientOpt: graphOpts.clientOpt,
+			Obj:                 objNew,
+			OriObj:              objOld,
+			Action:              action,
+			ClientOpt:           graphOpts.clientOpt,
+			DeletePreconditions: graphOpts.deletePreconditions,
 		}
 		dag.AddConnectRoot(vertex)
 	}
+	return nil
+}
+
+func validateDeletePreconditions(vertex graph.Vertex, obj client.Object, opts *GraphOptions) error {
+	if opts.deletePreconditions == nil {
+		return nil
+	}
+	requested := opts.deletePreconditions.UID
+	if requested == nil || *requested == "" {
+		return newDeleteUIDConflict(obj, "", valueOrEmpty(requested), "delete UID must not be empty")
+	}
+	if obj.GetUID() != "" && obj.GetUID() != *requested {
+		return newDeleteUIDConflict(obj, string(obj.GetUID()), string(*requested),
+			"object UID differs from requested UID")
+	}
+	if vertex == nil {
+		return nil
+	}
+	existing := vertex.(*ObjectVertex)
+	if existing.DeletePreconditions != nil && existing.DeletePreconditions.UID != nil &&
+		*existing.DeletePreconditions.UID != "" && *existing.DeletePreconditions.UID != *requested {
+		return newDeleteUIDConflict(obj, string(*existing.DeletePreconditions.UID), string(*requested),
+			"existing delete UID differs from requested UID")
+	}
+	if opts.replaceIfExisting && obj.GetUID() != *requested {
+		return newDeleteUIDConflict(obj, string(obj.GetUID()), string(*requested),
+			"replacement object UID differs from requested UID")
+	}
+	return nil
+}
+
+func newDeleteUIDConflict(obj client.Object, existingUID, requestedUID, reason string) error {
+	return &DeleteUIDConflict{
+		ObjectType:   fmt.Sprintf("%T", obj),
+		Namespace:    obj.GetNamespace(),
+		Name:         obj.GetName(),
+		ExistingUID:  existingUID,
+		RequestedUID: requestedUID,
+		Reason:       reason,
+	}
+}
+
+func valueOrEmpty(uid *types.UID) string {
+	if uid == nil {
+		return ""
+	}
+	return string(*uid)
 }
 
 func (r *realGraphClient) FindMatchedVertex(dag *graph.DAG, object client.Object) graph.Vertex {

--- a/pkg/controller/model/graph_client_test.go
+++ b/pkg/controller/model/graph_client_test.go
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package model
 
 import (
+	"errors"
 	"slices"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -27,6 +28,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
@@ -72,7 +74,7 @@ var _ = Describe("graph client test.", func() {
 			By("update&delete&status object")
 			graphCli.Status(dag, obj0, obj0.DeepCopy())
 			graphCli.Update(dag, obj1, obj1.DeepCopy())
-			graphCli.Delete(dag, obj2)
+			Expect(graphCli.Delete(dag, obj2)).Should(Succeed())
 			v0.Action = ActionStatusPtr()
 			v1.Action = ActionUpdatePtr()
 			v2.Action = ActionDeletePtr()
@@ -174,6 +176,63 @@ var _ = Describe("graph client test.", func() {
 			graphCli.Root(dag, obj, obj, nil)
 			Expect(graphCli.IsAction(dag, obj, nil)).Should(BeTrue())
 			Expect(graphCli.IsAction(dag, obj, ActionCreatePtr())).Should(BeFalse())
+		})
+
+		It("preserves delete UID preconditions when replacing an existing vertex", func() {
+			graphCli := NewGraphClient(nil)
+			dag := graph.NewDAG()
+			root := builder.NewInstanceSetBuilder(namespace, name).GetObject()
+			obj := builder.NewPodBuilder(namespace, name+"0").GetObject()
+			uid := types.UID("observed-pod-uid")
+
+			graphCli.Root(dag, root.DeepCopy(), root, ActionStatusPtr())
+			graphCli.Create(dag, obj)
+			Expect(graphCli.Delete(dag, obj, WithDeleteUID(uid))).Should(Succeed())
+
+			vertex, ok := graphCli.FindMatchedVertex(dag, obj).(*ObjectVertex)
+			Expect(ok).Should(BeTrue())
+			Expect(vertex.Action).Should(Equal(ActionDeletePtr()))
+			Expect(vertex.DeletePreconditions).ShouldNot(BeNil())
+			Expect(vertex.DeletePreconditions.UID).ShouldNot(BeNil())
+			Expect(*vertex.DeletePreconditions.UID).Should(Equal(uid))
+
+			By("accepting the same UID idempotently")
+			Expect(graphCli.Delete(dag, obj, WithDeleteUID(uid))).Should(Succeed())
+
+			By("preserving the UID when a later delete omits the optional contract")
+			Expect(graphCli.Delete(dag, obj)).Should(Succeed())
+			Expect(vertex.DeletePreconditions).ShouldNot(BeNil())
+			Expect(*vertex.DeletePreconditions.UID).Should(Equal(uid))
+
+			By("rejecting a different UID without overwriting the first precondition")
+			err := graphCli.Delete(dag, obj, WithDeleteUID(types.UID("replacement-pod-uid")))
+			Expect(err).Should(MatchError(ContainSubstring("delete UID conflict")))
+			var conflict *DeleteUIDConflict
+			Expect(errors.As(err, &conflict)).Should(BeTrue())
+			Expect(conflict.ExistingUID).Should(Equal(string(uid)))
+			Expect(conflict.RequestedUID).Should(Equal("replacement-pod-uid"))
+			Expect(*vertex.DeletePreconditions.UID).Should(Equal(uid))
+
+			By("rejecting an empty UID")
+			Expect(graphCli.Delete(dag, obj, WithDeleteUID(""))).
+				Should(MatchError(ContainSubstring("delete UID must not be empty")))
+
+			By("rejecting a replacement object whose UID differs from the precondition")
+			replacement := obj.DeepCopy()
+			replacement.UID = types.UID("replacement-pod-uid")
+			err = graphCli.Delete(dag, replacement, WithDeleteUID(uid), &ReplaceIfExistingOption{})
+			Expect(err).Should(MatchError(ContainSubstring("delete UID conflict")))
+			Expect(vertex.Obj).Should(BeIdenticalTo(obj))
+
+			By("ignoring delete preconditions on non-delete actions")
+			other := builder.NewPodBuilder(namespace, name+"1").GetObject()
+			graphCli.Update(dag, nil, other, WithDeleteUID(uid))
+			otherVertex := graphCli.FindMatchedVertex(dag, other).(*ObjectVertex)
+			Expect(otherVertex.DeletePreconditions).Should(BeNil())
+
+			By("clearing a stale delete precondition when the same vertex changes action")
+			graphCli.Update(dag, obj, obj.DeepCopy())
+			Expect(vertex.DeletePreconditions).Should(BeNil())
 		})
 	})
 })

--- a/pkg/controller/model/graph_options.go
+++ b/pkg/controller/model/graph_options.go
@@ -19,13 +19,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 package model
 
-import "sigs.k8s.io/controller-runtime/pkg/client"
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
 
 type GraphOptions struct {
 	replaceIfExisting     bool
 	haveDifferentTypeWith bool
 	clientOpt             any
 	propagationPolicy     client.PropagationPolicy
+	deletePreconditions   *metav1.Preconditions
 	subResource           string
 }
 
@@ -81,6 +86,22 @@ var _ GraphOption = &propagationPolicyOption{}
 func WithPropagationPolicy(policy client.PropagationPolicy) GraphOption {
 	return &propagationPolicyOption{
 		propagationPolicy: policy,
+	}
+}
+
+type deletePreconditionsOption struct {
+	deletePreconditions *metav1.Preconditions
+}
+
+func (o *deletePreconditionsOption) ApplyTo(opts *GraphOptions) {
+	opts.deletePreconditions = o.deletePreconditions
+}
+
+var _ GraphOption = &deletePreconditionsOption{}
+
+func WithDeleteUID(uid types.UID) GraphOption {
+	return &deletePreconditionsOption{
+		deletePreconditions: &metav1.Preconditions{UID: &uid},
 	}
 }
 

--- a/pkg/controller/model/transform_types.go
+++ b/pkg/controller/model/transform_types.go
@@ -25,6 +25,7 @@ import (
 
 	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v6/apis/volumesnapshot/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -66,12 +67,13 @@ type GVKNObjKey struct {
 // the root vertex(i.e. the cluster vertex) will be treated specially:
 // as all its meta, spec and status can be updated in one reconciliation loop
 type ObjectVertex struct {
-	Obj               client.Object
-	OriObj            client.Object
-	Action            *Action
-	SubResource       string
-	ClientOpt         any
-	PropagationPolicy client.PropagationPolicy
+	Obj                 client.Object
+	OriObj              client.Object
+	Action              *Action
+	SubResource         string
+	ClientOpt           any
+	PropagationPolicy   client.PropagationPolicy
+	DeletePreconditions *metav1.Preconditions
 }
 
 func (v *ObjectVertex) String() string {
@@ -87,11 +89,12 @@ func NewObjectVertex(oldObj, newObj client.Object, action *Action, opts ...Graph
 		opt.ApplyTo(graphOpts)
 	}
 	return &ObjectVertex{
-		Obj:         newObj,
-		OriObj:      oldObj,
-		Action:      action,
-		SubResource: graphOpts.subResource,
-		ClientOpt:   graphOpts.clientOpt,
+		Obj:                 newObj,
+		OriObj:              oldObj,
+		Action:              action,
+		SubResource:         graphOpts.subResource,
+		ClientOpt:           graphOpts.clientOpt,
+		DeletePreconditions: graphOpts.deletePreconditions,
 	}
 }
 

--- a/pkg/controller/systemaccount/protocol.go
+++ b/pkg/controller/systemaccount/protocol.go
@@ -1,0 +1,1055 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package systemaccount
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"reflect"
+	"slices"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/apecloud/kubeblocks/pkg/constant"
+)
+
+const (
+	RestoreProtocolV2       = "sar/v2"
+	ConflictProtocolV1      = "sar-conflict/v1"
+	LogicalTargetProtocolV1 = "sar-target/v1"
+
+	RestoreProfileInitialCluster = "initial-cluster"
+	RestoreProfileLegacyPVCGroup = "legacy-pvc-group"
+
+	SystemAccountScopeComponent = "component"
+	SystemAccountScopeSharding  = "sharding"
+
+	RestoreProtocolAnnotationKey          = "apps.kubeblocks.io/restore-protocol"
+	RestoreProfileAnnotationKey           = "apps.kubeblocks.io/restore-profile"
+	LogicalTargetDigestAnnotationKey      = "apps.kubeblocks.io/logical-target-digest"
+	RestoreOperationDigestAnnotationKey   = "apps.kubeblocks.io/restore-operation-digest"
+	RootClusterNamespaceAnnotationKey     = "apps.kubeblocks.io/root-cluster-namespace"
+	RootClusterNameAnnotationKey          = "apps.kubeblocks.io/root-cluster-name"
+	RootClusterUIDAnnotationKey           = "apps.kubeblocks.io/root-cluster-uid"
+	SourceAPIVersionAnnotationKey         = "apps.kubeblocks.io/restore-source-api-version"
+	SourceKindAnnotationKey               = "apps.kubeblocks.io/restore-source-kind"
+	SourceNamespaceAnnotationKey          = "apps.kubeblocks.io/restore-source-namespace"
+	SourceNameAnnotationKey               = "apps.kubeblocks.io/restore-source-name"
+	SourceUIDAnnotationKey                = "apps.kubeblocks.io/restore-source-uid"
+	TargetOwnerAPIVersionAnnotationKey    = "apps.kubeblocks.io/target-owner-api-version"
+	TargetOwnerKindAnnotationKey          = "apps.kubeblocks.io/target-owner-kind"
+	TargetOwnerNamespaceAnnotationKey     = "apps.kubeblocks.io/target-owner-namespace"
+	TargetOwnerNameAnnotationKey          = "apps.kubeblocks.io/target-owner-name"
+	TargetOwnerUIDAnnotationKey           = "apps.kubeblocks.io/target-owner-uid"
+	SystemAccountAnnotationKey            = "apps.kubeblocks.io/system-account"
+	SystemAccountScopeAnnotationKey       = "apps.kubeblocks.io/system-account-scope"
+	ShardingNameAnnotationKey             = "apps.kubeblocks.io/sharding-name"
+	CredentialIntentRevisionAnnotationKey = "apps.kubeblocks.io/credential-intent-revision"
+	TargetCommitRevisionAnnotationKey     = "apps.kubeblocks.io/target-commit-revision"
+	TargetSecretNameAnnotationKey         = "apps.kubeblocks.io/target-secret-name"
+	TargetSecretUIDAnnotationKey          = "apps.kubeblocks.io/target-secret-uid"
+	RestoreRequestPhaseAnnotationKey      = "apps.kubeblocks.io/restore-request-phase"
+	RestoreRequestReasonAnnotationKey     = "apps.kubeblocks.io/restore-request-reason"
+	RestoreRequestNameAnnotationKey       = "apps.kubeblocks.io/restore-request-name"
+	RestoreRequestUIDAnnotationKey        = "apps.kubeblocks.io/restore-request-uid"
+
+	RestoreDecisionAnnotationKey          = "apps.kubeblocks.io/restore-decision"
+	BlockingRequestNamespaceAnnotationKey = "apps.kubeblocks.io/blocking-request-namespace"
+	BlockingRequestNameAnnotationKey      = "apps.kubeblocks.io/blocking-request-name"
+	BlockingRequestUIDAnnotationKey       = "apps.kubeblocks.io/blocking-request-uid"
+	WinnerOperationDigestAnnotationKey    = "apps.kubeblocks.io/winner-operation-digest"
+	ObservedRequestPhaseAnnotationKey     = "apps.kubeblocks.io/observed-request-phase"
+	ObservedRequestRVAnnotationKey        = "apps.kubeblocks.io/observed-request-resource-version"
+
+	RestoreIntentEnvelopeDataKey   = "restore-intent.json"
+	RestoreConflictEnvelopeDataKey = "restore-conflict.json"
+	RestoreTargetEnvelopeDataKey   = "restore-target.json"
+
+	RestoreProtocolFinalizer = "systemaccount.apps.kubeblocks.io/restore-protection"
+
+	ConcurrentRestoreIntentReason         = "ConcurrentRestoreIntent"
+	OperationCredentialConflictReason     = "OperationCredentialConflict"
+	PreviousRestoreIntentFinalizingReason = "PreviousRestoreIntentFinalizing"
+	UnauthorizedRestoreProducerReason     = "UnauthorizedRestoreProducer"
+	RestoreIntentMismatchReason           = "RestoreIntentMismatch"
+	UnsupportedRestoreSourceReason        = "UnsupportedRestoreSource"
+	OperationTerminalReason               = "OperationTerminal"
+	RootUnavailableReason                 = "RootUnavailable"
+	TargetOwnerUnavailableReason          = "TargetOwnerUnavailable"
+	RequestDeletionRequestedReason        = "RequestDeletionRequested"
+	AccountUnavailableReason              = "AccountUnavailable"
+	TargetSemanticUnavailableReason       = "TargetSemanticUnavailable"
+	CredentialContinuityLostReason        = "CredentialContinuityLost"
+	PostWriteCancellationReason           = "PostWriteCancellation"
+	InvalidPhaseReason                    = "InvalidPhase"
+)
+
+const conflictReceiptNamePrefix = "system-account-conflict-"
+
+type RestoreRequestPhase string
+
+const (
+	RestoreRequestPhasePending   RestoreRequestPhase = "Pending"
+	RestoreRequestPhaseClaimed   RestoreRequestPhase = "Claimed"
+	RestoreRequestPhaseCommitted RestoreRequestPhase = "Committed"
+	RestoreRequestPhaseFailed    RestoreRequestPhase = "Failed"
+)
+
+func (p RestoreRequestPhase) Valid() bool {
+	switch p {
+	case RestoreRequestPhasePending, RestoreRequestPhaseClaimed,
+		RestoreRequestPhaseCommitted, RestoreRequestPhaseFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+func (p RestoreRequestPhase) Active() bool {
+	switch p {
+	case RestoreRequestPhasePending, RestoreRequestPhaseClaimed, RestoreRequestPhaseCommitted:
+		return true
+	default:
+		return false
+	}
+}
+
+type RestoreCommitReceipt struct {
+	TargetName     string
+	TargetUID      types.UID
+	CommitRevision string
+}
+
+var restoreFailureReasons = map[string]struct{}{
+	UnauthorizedRestoreProducerReason:     {},
+	RestoreIntentMismatchReason:           {},
+	UnsupportedRestoreSourceReason:        {},
+	OperationCredentialConflictReason:     {},
+	ConcurrentRestoreIntentReason:         {},
+	PreviousRestoreIntentFinalizingReason: {},
+	OperationTerminalReason:               {},
+	RootUnavailableReason:                 {},
+	TargetOwnerUnavailableReason:          {},
+	RequestDeletionRequestedReason:        {},
+	AccountUnavailableReason:              {},
+	TargetSemanticUnavailableReason:       {},
+	CredentialContinuityLostReason:        {},
+	PostWriteCancellationReason:           {},
+	InvalidPhaseReason:                    {},
+}
+
+func IsRestoreFailureReason(reason string) bool {
+	_, ok := restoreFailureReasons[reason]
+	return ok
+}
+
+// TransitionRestoreRequestV2 applies phase, reason, finalizer, and commit
+// receipt changes to one resourceVersion snapshot.
+func TransitionRestoreRequestV2(
+	request *corev1.Secret,
+	next RestoreRequestPhase,
+	reason string,
+	receipt *RestoreCommitReceipt,
+	releaseFinalizer bool,
+) (*corev1.Secret, error) {
+	if request == nil {
+		return nil, fmt.Errorf("restore request is nil")
+	}
+	current := RestoreRequestPhase(request.Annotations[RestoreRequestPhaseAnnotationKey])
+	if !current.Valid() || !next.Valid() {
+		return nil, fmt.Errorf("invalid restore request transition %q -> %q", current, next)
+	}
+	if !restoreTransitionAllowed(current, next) {
+		return nil, fmt.Errorf("restore request transition %q -> %q is not allowed", current, next)
+	}
+	if next == RestoreRequestPhaseFailed {
+		if _, ok := restoreFailureReasons[reason]; !ok {
+			return nil, fmt.Errorf("unsupported restore request failure reason %q", reason)
+		}
+	} else if reason != "" {
+		return nil, fmt.Errorf("phase %q must not carry failure reason %q", next, reason)
+	}
+	if next == RestoreRequestPhaseCommitted {
+		if receipt == nil || receipt.TargetName == "" || receipt.TargetUID == "" ||
+			receipt.CommitRevision == "" {
+			return nil, fmt.Errorf("committed transition requires a complete target receipt")
+		}
+	}
+	if releaseFinalizer && next != RestoreRequestPhaseCommitted &&
+		next != RestoreRequestPhaseFailed {
+		return nil, fmt.Errorf("phase %q cannot release the protocol finalizer", next)
+	}
+
+	updated := request.DeepCopy()
+	if updated.Annotations == nil {
+		updated.Annotations = map[string]string{}
+	}
+	updated.Annotations[RestoreRequestPhaseAnnotationKey] = string(next)
+	if reason == "" {
+		delete(updated.Annotations, RestoreRequestReasonAnnotationKey)
+	} else {
+		updated.Annotations[RestoreRequestReasonAnnotationKey] = reason
+	}
+	if next == RestoreRequestPhaseCommitted {
+		updated.Annotations[TargetSecretNameAnnotationKey] = receipt.TargetName
+		updated.Annotations[TargetSecretUIDAnnotationKey] = string(receipt.TargetUID)
+		updated.Annotations[TargetCommitRevisionAnnotationKey] = receipt.CommitRevision
+	}
+	if releaseFinalizer {
+		updated.Finalizers = slices.DeleteFunc(updated.Finalizers,
+			func(finalizer string) bool { return finalizer == RestoreProtocolFinalizer })
+	}
+	return updated, nil
+}
+
+func restoreTransitionAllowed(current, next RestoreRequestPhase) bool {
+	if current == next {
+		return true
+	}
+	switch current {
+	case RestoreRequestPhasePending:
+		return next == RestoreRequestPhaseClaimed || next == RestoreRequestPhaseFailed
+	case RestoreRequestPhaseClaimed:
+		return next == RestoreRequestPhaseCommitted || next == RestoreRequestPhaseFailed
+	case RestoreRequestPhaseCommitted:
+		return next == RestoreRequestPhaseFailed
+	default:
+		return false
+	}
+}
+
+type ObjectIdentity struct {
+	APIVersion string    `json:"apiVersion"`
+	Kind       string    `json:"kind"`
+	Namespace  string    `json:"namespace"`
+	Name       string    `json:"name"`
+	UID        types.UID `json:"uid"`
+}
+
+type SourceIdentity struct {
+	APIGroup  string `json:"apiGroup"`
+	Kind      string `json:"kind"`
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+}
+
+type RestoreOperationIdentity struct {
+	Protocol   string            `json:"protocol"`
+	Profile    string            `json:"profile"`
+	Root       ObjectIdentity    `json:"root"`
+	Source     SourceIdentity    `json:"source"`
+	PITR       string            `json:"pitr"`
+	Parameters map[string]string `json:"parameters"`
+}
+
+type LogicalTargetIdentity struct {
+	Protocol     string         `json:"protocol"`
+	Namespace    string         `json:"namespace"`
+	Root         ObjectIdentity `json:"root"`
+	Owner        ObjectIdentity `json:"owner"`
+	Scope        string         `json:"scope"`
+	ShardingName string         `json:"shardingName"`
+	Account      string         `json:"account"`
+}
+
+type CredentialIntent struct {
+	Operation      RestoreOperationIdentity `json:"operation"`
+	Target         LogicalTargetIdentity    `json:"target"`
+	ResolvedSource ObjectIdentity           `json:"resolvedSource"`
+	Credentials    map[string][]byte        `json:"credentials"`
+}
+
+type BlockingRequestSnapshot struct {
+	Namespace             string              `json:"namespace"`
+	Name                  string              `json:"name"`
+	UID                   types.UID           `json:"uid"`
+	ResourceVersion       string              `json:"resourceVersion"`
+	Phase                 RestoreRequestPhase `json:"phase"`
+	WinnerOperationDigest string              `json:"winnerOperationDigest"`
+}
+
+type ConflictEnvelope struct {
+	Protocol        string                   `json:"protocol"`
+	Decision        string                   `json:"decision"`
+	Target          LogicalTargetIdentity    `json:"target"`
+	LoserOperation  RestoreOperationIdentity `json:"loserOperation"`
+	BlockingRequest BlockingRequestSnapshot  `json:"blockingRequest"`
+}
+
+func OperationDigest(identity RestoreOperationIdentity) (string, error) {
+	encoded, err := encodeOperationIdentity(identity)
+	if err != nil {
+		return "", err
+	}
+	return sha256Hex(encoded), nil
+}
+
+func LogicalTargetDigest(identity LogicalTargetIdentity) (string, error) {
+	encoded, err := encodeLogicalTargetIdentity(identity)
+	if err != nil {
+		return "", err
+	}
+	return sha256Hex(encoded), nil
+}
+
+func RestoreRequestNameForTarget(identity LogicalTargetIdentity) (string, error) {
+	encoded, err := encodeLogicalTargetIdentity(identity)
+	if err != nil {
+		return "", err
+	}
+	digest := sha256.Sum256(encoded)
+	return restoreRequestNamePrefix + hex.EncodeToString(digest[:16]), nil
+}
+
+func ConflictReceiptName(target LogicalTargetIdentity, loser RestoreOperationIdentity) (string, error) {
+	targetBytes, err := encodeLogicalTargetIdentity(target)
+	if err != nil {
+		return "", err
+	}
+	operationBytes, err := encodeOperationIdentity(loser)
+	if err != nil {
+		return "", err
+	}
+	encoder := newCanonicalEncoder()
+	encoder.writeVersion(ConflictProtocolV1)
+	encoder.writeBytes(targetBytes)
+	encoder.writeBytes(operationBytes)
+	digest := sha256.Sum256(encoder.bytes())
+	return conflictReceiptNamePrefix + hex.EncodeToString(digest[:16]), nil
+}
+
+func CredentialIntentRevision(intent CredentialIntent) (string, error) {
+	if err := validateCredentialIntent(intent); err != nil {
+		return "", err
+	}
+	operationBytes, _ := encodeOperationIdentity(intent.Operation)
+	targetBytes, _ := encodeLogicalTargetIdentity(intent.Target)
+	encoder := newCanonicalEncoder()
+	encoder.writeVersion(RestoreProtocolV2)
+	encoder.writeBytes(operationBytes)
+	encoder.writeBytes(targetBytes)
+	encoder.writeObjectIdentity(intent.ResolvedSource)
+	encoder.writeBytesMap(intent.Credentials)
+	return sha256Hex(encoder.bytes()), nil
+}
+
+func BuildRestoreRequest(intent CredentialIntent) (*corev1.Secret, error) {
+	if err := validateCredentialIntent(intent); err != nil {
+		return nil, err
+	}
+	operationDigest, _ := OperationDigest(intent.Operation)
+	targetDigest, _ := LogicalTargetDigest(intent.Target)
+	intentRevision, _ := CredentialIntentRevision(intent)
+	name, _ := RestoreRequestNameForTarget(intent.Target)
+	envelope, err := json.Marshal(intent)
+	if err != nil {
+		return nil, fmt.Errorf("marshal restore intent: %w", err)
+	}
+	immutable := true
+	controller := false
+	blockOwnerDeletion := false
+	request := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: intent.Target.Namespace,
+			Name:      name,
+			Labels: map[string]string{
+				constant.SystemAccountRestoreRequestLabelKey: "true",
+			},
+			Annotations: requestIdentityAnnotations(intent, operationDigest, targetDigest, intentRevision),
+			Finalizers:  []string{RestoreProtocolFinalizer},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion:         intent.Operation.Root.APIVersion,
+				Kind:               intent.Operation.Root.Kind,
+				Name:               intent.Operation.Root.Name,
+				UID:                intent.Operation.Root.UID,
+				Controller:         &controller,
+				BlockOwnerDeletion: &blockOwnerDeletion,
+			}},
+		},
+		Immutable: &immutable,
+		Type:      corev1.SecretTypeOpaque,
+		Data:      maps.Clone(intent.Credentials),
+	}
+	request.Annotations[RestoreRequestPhaseAnnotationKey] = string(RestoreRequestPhasePending)
+	request.Data[RestoreIntentEnvelopeDataKey] = envelope
+	return request, nil
+}
+
+func ValidateRestoreRequestV2(request *corev1.Secret) (CredentialIntent, error) {
+	intent, err := DecodeRestoreRequestV2(request)
+	if err != nil {
+		return intent, err
+	}
+	if !slices.Contains(request.Finalizers, RestoreProtocolFinalizer) {
+		return intent, fmt.Errorf("restore request %s/%s has no protocol finalizer", request.Namespace, request.Name)
+	}
+	phase := RestoreRequestPhase(request.Annotations[RestoreRequestPhaseAnnotationKey])
+	if !phase.Valid() {
+		return intent, fmt.Errorf("restore request %s/%s has invalid phase %q", request.Namespace, request.Name, phase)
+	}
+	return intent, nil
+}
+
+// DecodeRestoreRequestV2 validates the immutable request identity and payload
+// while allowing lifecycle cleanup to inspect unknown phases or a request whose
+// protocol finalizer has already been released.
+func DecodeRestoreRequestV2(request *corev1.Secret) (CredentialIntent, error) {
+	var intent CredentialIntent
+	if request == nil {
+		return intent, fmt.Errorf("restore request is nil")
+	}
+	if request.Annotations[RestoreProtocolAnnotationKey] != RestoreProtocolV2 {
+		return intent, fmt.Errorf("restore request %s/%s has unsupported protocol", request.Namespace, request.Name)
+	}
+	if request.Labels[constant.SystemAccountRestoreRequestLabelKey] != "true" {
+		return intent, fmt.Errorf("restore request %s/%s has no request label", request.Namespace, request.Name)
+	}
+	if request.Immutable == nil || !*request.Immutable {
+		return intent, fmt.Errorf("restore request %s/%s is not immutable", request.Namespace, request.Name)
+	}
+	intent, err := DecodeRestoreIntentEnvelope(request)
+	if err != nil {
+		return intent, err
+	}
+	name, _ := RestoreRequestNameForTarget(intent.Target)
+	if request.Namespace != intent.Target.Namespace || request.Name != name {
+		return intent, fmt.Errorf("restore request %s/%s has a non-canonical logical-target name", request.Namespace, request.Name)
+	}
+	operationDigest, _ := OperationDigest(intent.Operation)
+	targetDigest, _ := LogicalTargetDigest(intent.Target)
+	intentRevision, _ := CredentialIntentRevision(intent)
+	expectedAnnotations := requestIdentityAnnotations(intent, operationDigest, targetDigest, intentRevision)
+	if err := validateAnnotationMirrors(request.Annotations, expectedAnnotations); err != nil {
+		return intent, fmt.Errorf("restore request %s/%s metadata mirror: %w", request.Namespace, request.Name, err)
+	}
+	if !reflect.DeepEqual(credentialsFromRequest(request.Data), intent.Credentials) {
+		return intent, fmt.Errorf("restore request %s/%s credential payload differs from envelope", request.Namespace, request.Name)
+	}
+	if err := validateRootOwnerReference(request.OwnerReferences, intent.Operation.Root); err != nil {
+		return intent, fmt.Errorf("restore request %s/%s ownerReference: %w", request.Namespace, request.Name, err)
+	}
+	if request.Annotations[constant.SystemAccountRestoreTargetAnnotationKey] != "" ||
+		request.Annotations[constant.SystemAccountProvisionedAnnotationKey] != "" {
+		return intent, fmt.Errorf("restore request %s/%s contains Apps-owned target semantics", request.Namespace, request.Name)
+	}
+	return intent, nil
+}
+
+// DecodeRestoreIntentEnvelope reads only the immutable request payload. The
+// lifecycle controller uses it to find the exact root after mutable metadata
+// has been damaged, without accepting that metadata for active reconciliation.
+func DecodeRestoreIntentEnvelope(request *corev1.Secret) (CredentialIntent, error) {
+	var intent CredentialIntent
+	if request == nil {
+		return intent, fmt.Errorf("restore request is nil")
+	}
+	if request.Immutable == nil || !*request.Immutable {
+		return intent, fmt.Errorf("restore request %s/%s is not immutable", request.Namespace, request.Name)
+	}
+	if err := json.Unmarshal(request.Data[RestoreIntentEnvelopeDataKey], &intent); err != nil {
+		return intent, fmt.Errorf("decode restore request %s/%s envelope: %w", request.Namespace, request.Name, err)
+	}
+	if err := validateCredentialIntent(intent); err != nil {
+		return intent, fmt.Errorf("restore request %s/%s envelope: %w", request.Namespace, request.Name, err)
+	}
+	return intent, nil
+}
+
+func RestoreConvergedV2(target, request *corev1.Secret, requiredFinalizer string) bool {
+	if target == nil || request == nil || !target.DeletionTimestamp.IsZero() ||
+		request.UID == "" ||
+		RestoreRequestPhase(request.Annotations[RestoreRequestPhaseAnnotationKey]) != RestoreRequestPhaseCommitted {
+		return false
+	}
+	intent, err := ValidateRestoreRequestV2(request)
+	if err != nil {
+		return false
+	}
+	if target.Namespace != intent.Target.Namespace ||
+		target.Name != request.Annotations[TargetSecretNameAnnotationKey] ||
+		target.UID == "" || string(target.UID) != request.Annotations[TargetSecretUIDAnnotationKey] ||
+		!TargetReceiptExactV2(target, request, requiredFinalizer) {
+		return false
+	}
+	revision, err := TargetCommitRevision(target, requiredFinalizer)
+	if err != nil {
+		return false
+	}
+	requestRevision := request.Annotations[TargetCommitRevisionAnnotationKey]
+	targetRevision := target.Annotations[TargetCommitRevisionAnnotationKey]
+	return revision == requestRevision && requestRevision == targetRevision
+}
+
+// TargetReceiptExactV2 verifies the live target commit without requiring the
+// request to have reached Committed. This closes the target-write/request-write
+// crash window for the Apps lifecycle handler.
+func TargetReceiptExactV2(target, request *corev1.Secret, requiredFinalizer string) bool {
+	if target == nil || request == nil || !target.DeletionTimestamp.IsZero() ||
+		target.UID == "" || request.UID == "" {
+		return false
+	}
+	intent, err := DecodeRestoreRequestV2(request)
+	if err != nil {
+		return false
+	}
+	if target.Namespace != intent.Target.Namespace ||
+		request.Name != target.Annotations[RestoreRequestNameAnnotationKey] ||
+		string(request.UID) != target.Annotations[RestoreRequestUIDAnnotationKey] ||
+		request.Annotations[RestoreOperationDigestAnnotationKey] !=
+			target.Annotations[RestoreOperationDigestAnnotationKey] ||
+		request.Annotations[CredentialIntentRevisionAnnotationKey] !=
+			target.Annotations[CredentialIntentRevisionAnnotationKey] ||
+		target.Annotations[constant.SystemAccountProvisionedAnnotationKey] != "true" ||
+		!slices.Contains(target.Finalizers, requiredFinalizer) ||
+		!reflect.DeepEqual(target.Data, intent.Credentials) {
+		return false
+	}
+	controller := metav1.GetControllerOf(target)
+	if controller == nil || controller.APIVersion != intent.Target.Owner.APIVersion ||
+		controller.Kind != intent.Target.Owner.Kind || controller.Name != intent.Target.Owner.Name ||
+		controller.UID != intent.Target.Owner.UID {
+		return false
+	}
+	revision, err := TargetCommitRevision(target, requiredFinalizer)
+	return err == nil && revision == target.Annotations[TargetCommitRevisionAnnotationKey]
+}
+
+// ClearTargetRestoreReceipt removes only sar/v2 commit receipts. Credential
+// bytes and the Apps-owned provisioned marker are deliberately retained.
+func ClearTargetRestoreReceipt(target *corev1.Secret) {
+	if target == nil || target.Annotations == nil {
+		return
+	}
+	delete(target.Annotations, RestoreOperationDigestAnnotationKey)
+	delete(target.Annotations, CredentialIntentRevisionAnnotationKey)
+	delete(target.Annotations, TargetCommitRevisionAnnotationKey)
+	delete(target.Annotations, RestoreRequestNameAnnotationKey)
+	delete(target.Annotations, RestoreRequestUIDAnnotationKey)
+}
+
+// ClearStaleTargetRestoreReceipt atomically invalidates protocol receipts when
+// an Apps-owned sealed target field changes. Ordinary labels and annotations
+// are outside the commit revision and therefore keep an exact receipt.
+func ClearStaleTargetRestoreReceipt(target *corev1.Secret, requiredFinalizer string) bool {
+	if target == nil || target.Annotations == nil {
+		return false
+	}
+	hasReceipt := false
+	for _, key := range []string{
+		RestoreOperationDigestAnnotationKey,
+		CredentialIntentRevisionAnnotationKey,
+		TargetCommitRevisionAnnotationKey,
+		RestoreRequestNameAnnotationKey,
+		RestoreRequestUIDAnnotationKey,
+	} {
+		if target.Annotations[key] != "" {
+			hasReceipt = true
+			break
+		}
+	}
+	if !hasReceipt {
+		return false
+	}
+	revision, err := TargetCommitRevision(target, requiredFinalizer)
+	if err == nil && revision == target.Annotations[TargetCommitRevisionAnnotationKey] {
+		return false
+	}
+	ClearTargetRestoreReceipt(target)
+	return true
+}
+
+func TargetCommitRevision(target *corev1.Secret, requiredFinalizer string) (string, error) {
+	if target == nil {
+		return "", fmt.Errorf("target Secret is nil")
+	}
+	controller := metav1.GetControllerOf(target)
+	if controller == nil {
+		return "", fmt.Errorf("target Secret %s/%s has no controller owner", target.Namespace, target.Name)
+	}
+	encoder := newCanonicalEncoder()
+	encoder.writeVersion("sar-target-commit/v1")
+	encoder.writeString(target.Namespace)
+	encoder.writeString(target.Name)
+	encoder.writeString(string(target.Type))
+	switch {
+	case target.Immutable == nil:
+		encoder.writeBytes(nil)
+	case *target.Immutable:
+		encoder.writeBytes([]byte{1})
+	default:
+		encoder.writeBytes([]byte{0})
+	}
+	encoder.writeBytesMap(target.Data)
+	encoder.writeString(controller.APIVersion)
+	encoder.writeString(controller.Kind)
+	encoder.writeString(controller.Name)
+	encoder.writeString(string(controller.UID))
+	encoder.writeString(requiredFinalizer)
+	if slices.Contains(target.Finalizers, requiredFinalizer) {
+		encoder.writeBytes([]byte{1})
+	} else {
+		encoder.writeBytes([]byte{0})
+	}
+	encoder.writeString(target.Annotations[constant.SystemAccountProvisionedAnnotationKey])
+	encoder.writeString(target.Annotations[RestoreOperationDigestAnnotationKey])
+	encoder.writeString(target.Annotations[CredentialIntentRevisionAnnotationKey])
+	encoder.writeString(target.Annotations[RestoreRequestNameAnnotationKey])
+	encoder.writeString(target.Annotations[RestoreRequestUIDAnnotationKey])
+	return sha256Hex(encoder.bytes()), nil
+}
+
+func BuildConflictReceipt(loser CredentialIntent, blockingRequest *corev1.Secret) (*corev1.Secret, error) {
+	if err := validateCredentialIntent(loser); err != nil {
+		return nil, err
+	}
+	winner, err := ValidateRestoreRequestV2(blockingRequest)
+	if err != nil {
+		return nil, fmt.Errorf("validate blocking request: %w", err)
+	}
+	loserTargetDigest, _ := LogicalTargetDigest(loser.Target)
+	winnerTargetDigest, _ := LogicalTargetDigest(winner.Target)
+	if loserTargetDigest != winnerTargetDigest {
+		return nil, fmt.Errorf("blocking request has a different logical target")
+	}
+	loserDigest, _ := OperationDigest(loser.Operation)
+	winnerDigest, _ := OperationDigest(winner.Operation)
+	if loserDigest == winnerDigest {
+		return nil, fmt.Errorf("blocking request belongs to the same restore operation")
+	}
+	phase := RestoreRequestPhase(blockingRequest.Annotations[RestoreRequestPhaseAnnotationKey])
+	if !phase.Active() {
+		return nil, fmt.Errorf("blocking phase %q is not active", phase)
+	}
+	if blockingRequest.UID == "" || blockingRequest.ResourceVersion == "" {
+		return nil, fmt.Errorf("blocking request UID and resourceVersion must not be empty")
+	}
+	envelope := ConflictEnvelope{
+		Protocol:       ConflictProtocolV1,
+		Decision:       ConcurrentRestoreIntentReason,
+		Target:         loser.Target,
+		LoserOperation: loser.Operation,
+		BlockingRequest: BlockingRequestSnapshot{
+			Namespace:             blockingRequest.Namespace,
+			Name:                  blockingRequest.Name,
+			UID:                   blockingRequest.UID,
+			ResourceVersion:       blockingRequest.ResourceVersion,
+			Phase:                 phase,
+			WinnerOperationDigest: winnerDigest,
+		},
+	}
+	name, err := ConflictReceiptName(loser.Target, loser.Operation)
+	if err != nil {
+		return nil, err
+	}
+	targetDigest, _ := LogicalTargetDigest(loser.Target)
+	annotations := conflictAnnotations(envelope, loserDigest, targetDigest)
+	immutable := true
+	controller := false
+	blockOwnerDeletion := false
+	receipt := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   loser.Target.Namespace,
+			Name:        name,
+			Annotations: annotations,
+			Finalizers:  []string{RestoreProtocolFinalizer},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion:         loser.Operation.Root.APIVersion,
+				Kind:               loser.Operation.Root.Kind,
+				Name:               loser.Operation.Root.Name,
+				UID:                loser.Operation.Root.UID,
+				Controller:         &controller,
+				BlockOwnerDeletion: &blockOwnerDeletion,
+			}},
+		},
+		Immutable: &immutable,
+		Type:      corev1.SecretTypeOpaque,
+		Data:      map[string][]byte{},
+	}
+	if err := EncodeConflictEnvelope(receipt, envelope); err != nil {
+		return nil, err
+	}
+	return receipt, nil
+}
+
+func ValidateConflictReceipt(receipt *corev1.Secret, contender CredentialIntent) (ConflictEnvelope, error) {
+	if err := validateCredentialIntent(contender); err != nil {
+		return ConflictEnvelope{}, fmt.Errorf("current contender: %w", err)
+	}
+	envelope, err := DecodeAndValidateConflictReceipt(receipt, true)
+	if err != nil {
+		return envelope, err
+	}
+	expectedTargetDigest, _ := LogicalTargetDigest(contender.Target)
+	actualTargetDigest, _ := LogicalTargetDigest(envelope.Target)
+	expectedOperationDigest, _ := OperationDigest(contender.Operation)
+	actualOperationDigest, _ := OperationDigest(envelope.LoserOperation)
+	if expectedTargetDigest != actualTargetDigest || expectedOperationDigest != actualOperationDigest {
+		return envelope, fmt.Errorf("conflict receipt %s/%s current contender identity mismatch", receipt.Namespace, receipt.Name)
+	}
+	return envelope, nil
+}
+
+// DecodeAndValidateConflictReceipt validates the sealed loser decision without
+// requiring credential bytes. Lifecycle cleanup may allow a finalizer that was
+// already released, while active arbitration requires it.
+func DecodeAndValidateConflictReceipt(
+	receipt *corev1.Secret,
+	requireFinalizer bool,
+) (ConflictEnvelope, error) {
+	var envelope ConflictEnvelope
+	if receipt == nil {
+		return envelope, fmt.Errorf("conflict receipt is nil")
+	}
+	if receipt.Annotations[RestoreProtocolAnnotationKey] != ConflictProtocolV1 ||
+		receipt.Annotations[RestoreDecisionAnnotationKey] != ConcurrentRestoreIntentReason {
+		return envelope, fmt.Errorf("conflict receipt %s/%s has invalid protocol or decision", receipt.Namespace, receipt.Name)
+	}
+	if receipt.Immutable == nil || !*receipt.Immutable {
+		return envelope, fmt.Errorf("conflict receipt %s/%s is not immutable", receipt.Namespace, receipt.Name)
+	}
+	if requireFinalizer && !slices.Contains(receipt.Finalizers, RestoreProtocolFinalizer) {
+		return envelope, fmt.Errorf("conflict receipt %s/%s has no protocol finalizer", receipt.Namespace, receipt.Name)
+	}
+	envelope, err := DecodeConflictEnvelope(receipt)
+	if err != nil {
+		return envelope, err
+	}
+	if envelope.Protocol != ConflictProtocolV1 || envelope.Decision != ConcurrentRestoreIntentReason {
+		return envelope, fmt.Errorf("conflict receipt %s/%s envelope has invalid protocol or decision", receipt.Namespace, receipt.Name)
+	}
+	if _, err := encodeLogicalTargetIdentity(envelope.Target); err != nil {
+		return envelope, fmt.Errorf("conflict receipt logical target: %w", err)
+	}
+	if _, err := encodeOperationIdentity(envelope.LoserOperation); err != nil {
+		return envelope, fmt.Errorf("conflict receipt loser operation: %w", err)
+	}
+	actualTargetDigest, _ := LogicalTargetDigest(envelope.Target)
+	actualOperationDigest, _ := OperationDigest(envelope.LoserOperation)
+	if envelope.BlockingRequest.Namespace == "" || envelope.BlockingRequest.Name == "" ||
+		envelope.BlockingRequest.UID == "" || envelope.BlockingRequest.ResourceVersion == "" ||
+		envelope.BlockingRequest.WinnerOperationDigest == "" {
+		return envelope, fmt.Errorf("conflict receipt %s/%s has incomplete blocking snapshot", receipt.Namespace, receipt.Name)
+	}
+	if !envelope.BlockingRequest.Phase.Active() {
+		return envelope, fmt.Errorf("conflict receipt %s/%s has invalid blocking phase %q",
+			receipt.Namespace, receipt.Name, envelope.BlockingRequest.Phase)
+	}
+	expectedAnnotations := conflictAnnotations(envelope, actualOperationDigest, actualTargetDigest)
+	if err := validateAnnotationMirrors(receipt.Annotations, expectedAnnotations); err != nil {
+		return envelope, fmt.Errorf("conflict receipt %s/%s metadata mirror: %w", receipt.Namespace, receipt.Name, err)
+	}
+	name, _ := ConflictReceiptName(envelope.Target, envelope.LoserOperation)
+	if receipt.Namespace != envelope.Target.Namespace || receipt.Name != name {
+		return envelope, fmt.Errorf("conflict receipt %s/%s has a non-canonical name", receipt.Namespace, receipt.Name)
+	}
+	if err := validateRootOwnerReference(receipt.OwnerReferences, envelope.LoserOperation.Root); err != nil {
+		return envelope, fmt.Errorf("conflict receipt %s/%s ownerReference: %w", receipt.Namespace, receipt.Name, err)
+	}
+	return envelope, nil
+}
+
+func DecodeConflictEnvelope(receipt *corev1.Secret) (ConflictEnvelope, error) {
+	var envelope ConflictEnvelope
+	if receipt == nil {
+		return envelope, fmt.Errorf("conflict receipt is nil")
+	}
+	if err := json.Unmarshal(receipt.Data[RestoreConflictEnvelopeDataKey], &envelope); err != nil {
+		return envelope, fmt.Errorf("decode conflict receipt %s/%s envelope: %w", receipt.Namespace, receipt.Name, err)
+	}
+	return envelope, nil
+}
+
+func EncodeConflictEnvelope(receipt *corev1.Secret, envelope ConflictEnvelope) error {
+	encoded, err := json.Marshal(envelope)
+	if err != nil {
+		return fmt.Errorf("encode conflict receipt envelope: %w", err)
+	}
+	if receipt.Data == nil {
+		receipt.Data = map[string][]byte{}
+	}
+	receipt.Data[RestoreConflictEnvelopeDataKey] = encoded
+	return nil
+}
+
+func requestIdentityAnnotations(intent CredentialIntent, operationDigest, targetDigest, intentRevision string) map[string]string {
+	return map[string]string{
+		RestoreProtocolAnnotationKey:          RestoreProtocolV2,
+		RestoreProfileAnnotationKey:           intent.Operation.Profile,
+		LogicalTargetDigestAnnotationKey:      targetDigest,
+		RestoreOperationDigestAnnotationKey:   operationDigest,
+		RootClusterNamespaceAnnotationKey:     intent.Operation.Root.Namespace,
+		RootClusterNameAnnotationKey:          intent.Operation.Root.Name,
+		RootClusterUIDAnnotationKey:           string(intent.Operation.Root.UID),
+		SourceAPIVersionAnnotationKey:         intent.ResolvedSource.APIVersion,
+		SourceKindAnnotationKey:               intent.ResolvedSource.Kind,
+		SourceNamespaceAnnotationKey:          intent.ResolvedSource.Namespace,
+		SourceNameAnnotationKey:               intent.ResolvedSource.Name,
+		SourceUIDAnnotationKey:                string(intent.ResolvedSource.UID),
+		TargetOwnerAPIVersionAnnotationKey:    intent.Target.Owner.APIVersion,
+		TargetOwnerKindAnnotationKey:          intent.Target.Owner.Kind,
+		TargetOwnerNamespaceAnnotationKey:     intent.Target.Owner.Namespace,
+		TargetOwnerNameAnnotationKey:          intent.Target.Owner.Name,
+		TargetOwnerUIDAnnotationKey:           string(intent.Target.Owner.UID),
+		SystemAccountAnnotationKey:            intent.Target.Account,
+		SystemAccountScopeAnnotationKey:       intent.Target.Scope,
+		ShardingNameAnnotationKey:             intent.Target.ShardingName,
+		CredentialIntentRevisionAnnotationKey: intentRevision,
+	}
+}
+
+func conflictAnnotations(envelope ConflictEnvelope, loserDigest, targetDigest string) map[string]string {
+	return map[string]string{
+		RestoreProtocolAnnotationKey:          ConflictProtocolV1,
+		RestoreDecisionAnnotationKey:          ConcurrentRestoreIntentReason,
+		LogicalTargetDigestAnnotationKey:      targetDigest,
+		RestoreOperationDigestAnnotationKey:   loserDigest,
+		RootClusterUIDAnnotationKey:           string(envelope.Target.Root.UID),
+		TargetOwnerUIDAnnotationKey:           string(envelope.Target.Owner.UID),
+		BlockingRequestNamespaceAnnotationKey: envelope.BlockingRequest.Namespace,
+		BlockingRequestNameAnnotationKey:      envelope.BlockingRequest.Name,
+		BlockingRequestUIDAnnotationKey:       string(envelope.BlockingRequest.UID),
+		WinnerOperationDigestAnnotationKey:    envelope.BlockingRequest.WinnerOperationDigest,
+		ObservedRequestPhaseAnnotationKey:     string(envelope.BlockingRequest.Phase),
+		ObservedRequestRVAnnotationKey:        envelope.BlockingRequest.ResourceVersion,
+	}
+}
+
+func validateCredentialIntent(intent CredentialIntent) error {
+	if _, err := encodeOperationIdentity(intent.Operation); err != nil {
+		return err
+	}
+	if _, err := encodeLogicalTargetIdentity(intent.Target); err != nil {
+		return err
+	}
+	if err := validateObjectIdentity("resolved source", intent.ResolvedSource); err != nil {
+		return err
+	}
+	if intent.Operation.Root != intent.Target.Root {
+		return fmt.Errorf("operation root and logical-target root differ")
+	}
+	if len(intent.Credentials) == 0 {
+		return fmt.Errorf("credential payload must not be empty")
+	}
+	if len(intent.Credentials[constant.AccountNameForSecret]) == 0 ||
+		len(intent.Credentials[constant.AccountPasswdForSecret]) == 0 {
+		return fmt.Errorf("credential payload requires account name and password")
+	}
+	if string(intent.Credentials[constant.AccountNameForSecret]) != intent.Target.Account {
+		return fmt.Errorf("credential account differs from logical target account")
+	}
+	return nil
+}
+
+func encodeOperationIdentity(identity RestoreOperationIdentity) ([]byte, error) {
+	if identity.Protocol != RestoreProtocolV2 {
+		return nil, fmt.Errorf("unsupported restore protocol %q", identity.Protocol)
+	}
+	if identity.Profile != RestoreProfileInitialCluster && identity.Profile != RestoreProfileLegacyPVCGroup {
+		return nil, fmt.Errorf("unsupported restore profile %q", identity.Profile)
+	}
+	if err := validateObjectIdentity("root", identity.Root); err != nil {
+		return nil, err
+	}
+	if identity.Root.Kind != "Cluster" {
+		return nil, fmt.Errorf("root kind must be Cluster")
+	}
+	if identity.Source.APIGroup == "" || identity.Source.Kind == "" ||
+		identity.Source.Namespace == "" || identity.Source.Name == "" {
+		return nil, fmt.Errorf("restore source identity must be complete")
+	}
+	encoder := newCanonicalEncoder()
+	encoder.writeVersion(identity.Protocol)
+	encoder.writeString(identity.Profile)
+	encoder.writeObjectIdentity(identity.Root)
+	encoder.writeString(identity.Source.APIGroup)
+	encoder.writeString(identity.Source.Kind)
+	encoder.writeString(identity.Source.Namespace)
+	encoder.writeString(identity.Source.Name)
+	encoder.writeString(identity.PITR)
+	encoder.writeStringMap(identity.Parameters)
+	return encoder.bytes(), nil
+}
+
+func encodeLogicalTargetIdentity(identity LogicalTargetIdentity) ([]byte, error) {
+	if identity.Protocol != LogicalTargetProtocolV1 {
+		return nil, fmt.Errorf("unsupported logical-target protocol %q", identity.Protocol)
+	}
+	if identity.Namespace == "" {
+		return nil, fmt.Errorf("logical-target namespace must not be empty")
+	}
+	if err := validateObjectIdentity("root", identity.Root); err != nil {
+		return nil, err
+	}
+	if err := validateObjectIdentity("target owner", identity.Owner); err != nil {
+		return nil, err
+	}
+	if identity.Namespace != identity.Root.Namespace || identity.Namespace != identity.Owner.Namespace {
+		return nil, fmt.Errorf("logical target, root, and target owner must share a namespace")
+	}
+	switch identity.Scope {
+	case SystemAccountScopeComponent:
+		if identity.Owner.Kind != "Component" {
+			return nil, fmt.Errorf("component scope requires a Component target owner")
+		}
+		if identity.ShardingName != "" {
+			return nil, fmt.Errorf("component scope must not carry a sharding name")
+		}
+	case SystemAccountScopeSharding:
+		if identity.Owner != identity.Root {
+			return nil, fmt.Errorf("sharding scope requires the root Cluster as target owner")
+		}
+		if identity.ShardingName == "" {
+			return nil, fmt.Errorf("sharding scope requires a sharding name")
+		}
+	default:
+		return nil, fmt.Errorf("unsupported system account scope %q", identity.Scope)
+	}
+	if identity.Account == "" {
+		return nil, fmt.Errorf("system account must not be empty")
+	}
+	encoder := newCanonicalEncoder()
+	encoder.writeVersion(identity.Protocol)
+	encoder.writeString(identity.Namespace)
+	encoder.writeObjectIdentity(identity.Root)
+	encoder.writeObjectIdentity(identity.Owner)
+	encoder.writeString(identity.Scope)
+	encoder.writeString(identity.ShardingName)
+	encoder.writeString(identity.Account)
+	return encoder.bytes(), nil
+}
+
+func validateObjectIdentity(field string, identity ObjectIdentity) error {
+	if identity.APIVersion == "" || identity.Kind == "" || identity.Namespace == "" ||
+		identity.Name == "" || identity.UID == "" {
+		return fmt.Errorf("%s identity must be complete", field)
+	}
+	return nil
+}
+
+func validateRootOwnerReference(refs []metav1.OwnerReference, root ObjectIdentity) error {
+	if len(refs) != 1 {
+		return fmt.Errorf("expected exactly one root ownerReference")
+	}
+	ref := refs[0]
+	if ref.APIVersion != root.APIVersion || ref.Kind != root.Kind ||
+		ref.Name != root.Name || ref.UID != root.UID ||
+		ref.Controller == nil || *ref.Controller ||
+		ref.BlockOwnerDeletion == nil || *ref.BlockOwnerDeletion {
+		return fmt.Errorf("root ownerReference does not match immutable root identity")
+	}
+	return nil
+}
+
+func validateAnnotationMirrors(actual, expected map[string]string) error {
+	for key, expectedValue := range expected {
+		actualValue, ok := actual[key]
+		if !ok || actualValue != expectedValue {
+			return fmt.Errorf("%s=%q, expected %q", key, actualValue, expectedValue)
+		}
+	}
+	return nil
+}
+
+func credentialsFromRequest(data map[string][]byte) map[string][]byte {
+	credentials := maps.Clone(data)
+	delete(credentials, RestoreIntentEnvelopeDataKey)
+	return credentials
+}
+
+func sha256Hex(value []byte) string {
+	digest := sha256.Sum256(value)
+	return hex.EncodeToString(digest[:])
+}
+
+type canonicalEncoder struct {
+	buffer bytes.Buffer
+}
+
+func newCanonicalEncoder() *canonicalEncoder {
+	return &canonicalEncoder{}
+}
+
+func (e *canonicalEncoder) bytes() []byte {
+	return e.buffer.Bytes()
+}
+
+func (e *canonicalEncoder) writeVersion(value string) {
+	_ = binary.Write(&e.buffer, binary.BigEndian, uint16(len(value)))
+	_, _ = e.buffer.WriteString(value)
+}
+
+func (e *canonicalEncoder) writeString(value string) {
+	_ = e.buffer.WriteByte(1)
+	_ = binary.Write(&e.buffer, binary.BigEndian, uint32(len(value)))
+	_, _ = e.buffer.WriteString(value)
+}
+
+func (e *canonicalEncoder) writeBytes(value []byte) {
+	if value == nil {
+		_ = e.buffer.WriteByte(0)
+		return
+	}
+	_ = e.buffer.WriteByte(1)
+	_ = binary.Write(&e.buffer, binary.BigEndian, uint32(len(value)))
+	_, _ = e.buffer.Write(value)
+}
+
+func (e *canonicalEncoder) writeObjectIdentity(identity ObjectIdentity) {
+	e.writeString(identity.APIVersion)
+	e.writeString(identity.Kind)
+	e.writeString(identity.Namespace)
+	e.writeString(identity.Name)
+	e.writeString(string(identity.UID))
+}
+
+func (e *canonicalEncoder) writeStringMap(value map[string]string) {
+	if value == nil {
+		_ = e.buffer.WriteByte(0)
+		return
+	}
+	_ = e.buffer.WriteByte(1)
+	keys := slices.Sorted(maps.Keys(value))
+	_ = binary.Write(&e.buffer, binary.BigEndian, uint32(len(keys)))
+	for _, key := range keys {
+		e.writeString(key)
+		e.writeString(value[key])
+	}
+}
+
+func (e *canonicalEncoder) writeBytesMap(value map[string][]byte) {
+	if value == nil {
+		_ = e.buffer.WriteByte(0)
+		return
+	}
+	_ = e.buffer.WriteByte(1)
+	keys := slices.Sorted(maps.Keys(value))
+	_ = binary.Write(&e.buffer, binary.BigEndian, uint32(len(keys)))
+	for _, key := range keys {
+		e.writeString(key)
+		e.writeBytes(value[key])
+	}
+}

--- a/pkg/controller/systemaccount/protocol_test.go
+++ b/pkg/controller/systemaccount/protocol_test.go
@@ -1,0 +1,400 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package systemaccount
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/apecloud/kubeblocks/pkg/constant"
+)
+
+func TestLogicalTargetSlotIsIndependentFromRestoreOperation(t *testing.T) {
+	first := testCredentialIntent()
+	second := testCredentialIntent()
+	second.Operation.Source.Name = "backup-2"
+	second.Operation.PITR = "2026-07-23T10:00:00Z"
+	second.ResolvedSource.UID = types.UID("backup-uid-2")
+
+	firstRequest, err := BuildRestoreRequest(first)
+	require.NoError(t, err)
+	secondRequest, err := BuildRestoreRequest(second)
+	require.NoError(t, err)
+
+	require.Equal(t, firstRequest.Name, secondRequest.Name)
+	require.Equal(t,
+		firstRequest.Annotations[LogicalTargetDigestAnnotationKey],
+		secondRequest.Annotations[LogicalTargetDigestAnnotationKey])
+	require.NotEqual(t,
+		firstRequest.Annotations[RestoreOperationDigestAnnotationKey],
+		secondRequest.Annotations[RestoreOperationDigestAnnotationKey])
+	require.NotEqual(t,
+		firstRequest.Annotations[CredentialIntentRevisionAnnotationKey],
+		secondRequest.Annotations[CredentialIntentRevisionAnnotationKey])
+	require.Len(t, firstRequest.Name, 55)
+}
+
+func TestCanonicalOperationEncodingDistinguishesNilAndEmptyParameters(t *testing.T) {
+	nilParameters := testCredentialIntent()
+	nilParameters.Operation.Parameters = nil
+	emptyParameters := testCredentialIntent()
+	emptyParameters.Operation.Parameters = map[string]string{}
+
+	nilDigest, err := OperationDigest(nilParameters.Operation)
+	require.NoError(t, err)
+	emptyDigest, err := OperationDigest(emptyParameters.Operation)
+	require.NoError(t, err)
+
+	require.NotEqual(t, nilDigest, emptyDigest)
+}
+
+func TestBuildRestoreRequestSealsProtocolEnvelope(t *testing.T) {
+	intent := testCredentialIntent()
+
+	request, err := BuildRestoreRequest(intent)
+	require.NoError(t, err)
+	require.Equal(t, RestoreProtocolV2, request.Annotations[RestoreProtocolAnnotationKey])
+	require.Equal(t, string(RestoreRequestPhasePending), request.Annotations[RestoreRequestPhaseAnnotationKey])
+	require.Equal(t, "true", request.Labels[constant.SystemAccountRestoreRequestLabelKey])
+	require.NotNil(t, request.Immutable)
+	require.True(t, *request.Immutable)
+	require.Contains(t, request.Finalizers, RestoreProtocolFinalizer)
+	require.NotContains(t, request.Annotations, constant.SystemAccountRestoreTargetAnnotationKey)
+	require.NotContains(t, request.Annotations, constant.SystemAccountProvisionedAnnotationKey)
+	require.NotContains(t, request.Data, RestoreTargetEnvelopeDataKey)
+	require.Equal(t, []byte("new-password"), request.Data[constant.AccountPasswdForSecret])
+	require.Len(t, request.OwnerReferences, 1)
+	require.Equal(t, intent.Operation.Root.UID, request.OwnerReferences[0].UID)
+	require.NotNil(t, request.OwnerReferences[0].Controller)
+	require.False(t, *request.OwnerReferences[0].Controller)
+	require.NotNil(t, request.OwnerReferences[0].BlockOwnerDeletion)
+	require.False(t, *request.OwnerReferences[0].BlockOwnerDeletion)
+
+	parsed, err := ValidateRestoreRequestV2(request)
+	require.NoError(t, err)
+	require.Equal(t, intent.Operation.Root, parsed.Operation.Root)
+	require.Equal(t, intent.Target, parsed.Target)
+	require.Equal(t, intent.ResolvedSource, parsed.ResolvedSource)
+
+	t.Run("metadata mirror tampering fails closed", func(t *testing.T) {
+		tampered := request.DeepCopy()
+		tampered.Annotations[TargetOwnerUIDAnnotationKey] = "replacement-owner"
+		_, err := ValidateRestoreRequestV2(tampered)
+		require.ErrorContains(t, err, "metadata mirror")
+
+		envelope, err := DecodeRestoreIntentEnvelope(tampered)
+		require.NoError(t, err)
+		require.Equal(t, intent.Operation.Root, envelope.Operation.Root)
+	})
+
+	t.Run("immutable envelope tampering fails closed", func(t *testing.T) {
+		tampered := request.DeepCopy()
+		tampered.Data[RestoreIntentEnvelopeDataKey] = []byte(`{"protocol":"sar/v2"}`)
+		_, err := ValidateRestoreRequestV2(tampered)
+		require.Error(t, err)
+	})
+}
+
+func TestCredentialRevisionChangesWithoutMovingLogicalTargetSlot(t *testing.T) {
+	first := testCredentialIntent()
+	second := testCredentialIntent()
+	second.ResolvedSource.UID = types.UID("replacement-backup-uid")
+	second.Credentials[constant.AccountPasswdForSecret] = []byte("rotated-password")
+
+	firstRequest, err := BuildRestoreRequest(first)
+	require.NoError(t, err)
+	secondRequest, err := BuildRestoreRequest(second)
+	require.NoError(t, err)
+
+	require.Equal(t, firstRequest.Name, secondRequest.Name)
+	require.Equal(t,
+		firstRequest.Annotations[RestoreOperationDigestAnnotationKey],
+		secondRequest.Annotations[RestoreOperationDigestAnnotationKey])
+	require.NotEqual(t,
+		firstRequest.Annotations[CredentialIntentRevisionAnnotationKey],
+		secondRequest.Annotations[CredentialIntentRevisionAnnotationKey])
+}
+
+func TestTransitionRestoreRequestV2Table(t *testing.T) {
+	phases := []RestoreRequestPhase{
+		RestoreRequestPhasePending,
+		RestoreRequestPhaseClaimed,
+		RestoreRequestPhaseCommitted,
+		RestoreRequestPhaseFailed,
+		"",
+		"Unknown",
+	}
+	allowed := map[string]bool{
+		"Pending/Pending":     true,
+		"Pending/Claimed":     true,
+		"Pending/Failed":      true,
+		"Claimed/Claimed":     true,
+		"Claimed/Committed":   true,
+		"Claimed/Failed":      true,
+		"Committed/Committed": true,
+		"Committed/Failed":    true,
+		"Failed/Failed":       true,
+	}
+	receipt := &RestoreCommitReceipt{
+		TargetName:     "target",
+		TargetUID:      "target-uid",
+		CommitRevision: "revision",
+	}
+	for _, current := range phases {
+		for _, next := range phases {
+			t.Run(fmt.Sprintf("%s-to-%s", current, next), func(t *testing.T) {
+				request, err := BuildRestoreRequest(testCredentialIntent())
+				require.NoError(t, err)
+				request.Annotations[RestoreRequestPhaseAnnotationKey] = string(current)
+				reason := ""
+				if next == RestoreRequestPhaseFailed {
+					reason = OperationTerminalReason
+				}
+				var commit *RestoreCommitReceipt
+				if next == RestoreRequestPhaseCommitted {
+					commit = receipt
+				}
+				updated, err := TransitionRestoreRequestV2(request, next, reason, commit, false)
+				if !allowed[string(current)+"/"+string(next)] {
+					require.Error(t, err)
+					return
+				}
+				require.NoError(t, err)
+				require.Equal(t, string(next), updated.Annotations[RestoreRequestPhaseAnnotationKey])
+				require.Contains(t, updated.Finalizers, RestoreProtocolFinalizer)
+			})
+		}
+	}
+
+	t.Run("active phase cannot release finalizer", func(t *testing.T) {
+		request, err := BuildRestoreRequest(testCredentialIntent())
+		require.NoError(t, err)
+		_, err = TransitionRestoreRequestV2(
+			request, RestoreRequestPhasePending, "", nil, true)
+		require.ErrorContains(t, err, "cannot release")
+	})
+
+	t.Run("failed phase releases finalizer with stable reason", func(t *testing.T) {
+		request, err := BuildRestoreRequest(testCredentialIntent())
+		require.NoError(t, err)
+		updated, err := TransitionRestoreRequestV2(
+			request, RestoreRequestPhaseFailed, RootUnavailableReason, nil, true)
+		require.NoError(t, err)
+		require.NotContains(t, updated.Finalizers, RestoreProtocolFinalizer)
+		require.Equal(t, RootUnavailableReason,
+			updated.Annotations[RestoreRequestReasonAnnotationKey])
+	})
+}
+
+func TestConflictReceiptKeepsFirstBlockingSnapshot(t *testing.T) {
+	loser := testCredentialIntent()
+	winner := testCredentialIntent()
+	winner.Operation.Source.Name = "winner-backup"
+	winnerRequest, err := BuildRestoreRequest(winner)
+	require.NoError(t, err)
+	winnerRequest.UID = types.UID("winner-request-uid")
+	winnerRequest.ResourceVersion = "17"
+	winnerRequest.Annotations[RestoreRequestPhaseAnnotationKey] = string(RestoreRequestPhaseClaimed)
+
+	receipt, err := BuildConflictReceipt(loser, winnerRequest)
+	require.NoError(t, err)
+	require.Equal(t, ConflictProtocolV1, receipt.Annotations[RestoreProtocolAnnotationKey])
+	require.Equal(t, ConcurrentRestoreIntentReason, receipt.Annotations[RestoreDecisionAnnotationKey])
+	require.NotContains(t, receipt.Data, constant.AccountPasswdForSecret)
+	require.NotNil(t, receipt.Immutable)
+	require.True(t, *receipt.Immutable)
+	require.Contains(t, receipt.Finalizers, RestoreProtocolFinalizer)
+
+	_, err = ValidateConflictReceipt(receipt, loser)
+	require.NoError(t, err)
+
+	t.Run("later winner replacement does not rewrite historical snapshot", func(t *testing.T) {
+		replacementWinner := winnerRequest.DeepCopy()
+		replacementWinner.UID = types.UID("winner-request-uid-2")
+		replacementWinner.ResourceVersion = "42"
+		replacementWinner.Annotations[RestoreOperationDigestAnnotationKey] = "different-winner-digest"
+
+		parsed, err := ValidateConflictReceipt(receipt, loser)
+		require.NoError(t, err)
+		require.Equal(t, winnerRequest.UID, parsed.BlockingRequest.UID)
+		require.NotEqual(t, replacementWinner.UID, parsed.BlockingRequest.UID)
+		require.Equal(t, "17", parsed.BlockingRequest.ResourceVersion)
+	})
+
+	t.Run("different current contender cannot reuse receipt", func(t *testing.T) {
+		otherLoser := testCredentialIntent()
+		otherLoser.Operation.PITR = "other-pitr"
+		_, err := ValidateConflictReceipt(receipt, otherLoser)
+		require.ErrorContains(t, err, "current contender")
+	})
+
+	t.Run("invalid sealed blocking phase fails closed", func(t *testing.T) {
+		tampered := receipt.DeepCopy()
+		envelope, err := DecodeConflictEnvelope(tampered)
+		require.NoError(t, err)
+		envelope.BlockingRequest.Phase = RestoreRequestPhaseFailed
+		require.NoError(t, EncodeConflictEnvelope(tampered, envelope))
+		tampered.Annotations[ObservedRequestPhaseAnnotationKey] = string(RestoreRequestPhaseFailed)
+		_, err = ValidateConflictReceipt(tampered, loser)
+		require.ErrorContains(t, err, "blocking phase")
+	})
+}
+
+func TestClearStaleTargetRestoreReceiptPreservesMetadataOnlyChanges(t *testing.T) {
+	intent := testCredentialIntent()
+	request, err := BuildRestoreRequest(intent)
+	require.NoError(t, err)
+	request.UID = "request-uid"
+	controller := true
+	blockOwnerDeletion := true
+	target := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  intent.Target.Namespace,
+			Name:       "cluster-mysql-admin",
+			UID:        "target-uid",
+			Finalizers: []string{constant.DBComponentFinalizerName},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion:         intent.Target.Owner.APIVersion,
+				Kind:               intent.Target.Owner.Kind,
+				Name:               intent.Target.Owner.Name,
+				UID:                intent.Target.Owner.UID,
+				Controller:         &controller,
+				BlockOwnerDeletion: &blockOwnerDeletion,
+			}},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			constant.AccountNameForSecret:   []byte(intent.Target.Account),
+			constant.AccountPasswdForSecret: []byte("new-password"),
+		},
+	}
+	applyTargetReceipt(target, request)
+	revision, err := TargetCommitRevision(target, constant.DBComponentFinalizerName)
+	require.NoError(t, err)
+	target.Annotations[TargetCommitRevisionAnnotationKey] = revision
+
+	target.Labels = map[string]string{"metadata-only": "changed"}
+	require.False(t, ClearStaleTargetRestoreReceipt(target, constant.DBComponentFinalizerName))
+	require.Equal(t, revision, target.Annotations[TargetCommitRevisionAnnotationKey])
+
+	target.Data[constant.AccountPasswdForSecret] = []byte("rotated-password")
+	require.True(t, ClearStaleTargetRestoreReceipt(target, constant.DBComponentFinalizerName))
+	require.NotContains(t, target.Annotations, RestoreOperationDigestAnnotationKey)
+	require.NotContains(t, target.Annotations, CredentialIntentRevisionAnnotationKey)
+	require.NotContains(t, target.Annotations, TargetCommitRevisionAnnotationKey)
+	require.NotContains(t, target.Annotations, RestoreRequestNameAnnotationKey)
+	require.NotContains(t, target.Annotations, RestoreRequestUIDAnnotationKey)
+}
+
+func testCredentialIntent() CredentialIntent {
+	return CredentialIntent{
+		Operation: RestoreOperationIdentity{
+			Protocol: RestoreProtocolV2,
+			Profile:  RestoreProfileInitialCluster,
+			Root: ObjectIdentity{
+				APIVersion: "apps.kubeblocks.io/v1",
+				Kind:       "Cluster",
+				Namespace:  "default",
+				Name:       "cluster",
+				UID:        types.UID("cluster-uid"),
+			},
+			Source: SourceIdentity{
+				APIGroup:  "dataprotection.kubeblocks.io",
+				Kind:      "Backup",
+				Namespace: "backup",
+				Name:      "backup-1",
+			},
+			PITR:       "",
+			Parameters: map[string]string{"restore": "all"},
+		},
+		Target: LogicalTargetIdentity{
+			Protocol:  LogicalTargetProtocolV1,
+			Namespace: "default",
+			Root: ObjectIdentity{
+				APIVersion: "apps.kubeblocks.io/v1",
+				Kind:       "Cluster",
+				Namespace:  "default",
+				Name:       "cluster",
+				UID:        types.UID("cluster-uid"),
+			},
+			Owner: ObjectIdentity{
+				APIVersion: "apps.kubeblocks.io/v1",
+				Kind:       "Component",
+				Namespace:  "default",
+				Name:       "cluster-mysql",
+				UID:        types.UID("component-uid"),
+			},
+			Scope:   SystemAccountScopeComponent,
+			Account: "root",
+		},
+		ResolvedSource: ObjectIdentity{
+			APIVersion: "dataprotection.kubeblocks.io/v1alpha1",
+			Kind:       "Backup",
+			Namespace:  "backup",
+			Name:       "backup-1",
+			UID:        types.UID("backup-uid-1"),
+		},
+		Credentials: map[string][]byte{
+			constant.AccountNameForSecret:   []byte("root"),
+			constant.AccountPasswdForSecret: []byte("new-password"),
+		},
+	}
+}
+
+func TestRequestOwnerReferenceRequiresExactNonBlockingRoot(t *testing.T) {
+	request, err := BuildRestoreRequest(testCredentialIntent())
+	require.NoError(t, err)
+	controller := true
+	request.OwnerReferences[0].Controller = &controller
+
+	_, err = ValidateRestoreRequestV2(request)
+	require.ErrorContains(t, err, "ownerReference")
+}
+
+func TestRestoreRequestPhaseValidation(t *testing.T) {
+	for _, phase := range []RestoreRequestPhase{
+		RestoreRequestPhasePending,
+		RestoreRequestPhaseClaimed,
+		RestoreRequestPhaseCommitted,
+		RestoreRequestPhaseFailed,
+	} {
+		require.True(t, phase.Valid())
+	}
+	require.False(t, RestoreRequestPhase("").Valid())
+	require.False(t, RestoreRequestPhase("Unknown").Valid())
+}
+
+func TestTargetOwnerIdentityCanRepresentShardingScope(t *testing.T) {
+	intent := testCredentialIntent()
+	intent.Target.Scope = SystemAccountScopeSharding
+	intent.Target.ShardingName = "shard"
+	intent.Target.Owner = intent.Target.Root
+	request, err := BuildRestoreRequest(intent)
+	require.NoError(t, err)
+	require.Equal(t, "shard", request.Annotations[ShardingNameAnnotationKey])
+}
+
+var _ = metav1.OwnerReference{}
+var _ = corev1.Secret{}

--- a/pkg/controller/systemaccount/restore.go
+++ b/pkg/controller/systemaccount/restore.go
@@ -25,6 +25,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"reflect"
@@ -36,6 +37,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/apecloud/kubeblocks/pkg/constant"
@@ -47,6 +49,26 @@ import (
 const restoreRequestNamePrefix = "system-account-restore-"
 
 const restoreRequestRequeueAfter = time.Second
+
+type TargetSemanticError struct {
+	Reason string
+	Cause  error
+}
+
+func (e *TargetSemanticError) Error() string {
+	return fmt.Sprintf("%s: %v", e.Reason, e.Cause)
+}
+
+func (e *TargetSemanticError) Unwrap() error {
+	return e.Cause
+}
+
+func NewTargetSemanticError(reason string, cause error) error {
+	if reason != AccountUnavailableReason && reason != TargetSemanticUnavailableReason {
+		reason = TargetSemanticUnavailableReason
+	}
+	return &TargetSemanticError{Reason: reason, Cause: cause}
+}
 
 type restoreRequestControllerIdentity struct {
 	APIVersion string    `json:"apiVersion"`
@@ -196,7 +218,12 @@ func ReconcileRestoreRequests(ctx context.Context,
 	graphCli model.GraphClient,
 	dag *graph.DAG,
 	owner client.Object,
-	ownedFinalizer string) (bool, error) {
+	ownedFinalizer string,
+	targetBuilders ...func(CredentialIntent) (*corev1.Secret, error)) (bool, error) {
+	var targetBuilder func(CredentialIntent) (*corev1.Secret, error)
+	if len(targetBuilders) > 0 {
+		targetBuilder = targetBuilders[0]
+	}
 	requests := &corev1.SecretList{}
 	if err := graphCli.List(ctx, requests,
 		client.InNamespace(owner.GetNamespace()),
@@ -210,20 +237,32 @@ func ReconcileRestoreRequests(ctx context.Context,
 	seenTargets := map[string]string{}
 	for i := range requests.Items {
 		request := &requests.Items[i]
-		targetName := request.Annotations[constant.SystemAccountRestoreTargetAnnotationKey]
-		if !metav1.IsControlledBy(request, owner) {
+		if request.Annotations[RestoreProtocolAnnotationKey] != RestoreProtocolV2 {
+			continue
+		}
+		envelope, err := DecodeRestoreIntentEnvelope(request)
+		if err != nil || !sameObjectIdentity(envelope.Target.Owner, owner) {
+			continue
+		}
+		intent, err := DecodeRestoreRequestV2(request)
+		if err != nil {
+			return true, err
+		}
+		phase := RestoreRequestPhase(request.Annotations[RestoreRequestPhaseAnnotationKey])
+		if !phase.Valid() || !slices.Contains(request.Finalizers, RestoreProtocolFinalizer) {
+			// Invalid-phase and finalizer-release paths belong to the
+			// independent lifecycle controller.
 			continue
 		}
 		handled = true
-		if err := ValidateRestoreRequest(request); err != nil {
-			return true, err
+		targetDigest := request.Annotations[LogicalTargetDigestAnnotationKey]
+		if previous, ok := seenTargets[targetDigest]; ok {
+			return true, fmt.Errorf("multiple system account restore requests %s and %s target logical slot %s",
+				previous, request.Name, targetDigest)
 		}
-		if previous, ok := seenTargets[targetName]; ok {
-			return true, fmt.Errorf("multiple system account restore requests %s and %s target %s/%s",
-				previous, request.Name, request.Namespace, targetName)
-		}
-		seenTargets[targetName] = request.Name
-		if err := reconcileRestoreRequest(ctx, graphCli, dag, owner, ownedFinalizer, request, targetName); err != nil {
+		seenTargets[targetDigest] = request.Name
+		if err := reconcileRestoreRequestV2(ctx, graphCli, dag, owner, ownedFinalizer,
+			request, intent, targetBuilder); err != nil {
 			return true, err
 		}
 	}
@@ -234,39 +273,126 @@ func ReconcileRestoreRequests(ctx context.Context,
 	return handled, nil
 }
 
-func reconcileRestoreRequest(ctx context.Context,
+func reconcileRestoreRequestV2(
+	ctx context.Context,
 	graphCli model.GraphClient,
 	dag *graph.DAG,
 	owner client.Object,
 	ownedFinalizer string,
 	request *corev1.Secret,
-	targetName string) error {
+	intent CredentialIntent,
+	targetBuilder func(CredentialIntent) (*corev1.Secret, error),
+) error {
+	phase := RestoreRequestPhase(request.Annotations[RestoreRequestPhaseAnnotationKey])
 	if !request.DeletionTimestamp.IsZero() {
+		if phase == RestoreRequestPhaseClaimed || phase == RestoreRequestPhaseCommitted {
+			target, exact, err := findLinkedTarget(ctx, graphCli, request, intent, ownedFinalizer)
+			if err != nil {
+				return err
+			}
+			if exact {
+				updated := target.DeepCopy()
+				ClearTargetRestoreReceipt(updated)
+				graphCli.Update(dag, target, updated)
+			}
+		}
+		if phase != RestoreRequestPhaseFailed {
+			return updateRestoreRequestState(graphCli, dag, request,
+				RestoreRequestPhaseFailed, RequestDeletionRequestedReason, nil)
+		}
 		return nil
 	}
+	switch phase {
+	case RestoreRequestPhasePending:
+		if targetBuilder == nil {
+			return updateRestoreRequestState(graphCli, dag, request,
+				RestoreRequestPhaseFailed, TargetSemanticUnavailableReason, nil)
+		}
+		if _, err := targetBuilder(intent); err != nil {
+			return updateRestoreRequestState(graphCli, dag, request,
+				RestoreRequestPhaseFailed, targetSemanticFailureReason(err), nil)
+		}
+		return updateRestoreRequestState(graphCli, dag, request, RestoreRequestPhaseClaimed, "", nil)
+	case RestoreRequestPhaseClaimed, RestoreRequestPhaseCommitted:
+		return reconcileClaimedRestoreRequestV2(ctx, graphCli, dag, owner, ownedFinalizer,
+			request, intent, targetBuilder)
+	case RestoreRequestPhaseFailed:
+		return nil
+	default:
+		return fmt.Errorf("system account restore request %s/%s has invalid phase %q",
+			request.Namespace, request.Name, phase)
+	}
+}
+
+func reconcileClaimedRestoreRequestV2(
+	ctx context.Context,
+	graphCli model.GraphClient,
+	dag *graph.DAG,
+	owner client.Object,
+	ownedFinalizer string,
+	request *corev1.Secret,
+	intent CredentialIntent,
+	targetBuilder func(CredentialIntent) (*corev1.Secret, error),
+) error {
+	if targetBuilder == nil {
+		return updateRestoreRequestState(graphCli, dag, request,
+			RestoreRequestPhaseFailed, TargetSemanticUnavailableReason, nil)
+	}
+	desired, err := targetBuilder(intent)
+	if err != nil {
+		reason := targetSemanticFailureReason(err)
+		target, exact, findErr := findLinkedTarget(ctx, graphCli, request, intent, ownedFinalizer)
+		if findErr != nil {
+			return findErr
+		}
+		phase := RestoreRequestPhase(request.Annotations[RestoreRequestPhaseAnnotationKey])
+		if reason == AccountUnavailableReason && exact {
+			if phase == RestoreRequestPhaseCommitted {
+				return nil
+			}
+			// The independent lifecycle controller owns the final
+			// post-write operation/owner check and Committed transition.
+			return nil
+		}
+		if reason == AccountUnavailableReason && phase == RestoreRequestPhaseCommitted {
+			reason = CredentialContinuityLostReason
+		}
+		if reason == TargetSemanticUnavailableReason && exact {
+			updated := target.DeepCopy()
+			ClearTargetRestoreReceipt(updated)
+			graphCli.Update(dag, target, updated)
+		}
+		return updateRestoreRequestState(graphCli, dag, request,
+			RestoreRequestPhaseFailed, reason, nil)
+	}
+	if desired.Namespace != intent.Target.Namespace || desired.Name == "" {
+		return updateRestoreRequestState(graphCli, dag, request,
+			RestoreRequestPhaseFailed, TargetSemanticUnavailableReason,
+			nil)
+	}
+	if !sameControllerIdentity(metav1.GetControllerOf(desired), objectOwnerReference(intent.Target.Owner)) ||
+		!controllerutil.ContainsFinalizer(desired, ownedFinalizer) {
+		return updateRestoreRequestState(graphCli, dag, request,
+			RestoreRequestPhaseFailed, TargetSemanticUnavailableReason,
+			nil)
+	}
+	applyTargetReceipt(desired, request)
 
 	target := &corev1.Secret{}
-	key := client.ObjectKey{Namespace: request.Namespace, Name: targetName}
+	key := client.ObjectKeyFromObject(desired)
 	if err := graphCli.Get(ctx, key, target); err != nil {
 		if !apierrors.IsNotFound(err) {
-			return err
-		}
-		desired, err := desiredTarget(request, owner, ownedFinalizer)
-		if err != nil {
 			return err
 		}
 		graphCli.Create(dag, desired)
 		return nil
 	}
-
-	expectedOwner := metav1.GetControllerOf(request)
-	if expectedOwner == nil {
-		return fmt.Errorf("system account restore request %s/%s has no controller owner", request.Namespace, request.Name)
-	}
-	if !hasOwnerReference(target, expectedOwner) {
+	if !sameControllerIdentity(metav1.GetControllerOf(target),
+		objectOwnerReference(intent.Target.Owner)) {
 		if len(target.OwnerReferences) > 0 || !target.DeletionTimestamp.IsZero() {
-			return fmt.Errorf("system account restore target %s is not owned by %s %s",
-				key, expectedOwner.Kind, expectedOwner.Name)
+			return updateRestoreRequestState(graphCli, dag, request,
+				RestoreRequestPhaseFailed, TargetOwnerUnavailableReason,
+				nil)
 		}
 		adopted := target.DeepCopy()
 		if err := intctrlutil.SetOwnership(owner, adopted, model.GetScheme(), ownedFinalizer); err != nil {
@@ -275,7 +401,6 @@ func reconcileRestoreRequest(ctx context.Context,
 		graphCli.Update(dag, target, adopted)
 		return nil
 	}
-
 	if !target.DeletionTimestamp.IsZero() {
 		if controllerutil.ContainsFinalizer(target, ownedFinalizer) {
 			updated := target.DeepCopy()
@@ -285,60 +410,186 @@ func reconcileRestoreRequest(ctx context.Context,
 		return nil
 	}
 
-	desired := target.DeepCopy()
-	desired.Type = request.Type
-	desired.Immutable = request.Immutable
-	desired.Data = maps.Clone(request.Data)
-	mergeStringMap(requestTargetLabels(request), &desired.Labels)
-	delete(desired.Labels, constant.SystemAccountRestoreRequestLabelKey)
-	mergeStringMap(requestTargetAnnotations(request), &desired.Annotations)
-	delete(desired.Annotations, constant.SystemAccountRestoreTargetAnnotationKey)
-	if err := intctrlutil.SetOwnership(owner, desired, model.GetScheme(), ownedFinalizer); err != nil {
+	preserveUnownedTargetMetadata(target, desired)
+	applyTargetReceipt(desired, request)
+	desired.ResourceVersion = target.ResourceVersion
+	desired.UID = target.UID
+	desired.CreationTimestamp = target.CreationTimestamp
+	desired.ManagedFields = target.ManagedFields
+	revision, err := TargetCommitRevision(desired, ownedFinalizer)
+	if err != nil {
 		return err
 	}
-	if reflect.DeepEqual(target, desired) {
-		if controllerutil.ContainsFinalizer(request, ownedFinalizer) {
-			updated := request.DeepCopy()
-			controllerutil.RemoveFinalizer(updated, ownedFinalizer)
-			graphCli.Update(dag, request, updated)
-		} else {
-			graphCli.Delete(dag, request)
+	desired.Annotations[TargetCommitRevisionAnnotationKey] = revision
+	if !reflect.DeepEqual(target, desired) {
+		if target.Immutable != nil && *target.Immutable &&
+			(!reflect.DeepEqual(target.Data, desired.Data) ||
+				!reflect.DeepEqual(target.Immutable, desired.Immutable) ||
+				target.Type != desired.Type) {
+			return graphCli.Delete(dag, target, model.WithDeleteUID(target.UID))
 		}
+		graphCli.Update(dag, target, desired)
 		return nil
 	}
-	if target.Immutable != nil && *target.Immutable &&
-		(!reflect.DeepEqual(target.Data, desired.Data) ||
-			!reflect.DeepEqual(target.Immutable, desired.Immutable) ||
-			target.Type != desired.Type) {
-		graphCli.Delete(dag, target)
-		return nil
-	}
-	graphCli.Update(dag, target, desired)
+	// Target and receipt are exact. The lifecycle controller re-reads the
+	// operation and owner before it commits the request.
 	return nil
 }
 
-func desiredTarget(request *corev1.Secret, owner client.Object, ownedFinalizer string) (*corev1.Secret, error) {
-	targetName := request.Annotations[constant.SystemAccountRestoreTargetAnnotationKey]
-	if targetName == "" {
-		return nil, fmt.Errorf("system account restore request %s/%s has no target", request.Namespace, request.Name)
+func preserveUnownedTargetMetadata(current, desired *corev1.Secret) {
+	labels := maps.Clone(current.Labels)
+	if labels == nil {
+		labels = map[string]string{}
 	}
-	annotations := maps.Clone(request.Annotations)
-	delete(annotations, constant.SystemAccountRestoreTargetAnnotationKey)
-	target := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:   request.Namespace,
-			Name:        targetName,
-			Labels:      requestTargetLabels(request),
-			Annotations: annotations,
-		},
-		Immutable: request.Immutable,
-		Type:      request.Type,
-		Data:      maps.Clone(request.Data),
+	maps.Copy(labels, desired.Labels)
+	desired.Labels = labels
+
+	annotations := maps.Clone(current.Annotations)
+	if annotations == nil {
+		annotations = map[string]string{}
 	}
-	if err := intctrlutil.SetOwnership(owner, target, model.GetScheme(), ownedFinalizer); err != nil {
-		return nil, err
+	maps.Copy(annotations, desired.Annotations)
+	desired.Annotations = annotations
+
+	finalizers := slices.Clone(current.Finalizers)
+	for _, finalizer := range desired.Finalizers {
+		if !slices.Contains(finalizers, finalizer) {
+			finalizers = append(finalizers, finalizer)
+		}
 	}
-	return target, nil
+	desired.Finalizers = finalizers
+
+	ownerReferences := slices.Clone(desired.OwnerReferences)
+	for _, ownerReference := range current.OwnerReferences {
+		if slices.ContainsFunc(ownerReferences, func(existing metav1.OwnerReference) bool {
+			return sameOwnerReferenceIdentity(existing, ownerReference)
+		}) {
+			continue
+		}
+		ownerReferences = append(ownerReferences, ownerReference)
+	}
+	desired.OwnerReferences = ownerReferences
+}
+
+func findLinkedTarget(
+	ctx context.Context,
+	graphCli model.GraphClient,
+	request *corev1.Secret,
+	intent CredentialIntent,
+	ownedFinalizer string,
+) (*corev1.Secret, bool, error) {
+	if name := request.Annotations[TargetSecretNameAnnotationKey]; name != "" {
+		target := &corev1.Secret{}
+		if err := graphCli.Get(ctx, client.ObjectKey{
+			Namespace: request.Namespace,
+			Name:      name,
+		}, target); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, false, nil
+			}
+			return nil, false, err
+		}
+		return target, TargetReceiptExactV2(target, request, ownedFinalizer), nil
+	}
+	targets := &corev1.SecretList{}
+	if err := graphCli.List(ctx, targets, client.InNamespace(intent.Target.Namespace)); err != nil {
+		return nil, false, err
+	}
+	var exactTarget *corev1.Secret
+	for i := range targets.Items {
+		target := &targets.Items[i]
+		if target.Annotations[RestoreRequestNameAnnotationKey] == request.Name &&
+			target.Annotations[RestoreRequestUIDAnnotationKey] == string(request.UID) &&
+			TargetReceiptExactV2(target, request, ownedFinalizer) {
+			if exactTarget != nil {
+				return nil, false, fmt.Errorf(
+					"multiple exact targets %s/%s and %s/%s link restore request %s/%s",
+					exactTarget.Namespace, exactTarget.Name, target.Namespace, target.Name,
+					request.Namespace, request.Name)
+			}
+			exactTarget = target
+		}
+	}
+	if exactTarget != nil {
+		return exactTarget, true, nil
+	}
+	return nil, false, nil
+}
+
+func targetSemanticFailureReason(err error) string {
+	var semanticErr *TargetSemanticError
+	if errors.As(err, &semanticErr) {
+		return semanticErr.Reason
+	}
+	return TargetSemanticUnavailableReason
+}
+
+func updateRestoreRequestState(
+	graphCli model.GraphClient,
+	dag *graph.DAG,
+	request *corev1.Secret,
+	phase RestoreRequestPhase,
+	reason string,
+	annotations map[string]string,
+) error {
+	var receipt *RestoreCommitReceipt
+	if phase == RestoreRequestPhaseCommitted {
+		receipt = &RestoreCommitReceipt{
+			TargetName:     annotations[TargetSecretNameAnnotationKey],
+			TargetUID:      types.UID(annotations[TargetSecretUIDAnnotationKey]),
+			CommitRevision: annotations[TargetCommitRevisionAnnotationKey],
+		}
+	}
+	updated, err := TransitionRestoreRequestV2(request, phase, reason, receipt, false)
+	if err != nil {
+		return err
+	}
+	graphCli.Update(dag, request, updated)
+	return nil
+}
+
+func applyTargetReceipt(target, request *corev1.Secret) {
+	if target.Annotations == nil {
+		target.Annotations = map[string]string{}
+	}
+	target.Annotations[constant.SystemAccountProvisionedAnnotationKey] = "true"
+	target.Annotations[RestoreProtocolAnnotationKey] = RestoreProtocolV2
+	target.Annotations[RestoreOperationDigestAnnotationKey] =
+		request.Annotations[RestoreOperationDigestAnnotationKey]
+	target.Annotations[CredentialIntentRevisionAnnotationKey] =
+		request.Annotations[CredentialIntentRevisionAnnotationKey]
+	target.Annotations[RestoreRequestNameAnnotationKey] = request.Name
+	target.Annotations[RestoreRequestUIDAnnotationKey] = string(request.UID)
+	delete(target.Annotations, constant.SystemAccountRestoreTargetAnnotationKey)
+	delete(target.Labels, constant.SystemAccountRestoreRequestLabelKey)
+}
+
+func objectOwnerReference(identity ObjectIdentity) *metav1.OwnerReference {
+	controller := true
+	blockOwnerDeletion := true
+	return &metav1.OwnerReference{
+		APIVersion:         identity.APIVersion,
+		Kind:               identity.Kind,
+		Name:               identity.Name,
+		UID:                identity.UID,
+		Controller:         &controller,
+		BlockOwnerDeletion: &blockOwnerDeletion,
+	}
+}
+
+func sameObjectIdentity(identity ObjectIdentity, object client.Object) bool {
+	if object == nil {
+		return false
+	}
+	gvk, err := apiutil.GVKForObject(object, model.GetScheme())
+	if err != nil {
+		return false
+	}
+	return identity.APIVersion == gvk.GroupVersion().String() &&
+		identity.Kind == gvk.Kind &&
+		identity.Namespace == object.GetNamespace() &&
+		identity.Name == object.GetName() &&
+		identity.UID == object.GetUID()
 }
 
 func requestTargetLabels(request *corev1.Secret) map[string]string {
@@ -355,29 +606,12 @@ func requestTargetAnnotations(request *corev1.Secret) map[string]string {
 
 func sameControllerIdentity(a, b *metav1.OwnerReference) bool {
 	return a != nil && b != nil &&
-		a.APIVersion == b.APIVersion &&
+		sameOwnerReferenceIdentity(*a, *b)
+}
+
+func sameOwnerReferenceIdentity(a, b metav1.OwnerReference) bool {
+	return a.APIVersion == b.APIVersion &&
 		a.Kind == b.Kind &&
 		a.Name == b.Name &&
 		a.UID == b.UID
-}
-
-func hasOwnerReference(object client.Object, expected *metav1.OwnerReference) bool {
-	return expected != nil && slices.ContainsFunc(object.GetOwnerReferences(), func(actual metav1.OwnerReference) bool {
-		return actual.APIVersion == expected.APIVersion &&
-			actual.Kind == expected.Kind &&
-			actual.Name == expected.Name &&
-			actual.UID == expected.UID
-	})
-}
-
-func mergeStringMap(from map[string]string, to *map[string]string) {
-	if len(from) == 0 {
-		return
-	}
-	if *to == nil {
-		*to = map[string]string{}
-	}
-	for key, value := range from {
-		(*to)[key] = value
-	}
 }

--- a/pkg/controller/systemaccount/restore.go
+++ b/pkg/controller/systemaccount/restore.go
@@ -1,0 +1,383 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package systemaccount
+
+import (
+	"cmp"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"reflect"
+	"slices"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/graph"
+	"github.com/apecloud/kubeblocks/pkg/controller/model"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+)
+
+const restoreRequestNamePrefix = "system-account-restore-"
+
+const restoreRequestRequeueAfter = time.Second
+
+type restoreRequestControllerIdentity struct {
+	APIVersion string    `json:"apiVersion"`
+	Kind       string    `json:"kind"`
+	Name       string    `json:"name"`
+	UID        types.UID `json:"uid"`
+}
+
+type restoreRequestRevisionPayload struct {
+	Namespace  string                           `json:"namespace"`
+	TargetName string                           `json:"targetName"`
+	Type       corev1.SecretType                `json:"type"`
+	Immutable  *bool                            `json:"immutable,omitempty"`
+	Data       map[string][]byte                `json:"data"`
+	Controller restoreRequestControllerIdentity `json:"controller"`
+}
+
+// RestoreRequestName returns the stable name of the replacement request for a
+// system account Secret. There is exactly one active request per target name.
+func RestoreRequestName(namespace, targetName string) string {
+	digest := sha256.Sum256([]byte(namespace + "/" + targetName))
+	return restoreRequestNamePrefix + hex.EncodeToString(digest[:8])
+}
+
+// SetRestoreRevision seals the request payload with a content-addressed
+// revision. Apps copies this revision to the target as the durable completion
+// marker observed by DataProtection. Labels and non-protocol annotations are
+// intentionally outside the seal so admission-added metadata remains valid.
+func SetRestoreRevision(request *corev1.Secret) error {
+	revision, err := restoreRevision(request)
+	if err != nil {
+		return err
+	}
+	if request.Annotations == nil {
+		request.Annotations = map[string]string{}
+	}
+	request.Annotations[constant.SystemAccountRestoreRevisionAnnotationKey] = revision
+	return nil
+}
+
+// ValidateRestoreRequest verifies the public metadata contract and the sealed
+// payload before Apps acts on a request.
+func ValidateRestoreRequest(request *corev1.Secret) error {
+	targetName := request.Annotations[constant.SystemAccountRestoreTargetAnnotationKey]
+	if targetName == "" {
+		return fmt.Errorf("system account restore request %s/%s has no target", request.Namespace, request.Name)
+	}
+	if request.Name != RestoreRequestName(request.Namespace, targetName) {
+		return fmt.Errorf("system account restore request %s/%s has a non-canonical name", request.Namespace, request.Name)
+	}
+	if request.Labels[constant.SystemAccountRestoreRequestLabelKey] != "true" {
+		return fmt.Errorf("system account restore request %s/%s has no request label", request.Namespace, request.Name)
+	}
+	if request.Annotations[constant.SystemAccountProvisionedAnnotationKey] != "true" {
+		return fmt.Errorf("system account restore request %s/%s is not marked provisioned", request.Namespace, request.Name)
+	}
+	if _, ok := request.Data[constant.AccountNameForSecret]; !ok {
+		return fmt.Errorf("system account restore request %s/%s has no account name", request.Namespace, request.Name)
+	}
+	if _, ok := request.Data[constant.AccountPasswdForSecret]; !ok {
+		return fmt.Errorf("system account restore request %s/%s has no account password", request.Namespace, request.Name)
+	}
+	expected, err := restoreRevision(request)
+	if err != nil {
+		return err
+	}
+	if actual := request.Annotations[constant.SystemAccountRestoreRevisionAnnotationKey]; actual != expected {
+		return fmt.Errorf("system account restore request %s/%s has an invalid revision", request.Namespace, request.Name)
+	}
+	return nil
+}
+
+// RestoreConverged reports whether Apps has committed this exact request to
+// the target. The persisted revision prevents an old request from being
+// mistaken for the current restore after a same-name replacement race.
+func RestoreConverged(target, request *corev1.Secret, ownedFinalizer string) bool {
+	if target == nil || request == nil || !target.DeletionTimestamp.IsZero() {
+		return false
+	}
+	if target.Namespace != request.Namespace ||
+		target.Name != request.Annotations[constant.SystemAccountRestoreTargetAnnotationKey] ||
+		target.Type != request.Type ||
+		!reflect.DeepEqual(target.Immutable, request.Immutable) ||
+		!reflect.DeepEqual(target.Data, request.Data) ||
+		!sameControllerIdentity(metav1.GetControllerOf(target), metav1.GetControllerOf(request)) ||
+		!controllerutil.ContainsFinalizer(target, ownedFinalizer) {
+		return false
+	}
+	if target.Labels[constant.SystemAccountRestoreRequestLabelKey] != "" ||
+		target.Annotations[constant.SystemAccountRestoreTargetAnnotationKey] != "" {
+		return false
+	}
+	for key, value := range requestTargetLabels(request) {
+		if target.Labels[key] != value {
+			return false
+		}
+	}
+	for key, value := range requestTargetAnnotations(request) {
+		if target.Annotations[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func restoreRevision(request *corev1.Secret) (string, error) {
+	targetName := request.Annotations[constant.SystemAccountRestoreTargetAnnotationKey]
+	if targetName == "" {
+		return "", fmt.Errorf("system account restore request %s/%s has no target", request.Namespace, request.Name)
+	}
+	controller := metav1.GetControllerOf(request)
+	if controller == nil {
+		return "", fmt.Errorf("system account restore request %s/%s has no controller owner", request.Namespace, request.Name)
+	}
+	payload := restoreRequestRevisionPayload{
+		Namespace:  request.Namespace,
+		TargetName: targetName,
+		Type:       request.Type,
+		Immutable:  request.Immutable,
+		Data:       request.Data,
+		Controller: restoreRequestControllerIdentity{
+			APIVersion: controller.APIVersion,
+			Kind:       controller.Kind,
+			Name:       controller.Name,
+			UID:        controller.UID,
+		},
+	}
+	serialized, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("serialize system account restore request %s/%s: %w", request.Namespace, request.Name, err)
+	}
+	digest := sha256.Sum256(serialized)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+// ReconcileRestoreRequests lets the Apps owner converge account Secret restore
+// requests. The caller owns all target mutations, finalizer handling, and
+// delete/recreate operations; the request writer never performs them.
+//
+// A request is a Secret selected by SystemAccountRestoreRequestLabelKey,
+// controlled by the target Component or Cluster, and sealed by
+// SystemAccountRestoreRevisionAnnotationKey. Apps keeps the request until it
+// has copied that revision and the requested credentials to an owned target.
+// This makes the target revision the commit point and the request the durable
+// retry state across delete/create races.
+func ReconcileRestoreRequests(ctx context.Context,
+	graphCli model.GraphClient,
+	dag *graph.DAG,
+	owner client.Object,
+	ownedFinalizer string) (bool, error) {
+	requests := &corev1.SecretList{}
+	if err := graphCli.List(ctx, requests,
+		client.InNamespace(owner.GetNamespace()),
+		client.MatchingLabels{constant.SystemAccountRestoreRequestLabelKey: "true"}); err != nil {
+		return false, err
+	}
+	slices.SortFunc(requests.Items, func(a, b corev1.Secret) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+	handled := false
+	seenTargets := map[string]string{}
+	for i := range requests.Items {
+		request := &requests.Items[i]
+		targetName := request.Annotations[constant.SystemAccountRestoreTargetAnnotationKey]
+		if !metav1.IsControlledBy(request, owner) {
+			continue
+		}
+		handled = true
+		if err := ValidateRestoreRequest(request); err != nil {
+			return true, err
+		}
+		if previous, ok := seenTargets[targetName]; ok {
+			return true, fmt.Errorf("multiple system account restore requests %s and %s target %s/%s",
+				previous, request.Name, request.Namespace, targetName)
+		}
+		seenTargets[targetName] = request.Name
+		if err := reconcileRestoreRequest(ctx, graphCli, dag, owner, ownedFinalizer, request, targetName); err != nil {
+			return true, err
+		}
+	}
+	if handled {
+		return true, intctrlutil.NewRequeueError(restoreRequestRequeueAfter,
+			fmt.Sprintf("waiting for system account restore requests owned by %s/%s", owner.GetNamespace(), owner.GetName()))
+	}
+	return handled, nil
+}
+
+func reconcileRestoreRequest(ctx context.Context,
+	graphCli model.GraphClient,
+	dag *graph.DAG,
+	owner client.Object,
+	ownedFinalizer string,
+	request *corev1.Secret,
+	targetName string) error {
+	if !request.DeletionTimestamp.IsZero() {
+		return nil
+	}
+
+	target := &corev1.Secret{}
+	key := client.ObjectKey{Namespace: request.Namespace, Name: targetName}
+	if err := graphCli.Get(ctx, key, target); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+		desired, err := desiredTarget(request, owner, ownedFinalizer)
+		if err != nil {
+			return err
+		}
+		graphCli.Create(dag, desired)
+		return nil
+	}
+
+	expectedOwner := metav1.GetControllerOf(request)
+	if expectedOwner == nil {
+		return fmt.Errorf("system account restore request %s/%s has no controller owner", request.Namespace, request.Name)
+	}
+	if !hasOwnerReference(target, expectedOwner) {
+		if len(target.OwnerReferences) > 0 || !target.DeletionTimestamp.IsZero() {
+			return fmt.Errorf("system account restore target %s is not owned by %s %s",
+				key, expectedOwner.Kind, expectedOwner.Name)
+		}
+		adopted := target.DeepCopy()
+		if err := intctrlutil.SetOwnership(owner, adopted, model.GetScheme(), ownedFinalizer); err != nil {
+			return err
+		}
+		graphCli.Update(dag, target, adopted)
+		return nil
+	}
+
+	if !target.DeletionTimestamp.IsZero() {
+		if controllerutil.ContainsFinalizer(target, ownedFinalizer) {
+			updated := target.DeepCopy()
+			controllerutil.RemoveFinalizer(updated, ownedFinalizer)
+			graphCli.Update(dag, target, updated)
+		}
+		return nil
+	}
+
+	desired := target.DeepCopy()
+	desired.Type = request.Type
+	desired.Immutable = request.Immutable
+	desired.Data = maps.Clone(request.Data)
+	mergeStringMap(requestTargetLabels(request), &desired.Labels)
+	delete(desired.Labels, constant.SystemAccountRestoreRequestLabelKey)
+	mergeStringMap(requestTargetAnnotations(request), &desired.Annotations)
+	delete(desired.Annotations, constant.SystemAccountRestoreTargetAnnotationKey)
+	if err := intctrlutil.SetOwnership(owner, desired, model.GetScheme(), ownedFinalizer); err != nil {
+		return err
+	}
+	if reflect.DeepEqual(target, desired) {
+		if controllerutil.ContainsFinalizer(request, ownedFinalizer) {
+			updated := request.DeepCopy()
+			controllerutil.RemoveFinalizer(updated, ownedFinalizer)
+			graphCli.Update(dag, request, updated)
+		} else {
+			graphCli.Delete(dag, request)
+		}
+		return nil
+	}
+	if target.Immutable != nil && *target.Immutable &&
+		(!reflect.DeepEqual(target.Data, desired.Data) ||
+			!reflect.DeepEqual(target.Immutable, desired.Immutable) ||
+			target.Type != desired.Type) {
+		graphCli.Delete(dag, target)
+		return nil
+	}
+	graphCli.Update(dag, target, desired)
+	return nil
+}
+
+func desiredTarget(request *corev1.Secret, owner client.Object, ownedFinalizer string) (*corev1.Secret, error) {
+	targetName := request.Annotations[constant.SystemAccountRestoreTargetAnnotationKey]
+	if targetName == "" {
+		return nil, fmt.Errorf("system account restore request %s/%s has no target", request.Namespace, request.Name)
+	}
+	annotations := maps.Clone(request.Annotations)
+	delete(annotations, constant.SystemAccountRestoreTargetAnnotationKey)
+	target := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   request.Namespace,
+			Name:        targetName,
+			Labels:      requestTargetLabels(request),
+			Annotations: annotations,
+		},
+		Immutable: request.Immutable,
+		Type:      request.Type,
+		Data:      maps.Clone(request.Data),
+	}
+	if err := intctrlutil.SetOwnership(owner, target, model.GetScheme(), ownedFinalizer); err != nil {
+		return nil, err
+	}
+	return target, nil
+}
+
+func requestTargetLabels(request *corev1.Secret) map[string]string {
+	labels := maps.Clone(request.Labels)
+	delete(labels, constant.SystemAccountRestoreRequestLabelKey)
+	return labels
+}
+
+func requestTargetAnnotations(request *corev1.Secret) map[string]string {
+	annotations := maps.Clone(request.Annotations)
+	delete(annotations, constant.SystemAccountRestoreTargetAnnotationKey)
+	return annotations
+}
+
+func sameControllerIdentity(a, b *metav1.OwnerReference) bool {
+	return a != nil && b != nil &&
+		a.APIVersion == b.APIVersion &&
+		a.Kind == b.Kind &&
+		a.Name == b.Name &&
+		a.UID == b.UID
+}
+
+func hasOwnerReference(object client.Object, expected *metav1.OwnerReference) bool {
+	return expected != nil && slices.ContainsFunc(object.GetOwnerReferences(), func(actual metav1.OwnerReference) bool {
+		return actual.APIVersion == expected.APIVersion &&
+			actual.Kind == expected.Kind &&
+			actual.Name == expected.Name &&
+			actual.UID == expected.UID
+	})
+}
+
+func mergeStringMap(from map[string]string, to *map[string]string) {
+	if len(from) == 0 {
+		return
+	}
+	if *to == nil {
+		*to = map[string]string{}
+	}
+	for key, value := range from {
+		(*to)[key] = value
+	}
+}

--- a/pkg/controller/systemaccount/restore_test.go
+++ b/pkg/controller/systemaccount/restore_test.go
@@ -1,0 +1,347 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package systemaccount
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/graph"
+	"github.com/apecloud/kubeblocks/pkg/controller/model"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+)
+
+func TestReconcileRestoreRequestsKeepsFinalizerOwnership(t *testing.T) {
+	registerModelScheme(t)
+	testCases := []struct {
+		name      string
+		owner     client.Object
+		finalizer string
+	}{
+		{
+			name: "Component owner",
+			owner: &appsv1.Component{
+				TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Component"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster-mysql", UID: types.UID("component-uid")},
+			},
+			finalizer: constant.DBComponentFinalizerName,
+		},
+		{
+			name: "Cluster owner",
+			owner: &appsv1.Cluster{
+				TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Cluster"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster", UID: types.UID("cluster-uid")},
+			},
+			finalizer: constant.DBClusterFinalizerName,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, corev1.AddToScheme(scheme))
+			require.NoError(t, appsv1.AddToScheme(scheme))
+			deletionTime := metav1.Now()
+			target := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:         "default",
+					Name:              "cluster-mysql-root",
+					DeletionTimestamp: &deletionTime,
+					Finalizers:        []string{testCase.finalizer, "another.example.io/finalizer"},
+				},
+				Immutable: boolPtr(true),
+				Data: map[string][]byte{
+					constant.AccountNameForSecret:   []byte("root"),
+					constant.AccountPasswdForSecret: []byte("old-password"),
+				},
+			}
+			request := newTestRestoreRequest(target.Name)
+			require.NoError(t, controllerutil.SetControllerReference(testCase.owner, target, scheme))
+			require.NoError(t, controllerutil.SetControllerReference(testCase.owner, request, scheme))
+			require.NoError(t, SetRestoreRevision(request))
+			graphCli := model.NewGraphClient(fake.NewClientBuilder().WithScheme(scheme).WithObjects(target, request).Build())
+			dag := graph.NewDAG()
+			graphCli.Root(dag, testCase.owner.DeepCopyObject().(client.Object), testCase.owner, model.ActionStatusPtr())
+
+			handled, err := ReconcileRestoreRequests(context.Background(), graphCli, dag, testCase.owner, testCase.finalizer)
+
+			require.True(t, intctrlutil.IsRequeueError(err), err)
+			require.True(t, handled)
+			require.True(t, graphCli.IsAction(dag, target, model.ActionUpdatePtr()))
+			vertex := graphCli.FindMatchedVertex(dag, target).(*model.ObjectVertex)
+			updated := vertex.Obj.(*corev1.Secret)
+			require.NotContains(t, updated.Finalizers, testCase.finalizer)
+			require.Contains(t, updated.Finalizers, "another.example.io/finalizer")
+		})
+	}
+}
+
+func TestReconcileRestoreRequestsCreatesTargetBeforeDeletingRequest(t *testing.T) {
+	registerModelScheme(t)
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	owner := &appsv1.Component{
+		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Component"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster-mysql", UID: types.UID("component-uid")},
+	}
+	request := newTestRestoreRequest("cluster-mysql-root")
+	require.NoError(t, controllerutil.SetControllerReference(owner, request, scheme))
+	require.NoError(t, SetRestoreRevision(request))
+	graphCli := model.NewGraphClient(fake.NewClientBuilder().WithScheme(scheme).WithObjects(request).Build())
+	dag := graph.NewDAG()
+	graphCli.Root(dag, owner.DeepCopy(), owner, model.ActionStatusPtr())
+
+	handled, err := ReconcileRestoreRequests(context.Background(), graphCli, dag, owner, constant.DBComponentFinalizerName)
+
+	require.True(t, intctrlutil.IsRequeueError(err), err)
+	require.True(t, handled)
+	objects := graphCli.FindAll(dag, &corev1.Secret{})
+	require.Len(t, objects, 1)
+	target := objects[0].(*corev1.Secret)
+	require.Equal(t, "cluster-mysql-root", target.Name)
+	require.True(t, graphCli.IsAction(dag, target, model.ActionCreatePtr()))
+	require.Contains(t, target.Finalizers, constant.DBComponentFinalizerName)
+	require.Equal(t, []byte("new-password"), target.Data[constant.AccountPasswdForSecret])
+	require.NotContains(t, target.Annotations, constant.SystemAccountRestoreTargetAnnotationKey)
+	require.NotContains(t, target.Labels, constant.SystemAccountRestoreRequestLabelKey)
+	require.Equal(t, request.Annotations[constant.SystemAccountRestoreRevisionAnnotationKey],
+		target.Annotations[constant.SystemAccountRestoreRevisionAnnotationKey])
+	require.False(t, graphCli.IsAction(dag, request, model.ActionDeletePtr()), "request must survive the target-create commit")
+}
+
+func TestReconcileRestoreRequestsDeletesImmutableTargetWithoutReleasingFinalizer(t *testing.T) {
+	registerModelScheme(t)
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	owner := &appsv1.Component{
+		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Component"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster-mysql", UID: types.UID("component-uid")},
+	}
+	request := newTestRestoreRequest("cluster-mysql-root")
+	request.Immutable = nil
+	target := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  "default",
+			Name:       "cluster-mysql-root",
+			Finalizers: []string{constant.DBComponentFinalizerName},
+		},
+		Immutable: boolPtr(true),
+		Type:      corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			constant.AccountNameForSecret:   []byte("root"),
+			constant.AccountPasswdForSecret: []byte("old-password"),
+		},
+	}
+	require.NoError(t, controllerutil.SetControllerReference(owner, request, scheme))
+	require.NoError(t, controllerutil.SetOwnerReference(owner, target, scheme))
+	require.NoError(t, SetRestoreRevision(request))
+	graphCli := model.NewGraphClient(fake.NewClientBuilder().WithScheme(scheme).WithObjects(target, request).Build())
+	dag := graph.NewDAG()
+	graphCli.Root(dag, owner.DeepCopy(), owner, model.ActionStatusPtr())
+
+	handled, err := ReconcileRestoreRequests(context.Background(), graphCli, dag, owner, constant.DBComponentFinalizerName)
+
+	require.True(t, intctrlutil.IsRequeueError(err), err)
+	require.True(t, handled)
+	require.True(t, graphCli.IsAction(dag, target, model.ActionDeletePtr()))
+	require.Contains(t, target.Finalizers, constant.DBComponentFinalizerName,
+		"the owner releases its finalizer only after deletion is observed")
+	require.False(t, graphCli.IsAction(dag, request, model.ActionDeletePtr()))
+}
+
+func TestReconcileRestoreRequestsAdoptsTargetBeforeMutatingIt(t *testing.T) {
+	registerModelScheme(t)
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	owner := &appsv1.Component{
+		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Component"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster-mysql", UID: types.UID("component-uid")},
+	}
+	request := newTestRestoreRequest("cluster-mysql-root")
+	request.Immutable = nil
+	target := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster-mysql-root"},
+		Type:       corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			constant.AccountNameForSecret:   []byte("root"),
+			constant.AccountPasswdForSecret: []byte("old-password"),
+		},
+	}
+	require.NoError(t, controllerutil.SetControllerReference(owner, request, scheme))
+	require.NoError(t, SetRestoreRevision(request))
+	graphCli := model.NewGraphClient(fake.NewClientBuilder().WithScheme(scheme).WithObjects(target, request).Build())
+	dag := graph.NewDAG()
+	graphCli.Root(dag, owner.DeepCopy(), owner, model.ActionStatusPtr())
+
+	handled, err := ReconcileRestoreRequests(context.Background(), graphCli, dag, owner, constant.DBComponentFinalizerName)
+
+	require.True(t, intctrlutil.IsRequeueError(err), err)
+	require.True(t, handled)
+	require.True(t, graphCli.IsAction(dag, target, model.ActionUpdatePtr()))
+	updated := graphCli.FindMatchedVertex(dag, target).(*model.ObjectVertex).Obj.(*corev1.Secret)
+	require.Equal(t, []byte("old-password"), updated.Data[constant.AccountPasswdForSecret],
+		"the ownership commit must precede the credential mutation")
+	require.True(t, metav1.IsControlledBy(updated, owner))
+	require.Contains(t, updated.Finalizers, constant.DBComponentFinalizerName)
+}
+
+func TestReconcileRestoreRequestsDoesNotReleaseAnotherOwnersFinalizer(t *testing.T) {
+	registerModelScheme(t)
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	owner := &appsv1.Component{
+		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Component"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster-mysql", UID: types.UID("component-uid")},
+	}
+	otherOwner := &appsv1.Component{
+		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Component"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "other-mysql", UID: types.UID("other-component-uid")},
+	}
+	request := newTestRestoreRequest("cluster-mysql-root")
+	deletionTime := metav1.Now()
+	target := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+		Namespace:         "default",
+		Name:              "cluster-mysql-root",
+		DeletionTimestamp: &deletionTime,
+		Finalizers:        []string{constant.DBComponentFinalizerName},
+	}}
+	require.NoError(t, controllerutil.SetControllerReference(owner, request, scheme))
+	require.NoError(t, controllerutil.SetControllerReference(otherOwner, target, scheme))
+	require.NoError(t, SetRestoreRevision(request))
+	graphCli := model.NewGraphClient(fake.NewClientBuilder().WithScheme(scheme).WithObjects(target, request).Build())
+	dag := graph.NewDAG()
+	graphCli.Root(dag, owner.DeepCopy(), owner, model.ActionStatusPtr())
+
+	handled, err := ReconcileRestoreRequests(context.Background(), graphCli, dag, owner, constant.DBComponentFinalizerName)
+
+	require.ErrorContains(t, err, "is not owned")
+	require.True(t, handled)
+	require.False(t, graphCli.IsAction(dag, target, model.ActionUpdatePtr()))
+	require.Contains(t, target.Finalizers, constant.DBComponentFinalizerName)
+}
+
+func TestReconcileRestoreRequestsDeletesRequestOnlyAfterTargetConverges(t *testing.T) {
+	registerModelScheme(t)
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	owner := &appsv1.Cluster{
+		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Cluster"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster", UID: types.UID("cluster-uid")},
+	}
+	request := newTestRestoreRequest("cluster-shard-root")
+	target := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   "default",
+			Name:        "cluster-shard-root",
+			Labels:      map[string]string{"role": "root"},
+			Annotations: map[string]string{constant.SystemAccountProvisionedAnnotationKey: "true"},
+			Finalizers:  []string{constant.DBClusterFinalizerName},
+		},
+		Immutable: boolPtr(true),
+		Type:      corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			constant.AccountNameForSecret:   []byte("root"),
+			constant.AccountPasswdForSecret: []byte("new-password"),
+		},
+	}
+	require.NoError(t, controllerutil.SetControllerReference(owner, request, scheme))
+	require.NoError(t, controllerutil.SetControllerReference(owner, target, scheme))
+	require.NoError(t, SetRestoreRevision(request))
+	target.Annotations[constant.SystemAccountRestoreRevisionAnnotationKey] =
+		request.Annotations[constant.SystemAccountRestoreRevisionAnnotationKey]
+	graphCli := model.NewGraphClient(fake.NewClientBuilder().WithScheme(scheme).WithObjects(target, request).Build())
+	dag := graph.NewDAG()
+	graphCli.Root(dag, owner.DeepCopy(), owner, model.ActionStatusPtr())
+
+	handled, err := ReconcileRestoreRequests(context.Background(), graphCli, dag, owner, constant.DBClusterFinalizerName)
+
+	require.True(t, intctrlutil.IsRequeueError(err), err)
+	require.True(t, handled)
+	require.True(t, graphCli.IsAction(dag, request, model.ActionDeletePtr()))
+	require.False(t, graphCli.IsAction(dag, target, model.ActionUpdatePtr()))
+}
+
+func TestValidateRestoreRequestRejectsTamperedPayload(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	owner := &appsv1.Component{
+		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Component"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster-mysql", UID: types.UID("component-uid")},
+	}
+	request := newTestRestoreRequest("cluster-mysql-root")
+	require.NoError(t, controllerutil.SetControllerReference(owner, request, scheme))
+	require.NoError(t, SetRestoreRevision(request))
+	request.Labels["admission.example.io/injected"] = "true"
+	request.Annotations["admission.example.io/injected"] = "true"
+	require.NoError(t, ValidateRestoreRequest(request), "admission metadata is outside the sealed credential payload")
+	request.Data[constant.AccountPasswdForSecret] = []byte("tampered-password")
+
+	require.ErrorContains(t, ValidateRestoreRequest(request), "invalid revision")
+}
+
+func newTestRestoreRequest(targetName string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      RestoreRequestName("default", targetName),
+			Labels: map[string]string{
+				"role": "root",
+				constant.SystemAccountRestoreRequestLabelKey: "true",
+			},
+			Annotations: map[string]string{
+				constant.SystemAccountRestoreTargetAnnotationKey: targetName,
+				constant.SystemAccountProvisionedAnnotationKey:   "true",
+			},
+		},
+		Immutable: boolPtr(true),
+		Type:      corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			constant.AccountNameForSecret:   []byte("root"),
+			constant.AccountPasswdForSecret: []byte("new-password"),
+		},
+	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}
+
+func registerModelScheme(t *testing.T) {
+	t.Helper()
+	require.NoError(t, corev1.AddToScheme(model.GetScheme()))
+	require.NoError(t, appsv1.AddToScheme(model.GetScheme()))
+}

--- a/pkg/controller/systemaccount/restore_test.go
+++ b/pkg/controller/systemaccount/restore_test.go
@@ -39,309 +39,314 @@ import (
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 )
 
-func TestReconcileRestoreRequestsKeepsFinalizerOwnership(t *testing.T) {
-	registerModelScheme(t)
-	testCases := []struct {
-		name      string
-		owner     client.Object
-		finalizer string
-	}{
-		{
-			name: "Component owner",
-			owner: &appsv1.Component{
-				TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Component"},
-				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster-mysql", UID: types.UID("component-uid")},
-			},
-			finalizer: constant.DBComponentFinalizerName,
-		},
-		{
-			name: "Cluster owner",
-			owner: &appsv1.Cluster{
-				TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Cluster"},
-				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster", UID: types.UID("cluster-uid")},
-			},
-			finalizer: constant.DBClusterFinalizerName,
-		},
-	}
+func TestRestoreRequestPendingClaimsBeforeTargetMutation(t *testing.T) {
+	fixture := newRestoreStateFixture(t)
+	graphCli, dag := fixture.graph()
 
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			scheme := runtime.NewScheme()
-			require.NoError(t, corev1.AddToScheme(scheme))
-			require.NoError(t, appsv1.AddToScheme(scheme))
-			deletionTime := metav1.Now()
-			target := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace:         "default",
-					Name:              "cluster-mysql-root",
-					DeletionTimestamp: &deletionTime,
-					Finalizers:        []string{testCase.finalizer, "another.example.io/finalizer"},
-				},
-				Immutable: boolPtr(true),
-				Data: map[string][]byte{
-					constant.AccountNameForSecret:   []byte("root"),
-					constant.AccountPasswdForSecret: []byte("old-password"),
-				},
-			}
-			request := newTestRestoreRequest(target.Name)
-			require.NoError(t, controllerutil.SetControllerReference(testCase.owner, target, scheme))
-			require.NoError(t, controllerutil.SetControllerReference(testCase.owner, request, scheme))
-			require.NoError(t, SetRestoreRevision(request))
-			graphCli := model.NewGraphClient(fake.NewClientBuilder().WithScheme(scheme).WithObjects(target, request).Build())
-			dag := graph.NewDAG()
-			graphCli.Root(dag, testCase.owner.DeepCopyObject().(client.Object), testCase.owner, model.ActionStatusPtr())
+	handled, err := ReconcileRestoreRequests(context.Background(), graphCli, dag,
+		fixture.owner, constant.DBComponentFinalizerName, fixture.targetBuilder)
 
-			handled, err := ReconcileRestoreRequests(context.Background(), graphCli, dag, testCase.owner, testCase.finalizer)
-
-			require.True(t, intctrlutil.IsRequeueError(err), err)
-			require.True(t, handled)
-			require.True(t, graphCli.IsAction(dag, target, model.ActionUpdatePtr()))
-			vertex := graphCli.FindMatchedVertex(dag, target).(*model.ObjectVertex)
-			updated := vertex.Obj.(*corev1.Secret)
-			require.NotContains(t, updated.Finalizers, testCase.finalizer)
-			require.Contains(t, updated.Finalizers, "another.example.io/finalizer")
-		})
-	}
+	require.True(t, handled)
+	require.True(t, intctrlutil.IsRequeueError(err), err)
+	require.True(t, graphCli.IsAction(dag, fixture.request, model.ActionUpdatePtr()))
+	updated := graphCli.FindMatchedVertex(dag, fixture.request).(*model.ObjectVertex).Obj.(*corev1.Secret)
+	require.Equal(t, string(RestoreRequestPhaseClaimed),
+		updated.Annotations[RestoreRequestPhaseAnnotationKey])
+	require.Len(t, graphCli.FindAll(dag, &corev1.Secret{}), 1,
+		"claim round must not mutate the target")
 }
 
-func TestReconcileRestoreRequestsCreatesTargetBeforeDeletingRequest(t *testing.T) {
-	registerModelScheme(t)
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
-	require.NoError(t, appsv1.AddToScheme(scheme))
-	owner := &appsv1.Component{
-		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Component"},
-		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster-mysql", UID: types.UID("component-uid")},
-	}
-	request := newTestRestoreRequest("cluster-mysql-root")
-	require.NoError(t, controllerutil.SetControllerReference(owner, request, scheme))
-	require.NoError(t, SetRestoreRevision(request))
-	graphCli := model.NewGraphClient(fake.NewClientBuilder().WithScheme(scheme).WithObjects(request).Build())
-	dag := graph.NewDAG()
-	graphCli.Root(dag, owner.DeepCopy(), owner, model.ActionStatusPtr())
+func TestClaimedRestoreRequestCreatesAppsOwnedTarget(t *testing.T) {
+	fixture := newRestoreStateFixture(t)
+	fixture.request.Annotations[RestoreRequestPhaseAnnotationKey] = string(RestoreRequestPhaseClaimed)
+	graphCli, dag := fixture.graph()
 
-	handled, err := ReconcileRestoreRequests(context.Background(), graphCli, dag, owner, constant.DBComponentFinalizerName)
+	handled, err := ReconcileRestoreRequests(context.Background(), graphCli, dag,
+		fixture.owner, constant.DBComponentFinalizerName, fixture.targetBuilder)
 
-	require.True(t, intctrlutil.IsRequeueError(err), err)
 	require.True(t, handled)
-	objects := graphCli.FindAll(dag, &corev1.Secret{})
-	require.Len(t, objects, 1)
-	target := objects[0].(*corev1.Secret)
-	require.Equal(t, "cluster-mysql-root", target.Name)
+	require.True(t, intctrlutil.IsRequeueError(err), err)
+	target := findTargetVertex(t, graphCli, dag, fixture.request)
 	require.True(t, graphCli.IsAction(dag, target, model.ActionCreatePtr()))
-	require.Contains(t, target.Finalizers, constant.DBComponentFinalizerName)
 	require.Equal(t, []byte("new-password"), target.Data[constant.AccountPasswdForSecret])
-	require.NotContains(t, target.Annotations, constant.SystemAccountRestoreTargetAnnotationKey)
-	require.NotContains(t, target.Labels, constant.SystemAccountRestoreRequestLabelKey)
-	require.Equal(t, request.Annotations[constant.SystemAccountRestoreRevisionAnnotationKey],
-		target.Annotations[constant.SystemAccountRestoreRevisionAnnotationKey])
-	require.False(t, graphCli.IsAction(dag, request, model.ActionDeletePtr()), "request must survive the target-create commit")
-}
-
-func TestReconcileRestoreRequestsDeletesImmutableTargetWithoutReleasingFinalizer(t *testing.T) {
-	registerModelScheme(t)
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
-	require.NoError(t, appsv1.AddToScheme(scheme))
-	owner := &appsv1.Component{
-		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Component"},
-		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster-mysql", UID: types.UID("component-uid")},
-	}
-	request := newTestRestoreRequest("cluster-mysql-root")
-	request.Immutable = nil
-	target := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:  "default",
-			Name:       "cluster-mysql-root",
-			Finalizers: []string{constant.DBComponentFinalizerName},
-		},
-		Immutable: boolPtr(true),
-		Type:      corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			constant.AccountNameForSecret:   []byte("root"),
-			constant.AccountPasswdForSecret: []byte("old-password"),
-		},
-	}
-	require.NoError(t, controllerutil.SetControllerReference(owner, request, scheme))
-	require.NoError(t, controllerutil.SetOwnerReference(owner, target, scheme))
-	require.NoError(t, SetRestoreRevision(request))
-	graphCli := model.NewGraphClient(fake.NewClientBuilder().WithScheme(scheme).WithObjects(target, request).Build())
-	dag := graph.NewDAG()
-	graphCli.Root(dag, owner.DeepCopy(), owner, model.ActionStatusPtr())
-
-	handled, err := ReconcileRestoreRequests(context.Background(), graphCli, dag, owner, constant.DBComponentFinalizerName)
-
-	require.True(t, intctrlutil.IsRequeueError(err), err)
-	require.True(t, handled)
-	require.True(t, graphCli.IsAction(dag, target, model.ActionDeletePtr()))
-	require.Contains(t, target.Finalizers, constant.DBComponentFinalizerName,
-		"the owner releases its finalizer only after deletion is observed")
-	require.False(t, graphCli.IsAction(dag, request, model.ActionDeletePtr()))
-}
-
-func TestReconcileRestoreRequestsAdoptsTargetBeforeMutatingIt(t *testing.T) {
-	registerModelScheme(t)
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
-	require.NoError(t, appsv1.AddToScheme(scheme))
-	owner := &appsv1.Component{
-		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Component"},
-		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster-mysql", UID: types.UID("component-uid")},
-	}
-	request := newTestRestoreRequest("cluster-mysql-root")
-	request.Immutable = nil
-	target := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster-mysql-root"},
-		Type:       corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			constant.AccountNameForSecret:   []byte("root"),
-			constant.AccountPasswdForSecret: []byte("old-password"),
-		},
-	}
-	require.NoError(t, controllerutil.SetControllerReference(owner, request, scheme))
-	require.NoError(t, SetRestoreRevision(request))
-	graphCli := model.NewGraphClient(fake.NewClientBuilder().WithScheme(scheme).WithObjects(target, request).Build())
-	dag := graph.NewDAG()
-	graphCli.Root(dag, owner.DeepCopy(), owner, model.ActionStatusPtr())
-
-	handled, err := ReconcileRestoreRequests(context.Background(), graphCli, dag, owner, constant.DBComponentFinalizerName)
-
-	require.True(t, intctrlutil.IsRequeueError(err), err)
-	require.True(t, handled)
-	require.True(t, graphCli.IsAction(dag, target, model.ActionUpdatePtr()))
-	updated := graphCli.FindMatchedVertex(dag, target).(*model.ObjectVertex).Obj.(*corev1.Secret)
-	require.Equal(t, []byte("old-password"), updated.Data[constant.AccountPasswdForSecret],
-		"the ownership commit must precede the credential mutation")
-	require.True(t, metav1.IsControlledBy(updated, owner))
-	require.Contains(t, updated.Finalizers, constant.DBComponentFinalizerName)
-}
-
-func TestReconcileRestoreRequestsDoesNotReleaseAnotherOwnersFinalizer(t *testing.T) {
-	registerModelScheme(t)
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
-	require.NoError(t, appsv1.AddToScheme(scheme))
-	owner := &appsv1.Component{
-		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Component"},
-		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster-mysql", UID: types.UID("component-uid")},
-	}
-	otherOwner := &appsv1.Component{
-		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Component"},
-		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "other-mysql", UID: types.UID("other-component-uid")},
-	}
-	request := newTestRestoreRequest("cluster-mysql-root")
-	deletionTime := metav1.Now()
-	target := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
-		Namespace:         "default",
-		Name:              "cluster-mysql-root",
-		DeletionTimestamp: &deletionTime,
-		Finalizers:        []string{constant.DBComponentFinalizerName},
-	}}
-	require.NoError(t, controllerutil.SetControllerReference(owner, request, scheme))
-	require.NoError(t, controllerutil.SetControllerReference(otherOwner, target, scheme))
-	require.NoError(t, SetRestoreRevision(request))
-	graphCli := model.NewGraphClient(fake.NewClientBuilder().WithScheme(scheme).WithObjects(target, request).Build())
-	dag := graph.NewDAG()
-	graphCli.Root(dag, owner.DeepCopy(), owner, model.ActionStatusPtr())
-
-	handled, err := ReconcileRestoreRequests(context.Background(), graphCli, dag, owner, constant.DBComponentFinalizerName)
-
-	require.ErrorContains(t, err, "is not owned")
-	require.True(t, handled)
-	require.False(t, graphCli.IsAction(dag, target, model.ActionUpdatePtr()))
+	require.Equal(t, "true", target.Annotations[constant.SystemAccountProvisionedAnnotationKey])
+	require.Equal(t, fixture.request.Name, target.Annotations[RestoreRequestNameAnnotationKey])
+	require.Equal(t, string(fixture.request.UID), target.Annotations[RestoreRequestUIDAnnotationKey])
 	require.Contains(t, target.Finalizers, constant.DBComponentFinalizerName)
+	require.NotContains(t, target.Labels, constant.SystemAccountRestoreRequestLabelKey)
 }
 
-func TestReconcileRestoreRequestsDeletesRequestOnlyAfterTargetConverges(t *testing.T) {
-	registerModelScheme(t)
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
-	require.NoError(t, appsv1.AddToScheme(scheme))
-	owner := &appsv1.Cluster{
-		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Cluster"},
-		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster", UID: types.UID("cluster-uid")},
-	}
-	request := newTestRestoreRequest("cluster-shard-root")
-	target := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:   "default",
-			Name:        "cluster-shard-root",
-			Labels:      map[string]string{"role": "root"},
-			Annotations: map[string]string{constant.SystemAccountProvisionedAnnotationKey: "true"},
-			Finalizers:  []string{constant.DBClusterFinalizerName},
-		},
-		Immutable: boolPtr(true),
-		Type:      corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			constant.AccountNameForSecret:   []byte("root"),
-			constant.AccountPasswdForSecret: []byte("new-password"),
-		},
-	}
-	require.NoError(t, controllerutil.SetControllerReference(owner, request, scheme))
-	require.NoError(t, controllerutil.SetControllerReference(owner, target, scheme))
-	require.NoError(t, SetRestoreRevision(request))
-	target.Annotations[constant.SystemAccountRestoreRevisionAnnotationKey] =
-		request.Annotations[constant.SystemAccountRestoreRevisionAnnotationKey]
-	graphCli := model.NewGraphClient(fake.NewClientBuilder().WithScheme(scheme).WithObjects(target, request).Build())
-	dag := graph.NewDAG()
-	graphCli.Root(dag, owner.DeepCopy(), owner, model.ActionStatusPtr())
+func TestClaimedRestoreRequestLeavesExactTargetForLifecycleCommit(t *testing.T) {
+	fixture := newRestoreStateFixture(t)
+	fixture.request.Annotations[RestoreRequestPhaseAnnotationKey] = string(RestoreRequestPhaseClaimed)
+	target, err := fixture.targetBuilder(fixture.intent)
+	require.NoError(t, err)
+	target.UID = types.UID("target-uid")
+	target.ResourceVersion = "7"
+	applyTargetReceipt(target, fixture.request)
+	revision, err := TargetCommitRevision(target, constant.DBComponentFinalizerName)
+	require.NoError(t, err)
+	target.Annotations[TargetCommitRevisionAnnotationKey] = revision
+	fixture.objects = append(fixture.objects, target)
+	graphCli, dag := fixture.graph()
 
-	handled, err := ReconcileRestoreRequests(context.Background(), graphCli, dag, owner, constant.DBClusterFinalizerName)
+	handled, err := ReconcileRestoreRequests(context.Background(), graphCli, dag,
+		fixture.owner, constant.DBComponentFinalizerName, fixture.targetBuilder)
 
-	require.True(t, intctrlutil.IsRequeueError(err), err)
 	require.True(t, handled)
-	require.True(t, graphCli.IsAction(dag, request, model.ActionDeletePtr()))
+	require.True(t, intctrlutil.IsRequeueError(err), err)
+	require.False(t, graphCli.IsAction(dag, fixture.request, model.ActionUpdatePtr()),
+		"the target transformer must not commit before the lifecycle controller rechecks the operation")
+	require.Equal(t, string(RestoreRequestPhaseClaimed),
+		fixture.request.Annotations[RestoreRequestPhaseAnnotationKey])
+	require.Equal(t, revision, target.Annotations[TargetCommitRevisionAnnotationKey])
+}
+
+func TestClaimedRestoreRequestDeletesImmutableTargetWithObservedUID(t *testing.T) {
+	fixture := newRestoreStateFixture(t)
+	fixture.request.Annotations[RestoreRequestPhaseAnnotationKey] = string(RestoreRequestPhaseClaimed)
+	target, err := fixture.targetBuilder(fixture.intent)
+	require.NoError(t, err)
+	immutable := true
+	target.Immutable = &immutable
+	target.UID = types.UID("old-target-uid")
+	target.ResourceVersion = "8"
+	target.Data[constant.AccountPasswdForSecret] = []byte("old-password")
+	fixture.objects = append(fixture.objects, target)
+	graphCli, dag := fixture.graph()
+
+	handled, err := ReconcileRestoreRequests(context.Background(), graphCli, dag,
+		fixture.owner, constant.DBComponentFinalizerName, fixture.targetBuilder)
+
+	require.True(t, handled)
+	require.True(t, intctrlutil.IsRequeueError(err), err)
+	require.True(t, graphCli.IsAction(dag, target, model.ActionDeletePtr()))
+	vertex := graphCli.FindMatchedVertex(dag, target).(*model.ObjectVertex)
+	require.NotNil(t, vertex.DeletePreconditions)
+	require.NotNil(t, vertex.DeletePreconditions.UID)
+	require.Equal(t, target.UID, *vertex.DeletePreconditions.UID)
+	require.False(t, graphCli.IsAction(dag, fixture.request, model.ActionUpdatePtr()))
+}
+
+func TestClaimedRestoreRequestPreservesUnownedTargetMetadata(t *testing.T) {
+	fixture := newRestoreStateFixture(t)
+	fixture.request.Annotations[RestoreRequestPhaseAnnotationKey] = string(RestoreRequestPhaseClaimed)
+	target, err := fixture.targetBuilder(fixture.intent)
+	require.NoError(t, err)
+	target.UID = "target-uid"
+	target.ResourceVersion = "8"
+	target.Data[constant.AccountPasswdForSecret] = []byte("old-password")
+	target.Labels["external-label"] = "keep"
+	target.Annotations["external-annotation"] = "keep"
+	target.Finalizers = append(target.Finalizers, "external.example.io/protection")
+	notController := false
+	target.OwnerReferences = append(target.OwnerReferences, metav1.OwnerReference{
+		APIVersion: "example.io/v1",
+		Kind:       "Observer",
+		Name:       "observer",
+		UID:        "observer-uid",
+		Controller: &notController,
+	})
+	fixture.objects = append(fixture.objects, target)
+	graphCli, dag := fixture.graph()
+
+	handled, reconcileErr := ReconcileRestoreRequests(context.Background(), graphCli, dag,
+		fixture.owner, constant.DBComponentFinalizerName, fixture.targetBuilder)
+
+	require.True(t, handled)
+	require.True(t, intctrlutil.IsRequeueError(reconcileErr), reconcileErr)
+	vertex := graphCli.FindMatchedVertex(dag, target).(*model.ObjectVertex)
+	require.Equal(t, model.ActionUpdatePtr(), vertex.Action)
+	updated := vertex.Obj.(*corev1.Secret)
+	require.Equal(t, "keep", updated.Labels["external-label"])
+	require.Equal(t, "keep", updated.Annotations["external-annotation"])
+	require.Contains(t, updated.Finalizers, "external.example.io/protection")
+	require.Contains(t, updated.OwnerReferences, target.OwnerReferences[1])
+	require.Equal(t, []byte("new-password"), updated.Data[constant.AccountPasswdForSecret])
+}
+
+func TestDeletingRequestFailsWithoutTargetMutation(t *testing.T) {
+	fixture := newRestoreStateFixture(t)
+	fixture.request.Annotations[RestoreRequestPhaseAnnotationKey] = string(RestoreRequestPhaseClaimed)
+	now := metav1.Now()
+	fixture.request.DeletionTimestamp = &now
+	graphCli, dag := fixture.graph()
+
+	handled, err := ReconcileRestoreRequests(context.Background(), graphCli, dag,
+		fixture.owner, constant.DBComponentFinalizerName, fixture.targetBuilder)
+
+	require.True(t, handled)
+	require.True(t, intctrlutil.IsRequeueError(err), err)
+	updated := graphCli.FindMatchedVertex(dag, fixture.request).(*model.ObjectVertex).Obj.(*corev1.Secret)
+	require.Equal(t, string(RestoreRequestPhaseFailed),
+		updated.Annotations[RestoreRequestPhaseAnnotationKey])
+	require.Equal(t, "RequestDeletionRequested",
+		updated.Annotations[RestoreRequestReasonAnnotationKey])
+	require.Len(t, graphCli.FindAll(dag, &corev1.Secret{}), 1)
+}
+
+func TestUnavailableTargetSemanticFailsPendingRequest(t *testing.T) {
+	fixture := newRestoreStateFixture(t)
+	graphCli, dag := fixture.graph()
+
+	handled, err := ReconcileRestoreRequests(context.Background(), graphCli, dag,
+		fixture.owner, constant.DBComponentFinalizerName,
+		func(CredentialIntent) (*corev1.Secret, error) {
+			return nil, context.Canceled
+		})
+
+	require.True(t, handled)
+	require.True(t, intctrlutil.IsRequeueError(err), err)
+	updated := graphCli.FindMatchedVertex(dag, fixture.request).(*model.ObjectVertex).Obj.(*corev1.Secret)
+	require.Equal(t, string(RestoreRequestPhaseFailed),
+		updated.Annotations[RestoreRequestPhaseAnnotationKey])
+	require.Equal(t, "TargetSemanticUnavailable",
+		updated.Annotations[RestoreRequestReasonAnnotationKey])
+}
+
+func TestClaimedRestoreRequestRejectsMatchingNonControllerOwnerReference(t *testing.T) {
+	fixture := newRestoreStateFixture(t)
+	fixture.request.Annotations[RestoreRequestPhaseAnnotationKey] = string(RestoreRequestPhaseClaimed)
+	target, err := fixture.targetBuilder(fixture.intent)
+	require.NoError(t, err)
+	notController := false
+	target.OwnerReferences[0].Controller = &notController
+	controller := true
+	target.OwnerReferences = append(target.OwnerReferences, metav1.OwnerReference{
+		APIVersion: appsv1.GroupVersion.String(),
+		Kind:       appsv1.ComponentKind,
+		Name:       "foreign-component",
+		UID:        "foreign-component-uid",
+		Controller: &controller,
+	})
+	fixture.objects = append(fixture.objects, target)
+	graphCli, dag := fixture.graph()
+
+	handled, reconcileErr := ReconcileRestoreRequests(context.Background(), graphCli, dag,
+		fixture.owner, constant.DBComponentFinalizerName, fixture.targetBuilder)
+
+	require.True(t, handled)
+	require.True(t, intctrlutil.IsRequeueError(reconcileErr), reconcileErr)
+	updated := graphCli.FindMatchedVertex(dag, fixture.request).(*model.ObjectVertex).Obj.(*corev1.Secret)
+	require.Equal(t, string(RestoreRequestPhaseFailed),
+		updated.Annotations[RestoreRequestPhaseAnnotationKey])
+	require.Equal(t, TargetOwnerUnavailableReason,
+		updated.Annotations[RestoreRequestReasonAnnotationKey])
 	require.False(t, graphCli.IsAction(dag, target, model.ActionUpdatePtr()))
 }
 
-func TestValidateRestoreRequestRejectsTamperedPayload(t *testing.T) {
+func TestReconcileRestoreRequestsIgnoresDamagedForeignRequest(t *testing.T) {
+	fixture := newRestoreStateFixture(t)
+	foreignIntent := fixture.intent
+	foreignIntent.Target.Owner = ObjectIdentity{
+		APIVersion: appsv1.GroupVersion.String(),
+		Kind:       appsv1.ComponentKind,
+		Namespace:  fixture.owner.Namespace,
+		Name:       "foreign-component",
+		UID:        "foreign-component-uid",
+	}
+	foreign, err := BuildRestoreRequest(foreignIntent)
+	require.NoError(t, err)
+	foreign.UID = "foreign-request-uid"
+	foreign.ResourceVersion = "1"
+	foreign.Annotations[LogicalTargetDigestAnnotationKey] = "damaged"
+	fixture.objects = []client.Object{foreign}
+	graphCli, dag := fixture.graph()
+
+	handled, reconcileErr := ReconcileRestoreRequests(context.Background(), graphCli, dag,
+		fixture.owner, constant.DBComponentFinalizerName, fixture.targetBuilder)
+
+	require.NoError(t, reconcileErr)
+	require.False(t, handled)
+	require.Empty(t, graphCli.FindAll(dag, &corev1.Secret{}))
+}
+
+type restoreStateFixture struct {
+	t       *testing.T
+	scheme  *runtime.Scheme
+	root    *appsv1.Cluster
+	owner   *appsv1.Component
+	intent  CredentialIntent
+	request *corev1.Secret
+	objects []client.Object
+}
+
+func newRestoreStateFixture(t *testing.T) *restoreStateFixture {
+	t.Helper()
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 	require.NoError(t, appsv1.AddToScheme(scheme))
-	owner := &appsv1.Component{
-		TypeMeta:   metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Component"},
-		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster-mysql", UID: types.UID("component-uid")},
-	}
-	request := newTestRestoreRequest("cluster-mysql-root")
-	require.NoError(t, controllerutil.SetControllerReference(owner, request, scheme))
-	require.NoError(t, SetRestoreRevision(request))
-	request.Labels["admission.example.io/injected"] = "true"
-	request.Annotations["admission.example.io/injected"] = "true"
-	require.NoError(t, ValidateRestoreRequest(request), "admission metadata is outside the sealed credential payload")
-	request.Data[constant.AccountPasswdForSecret] = []byte("tampered-password")
-
-	require.ErrorContains(t, ValidateRestoreRequest(request), "invalid revision")
-}
-
-func newTestRestoreRequest(targetName string) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      RestoreRequestName("default", targetName),
-			Labels: map[string]string{
-				"role": "root",
-				constant.SystemAccountRestoreRequestLabelKey: "true",
-			},
-			Annotations: map[string]string{
-				constant.SystemAccountRestoreTargetAnnotationKey: targetName,
-				constant.SystemAccountProvisionedAnnotationKey:   "true",
-			},
-		},
-		Immutable: boolPtr(true),
-		Type:      corev1.SecretTypeOpaque,
-		Data: map[string][]byte{
-			constant.AccountNameForSecret:   []byte("root"),
-			constant.AccountPasswdForSecret: []byte("new-password"),
-		},
-	}
-}
-
-func boolPtr(value bool) *bool {
-	return &value
-}
-
-func registerModelScheme(t *testing.T) {
-	t.Helper()
 	require.NoError(t, corev1.AddToScheme(model.GetScheme()))
 	require.NoError(t, appsv1.AddToScheme(model.GetScheme()))
+	root := &appsv1.Cluster{
+		TypeMeta: metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Cluster"},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "cluster",
+			UID:       types.UID("cluster-uid"),
+		},
+	}
+	owner := &appsv1.Component{
+		TypeMeta: metav1.TypeMeta{APIVersion: appsv1.GroupVersion.String(), Kind: "Component"},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "cluster-mysql",
+			UID:       types.UID("component-uid"),
+		},
+	}
+	intent := testCredentialIntent()
+	request, err := BuildRestoreRequest(intent)
+	require.NoError(t, err)
+	request.UID = types.UID("request-uid")
+	request.ResourceVersion = "3"
+	return &restoreStateFixture{
+		t:       t,
+		scheme:  scheme,
+		root:    root,
+		owner:   owner,
+		intent:  intent,
+		request: request,
+		objects: []client.Object{request},
+	}
+}
+
+func (f *restoreStateFixture) graph() (model.GraphClient, *graph.DAG) {
+	f.t.Helper()
+	cli := fake.NewClientBuilder().WithScheme(f.scheme).WithObjects(f.objects...).Build()
+	graphCli := model.NewGraphClient(cli)
+	dag := graph.NewDAG()
+	graphCli.Root(dag, f.owner.DeepCopy(), f.owner, model.ActionStatusPtr())
+	return graphCli, dag
+}
+
+func (f *restoreStateFixture) targetBuilder(intent CredentialIntent) (*corev1.Secret, error) {
+	f.t.Helper()
+	target := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   intent.Target.Namespace,
+			Name:        "cluster-mysql-root",
+			Labels:      map[string]string{"role": "root"},
+			Annotations: map[string]string{"semantic": "live"},
+			Finalizers:  []string{constant.DBComponentFinalizerName},
+		},
+		Type: corev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			constant.AccountNameForSecret:   append([]byte(nil), intent.Credentials[constant.AccountNameForSecret]...),
+			constant.AccountPasswdForSecret: append([]byte(nil), intent.Credentials[constant.AccountPasswdForSecret]...),
+		},
+	}
+	require.NoError(f.t, controllerutil.SetControllerReference(f.owner, target, f.scheme))
+	return target, nil
+}
+
+func findTargetVertex(t *testing.T, graphCli model.GraphClient, dag *graph.DAG, request *corev1.Secret) *corev1.Secret {
+	t.Helper()
+	for _, object := range graphCli.FindAll(dag, &corev1.Secret{}) {
+		secret := object.(*corev1.Secret)
+		if secret.Name != request.Name {
+			return secret
+		}
+	}
+	t.Fatal("target vertex not found")
+	return nil
 }


### PR DESCRIPTION
Replaces #10575.
Fixes #10574.

## What changed
- Introduces a versioned `sar/v2` protocol with canonical logical-target and operation identities, immutable restore requests, durable conflict receipts, explicit phases/reasons, and exact commit revisions.
- Makes DataProtection the proposal/arbitration owner while Apps remains the sole target Secret writer. Component, sharding, and Cluster paths validate live ownership before committing credentials.
- Adds independent request and conflict lifecycle reconcilers, deterministic create-response recovery, terminal/manual-deletion handling, and condition-only conflict projection.
- Adds typed UID-preconditioned graph deletes and propagates delete errors through existing Apps transformers.
- Covers concurrent operations, create/update crash windows, immutable target replacement, foreign request isolation, deleting resources, receipt convergence, and plan-builder UID continuity.

## Design contract
Implementation is bound to the independently reviewed v2.2 design artifact SHA256:

`31362aadd041210b803dc0b55e3021193416cd7874f6d3f8c96dc15bb03cbfc8`

## Validation
- `KUBEBUILDER_ASSETS='<envtest 1.26.1>' go test ./...`
- `KUBEBUILDER_ASSETS='<envtest 1.26.1>' go test ./pkg/controller/model ./pkg/controller/systemaccount ./controllers/apps/cluster ./controllers/apps/component ./controllers/apps/rollout ./controllers/dataprotection`
- `go vet ./cmd/manager ./cmd/dataprotection ./controllers/apps ./controllers/apps/cluster ./controllers/apps/component ./controllers/apps/rollout ./controllers/dataprotection ./pkg/controller/model ./pkg/controller/systemaccount`
- Go 1.26-built `golangci-lint v2.8.0 run ./...` (`0 issues`)
- `git diff --check`

## Evidence boundary
- Local source, static checks, unit tests, and envtest are green on exact commit `f352bd5725183fc311b34555fc4931fcc95dcef4`.
- Runtime/product validation is N=0 and is not claimed by this PR.
