### PR TITLE
fix(sharding): enable shared TLS for sharding

### DIFF
--- a/controllers/apps/cluster/cluster_controller.go
+++ b/controllers/apps/cluster/cluster_controller.go
@@ -134,10 +134,10 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			&clusterNormalizationTransformer{},
 			// placement replicas across data-plane k8s clusters
 			&clusterPlacementTransformer{multiClusterMgr: r.MultiClusterMgr},
-			// handle cluster shared TLS
-			&clusterShardingTLSTransformer{},
 			// handle cluster shared account
 			&clusterShardingAccountTransformer{},
+			// handle cluster shared TLS
+			&clusterShardingTLSTransformer{},
 			// handle cluster services
 			&clusterServiceTransformer{},
 			// create all cluster components objects

--- a/controllers/apps/cluster/cluster_controller.go
+++ b/controllers/apps/cluster/cluster_controller.go
@@ -134,6 +134,8 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			&clusterNormalizationTransformer{},
 			// placement replicas across data-plane k8s clusters
 			&clusterPlacementTransformer{multiClusterMgr: r.MultiClusterMgr},
+			// handle cluster shared TLS
+			&clusterShardingTLSTransformer{},
 			// handle cluster shared account
 			&clusterShardingAccountTransformer{},
 			// handle cluster services

--- a/controllers/apps/cluster/cluster_controller_test.go
+++ b/controllers/apps/cluster/cluster_controller_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
@@ -107,6 +108,7 @@ var _ = Describe("Cluster Controller", func() {
 		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.ServiceSignature, true, inNS, ml)
 		// non-namespaced
 		testapps.ClearResources(&testCtx, generics.StorageClassSignature, ml)
+		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.ShardingDefinitionSignature, true, ml)
 		resetTestContext()
 	}
 
