### PR TITLE
fix(instanceset): round rolling update replicas up

### DIFF
--- a/apis/apps/v1/types.go
+++ b/apis/apps/v1/types.go
@@ -640,7 +640,7 @@ type RollingUpdate struct {
 
 	// The maximum number of instances that can be unavailable during the update.
 	// Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
-	// Absolute number is calculated from percentage by rounding up. This can not be 0.
+	// Absolute number is calculated from percentage by rounding down, with a minimum value of 1.
 	// Defaults to 1. The field applies to all instances. That means if there is any unavailable pod,
 	// it will be counted towards MaxUnavailable.
 	//

--- a/config/crd/bases/apps.kubeblocks.io_clusters.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusters.yaml
@@ -870,7 +870,7 @@ spec:
                               description: |-
                                 The maximum number of instances that can be unavailable during the update.
                                 Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
-                                Absolute number is calculated from percentage by rounding up. This can not be 0.
+                                Absolute number is calculated from percentage by rounding down, with a minimum value of 1.
                                 Defaults to 1. The field applies to all instances. That means if there is any unavailable pod,
                                 it will be counted towards MaxUnavailable.
                               x-kubernetes-int-or-string: true
@@ -12056,7 +12056,7 @@ spec:
                                   description: |-
                                     The maximum number of instances that can be unavailable during the update.
                                     Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
-                                    Absolute number is calculated from percentage by rounding up. This can not be 0.
+                                    Absolute number is calculated from percentage by rounding down, with a minimum value of 1.
                                     Defaults to 1. The field applies to all instances. That means if there is any unavailable pod,
                                     it will be counted towards MaxUnavailable.
                                   x-kubernetes-int-or-string: true

--- a/config/crd/bases/apps.kubeblocks.io_components.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_components.yaml
@@ -1182,7 +1182,7 @@ spec:
                         description: |-
                           The maximum number of instances that can be unavailable during the update.
                           Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
-                          Absolute number is calculated from percentage by rounding up. This can not be 0.
+                          Absolute number is calculated from percentage by rounding down, with a minimum value of 1.
                           Defaults to 1. The field applies to all instances. That means if there is any unavailable pod,
                           it will be counted towards MaxUnavailable.
                         x-kubernetes-int-or-string: true

--- a/config/crd/bases/workloads.kubeblocks.io_instancesets.yaml
+++ b/config/crd/bases/workloads.kubeblocks.io_instancesets.yaml
@@ -602,7 +602,7 @@ spec:
                         description: |-
                           The maximum number of instances that can be unavailable during the update.
                           Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
-                          Absolute number is calculated from percentage by rounding up. This can not be 0.
+                          Absolute number is calculated from percentage by rounding down, with a minimum value of 1.
                           Defaults to 1. The field applies to all instances. That means if there is any unavailable pod,
                           it will be counted towards MaxUnavailable.
                         x-kubernetes-int-or-string: true

--- a/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
@@ -870,7 +870,7 @@ spec:
                               description: |-
                                 The maximum number of instances that can be unavailable during the update.
                                 Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
-                                Absolute number is calculated from percentage by rounding up. This can not be 0.
+                                Absolute number is calculated from percentage by rounding down, with a minimum value of 1.
                                 Defaults to 1. The field applies to all instances. That means if there is any unavailable pod,
                                 it will be counted towards MaxUnavailable.
                               x-kubernetes-int-or-string: true
@@ -12056,7 +12056,7 @@ spec:
                                   description: |-
                                     The maximum number of instances that can be unavailable during the update.
                                     Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
-                                    Absolute number is calculated from percentage by rounding up. This can not be 0.
+                                    Absolute number is calculated from percentage by rounding down, with a minimum value of 1.
                                     Defaults to 1. The field applies to all instances. That means if there is any unavailable pod,
                                     it will be counted towards MaxUnavailable.
                                   x-kubernetes-int-or-string: true

--- a/deploy/helm/crds/apps.kubeblocks.io_components.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_components.yaml
@@ -1182,7 +1182,7 @@ spec:
                         description: |-
                           The maximum number of instances that can be unavailable during the update.
                           Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
-                          Absolute number is calculated from percentage by rounding up. This can not be 0.
+                          Absolute number is calculated from percentage by rounding down, with a minimum value of 1.
                           Defaults to 1. The field applies to all instances. That means if there is any unavailable pod,
                           it will be counted towards MaxUnavailable.
                         x-kubernetes-int-or-string: true

--- a/deploy/helm/crds/workloads.kubeblocks.io_instancesets.yaml
+++ b/deploy/helm/crds/workloads.kubeblocks.io_instancesets.yaml
@@ -602,7 +602,7 @@ spec:
                         description: |-
                           The maximum number of instances that can be unavailable during the update.
                           Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
-                          Absolute number is calculated from percentage by rounding up. This can not be 0.
+                          Absolute number is calculated from percentage by rounding down, with a minimum value of 1.
                           Defaults to 1. The field applies to all instances. That means if there is any unavailable pod,
                           it will be counted towards MaxUnavailable.
                         x-kubernetes-int-or-string: true

--- a/docs/developer_docs/api-reference/cluster.md
+++ b/docs/developer_docs/api-reference/cluster.md
@@ -10798,7 +10798,7 @@ Kubernetes api utils intstr.IntOrString
 <em>(Optional)</em>
 <p>The maximum number of instances that can be unavailable during the update.
 Value can be an absolute number (ex: 5) or a percentage of desired instances (ex: 10%).
-Absolute number is calculated from percentage by rounding up. This can not be 0.
+Absolute number is calculated from percentage by rounding down, with a minimum value of 1.
 Defaults to 1. The field applies to all instances. That means if there is any unavailable pod,
 it will be counted towards MaxUnavailable.</p>
 </td>

--- a/pkg/controller/instanceset/reconciler_update.go
+++ b/pkg/controller/instanceset/reconciler_update.go
@@ -435,7 +435,7 @@ func parseReplicasNMaxUnavailable(updateStrategy *workloads.InstanceUpdateStrate
 	}
 	var err error
 	if rollingUpdate.Replicas != nil {
-		replicas, err = intstr.GetScaledValueFromIntOrPercent(rollingUpdate.Replicas, totalReplicas, false)
+		replicas, err = intstr.GetScaledValueFromIntOrPercent(rollingUpdate.Replicas, totalReplicas, true)
 		if err != nil {
 			return replicas, maxUnavailable, err
 		}

--- a/pkg/controller/instanceset/reconciler_update_test.go
+++ b/pkg/controller/instanceset/reconciler_update_test.go
@@ -50,6 +50,26 @@ import (
 var _ = Describe("update reconciler test", func() {
 	var replicas int32
 
+	DescribeTable("parse rolling update quotas",
+		func(totalReplicas int, replicasValue, maxUnavailableValue intstr.IntOrString, expectedReplicas, expectedMaxUnavailable int) {
+			strategy := &workloads.InstanceUpdateStrategy{
+				RollingUpdate: &workloads.RollingUpdate{
+					Replicas:       &replicasValue,
+					MaxUnavailable: &maxUnavailableValue,
+				},
+			}
+
+			replicas, maxUnavailable, err := parseReplicasNMaxUnavailable(strategy, totalReplicas)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(replicas).Should(Equal(expectedReplicas))
+			Expect(maxUnavailable).Should(Equal(expectedMaxUnavailable))
+		},
+		Entry("rounds replicas up and maxUnavailable down", 3, intstr.FromString("34%"), intstr.FromString("34%"), 2, 1),
+		Entry("keeps maxUnavailable at least one", 3, intstr.FromString("10%"), intstr.FromString("10%"), 1, 1),
+		Entry("keeps exact percentage results", 4, intstr.FromString("50%"), intstr.FromString("50%"), 2, 2),
+		Entry("keeps absolute values", 3, intstr.FromInt32(2), intstr.FromInt32(1), 2, 1),
+	)
+
 	BeforeEach(func() {
 		replicas = 3
 		its = builder.NewInstanceSetBuilder(namespace, name).

--- a/pkg/controller/instanceset2/reconciler_update.go
+++ b/pkg/controller/instanceset2/reconciler_update.go
@@ -182,7 +182,7 @@ func parseReplicasNMaxUnavailable(updateStrategy *workloads.InstanceUpdateStrate
 	}
 	var err error
 	if rollingUpdate.Replicas != nil {
-		replicas, err = intstr.GetScaledValueFromIntOrPercent(rollingUpdate.Replicas, totalReplicas, false)
+		replicas, err = intstr.GetScaledValueFromIntOrPercent(rollingUpdate.Replicas, totalReplicas, true)
 		if err != nil {
 			return replicas, maxUnavailable, err
 		}

--- a/pkg/controller/instanceset2/reconciler_update_test.go
+++ b/pkg/controller/instanceset2/reconciler_update_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package instanceset2
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+)
+
+func TestParseReplicasNMaxUnavailable(t *testing.T) {
+	tests := []struct {
+		name                   string
+		totalReplicas          int
+		replicas               intstr.IntOrString
+		maxUnavailable         intstr.IntOrString
+		expectedReplicas       int
+		expectedMaxUnavailable int
+	}{
+		{"round replicas up and maxUnavailable down", 3, intstr.FromString("34%"), intstr.FromString("34%"), 2, 1},
+		{"keep maxUnavailable at least one", 3, intstr.FromString("10%"), intstr.FromString("10%"), 1, 1},
+		{"keep exact percentage results", 4, intstr.FromString("50%"), intstr.FromString("50%"), 2, 2},
+		{"keep absolute values", 3, intstr.FromInt32(2), intstr.FromInt32(1), 2, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			strategy := &workloads.InstanceUpdateStrategy{
+				RollingUpdate: &workloads.RollingUpdate{
+					Replicas:       &tt.replicas,
+					MaxUnavailable: &tt.maxUnavailable,
+				},
+			}
+
+			replicas, maxUnavailable, err := parseReplicasNMaxUnavailable(strategy, tt.totalReplicas)
+			if err != nil {
+				t.Fatalf("parse rolling update quotas: %v", err)
+			}
+			if replicas != tt.expectedReplicas || maxUnavailable != tt.expectedMaxUnavailable {
+				t.Fatalf("quotas = (%d, %d), want (%d, %d)",
+					replicas, maxUnavailable, tt.expectedReplicas, tt.expectedMaxUnavailable)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- backport #10676 to `release-1.1`
- round percentage-based `rollingUpdate.replicas` up in both the legacy Pod and Instance API update paths
- preserve the conservative `rollingUpdate.maxUnavailable` behavior: round percentages down and clamp the result to at least 1
- update the API documentation and generated CRD/API reference artifacts
- add regression coverage in the conventional `reconciler_update_test.go` files

For three instances with both fields set to `34%`, the resolved quotas are `replicas: 2` and `maxUnavailable: 1`.

## Tests

- `scripts/codex-go-test.sh ./pkg/controller/instanceset -run TestAPIs -ginkgo.focus="update reconciler test" -count=1`
- `scripts/codex-go-test.sh ./pkg/controller/instanceset2 -run TestParseReplicasNMaxUnavailable -count=1`

Backport of #10676, following the original fix tracked in #10641.

Fixes https://github.com/apecloud/kubeblocks/issues/10783
