### PR TITLE
fix: keep tools image updates in place for live pods

### DIFF
--- a/pkg/controller/instanceset/in_place_update_util.go
+++ b/pkg/controller/instanceset/in_place_update_util.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/ptr"
 
+	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
@@ -305,6 +306,25 @@ func safeMetadataOnlyInPlaceUpdate(old, new *corev1.Pod) bool {
 	return true
 }
 
+// safeKBManagedImageOnlyInPlaceUpdate returns true when the only effective
+// difference is a KB-managed tools image update. These updates should patch the
+// Pod in place without inheriting application upgrade policy or invoking
+// database switchover. Init container image patches only converge PodSpec and
+// revision state; already-completed init containers are not re-run, so any
+// init-time copied tools refresh on the next natural Pod recreation. Live-only
+// admission fields are preserved by copyAndMerge.
+func safeKBManagedImageOnlyInPlaceUpdate(old, new *corev1.Pod) bool {
+	if !intctrlutil.OnlyKBManagedPodImagesChanged(old, new) {
+		return false
+	}
+
+	oldCopy := old.DeepCopy()
+	newCopy := new.DeepCopy()
+	oldCopy.Spec.InitContainers = newCopy.Spec.InitContainers
+	oldCopy.Spec.Containers = newCopy.Spec.Containers
+	return equalBasicInPlaceFields(oldCopy, newCopy) && equalResourcesInPlaceFields(oldCopy, newCopy)
+}
+
 // equalUpgradeRestartAnnotations returns true when old and new agree on every
 // annotation whose key is prefixed with constant.UpgradeRestartAnnotationKey
 // ("config.kubeblocks.io/restart"). The parameters controller writes these via
@@ -422,10 +442,10 @@ func getPodUpdatePolicy(its *workloads.InstanceSet, pod *corev1.Pod) (podUpdateP
 }
 
 func getPodUpdatePolicyInSpec(its *workloads.InstanceSet, old, new *corev1.Pod) workloads.PodUpdatePolicyType {
-	if !equalField(old.Spec.InitContainers, new.Spec.InitContainers) {
-		return its.Spec.PodUpgradePolicy
-	}
-	if !equalField(old.Spec.Containers, new.Spec.Containers) {
+	if !equalField(old.Spec.InitContainers, new.Spec.InitContainers) || !equalField(old.Spec.Containers, new.Spec.Containers) {
+		if its.Spec.PodUpgradePolicy == kbappsv1.ReCreatePodUpdatePolicyType && safeKBManagedImageOnlyInPlaceUpdate(old, new) {
+			return kbappsv1.PreferInPlacePodUpdatePolicyType
+		}
 		return its.Spec.PodUpgradePolicy
 	}
 	return its.Spec.PodUpdatePolicy

--- a/pkg/controller/instanceset/in_place_update_util_test.go
+++ b/pkg/controller/instanceset/in_place_update_util_test.go
@@ -140,6 +140,59 @@ var _ = Describe("instance util test", func() {
 		})
 	})
 
