### PR TITLE
fix: resolve extra component vars during scale-in

### DIFF
--- a/pkg/controller/component/vars.go
+++ b/pkg/controller/component/vars.go
@@ -1413,7 +1413,13 @@ func resolveReferentComponents(synthesizedComp *SynthesizedComponent, objRef app
 			total += cnt
 		}
 	}
-	if len(compNames) != int(total) {
+	if total == 0 && len(compNames) > 0 {
+		return nil, fmt.Errorf("unexpected component objects found when resolving vars, actual: %d", len(compNames))
+	}
+	// During scale-in the desired count is reduced before the extra component
+	// is deleted. Keep all existing referents available to the shard-remove
+	// action, while still blocking when any desired component is missing.
+	if len(compNames) < int(total) {
 		return nil, fmt.Errorf("insufficient component objects to resolve vars, expected: %d, actual: %d", total, len(compNames))
 	}
 	if len(compNames) == 0 {

--- a/pkg/controller/component/vars_test.go
+++ b/pkg/controller/component/vars_test.go
@@ -2932,6 +2932,45 @@ var _ = Describe("vars", func() {
 				checkEnvVarWithValue(envVars, svcVarName1, svcName1)
 				checkEnvVarWithValue(envVars, svcVarName2, svcName2)
 			})
+
+			It("require all component objects - true with extra component during scale-in", func() {
+				synthesizedComp.Comp2CompDefs = map[string]string{
+					compName1: synthesizedComp.CompDefName,
+					compName2: synthesizedComp.CompDefName,
+					compName3: synthesizedComp.CompDefName,
+				}
+				synthesizedComp.CompDef2CompCnt = map[string]int32{
+					synthesizedComp.CompDefName: int32(2),
+				}
+
+				compNames, err := resolveReferentComponents(synthesizedComp, appsv1.ClusterObjectReference{
+					CompDef: synthesizedComp.CompDefName,
+					MultipleClusterObjectOption: &appsv1.MultipleClusterObjectOption{
+						RequireAllComponentObjects: ptr.To(true),
+						Strategy:                   appsv1.MultipleClusterObjectStrategyCombined,
+					},
+				})
+
+				Expect(err).Should(Succeed())
+				Expect(compNames).Should(ConsistOf(compName1, compName2, compName3))
+			})
+
+			It("require all component objects - true with only unexpected components", func() {
+				synthesizedComp.Comp2CompDefs = map[string]string{
+					compName1: synthesizedComp.CompDefName,
+				}
+				synthesizedComp.CompDef2CompCnt = map[string]int32{}
+
+				_, err := resolveReferentComponents(synthesizedComp, appsv1.ClusterObjectReference{
+					CompDef: synthesizedComp.CompDefName,
+					MultipleClusterObjectOption: &appsv1.MultipleClusterObjectOption{
+						RequireAllComponentObjects: ptr.To(true),
+						Strategy:                   appsv1.MultipleClusterObjectStrategyCombined,
+					},
+				})
+
+				Expect(err).Should(MatchError("unexpected component objects found when resolving vars, actual: 1"))
+			})
 		})
 
 		Context("vars reference and escaping", func() {


### PR DESCRIPTION
Fixes #10722.

## What changed

- Treat `requireAllComponentObjects` as a minimum desired-cardinality gate.
- Keep all matching live Component objects in the resolved result when scale-in has reduced the desired count but the extra Component still exists.
- Preserve failures for missing desired Components and for orphan-only matches when the desired count is zero.

## Why

Shard scale-in updates `Cluster.spec.shardings[*].shards` before the shard-remove lifecycle action deletes the extra Component. The lifecycle action needs the complete live shard set, but the previous exact-cardinality check rejected the expected transitional state (`desired=3`, `live=4`). That prevented the shard-remove action from running and left HorizontalScaling at `0/1`.

## Tests

- Focused RED before the fix: extra matching Component failed with `expected: 2, actual: 3`.
- `go test ./pkg/controller/component ./controllers/apps/cluster -count=1`
