### PR TITLE
fix(apps): skip inheriting restore annotation for restored components

### DIFF
--- a/controllers/apps/cluster/transformer_cluster_component.go
+++ b/controllers/apps/cluster/transformer_cluster_component.go
@@ -251,7 +251,13 @@ func copyAndMergeComponent(oldCompObj, newCompObj *appsv1.Component) *appsv1.Com
 	}
 
 	// Merge metadata
-	ictrlutil.MergeMetadataMapInplace(compProto.Annotations, &compObjCopy.Annotations)
+	protoAnnotations := compProto.Annotations
+	if oldCompObj.Annotations[constant.RestoreDoneAnnotationKey] == "true" {
+		// the component has finished the restore, don't inherit the restore annotation from the cluster anymore,
+		// otherwise the restore flow will be re-triggered repeatedly and cause a reconcile loop
+		delete(protoAnnotations, constant.RestoreFromBackupAnnotationKey)
+	}
+	ictrlutil.MergeMetadataMapInplace(protoAnnotations, &compObjCopy.Annotations)
 	ictrlutil.MergeMetadataMapInplace(compProto.Labels, &compObjCopy.Labels)
 
 	// Merge all spec fields

--- a/controllers/apps/cluster/transformer_cluster_component_test.go
+++ b/controllers/apps/cluster/transformer_cluster_component_test.go
@@ -1729,6 +1729,25 @@ var _ = Describe("cluster component transformer test", func() {
 			Expect(result.Spec.VolumeClaimTemplates).To(HaveLen(1))
 		})
 
+		It("should not inherit the restore annotation when the component has finished the restore", func() {
+			oldCompObj.Annotations = map[string]string{constant.RestoreDoneAnnotationKey: "true"}
+			newCompObj.Annotations = map[string]string{
+				constant.RestoreFromBackupAnnotationKey: `{"shard":{"name":"test-backup"}}`,
+			}
+			result := copyAndMergeComponent(oldCompObj, newCompObj)
+			Expect(result).To(BeNil())
+		})
+
+		It("should inherit the restore annotation when the restore is not done", func() {
+			oldCompObj.Annotations = map[string]string{}
+			newCompObj.Annotations = map[string]string{
+				constant.RestoreFromBackupAnnotationKey: `{"shard":{"name":"test-backup"}}`,
+			}
+			result := copyAndMergeComponent(oldCompObj, newCompObj)
+			Expect(result).NotTo(BeNil())
+			Expect(result.Annotations).To(HaveKey(constant.RestoreFromBackupAnnotationKey))
+		})
+
 		It("should normalize CPU resources", func() {
 			// 1000m is equivalent to 1
 			oldCompObj.Spec.Resources.Limits[corev1.ResourceCPU] = resource.MustParse("1")


### PR DESCRIPTION
## What's changed

Fix an infinite reconcile loop in sharded clusters restored from backup:

1. The cluster controller's `BuildComponent` inherits `kubeblocks.io/restore-from-backup` from the Cluster onto every Component via `InheritedAnnotations()` (`pkg/constant/annotations.go`).
2. Once a shard component finishes restoring, the component controller's restore transformer (`DoRestore`) deletes that annotation and sets `kubeblocks.io/restore-done=true` — but the Cluster still carries the restore annotation, so the next cluster reconcile inherits it back onto the component.
3. This ping-pong re-triggers the restore flow on every reconcile, keeping `spec.generation` growing indefinitely (observed: generation 4000+ in ~30 min), which in turn floods dependent shard components with `kubeblocks.io/reconcile: <shard>@<gen>` annotations via the notifier transformer (churning their resourceVersions too).

## The fix

In `copyAndMergeComponent` (`controllers/apps/cluster/transformer_cluster_component.go`), when the running component already has `kubeblocks.io/restore-done=true`, exclude `kubeblocks.io/restore-from-backup` from the proto annotations before merging, so the annotation is never inherited back and the loop stops.

## Tests

- Added 2 ginkgo specs in `transformer_cluster_component_test.go`:
  - restore-done=true → restore annotation is not inherited back (merge returns nil, no update)
  - restore not done → annotation is still inherited (update happens)
- `go build`, `go vet` and the `testing component merge functionality` spec group all pass (17/17).

## Related

Fixes generation/reconcile loop observed on `almon-587bb9db84-shard-wg6/76n` (restore clone from `aloe0-c98784b5f-20260731114909`).