+	Context("KB-managed tools image update", func() {
+		It("ignores live-only admission state and keeps other upgrade changes strict", func() {
+			oldToolsImage := viper.GetString(constant.KBToolsImage)
+			defer viper.Set(constant.KBToolsImage, oldToolsImage)
+			viper.Set(constant.KBToolsImage, "docker.io/apecloud/kubeblocks-tools:1.0.0")
+
+			oldPod := &corev1.Pod{Spec: corev1.PodSpec{
+				InitContainers: []corev1.Container{{
+					Name: "init-kbagent", Image: "docker.io/apecloud/kubeblocks-tools:1.0.0", Command: []string{"cp"},
+				}},
+				Containers: []corev1.Container{
+					{Name: "app", Image: "docker.io/apecloud/redis:7.2"},
+					{Name: "kbagent", Image: "docker.io/apecloud/kubeblocks-tools:1.0.0", Command: []string{"/bin/kbagent"}},
+				},
+			}}
+			newPod := oldPod.DeepCopy()
+			newPod.Spec.InitContainers[0].Image = "mirror.local/apecloud/kubeblocks-tools:1.1.0"
+			newPod.Spec.Containers[1].Image = "mirror.local/apecloud/kubeblocks-tools:1.1.0"
+			oldPod.Spec.InitContainers[0].TerminationMessagePath = corev1.TerminationMessagePathDefault
+			oldPod.Spec.Containers[1].Env = []corev1.EnvVar{{Name: "ADMISSION_INJECTED", Value: "true"}}
+			oldPod.Spec.Containers[1].VolumeMounts = []corev1.VolumeMount{{
+				Name:      "kube-api-access",
+				MountPath: "/var/run/secrets/kubernetes.io/serviceaccount",
+				ReadOnly:  true,
+			}}
+			oldPod.Spec.Containers = append(oldPod.Spec.Containers, corev1.Container{
+				Name: "injected-sidecar", Image: "example.com/mesh-sidecar:1.0",
+			})
+
+			its := builder.NewInstanceSetBuilder(namespace, name).
+				SetPodUpdatePolicy(kbappsv1.ReCreatePodUpdatePolicyType).
+				SetPodUpgradePolicy(kbappsv1.ReCreatePodUpdatePolicyType).
+				GetObject()
+			Expect(getPodUpdatePolicyInSpec(its, oldPod, newPod)).Should(Equal(kbappsv1.PreferInPlacePodUpdatePolicyType))
+			Expect(safeKBManagedImageOnlyInPlaceUpdate(oldPod, newPod)).Should(BeTrue())
+
+			strictInPlaceITS := builder.NewInstanceSetBuilder(namespace, name).
+				SetPodUpdatePolicy(kbappsv1.ReCreatePodUpdatePolicyType).
+				SetPodUpgradePolicy(kbappsv1.StrictInPlacePodUpdatePolicyType).
+				GetObject()
+			Expect(getPodUpdatePolicyInSpec(strictInPlaceITS, oldPod, newPod)).Should(Equal(kbappsv1.StrictInPlacePodUpdatePolicyType))
+
+			labelChangedPod := newPod.DeepCopy()
+			labelChangedPod.Labels = map[string]string{"extra": "true"}
+			Expect(getPodUpdatePolicyInSpec(its, oldPod, labelChangedPod)).Should(Equal(kbappsv1.ReCreatePodUpdatePolicyType))
+			Expect(safeKBManagedImageOnlyInPlaceUpdate(oldPod, labelChangedPod)).Should(BeFalse())
+
+			appChangedPod := newPod.DeepCopy()
+			appChangedPod.Spec.Containers[0].Image = "docker.io/apecloud/redis:7.4"
+			Expect(getPodUpdatePolicyInSpec(its, oldPod, appChangedPod)).Should(Equal(kbappsv1.ReCreatePodUpdatePolicyType))
+		})
+	})
+
 	Context("getPodUpdatePolicy", func() {
 		It("should work well", func() {
 			By("build an updated pod")

--- a/pkg/controller/instanceset/reconciler_update.go
+++ b/pkg/controller/instanceset/reconciler_update.go
@@ -188,7 +188,7 @@ func (r *updateReconciler) Reconcile(tree *kubebuilderx.ObjectTree) (kubebuilder
 			switch {
 			case !equalResourcesInPlaceFields(pod, newInstance.pod) && supportResizeSubResource:
 				err = tree.Update(newPod, kubebuilderx.WithSubResource("resize"))
-			case safeMetadataOnlyInPlaceUpdate(pod, newInstance.pod):
+			case safeMetadataOnlyInPlaceUpdate(pod, newInstance.pod), safeKBManagedImageOnlyInPlaceUpdate(pod, newInstance.pod):
 				err = tree.Update(newPod, kubebuilderx.WithPatch(true))
 			default:
 				if err = r.switchover(tree, its, newPod.(*corev1.Pod)); err != nil {

--- a/pkg/controller/instanceset/reconciler_update_test.go
+++ b/pkg/controller/instanceset/reconciler_update_test.go
@@ -529,6 +529,161 @@ var _ = Describe("update reconciler test", func() {
 			Expect(spy.switchoverCalls).Should(Equal(0),
 				"switchover must not be invoked when only the config-hash annotation differs")
 		})
+
+		It("patches KB-managed tools images on an admitted live Pod", func() {
+			oldToolsImage := viper.GetString(constant.KBToolsImage)
+			defer viper.Set(constant.KBToolsImage, oldToolsImage)
+			viper.Set(constant.KBToolsImage, "docker.io/apecloud/kubeblocks-tools:1.0.0")
+
+			origSupportResize := intctrlutil.SupportResizeSubResource
+			intctrlutil.SupportResizeSubResource = func() (bool, error) { return false, nil }
+			defer func() { intctrlutil.SupportResizeSubResource = origSupportResize }()
+
+			spy := &lifecycleCallSpy{}
+			origNewLifecycleAction := newLifecycleAction
+			newLifecycleAction = func(_ string, _ string, _ string, _ *kbappsv1.ComponentLifecycleActions, _ map[string]any, _ *corev1.Pod, _ ...*corev1.Pod) (lifecycle.Lifecycle, error) {
+				return spy, nil
+			}
+			defer func() { newLifecycleAction = origNewLifecycleAction }()
+
+			its.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+			its.Spec.Replicas = ptr.To[int32](1)
+			its.Spec.PodUpdatePolicy = kbappsv1.ReCreatePodUpdatePolicyType
+			its.Spec.PodUpgradePolicy = kbappsv1.ReCreatePodUpdatePolicyType
+			its.Spec.Template.Spec.ServiceAccountName = "current-sa"
+			its.Spec.Template.Spec.InitContainers = append(its.Spec.Template.Spec.InitContainers, corev1.Container{
+				Name: "init-kbagent", Image: "docker.io/apecloud/kubeblocks-tools:1.0.0", Command: []string{"cp"},
+			})
+			its.Spec.Template.Spec.Containers = append(its.Spec.Template.Spec.Containers, corev1.Container{
+				Name: "kbagent", Image: "docker.io/apecloud/kubeblocks-tools:1.0.0", Command: []string{"/bin/kbagent"},
+			})
+			its.Spec.MembershipReconfiguration = &workloads.MembershipReconfiguration{
+				Switchover: &kbappsv1.Action{Exec: &kbappsv1.ExecAction{Command: []string{"true"}}},
+			}
+
+			tree := kubebuilderx.NewObjectTree()
+			tree.SetRoot(its)
+			prepareForUpdate(tree)
+
+			pods := tree.List(&corev1.Pod{})
+			Expect(pods).Should(HaveLen(1))
+			pod := pods[0].(*corev1.Pod)
+			pod.UID = "live-pod-uid"
+			pod.Spec.AutomountServiceAccountToken = ptr.To(true)
+			pod.Spec.Volumes = append(pod.Spec.Volumes, corev1.Volume{Name: "kube-api-access"})
+			for i := range pod.Spec.InitContainers {
+				if pod.Spec.InitContainers[i].Name == "init-kbagent" {
+					pod.Spec.InitContainers[i].ImagePullPolicy = corev1.PullIfNotPresent
+					pod.Spec.InitContainers[i].TerminationMessagePath = corev1.TerminationMessagePathDefault
+				}
+			}
+			for i := range pod.Spec.Containers {
+				if pod.Spec.Containers[i].Name == "kbagent" {
+					pod.Spec.Containers[i].Env = []corev1.EnvVar{{Name: "ADMISSION_INJECTED", Value: "true"}}
+					pod.Spec.Containers[i].VolumeMounts = []corev1.VolumeMount{{
+						Name: "kube-api-access", MountPath: "/var/run/secrets/kubernetes.io/serviceaccount", ReadOnly: true,
+					}}
+				}
+			}
+			pod.Spec.Containers = append(pod.Spec.Containers, corev1.Container{
+				Name: "injected-sidecar", Image: "example.com/mesh-sidecar:1.0",
+			})
+			pod.Status.Phase = corev1.PodRunning
+			pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
+				Type: corev1.PodReady, Status: corev1.ConditionTrue,
+				LastTransitionTime: metav1.NewTime(time.Now().Add(-1 * minReadySeconds * time.Second)),
+			})
+
+			for i := range its.Spec.Template.Spec.InitContainers {
+				if its.Spec.Template.Spec.InitContainers[i].Name == "init-kbagent" {
+					its.Spec.Template.Spec.InitContainers[i].Image = "mirror.local/apecloud/kubeblocks-tools:1.1.0"
+				}
+			}
+			for i := range its.Spec.Template.Spec.Containers {
+				if its.Spec.Template.Spec.Containers[i].Name == "kbagent" {
+					its.Spec.Template.Spec.Containers[i].Image = "mirror.local/apecloud/kubeblocks-tools:1.1.0"
+				}
+			}
+
+			res, err := NewUpdateReconciler().Reconcile(tree)
+			Expect(err).Should(BeNil())
+			Expect(res).Should(Equal(kubebuilderx.Continue))
+
+			postPods := tree.List(&corev1.Pod{})
+			Expect(postPods).Should(HaveLen(1), "pod should be patched in place")
+			updatedPod := postPods[0].(*corev1.Pod)
+			Expect(updatedPod.UID).Should(Equal(pod.UID))
+			Expect(updatedPod.Spec.ServiceAccountName).Should(Equal("current-sa"))
+			Expect(updatedPod.Spec.AutomountServiceAccountToken).Should(Equal(ptr.To(true)))
+			Expect(updatedPod.Spec.Volumes).Should(ContainElement(HaveField("Name", "kube-api-access")))
+			_, updatedInitKBAgent := intctrlutil.GetContainerByName(updatedPod.Spec.InitContainers, "init-kbagent")
+			Expect(updatedInitKBAgent).ShouldNot(BeNil())
+			Expect(updatedInitKBAgent.Image).Should(Equal("mirror.local/apecloud/kubeblocks-tools:1.1.0"))
+			Expect(updatedInitKBAgent.ImagePullPolicy).Should(Equal(corev1.PullIfNotPresent))
+			_, updatedKBAgent := intctrlutil.GetContainerByName(updatedPod.Spec.Containers, "kbagent")
+			Expect(updatedKBAgent).ShouldNot(BeNil())
+			Expect(updatedKBAgent.Image).Should(Equal("mirror.local/apecloud/kubeblocks-tools:1.1.0"))
+			Expect(updatedKBAgent.Env).Should(ContainElement(corev1.EnvVar{Name: "ADMISSION_INJECTED", Value: "true"}))
+			Expect(updatedKBAgent.VolumeMounts).Should(ContainElement(HaveField("Name", "kube-api-access")))
+			_, injectedSidecar := intctrlutil.GetContainerByName(updatedPod.Spec.Containers, "injected-sidecar")
+			Expect(injectedSidecar).ShouldNot(BeNil())
+			Expect(injectedSidecar.Image).Should(Equal("example.com/mesh-sidecar:1.0"))
+			_, option, err := tree.GetWithOption(updatedPod)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(option.Patch).Should(BeTrue())
+			Expect(spy.switchoverCalls).Should(Equal(0))
+		})
+
+		DescribeTable("keeps recreation policy for non-tools-image changes",
+			func(mutateTemplate func(*workloads.InstanceSet)) {
+				oldToolsImage := viper.GetString(constant.KBToolsImage)
+				defer viper.Set(constant.KBToolsImage, oldToolsImage)
+				viper.Set(constant.KBToolsImage, "docker.io/apecloud/kubeblocks-tools:1.0.0")
+
+				its.Spec.PodManagementPolicy = appsv1.ParallelPodManagement
+				its.Spec.Replicas = ptr.To[int32](1)
+				its.Spec.PodUpdatePolicy = kbappsv1.ReCreatePodUpdatePolicyType
+				its.Spec.PodUpgradePolicy = kbappsv1.ReCreatePodUpdatePolicyType
+				its.Spec.Template.Spec.Containers = append(its.Spec.Template.Spec.Containers, corev1.Container{
+					Name: "kbagent", Image: "docker.io/apecloud/kubeblocks-tools:1.0.0", Command: []string{"/bin/kbagent"},
+				})
+
+				tree := kubebuilderx.NewObjectTree()
+				tree.SetRoot(its)
+				prepareForUpdate(tree)
+				mutateTemplate(its)
+
+				res, err := NewRevisionUpdateReconciler().Reconcile(tree)
+				Expect(err).Should(BeNil())
+				Expect(res).Should(Equal(kubebuilderx.Continue))
+				pod := tree.List(&corev1.Pod{})[0].(*corev1.Pod)
+				pod.Status.Phase = corev1.PodRunning
+				pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
+					Type: corev1.PodReady, Status: corev1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(time.Now().Add(-1 * minReadySeconds * time.Second)),
+				})
+
+				res, err = NewUpdateReconciler().Reconcile(tree)
+				Expect(err).Should(BeNil())
+				Expect(res).Should(Equal(kubebuilderx.Continue))
+				Expect(tree.List(&corev1.Pod{})).Should(BeEmpty(), "the Pod must be recreated, not patched")
+			},
+			Entry("non-image template changes with a tools image update", func(its *workloads.InstanceSet) {
+				for i := range its.Spec.Template.Spec.Containers {
+					if its.Spec.Template.Spec.Containers[i].Name == "kbagent" {
+						its.Spec.Template.Spec.Containers[i].Image = "mirror.local/apecloud/kubeblocks-tools:1.1.0"
+						its.Spec.Template.Spec.Containers[i].Env = []corev1.EnvVar{{Name: "TEMPLATE_CHANGE", Value: "true"}}
+					}
+				}
+			}),
+			Entry("application image changes", func(its *workloads.InstanceSet) {
+				its.Spec.Template.Spec.Containers[0].Image = "example.com/application:new"
+			}),
+			Entry("a template-owned container is removed while tools images change", func(its *workloads.InstanceSet) {
+				its.Spec.Template.Spec.Containers = its.Spec.Template.Spec.Containers[1:]
+				its.Spec.Template.Spec.Containers[0].Image = "mirror.local/apecloud/kubeblocks-tools:1.1.0"
+			}),
+		)
 	})
 })
 

