### PR TITLE
fix(dataprotection): wait for running backup actions

### DIFF
--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -599,7 +599,8 @@ func (r *BackupReconciler) handleRunningPhase(
 		return intctrlutil.Requeue(reqCtx.Log, msg)
 	}
 
-	if backup.Labels[dptypes.BackupTypeLabelKey] == string(dpv1alpha1.BackupTypeContinuous) {
+	continuousBackup := backup.Labels[dptypes.BackupTypeLabelKey] == string(dpv1alpha1.BackupTypeContinuous)
+	if continuousBackup {
 		// check if the continuous backup is completed.
 		if completed, err := r.checkIsCompletedDuringRunning(reqCtx, backup); err != nil {
 			return RecorderEventAndRequeue(reqCtx, r.Recorder, backup, err)
@@ -665,6 +666,10 @@ func (r *BackupReconciler) handleRunningPhase(
 				}
 			}
 		}
+	}
+	if continuousBackup && existFailedAction {
+		return r.updateStatusIfFailed(reqCtx, backup, request.Backup,
+			fmt.Errorf("there are failed actions, you can obtain the more information in the status.actions"))
 	}
 	if waiting {
 		// reset time related fields for continuous backup

--- a/controllers/dataprotection/backup_controller.go
+++ b/controllers/dataprotection/backup_controller.go
@@ -666,10 +666,6 @@ func (r *BackupReconciler) handleRunningPhase(
 			}
 		}
 	}
-	if existFailedAction {
-		return r.updateStatusIfFailed(reqCtx, backup, request.Backup,
-			fmt.Errorf("there are failed actions, you can obtain the more information in the status.actions"))
-	}
 	if waiting {
 		// reset time related fields for continuous backup
 		request.Status.CompletionTimestamp = nil
@@ -683,6 +679,10 @@ func (r *BackupReconciler) handleRunningPhase(
 			return intctrlutil.CheckedRequeueWithError(err, reqCtx.Log, "")
 		}
 		return intctrlutil.Reconciled()
+	}
+	if existFailedAction {
+		return r.updateStatusIfFailed(reqCtx, backup, request.Backup,
+			fmt.Errorf("there are failed actions, you can obtain the more information in the status.actions"))
 	}
 	return r.completeBackup(reqCtx, backup, request.Backup)
 }

--- a/controllers/dataprotection/backup_controller_test.go
+++ b/controllers/dataprotection/backup_controller_test.go
@@ -851,6 +851,102 @@ var _ = Describe("Backup Controller test", func() {
 			})).Should(Succeed())
 		})
 
