### PR TITLE
fix: keep tools image updates in place for live pods

### DIFF
--- a/pkg/controller/instance/in_place_update_utils.go
+++ b/pkg/controller/instance/in_place_update_utils.go
@@ -293,12 +293,7 @@ func safeMetadataOnlyInPlaceUpdate(old, new *corev1.Pod) bool {
 // revision state; already-completed init containers are not re-run, so any
 // init-time copied tools refresh on the next natural Pod recreation.
 func safeKBManagedImageOnlyInPlaceUpdate(old, new *corev1.Pod) bool {
-	initChanged, ok := intctrlutil.OnlyKBManagedContainerImageChanged(old.Spec.InitContainers, new.Spec.InitContainers)
-	if !ok {
-		return false
-	}
-	containerChanged, ok := intctrlutil.OnlyKBManagedContainerImageChanged(old.Spec.Containers, new.Spec.Containers)
-	if !ok || (!initChanged && !containerChanged) {
+	if !intctrlutil.OnlyKBManagedPodImagesChanged(old, new) {
 		return false
 	}
 

--- a/pkg/controller/instance/utils_test.go
+++ b/pkg/controller/instance/utils_test.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,6 +34,8 @@ import (
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/builder"
+	"github.com/apecloud/kubeblocks/pkg/controller/kubebuilderx"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
 
@@ -76,6 +79,15 @@ func TestGetPodUpdatePolicyInSpecForKBManagedToolsImage(t *testing.T) {
 	newPod.Spec.InitContainers[0].Image = "mirror.local/apecloud/kubeblocks-tools:1.1.0"
 	newPod.Spec.Containers[1].Image = "mirror.local/apecloud/kubeblocks-tools:1.1.0"
 
+	// Simulate fields added only to the admitted live Pod. They are absent
+	// from the template-built desired Pod and must survive an image patch.
+	oldPod.Spec.InitContainers[0].ImagePullPolicy = corev1.PullIfNotPresent
+	oldPod.Spec.Containers[1].Env = []corev1.EnvVar{{Name: "ADMISSION_INJECTED", Value: "true"}}
+	oldPod.Spec.Containers[1].VolumeMounts = []corev1.VolumeMount{{
+		Name:      "kube-api-access",
+		MountPath: "/var/run/secrets/kubernetes.io/serviceaccount",
+		ReadOnly:  true,
+	}}
 	inst := builder.NewInstanceBuilder("default", "inst-0").
 		SetPodUpdatePolicy(kbappsv1.ReCreatePodUpdatePolicyType).
 		SetPodUpgradePolicy(kbappsv1.ReCreatePodUpdatePolicyType).
@@ -92,7 +104,7 @@ func TestGetPodUpdatePolicyInSpecForKBManagedToolsImage(t *testing.T) {
 		t.Fatalf("expected StrictInPlace for KB-managed tools image change with StrictInPlace policy, got %s", policy)
 	}
 	if !safeKBManagedImageOnlyInPlaceUpdate(oldPod, newPod) {
-		t.Fatalf("expected KB-managed tools image-only change to skip switchover")
+		t.Fatalf("expected live-only admitted fields not to block the KB-managed tools image update")
 	}
 
 	labelChangedPod := newPod.DeepCopy()
@@ -108,6 +120,125 @@ func TestGetPodUpdatePolicyInSpecForKBManagedToolsImage(t *testing.T) {
 	appChangedPod.Spec.Containers[0].Image = "docker.io/apecloud/redis:7.4"
 	if policy := getPodUpdatePolicyInSpec(inst, oldPod, appChangedPod); policy != kbappsv1.ReCreatePodUpdatePolicyType {
 		t.Fatalf("expected ReCreate for app image change, got %s", policy)
+	}
+
+	revisionChangedPod := newPod.DeepCopy()
+	revisionChangedPod.Spec.Containers[1].Env = []corev1.EnvVar{{Name: "TEMPLATE_CHANGE", Value: "true"}}
+	revisionChangedInst := builder.NewInstanceBuilder("default", "inst-0").
+		SetPodTemplate(corev1.PodTemplateSpec{Spec: revisionChangedPod.Spec}).
+		SetPodUpdatePolicy(kbappsv1.ReCreatePodUpdatePolicyType).
+		SetPodUpgradePolicy(kbappsv1.ReCreatePodUpdatePolicyType).
+		GetObject()
+	revisionChangedInst.Status.UpdateRevision = "desired-revision"
+	oldPod.Labels = map[string]string{appsv1.ControllerRevisionHashLabelKey: "live-revision"}
+	policy, _, err := getPodUpdatePolicy(revisionChangedInst, oldPod)
+	if err != nil {
+		t.Fatalf("getPodUpdatePolicy() error = %v", err)
+	}
+	if policy != recreatePolicy {
+		t.Fatalf("expected revision-classified non-image template change to recreate, got %s", policy)
+	}
+
+	removedContainerSpec := *newPod.Spec.DeepCopy()
+	removedContainerSpec.Containers = removedContainerSpec.Containers[1:]
+	containerRemovedInst := builder.NewInstanceBuilder("default", "inst-0").
+		SetPodTemplate(corev1.PodTemplateSpec{Spec: removedContainerSpec}).
+		SetPodUpdatePolicy(kbappsv1.ReCreatePodUpdatePolicyType).
+		SetPodUpgradePolicy(kbappsv1.ReCreatePodUpdatePolicyType).
+		GetObject()
+	containerRemovedInst.Status.UpdateRevision = "desired-revision"
+	policy, _, err = getPodUpdatePolicy(containerRemovedInst, oldPod)
+	if err != nil {
+		t.Fatalf("getPodUpdatePolicy() for removed container error = %v", err)
+	}
+	if policy != recreatePolicy {
+		t.Fatalf("expected a template-owned container removal to recreate, got %s", policy)
+	}
+}
+
+func TestUpdateReconcilerPatchesKBManagedToolsImagesOnAdmittedPod(t *testing.T) {
+	oldToolsImage := viper.GetString(constant.KBToolsImage)
+	defer viper.Set(constant.KBToolsImage, oldToolsImage)
+	viper.Set(constant.KBToolsImage, "docker.io/apecloud/kubeblocks-tools:1.0.0")
+	origSupportResize := intctrlutil.SupportResizeSubResource
+	defer func() { intctrlutil.SupportResizeSubResource = origSupportResize }()
+	intctrlutil.SupportResizeSubResource = func() (bool, error) { return false, nil }
+
+	inst := builder.NewInstanceBuilder("default", "inst-0").
+		SetInitContainers([]corev1.Container{{
+			Name: "init-kbagent", Image: "docker.io/apecloud/kubeblocks-tools:1.0.0", Command: []string{"cp"},
+		}}).
+		SetContainers([]corev1.Container{
+			{Name: "app", Image: "docker.io/apecloud/redis:7.2"},
+			{Name: "kbagent", Image: "docker.io/apecloud/kubeblocks-tools:1.0.0", Command: []string{"/bin/kbagent"}},
+		}).
+		SetPodUpdatePolicy(kbappsv1.ReCreatePodUpdatePolicyType).
+		SetPodUpgradePolicy(kbappsv1.ReCreatePodUpdatePolicyType).
+		GetObject()
+	revision, err := buildInstancePodRevision(&inst.Spec.Template, inst)
+	if err != nil {
+		t.Fatalf("buildInstancePodRevision() error = %v", err)
+	}
+	inst.Status.UpdateRevision = revision
+	pod, err := buildInstancePod(inst, revision)
+	if err != nil {
+		t.Fatalf("buildInstancePod() error = %v", err)
+	}
+	pod.UID = "live-pod-uid"
+	pod.Spec.InitContainers[0].ImagePullPolicy = corev1.PullIfNotPresent
+	pod.Spec.InitContainers[0].TerminationMessagePath = corev1.TerminationMessagePathDefault
+	pod.Spec.Containers[1].Env = []corev1.EnvVar{{Name: "ADMISSION_INJECTED", Value: "true"}}
+	pod.Spec.Containers[1].VolumeMounts = []corev1.VolumeMount{{
+		Name:      "kube-api-access",
+		MountPath: "/var/run/secrets/kubernetes.io/serviceaccount",
+		ReadOnly:  true,
+	}}
+	pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{
+		Name: "injected-sidecar", Image: "example.com/mesh-sidecar:1.0",
+	})
+	pod.Status.Phase = corev1.PodRunning
+	pod.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}
+
+	inst.Spec.Template.Spec.InitContainers[0].Image = "mirror.local/apecloud/kubeblocks-tools:1.1.0"
+	inst.Spec.Template.Spec.Containers[1].Image = "mirror.local/apecloud/kubeblocks-tools:1.1.0"
+	tree := kubebuilderx.NewObjectTree()
+	tree.SetRoot(inst)
+	if err = tree.Add(pod); err != nil {
+		t.Fatalf("ObjectTree.Add() error = %v", err)
+	}
+
+	if _, err = NewUpdateReconciler().Reconcile(tree); err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	postPods := tree.List(&corev1.Pod{})
+	if len(postPods) != 1 {
+		t.Fatalf("expected Pod to be patched in place, got %d Pods", len(postPods))
+	}
+	updatedPod := postPods[0].(*corev1.Pod)
+	if updatedPod.UID != pod.UID {
+		t.Fatalf("expected Pod UID %q to be preserved, got %q", pod.UID, updatedPod.UID)
+	}
+	_, updatedInitKBAgent := intctrlutil.GetContainerByName(updatedPod.Spec.InitContainers, "init-kbagent")
+	if updatedInitKBAgent == nil || updatedInitKBAgent.Image != "mirror.local/apecloud/kubeblocks-tools:1.1.0" ||
+		updatedInitKBAgent.ImagePullPolicy != corev1.PullIfNotPresent {
+		t.Fatalf("unexpected updated init-kbagent: %#v", updatedInitKBAgent)
+	}
+	_, updatedKBAgent := intctrlutil.GetContainerByName(updatedPod.Spec.Containers, "kbagent")
+	if updatedKBAgent == nil || updatedKBAgent.Image != "mirror.local/apecloud/kubeblocks-tools:1.1.0" ||
+		len(updatedKBAgent.Env) != 1 || updatedKBAgent.Env[0].Name != "ADMISSION_INJECTED" ||
+		len(updatedKBAgent.VolumeMounts) != 1 || updatedKBAgent.VolumeMounts[0].Name != "kube-api-access" {
+		t.Fatalf("unexpected updated kbagent: %#v", updatedKBAgent)
+	}
+	_, injectedSidecar := intctrlutil.GetContainerByName(updatedPod.Spec.Containers, "injected-sidecar")
+	if injectedSidecar == nil || injectedSidecar.Image != "example.com/mesh-sidecar:1.0" {
+		t.Fatalf("injected sidecar was not preserved: %#v", injectedSidecar)
+	}
+	_, option, err := tree.GetWithOption(updatedPod)
+	if err != nil {
+		t.Fatalf("ObjectTree.GetWithOption() error = %v", err)
+	}
+	if !option.Patch {
+		t.Fatal("expected KB-managed image-only update to use a patch")
 	}
 }
 

--- a/pkg/controller/instanceset/in_place_update_util.go
+++ b/pkg/controller/instanceset/in_place_update_util.go
@@ -302,12 +302,7 @@ func safeMetadataOnlyInPlaceUpdate(old, new *corev1.Pod) bool {
 // revision state; already-completed init containers are not re-run, so any
 // init-time copied tools refresh on the next natural Pod recreation.
 func safeKBManagedImageOnlyInPlaceUpdate(old, new *corev1.Pod) bool {
-	initChanged, ok := intctrlutil.OnlyKBManagedContainerImageChanged(old.Spec.InitContainers, new.Spec.InitContainers)
-	if !ok {
-		return false
-	}
-	containerChanged, ok := intctrlutil.OnlyKBManagedContainerImageChanged(old.Spec.Containers, new.Spec.Containers)
-	if !ok || (!initChanged && !containerChanged) {
+	if !intctrlutil.OnlyKBManagedPodImagesChanged(old, new) {
 		return false
 	}
 

--- a/pkg/controller/instanceset/in_place_update_util_test.go
+++ b/pkg/controller/instanceset/in_place_update_util_test.go
@@ -150,13 +150,19 @@ var _ = Describe("instance util test", func() {
 			newPod := oldPod.DeepCopy()
 			newPod.Spec.Containers[1].Image = "mirror.local/apecloud/kubeblocks-tools:1.1.0"
 			newPod.Spec.InitContainers[0].Image = "mirror.local/apecloud/kubeblocks-tools:1.1.0"
-
+			oldPod.Spec.InitContainers[0].TerminationMessagePath = corev1.TerminationMessagePathDefault
+			oldPod.Spec.Containers[1].VolumeMounts = []corev1.VolumeMount{{
+				Name:      "kube-api-access",
+				MountPath: "/var/run/secrets/kubernetes.io/serviceaccount",
+				ReadOnly:  true,
+			}}
 			its := builder.NewInstanceSetBuilder(namespace, name).
 				SetPodUpdatePolicy(kbappsv1.ReCreatePodUpdatePolicyType).
 				SetPodUpgradePolicy(kbappsv1.ReCreatePodUpdatePolicyType).
 				GetObject()
 
 			Expect(getPodUpdatePolicyInSpec(its, oldPod, newPod)).Should(Equal(kbappsv1.PreferInPlacePodUpdatePolicyType))
+			Expect(safeKBManagedImageOnlyInPlaceUpdate(oldPod, newPod)).Should(BeTrue())
 
 			strictInPlaceITS := builder.NewInstanceSetBuilder(namespace, name).
 				SetPodUpdatePolicy(kbappsv1.ReCreatePodUpdatePolicyType).

--- a/pkg/controller/instanceset/reconciler_update_test.go
+++ b/pkg/controller/instanceset/reconciler_update_test.go
@@ -563,6 +563,12 @@ var _ = Describe("update reconciler test", func() {
 			its.Spec.Replicas = ptr.To[int32](1)
 			its.Spec.PodUpdatePolicy = kbappsv1.ReCreatePodUpdatePolicyType
 			its.Spec.PodUpgradePolicy = kbappsv1.ReCreatePodUpdatePolicyType
+			its.Spec.Template.Spec.ServiceAccountName = "current-sa"
+			its.Spec.Template.Spec.InitContainers = append(its.Spec.Template.Spec.InitContainers, corev1.Container{
+				Name:    "init-kbagent",
+				Image:   "docker.io/apecloud/kubeblocks-tools:1.0.0",
+				Command: []string{"cp"},
+			})
 			its.Spec.Template.Spec.Containers = append(its.Spec.Template.Spec.Containers, corev1.Container{
 				Name:    "kbagent",
 				Image:   "docker.io/apecloud/kubeblocks-tools:1.0.0",
@@ -581,13 +587,48 @@ var _ = Describe("update reconciler test", func() {
 			pods := tree.List(&corev1.Pod{})
 			Expect(pods).Should(HaveLen(1))
 			pod := pods[0].(*corev1.Pod)
+			pod.UID = "live-pod-uid"
+			pod.Spec.AutomountServiceAccountToken = ptr.To(true)
+			pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{
+				Name: "kube-api-access",
+				VolumeSource: corev1.VolumeSource{Projected: &corev1.ProjectedVolumeSource{
+					Sources: []corev1.VolumeProjection{{ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+						Path: "token",
+					}}},
+				}},
+			})
+			for i := range pod.Spec.InitContainers {
+				if pod.Spec.InitContainers[i].Name == "init-kbagent" {
+					pod.Spec.InitContainers[i].ImagePullPolicy = corev1.PullIfNotPresent
+					pod.Spec.InitContainers[i].TerminationMessagePath = corev1.TerminationMessagePathDefault
+				}
+			}
+			for i := range pod.Spec.Containers {
+				if pod.Spec.Containers[i].Name == "kbagent" {
+					pod.Spec.Containers[i].Env = []corev1.EnvVar{{Name: "ADMISSION_INJECTED", Value: "true"}}
+					pod.Spec.Containers[i].VolumeMounts = []corev1.VolumeMount{{
+						Name:      "kube-api-access",
+						MountPath: "/var/run/secrets/kubernetes.io/serviceaccount",
+						ReadOnly:  true,
+					}}
+				}
+			}
 			pod.Status.Phase = corev1.PodRunning
 			pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
 				Type:               corev1.PodReady,
 				Status:             corev1.ConditionTrue,
 				LastTransitionTime: metav1.NewTime(time.Now().Add(-1 * minReadySeconds * time.Second)),
 			})
+			if its.Annotations == nil {
+				its.Annotations = map[string]string{}
+			}
+			its.Annotations[constant.ProposedServiceAccountNameAnnotationKey] = "proposed-sa"
 
+			for i := range its.Spec.Template.Spec.InitContainers {
+				if its.Spec.Template.Spec.InitContainers[i].Name == "init-kbagent" {
+					its.Spec.Template.Spec.InitContainers[i].Image = "mirror.local/apecloud/kubeblocks-tools:1.1.0"
+				}
+			}
 			for i := range its.Spec.Template.Spec.Containers {
 				if its.Spec.Template.Spec.Containers[i].Name == "kbagent" {
 					its.Spec.Template.Spec.Containers[i].Image = "mirror.local/apecloud/kubeblocks-tools:1.1.0"
@@ -603,9 +644,20 @@ var _ = Describe("update reconciler test", func() {
 			Expect(postPods).Should(HaveLen(1),
 				"pod should be in-place updated, not deleted/recreated")
 			updatedPod := postPods[0].(*corev1.Pod)
+			Expect(updatedPod.UID).Should(Equal(pod.UID), "an image-only update must preserve Pod identity")
+			Expect(updatedPod.Spec.ServiceAccountName).Should(Equal("current-sa"),
+				"the proposed immutable service account must not be applied by the image patch")
+			Expect(updatedPod.Spec.AutomountServiceAccountToken).Should(Equal(ptr.To(true)))
+			Expect(updatedPod.Spec.Volumes).Should(ContainElement(HaveField("Name", "kube-api-access")))
+			_, updatedInitKBAgent := intctrlutil.GetContainerByName(updatedPod.Spec.InitContainers, "init-kbagent")
+			Expect(updatedInitKBAgent).ShouldNot(BeNil())
+			Expect(updatedInitKBAgent.Image).Should(Equal("mirror.local/apecloud/kubeblocks-tools:1.1.0"))
+			Expect(updatedInitKBAgent.ImagePullPolicy).Should(Equal(corev1.PullIfNotPresent))
 			_, updatedKBAgent := intctrlutil.GetContainerByName(updatedPod.Spec.Containers, "kbagent")
 			Expect(updatedKBAgent).ShouldNot(BeNil())
 			Expect(updatedKBAgent.Image).Should(Equal("mirror.local/apecloud/kubeblocks-tools:1.1.0"))
+			Expect(updatedKBAgent.Env).Should(ContainElement(corev1.EnvVar{Name: "ADMISSION_INJECTED", Value: "true"}))
+			Expect(updatedKBAgent.VolumeMounts).Should(ContainElement(HaveField("Name", "kube-api-access")))
 			_, option, err := tree.GetWithOption(updatedPod)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(option.Patch).Should(BeTrue(),
@@ -613,6 +665,61 @@ var _ = Describe("update reconciler test", func() {
 			Expect(spy.switchoverCalls).Should(Equal(0),
 				"switchover must not be invoked when only KB-managed tools images differ")
 		})
+
+		DescribeTable("keeps recreation policy for revision and application image changes",
+			func(mutateTemplate func(*workloads.InstanceSet)) {
+				oldToolsImage := viper.GetString(constant.KBToolsImage)
+				defer viper.Set(constant.KBToolsImage, oldToolsImage)
+				viper.Set(constant.KBToolsImage, "docker.io/apecloud/kubeblocks-tools:1.0.0")
+
+				its.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+				its.Spec.Replicas = ptr.To[int32](1)
+				its.Spec.PodUpdatePolicy = kbappsv1.ReCreatePodUpdatePolicyType
+				its.Spec.PodUpgradePolicy = kbappsv1.ReCreatePodUpdatePolicyType
+				its.Spec.Template.Spec.Containers = append(its.Spec.Template.Spec.Containers, corev1.Container{
+					Name:    "kbagent",
+					Image:   "docker.io/apecloud/kubeblocks-tools:1.0.0",
+					Command: []string{"/bin/kbagent"},
+				})
+
+				tree := kubebuilderx.NewObjectTree()
+				tree.SetRoot(its)
+				prepareForUpdate(tree)
+				mutateTemplate(its)
+
+				res, err := NewRevisionUpdateReconciler().Reconcile(tree)
+				Expect(err).Should(BeNil())
+				Expect(res).Should(Equal(kubebuilderx.Continue))
+
+				pod := tree.List(&corev1.Pod{})[0].(*corev1.Pod)
+				pod.Status.Phase = corev1.PodRunning
+				pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
+					Type:               corev1.PodReady,
+					Status:             corev1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(time.Now().Add(-1 * minReadySeconds * time.Second)),
+				})
+
+				res, err = NewUpdateReconciler().Reconcile(tree)
+				Expect(err).Should(BeNil())
+				Expect(res).Should(Equal(kubebuilderx.Continue))
+				Expect(tree.List(&corev1.Pod{})).Should(BeEmpty(), "the Pod must be recreated, not patched")
+			},
+			Entry("non-image template changes despite a simultaneous tools image update", func(its *workloads.InstanceSet) {
+				for i := range its.Spec.Template.Spec.Containers {
+					if its.Spec.Template.Spec.Containers[i].Name == "kbagent" {
+						its.Spec.Template.Spec.Containers[i].Image = "mirror.local/apecloud/kubeblocks-tools:1.1.0"
+						its.Spec.Template.Spec.Containers[i].Env = []corev1.EnvVar{{Name: "TEMPLATE_CHANGE", Value: "true"}}
+					}
+				}
+			}),
+			Entry("application image changes", func(its *workloads.InstanceSet) {
+				its.Spec.Template.Spec.Containers[0].Image = "example.com/application:new"
+			}),
+			Entry("a template-owned container is removed while tools images change", func(its *workloads.InstanceSet) {
+				its.Spec.Template.Spec.Containers = its.Spec.Template.Spec.Containers[1:]
+				its.Spec.Template.Spec.Containers[0].Image = "mirror.local/apecloud/kubeblocks-tools:1.1.0"
+			}),
+		)
 	})
 })
 

--- a/pkg/controllerutil/image_util.go
+++ b/pkg/controllerutil/image_util.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 
@@ -329,6 +330,48 @@ func onlyKBManagedContainerImageChanged(oldContainers, newContainers []corev1.Co
 		if !isKBManagedContainerName(oldContainer.Name) ||
 			!sameImageRepositoryName(oldImage, toolsImage) ||
 			!sameImageRepositoryName(newImage, toolsImage) {
+			return false, false
+		}
+		changed = true
+	}
+	return changed, true
+}
+
+// OnlyKBManagedPodImagesChanged returns true when all desired container image
+// differences in a Pod are KB-managed tools image changes and at least one such
+// image changed. Unlike template-to-template classification, it ignores
+// non-image container fields present only on the live Pod because admission may
+// add them and in-place updates start from a clone of that Pod. Desired
+// non-image container changes remain owned by workload revision classification.
+func OnlyKBManagedPodImagesChanged(old, new *corev1.Pod) bool {
+	toolsImage := viper.GetString(constant.KBToolsImage)
+	if toolsImage == "" {
+		return false
+	}
+	initChanged, ok := onlyKBManagedLiveContainerImagesChanged(old.Spec.InitContainers, new.Spec.InitContainers, toolsImage)
+	if !ok {
+		return false
+	}
+	containerChanged, ok := onlyKBManagedLiveContainerImagesChanged(old.Spec.Containers, new.Spec.Containers, toolsImage)
+	return ok && (initChanged || containerChanged)
+}
+
+func onlyKBManagedLiveContainerImagesChanged(oldContainers, newContainers []corev1.Container, toolsImage string) (bool, bool) {
+	changed := false
+	for _, newContainer := range newContainers {
+		index := slices.IndexFunc(oldContainers, func(oldContainer corev1.Container) bool {
+			return oldContainer.Name == newContainer.Name
+		})
+		if index < 0 {
+			return false, false
+		}
+		oldContainer := oldContainers[index]
+		if EqualContainerImageInSpec(oldContainer.Image, newContainer.Image) {
+			continue
+		}
+		if !isKBManagedContainerName(oldContainer.Name) ||
+			!sameImageRepositoryName(oldContainer.Image, toolsImage) ||
+			!sameImageRepositoryName(newContainer.Image, toolsImage) {
 			return false, false
 		}
 		changed = true

--- a/pkg/controllerutil/image_util_test.go
+++ b/pkg/controllerutil/image_util_test.go
@@ -21,6 +21,7 @@ package controllerutil
 
 import (
 	"fmt"
+	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -30,6 +31,50 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+func TestOnlyKBManagedPodImagesChangedIgnoresLiveOnlyContainerState(t *testing.T) {
+	oldToolsImage := viper.GetString(constant.KBToolsImage)
+	defer viper.Set(constant.KBToolsImage, oldToolsImage)
+	viper.Set(constant.KBToolsImage, "docker.io/apecloud/kubeblocks-tools:1.0.0")
+
+	desired := &corev1.Pod{Spec: corev1.PodSpec{
+		InitContainers: []corev1.Container{{
+			Name: "init-kbagent", Image: "mirror.local/apecloud/kubeblocks-tools:1.1.0",
+		}},
+		Containers: []corev1.Container{
+			{Name: "app", Image: "docker.io/apecloud/redis:7.2"},
+			{Name: "kbagent", Image: "mirror.local/apecloud/kubeblocks-tools:1.1.0"},
+		},
+	}}
+	live := desired.DeepCopy()
+	live.Spec.InitContainers[0].Image = "docker.io/apecloud/kubeblocks-tools:1.0.0"
+	live.Spec.InitContainers[0].ImagePullPolicy = corev1.PullIfNotPresent
+	live.Spec.Containers[1].Image = "docker.io/apecloud/kubeblocks-tools:1.0.0"
+	live.Spec.Containers[1].Env = []corev1.EnvVar{{Name: "ADMISSION_INJECTED", Value: "true"}}
+	live.Spec.Containers[1].VolumeMounts = []corev1.VolumeMount{{
+		Name:      "kube-api-access",
+		MountPath: "/var/run/secrets/kubernetes.io/serviceaccount",
+		ReadOnly:  true,
+	}}
+	live.Spec.Containers = append(live.Spec.Containers, corev1.Container{
+		Name: "injected-sidecar", Image: "example.com/mesh-sidecar:1.0",
+	})
+	if !OnlyKBManagedPodImagesChanged(live, desired) {
+		t.Fatal("live-only defaults, fields, and containers must not block a tools image-only update")
+	}
+
+	appChanged := desired.DeepCopy()
+	appChanged.Spec.Containers[0].Image = "docker.io/apecloud/redis:7.4"
+	if OnlyKBManagedPodImagesChanged(live, appChanged) {
+		t.Fatal("application image changes must not be classified as KB-managed tools image changes")
+	}
+
+	missingLiveContainer := desired.DeepCopy()
+	missingLiveContainer.Spec.Containers = missingLiveContainer.Spec.Containers[:1]
+	if OnlyKBManagedPodImagesChanged(missingLiveContainer, desired) {
+		t.Fatal("a desired container missing from the live Pod must not be classified as an image-only update")
+	}
+}
 
 var _ = Describe("image util test", func() {
 	imageList := [][]string{
@@ -121,6 +166,19 @@ var _ = Describe("image util test", func() {
 		changed, ok = OnlyKBManagedContainerImageChanged(basePod.Spec.Containers, newPod.Spec.Containers)
 		Expect(ok).Should(BeTrue())
 		Expect(changed).Should(BeTrue())
+		Expect(OnlyKBManagedPodImagesChanged(basePod, newPod)).Should(BeTrue())
+
+		liveDefaultedPod := basePod.DeepCopy()
+		liveDefaultedPod.Spec.InitContainers[0].ImagePullPolicy = corev1.PullIfNotPresent
+		liveDefaultedPod.Spec.InitContainers[0].TerminationMessagePath = corev1.TerminationMessagePathDefault
+		liveDefaultedPod.Spec.Containers[1].Env = []corev1.EnvVar{{Name: "ADMISSION_INJECTED", Value: "true"}}
+		liveDefaultedPod.Spec.Containers[1].VolumeMounts = []corev1.VolumeMount{{
+			Name:      "kube-api-access",
+			MountPath: "/var/run/secrets/kubernetes.io/serviceaccount",
+			ReadOnly:  true,
+		}}
+		Expect(OnlyKBManagedPodImagesChanged(liveDefaultedPod, newPod)).Should(BeTrue(),
+			"live-only defaults and injected fields must not affect image classification")
 
 		appChangedPod := basePod.DeepCopy()
 		appChangedPod.Spec.Containers[0].Image = "docker.io/apecloud/redis:7.4"
@@ -138,10 +196,15 @@ var _ = Describe("image util test", func() {
 		_, ok = OnlyKBManagedContainerImageChanged(basePod.Spec.Containers, agentEnvChangedPod.Spec.Containers)
 		Expect(ok).Should(BeFalse())
 
-		removedContainerPod := basePod.DeepCopy()
-		removedContainerPod.Spec.Containers = removedContainerPod.Spec.Containers[:len(removedContainerPod.Spec.Containers)-1]
-		_, ok = OnlyKBManagedContainerImageChanged(basePod.Spec.Containers, removedContainerPod.Spec.Containers)
+		addedDesiredContainerPod := newPod.DeepCopy()
+		addedDesiredContainerPod.Spec.Containers = append(addedDesiredContainerPod.Spec.Containers, corev1.Container{
+			Name:  "new-template-sidecar",
+			Image: "example.com/template:1.0",
+		})
+		_, ok = OnlyKBManagedContainerImageChanged(basePod.Spec.Containers, addedDesiredContainerPod.Spec.Containers)
 		Expect(ok).Should(BeFalse())
+
+		Expect(OnlyKBManagedPodImagesChanged(basePod, basePod.DeepCopy())).Should(BeFalse())
 	})
 
 	It("only expands image when config does not exist", func() {


### PR DESCRIPTION
## What this PR changes

- adds a live-Pod-aware classifier for KubeBlocks-managed tools image changes
- uses the same classifier in both Instance and InstanceSet update paths
- keeps the existing strict template-to-template classifier unchanged
- adds regression coverage for API-defaulted/admission-injected fields and sidecars, service-account token mounts, proposed service accounts, application image changes, and non-image/container-shape revision changes

## Root cause

The image-only compatibility path cleared the image field and then compared the full live and desired Container objects with `reflect.DeepEqual`. Live Pods contain Kubernetes-defaulted and admission-injected fields that are absent from the workload template, so a KubeBlocks tools image-only change was misclassified and inherited `podUpgradePolicy: ReCreate`.

The new live-Pod classifier limits this check to image differences in desired containers. Workload revisions remain responsible for non-in-place template and container-shape changes, while the existing clone-and-merge update path preserves live-only fields and admission-injected containers.

## Impact

Upgrading the KubeBlocks tools/kbagent image no longer recreates existing database Pods solely because their live Container objects contain API-defaulted or admission-injected fields. Application image changes and revision-changing template changes continue to follow the configured upgrade policy.

Fixes #10726.

## Validation

- `go test ./pkg/controllerutil -count=1`
- `go test ./pkg/controller/instance ./pkg/controller/instanceset ./pkg/controller/instanceset2 -count=1`
- `go test ./pkg/controller/... -run '^$' -count=1`
- `go test ./controllers/... -run '^$' -count=1`
- `git diff --check`
