### PR TITLE
chore(dataprotection): separate successful population release from deletion cleanup

### DIFF
--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -173,7 +173,7 @@ func (r *VolumePopulatorReconciler) syncPVC(reqCtx intctrlutil.RequestCtx, pvc *
 		return nil
 	}
 	if !pvc.DeletionTimestamp.IsZero() {
-		return r.Cleanup(reqCtx, pvc)
+		return r.cleanupDeletingPVC(reqCtx, pvc)
 	}
 	var restoreCtx *pvcRestoreContext
 	if pvc.Spec.DataSourceRef.Kind == dptypes.RestoreKind {
@@ -191,7 +191,7 @@ func (r *VolumePopulatorReconciler) syncPVC(reqCtx intctrlutil.RequestCtx, pvc *
 	if err = r.completeBoundPVCIfNeeded(reqCtx, pvc, restoreCtx); err != nil {
 		return err
 	}
-	return r.Cleanup(reqCtx, pvc)
+	return nil
 }
 
 // dispatchUnboundPVC routes an unbound PVC to either Populate or ProvisionOnly.
@@ -1014,7 +1014,7 @@ func (r *VolumePopulatorReconciler) completeBoundPVCIfNeeded(reqCtx intctrlutil.
 		// actions may need the workload pod to start, which cannot happen while
 		// the populate PVC still owns the restored PV or while the target PVC is
 		// still marked as being populated.
-		if err := r.Cleanup(reqCtx, pvc); err != nil {
+		if err := r.releasePopulateResources(reqCtx, pvc); err != nil {
 			return err
 		}
 		reason := ReasonPopulatingSucceed
@@ -1613,7 +1613,26 @@ func postReadyRestoreName(componentUID types.UID) string {
 	return constant.ShortenKubeName(fmt.Sprintf("restore-%s-post-ready", componentUID), constant.KubeNameMaxLength)
 }
 
-func (r *VolumePopulatorReconciler) Cleanup(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim) error {
+// cleanupDeletingPVC releases population resources when the target PVC is
+// being deleted. Keep this entry point separate from successful completion so
+// deletion-specific teardown can evolve without broadening the success path.
+func (r *VolumePopulatorReconciler) cleanupDeletingPVC(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim) error {
+	if err := r.deletePopulatePVC(reqCtx, pvc); err != nil {
+		return err
+	}
+	return r.releaseTargetPVC(reqCtx, pvc)
+}
+
+// releasePopulateResources releases only the temporary PVC and the target PVC
+// finalizer after population has succeeded.
+func (r *VolumePopulatorReconciler) releasePopulateResources(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim) error {
+	if err := r.deletePopulatePVC(reqCtx, pvc); err != nil {
+		return err
+	}
+	return r.releaseTargetPVC(reqCtx, pvc)
+}
+
+func (r *VolumePopulatorReconciler) deletePopulatePVC(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim) error {
 	populatePVC := &corev1.PersistentVolumeClaim{}
 	if err := r.Client.Get(reqCtx.Ctx, types.NamespacedName{Name: getPopulatePVCName(pvc.UID),
 		Namespace: pvc.Namespace}, populatePVC); err != nil {
@@ -1623,7 +1642,10 @@ func (r *VolumePopulatorReconciler) Cleanup(reqCtx intctrlutil.RequestCtx, pvc *
 	} else if err = r.Client.Delete(reqCtx.Ctx, populatePVC); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
+	return nil
+}
 
+func (r *VolumePopulatorReconciler) releaseTargetPVC(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim) error {
 	if slices.Contains(pvc.Finalizers, dptypes.DataProtectionFinalizerName) {
 		pvcPatch := client.MergeFrom(pvc.DeepCopy())
 		controllerutil.RemoveFinalizer(pvc, dptypes.DataProtectionFinalizerName)

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -1536,6 +1536,31 @@ func TestDeletingTargetPVCCleansPopulationWithoutValidatingSource(t *testing.T) 
 	require.True(t, apierrors.IsNotFound(err), "populate PVC should be deleted, got: %v", err)
 }
 
+func TestSuccessfulPopulateReleaseRemovesOnlyHelperAndTargetFinalizer(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+		Namespace:  "default",
+		Name:       "data-0",
+		UID:        "data-0-uid",
+		Finalizers: []string{dptypes.DataProtectionFinalizerName, "example.io/keep"},
+	}}
+	helper := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+		Namespace: pvc.Namespace,
+		Name:      getPopulatePVCName(pvc.UID),
+	}}
+	reconciler := &VolumePopulatorReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc, helper).Build()}
+
+	err := reconciler.releasePopulateResources(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc)
+
+	require.NoError(t, err)
+	require.True(t, apierrors.IsNotFound(reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(helper), &corev1.PersistentVolumeClaim{})))
+	current := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), current))
+	require.NotContains(t, current.Finalizers, dptypes.DataProtectionFinalizerName)
+	require.Contains(t, current.Finalizers, "example.io/keep")
+}
+
 func TestPopulateCreatesExecutionRestoreAndPolls(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))


### PR DESCRIPTION
Part 3 of 4 for #10755.

## Problem

The same broad Cleanup entry point was used by successful restore completion and target-PVC deletion, and the bound success path called cleanup again after completion.

## Changes

- split deleting-PVC cleanup and successful helper release into explicit entry points
- share only narrow helper-PVC deletion and target-finalizer primitives
- remove the duplicate cleanup call at the end of the successful bound path
- preserve existing deletion cleanup behavior

## Scope

This PR does not add Cluster finalizers, binding-complete gating, rebind provenance validation, execution phase changes, or workload gates.

## Tests

- full controllers/dataprotection suite
- focused successful release and deleting-PVC cleanup tests

Fixes #10755
