### PR TITLE
refactor(apps): move restore annotation guard to restore transformer

### DIFF
--- a/controllers/apps/cluster/transformer_cluster_component.go
+++ b/controllers/apps/cluster/transformer_cluster_component.go
@@ -251,7 +251,13 @@ func copyAndMergeComponent(oldCompObj, newCompObj *appsv1.Component) *appsv1.Com
 	}
 
 	// Merge metadata
-	ictrlutil.MergeMetadataMapInplace(compProto.Annotations, &compObjCopy.Annotations)
+	protoAnnotations := compProto.Annotations
+	if oldCompObj.Annotations[constant.RestoreDoneAnnotationKey] == "true" {
+		// the component has finished the restore, don't inherit the restore annotation from the cluster anymore,
+		// otherwise the restore flow will be re-triggered repeatedly and cause a reconcile loop
+		delete(protoAnnotations, constant.RestoreFromBackupAnnotationKey)
+	}
+	ictrlutil.MergeMetadataMapInplace(protoAnnotations, &compObjCopy.Annotations)
 	ictrlutil.MergeMetadataMapInplace(compProto.Labels, &compObjCopy.Labels)
 
 	// Merge all spec fields

--- a/controllers/apps/cluster/transformer_cluster_component.go
+++ b/controllers/apps/cluster/transformer_cluster_component.go
@@ -251,13 +251,7 @@ func copyAndMergeComponent(oldCompObj, newCompObj *appsv1.Component) *appsv1.Com
 	}
 
 	// Merge metadata
-	protoAnnotations := compProto.Annotations
-	if oldCompObj.Annotations[constant.RestoreDoneAnnotationKey] == "true" {
-		// the component has finished the restore, don't inherit the restore annotation from the cluster anymore,
-		// otherwise the restore flow will be re-triggered repeatedly and cause a reconcile loop
-		delete(protoAnnotations, constant.RestoreFromBackupAnnotationKey)
-	}
-	ictrlutil.MergeMetadataMapInplace(protoAnnotations, &compObjCopy.Annotations)
+	mergeComponentAnnotations(compObjCopy, compProto.Annotations)
 	ictrlutil.MergeMetadataMapInplace(compProto.Labels, &compObjCopy.Labels)
 
 	// Merge all spec fields

--- a/controllers/apps/cluster/transformer_cluster_component_test.go
+++ b/controllers/apps/cluster/transformer_cluster_component_test.go
@@ -1729,6 +1729,25 @@ var _ = Describe("cluster component transformer test", func() {
 			Expect(result.Spec.VolumeClaimTemplates).To(HaveLen(1))
 		})
 
+		It("should not inherit the restore annotation when the component has finished the restore", func() {
+			oldCompObj.Annotations = map[string]string{constant.RestoreDoneAnnotationKey: "true"}
+			newCompObj.Annotations = map[string]string{
+				constant.RestoreFromBackupAnnotationKey: `{"shard":{"name":"test-backup"}}`,
+			}
+			result := copyAndMergeComponent(oldCompObj, newCompObj)
+			Expect(result).To(BeNil())
+		})
+
+		It("should inherit the restore annotation when the restore is not done", func() {
+			oldCompObj.Annotations = map[string]string{}
+			newCompObj.Annotations = map[string]string{
+				constant.RestoreFromBackupAnnotationKey: `{"shard":{"name":"test-backup"}}`,
+			}
+			result := copyAndMergeComponent(oldCompObj, newCompObj)
+			Expect(result).NotTo(BeNil())
+			Expect(result.Annotations).To(HaveKey(constant.RestoreFromBackupAnnotationKey))
+		})
+
 		It("should normalize CPU resources", func() {
 			// 1000m is equivalent to 1
 			oldCompObj.Spec.Resources.Limits[corev1.ResourceCPU] = resource.MustParse("1")

--- a/controllers/apps/cluster/transformer_cluster_restore.go
+++ b/controllers/apps/cluster/transformer_cluster_restore.go
@@ -146,6 +146,16 @@ func (c *clusterRestoreTransformer) Transform(ctx graph.TransformContext, dag *g
 	return nil
 }
 
+// mergeComponentAnnotations merges the proto annotations into the component object, but excludes
+// the restore annotation when the component has finished the restore, otherwise the restore flow
+// will be re-triggered repeatedly and cause a reconcile loop.
+func mergeComponentAnnotations(compObjCopy *appsv1.Component, protoAnnotations map[string]string) {
+	if compObjCopy.Annotations[constant.RestoreDoneAnnotationKey] == "true" {
+		delete(protoAnnotations, constant.RestoreFromBackupAnnotationKey)
+	}
+	intctrlutil.MergeMetadataMapInplace(protoAnnotations, &compObjCopy.Annotations)
+}
+
 func (c *clusterRestoreTransformer) initClusterAnnotations(compName string) map[string]string {
 	if c.annotations == nil {
 		c.annotations = make(map[string]map[string]string)


### PR DESCRIPTION
## What's changed

Follow-up to #10731 (already merged). Moves the restore-annotation inheritance guard out of `copyAndMergeComponent` into `transformer_cluster_restore.go` as a dedicated helper `mergeComponentAnnotations`, so the generic component merge logic stays clean and the restore-specific behavior lives with the restore transformer.

## Behavior

Identical to #10731:

- When the running component has `kubeblocks.io/restore-done=true`, the `kubeblocks.io/restore-from-backup` annotation is excluded before merging proto annotations, preventing the restore flow from being re-triggered repeatedly (reconcile loop that kept bumping `spec.generation` and flooding dependent shards with `kubeblocks.io/reconcile` annotations).

## Tests

- Existing ginkgo specs in `transformer_cluster_component_test.go` cover the behavior via `copyAndMergeComponent` (unchanged, all pass).
- `go build`, `go vet` pass.