### PR TITLE
chore(dataprotection): leave PVC bound status to Kubernetes

### DIFF
--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -1027,9 +1027,6 @@ func (r *VolumePopulatorReconciler) completeBoundPVCIfNeeded(reqCtx intctrlutil.
 			return err
 		}
 	}
-	if err := r.syncTargetPVCBoundStatusIfReady(reqCtx, pvc); err != nil {
-		return err
-	}
 	postReadyCompleted, err := r.ensurePostReadyRestoreCompleted(reqCtx, pvc, restoreCtx)
 	if err != nil {
 		return err
@@ -1817,48 +1814,6 @@ func (r *VolumePopulatorReconciler) bindTargetPVCToPV(reqCtx intctrlutil.Request
 	patch := client.MergeFrom(pvc.DeepCopy())
 	pvc.Spec.VolumeName = pvName
 	return r.Client.Patch(reqCtx.Ctx, pvc, patch)
-}
-
-func pvClaimRefMatchesPVC(claimRef *corev1.ObjectReference, pvc *corev1.PersistentVolumeClaim) bool {
-	return claimRef != nil &&
-		claimRef.Name == pvc.Name &&
-		claimRef.Namespace == pvc.Namespace &&
-		claimRef.UID == pvc.UID
-}
-
-func (r *VolumePopulatorReconciler) syncTargetPVCBoundStatusIfReady(reqCtx intctrlutil.RequestCtx,
-	pvc *corev1.PersistentVolumeClaim) error {
-	if pvc.Spec.VolumeName == "" {
-		return nil
-	}
-	pv := &corev1.PersistentVolume{}
-	if err := r.Client.Get(reqCtx.Ctx, types.NamespacedName{Name: pvc.Spec.VolumeName}, pv); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-	if !pvClaimRefMatchesPVC(pv.Spec.ClaimRef, pvc) {
-		return nil
-	}
-	return r.syncTargetPVCBoundStatus(reqCtx, pvc, pv)
-}
-
-func (r *VolumePopulatorReconciler) syncTargetPVCBoundStatus(reqCtx intctrlutil.RequestCtx,
-	pvc *corev1.PersistentVolumeClaim,
-	pv *corev1.PersistentVolume) error {
-	capacity := pv.Spec.Capacity.DeepCopy()
-	accessModes := slices.Clone(pv.Spec.AccessModes)
-	if pvc.Status.Phase == corev1.ClaimBound &&
-		reflect.DeepEqual(pvc.Status.Capacity, capacity) &&
-		slices.Equal(pvc.Status.AccessModes, accessModes) {
-		return nil
-	}
-	patch := client.MergeFrom(pvc.DeepCopy())
-	pvc.Status.Phase = corev1.ClaimBound
-	pvc.Status.Capacity = capacity
-	pvc.Status.AccessModes = accessModes
-	return r.Client.Status().Patch(reqCtx.Ctx, pvc, patch)
 }
 
 func (r *VolumePopulatorReconciler) UpdatePVCConditions(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim, reason, message string) error {

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -1930,6 +1930,7 @@ func TestCompleteBoundPVCReleasesPopulatePVCBeforeWaitingForPostReady(t *testing
 	pvc.UID = types.UID("target-pvc")
 	pvc.Finalizers = []string{dptypes.DataProtectionFinalizerName}
 	pvc.Spec.VolumeName = "data-pv"
+	pvc.Status.Phase = corev1.ClaimPending
 	pvc.Spec.DataSourceRef = &corev1.TypedObjectReference{
 		APIGroup: &apiGroup,
 		Kind:     dptypes.BackupKind,
@@ -2007,9 +2008,9 @@ func TestCompleteBoundPVCReleasesPopulatePVCBeforeWaitingForPostReady(t *testing
 	currentPVC := &corev1.PersistentVolumeClaim{}
 	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), currentPVC))
 	require.NotContains(t, currentPVC.Finalizers, dptypes.DataProtectionFinalizerName)
-	require.Equal(t, corev1.ClaimBound, currentPVC.Status.Phase)
-	require.Equal(t, resource.MustParse("1Gi"), currentPVC.Status.Capacity[corev1.ResourceStorage])
-	require.Equal(t, []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}, currentPVC.Status.AccessModes)
+	require.Equal(t, corev1.ClaimPending, currentPVC.Status.Phase)
+	require.Empty(t, currentPVC.Status.Capacity)
+	require.Empty(t, currentPVC.Status.AccessModes)
 	populatingCondition := findPVCConditionByType(currentPVC, string(PersistentVolumeClaimPopulating))
 	require.NotNil(t, populatingCondition)
 	require.Equal(t, ReasonPopulatingSucceed, populatingCondition.Reason)


### PR DESCRIPTION
Related to #10755.

Follow-up to #10337.

## Problem

VolumePopulator mirrors a rebound PV into the target PVC status by setting `status.phase=Bound`, capacity, and access modes. Kubernetes' PV controller already owns those status fields, and the scheduler's fully-bound contract is based on `spec.volumeName` plus `pv.kubernetes.io/bind-completed`, not PVC phase.

Keeping a second status writer duplicates the PV controller and can race with its status updates.

## Changes

- remove the VolumePopulator PVC Bound status synchronization call
- remove the helper functions used only by that synchronization
- keep KubeBlocks-owned `Populating` and `Restore` conditions unchanged
- assert that release/postReady processing does not change a Pending PVC's phase, capacity, or access modes even when the PV is already Bound and its ClaimRef matches

## Scope

This PR does not change PV/PVC rebind behavior, helper cleanup, postReady behavior, or the binding-complete predicate introduced separately by #10779. Kubernetes remains responsible for converging the target PVC status after binding.

## Tests

- focused `completeBoundPVCIfNeeded` lifecycle tests
- full `controllers/dataprotection` suite (156 Ginkgo specs plus unit tests)
- clean three-way merge check with #10779