+		It("waits for a running sibling before failing a multi-target backup", func() {
+			By("Set backupMethod's targets")
+			Expect(testapps.ChangeObj(&testCtx, backupPolicy, func(bp *dpv1alpha1.BackupPolicy) {
+				podSelector := &dpv1alpha1.PodSelector{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							constant.AppInstanceLabelKey:    testdp.ClusterName,
+							constant.KBAppComponentLabelKey: testdp.ComponentName,
+						},
+					},
+					Strategy: dpv1alpha1.PodSelectionStrategyAny,
+				}
+				backupPolicy.Spec.BackupMethods[0].Targets = []dpv1alpha1.BackupTarget{
+					{Name: testdp.ComponentName + "-0", PodSelector: podSelector},
+					{Name: testdp.ComponentName + "-1", PodSelector: podSelector},
+				}
+			})).Should(Succeed())
+			targets := backupPolicy.Spec.BackupMethods[0].Targets
+			backup := testdp.NewFakeBackup(&testCtx, nil)
+			backupKey := client.ObjectKeyFromObject(backup)
+			getJobKey := func(targetName string) client.ObjectKey {
+				return client.ObjectKey{
+					Name:      dpbackup.GenerateBackupJobName(backup, fmt.Sprintf("%s-%s-0", dpbackup.BackupDataJobNamePrefix, targetName)),
+					Namespace: backup.Namespace,
+				}
+			}
+
+			By("wait for both target jobs to be created")
+			Eventually(testapps.CheckObjExists(&testCtx, getJobKey(targets[0].Name), &batchv1.Job{}, true)).Should(Succeed())
+			Eventually(testapps.CheckObjExists(&testCtx, getJobKey(targets[1].Name), &batchv1.Job{}, true)).Should(Succeed())
+
+			By("pause reconciliation")
+			Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
+				if fetched.Annotations == nil {
+					fetched.Annotations = map[string]string{}
+				}
+				fetched.Annotations[dptypes.SkipReconciliationAnnotationKey] = "true"
+			})).Should(Succeed())
+			Consistently(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+				g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseRunning))
+			}), time.Second).Should(Succeed())
+
+			failedJobKey := getJobKey(targets[0].Name)
+			testdp.PatchK8sJobStatus(&testCtx, failedJobKey, batchv1.JobFailed)
+			runningJobKey := getJobKey(targets[1].Name)
+			runningJob := &batchv1.Job{}
+			Expect(k8sClient.Get(ctx, runningJobKey, runningJob)).Should(Succeed())
+			runningPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      runningJob.Name + "-running",
+					Namespace: runningJob.Namespace,
+					Labels:    map[string]string{"job-name": runningJob.Name},
+					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(
+						runningJob, batchv1.SchemeGroupVersion.WithKind(constant.JobKind))},
+				},
+				Spec: corev1.PodSpec{
+					Containers:    []corev1.Container{{Name: "backup", Image: testapps.ApeCloudMySQLImage}},
+					RestartPolicy: corev1.RestartPolicyNever,
+				},
+			}
+			Expect(testCtx.CreateObj(ctx, runningPod)).Should(Succeed())
+			Expect(testapps.ChangeObjStatus(&testCtx, runningPod, func() {
+				runningPod.Status.Phase = corev1.PodRunning
+			})).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, targetPod)).Should(Succeed())
+			Eventually(testapps.CheckObjExists(&testCtx, client.ObjectKeyFromObject(targetPod), &corev1.Pod{}, false)).Should(Succeed())
+
+			By("resume reconciliation and keep the aggregate backup running")
+			Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
+				delete(fetched.Annotations, dptypes.SkipReconciliationAnnotationKey)
+			})).Should(Succeed())
+			Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+				g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseRunning))
+				g.Expect(fetched.Status.Actions).To(HaveLen(2))
+				phases := map[string]dpv1alpha1.ActionPhase{}
+				for _, actionStatus := range fetched.Status.Actions {
+					phases[actionStatus.ObjectRef.Name] = actionStatus.Phase
+				}
+				g.Expect(phases[failedJobKey.Name]).To(Equal(dpv1alpha1.ActionPhaseFailed))
+				g.Expect(phases[runningJobKey.Name]).To(Equal(dpv1alpha1.ActionPhaseRunning))
+			})).Should(Succeed())
+
+			By("complete the sibling job and aggregate the backup as failed")
+			testdp.PatchK8sJobStatus(&testCtx, runningJobKey, batchv1.JobComplete)
+			Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+				g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseFailed))
+				g.Expect(fetched.Status.Actions).To(HaveLen(2))
+				phases := map[string]dpv1alpha1.ActionPhase{}
+				for _, actionStatus := range fetched.Status.Actions {
+					phases[actionStatus.ObjectRef.Name] = actionStatus.Phase
+				}
+				g.Expect(phases[failedJobKey.Name]).To(Equal(dpv1alpha1.ActionPhaseFailed))
+				g.Expect(phases[runningJobKey.Name]).To(Equal(dpv1alpha1.ActionPhaseCompleted))
+			})).Should(Succeed())
+		})
+
 		It("create a backup using fallbackLabelSelector", func() {
 			podFactory := func(name string) *testapps.MockPodFactory {
 				return testapps.NewPodFactory(testCtx.DefaultNamespace, name).

--- a/controllers/dataprotection/backup_controller_test.go
+++ b/controllers/dataprotection/backup_controller_test.go
@@ -231,6 +231,7 @@ var _ = Describe("Backup Controller test", func() {
 
 		testapps.ClearResources(&testCtx, generics.ClusterSignature, inNS, ml)
 		testapps.ClearResources(&testCtx, generics.PodSignature, inNS, ml)
+		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.BackupScheduleSignature, true, inNS)
 		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.BackupSignature, true, inNS)
 		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.BackupRepoSignature, true, ml)
 
@@ -1780,6 +1781,101 @@ var _ = Describe("Backup Controller test", func() {
 				By("check backup phase")
 				Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
 					g.Expect(fetched.Status.Phase).Should(Equal(dpv1alpha1.BackupPhaseFailed))
+				})).Should(Succeed())
+			})
+
+			It("fails a multi-target continuous backup when a sibling action is still running", func() {
+				By("create the continuous action set, backup repository, and two backup targets")
+				actionSet := testdp.NewFakeActionSet(&testCtx, func(actionSet *dpv1alpha1.ActionSet) {
+					actionSet.Spec.BackupType = dpv1alpha1.BackupTypeContinuous
+				})
+				_ = testdp.NewFakeStorageProvider(&testCtx, nil)
+				_, _ = testdp.NewFakeBackupRepo(&testCtx, nil)
+				backupPolicy = testdp.NewFakeBackupPolicy(&testCtx, func(fetched *dpv1alpha1.BackupPolicy) {
+					podSelector := &dpv1alpha1.PodSelector{
+						LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+							constant.AppInstanceLabelKey:    testdp.ClusterName,
+							constant.KBAppComponentLabelKey: testdp.ComponentName,
+						}},
+						Strategy: dpv1alpha1.PodSelectionStrategyAny,
+					}
+					fetched.Spec.BackupMethods[0].Targets = []dpv1alpha1.BackupTarget{
+						{Name: testdp.ComponentName + "-0", PodSelector: podSelector},
+						{Name: testdp.ComponentName + "-1", PodSelector: podSelector},
+					}
+				})
+				Expect(actionSet.Spec.BackupType).To(Equal(dpv1alpha1.BackupTypeContinuous))
+
+				By("enable the continuous schedule and wait for both stateful actions")
+				backupSchedule := testdp.NewFakeBackupSchedule(&testCtx, func(schedule *dpv1alpha1.BackupSchedule) {
+					schedule.Spec.Schedules[0].Enabled = pointer.Bool(true)
+				})
+				backupName := dpbackup.GenerateCRNameByBackupSchedule(backupSchedule, testdp.BackupMethodName)
+				backupKey := client.ObjectKey{Name: backupName, Namespace: testCtx.DefaultNamespace}
+				backup := &dpv1alpha1.Backup{}
+				Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+					g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseRunning))
+					backup = fetched.DeepCopy()
+				})).Should(Succeed())
+				targets := backupPolicy.Spec.BackupMethods[0].Targets
+				getStatefulSetKey := func(targetName string) client.ObjectKey {
+					return client.ObjectKey{
+						Name:      dpbackup.GenerateBackupStatefulSetName(backup, targetName, dpbackup.BackupDataJobNamePrefix),
+						Namespace: backup.Namespace,
+					}
+				}
+				failedStatefulSetKey := getStatefulSetKey(targets[0].Name)
+				runningStatefulSetKey := getStatefulSetKey(targets[1].Name)
+				Eventually(testapps.CheckObjExists(&testCtx, failedStatefulSetKey, &appsv1.StatefulSet{}, true)).Should(Succeed())
+				Eventually(testapps.CheckObjExists(&testCtx, runningStatefulSetKey, &appsv1.StatefulSet{}, true)).Should(Succeed())
+
+				By("pause reconciliation and make one stateful action fail permanently")
+				Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
+					if fetched.Annotations == nil {
+						fetched.Annotations = map[string]string{}
+					}
+					fetched.Annotations[dptypes.SkipReconciliationAnnotationKey] = "true"
+				})).Should(Succeed())
+				failedPod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      failedStatefulSetKey.Name + "-0",
+						Namespace: failedStatefulSetKey.Namespace,
+						Labels:    map[string]string{testCtx.TestObjLabelKey: "true"},
+					},
+					Spec: corev1.PodSpec{
+						Containers:    []corev1.Container{{Name: "backup", Image: testapps.ApeCloudMySQLImage}},
+						RestartPolicy: corev1.RestartPolicyAlways,
+					},
+				}
+				Expect(testCtx.CreateObj(ctx, failedPod)).Should(Succeed())
+				Expect(testapps.ChangeObjStatus(&testCtx, failedPod, func() {
+					failedPod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+						Name: "backup",
+						State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+							Reason:  "CrashLoopBackOff",
+							Message: "archive action failed",
+						}},
+					}}
+					failedPod.Status.Conditions = []corev1.PodCondition{{
+						Type:               corev1.ContainersReady,
+						Status:             corev1.ConditionFalse,
+						LastTransitionTime: metav1.NewTime(time.Now().Add(-intctrlutil.PodContainerFailedTimeout - time.Second)),
+					}}
+				})).Should(Succeed())
+
+				By("resume reconciliation and expose the failed continuous target")
+				Eventually(testapps.GetAndChangeObj(&testCtx, backupKey, func(fetched *dpv1alpha1.Backup) {
+					delete(fetched.Annotations, dptypes.SkipReconciliationAnnotationKey)
+				})).Should(Succeed())
+				Eventually(testapps.CheckObj(&testCtx, backupKey, func(g Gomega, fetched *dpv1alpha1.Backup) {
+					g.Expect(fetched.Status.Phase).To(Equal(dpv1alpha1.BackupPhaseFailed))
+					g.Expect(fetched.Status.Actions).To(HaveLen(2))
+					phases := map[string]dpv1alpha1.ActionPhase{}
+					for _, actionStatus := range fetched.Status.Actions {
+						phases[actionStatus.ObjectRef.Name] = actionStatus.Phase
+					}
+					g.Expect(phases[failedStatefulSetKey.Name]).To(Equal(dpv1alpha1.ActionPhaseFailed))
+					g.Expect(phases[runningStatefulSetKey.Name]).To(Equal(dpv1alpha1.ActionPhaseRunning))
 				})).Should(Succeed())
 			})
 


### PR DESCRIPTION
## What changed

Backport PR #10735 to `release-1.1` on top of the merged #10729 backport.

- keep a finite multi-target Backup Running while any sibling Job action remains active, even when another action failed
- aggregate the finite Backup as Failed after every sibling is terminal
- fail a Continuous multi-target Backup immediately when any StatefulSet action fails, because healthy continuous actions can remain Running for the schedule lifetime
- preserve every observed action phase in `status.actions`
- retain the strict Pending/no-Pod fallback behavior from #10729

## Validation

Exact release head: `095997ab8ea2ebf0c6119d54e2e9ff10ef5c8152`.

- focused finite and Continuous opposite-boundary envtests: PASS
- full `controllers/dataprotection`: PASS in 37.2s
- `go vet ./controllers/dataprotection`: PASS
- Go 1.25.10 scoped `make check-diff`: PASS, 80.9% coverage, clean branch

This is source and envtest evidence; runtime product validation is not claimed.

Refs #10728
Refs #10735
Fixes #10737