--- a/pkg/controllerutil/image_util.go
+++ b/pkg/controllerutil/image_util.go
@@ -25,13 +25,16 @@ import (
 	_ "crypto/sha512"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 
 	"github.com/distribution/reference"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/kbagent"
 	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
 
@@ -283,4 +286,81 @@ func imageBaseName(name string) string {
 		return name
 	}
 	return name[index+1:]
+}
+
+const (
+	legacyConfigManagerContainerName = "config-manager"
+	legacyConfigManagerToolsInitName = "install-config-manager-tool"
+)
+
+// OnlyKBManagedPodImagesChanged returns true when all desired container image
+// differences in a Pod are KB-managed tools image changes and at least one such
+// image changed. It ignores non-image fields and containers present only on the
+// live Pod because admission may add them and in-place updates start from a
+// clone of that Pod. Desired non-image changes remain owned by workload
+// revision classification.
+func OnlyKBManagedPodImagesChanged(old, new *corev1.Pod) bool {
+	toolsImage := viper.GetString(constant.KBToolsImage)
+	if toolsImage == "" {
+		return false
+	}
+	initChanged, ok := onlyKBManagedLiveContainerImagesChanged(old.Spec.InitContainers, new.Spec.InitContainers, toolsImage)
+	if !ok {
+		return false
+	}
+	containerChanged, ok := onlyKBManagedLiveContainerImagesChanged(old.Spec.Containers, new.Spec.Containers, toolsImage)
+	return ok && (initChanged || containerChanged)
+}
+
+func onlyKBManagedLiveContainerImagesChanged(oldContainers, newContainers []corev1.Container, toolsImage string) (bool, bool) {
+	changed := false
+	for _, newContainer := range newContainers {
+		index := slices.IndexFunc(oldContainers, func(oldContainer corev1.Container) bool {
+			return oldContainer.Name == newContainer.Name
+		})
+		if index < 0 {
+			return false, false
+		}
+		oldContainer := oldContainers[index]
+		if EqualContainerImageInSpec(oldContainer.Image, newContainer.Image) {
+			continue
+		}
+		if !isKBManagedContainerName(oldContainer.Name) ||
+			!sameImageRepositoryName(oldContainer.Image, toolsImage) ||
+			!sameImageRepositoryName(newContainer.Image, toolsImage) {
+			return false, false
+		}
+		changed = true
+	}
+	return changed, true
+}
+
+func isKBManagedContainerName(name string) bool {
+	switch name {
+	case kbagent.ContainerName, kbagent.ContainerName4Worker, kbagent.InitContainerName,
+		legacyConfigManagerContainerName, legacyConfigManagerToolsInitName:
+		return true
+	default:
+		return false
+	}
+}
+
+func sameImageRepositoryName(image, target string) bool {
+	imageNamespace, imageRepository, ok := imageRepositoryName(image)
+	if !ok {
+		return false
+	}
+	targetNamespace, targetRepository, ok := imageRepositoryName(target)
+	if !ok {
+		return false
+	}
+	return imageNamespace == targetNamespace && imageRepository == targetRepository
+}
+
+func imageRepositoryName(image string) (string, string, bool) {
+	_, namespace, repository, _, err := parseImageName(image)
+	if err != nil {
+		return "", "", false
+	}
+	return namespace, repository, true
 }

