### PR TITLE
chore(dataprotection): cover empty restored account password

### DIFF
--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -2505,11 +2505,14 @@ func TestRestoreSystemAccountSecretsRestoresComponentAndShardingSecrets(t *testi
 	encryptor := intctrlutil.NewEncryptor("")
 	componentPassword, err := encryptor.Encrypt([]byte("component-password"))
 	require.NoError(t, err)
+	emptyPassword, err := encryptor.Encrypt(nil)
+	require.NoError(t, err)
 	shardingPassword, err := encryptor.Encrypt([]byte("sharding-password"))
 	require.NoError(t, err)
 	accounts, err := json.Marshal(map[string]map[string]string{
 		"mysql": {
-			"admin": componentPassword,
+			"admin":        componentPassword,
+			"passwordless": emptyPassword,
 		},
 		"shard": {
 			"root": shardingPassword,
@@ -2570,6 +2573,14 @@ func TestRestoreSystemAccountSecretsRestoresComponentAndShardingSecrets(t *testi
 	require.Len(t, componentSecret.OwnerReferences, 1)
 	require.Equal(t, "Component", componentSecret.OwnerReferences[0].Kind)
 	require.Equal(t, component.Name, componentSecret.OwnerReferences[0].Name)
+
+	emptyPasswordSecret := &corev1.Secret{}
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKey{
+		Namespace: "default",
+		Name:      constant.GenerateAccountSecretName("cluster", "mysql", "passwordless"),
+	}, emptyPasswordSecret))
+	require.Contains(t, emptyPasswordSecret.Data, constant.AccountPasswdForSecret)
+	require.Equal(t, []byte{}, emptyPasswordSecret.Data[constant.AccountPasswdForSecret])
 
 	shardingSecret := &corev1.Secret{}
 	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKey{


### PR DESCRIPTION
## What changed

- extend the existing system-account restore test with an explicitly present empty password
- verify the restored Secret keeps the password key with a zero-length value
- keep the existing non-empty component and shared-sharding coverage

## Why

The main restore path already preserves empty system-account passwords by decrypting every account entry from the Backup annotation and upserting the exact value into the managed Secret. This test locks that behavior and prevents a future fallback or generation change from treating an explicitly empty password as missing.

## Validation

```bash
go test -overlay=<generated-mock-overlay.json> \
  ./controllers/dataprotection \
  -run '^TestRestoreSystemAccountSecretsRestoresComponentAndShardingSecrets$' \
  -count=1
```

The focused test passed. The overlay only supplies the generated test client mock omitted from the checkout and is not part of this change.