@@ -126,9 +128,18 @@ var _ = Describe("Cluster Controller", func() {
 
 	createAllDefinitionObjects := func() {
 		By("Create a componentDefinition obj")
-		compDefObj = testapps.NewComponentDefinitionFactory(compDefName).
+		compDefFactory := testapps.NewComponentDefinitionFactory(compDefName).
 			WithRandomName().
-			SetDefaultSpec().
+			SetDefaultSpec()
+		caFile, certFile, keyFile := "ca.crt", "tls.crt", "tls.key"
+		compDefFactory.Get().Spec.TLS = &appsv1.TLS{
+			VolumeName: "tls",
+			MountPath:  "/etc/tls",
+			CAFile:     &caFile,
+			CertFile:   &certFile,
+			KeyFile:    &keyFile,
+		}
+		compDefObj = compDefFactory.
 			Create(&testCtx).
 			GetObject()
 
@@ -784,6 +795,72 @@ var _ = Describe("Cluster Controller", func() {
 
 		It("create sharding cluster", func() {
 			testShardingClusterComponent(defaultCompName, compDefObj.Name, createClusterObjWithSharding, defaultShardCount)
+		})
+
+		It("creates one KubeBlocks TLS source shared by every shard", func() {
+			shardingDef := testapps.NewShardingDefinitionFactory("shared-tls-sharding", compDefObj.Name).
+				WithRandomName()
+			shardingDef.Get().Spec.TLS = &appsv1.ShardingTLS{Shared: ptr.To(true)}
+			shardingDefObj := shardingDef.Create(&testCtx).GetObject()
+			Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(shardingDefObj),
+				func(g Gomega, definition *appsv1.ShardingDefinition) {
+					g.Expect(definition.Status.ObservedGeneration).Should(Equal(definition.Generation))
+					g.Expect(definition.Status.Phase).Should(Equal(appsv1.AvailablePhase))
+				})).Should(Succeed())
+
+			createClusterObjNoWait("", func(factory *testapps.MockClusterFactory) {
+				factory.AddSharding(defaultCompName, shardingDefObj.Name, "").
+					SetShards(defaultShardCount)
+				sharding := &factory.Get().Spec.Shardings[len(factory.Get().Spec.Shardings)-1]
+				sharding.Template.TLS = true
+				sharding.Template.Issuer = &appsv1.Issuer{Name: appsv1.IssuerKubeBlocks}
+			})
+
+			sharedSecretKey := types.NamespacedName{
+				Namespace: clusterKey.Namespace,
+				Name:      shardingTLSSecretName(clusterKey.Name, defaultCompName),
+			}
+			Eventually(testapps.CheckObj(&testCtx, sharedSecretKey, func(g Gomega, secret *corev1.Secret) {
+				g.Expect(secret.Data).Should(HaveKey("ca.crt"))
+				g.Expect(secret.Data).Should(HaveKey("tls.crt"))
+				g.Expect(secret.Data).Should(HaveKey("tls.key"))
+			})).Should(Succeed())
+			sharedSecret := &corev1.Secret{}
+			Eventually(testapps.CheckObjExists(&testCtx, sharedSecretKey, sharedSecret, true)).Should(Succeed())
+			originalCA := slices.Clone(sharedSecret.Data["ca.crt"])
+
+			checkComponents := func(expectedCount int) {
+				componentList := &appsv1.ComponentList{}
+				Eventually(func(g Gomega) {
+					g.Expect(testCtx.Cli.List(testCtx.Ctx, componentList,
+						client.InNamespace(clusterKey.Namespace),
+						client.MatchingLabels{
+							constant.AppInstanceLabelKey:       clusterKey.Name,
+							constant.KBAppShardingNameLabelKey: defaultCompName,
+						})).Should(Succeed())
+					g.Expect(componentList.Items).Should(HaveLen(expectedCount))
+					for i := range componentList.Items {
+						tls := componentList.Items[i].Spec.TLSConfig
+						g.Expect(tls).ShouldNot(BeNil())
+						g.Expect(tls.Enable).Should(BeTrue())
+						g.Expect(tls.Issuer).ShouldNot(BeNil())
+						g.Expect(tls.Issuer.Name).Should(Equal(appsv1.IssuerUserProvided))
+						g.Expect(tls.Issuer.SecretRef).ShouldNot(BeNil())
+						g.Expect(tls.Issuer.SecretRef.Name).Should(Equal(sharedSecretKey.Name))
+						g.Expect(tls.Issuer.SecretRef.Namespace).Should(Equal(sharedSecretKey.Namespace))
+					}
+				}).Should(Succeed())
+			}
+			checkComponents(defaultShardCount)
+
+			By("scaling out without rotating the shared CA")
+			Expect(testapps.GetAndChangeObj(&testCtx, clusterKey, func(cluster *appsv1.Cluster) {
+				cluster.Spec.Shardings[0].Shards++
+			})()).Should(Succeed())
+			checkComponents(defaultShardCount + 1)
+			Eventually(testapps.CheckObj(&testCtx, sharedSecretKey, func(g Gomega, secret *corev1.Secret) {
+				g.Expect(secret.Data["ca.crt"]).Should(Equal(originalCA))
+			})).Should(Succeed())
 		})
 
 		It("create cluster with default topology", func() {

--- a/controllers/apps/cluster/cluster_controller_test.go
+++ b/controllers/apps/cluster/cluster_controller_test.go
@@ -863,6 +863,65 @@ var _ = Describe("Cluster Controller", func() {
 			})).Should(Succeed())
 		})
 
+		It("applies shared TLS per shard template ShardingDefinition", func() {
+			createShardingDef := func(prefix string, shared bool) *appsv1.ShardingDefinition {
+				factory := testapps.NewShardingDefinitionFactory(prefix, compDefObj.Name).WithRandomName()
+				factory.Get().Spec.TLS = &appsv1.ShardingTLS{Shared: ptr.To(shared)}
+				obj := factory.Create(&testCtx).GetObject()
+				Eventually(testapps.CheckObj(&testCtx, client.ObjectKeyFromObject(obj),
+					func(g Gomega, definition *appsv1.ShardingDefinition) {
+						g.Expect(definition.Status.Phase).Should(Equal(appsv1.AvailablePhase))
+					})).Should(Succeed())
+				return obj
+			}
+			plainDef := createShardingDef("plain-tls-sharding", false)
+			sharedDef := createShardingDef("shared-tls-sharding", true)
+
+			createClusterObjNoWait("", func(factory *testapps.MockClusterFactory) {
+				factory.AddSharding(defaultCompName, plainDef.Name, "").SetShards(2)
+				sharding := &factory.Get().Spec.Shardings[len(factory.Get().Spec.Shardings)-1]
+				sharding.Template.TLS = true
+				sharding.Template.Issuer = &appsv1.Issuer{Name: appsv1.IssuerKubeBlocks}
+				sharding.ShardTemplates = []appsv1.ShardTemplate{
+					{Name: "private", ShardingDef: ptr.To(plainDef.Name), Shards: ptr.To[int32](1)},
+					{Name: "shared", ShardingDef: ptr.To(sharedDef.Name), Shards: ptr.To[int32](1)},
+				}
+			})
+
+			Eventually(func(g Gomega) {
+				components := &appsv1.ComponentList{}
+				g.Expect(testCtx.Cli.List(testCtx.Ctx, components,
+					client.InNamespace(clusterKey.Namespace),
+					client.MatchingLabels{
+						constant.AppInstanceLabelKey:       clusterKey.Name,
+						constant.KBAppShardingNameLabelKey: defaultCompName,
+					})).Should(Succeed())
+				g.Expect(components.Items).Should(HaveLen(2))
+				seen := map[string]bool{}
+				for i := range components.Items {
+					component := &components.Items[i]
+					templateName := component.Labels[constant.KBAppShardTemplateLabelKey]
+					seen[templateName] = true
+					g.Expect(component.Spec.TLSConfig).ShouldNot(BeNil())
+					g.Expect(component.Spec.TLSConfig.Issuer).ShouldNot(BeNil())
+					switch templateName {
+					case "private":
+						g.Expect(component.Spec.TLSConfig.Issuer.Name).Should(Equal(appsv1.IssuerKubeBlocks))
+					case "shared":
+						g.Expect(component.Spec.TLSConfig.Issuer.Name).Should(Equal(appsv1.IssuerUserProvided))
+						g.Expect(component.Spec.TLSConfig.Issuer.SecretRef.Name).Should(
+							Equal(shardingTLSSecretName(clusterKey.Name, defaultCompName)))
+					}
+				}
+				g.Expect(seen).Should(HaveKeyWithValue("private", true))
+				g.Expect(seen).Should(HaveKeyWithValue("shared", true))
+			}).Should(Succeed())
+
+			Eventually(testapps.CheckObj(&testCtx, clusterKey, func(g Gomega, cluster *appsv1.Cluster) {
+				g.Expect(cluster.Spec.Shardings[0].Template.Issuer.Name).Should(Equal(appsv1.IssuerKubeBlocks))
+			})).Should(Succeed())
+		})
+
 		It("create cluster with default topology", func() {
 			testClusterComponentWithTopology("", defaultCompName, nil, compDefObj.Name, latestServiceVersion)
 		})

--- a/controllers/apps/cluster/transformer_cluster_sharding_test.go
+++ b/controllers/apps/cluster/transformer_cluster_sharding_test.go
@@ -139,6 +139,14 @@ var _ = Describe("cluster sharding shared transformers", func() {
 		transCtx := newTransformContext()
 		sharding := newSharding()
 		compDef := newComponentDefinition()
+		flattenedComp := sharding.Template.DeepCopy()
+		templatedComp := sharding.Template.DeepCopy()
+		transCtx.shardingComps = map[string][]*appsv1.ClusterComponentSpec{
+			sharding.Name: {flattenedComp},
+		}
+		transCtx.shardingCompsWithTpl = map[string]map[string][]*appsv1.ClusterComponentSpec{
+			sharding.Name: {"template": {templatedComp}},
+		}
 
 		secret := transformer.newTLSSecret(transCtx, sharding, compDef)
 		Expect(secret.Namespace).Should(Equal(namespace))
@@ -158,6 +166,26 @@ var _ = Describe("cluster sharding shared transformers", func() {
 		Expect(sharding.Template.Issuer.SecretRef.CA).Should(Equal("ca.pem"))
 		Expect(sharding.Template.Issuer.SecretRef.Cert).Should(Equal("tls.crt"))
 		Expect(sharding.Template.Issuer.SecretRef.Key).Should(Equal("tls.key"))
+		for _, comp := range []*appsv1.ClusterComponentSpec{flattenedComp, templatedComp} {
+			Expect(comp.Issuer.Name).Should(Equal(appsv1.IssuerUserProvided))
+			Expect(comp.Issuer.SecretRef.Name).Should(Equal(shardingTLSSecretName(clusterName, shardingName)))
+			Expect(comp.Issuer.SecretRef.CA).Should(Equal("ca.pem"))
+			Expect(comp.Issuer.SecretRef.Cert).Should(Equal("tls.crt"))
+			Expect(comp.Issuer.SecretRef.Key).Should(Equal("tls.key"))
+		}
+	})
+
+	It("keeps managed labels authoritative on the shared TLS secret", func() {
+		transformer := &clusterShardingTLSTransformer{}
+		transCtx := newTransformContext()
+		sharding := newSharding()
+		compDef := newComponentDefinition()
+		sharding.Template.Labels[constant.AppInstanceLabelKey] = "other-cluster"
+		compDef.Spec.Labels[constant.KBAppShardingNameLabelKey] = "other-sharding"
+
+		secret := transformer.newTLSSecret(transCtx, sharding, compDef)
+		Expect(secret.Labels).Should(HaveKeyWithValue(constant.AppInstanceLabelKey, clusterName))
+		Expect(secret.Labels).Should(HaveKeyWithValue(constant.KBAppShardingNameLabelKey, shardingName))
 	})
 
 	It("handles stable shared TLS reconciliation guard branches", func() {
@@ -203,10 +231,35 @@ var _ = Describe("cluster sharding shared transformers", func() {
 		Expect(secret).Should(BeNil())
 
 		existing := &corev1.Secret{ObjectMeta: metav1ObjectMeta(shardingTLSSecretName(clusterName, shardingName), namespace)}
+		existing.Labels = constant.GetClusterLabels(clusterName, map[string]string{
+			constant.KBAppShardingNameLabelKey: shardingName,
+		})
 		secret, err = transformer.checkTLSSecret(newTransformContext(existing), sharding)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(secret).ShouldNot(BeNil())
 		Expect(secret.Name).Should(Equal(existing.Name))
+
+		unmanaged := existing.DeepCopy()
+		unmanaged.Labels = nil
+		secret, err = transformer.checkTLSSecret(newTransformContext(unmanaged), sharding)
+		Expect(err).Should(MatchError(ContainSubstring("is not managed by sharding")))
+		Expect(secret).Should(BeNil())
+	})
+
+	It("rejects shared TLS before dereferencing an unavailable TLS definition", func() {
+		transformer := &clusterShardingTLSTransformer{}
+		sharding := newSharding()
+		transCtx := newTransformContext()
+		transCtx.componentDefs = map[string]*appsv1.ComponentDefinition{}
+
+		Expect(transformer.reconcileShardingTLS(transCtx, nil, nil, sharding)).Should(
+			MatchError(ContainSubstring("component definition \"compdef\" not found")))
+
+		compDef := newComponentDefinition()
+		compDef.Spec.TLS = nil
+		transCtx.componentDefs[compDefName] = compDef
+		Expect(transformer.reconcileShardingTLS(transCtx, nil, nil, sharding)).Should(
+			MatchError(ContainSubstring("doesn't support it")))
 	})
 
 	It("resolves shared system accounts and applies cluster-level overrides", func() {

--- a/controllers/apps/cluster/transformer_cluster_sharding_test.go
+++ b/controllers/apps/cluster/transformer_cluster_sharding_test.go
@@ -194,6 +194,10 @@ var _ = Describe("cluster sharding shared transformers", func() {
 		sharding.Template.TLS = true
 		Expect(transformer.reconcileShardingTLS(transCtx, nil, nil, sharding, sets.New(""))).Should(MatchError("issuer shouldn't be nil when tls enabled"))
 
+		sharding.Template.Issuer = &appsv1.Issuer{Name: appsv1.IssuerName("unsupported")}
+		Expect(transformer.reconcileShardingTLS(transCtx, nil, nil, sharding, sets.New(""))).Should(
+			MatchError(`unsupported TLS issuer "unsupported"`))
+
 		sharding.Template.Issuer = &appsv1.Issuer{Name: appsv1.IssuerUserProvided}
 		Expect(transformer.reconcileShardingTLS(transCtx, nil, nil, sharding, sets.New(""))).Should(Succeed())
 	})

--- a/controllers/apps/cluster/transformer_cluster_sharding_test.go
+++ b/controllers/apps/cluster/transformer_cluster_sharding_test.go
@@ -29,6 +29,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -138,40 +139,34 @@ var _ = Describe("cluster sharding shared transformers", func() {
 		transformer := &clusterShardingTLSTransformer{}
 		transCtx := newTransformContext()
 		sharding := newSharding()
-		compDef := newComponentDefinition()
 		flattenedComp := sharding.Template.DeepCopy()
+		flattenedComp.Name = "default-shard"
 		templatedComp := sharding.Template.DeepCopy()
+		templatedComp.Name = "templated-shard"
 		transCtx.shardingComps = map[string][]*appsv1.ClusterComponentSpec{
-			sharding.Name: {flattenedComp},
+			sharding.Name: {flattenedComp, templatedComp},
 		}
 		transCtx.shardingCompsWithTpl = map[string]map[string][]*appsv1.ClusterComponentSpec{
-			sharding.Name: {"template": {templatedComp}},
+			sharding.Name: {"": {flattenedComp}, "template": {templatedComp}},
 		}
 
-		secret := transformer.newTLSSecret(transCtx, sharding, compDef)
+		secret := transformer.newTLSSecret(transCtx, sharding)
 		Expect(secret.Namespace).Should(Equal(namespace))
 		Expect(secret.Name).Should(Equal(shardingTLSSecretName(clusterName, shardingName)))
 		Expect(secret.Labels).Should(HaveKeyWithValue(constant.AppInstanceLabelKey, clusterName))
 		Expect(secret.Labels).Should(HaveKeyWithValue(constant.KBAppShardingNameLabelKey, shardingName))
 		Expect(secret.Labels).Should(HaveKeyWithValue("template-label", "yes"))
-		Expect(secret.Labels).Should(HaveKeyWithValue("def-label", "yes"))
 		Expect(secret.Annotations).Should(HaveKeyWithValue("template-annotation", "yes"))
-		Expect(secret.Annotations).Should(HaveKeyWithValue("def-annotation", "yes"))
 		Expect(secret.Data).Should(BeEmpty())
 
-		transformer.rewriteTLSConfig(transCtx, sharding, compDef)
-		Expect(sharding.Template.Issuer.Name).Should(Equal(appsv1.IssuerUserProvided))
-		Expect(sharding.Template.Issuer.SecretRef.Namespace).Should(Equal(namespace))
-		Expect(sharding.Template.Issuer.SecretRef.Name).Should(Equal(shardingTLSSecretName(clusterName, shardingName)))
-		Expect(sharding.Template.Issuer.SecretRef.CA).Should(Equal("ca.pem"))
-		Expect(sharding.Template.Issuer.SecretRef.Cert).Should(Equal("tls.crt"))
-		Expect(sharding.Template.Issuer.SecretRef.Key).Should(Equal("tls.key"))
+		transformer.rewriteTLSConfig(transCtx, sharding, sets.New("", "template"))
+		Expect(sharding.Template.Issuer.Name).Should(Equal(appsv1.IssuerKubeBlocks))
 		for _, comp := range []*appsv1.ClusterComponentSpec{flattenedComp, templatedComp} {
 			Expect(comp.Issuer.Name).Should(Equal(appsv1.IssuerUserProvided))
 			Expect(comp.Issuer.SecretRef.Name).Should(Equal(shardingTLSSecretName(clusterName, shardingName)))
-			Expect(comp.Issuer.SecretRef.CA).Should(Equal("ca.pem"))
-			Expect(comp.Issuer.SecretRef.Cert).Should(Equal("tls.crt"))
-			Expect(comp.Issuer.SecretRef.Key).Should(Equal("tls.key"))
+			Expect(comp.Issuer.SecretRef.CA).Should(Equal(shardingTLSCAKey))
+			Expect(comp.Issuer.SecretRef.Cert).Should(Equal(shardingTLSCertKey))
+			Expect(comp.Issuer.SecretRef.Key).Should(Equal(shardingTLSKeyKey))
 		}
 	})
 
@@ -179,11 +174,10 @@ var _ = Describe("cluster sharding shared transformers", func() {
 		transformer := &clusterShardingTLSTransformer{}
 		transCtx := newTransformContext()
 		sharding := newSharding()
-		compDef := newComponentDefinition()
 		sharding.Template.Labels[constant.AppInstanceLabelKey] = "other-cluster"
-		compDef.Spec.Labels[constant.KBAppShardingNameLabelKey] = "other-sharding"
+		sharding.Template.Labels[constant.KBAppShardingNameLabelKey] = "other-sharding"
 
-		secret := transformer.newTLSSecret(transCtx, sharding, compDef)
+		secret := transformer.newTLSSecret(transCtx, sharding)
 		Expect(secret.Labels).Should(HaveKeyWithValue(constant.AppInstanceLabelKey, clusterName))
 		Expect(secret.Labels).Should(HaveKeyWithValue(constant.KBAppShardingNameLabelKey, shardingName))
 	})
@@ -195,31 +189,76 @@ var _ = Describe("cluster sharding shared transformers", func() {
 
 		sharding.Template.TLS = false
 		sharding.Template.Issuer = nil
-		Expect(transformer.reconcileShardingTLS(transCtx, nil, nil, sharding)).Should(Succeed())
+		Expect(transformer.reconcileShardingTLS(transCtx, nil, nil, sharding, sets.New(""))).Should(Succeed())
 
 		sharding.Template.TLS = true
-		Expect(transformer.reconcileShardingTLS(transCtx, nil, nil, sharding)).Should(MatchError("issuer shouldn't be nil when tls enabled"))
+		Expect(transformer.reconcileShardingTLS(transCtx, nil, nil, sharding, sets.New(""))).Should(MatchError("issuer shouldn't be nil when tls enabled"))
 
 		sharding.Template.Issuer = &appsv1.Issuer{Name: appsv1.IssuerUserProvided}
-		Expect(transformer.reconcileShardingTLS(transCtx, nil, nil, sharding)).Should(Succeed())
+		Expect(transformer.reconcileShardingTLS(transCtx, nil, nil, sharding, sets.New(""))).Should(Succeed())
 	})
 
-	It("reconciles only sharding definitions marked with shared TLS", func() {
+	It("honors TLS sharing overrides from each shard template's ShardingDefinition", func() {
 		transformer := &clusterShardingTLSTransformer{}
 		transCtx := newTransformContext()
 		sharding := newSharding()
-		sharding.Template.Issuer = &appsv1.Issuer{Name: appsv1.IssuerUserProvided}
-		transCtx.shardings = []*appsv1.ClusterSharding{
-			sharding,
-			{Name: "plain", ShardingDef: "plain-def"},
-			{Name: "missing", ShardingDef: "missing-def"},
+		sharding.ShardTemplates = []appsv1.ShardTemplate{
+			{Name: "private", ShardingDef: ptr.To("plain-def")},
+			{Name: "shared", ShardingDef: ptr.To("shared-def")},
 		}
 		transCtx.shardingDefs = map[string]*appsv1.ShardingDefinition{
-			"sharddef":  newShardingDefinition(),
-			"plain-def": {Spec: appsv1.ShardingDefinitionSpec{TLS: &appsv1.ShardingTLS{Shared: ptr.To(false)}}},
+			"sharddef":   newShardingDefinition(), // the default group shares TLS
+			"shared-def": newShardingDefinition(),
+			"plain-def":  {Spec: appsv1.ShardingDefinitionSpec{TLS: &appsv1.ShardingTLS{Shared: ptr.To(false)}}},
 		}
 
-		Expect(transformer.reconcileShardingTLSs(transCtx, nil, nil)).Should(Succeed())
+		defaultComp := sharding.Template.DeepCopy()
+		defaultComp.Name = "default"
+		privateComp := sharding.Template.DeepCopy()
+		privateComp.Name = "private"
+		sharedComp := sharding.Template.DeepCopy()
+		sharedComp.Name = "shared"
+		transCtx.shardingComps = map[string][]*appsv1.ClusterComponentSpec{
+			sharding.Name: {defaultComp, privateComp, sharedComp},
+		}
+		transCtx.shardingCompsWithTpl = map[string]map[string][]*appsv1.ClusterComponentSpec{
+			sharding.Name: {"": {defaultComp}, "private": {privateComp}, "shared": {sharedComp}},
+		}
+		sharedTemplates := transformer.sharedShardTemplates(transCtx, sharding)
+		Expect(sharedTemplates).Should(Equal(sets.New("", "shared")))
+		transformer.rewriteTLSConfig(transCtx, sharding, sharedTemplates)
+		Expect(defaultComp.Issuer.Name).Should(Equal(appsv1.IssuerUserProvided))
+		Expect(sharedComp.Issuer.Name).Should(Equal(appsv1.IssuerUserProvided))
+		Expect(privateComp.Issuer.Name).Should(Equal(appsv1.IssuerKubeBlocks))
+		Expect(sharding.Template.Issuer.Name).Should(Equal(appsv1.IssuerKubeBlocks))
+	})
+
+	It("uses fixed source keys when ComponentDefinition TLS file names are omitted", func() {
+		transformer := &clusterShardingTLSTransformer{}
+		transCtx := newTransformContext()
+		sharding := newSharding()
+		compDef := newComponentDefinition()
+		compDef.Spec.TLS.CAFile = nil
+		compDef.Spec.TLS.CertFile = nil
+		compDef.Spec.TLS.KeyFile = nil
+		transCtx.componentDefs = map[string]*appsv1.ComponentDefinition{compDef.Name: compDef}
+
+		secret, err := transformer.buildTLSSecret(transCtx, sharding)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(secret.Data).Should(HaveKey(shardingTLSCAKey))
+		Expect(secret.Data).Should(HaveKey(shardingTLSCertKey))
+		Expect(secret.Data).Should(HaveKey(shardingTLSKeyKey))
+
+		comp := sharding.Template.DeepCopy()
+		comp.Name = "shared"
+		transCtx.shardingComps = map[string][]*appsv1.ClusterComponentSpec{sharding.Name: {comp}}
+		transCtx.shardingCompsWithTpl = map[string]map[string][]*appsv1.ClusterComponentSpec{
+			sharding.Name: {"": {comp}},
+		}
+		transformer.rewriteTLSConfig(transCtx, sharding, sets.New(""))
+		Expect(comp.Issuer.SecretRef.CA).Should(Equal(shardingTLSCAKey))
+		Expect(comp.Issuer.SecretRef.Cert).Should(Equal(shardingTLSCertKey))
+		Expect(comp.Issuer.SecretRef.Key).Should(Equal(shardingTLSKeyKey))
 	})
 
 	It("checks shared TLS secret existence with a fake client", func() {
@@ -252,13 +291,13 @@ var _ = Describe("cluster sharding shared transformers", func() {
 		transCtx := newTransformContext()
 		transCtx.componentDefs = map[string]*appsv1.ComponentDefinition{}
 
-		Expect(transformer.reconcileShardingTLS(transCtx, nil, nil, sharding)).Should(
+		Expect(transformer.reconcileShardingTLS(transCtx, nil, nil, sharding, sets.New(""))).Should(
 			MatchError(ContainSubstring("component definition \"compdef\" not found")))
 
 		compDef := newComponentDefinition()
 		compDef.Spec.TLS = nil
 		transCtx.componentDefs[compDefName] = compDef
-		Expect(transformer.reconcileShardingTLS(transCtx, nil, nil, sharding)).Should(
+		Expect(transformer.reconcileShardingTLS(transCtx, nil, nil, sharding, sets.New(""))).Should(
 			MatchError(ContainSubstring("doesn't support it")))
 	})
 

--- a/controllers/apps/cluster/transformer_cluster_sharding_tls.go
+++ b/controllers/apps/cluster/transformer_cluster_sharding_tls.go
@@ -40,16 +40,16 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/plan"
 )
 
-// clusterShardingTLSTransformer handles shared TLS for sharding.
-type clusterShardingTLSTransformer struct{}
-
-var _ graph.Transformer = &clusterShardingTLSTransformer{}
-
 const (
 	shardingTLSCAKey   = "ca.crt"
 	shardingTLSCertKey = "tls.crt"
 	shardingTLSKeyKey  = "tls.key"
 )
+
+var _ graph.Transformer = &clusterShardingTLSTransformer{}
+
+// clusterShardingTLSTransformer handles shared TLS for sharding.
+type clusterShardingTLSTransformer struct{}
 
 func (t *clusterShardingTLSTransformer) Transform(ctx graph.TransformContext, dag *graph.DAG) error {
 	transCtx, _ := ctx.(*clusterTransformContext)
@@ -113,10 +113,12 @@ func (t *clusterShardingTLSTransformer) reconcileShardingTLS(transCtx *clusterTr
 	if sharding.Template.Issuer == nil {
 		return fmt.Errorf("issuer shouldn't be nil when tls enabled")
 	}
-	if sharding.Template.Issuer.Name == appsv1.IssuerUserProvided {
+	switch sharding.Template.Issuer.Name {
+	case appsv1.IssuerUserProvided:
 		return nil // all components will share the same secret
-	}
-	if sharding.Template.Issuer.Name != appsv1.IssuerKubeBlocks {
+	case appsv1.IssuerKubeBlocks:
+		// generate and distribute a shared certificate below
+	default:
 		return fmt.Errorf("unsupported TLS issuer %q", sharding.Template.Issuer.Name)
 	}
 

--- a/controllers/apps/cluster/transformer_cluster_sharding_tls.go
+++ b/controllers/apps/cluster/transformer_cluster_sharding_tls.go
@@ -26,6 +26,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
@@ -42,6 +44,12 @@ import (
 type clusterShardingTLSTransformer struct{}
 
 var _ graph.Transformer = &clusterShardingTLSTransformer{}
+
+const (
+	shardingTLSCAKey   = "ca.crt"
+	shardingTLSCertKey = "tls.crt"
+	shardingTLSKeyKey  = "tls.key"
+)
 
 func (t *clusterShardingTLSTransformer) Transform(ctx graph.TransformContext, dag *graph.DAG) error {
 	transCtx, _ := ctx.(*clusterTransformContext)
@@ -61,21 +69,44 @@ func (t *clusterShardingTLSTransformer) Transform(ctx graph.TransformContext, da
 func (t *clusterShardingTLSTransformer) reconcileShardingTLSs(
 	transCtx *clusterTransformContext, graphCli model.GraphClient, dag *graph.DAG) error {
 	for _, sharding := range transCtx.shardings {
-		shardDef, ok := transCtx.shardingDefs[sharding.ShardingDef]
-		if ok {
-			tls := shardDef.Spec.TLS
-			if tls != nil && tls.Shared != nil && *tls.Shared {
-				if err := t.reconcileShardingTLS(transCtx, graphCli, dag, sharding); err != nil {
-					return err
-				}
-			}
+		sharedTemplates := t.sharedShardTemplates(transCtx, sharding)
+		if sharedTemplates.Len() == 0 {
+			continue
+		}
+		if err := t.reconcileShardingTLS(transCtx, graphCli, dag, sharding, sharedTemplates); err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
+func (t *clusterShardingTLSTransformer) sharedShardTemplates(
+	transCtx *clusterTransformContext, sharding *appsv1.ClusterSharding) sets.Set[string] {
+	shared := func(shardingDefName string) bool {
+		shardingDef, ok := transCtx.shardingDefs[shardingDefName]
+		if !ok || shardingDef.Spec.TLS == nil {
+			return false
+		}
+		return ptr.Deref(shardingDef.Spec.TLS.Shared, false)
+	}
+
+	templates := sets.New[string]()
+	activeTemplates := transCtx.shardingCompsWithTpl[sharding.Name]
+	if _, active := activeTemplates[""]; active && shared(sharding.ShardingDef) {
+		templates.Insert("") // the default shard template
+	}
+	for _, shardTemplate := range sharding.ShardTemplates {
+		_, active := activeTemplates[shardTemplate.Name]
+		if active && shared(ptr.Deref(shardTemplate.ShardingDef, sharding.ShardingDef)) {
+			templates.Insert(shardTemplate.Name)
+		}
+	}
+	return templates
+}
+
 func (t *clusterShardingTLSTransformer) reconcileShardingTLS(transCtx *clusterTransformContext,
-	graphCli model.GraphClient, dag *graph.DAG, sharding *appsv1.ClusterSharding) error {
+	graphCli model.GraphClient, dag *graph.DAG, sharding *appsv1.ClusterSharding,
+	sharedTemplates sets.Set[string]) error {
 	if !sharding.Template.TLS {
 		return nil
 	}
@@ -89,13 +120,8 @@ func (t *clusterShardingTLSTransformer) reconcileShardingTLS(transCtx *clusterTr
 		return fmt.Errorf("unsupported TLS issuer %q", sharding.Template.Issuer.Name)
 	}
 
-	compDef, ok := transCtx.componentDefs[sharding.Template.ComponentDef]
-	if !ok || compDef == nil {
-		return fmt.Errorf("component definition %q not found for sharding %q",
-			sharding.Template.ComponentDef, sharding.Name)
-	}
-	if compDef.Spec.TLS == nil {
-		return fmt.Errorf("TLS is enabled but component definition %q doesn't support it", compDef.Name)
+	if err := t.validateComponentDefinitions(transCtx, sharding, sharedTemplates); err != nil {
+		return err
 	}
 
 	secret, err := t.checkTLSSecret(transCtx, sharding)
@@ -104,13 +130,13 @@ func (t *clusterShardingTLSTransformer) reconcileShardingTLS(transCtx *clusterTr
 	}
 
 	if secret == nil {
-		obj, err1 := t.buildTLSSecret(transCtx, sharding, compDef)
+		obj, err1 := t.buildTLSSecret(transCtx, sharding)
 		if err1 != nil {
 			return err1
 		}
 		graphCli.Create(dag, obj)
 	} else {
-		proto := t.newTLSSecret(transCtx, sharding, compDef)
+		proto := t.newTLSSecret(transCtx, sharding)
 		secretCopy := secret.DeepCopy()
 		secretCopy.Labels = proto.Labels
 		secretCopy.Annotations = proto.Annotations
@@ -119,8 +145,36 @@ func (t *clusterShardingTLSTransformer) reconcileShardingTLS(transCtx *clusterTr
 		}
 	}
 
-	t.rewriteTLSConfig(transCtx, sharding, compDef)
+	t.rewriteTLSConfig(transCtx, sharding, sharedTemplates)
 
+	return nil
+}
+
+func (t *clusterShardingTLSTransformer) validateComponentDefinitions(transCtx *clusterTransformContext,
+	sharding *appsv1.ClusterSharding, sharedTemplates sets.Set[string]) error {
+	componentDefName := func(templateName string) string {
+		if templateName == "" {
+			return sharding.Template.ComponentDef
+		}
+		for _, shardTemplate := range sharding.ShardTemplates {
+			if shardTemplate.Name == templateName {
+				return ptr.Deref(shardTemplate.CompDef, sharding.Template.ComponentDef)
+			}
+		}
+		return ""
+	}
+
+	for templateName := range sharedTemplates {
+		name := componentDefName(templateName)
+		compDef, ok := transCtx.componentDefs[name]
+		if !ok || compDef == nil {
+			return fmt.Errorf("component definition %q not found for shard template %q of sharding %q",
+				name, templateName, sharding.Name)
+		}
+		if compDef.Spec.TLS == nil {
+			return fmt.Errorf("TLS is enabled but component definition %q doesn't support it", compDef.Name)
+		}
+	}
 	return nil
 }
 
@@ -155,18 +209,24 @@ func (t *clusterShardingTLSTransformer) checkTLSSecret(
 }
 
 func (t *clusterShardingTLSTransformer) buildTLSSecret(transCtx *clusterTransformContext,
-	sharding *appsv1.ClusterSharding, compDef *appsv1.ComponentDefinition) (*corev1.Secret, error) {
+	sharding *appsv1.ClusterSharding) (*corev1.Secret, error) {
 	synthesizedComp := component.SynthesizedComponent{
 		Namespace:   transCtx.Cluster.Namespace,
 		ClusterName: transCtx.Cluster.Name,
 		Name:        sharding.Name,
 	}
-	secret := t.newTLSSecret(transCtx, sharding, compDef)
+	secret := t.newTLSSecret(transCtx, sharding)
+	// The sharding Secret is an internal certificate source. Fixed keys decouple
+	// it from the optional file names declared by each ComponentDefinition.
+	caFile, certFile, keyFile := shardingTLSCAKey, shardingTLSCertKey, shardingTLSKeyKey
+	compDef := &appsv1.ComponentDefinition{Spec: appsv1.ComponentDefinitionSpec{TLS: &appsv1.TLS{
+		CAFile: &caFile, CertFile: &certFile, KeyFile: &keyFile,
+	}}}
 	return plan.ComposeTLSCertsWithSecret(compDef, synthesizedComp, secret)
 }
 
 func (t *clusterShardingTLSTransformer) newTLSSecret(transCtx *clusterTransformContext,
-	sharding *appsv1.ClusterSharding, compDef *appsv1.ComponentDefinition) *corev1.Secret {
+	sharding *appsv1.ClusterSharding) *corev1.Secret {
 	var (
 		cluster      = transCtx.Cluster
 		namespace    = cluster.Namespace
@@ -178,46 +238,43 @@ func (t *clusterShardingTLSTransformer) newTLSSecret(transCtx *clusterTransformC
 	}
 	return builder.NewSecretBuilder(namespace, shardingTLSSecretName(clusterName, shardingName)).
 		AddLabelsInMap(sharding.Template.Labels).
-		AddLabelsInMap(compDef.Spec.Labels).
 		AddLabelsInMap(constant.GetClusterLabels(clusterName, shardingLabels)).
 		AddAnnotationsInMap(sharding.Template.Annotations).
-		AddAnnotationsInMap(compDef.Spec.Annotations).
 		SetData(map[string][]byte{}).
 		GetObject()
 }
 
 func (t *clusterShardingTLSTransformer) rewriteTLSConfig(
-	transCtx *clusterTransformContext, sharding *appsv1.ClusterSharding, compDef *appsv1.ComponentDefinition) {
+	transCtx *clusterTransformContext, sharding *appsv1.ClusterSharding, sharedTemplates sets.Set[string]) {
 	newIssuer := func() *appsv1.Issuer {
-		issuer := &appsv1.Issuer{
+		return &appsv1.Issuer{
 			Name: appsv1.IssuerUserProvided,
 			SecretRef: &appsv1.TLSSecretRef{
 				Namespace: transCtx.Cluster.Namespace,
 				Name:      shardingTLSSecretName(transCtx.Cluster.Name, sharding.Name),
+				CA:        shardingTLSCAKey,
+				Cert:      shardingTLSCertKey,
+				Key:       shardingTLSKeyKey,
 			},
 		}
-		tls := compDef.Spec.TLS
-		if tls.CAFile != nil {
-			issuer.SecretRef.CA = *tls.CAFile
-		}
-		if tls.CertFile != nil {
-			issuer.SecretRef.Cert = *tls.CertFile
-		}
-		if tls.KeyFile != nil {
-			issuer.SecretRef.Key = *tls.KeyFile
-		}
-		return issuer
 	}
 
 	// Normalization expands a sharding into component specs before this transformer
-	// runs. Rewrite both the sharding template and those expanded specs so the
-	// Component objects reference the shared Secret.
-	sharding.Template.Issuer = newIssuer()
-	for _, comp := range transCtx.shardingComps[sharding.Name] {
-		comp.Issuer = newIssuer()
-	}
-	for _, comps := range transCtx.shardingCompsWithTpl[sharding.Name] {
+	// runs. Rewrite only the expanded specs whose effective ShardingDefinition
+	// enables sharing. Keep the Cluster spec unchanged so template-specific
+	// opt-outs continue to inherit the user's original KubeBlocks issuer.
+	sharedComponentNames := sets.New[string]()
+	for templateName, comps := range transCtx.shardingCompsWithTpl[sharding.Name] {
+		if !sharedTemplates.Has(templateName) {
+			continue
+		}
 		for _, comp := range comps {
+			comp.Issuer = newIssuer()
+			sharedComponentNames.Insert(comp.Name)
+		}
+	}
+	for _, comp := range transCtx.shardingComps[sharding.Name] {
+		if sharedComponentNames.Has(comp.Name) {
 			comp.Issuer = newIssuer()
 		}
 	}

--- a/controllers/apps/cluster/transformer_cluster_sharding_tls.go
+++ b/controllers/apps/cluster/transformer_cluster_sharding_tls.go
@@ -216,13 +216,9 @@ func (t *clusterShardingTLSTransformer) buildTLSSecret(transCtx *clusterTransfor
 		Name:        sharding.Name,
 	}
 	secret := t.newTLSSecret(transCtx, sharding)
-	// The sharding Secret is an internal certificate source. Fixed keys decouple
-	// it from the optional file names declared by each ComponentDefinition.
 	caFile, certFile, keyFile := shardingTLSCAKey, shardingTLSCertKey, shardingTLSKeyKey
-	compDef := &appsv1.ComponentDefinition{Spec: appsv1.ComponentDefinitionSpec{TLS: &appsv1.TLS{
-		CAFile: &caFile, CertFile: &certFile, KeyFile: &keyFile,
-	}}}
-	return plan.ComposeTLSCertsWithSecret(compDef, synthesizedComp, secret)
+	keys := plan.TLSSecretKeys{CA: &caFile, Cert: &certFile, Key: &keyFile}
+	return plan.ComposeTLSCertsWithSecret(keys, synthesizedComp, secret)
 }
 
 func (t *clusterShardingTLSTransformer) newTLSSecret(transCtx *clusterTransformContext,

--- a/controllers/apps/cluster/transformer_cluster_sharding_tls.go
+++ b/controllers/apps/cluster/transformer_cluster_sharding_tls.go
@@ -261,20 +261,15 @@ func (t *clusterShardingTLSTransformer) rewriteTLSConfig(
 
 	// Normalization expands a sharding into component specs before this transformer
 	// runs. Rewrite only the expanded specs whose effective ShardingDefinition
-	// enables sharing. Keep the Cluster spec unchanged so template-specific
-	// opt-outs continue to inherit the user's original KubeBlocks issuer.
-	sharedComponentNames := sets.New[string]()
+	// enables sharing. shardingCompsWithTpl and shardingComps contain the same
+	// component pointers, so updating the grouped view also updates the flat view.
+	// Keep the Cluster spec unchanged so template-specific opt-outs continue to
+	// inherit the user's original KubeBlocks issuer.
 	for templateName, comps := range transCtx.shardingCompsWithTpl[sharding.Name] {
 		if !sharedTemplates.Has(templateName) {
 			continue
 		}
 		for _, comp := range comps {
-			comp.Issuer = newIssuer()
-			sharedComponentNames.Insert(comp.Name)
-		}
-	}
-	for _, comp := range transCtx.shardingComps[sharding.Name] {
-		if sharedComponentNames.Has(comp.Name) {
 			comp.Issuer = newIssuer()
 		}
 	}

--- a/controllers/apps/cluster/transformer_cluster_sharding_tls.go
+++ b/controllers/apps/cluster/transformer_cluster_sharding_tls.go
@@ -80,8 +80,7 @@ func (t *clusterShardingTLSTransformer) reconcileShardingTLSs(
 	return nil
 }
 
-func (t *clusterShardingTLSTransformer) sharedShardTemplates(transCtx *clusterTransformContext,
-	sharding *appsv1.ClusterSharding) sets.Set[string] {
+func (t *clusterShardingTLSTransformer) sharedShardTemplates(transCtx *clusterTransformContext, sharding *appsv1.ClusterSharding) sets.Set[string] {
 	shared := func(shardingDefName string) bool {
 		shardingDef, ok := transCtx.shardingDefs[shardingDefName]
 		if !ok || shardingDef.Spec.TLS == nil {
@@ -209,8 +208,7 @@ func (t *clusterShardingTLSTransformer) checkTLSSecret(
 	return secret, nil
 }
 
-func (t *clusterShardingTLSTransformer) buildTLSSecret(transCtx *clusterTransformContext,
-	sharding *appsv1.ClusterSharding) (*corev1.Secret, error) {
+func (t *clusterShardingTLSTransformer) buildTLSSecret(transCtx *clusterTransformContext, sharding *appsv1.ClusterSharding) (*corev1.Secret, error) {
 	synthesizedComp := component.SynthesizedComponent{
 		Namespace:   transCtx.Cluster.Namespace,
 		ClusterName: transCtx.Cluster.Name,
@@ -222,8 +220,7 @@ func (t *clusterShardingTLSTransformer) buildTLSSecret(transCtx *clusterTransfor
 	return plan.ComposeTLSCertsWithSecret(synthesizedComp, keys, secret)
 }
 
-func (t *clusterShardingTLSTransformer) newTLSSecret(transCtx *clusterTransformContext,
-	sharding *appsv1.ClusterSharding) *corev1.Secret {
+func (t *clusterShardingTLSTransformer) newTLSSecret(transCtx *clusterTransformContext, sharding *appsv1.ClusterSharding) *corev1.Secret {
 	var (
 		cluster      = transCtx.Cluster
 		namespace    = cluster.Namespace

--- a/controllers/apps/cluster/transformer_cluster_sharding_tls.go
+++ b/controllers/apps/cluster/transformer_cluster_sharding_tls.go
@@ -24,6 +24,7 @@ import (
 	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -84,13 +85,24 @@ func (t *clusterShardingTLSTransformer) reconcileShardingTLS(transCtx *clusterTr
 	if sharding.Template.Issuer.Name == appsv1.IssuerUserProvided {
 		return nil // all components will share the same secret
 	}
+	if sharding.Template.Issuer.Name != appsv1.IssuerKubeBlocks {
+		return fmt.Errorf("unsupported TLS issuer %q", sharding.Template.Issuer.Name)
+	}
+
+	compDef, ok := transCtx.componentDefs[sharding.Template.ComponentDef]
+	if !ok || compDef == nil {
+		return fmt.Errorf("component definition %q not found for sharding %q",
+			sharding.Template.ComponentDef, sharding.Name)
+	}
+	if compDef.Spec.TLS == nil {
+		return fmt.Errorf("TLS is enabled but component definition %q doesn't support it", compDef.Name)
+	}
 
 	secret, err := t.checkTLSSecret(transCtx, sharding)
 	if err != nil {
 		return err
 	}
 
-	compDef := transCtx.componentDefs[sharding.Template.ComponentDef]
 	if secret == nil {
 		obj, err1 := t.buildTLSSecret(transCtx, sharding, compDef)
 		if err1 != nil {
@@ -123,8 +135,21 @@ func (t *clusterShardingTLSTransformer) checkTLSSecret(
 	}
 	secret := &corev1.Secret{}
 	err := transCtx.GetClient().Get(transCtx.GetContext(), secretKey, secret)
+	if apierrors.IsNotFound(err) {
+		return nil, nil
+	}
 	if err != nil {
-		return nil, client.IgnoreNotFound(err)
+		return nil, err
+	}
+
+	managedLabels := constant.GetClusterLabels(cluster.Name, map[string]string{
+		constant.KBAppShardingNameLabelKey: sharding.Name,
+	})
+	for key, value := range managedLabels {
+		if secret.Labels[key] != value {
+			return nil, fmt.Errorf("secret %s/%s already exists but is not managed by sharding %s",
+				secret.Namespace, secret.Name, sharding.Name)
+		}
 	}
 	return secret, nil
 }
@@ -152,9 +177,9 @@ func (t *clusterShardingTLSTransformer) newTLSSecret(transCtx *clusterTransformC
 		constant.KBAppShardingNameLabelKey: shardingName,
 	}
 	return builder.NewSecretBuilder(namespace, shardingTLSSecretName(clusterName, shardingName)).
-		AddLabelsInMap(constant.GetClusterLabels(clusterName, shardingLabels)).
 		AddLabelsInMap(sharding.Template.Labels).
 		AddLabelsInMap(compDef.Spec.Labels).
+		AddLabelsInMap(constant.GetClusterLabels(clusterName, shardingLabels)).
 		AddAnnotationsInMap(sharding.Template.Annotations).
 		AddAnnotationsInMap(compDef.Spec.Annotations).
 		SetData(map[string][]byte{}).
@@ -163,22 +188,38 @@ func (t *clusterShardingTLSTransformer) newTLSSecret(transCtx *clusterTransformC
 
 func (t *clusterShardingTLSTransformer) rewriteTLSConfig(
 	transCtx *clusterTransformContext, sharding *appsv1.ClusterSharding, compDef *appsv1.ComponentDefinition) {
-	sharding.Template.Issuer = &appsv1.Issuer{
-		Name: appsv1.IssuerUserProvided,
-		SecretRef: &appsv1.TLSSecretRef{
-			Namespace: transCtx.Cluster.Namespace,
-			Name:      shardingTLSSecretName(transCtx.Cluster.Name, sharding.Name),
-		},
+	newIssuer := func() *appsv1.Issuer {
+		issuer := &appsv1.Issuer{
+			Name: appsv1.IssuerUserProvided,
+			SecretRef: &appsv1.TLSSecretRef{
+				Namespace: transCtx.Cluster.Namespace,
+				Name:      shardingTLSSecretName(transCtx.Cluster.Name, sharding.Name),
+			},
+		}
+		tls := compDef.Spec.TLS
+		if tls.CAFile != nil {
+			issuer.SecretRef.CA = *tls.CAFile
+		}
+		if tls.CertFile != nil {
+			issuer.SecretRef.Cert = *tls.CertFile
+		}
+		if tls.KeyFile != nil {
+			issuer.SecretRef.Key = *tls.KeyFile
+		}
+		return issuer
 	}
-	tls := compDef.Spec.TLS
-	if tls.CAFile != nil {
-		sharding.Template.Issuer.SecretRef.CA = *tls.CAFile
+
+	// Normalization expands a sharding into component specs before this transformer
+	// runs. Rewrite both the sharding template and those expanded specs so the
+	// Component objects reference the shared Secret.
+	sharding.Template.Issuer = newIssuer()
+	for _, comp := range transCtx.shardingComps[sharding.Name] {
+		comp.Issuer = newIssuer()
 	}
-	if tls.CertFile != nil {
-		sharding.Template.Issuer.SecretRef.Cert = *tls.CertFile
-	}
-	if tls.KeyFile != nil {
-		sharding.Template.Issuer.SecretRef.Key = *tls.KeyFile
+	for _, comps := range transCtx.shardingCompsWithTpl[sharding.Name] {
+		for _, comp := range comps {
+			comp.Issuer = newIssuer()
+		}
 	}
 }
 

--- a/controllers/apps/cluster/transformer_cluster_sharding_tls.go
+++ b/controllers/apps/cluster/transformer_cluster_sharding_tls.go
@@ -80,8 +80,8 @@ func (t *clusterShardingTLSTransformer) reconcileShardingTLSs(
 	return nil
 }
 
-func (t *clusterShardingTLSTransformer) sharedShardTemplates(
-	transCtx *clusterTransformContext, sharding *appsv1.ClusterSharding) sets.Set[string] {
+func (t *clusterShardingTLSTransformer) sharedShardTemplates(transCtx *clusterTransformContext,
+	sharding *appsv1.ClusterSharding) sets.Set[string] {
 	shared := func(shardingDefName string) bool {
 		shardingDef, ok := transCtx.shardingDefs[shardingDefName]
 		if !ok || shardingDef.Spec.TLS == nil {
@@ -105,8 +105,7 @@ func (t *clusterShardingTLSTransformer) sharedShardTemplates(
 }
 
 func (t *clusterShardingTLSTransformer) reconcileShardingTLS(transCtx *clusterTransformContext,
-	graphCli model.GraphClient, dag *graph.DAG, sharding *appsv1.ClusterSharding,
-	sharedTemplates sets.Set[string]) error {
+	graphCli model.GraphClient, dag *graph.DAG, sharding *appsv1.ClusterSharding, sharedTemplates sets.Set[string]) error {
 	if !sharding.Template.TLS {
 		return nil
 	}
@@ -220,7 +219,7 @@ func (t *clusterShardingTLSTransformer) buildTLSSecret(transCtx *clusterTransfor
 	secret := t.newTLSSecret(transCtx, sharding)
 	caFile, certFile, keyFile := shardingTLSCAKey, shardingTLSCertKey, shardingTLSKeyKey
 	keys := plan.TLSSecretKeys{CA: &caFile, Cert: &certFile, Key: &keyFile}
-	return plan.ComposeTLSCertsWithSecret(keys, synthesizedComp, secret)
+	return plan.ComposeTLSCertsWithSecret(synthesizedComp, keys, secret)
 }
 
 func (t *clusterShardingTLSTransformer) newTLSSecret(transCtx *clusterTransformContext,
@@ -242,8 +241,8 @@ func (t *clusterShardingTLSTransformer) newTLSSecret(transCtx *clusterTransformC
 		GetObject()
 }
 
-func (t *clusterShardingTLSTransformer) rewriteTLSConfig(
-	transCtx *clusterTransformContext, sharding *appsv1.ClusterSharding, sharedTemplates sets.Set[string]) {
+func (t *clusterShardingTLSTransformer) rewriteTLSConfig(transCtx *clusterTransformContext,
+	sharding *appsv1.ClusterSharding, sharedTemplates sets.Set[string]) {
 	newIssuer := func() *appsv1.Issuer {
 		return &appsv1.Issuer{
 			Name: appsv1.IssuerUserProvided,

--- a/controllers/apps/cluster/transformer_cluster_sharding_tls.go
+++ b/controllers/apps/cluster/transformer_cluster_sharding_tls.go
@@ -46,10 +46,10 @@ const (
 	shardingTLSKeyKey  = "tls.key"
 )
 
-var _ graph.Transformer = &clusterShardingTLSTransformer{}
-
 // clusterShardingTLSTransformer handles shared TLS for sharding.
 type clusterShardingTLSTransformer struct{}
+
+var _ graph.Transformer = &clusterShardingTLSTransformer{}
 
 func (t *clusterShardingTLSTransformer) Transform(ctx graph.TransformContext, dag *graph.DAG) error {
 	transCtx, _ := ctx.(*clusterTransformContext)

--- a/controllers/apps/component/transformer_component_tls.go
+++ b/controllers/apps/component/transformer_component_tls.go
@@ -203,7 +203,9 @@ func (i *tlsIssuerKubeBlocks) create(ctx context.Context, cli client.Reader) (*c
 	if err != nil {
 		return nil, err
 	}
-	return plan.ComposeTLSCertsWithSecret(i.compDef, *i.synthesizedComp, proto)
+	tls := i.compDef.Spec.TLS
+	keys := plan.TLSSecretKeys{CA: tls.CAFile, Cert: tls.CertFile, Key: tls.KeyFile}
+	return plan.ComposeTLSCertsWithSecret(keys, *i.synthesizedComp, proto)
 }
 
 func (i *tlsIssuerKubeBlocks) delete(ctx context.Context, cli client.Reader, secret *corev1.Secret) (*corev1.Secret, error) {

--- a/controllers/apps/component/transformer_component_tls.go
+++ b/controllers/apps/component/transformer_component_tls.go
@@ -205,7 +205,7 @@ func (i *tlsIssuerKubeBlocks) create(ctx context.Context, cli client.Reader) (*c
 	}
 	tls := i.compDef.Spec.TLS
 	keys := plan.TLSSecretKeys{CA: tls.CAFile, Cert: tls.CertFile, Key: tls.KeyFile}
-	return plan.ComposeTLSCertsWithSecret(keys, *i.synthesizedComp, proto)
+	return plan.ComposeTLSCertsWithSecret(*i.synthesizedComp, keys, proto)
 }
 
 func (i *tlsIssuerKubeBlocks) delete(ctx context.Context, cli client.Reader, secret *corev1.Secret) (*corev1.Secret, error) {

--- a/controllers/apps/component/transformer_component_tls_test.go
+++ b/controllers/apps/component/transformer_component_tls_test.go
@@ -262,6 +262,27 @@ var _ = Describe("TLS transformer test", func() {
 			checkTLSSecret(true, appsv1.IssuerUserProvided)
 			checkVolumeNMounts(true)
 		})
+
+		It("w/ define, enabled - user with optional TLS file names omitted", func() {
+			// A shared sharding TLS source always contains CA, cert, and key. The
+			// ComponentDefinition still controls which files are copied locally.
+			transCtx.CompDef.Spec.TLS = &appsv1.TLS{
+				VolumeName: tls.VolumeName,
+				MountPath:  tls.MountPath,
+				CertFile:   ptr.To("server.crt"),
+			}
+			transCtx.SynthesizeComponent.TLSConfig = tlsConfig4User
+
+			transformer := &componentTLSTransformer{}
+			Expect(transformer.Transform(transCtx, dag)).Should(Succeed())
+
+			graphCli := transCtx.Client.(model.GraphClient)
+			objs := graphCli.FindAll(dag, &corev1.Secret{})
+			Expect(objs).Should(HaveLen(1))
+			secret := objs[0].(*corev1.Secret)
+			Expect(secret.Data).Should(HaveLen(1))
+			Expect(secret.Data).Should(HaveKeyWithValue("server.crt", tlsSecret4User.Data["cert"]))
+		})
 	})
 
 	Context("update & disable", func() {

--- a/pkg/controller/plan/tls.go
+++ b/pkg/controller/plan/tls.go
@@ -29,11 +29,18 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 
-	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 )
 
-func ComposeTLSCertsWithSecret(compDef *appsv1.ComponentDefinition,
+// TLSSecretKeys identifies where generated certificate data is stored in a Secret.
+// A nil key omits the corresponding certificate data.
+type TLSSecretKeys struct {
+	CA   *string
+	Cert *string
+	Key  *string
+}
+
+func ComposeTLSCertsWithSecret(keys TLSSecretKeys,
 	synthesizedComp component.SynthesizedComponent, secret *corev1.Secret) (*corev1.Secret, error) {
 	var (
 		namespace   = synthesizedComp.Namespace
@@ -65,14 +72,14 @@ func ComposeTLSCertsWithSecret(compDef *appsv1.ComponentDefinition,
 		return nil, errors.Errorf("generate TLS certificates failed with cluster name %s, component name %s in namespace %s",
 			clusterName, compName, namespace)
 	}
-	if compDef.Spec.TLS.CAFile != nil {
-		secret.Data[*compDef.Spec.TLS.CAFile] = []byte(parts[0])
+	if keys.CA != nil {
+		secret.Data[*keys.CA] = []byte(parts[0])
 	}
-	if compDef.Spec.TLS.CertFile != nil {
-		secret.Data[*compDef.Spec.TLS.CertFile] = []byte(parts[1])
+	if keys.Cert != nil {
+		secret.Data[*keys.Cert] = []byte(parts[1])
 	}
-	if compDef.Spec.TLS.KeyFile != nil {
-		secret.Data[*compDef.Spec.TLS.KeyFile] = []byte(parts[2])
+	if keys.Key != nil {
+		secret.Data[*keys.Key] = []byte(parts[2])
 	}
 	return secret, nil
 }

--- a/pkg/controller/plan/tls.go
+++ b/pkg/controller/plan/tls.go
@@ -40,8 +40,8 @@ type TLSSecretKeys struct {
 	Key  *string
 }
 
-func ComposeTLSCertsWithSecret(keys TLSSecretKeys,
-	synthesizedComp component.SynthesizedComponent, secret *corev1.Secret) (*corev1.Secret, error) {
+func ComposeTLSCertsWithSecret(synthesizedComp component.SynthesizedComponent,
+	keys TLSSecretKeys, secret *corev1.Secret) (*corev1.Secret, error) {
 	var (
 		namespace   = synthesizedComp.Namespace
 		clusterName = synthesizedComp.ClusterName

--- a/pkg/controller/plan/tls_test.go
+++ b/pkg/controller/plan/tls_test.go
@@ -49,7 +49,7 @@ var _ = Describe("TLS test", func() {
 			},
 			Data: map[string][]byte{},
 		}
-		_, err := ComposeTLSCertsWithSecret(keys, synthesizedComp, secret)
+		_, err := ComposeTLSCertsWithSecret(synthesizedComp, keys, secret)
 		Expect(err).Should(BeNil())
 		Expect(secret.Data).ShouldNot(BeNil())
 		Expect(secret.Data[*keys.CA]).ShouldNot(BeZero())

--- a/pkg/controller/plan/tls_test.go
+++ b/pkg/controller/plan/tls_test.go
@@ -27,20 +27,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
-	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 )
 
 var _ = Describe("TLS test", func() {
 	It("ComposeTLSCertsWithSecret", func() {
-		compDef := &appsv1.ComponentDefinition{
-			Spec: appsv1.ComponentDefinitionSpec{
-				TLS: &appsv1.TLS{
-					CAFile:   ptr.To("ca.pem"),
-					CertFile: ptr.To("cert.pem"),
-					KeyFile:  ptr.To("key.pem"),
-				},
-			},
+		keys := TLSSecretKeys{
+			CA:   ptr.To("ca.pem"),
+			Cert: ptr.To("cert.pem"),
+			Key:  ptr.To("key.pem"),
 		}
 		synthesizedComp := component.SynthesizedComponent{
 			Namespace:   testCtx.DefaultNamespace,
@@ -54,11 +49,11 @@ var _ = Describe("TLS test", func() {
 			},
 			Data: map[string][]byte{},
 		}
-		_, err := ComposeTLSCertsWithSecret(compDef, synthesizedComp, secret)
+		_, err := ComposeTLSCertsWithSecret(keys, synthesizedComp, secret)
 		Expect(err).Should(BeNil())
 		Expect(secret.Data).ShouldNot(BeNil())
-		Expect(secret.Data[*compDef.Spec.TLS.CAFile]).ShouldNot(BeZero())
-		Expect(secret.Data[*compDef.Spec.TLS.CertFile]).ShouldNot(BeZero())
-		Expect(secret.Data[*compDef.Spec.TLS.KeyFile]).ShouldNot(BeZero())
+		Expect(secret.Data[*keys.CA]).ShouldNot(BeZero())
+		Expect(secret.Data[*keys.Cert]).ShouldNot(BeZero())
+		Expect(secret.Data[*keys.Key]).ShouldNot(BeZero())
 	})
 })


### PR DESCRIPTION
## What changed

- register the shared sharding TLS transformer in the Cluster reconciliation chain
- evaluate `spec.tls.shared` from each active shard group's effective `ShardingDefinition`, including `ShardTemplate.shardingDef` overrides
- rewrite only the already-expanded shard Component specs whose effective definition enables sharing
- use fixed internal keys (`ca.crt`, `tls.crt`, and `tls.key`) in the shared source Secret, while preserving each ComponentDefinition's optional TLS file declarations
- validate referenced ComponentDefinitions and reject collisions with same-name Secrets that are not managed by the sharding
- keep KubeBlocks-managed labels authoritative
- add controller-level coverage for provisioning, scale-out without CA rotation, and heterogeneous shard-template sharing policies

## Why

`ShardingDefinition.spec.tls.shared` was accepted by the API, but `clusterShardingTLSTransformer` was never registered, so every shard continued to receive an independently generated CA.

Registration alone is not sufficient: normalization expands shard Component specs before this transformer runs. The original transformer only rewrote the sharding template, leaving those expanded specs configured with the original `KubeBlocks` issuer. This change updates the expanded Component specs before Component objects are created.

Shard templates may override the top-level `ShardingDefinition`; sharing is therefore evaluated per active default/template group instead of being inherited unconditionally from the top-level definition.

The shared Secret is an internal certificate source and always contains the complete CA/certificate/key set under fixed keys. Each Component controller still copies only the files declared by its ComponentDefinition, preserving the existing optional-file semantics.

## Impact

For shard groups configured with `spec.tls.shared: true` and the `KubeBlocks` issuer, KubeBlocks creates one `<cluster>-<sharding>-tls` Secret and makes those shard Components consume the shared trust root. Groups whose effective ShardingDefinition has sharing disabled retain the original issuer. Existing `UserProvided` behavior is unchanged.

## Known limitations / follow-ups

- **Certificate SANs:** this PR addresses shared trust-chain validation only. The shared certificate is generated from the sharding-level service name, while actual shard services include a shard identifier. Engines that enable DNS hostname verification may therefore reject the certificate. Generating per-shard leaf certificates with matching SANs while retaining a shared CA is intentionally left to a follow-up.
- **Shared TLS lifecycle:** this PR does not delete the managed `<cluster>-<sharding>-tls` source Secret when the last shared consumer is removed, `Shared` becomes `false`, or TLS is disabled. A follow-up should define the cleanup semantics and also rotate per-shard certificates when transitioning from shared TLS back to non-shared KubeBlocks-managed TLS.

Fixes #10756

## Validation

- `scripts/codex-go-test.sh ./controllers/apps/cluster -count=1`
- `scripts/codex-go-test.sh ./controllers/apps/component -count=1`
- `scripts/codex-go-test.sh ./pkg/controller/plan -run TestAPIs -ginkgo.focus='TLS test' -count=1`
