### PR TITLE
fix(sharding): preserve shared account source reference

### DIFF
--- a/controllers/apps/cluster/transformer_cluster_sharding_account.go
+++ b/controllers/apps/cluster/transformer_cluster_sharding_account.go
@@ -341,8 +341,7 @@ func (t *clusterShardingAccountTransformer) rewriteSystemAccount(transCtx *clust
 		SecretRefRevision: revision,
 	}
 
-	// update sharding
-	for i, sharding := range transCtx.shardings {
+	for _, sharding := range transCtx.shardings {
 		if sharding.Name == shardingName {
 			for _, account := range sharding.Template.SystemAccounts {
 				if account.Name == accountName {
@@ -350,13 +349,13 @@ func (t *clusterShardingAccountTransformer) rewriteSystemAccount(transCtx *clust
 					break
 				}
 			}
-			transCtx.shardings[i].Template.SystemAccounts =
-				upsertSystemAccount(transCtx.shardings[i].Template.SystemAccounts, newAccount)
 			break
 		}
 	}
 
-	// update sharding components
+	// Rewrite only the expanded component specs and keep the sharding declaration
+	// unchanged, so a user-provided source Secret remains the source on the next
+	// reconcile. shardingComps and shardingCompsWithTpl share component pointers.
 	shardingComps := transCtx.shardingComps[shardingName]
 	for i := range shardingComps {
 		shardingComps[i].SystemAccounts = upsertSystemAccount(shardingComps[i].SystemAccounts, newAccount)

--- a/controllers/apps/cluster/transformer_cluster_sharding_account_test.go
+++ b/controllers/apps/cluster/transformer_cluster_sharding_account_test.go
@@ -409,6 +409,7 @@ var _ = Describe("cluster sharding shared system account password contract", fun
 		transformer, transCtx, graphCli, dag, shardingSpec, managed :=
 			newSourceSecretReconcile([]byte("new-password"), []byte("old-password"), false)
 		shardingSpec.Template.SystemAccounts[0].SecretRefRevision = "opaque-revision"
+		(&clusterNormalizationTransformer{}).writeBackCompNShardingSpecs(transCtx)
 
 		Expect(transformer.reconcileShardingAccount(transCtx, graphCli, dag, shardingSpec, accountName)).To(Succeed())
 		updated := graphCli.FindMatchedVertex(dag, managed).(*model.ObjectVertex).Obj.(*corev1.Secret)
@@ -418,7 +419,11 @@ var _ = Describe("cluster sharding shared system account password contract", fun
 		Expect(err).NotTo(HaveOccurred())
 		Expect(managedRevision).To(Equal(sourceSecretRevision(source, passwordKey)))
 		Expect(managedRevision).NotTo(Equal("opaque-revision"))
-		Expect(shardingSpec.Template.SystemAccounts[0].SecretRefRevision).To(Equal(managedRevision))
+		Expect(shardingSpec.Template.SystemAccounts[0].SecretRef.Name).To(Equal("source-account"))
+		Expect(shardingSpec.Template.SystemAccounts[0].SecretRefRevision).To(Equal("opaque-revision"))
+		persisted := transCtx.Cluster.Spec.Shardings[0].Template.SystemAccounts[0]
+		Expect(persisted.SecretRef.Name).To(Equal("source-account"))
+		Expect(persisted.SecretRefRevision).To(Equal("opaque-revision"))
 		for _, comp := range transCtx.shardingComps[sharding] {
 			Expect(comp.SystemAccounts[0].SecretRefRevision).To(Equal(managedRevision))
 		}


### PR DESCRIPTION
## What changed

- keep the normalized sharding account declaration and user-provided source Secret reference unchanged
- rewrite only the expanded shard Component specs to use the managed shared-account Secret and revision
- verify that the Cluster/source intent remains stable while generated Components receive the managed revision

## Why

The shared-account transformer wrote the managed Secret reference back into the normalized sharding. On the next reconcile, the managed Secret could be treated as its own source, causing its resource-version-derived revision to change repeatedly and preventing reconciliation from converging.

This is the `release-1.1` backport of #10785.

## Validation

- shared sharding account contract tests
- complete `controllers/apps/cluster` test suite

Both were run with the repository's generated Kubernetes client mock supplied through a local Go overlay.

Closes #10769
