### PR TITLE
fix(instanceset): round rolling update replicas up

### DIFF
--- a/apis/apps/v1/types.go
+++ b/apis/apps/v1/types.go
@@ -621,7 +621,7 @@ type RollingUpdate struct {
 
 	// The maximum number of instances that can be unavailable during the update.
 	// Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
-	// Absolute number is calculated from percentage by rounding up. This can not be 0.
+	// Absolute number is calculated from percentage by rounding down, with a minimum value of 1.
 	// Defaults to 1. The field applies to all instances. That means if there is any unavailable pod,
 	// it will be counted towards MaxUnavailable.
 	//

--- a/config/crd/bases/apps.kubeblocks.io_clusters.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusters.yaml
@@ -853,7 +853,7 @@ spec:
                               description: |-
                                 The maximum number of instances that can be unavailable during the update.
                                 Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
-                                Absolute number is calculated from percentage by rounding up. This can not be 0.
+                                Absolute number is calculated from percentage by rounding down, with a minimum value of 1.
                                 Defaults to 1. The field applies to all instances. That means if there is any unavailable pod,
                                 it will be counted towards MaxUnavailable.
                               x-kubernetes-int-or-string: true
@@ -8213,7 +8213,7 @@ spec:
                                   description: |-
                                     The maximum number of instances that can be unavailable during the update.
                                     Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
-                                    Absolute number is calculated from percentage by rounding up. This can not be 0.
+                                    Absolute number is calculated from percentage by rounding down, with a minimum value of 1.
                                     Defaults to 1. The field applies to all instances. That means if there is any unavailable pod,
                                     it will be counted towards MaxUnavailable.
                                   x-kubernetes-int-or-string: true

--- a/config/crd/bases/apps.kubeblocks.io_components.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_components.yaml
@@ -730,7 +730,7 @@ spec:
                         description: |-
                           The maximum number of instances that can be unavailable during the update.
                           Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
-                          Absolute number is calculated from percentage by rounding up. This can not be 0.
+                          Absolute number is calculated from percentage by rounding down, with a minimum value of 1.
                           Defaults to 1. The field applies to all instances. That means if there is any unavailable pod,
                           it will be counted towards MaxUnavailable.
                         x-kubernetes-int-or-string: true

--- a/config/crd/bases/workloads.kubeblocks.io_instancesets.yaml
+++ b/config/crd/bases/workloads.kubeblocks.io_instancesets.yaml
@@ -551,7 +551,7 @@ spec:
                         description: |-
                           The maximum number of instances that can be unavailable during the update.
                           Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
-                          Absolute number is calculated from percentage by rounding up. This can not be 0.
+                          Absolute number is calculated from percentage by rounding down, with a minimum value of 1.
                           Defaults to 1. The field applies to all instances. That means if there is any unavailable pod,
                           it will be counted towards MaxUnavailable.
                         x-kubernetes-int-or-string: true

--- a/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
@@ -853,7 +853,7 @@ spec:
                               description: |-
                                 The maximum number of instances that can be unavailable during the update.
                                 Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
-                                Absolute number is calculated from percentage by rounding up. This can not be 0.
+                                Absolute number is calculated from percentage by rounding down, with a minimum value of 1.
                                 Defaults to 1. The field applies to all instances. That means if there is any unavailable pod,
                                 it will be counted towards MaxUnavailable.
                               x-kubernetes-int-or-string: true
@@ -8213,7 +8213,7 @@ spec:
                                   description: |-
                                     The maximum number of instances that can be unavailable during the update.
                                     Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
-                                    Absolute number is calculated from percentage by rounding up. This can not be 0.
+                                    Absolute number is calculated from percentage by rounding down, with a minimum value of 1.
                                     Defaults to 1. The field applies to all instances. That means if there is any unavailable pod,
                                     it will be counted towards MaxUnavailable.
                                   x-kubernetes-int-or-string: true

--- a/deploy/helm/crds/apps.kubeblocks.io_components.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_components.yaml
@@ -730,7 +730,7 @@ spec:
                         description: |-
                           The maximum number of instances that can be unavailable during the update.
                           Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
-                          Absolute number is calculated from percentage by rounding up. This can not be 0.
+                          Absolute number is calculated from percentage by rounding down, with a minimum value of 1.
                           Defaults to 1. The field applies to all instances. That means if there is any unavailable pod,
                           it will be counted towards MaxUnavailable.
                         x-kubernetes-int-or-string: true

--- a/deploy/helm/crds/workloads.kubeblocks.io_instancesets.yaml
+++ b/deploy/helm/crds/workloads.kubeblocks.io_instancesets.yaml
@@ -551,7 +551,7 @@ spec:
                         description: |-
                           The maximum number of instances that can be unavailable during the update.
                           Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
-                          Absolute number is calculated from percentage by rounding up. This can not be 0.
+                          Absolute number is calculated from percentage by rounding down, with a minimum value of 1.
                           Defaults to 1. The field applies to all instances. That means if there is any unavailable pod,
                           it will be counted towards MaxUnavailable.
                         x-kubernetes-int-or-string: true

--- a/docs/developer_docs/api-reference/cluster.md
+++ b/docs/developer_docs/api-reference/cluster.md
@@ -9994,7 +9994,7 @@ Kubernetes api utils intstr.IntOrString
 <em>(Optional)</em>
 <p>The maximum number of instances that can be unavailable during the update.
 Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
-Absolute number is calculated from percentage by rounding up. This can not be 0.
+Absolute number is calculated from percentage by rounding down, with a minimum value of 1.
 Defaults to 1. The field applies to all instances. That means if there is any unavailable pod,
 it will be counted towards MaxUnavailable.</p>
 </td>

--- a/pkg/controller/instanceset/reconciler_update.go
+++ b/pkg/controller/instanceset/reconciler_update.go
@@ -477,7 +477,7 @@ func parseReplicasNMaxUnavailable(updateStrategy *workloads.InstanceUpdateStrate
 	}
 	var err error
 	if rollingUpdate.Replicas != nil {
-		replicas, err = intstr.GetScaledValueFromIntOrPercent(rollingUpdate.Replicas, totalReplicas, false)
+		replicas, err = intstr.GetScaledValueFromIntOrPercent(rollingUpdate.Replicas, totalReplicas, true)
 		if err != nil {
 			return replicas, maxUnavailable, err
 		}

--- a/pkg/controller/instanceset/reconciler_update_test.go
+++ b/pkg/controller/instanceset/reconciler_update_test.go
@@ -49,6 +49,26 @@ import (
 var _ = Describe("update reconciler test", func() {
 	var replicas int32
 
+	DescribeTable("parse rolling update quotas",
+		func(totalReplicas int, replicasValue, maxUnavailableValue intstr.IntOrString, expectedReplicas, expectedMaxUnavailable int) {
+			strategy := &workloads.InstanceUpdateStrategy{
+				RollingUpdate: &workloads.RollingUpdate{
+					Replicas:       &replicasValue,
+					MaxUnavailable: &maxUnavailableValue,
+				},
+			}
+
+			replicas, maxUnavailable, err := parseReplicasNMaxUnavailable(strategy, totalReplicas)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(replicas).Should(Equal(expectedReplicas))
+			Expect(maxUnavailable).Should(Equal(expectedMaxUnavailable))
+		},
+		Entry("rounds replicas up and maxUnavailable down", 3, intstr.FromString("34%"), intstr.FromString("34%"), 2, 1),
+		Entry("keeps maxUnavailable at least one", 3, intstr.FromString("10%"), intstr.FromString("10%"), 1, 1),
+		Entry("keeps exact percentage results", 4, intstr.FromString("50%"), intstr.FromString("50%"), 2, 2),
+		Entry("keeps absolute values", 3, intstr.FromInt32(2), intstr.FromInt32(1), 2, 1),
+	)
+
 	BeforeEach(func() {
 		replicas = 3
 		its = builder.NewInstanceSetBuilder(namespace, name).


### PR DESCRIPTION
## Summary

- backport #10676 to `release-1.0`
- round percentage-based `rollingUpdate.replicas` up in the legacy InstanceSet update path
- preserve the conservative `rollingUpdate.maxUnavailable` behavior: round percentages down and clamp the result to at least 1
- update the API documentation and generated CRD/API reference artifacts
- add regression coverage in the existing `reconciler_update_test.go`

For three instances with both fields set to `34%`, the resolved quotas are `replicas: 2` and `maxUnavailable: 1`.

`release-1.0` does not contain the InstanceSet2 update path, so this backport intentionally changes only the legacy controller.

## Tests

- `scripts/codex-go-test.sh ./pkg/controller/instanceset -run TestAPIs -ginkgo.focus="update reconciler test" -count=1`

Backport of #10676, following the original fix tracked in #10641.

Fixes https://github.com/apecloud/kubeblocks/issues/10784
