### PR TITLE
feat: support volume expansion config rerender trigger

### DIFF
--- a/apis/apps/v1alpha1/type.go
+++ b/apis/apps/v1alpha1/type.go
@@ -174,7 +174,7 @@ type ComponentConfigSpec struct {
 	// +optional
 	InjectEnvTo []string `json:"injectEnvTo,omitempty"`
 
-	// Specifies whether the configuration needs to be re-rendered after v-scale or h-scale operations to reflect changes.
+	// Specifies whether the configuration needs to be re-rendered after scaling, TLS, or volume expansion operations to reflect changes.
 	//
 	// In some scenarios, the configuration may need to be updated to reflect the changes in resource allocation
 	// or cluster topology. Examples:
@@ -182,6 +182,7 @@ type ComponentConfigSpec struct {
 	// - Redis: adjust maxmemory after v-scale operation.
 	// - MySQL: increase max connections after v-scale operation.
 	// - Zookeeper: update zoo.cfg with new node addresses after h-scale operation.
+	// - Doris: update file cache capacity after volume expansion operation.
 	//
 	// +listType=set
 	// +optional
@@ -193,15 +194,16 @@ type ComponentConfigSpec struct {
 	AsSecret *bool `json:"asSecret,omitempty"`
 }
 
-// RerenderResourceType defines the resource requirements for a component.
+// RerenderResourceType defines the resource changes that can trigger configuration re-rendering.
 // +enum
-// +kubebuilder:validation:Enum={vscale,hscale,tls,shardingHScale}
+// +kubebuilder:validation:Enum={vscale,hscale,tls,shardingHScale,volumeExpansion}
 type RerenderResourceType string
 
 const (
-	ComponentVScaleType         RerenderResourceType = "vscale"
-	ComponentHScaleType         RerenderResourceType = "hscale"
-	ShardingComponentHScaleType RerenderResourceType = "shardingHScale"
+	ComponentVScaleType          RerenderResourceType = "vscale"
+	ComponentHScaleType          RerenderResourceType = "hscale"
+	ShardingComponentHScaleType  RerenderResourceType = "shardingHScale"
+	ComponentVolumeExpansionType RerenderResourceType = "volumeExpansion"
 )
 
 // MergedPolicy defines how to merge external imported templates into component templates.

--- a/apis/parameters/v1alpha1/paramconfigrenderer_types.go
+++ b/apis/parameters/v1alpha1/paramconfigrenderer_types.go
@@ -121,7 +121,7 @@ type ComponentConfigDescription struct {
 	// +optional
 	FileFormatConfig *FileFormatConfig `json:"fileFormatConfig,omitempty"`
 
-	// Specifies whether the configuration needs to be re-rendered after v-scale or h-scale operations to reflect changes.
+	// Specifies whether the configuration needs to be re-rendered after scaling, TLS, or volume expansion operations to reflect changes.
 	//
 	// In some scenarios, the configuration may need to be updated to reflect the changes in resource allocation
 	// or cluster topology. Examples:
@@ -129,6 +129,7 @@ type ComponentConfigDescription struct {
 	// - Redis: adjust maxmemory after v-scale operation.
 	// - MySQL: increase max connections after v-scale operation.
 	// - Zookeeper: update zoo.cfg with new node addresses after h-scale operation.
+	// - Doris: update file cache capacity after volume expansion operation.
 	//
 	// +listType=set
 	// +optional

--- a/apis/parameters/v1alpha1/types.go
+++ b/apis/parameters/v1alpha1/types.go
@@ -60,16 +60,17 @@ const (
 
 // Deprecated: It is retained for API compatibility with existing ParamConfigRenderer objects.
 //
-// RerenderResourceType defines the resource requirements for a component.
+// RerenderResourceType defines the resource changes that can trigger configuration re-rendering.
 // +enum
-// +kubebuilder:validation:Enum={vscale,hscale,tls,shardingHScale}
+// +kubebuilder:validation:Enum={vscale,hscale,tls,shardingHScale,volumeExpansion}
 type RerenderResourceType string
 
 const (
-	ComponentVScaleType         RerenderResourceType = "vscale"
-	ComponentHScaleType         RerenderResourceType = "hscale"
-	ComponentTLSType            RerenderResourceType = "tls"
-	ShardingComponentHScaleType RerenderResourceType = "shardingHScale"
+	ComponentVScaleType          RerenderResourceType = "vscale"
+	ComponentHScaleType          RerenderResourceType = "hscale"
+	ComponentTLSType             RerenderResourceType = "tls"
+	ShardingComponentHScaleType  RerenderResourceType = "shardingHScale"
+	ComponentVolumeExpansionType RerenderResourceType = "volumeExpansion"
 )
 
 // ParameterPhase defines the Configuration FSM phase

--- a/config/crd/bases/apps.kubeblocks.io_configurations.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_configurations.yaml
@@ -235,7 +235,7 @@ spec:
                           type: string
                         reRenderResourceTypes:
                           description: |-
-                            Specifies whether the configuration needs to be re-rendered after v-scale or h-scale operations to reflect changes.
+                            Specifies whether the configuration needs to be re-rendered after scaling, TLS, or volume expansion operations to reflect changes.
 
                             In some scenarios, the configuration may need to be updated to reflect the changes in resource allocation
                             or cluster topology. Examples:
@@ -243,6 +243,7 @@ spec:
                             - Redis: adjust maxmemory after v-scale operation.
                             - MySQL: increase max connections after v-scale operation.
                             - Zookeeper: update zoo.cfg with new node addresses after h-scale operation.
+                            - Doris: update file cache capacity after volume expansion operation.
                           items:
                             description: RerenderResourceType defines the resource
                               requirements for a component.
@@ -251,6 +252,7 @@ spec:
                             - hscale
                             - tls
                             - shardingHScale
+                            - volumeExpansion
                             type: string
                           type: array
                           x-kubernetes-list-type: set

--- a/config/crd/bases/parameters.kubeblocks.io_paramconfigrenderers.yaml
+++ b/config/crd/bases/parameters.kubeblocks.io_paramconfigrenderers.yaml
@@ -135,7 +135,7 @@ spec:
                       type: string
                     reRenderResourceTypes:
                       description: |-
-                        Specifies whether the configuration needs to be re-rendered after v-scale or h-scale operations to reflect changes.
+                        Specifies whether the configuration needs to be re-rendered after scaling, TLS, or volume expansion operations to reflect changes.
 
                         In some scenarios, the configuration may need to be updated to reflect the changes in resource allocation
                         or cluster topology. Examples:
@@ -143,6 +143,7 @@ spec:
                         - Redis: adjust maxmemory after v-scale operation.
                         - MySQL: increase max connections after v-scale operation.
                         - Zookeeper: update zoo.cfg with new node addresses after h-scale operation.
+                        - Doris: update file cache capacity after volume expansion operation.
                       items:
                         description: |-
                           Deprecated: It is retained for API compatibility with existing ParamConfigRenderer objects.
@@ -153,6 +154,7 @@ spec:
                         - hscale
                         - tls
                         - shardingHScale
+                        - volumeExpansion
                         type: string
                       type: array
                       x-kubernetes-list-type: set

--- a/controllers/parameters/componentparameter_controller_utils.go
+++ b/controllers/parameters/componentparameter_controller_utils.go
@@ -60,10 +60,14 @@ func reconcileConfigItemDetailsIntoSpec(ctx context.Context, cli client.Client, 
 	if err != nil {
 		return false, err
 	}
+	if err = applyRerenderPayloads(configItemDetails, &fetchTask.ComponentObj.Spec, configDescs); err != nil {
+		return false, err
+	}
 	expected := compParam.DeepCopy()
 	expected.Spec.ConfigItemDetails = configItemDetails
 	merged := parameters.MergeComponentParameter(expected, compParam, func(dest, expected *parametersv1alpha1.ConfigTemplateItemDetail) {
 		mergeMissingConfigFileParams(dest, expected)
+		mergeManagedPayload(dest, expected, constant.VolumeClaimTemplatesPayload)
 		if dest.CustomTemplates == nil && expected.CustomTemplates != nil {
 			dest.CustomTemplates = expected.CustomTemplates
 		}
@@ -91,6 +95,103 @@ func mergeMissingConfigFileParams(dest, expected *parametersv1alpha1.ConfigTempl
 		}
 		dest.ConfigFileParams[file] = *params.DeepCopy()
 	}
+}
+
+type volumeClaimTemplatePayload struct {
+	Name    string `json:"name"`
+	Storage string `json:"storage,omitempty"`
+}
+
+func applyRerenderPayloads(items []parametersv1alpha1.ConfigTemplateItemDetail,
+	componentSpec *appsv1.ComponentSpec,
+	configDescs []parametersv1alpha1.ComponentConfigDescription) error {
+	if componentSpec == nil {
+		return nil
+	}
+	for i := range items {
+		descs := parameters.GetComponentConfigDescriptions(configDescs, items[i].Name)
+		if !rerenderConfigEnabled(descs, parametersv1alpha1.ComponentVolumeExpansionType) {
+			if err := patchConfigItemPayload(&items[i], constant.VolumeClaimTemplatesPayload, nil); err != nil {
+				return err
+			}
+			continue
+		}
+		payload := volumeClaimTemplatesPayload(componentSpec.VolumeClaimTemplates)
+		if len(payload) == 0 {
+			if err := patchConfigItemPayload(&items[i], constant.VolumeClaimTemplatesPayload, nil); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := patchConfigItemPayload(&items[i], constant.VolumeClaimTemplatesPayload, payload); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func rerenderConfigEnabled(configDescs []parametersv1alpha1.ComponentConfigDescription, rerenderType parametersv1alpha1.RerenderResourceType) bool {
+	for _, desc := range configDescs {
+		if slices.Contains(desc.ReRenderResourceTypes, rerenderType) {
+			return true
+		}
+	}
+	return false
+}
+
+func volumeClaimTemplatesPayload(vcts []appsv1.PersistentVolumeClaimTemplate) []volumeClaimTemplatePayload {
+	payload := make([]volumeClaimTemplatePayload, 0, len(vcts))
+	for _, vct := range vcts {
+		storage := vct.Spec.Resources.Requests[corev1.ResourceStorage]
+		payload = append(payload, volumeClaimTemplatePayload{
+			Name:    vct.Name,
+			Storage: storage.String(),
+		})
+	}
+	return payload
+}
+
+func patchConfigItemPayload(item *parametersv1alpha1.ConfigTemplateItemDetail, payloadID string, payload any) error {
+	if item == nil {
+		return nil
+	}
+	if payload == nil {
+		if item.Payload != nil {
+			delete(item.Payload, payloadID)
+			if len(item.Payload) == 0 {
+				item.Payload = nil
+			}
+		}
+		return nil
+	}
+	newPayload, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	if item.Payload == nil {
+		item.Payload = parametersv1alpha1.Payload{}
+	}
+	item.Payload[payloadID] = newPayload
+	return nil
+}
+
+func mergeManagedPayload(dest, expected *parametersv1alpha1.ConfigTemplateItemDetail, payloadID string) {
+	if expected == nil {
+		return
+	}
+	if expected.Payload == nil {
+		_ = patchConfigItemPayload(dest, payloadID, nil)
+		return
+	}
+	payload, ok := expected.Payload[payloadID]
+	if !ok {
+		_ = patchConfigItemPayload(dest, payloadID, nil)
+		return
+	}
+	if dest.Payload == nil {
+		dest.Payload = parametersv1alpha1.Payload{}
+	}
+	dest.Payload[payloadID] = slices.Clone(payload)
 }
 
 func reconcileParameterValuesIntoSpec(ctx context.Context, cli client.Client, compParam *parametersv1alpha1.ComponentParameter, fetchTask *Task) (bool, error) {

--- a/controllers/parameters/componentparameter_controller_utils_test.go
+++ b/controllers/parameters/componentparameter_controller_utils_test.go
@@ -20,11 +20,16 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package parameters
 
 import (
+	"encoding/json"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/ptr"
 
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	parametersv1alpha1 "github.com/apecloud/kubeblocks/apis/parameters/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
 	parampkg "github.com/apecloud/kubeblocks/pkg/parameters"
 )
 
@@ -146,6 +151,90 @@ func TestMergeMissingConfigFileParams(t *testing.T) {
 	*expected.ConfigFileParams["log.conf"].Parameters["slow_query_log"] = "0"
 	if got := dest.ConfigFileParams["log.conf"].Parameters["slow_query_log"]; got == nil || *got != "1" {
 		t.Fatalf("expected merged params to be deep-copied, got %#v", got)
+	}
+}
+
+func TestApplyRerenderPayloads(t *testing.T) {
+	items := []parametersv1alpha1.ConfigTemplateItemDetail{
+		{Name: "be-cm"},
+		{
+			Name: "fe-cm",
+			Payload: parametersv1alpha1.Payload{
+				"external": json.RawMessage(`"keep"`),
+			},
+		},
+	}
+	componentSpec := &appsv1.ComponentSpec{
+		VolumeClaimTemplates: []appsv1.PersistentVolumeClaimTemplate{{
+			Name: "data",
+			Spec: corev1.PersistentVolumeClaimSpec{
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("5Gi"),
+					},
+				},
+			},
+		}},
+	}
+	configDescs := []parametersv1alpha1.ComponentConfigDescription{{
+		Name:         "be.conf",
+		TemplateName: "be-cm",
+		ReRenderResourceTypes: []parametersv1alpha1.RerenderResourceType{
+			parametersv1alpha1.ComponentVolumeExpansionType,
+		},
+	}}
+
+	if err := applyRerenderPayloads(items, componentSpec, configDescs); err != nil {
+		t.Fatalf("applyRerenderPayloads() error = %v", err)
+	}
+
+	payload, ok := items[0].Payload[constant.VolumeClaimTemplatesPayload]
+	if !ok {
+		t.Fatalf("expected volume claim template payload on opted-in item")
+	}
+	var decoded []volumeClaimTemplatePayload
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("failed to decode payload: %v", err)
+	}
+	if len(decoded) != 1 || decoded[0].Name != "data" || decoded[0].Storage != "5Gi" {
+		t.Fatalf("unexpected payload: %#v", decoded)
+	}
+	if _, ok = items[1].Payload[constant.VolumeClaimTemplatesPayload]; ok {
+		t.Fatalf("did not expect managed payload on item without volumeExpansion trigger")
+	}
+	if string(items[1].Payload["external"]) != `"keep"` {
+		t.Fatalf("expected unrelated payload key to be preserved, got %s", string(items[1].Payload["external"]))
+	}
+}
+
+func TestMergeManagedPayload(t *testing.T) {
+	dest := &parametersv1alpha1.ConfigTemplateItemDetail{
+		Payload: parametersv1alpha1.Payload{
+			constant.VolumeClaimTemplatesPayload: json.RawMessage(`[{"name":"data","storage":"5Gi"}]`),
+			"external":                           json.RawMessage(`"keep"`),
+		},
+	}
+	expected := &parametersv1alpha1.ConfigTemplateItemDetail{
+		Payload: parametersv1alpha1.Payload{
+			constant.VolumeClaimTemplatesPayload: json.RawMessage(`[{"name":"data","storage":"8Gi"}]`),
+		},
+	}
+
+	mergeManagedPayload(dest, expected, constant.VolumeClaimTemplatesPayload)
+
+	if got := string(dest.Payload[constant.VolumeClaimTemplatesPayload]); got != `[{"name":"data","storage":"8Gi"}]` {
+		t.Fatalf("expected managed payload to be updated, got %s", got)
+	}
+	if got := string(dest.Payload["external"]); got != `"keep"` {
+		t.Fatalf("expected external payload key to be preserved, got %s", got)
+	}
+
+	mergeManagedPayload(dest, &parametersv1alpha1.ConfigTemplateItemDetail{}, constant.VolumeClaimTemplatesPayload)
+	if _, ok := dest.Payload[constant.VolumeClaimTemplatesPayload]; ok {
+		t.Fatalf("expected managed payload key to be removed when trigger is absent")
+	}
+	if got := string(dest.Payload["external"]); got != `"keep"` {
+		t.Fatalf("expected external payload key to remain after managed removal, got %s", got)
 	}
 }
 

--- a/deploy/helm/crds/apps.kubeblocks.io_configurations.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_configurations.yaml
@@ -235,7 +235,7 @@ spec:
                           type: string
                         reRenderResourceTypes:
                           description: |-
-                            Specifies whether the configuration needs to be re-rendered after v-scale or h-scale operations to reflect changes.
+                            Specifies whether the configuration needs to be re-rendered after scaling, TLS, or volume expansion operations to reflect changes.
 
                             In some scenarios, the configuration may need to be updated to reflect the changes in resource allocation
                             or cluster topology. Examples:
@@ -243,6 +243,7 @@ spec:
                             - Redis: adjust maxmemory after v-scale operation.
                             - MySQL: increase max connections after v-scale operation.
                             - Zookeeper: update zoo.cfg with new node addresses after h-scale operation.
+                            - Doris: update file cache capacity after volume expansion operation.
                           items:
                             description: RerenderResourceType defines the resource
                               requirements for a component.
@@ -251,6 +252,7 @@ spec:
                             - hscale
                             - tls
                             - shardingHScale
+                            - volumeExpansion
                             type: string
                           type: array
                           x-kubernetes-list-type: set

--- a/deploy/helm/crds/parameters.kubeblocks.io_paramconfigrenderers.yaml
+++ b/deploy/helm/crds/parameters.kubeblocks.io_paramconfigrenderers.yaml
@@ -135,7 +135,7 @@ spec:
                       type: string
                     reRenderResourceTypes:
                       description: |-
-                        Specifies whether the configuration needs to be re-rendered after v-scale or h-scale operations to reflect changes.
+                        Specifies whether the configuration needs to be re-rendered after scaling, TLS, or volume expansion operations to reflect changes.
 
                         In some scenarios, the configuration may need to be updated to reflect the changes in resource allocation
                         or cluster topology. Examples:
@@ -143,6 +143,7 @@ spec:
                         - Redis: adjust maxmemory after v-scale operation.
                         - MySQL: increase max connections after v-scale operation.
                         - Zookeeper: update zoo.cfg with new node addresses after h-scale operation.
+                        - Doris: update file cache capacity after volume expansion operation.
                       items:
                         description: |-
                           Deprecated: It is retained for API compatibility with existing ParamConfigRenderer objects.
@@ -153,6 +154,7 @@ spec:
                         - hscale
                         - tls
                         - shardingHScale
+                        - volumeExpansion
                         type: string
                       type: array
                       x-kubernetes-list-type: set

--- a/pkg/constant/config.go
+++ b/pkg/constant/config.go
@@ -47,5 +47,9 @@ const (
 )
 
 const (
+	VolumeClaimTemplatesPayload = "volumeClaimTemplates"
+)
+
+const (
 	FeatureGateIgnoreConfigTemplateDefaultMode = "IGNORE_CONFIG_TEMPLATE_DEFAULT_MODE"
 )


### PR DESCRIPTION
#### What type of PR is this?
/kind enhancement
/area configuration
/area operations

#### What this PR does / why we need it:
This draft PR attempts to address #10716 by adding an opt-in configuration re-render trigger for volume expansion.

Some addons render configuration values from component PVC sizes. For example, Doris/SelectDB can derive local file cache capacity from the BE `data` PVC. Today the existing `reRenderResourceTypes` values cover resource scaling, TLS, and sharding topology changes, but not PVC capacity changes. After a VolumeExpansion operation, disk-derived configuration values can therefore remain stale.

This PR adds:

- a new `reRenderResourceTypes` enum value: `volumeExpansion`;
- CRD schema updates for both `parameters.kubeblocks.io/ParamConfigRenderer` and the deprecated `apps.kubeblocks.io/Configuration` API surface;
- a managed `volumeClaimTemplates` payload snapshot on `ComponentParameter.spec.configItemDetails[]` for config templates that opt into `volumeExpansion`;
- focused unit tests for payload generation, payload update, and preservation of unrelated external payload keys.

When a Component's volumeClaimTemplates storage request changes, the managed payload changes, so the existing ComponentParameter/ConfigMap re-render comparison can detect the config item update and re-render the affected template.

#### Which issue(s) this PR fixes:
Fixes #10716

#### Special notes for your reviewer:
This is intentionally opened as a draft PR because the final controller integration should be reviewed carefully against the current main configuration architecture and the release-1.0 backport path.

Please consider picking/backporting the final fix to `release-1.0` after review, because the Doris/SelectDB addon scenario was observed on KubeBlocks 1.0.x.

#### Does this PR introduce a user-facing change?
```release-note
Add `volumeExpansion` as a configuration re-render trigger type so addons can opt in to re-render disk-capacity-derived configuration after PVC expansion.
```

#### Test result
Passed:

```bash
go test ./controllers/parameters -run 'Test(ApplyRerenderPayloads|MergeManagedPayload)'
go test ./apis/parameters/v1alpha1 ./apis/apps/v1alpha1 ./pkg/constant
go test ./pkg/parameters -run '^$'
go test ./controllers/parameters -run '^$'
git diff --check
```

Blocked locally by missing envtest binaries:

```bash
go test ./controllers/parameters
go test ./pkg/parameters
```

Both full package test runs failed before executing specs because `/usr/local/kubebuilder/bin/etcd` was not present in the local environment.