--- a/pkg/controllerutil/image_util_test.go
+++ b/pkg/controllerutil/image_util_test.go
@@ -21,10 +21,59 @@ package controllerutil
 
 import (
 	"fmt"
+	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
+
+func TestOnlyKBManagedPodImagesChangedIgnoresLiveOnlyContainerState(t *testing.T) {
+	oldToolsImage := viper.GetString(constant.KBToolsImage)
+	defer viper.Set(constant.KBToolsImage, oldToolsImage)
+	viper.Set(constant.KBToolsImage, "docker.io/apecloud/kubeblocks-tools:1.0.0")
+
+	desired := &corev1.Pod{Spec: corev1.PodSpec{
+		InitContainers: []corev1.Container{{
+			Name: "init-kbagent", Image: "mirror.local/apecloud/kubeblocks-tools:1.1.0",
+		}},
+		Containers: []corev1.Container{
+			{Name: "app", Image: "docker.io/apecloud/redis:7.2"},
+			{Name: "kbagent", Image: "mirror.local/apecloud/kubeblocks-tools:1.1.0"},
+		},
+	}}
+	live := desired.DeepCopy()
+	live.Spec.InitContainers[0].Image = "docker.io/apecloud/kubeblocks-tools:1.0.0"
+	live.Spec.InitContainers[0].ImagePullPolicy = corev1.PullIfNotPresent
+	live.Spec.Containers[1].Image = "docker.io/apecloud/kubeblocks-tools:1.0.0"
+	live.Spec.Containers[1].Env = []corev1.EnvVar{{Name: "ADMISSION_INJECTED", Value: "true"}}
+	live.Spec.Containers[1].VolumeMounts = []corev1.VolumeMount{{
+		Name:      "kube-api-access",
+		MountPath: "/var/run/secrets/kubernetes.io/serviceaccount",
+		ReadOnly:  true,
+	}}
+	live.Spec.Containers = append(live.Spec.Containers, corev1.Container{
+		Name: "injected-sidecar", Image: "example.com/mesh-sidecar:1.0",
+	})
+	if !OnlyKBManagedPodImagesChanged(live, desired) {
+		t.Fatal("live-only defaults, fields, and containers must not block a tools image-only update")
+	}
+
+	appChanged := desired.DeepCopy()
+	appChanged.Spec.Containers[0].Image = "docker.io/apecloud/redis:7.4"
+	if OnlyKBManagedPodImagesChanged(live, appChanged) {
+		t.Fatal("application image changes must not be classified as KB-managed tools image changes")
+	}
+
+	missingLiveContainer := desired.DeepCopy()
+	missingLiveContainer.Spec.Containers = missingLiveContainer.Spec.Containers[:1]
+	if OnlyKBManagedPodImagesChanged(missingLiveContainer, desired) {
+		t.Fatal("a desired container missing from the live Pod must not be classified as an image-only update")
+	}
+}
 
 var _ = Describe("image util test", func() {
 	imageList := [][]string{


### PR DESCRIPTION
## What this PR changes

- backports live-Pod-aware KubeBlocks tools image classification to the release-1.0 InstanceSet path
- keeps recognized tools image-only changes in place even when `podUpgradePolicy` is `ReCreate`
- patches from the live Pod so Kubernetes-defaulted fields and admission-injected fields or sidecars are preserved
- keeps application image, non-image template, resource, metadata, and container-shape changes on their existing policy paths

## Why this is an independent backport

The main fix in #10747 cherry-picks cleanly to release-1.1, so that version is handled with the `pick-1.1` label. release-1.0 predates the tools-image compatibility path added by #10497 and does not contain the newer Instance controller path, so the main commit cannot be cherry-picked directly.

This PR carries only the minimal InstanceSet implementation required by release-1.0; it does not introduce the newer Instance controller or unrelated API/CRD changes.

## Root cause and impact

Tools image changes otherwise inherit `podUpgradePolicy: ReCreate`. Live Pods also contain Kubernetes-defaulted and admission-injected container state that must not be interpreted as a desired workload change. The new classifier compares the desired container images by name, recognizes only KubeBlocks-managed tools repositories, and relies on workload revisions for desired non-image changes.

Existing database Pods are patched instead of recreated for a tools image-only update. Application image changes and revision-changing template changes continue to recreate according to the configured policy.

Fixes #10726. Backport of #10747.

## Validation

- `go test ./pkg/controllerutil ./pkg/controller/instanceset -count=1`
- `go test ./pkg/controller/... -run '^$' -count=1`
- relevant `controllers/apps` packages compile successfully
- `git diff --check`
