### PR TITLE
fix(dataprotection): wait for Kubernetes PVC binding before restore completion

### DIFF
--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -1085,7 +1085,7 @@ func (r *VolumePopulatorReconciler) waitForSerialPredecessors(reqCtx intctrlutil
 		if cond != nil && cond.Status == corev1.ConditionFalse {
 			return intctrlutil.NewFatalError(fmt.Sprintf("previous restore PVC %s/%s failed: %s", item.Namespace, item.Name, cond.Message))
 		}
-		if pvcBindingCompleted(item) {
+		if pvcReadyForRestoreProgression(item) {
 			continue
 		}
 		if err = r.UpdatePVCConditions(reqCtx, pvc, ReasonPopulatingProcessing,
@@ -1390,7 +1390,7 @@ func (r *VolumePopulatorReconciler) allRestorePVCsForComponentBound(reqCtx intct
 		if cond != nil && cond.Status == corev1.ConditionFalse {
 			return false, intctrlutil.NewFatalError(fmt.Sprintf("restore PVC %s/%s failed: %s", item.Namespace, item.Name, cond.Message))
 		}
-		if !pvcBindingCompleted(item) {
+		if !pvcReadyForRestoreProgression(item) {
 			return false, nil
 		}
 	}
@@ -1408,7 +1408,7 @@ func (r *VolumePopulatorReconciler) allRestorePVCsForClusterBound(reqCtx intctrl
 		if cond != nil && cond.Status == corev1.ConditionFalse {
 			return false, intctrlutil.NewFatalError(fmt.Sprintf("restore PVC %s/%s failed: %s", item.Namespace, item.Name, cond.Message))
 		}
-		if !pvcBindingCompleted(item) {
+		if !pvcReadyForRestoreProgression(item) {
 			return false, nil
 		}
 	}
@@ -1463,6 +1463,10 @@ func pvcPopulateReleased(pvc *corev1.PersistentVolumeClaim) bool {
 	cond := findPVCConditionByType(pvc, string(PersistentVolumeClaimPopulating))
 	return cond != nil && cond.Status == corev1.ConditionTrue &&
 		(cond.Reason == ReasonPopulatingSucceed || cond.Reason == ReasonPopulatingProvisioned)
+}
+
+func pvcReadyForRestoreProgression(pvc *corev1.PersistentVolumeClaim) bool {
+	return pvcPopulateReleased(pvc) || pvcBindingCompleted(pvc)
 }
 
 func (r *VolumePopulatorReconciler) listRestorePVCsForComponent(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim) ([]corev1.PersistentVolumeClaim, error) {

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -999,11 +999,6 @@ func (r *VolumePopulatorReconciler) completeBoundPVCIfNeeded(reqCtx intctrlutil.
 	pvc *corev1.PersistentVolumeClaim,
 	restoreCtx *pvcRestoreContext) error {
 	if !pvcBindingCompleted(pvc) {
-		if err := r.UpdatePVCConditions(reqCtx, pvc, ReasonPopulatingProcessing,
-			fmt.Sprintf("Waiting for Kubernetes to complete binding target PVC %s/%s to PV %s",
-				pvc.Namespace, pvc.Name, pvc.Spec.VolumeName)); err != nil {
-			return err
-		}
 		return intctrlutil.NewRequeueError(reconcileInterval, "waiting for Kubernetes to complete target PVC binding")
 	}
 	populateReleased := pvcPopulateReleased(pvc)
@@ -1034,6 +1029,9 @@ func (r *VolumePopulatorReconciler) completeBoundPVCIfNeeded(reqCtx intctrlutil.
 		if err := r.updatePVCPopulatingCondition(reqCtx, pvc, reason, message); err != nil {
 			return err
 		}
+	}
+	if err := r.syncTargetPVCBoundStatusIfReady(reqCtx, pvc); err != nil {
+		return err
 	}
 	postReadyCompleted, err := r.ensurePostReadyRestoreCompleted(reqCtx, pvc, restoreCtx)
 	if err != nil {
@@ -1822,6 +1820,48 @@ func (r *VolumePopulatorReconciler) bindTargetPVCToPV(reqCtx intctrlutil.Request
 	patch := client.MergeFrom(pvc.DeepCopy())
 	pvc.Spec.VolumeName = pvName
 	return r.Client.Patch(reqCtx.Ctx, pvc, patch)
+}
+
+func pvClaimRefMatchesPVC(claimRef *corev1.ObjectReference, pvc *corev1.PersistentVolumeClaim) bool {
+	return claimRef != nil &&
+		claimRef.Name == pvc.Name &&
+		claimRef.Namespace == pvc.Namespace &&
+		claimRef.UID == pvc.UID
+}
+
+func (r *VolumePopulatorReconciler) syncTargetPVCBoundStatusIfReady(reqCtx intctrlutil.RequestCtx,
+	pvc *corev1.PersistentVolumeClaim) error {
+	if pvc.Spec.VolumeName == "" {
+		return nil
+	}
+	pv := &corev1.PersistentVolume{}
+	if err := r.Client.Get(reqCtx.Ctx, types.NamespacedName{Name: pvc.Spec.VolumeName}, pv); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	if !pvClaimRefMatchesPVC(pv.Spec.ClaimRef, pvc) {
+		return nil
+	}
+	return r.syncTargetPVCBoundStatus(reqCtx, pvc, pv)
+}
+
+func (r *VolumePopulatorReconciler) syncTargetPVCBoundStatus(reqCtx intctrlutil.RequestCtx,
+	pvc *corev1.PersistentVolumeClaim,
+	pv *corev1.PersistentVolume) error {
+	capacity := pv.Spec.Capacity.DeepCopy()
+	accessModes := slices.Clone(pv.Spec.AccessModes)
+	if pvc.Status.Phase == corev1.ClaimBound &&
+		reflect.DeepEqual(pvc.Status.Capacity, capacity) &&
+		slices.Equal(pvc.Status.AccessModes, accessModes) {
+		return nil
+	}
+	patch := client.MergeFrom(pvc.DeepCopy())
+	pvc.Status.Phase = corev1.ClaimBound
+	pvc.Status.Capacity = capacity
+	pvc.Status.AccessModes = accessModes
+	return r.Client.Status().Patch(reqCtx.Ctx, pvc, patch)
 }
 
 func pvcBindingCompleted(pvc *corev1.PersistentVolumeClaim) bool {

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -998,9 +998,6 @@ func (r *VolumePopulatorReconciler) ProvisionOnly(reqCtx intctrlutil.RequestCtx,
 func (r *VolumePopulatorReconciler) completeBoundPVCIfNeeded(reqCtx intctrlutil.RequestCtx,
 	pvc *corev1.PersistentVolumeClaim,
 	restoreCtx *pvcRestoreContext) error {
-	if !pvcBindingCompleted(pvc) {
-		return intctrlutil.NewRequeueError(reconcileInterval, "waiting for Kubernetes to complete target PVC binding")
-	}
 	populateReleased := pvcPopulateReleased(pvc)
 	for i := range pvc.Status.Conditions {
 		condition := pvc.Status.Conditions[i]
@@ -1013,6 +1010,9 @@ func (r *VolumePopulatorReconciler) completeBoundPVCIfNeeded(reqCtx intctrlutil.
 		break
 	}
 	if !populateReleased {
+		if !pvcBindingCompleted(pvc) {
+			return intctrlutil.NewRequeueError(reconcileInterval, "waiting for Kubernetes to complete target PVC binding")
+		}
 		// Release the target PVC after prepareData and PV rebind. PostReady
 		// actions may need the workload pod to start, which cannot happen while
 		// the populate PVC still owns the restored PV or while the target PVC is

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -998,6 +998,14 @@ func (r *VolumePopulatorReconciler) ProvisionOnly(reqCtx intctrlutil.RequestCtx,
 func (r *VolumePopulatorReconciler) completeBoundPVCIfNeeded(reqCtx intctrlutil.RequestCtx,
 	pvc *corev1.PersistentVolumeClaim,
 	restoreCtx *pvcRestoreContext) error {
+	if !pvcBindingCompleted(pvc) {
+		if err := r.UpdatePVCConditions(reqCtx, pvc, ReasonPopulatingProcessing,
+			fmt.Sprintf("Waiting for Kubernetes to complete binding target PVC %s/%s to PV %s",
+				pvc.Namespace, pvc.Name, pvc.Spec.VolumeName)); err != nil {
+			return err
+		}
+		return intctrlutil.NewRequeueError(reconcileInterval, "waiting for Kubernetes to complete target PVC binding")
+	}
 	populateReleased := pvcPopulateReleased(pvc)
 	for i := range pvc.Status.Conditions {
 		condition := pvc.Status.Conditions[i]
@@ -1026,9 +1034,6 @@ func (r *VolumePopulatorReconciler) completeBoundPVCIfNeeded(reqCtx intctrlutil.
 		if err := r.updatePVCPopulatingCondition(reqCtx, pvc, reason, message); err != nil {
 			return err
 		}
-	}
-	if err := r.syncTargetPVCBoundStatusIfReady(reqCtx, pvc); err != nil {
-		return err
 	}
 	postReadyCompleted, err := r.ensurePostReadyRestoreCompleted(reqCtx, pvc, restoreCtx)
 	if err != nil {
@@ -1082,7 +1087,7 @@ func (r *VolumePopulatorReconciler) waitForSerialPredecessors(reqCtx intctrlutil
 		if cond != nil && cond.Status == corev1.ConditionFalse {
 			return intctrlutil.NewFatalError(fmt.Sprintf("previous restore PVC %s/%s failed: %s", item.Namespace, item.Name, cond.Message))
 		}
-		if item.Spec.VolumeName != "" {
+		if pvcBindingCompleted(item) {
 			continue
 		}
 		if err = r.UpdatePVCConditions(reqCtx, pvc, ReasonPopulatingProcessing,
@@ -1387,7 +1392,7 @@ func (r *VolumePopulatorReconciler) allRestorePVCsForComponentBound(reqCtx intct
 		if cond != nil && cond.Status == corev1.ConditionFalse {
 			return false, intctrlutil.NewFatalError(fmt.Sprintf("restore PVC %s/%s failed: %s", item.Namespace, item.Name, cond.Message))
 		}
-		if item.Spec.VolumeName == "" {
+		if !pvcBindingCompleted(item) {
 			return false, nil
 		}
 	}
@@ -1405,7 +1410,7 @@ func (r *VolumePopulatorReconciler) allRestorePVCsForClusterBound(reqCtx intctrl
 		if cond != nil && cond.Status == corev1.ConditionFalse {
 			return false, intctrlutil.NewFatalError(fmt.Sprintf("restore PVC %s/%s failed: %s", item.Namespace, item.Name, cond.Message))
 		}
-		if item.Spec.VolumeName == "" {
+		if !pvcBindingCompleted(item) {
 			return false, nil
 		}
 	}
@@ -1819,46 +1824,12 @@ func (r *VolumePopulatorReconciler) bindTargetPVCToPV(reqCtx intctrlutil.Request
 	return r.Client.Patch(reqCtx.Ctx, pvc, patch)
 }
 
-func pvClaimRefMatchesPVC(claimRef *corev1.ObjectReference, pvc *corev1.PersistentVolumeClaim) bool {
-	return claimRef != nil &&
-		claimRef.Name == pvc.Name &&
-		claimRef.Namespace == pvc.Namespace &&
-		claimRef.UID == pvc.UID
-}
-
-func (r *VolumePopulatorReconciler) syncTargetPVCBoundStatusIfReady(reqCtx intctrlutil.RequestCtx,
-	pvc *corev1.PersistentVolumeClaim) error {
+func pvcBindingCompleted(pvc *corev1.PersistentVolumeClaim) bool {
 	if pvc.Spec.VolumeName == "" {
-		return nil
+		return false
 	}
-	pv := &corev1.PersistentVolume{}
-	if err := r.Client.Get(reqCtx.Ctx, types.NamespacedName{Name: pvc.Spec.VolumeName}, pv); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-	if !pvClaimRefMatchesPVC(pv.Spec.ClaimRef, pvc) {
-		return nil
-	}
-	return r.syncTargetPVCBoundStatus(reqCtx, pvc, pv)
-}
-
-func (r *VolumePopulatorReconciler) syncTargetPVCBoundStatus(reqCtx intctrlutil.RequestCtx,
-	pvc *corev1.PersistentVolumeClaim,
-	pv *corev1.PersistentVolume) error {
-	capacity := pv.Spec.Capacity.DeepCopy()
-	accessModes := slices.Clone(pv.Spec.AccessModes)
-	if pvc.Status.Phase == corev1.ClaimBound &&
-		reflect.DeepEqual(pvc.Status.Capacity, capacity) &&
-		slices.Equal(pvc.Status.AccessModes, accessModes) {
-		return nil
-	}
-	patch := client.MergeFrom(pvc.DeepCopy())
-	pvc.Status.Phase = corev1.ClaimBound
-	pvc.Status.Capacity = capacity
-	pvc.Status.AccessModes = accessModes
-	return r.Client.Status().Patch(reqCtx.Ctx, pvc, patch)
+	_, completed := pvc.Annotations[volume.AnnBindCompleted]
+	return completed
 }
 
 func (r *VolumePopulatorReconciler) UpdatePVCConditions(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim, reason, message string) error {

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -2054,8 +2054,9 @@ func TestCompleteBoundPVCReleasesPopulatePVCBeforeWaitingForPostReady(t *testing
 	currentPVC := &corev1.PersistentVolumeClaim{}
 	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), currentPVC))
 	require.NotContains(t, currentPVC.Finalizers, dptypes.DataProtectionFinalizerName)
-	require.NotEqual(t, corev1.ClaimBound, currentPVC.Status.Phase,
-		"the Kubernetes PV controller, not VolumePopulator, owns PVC bound status")
+	require.Equal(t, corev1.ClaimBound, currentPVC.Status.Phase)
+	require.Equal(t, resource.MustParse("1Gi"), currentPVC.Status.Capacity[corev1.ResourceStorage])
+	require.Equal(t, []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}, currentPVC.Status.AccessModes)
 	populatingCondition := findPVCConditionByType(currentPVC, string(PersistentVolumeClaimPopulating))
 	require.NotNil(t, populatingCondition)
 	require.Equal(t, ReasonPopulatingSucceed, populatingCondition.Reason)

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -1944,6 +1944,18 @@ func TestCompleteBoundPVCWaitsForKubernetesBinding(t *testing.T) {
 			Finalizers: []string{dptypes.DataProtectionFinalizerName},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{VolumeName: "restored-pv"},
+		Status: corev1.PersistentVolumeClaimStatus{Conditions: []corev1.PersistentVolumeClaimCondition{
+			{
+				Type:   PersistentVolumeClaimPopulating,
+				Status: corev1.ConditionTrue,
+				Reason: ReasonPopulatingProcessing,
+			},
+			{
+				Type:   corev1.PersistentVolumeClaimConditionType(kbappsv1.ConditionTypeRestore),
+				Status: corev1.ConditionUnknown,
+				Reason: ReasonPopulatingProcessing,
+			},
+		}},
 	}
 	helper := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
 		Namespace: pvc.Namespace,
@@ -1962,6 +1974,64 @@ func TestCompleteBoundPVCWaitsForKubernetesBinding(t *testing.T) {
 	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), currentPVC))
 	require.Contains(t, currentPVC.Finalizers, dptypes.DataProtectionFinalizerName)
 	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(helper), &corev1.PersistentVolumeClaim{}))
+	restoreCondition := findPVCConditionByType(currentPVC, kbappsv1.ConditionTypeRestore)
+	require.NotNil(t, restoreCondition)
+	require.Equal(t, corev1.ConditionUnknown, restoreCondition.Status)
+}
+
+func TestCompleteBoundPVCKeepsFailedRestoreTerminalWhileBindingIsIncomplete(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "target"},
+		Spec:       corev1.PersistentVolumeClaimSpec{VolumeName: "restored-pv"},
+		Status: corev1.PersistentVolumeClaimStatus{Conditions: []corev1.PersistentVolumeClaimCondition{{
+			Type:   corev1.PersistentVolumeClaimConditionType(kbappsv1.ConditionTypeRestore),
+			Status: corev1.ConditionFalse,
+			Reason: ReasonPopulatingFailed,
+		}}},
+	}
+	reconciler := &VolumePopulatorReconciler{
+		Client:   fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(pvc).WithObjects(pvc).Build(),
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	err := reconciler.completeBoundPVCIfNeeded(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, &pvcRestoreContext{})
+
+	require.NoError(t, err)
+}
+
+func TestCompleteBoundPVCDoesNotReapplyBindingGateAfterPopulateReleased(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "target"},
+		Spec:       corev1.PersistentVolumeClaimSpec{VolumeName: "restored-pv"},
+		Status: corev1.PersistentVolumeClaimStatus{Conditions: []corev1.PersistentVolumeClaimCondition{{
+			Type:   PersistentVolumeClaimPopulating,
+			Status: corev1.ConditionTrue,
+			Reason: ReasonPopulatingSucceed,
+		}}},
+	}
+	reconciler := &VolumePopulatorReconciler{
+		Client:   fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(pvc).WithObjects(pvc).Build(),
+		Scheme:   scheme,
+		Recorder: record.NewFakeRecorder(10),
+	}
+	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{}, nil, scheme, reconciler.Client)
+
+	err := reconciler.completeBoundPVCIfNeeded(
+		intctrlutil.RequestCtx{Ctx: context.Background()},
+		pvc,
+		&pvcRestoreContext{restoreMgr: restoreMgr, mode: pvcRestoreModeRestoreData},
+	)
+
+	require.NoError(t, err)
+	currentPVC := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), currentPVC))
+	restoreCondition := findPVCConditionByType(currentPVC, kbappsv1.ConditionTypeRestore)
+	require.NotNil(t, restoreCondition)
+	require.Equal(t, corev1.ConditionTrue, restoreCondition.Status)
 }
 
 func TestCompleteBoundPVCReleasesPopulatePVCBeforeWaitingForPostReady(t *testing.T) {

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -2443,6 +2443,60 @@ func TestWaitForSerialPredecessorsAllowsAfterEarlierBoundPVC(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestWaitForSerialPredecessorsAllowsAfterEarlierReleasedPVC(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
+	previous := newRestorePVCForSerialTest("data-target-0", "pv-0")
+	previous.Status.Conditions = []corev1.PersistentVolumeClaimCondition{{
+		Type:   PersistentVolumeClaimPopulating,
+		Status: corev1.ConditionTrue,
+		Reason: ReasonPopulatingSucceed,
+	}}
+	current := newRestorePVCForSerialTest("data-target-1", "")
+	backup := newBackupForRestoreDecision([]string{"data"}, nil)
+	reconciler := &VolumePopulatorReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(previous, current, backup).Build()}
+	restoreMgr := dprestore.NewRestoreManager(&dpv1alpha1.Restore{
+		Spec: dpv1alpha1.RestoreSpec{
+			PrepareDataConfig: &dpv1alpha1.PrepareDataConfig{
+				VolumeClaimRestorePolicy: dpv1alpha1.VolumeClaimRestorePolicySerial,
+			},
+		},
+	}, nil, scheme, reconciler.Client)
+
+	err := reconciler.waitForSerialPredecessors(intctrlutil.RequestCtx{Ctx: context.Background()}, current, restoreMgr)
+
+	require.NoError(t, err)
+}
+
+func TestRestorePVCAggregationAllowsReleasedPVCWithoutBindingAnnotation(t *testing.T) {
+	for _, reason := range []string{ReasonPopulatingSucceed, ReasonPopulatingProvisioned} {
+		t.Run(reason, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, corev1.AddToScheme(scheme))
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "target"},
+				Spec:       corev1.PersistentVolumeClaimSpec{VolumeName: "pv-0"},
+				Status: corev1.PersistentVolumeClaimStatus{Conditions: []corev1.PersistentVolumeClaimCondition{{
+					Type:   PersistentVolumeClaimPopulating,
+					Status: corev1.ConditionTrue,
+					Reason: reason,
+				}}},
+			}
+			reconciler := &VolumePopulatorReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc).Build()}
+			reqCtx := intctrlutil.RequestCtx{Ctx: context.Background()}
+
+			componentReady, err := reconciler.allRestorePVCsForComponentBound(reqCtx, pvc)
+			require.NoError(t, err)
+			require.True(t, componentReady)
+
+			clusterReady, err := reconciler.allRestorePVCsForClusterBound(reqCtx, pvc)
+			require.NoError(t, err)
+			require.True(t, clusterReady)
+		})
+	}
+}
+
 func TestWaitForSerialPredecessorsSkipsProvisionOnlyPVC(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-helpers/storage/volume"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -492,6 +493,17 @@ var _ = Describe("Volume Populator Controller test", func() {
 			Expect(jobOwner.Name).Should(Equal(populatePVCName))
 			checkJobsSA(jobList)
 			testdp.ReplaceK8sJobStatus(&testCtx, client.ObjectKeyFromObject(&jobList.Items[0]), batchv1.JobComplete)
+
+			By("mock Kubernetes PV controller completing the target PVC binding")
+			Eventually(testapps.CheckObj(&testCtx, pvcKey, func(g Gomega, target *corev1.PersistentVolumeClaim) {
+				g.Expect(target.Spec.VolumeName).ShouldNot(BeEmpty())
+			})).Should(Succeed())
+			Expect(testapps.GetAndChangeObj(&testCtx, pvcKey, func(target *corev1.PersistentVolumeClaim) {
+				if target.Annotations == nil {
+					target.Annotations = map[string]string{}
+				}
+				target.Annotations[volume.AnnBindCompleted] = "yes"
+			})()).Should(Succeed())
 
 			By("expect for pvc has been populated")
 			Eventually(testapps.CheckObj(&testCtx, pvcKey, func(g Gomega, tmpPVC *corev1.PersistentVolumeClaim) {
@@ -1801,6 +1813,7 @@ func TestEnsurePostReadyRestoreCompletedDoesNotReuseStaleRestore(t *testing.T) {
 	pvc := newPVCForRestoreDecision("data", "mysql", "")
 	pvc.UID = types.UID("current-pvc")
 	pvc.Spec.VolumeName = "target-pv"
+	pvc.Annotations[volume.AnnBindCompleted] = "yes"
 	pvc.Spec.DataSourceRef = &corev1.TypedObjectReference{
 		APIGroup: &apiGroup,
 		Kind:     dptypes.BackupKind,
@@ -1867,6 +1880,7 @@ func TestEnsurePostReadyRestoreCompletedUsesOneRestorePerComponent(t *testing.T)
 	pvc1 := newPVCForRestoreDecision("data", "mysql", "")
 	pvc1.UID = types.UID("data-pvc")
 	pvc1.Spec.VolumeName = "data-pv"
+	pvc1.Annotations[volume.AnnBindCompleted] = "yes"
 	pvc1.Spec.DataSourceRef = &corev1.TypedObjectReference{
 		APIGroup: &apiGroup,
 		Kind:     dptypes.BackupKind,
@@ -1877,6 +1891,7 @@ func TestEnsurePostReadyRestoreCompletedUsesOneRestorePerComponent(t *testing.T)
 	pvc2 := newPVCForRestoreDecision("logs", "mysql", "")
 	pvc2.UID = types.UID("logs-pvc")
 	pvc2.Spec.VolumeName = "logs-pv"
+	pvc2.Annotations[volume.AnnBindCompleted] = "yes"
 	pvc2.Spec.DataSourceRef = pvc1.Spec.DataSourceRef.DeepCopy()
 	pvc2.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
 	pvc2.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
@@ -1918,6 +1933,37 @@ func TestEnsurePostReadyRestoreCompletedUsesOneRestorePerComponent(t *testing.T)
 	require.Equal(t, backup.Name, restoreList.Items[0].Spec.Backup.Name)
 }
 
+func TestCompleteBoundPVCWaitsForKubernetesBinding(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:  "default",
+			Name:       "target",
+			UID:        "target-uid",
+			Finalizers: []string{dptypes.DataProtectionFinalizerName},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{VolumeName: "restored-pv"},
+	}
+	helper := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+		Namespace: pvc.Namespace,
+		Name:      getPopulatePVCName(pvc.UID),
+	}}
+	reconciler := &VolumePopulatorReconciler{
+		Client:   fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(pvc).WithObjects(pvc, helper).Build(),
+		Recorder: record.NewFakeRecorder(10),
+	}
+
+	err := reconciler.completeBoundPVCIfNeeded(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, &pvcRestoreContext{})
+
+	require.Error(t, err)
+	require.True(t, intctrlutil.IsRequeueError(err), err)
+	currentPVC := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), currentPVC))
+	require.Contains(t, currentPVC.Finalizers, dptypes.DataProtectionFinalizerName)
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(helper), &corev1.PersistentVolumeClaim{}))
+}
+
 func TestCompleteBoundPVCReleasesPopulatePVCBeforeWaitingForPostReady(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
@@ -1930,6 +1976,7 @@ func TestCompleteBoundPVCReleasesPopulatePVCBeforeWaitingForPostReady(t *testing
 	pvc.UID = types.UID("target-pvc")
 	pvc.Finalizers = []string{dptypes.DataProtectionFinalizerName}
 	pvc.Spec.VolumeName = "data-pv"
+	pvc.Annotations[volume.AnnBindCompleted] = "yes"
 	pvc.Spec.DataSourceRef = &corev1.TypedObjectReference{
 		APIGroup: &apiGroup,
 		Kind:     dptypes.BackupKind,
@@ -2007,9 +2054,8 @@ func TestCompleteBoundPVCReleasesPopulatePVCBeforeWaitingForPostReady(t *testing
 	currentPVC := &corev1.PersistentVolumeClaim{}
 	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), currentPVC))
 	require.NotContains(t, currentPVC.Finalizers, dptypes.DataProtectionFinalizerName)
-	require.Equal(t, corev1.ClaimBound, currentPVC.Status.Phase)
-	require.Equal(t, resource.MustParse("1Gi"), currentPVC.Status.Capacity[corev1.ResourceStorage])
-	require.Equal(t, []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}, currentPVC.Status.AccessModes)
+	require.NotEqual(t, corev1.ClaimBound, currentPVC.Status.Phase,
+		"the Kubernetes PV controller, not VolumePopulator, owns PVC bound status")
 	populatingCondition := findPVCConditionByType(currentPVC, string(PersistentVolumeClaimPopulating))
 	require.NotNil(t, populatingCondition)
 	require.Equal(t, ReasonPopulatingSucceed, populatingCondition.Reason)
@@ -2037,6 +2083,7 @@ func TestCompleteBoundPVCContinuesPostReadyAfterPopulateReleased(t *testing.T) {
 	}
 	pvc.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
 	pvc.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+	pvc.Annotations[volume.AnnBindCompleted] = "yes"
 	pvc.Status.Conditions = []corev1.PersistentVolumeClaimCondition{
 		{
 			Type:   PersistentVolumeClaimPopulating,
@@ -2104,6 +2151,7 @@ func TestCompleteBoundPVCMarksRestoreSucceededAfterPostReadyCompleted(t *testing
 	}
 	pvc.Annotations[constant.RestoreSourceKindAnnotationKey] = dptypes.BackupKind
 	pvc.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = backup.Namespace
+	pvc.Annotations[volume.AnnBindCompleted] = "yes"
 	pvc.Status.Conditions = []corev1.PersistentVolumeClaimCondition{{
 		Type:   PersistentVolumeClaimPopulating,
 		Status: corev1.ConditionTrue,
@@ -2169,6 +2217,7 @@ func TestEnsurePostReadyRestoreCompletedRejectsMismatchedExistingRestore(t *test
 	pvc := newPVCForRestoreDecision("data", "mysql", "")
 	pvc.UID = types.UID("data-pvc")
 	pvc.Spec.VolumeName = "data-pv"
+	pvc.Annotations[volume.AnnBindCompleted] = "yes"
 	pvc.Spec.DataSourceRef = &corev1.TypedObjectReference{
 		APIGroup: &apiGroup,
 		Kind:     dptypes.BackupKind,
@@ -2306,6 +2355,7 @@ func TestWaitForSerialPredecessorsAllowsAfterEarlierBoundPVC(t *testing.T) {
 	require.NoError(t, corev1.AddToScheme(scheme))
 	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
 	previous := newRestorePVCForSerialTest("data-target-0", "pv-0")
+	previous.Annotations[volume.AnnBindCompleted] = "yes"
 	current := newRestorePVCForSerialTest("data-target-1", "")
 	backup := newBackupForRestoreDecision([]string{"data"}, nil)
 	reconciler := &VolumePopulatorReconciler{Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(previous, current, backup).Build()}
@@ -2709,6 +2759,7 @@ func TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_ShouldNotSilentlySk
 	pdPVC := newPVCForRestoreDecision("data", "pd", "")
 	pdPVC.UID = types.UID("pd-pvc-uid")
 	pdPVC.Spec.VolumeName = "pd-data-pv"
+	pdPVC.Annotations[volume.AnnBindCompleted] = "yes"
 	pdPVC.Spec.DataSourceRef = &corev1.TypedObjectReference{
 		APIGroup: &apiGroup,
 		Kind:     dptypes.BackupKind,
@@ -2721,6 +2772,7 @@ func TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_ShouldNotSilentlySk
 	tikvPVC := newPVCForRestoreDecision("data", "tikv", "")
 	tikvPVC.UID = types.UID("tikv-pvc-uid")
 	tikvPVC.Spec.VolumeName = "tikv-data-pv"
+	tikvPVC.Annotations[volume.AnnBindCompleted] = "yes"
 	tikvPVC.Spec.DataSourceRef = &corev1.TypedObjectReference{
 		APIGroup: &apiGroup,
 		Kind:     dptypes.BackupKind,
@@ -2864,6 +2916,7 @@ func TestEnsurePostReadyRestore_MultiComponent_PrepareDataAndPostReady_Redirects
 	pdPVC := newPVCForRestoreDecision("data", "pd", "")
 	pdPVC.UID = types.UID("pd-pvc-uid")
 	pdPVC.Spec.VolumeName = "pd-data-pv"
+	pdPVC.Annotations[volume.AnnBindCompleted] = "yes"
 	pdPVC.Spec.DataSourceRef = &corev1.TypedObjectReference{
 		APIGroup: &apiGroup,
 		Kind:     dptypes.BackupKind,
@@ -2948,6 +3001,7 @@ func TestEnsurePostReadyRestore_ShardingMissingTargetSkip_DoesNotRedirect(t *tes
 	pvc := newPVCForRestoreDecision("data", "shard-c", "shard")
 	pvc.UID = types.UID("shard-c-pvc-uid")
 	pvc.Spec.VolumeName = "shard-c-data-pv"
+	pvc.Annotations[volume.AnnBindCompleted] = "yes"
 	pvc.Spec.DataSourceRef = &corev1.TypedObjectReference{
 		APIGroup: &apiGroup,
 		Kind:     dptypes.BackupKind,
@@ -3012,6 +3066,7 @@ func TestEnsurePostReadyRestore_ShardingSingleTargetMissingTargetSkip_DoesNotRed
 	pvc := newPVCForRestoreDecision("data", "shard-b", "shard")
 	pvc.UID = types.UID("shard-b-pvc-uid")
 	pvc.Spec.VolumeName = "shard-b-data-pv"
+	pvc.Annotations[volume.AnnBindCompleted] = "yes"
 	pvc.Spec.DataSourceRef = &corev1.TypedObjectReference{
 		APIGroup: &apiGroup,
 		Kind:     dptypes.BackupKind,
@@ -3085,6 +3140,7 @@ func TestEnsurePostReadyRestore_MultiComponent_PostReadyRedirectPreservesTargetE
 	pdPVC := newPVCForRestoreDecision("data", "pd", "")
 	pdPVC.UID = types.UID("pd-pvc-uid")
 	pdPVC.Spec.VolumeName = "pd-data-pv"
+	pdPVC.Annotations[volume.AnnBindCompleted] = "yes"
 	pdPVC.Spec.DataSourceRef = &corev1.TypedObjectReference{
 		APIGroup: &apiGroup,
 		Kind:     dptypes.BackupKind,
@@ -3213,6 +3269,7 @@ func TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_TargetComponentNotY
 	pdPVC := newPVCForRestoreDecision("data", "pd", "")
 	pdPVC.UID = types.UID("pd-pvc-uid")
 	pdPVC.Spec.VolumeName = "pd-data-pv"
+	pdPVC.Annotations[volume.AnnBindCompleted] = "yes"
 	pdPVC.Spec.DataSourceRef = &corev1.TypedObjectReference{
 		APIGroup: &apiGroup,
 		Kind:     dptypes.BackupKind,
@@ -3306,6 +3363,7 @@ func TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_WaitsForAllComponen
 	pdPVC := newPVCForRestoreDecision("data", "pd", "")
 	pdPVC.UID = types.UID("pd-pvc-uid")
 	pdPVC.Spec.VolumeName = "pd-data-pv"
+	pdPVC.Annotations[volume.AnnBindCompleted] = "yes"
 	pdPVC.Spec.DataSourceRef = &corev1.TypedObjectReference{
 		APIGroup: &apiGroup,
 		Kind:     dptypes.BackupKind,
@@ -3417,6 +3475,7 @@ func TestEnsurePostReadyRestore_MultiComponent_PostReadyOnly_TargetsSlice(t *tes
 	pdPVC := newPVCForRestoreDecision("data", "pd", "")
 	pdPVC.UID = types.UID("pd-pvc-uid")
 	pdPVC.Spec.VolumeName = "pd-data-pv"
+	pdPVC.Annotations[volume.AnnBindCompleted] = "yes"
 	pdPVC.Spec.DataSourceRef = &corev1.TypedObjectReference{
 		APIGroup: &apiGroup,
 		Kind:     dptypes.BackupKind,


### PR DESCRIPTION
Part 1 of 4 for #10755.

## Problem

VolumePopulator used `spec.volumeName != ""` as the restore-complete signal. That is weaker than the binding contract consumed by Kubernetes scheduling and can release restore resources before the PV controller has completed the binding.

## Changes

- wait for both `spec.volumeName` and `pv.kubernetes.io/bind-completed` before the first successful release
- apply the binding gate only to the unreleased lifecycle transition so failed and already released PVC states remain idempotent
- use the same binding-complete predicate for serial prepareData and postReady gates
- keep helper resources and `Restore=Unknown` while formal binding is pending
- preserve the existing PVC Bound status synchronization unchanged; its removal is isolated in #10780

## Scope

This PR consumes the Kubernetes binding-complete signal. Restored-PV ClaimRef and populate-from provenance validation is intentionally isolated in #10778. This PR does not add provisioner compatibility handling, Cluster finalizers, cleanup-path refactoring, or change PVC status ownership.

## Tests

- full `controllers/dataprotection` suite (156 Ginkgo specs plus unit tests)
- focused binding-complete, failed-terminal, released-reentry, serial, and postReady tests

Fixes #10755
