### PR TITLE
fix: resolve lifecycle action images for instance templates

### DIFF
--- a/pkg/controller/component/component_version.go
+++ b/pkg/controller/component/component_version.go
@@ -216,7 +216,6 @@ func resolveImagesWithCompVersions4Template(compDef *appsv1.ComponentDefinition,
 	}
 
 	if err = func() error {
-		var actionImage string
 		hasExecAction := false
 		for name, action := range actionsToResolveImage(compDef) {
 			if action != nil && action.Exec != nil {
@@ -225,23 +224,21 @@ func resolveImagesWithCompVersions4Template(compDef *appsv1.ComponentDefinition,
 					if app.err != nil {
 						return app.err
 					}
-					if len(app.image) > 0 {
-						if len(actionImage) > 0 && actionImage != app.image {
-							return fmt.Errorf("only one exec image is allowed in lifecycle actions")
-						}
-						actionImage = app.image
+					if image, ok := images[kbagent.ContainerName]; !ok || len(image) == 0 {
+						images[kbagent.ContainerName] = app.image
+					}
+					if image, ok := images[kbagent.ContainerName4Worker]; !ok || len(image) == 0 {
+						images[kbagent.ContainerName4Worker] = app.image
 					}
 				}
 			}
 		}
-		if hasExecAction {
-			if len(actionImage) == 0 {
-				// Instance template image overrides are applied directly to Pod containers without passing
-				// through buildKBAgentContainer, so materialize the default tools image here.
-				actionImage = viper.GetString(constant.KBToolsImage)
-			}
-			images[kbagent.ContainerName] = actionImage
-			images[kbagent.ContainerName4Worker] = actionImage
+		if hasExecAction && len(images[kbagent.ContainerName]) == 0 {
+			// Instance template image overrides are applied directly to Pod containers without passing
+			// through buildKBAgentContainer, so materialize the default tools image here.
+			image := viper.GetString(constant.KBToolsImage)
+			images[kbagent.ContainerName] = image
+			images[kbagent.ContainerName4Worker] = image
 		}
 		return nil
 	}(); err != nil {

--- a/pkg/controller/component/component_version.go
+++ b/pkg/controller/component/component_version.go
@@ -214,20 +214,30 @@ func resolveImagesWithCompVersions4Template(compDef *appsv1.ComponentDefinition,
 	}
 
 	if err = func() error {
+		var actionImage string
+		hasExecAction := false
 		for name, action := range actionsToResolveImage(compDef) {
 			if action != nil && action.Exec != nil {
+				hasExecAction = true
 				if app, ok := apps[name]; ok {
 					if app.err != nil {
 						return app.err
 					}
-					if image, ok := images[kbagent.ContainerName]; !ok || len(image) == 0 {
-						images[kbagent.ContainerName] = app.image
-					}
-					if image, ok := images[kbagent.ContainerName4Worker]; !ok || len(image) == 0 {
-						images[kbagent.ContainerName4Worker] = app.image
+					if len(app.image) > 0 {
+						if len(actionImage) > 0 && actionImage != app.image {
+							return fmt.Errorf("only one exec image is allowed in lifecycle actions")
+						}
+						actionImage = app.image
 					}
 				}
 			}
+		}
+		if hasExecAction {
+			if len(actionImage) == 0 {
+				actionImage = kbToolsImage()
+			}
+			images[kbagent.ContainerName] = actionImage
+			images[kbagent.ContainerName4Worker] = actionImage
 		}
 		return nil
 	}(); err != nil {

--- a/pkg/controller/component/component_version.go
+++ b/pkg/controller/component/component_version.go
@@ -33,7 +33,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/kbagent"
+	viper "github.com/apecloud/kubeblocks/pkg/viperx"
 )
 
 // CompatibleCompVersions4Definition returns all component versions that are compatible with specified component definition.
@@ -234,7 +236,9 @@ func resolveImagesWithCompVersions4Template(compDef *appsv1.ComponentDefinition,
 		}
 		if hasExecAction {
 			if len(actionImage) == 0 {
-				actionImage = kbToolsImage()
+				// Instance template image overrides are applied directly to Pod containers without passing
+				// through buildKBAgentContainer, so materialize the default tools image here.
+				actionImage = viper.GetString(constant.KBToolsImage)
 			}
 			images[kbagent.ContainerName] = actionImage
 			images[kbagent.ContainerName4Worker] = actionImage

--- a/pkg/controller/component/component_version_test.go
+++ b/pkg/controller/component/component_version_test.go
@@ -80,7 +80,11 @@ var _ = Describe("Component Version", func() {
 			const (
 				appName        = "app"
 				serviceVersion = "2.0.0"
+				toolsImage     = "docker.io/apecloud/kubeblocks-tools:test"
 			)
+			oldToolsImage := viperx.GetString(constant.KBToolsImage)
+			defer viperx.Set(constant.KBToolsImage, oldToolsImage)
+			viperx.Set(constant.KBToolsImage, toolsImage)
 
 			newAction := func() *appsv1.Action {
 				return &appsv1.Action{Exec: &appsv1.ExecAction{Command: []string{"true"}}}
@@ -110,8 +114,9 @@ var _ = Describe("Component Version", func() {
 				newCompVersion(map[string]string{appName: "app:2.0.0"}),
 			}, serviceVersion)
 			Expect(err).ShouldNot(HaveOccurred())
-			Expect(images).Should(HaveKeyWithValue(kbagent.ContainerName, viperx.GetString(constant.KBToolsImage)))
-			Expect(images).Should(HaveKeyWithValue(kbagent.ContainerName4Worker, viperx.GetString(constant.KBToolsImage)))
+			Expect(viperx.GetString(constant.KBToolsImage)).Should(Equal(toolsImage))
+			Expect(images).Should(HaveKeyWithValue(kbagent.ContainerName, toolsImage))
+			Expect(images).Should(HaveKeyWithValue(kbagent.ContainerName4Worker, toolsImage))
 		})
 
 		It("resolve images before and after new release", func() {

--- a/pkg/controller/component/component_version_test.go
+++ b/pkg/controller/component/component_version_test.go
@@ -76,11 +76,10 @@ var _ = Describe("Component Version", func() {
 			Expect(apps["action1"].err).NotTo(HaveOccurred())
 		})
 
-		It("resolves lifecycle action images for an instance template", func() {
+		It("uses the KB tools image for instance template actions without images", func() {
 			const (
 				appName        = "app"
 				serviceVersion = "2.0.0"
-				customImage    = "custom-action:2.0.0"
 			)
 
 			newAction := func() *appsv1.Action {
@@ -113,24 +112,6 @@ var _ = Describe("Component Version", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(images).Should(HaveKeyWithValue(kbagent.ContainerName, viperx.GetString(constant.KBToolsImage)))
 			Expect(images).Should(HaveKeyWithValue(kbagent.ContainerName4Worker, viperx.GetString(constant.KBToolsImage)))
-
-			By("using the single custom action image when other actions have none")
-			images, err = resolveImagesWithCompVersions4Template(newCompDef(), []*appsv1.ComponentVersion{
-				newCompVersion(map[string]string{appName: "app:2.0.0", "memberJoin": customImage}),
-			}, serviceVersion)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(images).Should(HaveKeyWithValue(kbagent.ContainerName, customImage))
-			Expect(images).Should(HaveKeyWithValue(kbagent.ContainerName4Worker, customImage))
-
-			By("rejecting conflicting custom action images")
-			_, err = resolveImagesWithCompVersions4Template(newCompDef(), []*appsv1.ComponentVersion{
-				newCompVersion(map[string]string{
-					appName:       "app:2.0.0",
-					"memberJoin":  "member-join:2.0.0",
-					"memberLeave": "member-leave:2.0.0",
-				}),
-			}, serviceVersion)
-			Expect(err).Should(MatchError("only one exec image is allowed in lifecycle actions"))
 		})
 
 		It("resolve images before and after new release", func() {

--- a/pkg/controller/component/component_version_test.go
+++ b/pkg/controller/component/component_version_test.go
@@ -27,8 +27,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/generics"
+	"github.com/apecloud/kubeblocks/pkg/kbagent"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
+	viperx "github.com/apecloud/kubeblocks/pkg/viperx"
 )
 
 var _ = Describe("Component Version", func() {
@@ -71,6 +74,63 @@ var _ = Describe("Component Version", func() {
 			Expect(apps["image2"].err).To(HaveOccurred())
 
 			Expect(apps["action1"].err).NotTo(HaveOccurred())
+		})
+
+		It("resolves lifecycle action images for an instance template", func() {
+			const (
+				appName        = "app"
+				serviceVersion = "2.0.0"
+				customImage    = "custom-action:2.0.0"
+			)
+
+			newAction := func() *appsv1.Action {
+				return &appsv1.Action{Exec: &appsv1.ExecAction{Command: []string{"true"}}}
+			}
+			newCompDef := func() *appsv1.ComponentDefinition {
+				return testapps.NewComponentDefinitionFactory("test-action-images").
+					SetServiceVersion("1.0.0").
+					SetRuntime(&corev1.Container{Name: appName, Image: "app:1.0.0"}).
+					SetLifecycleAction("memberJoin", newAction()).
+					SetLifecycleAction("memberLeave", newAction()).
+					GetObject()
+			}
+			newCompVersion := func(images map[string]string) *appsv1.ComponentVersion {
+				return testapps.NewComponentVersionFactory("test-action-images").
+					SetSpec(appsv1.ComponentVersionSpec{
+						Releases: []appsv1.ComponentVersionRelease{{
+							Name:           "r0",
+							ServiceVersion: serviceVersion,
+							Images:         images,
+						}},
+					}).
+					GetObject()
+			}
+
+			By("using the KB tools image when no action image is configured")
+			images, err := resolveImagesWithCompVersions4Template(newCompDef(), []*appsv1.ComponentVersion{
+				newCompVersion(map[string]string{appName: "app:2.0.0"}),
+			}, serviceVersion)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(images).Should(HaveKeyWithValue(kbagent.ContainerName, viperx.GetString(constant.KBToolsImage)))
+			Expect(images).Should(HaveKeyWithValue(kbagent.ContainerName4Worker, viperx.GetString(constant.KBToolsImage)))
+
+			By("using the single custom action image when other actions have none")
+			images, err = resolveImagesWithCompVersions4Template(newCompDef(), []*appsv1.ComponentVersion{
+				newCompVersion(map[string]string{appName: "app:2.0.0", "memberJoin": customImage}),
+			}, serviceVersion)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(images).Should(HaveKeyWithValue(kbagent.ContainerName, customImage))
+			Expect(images).Should(HaveKeyWithValue(kbagent.ContainerName4Worker, customImage))
+
+			By("rejecting conflicting custom action images")
+			_, err = resolveImagesWithCompVersions4Template(newCompDef(), []*appsv1.ComponentVersion{
+				newCompVersion(map[string]string{
+					appName:       "app:2.0.0",
+					"memberJoin":  "member-join:2.0.0",
+					"memberLeave": "member-leave:2.0.0",
+				}),
+			}, serviceVersion)
+			Expect(err).Should(MatchError("only one exec image is allowed in lifecycle actions"))
 		})
 
 		It("resolve images before and after new release", func() {

--- a/pkg/controller/component/kbagent.go
+++ b/pkg/controller/component/kbagent.go
@@ -55,6 +55,10 @@ var (
 	roleLabelVolumeMount = corev1.VolumeMount{Name: roleLabelVolumeName, MountPath: podMetadataMountPath, ReadOnly: true}
 )
 
+func kbToolsImage() string {
+	return viper.GetString(constant.KBToolsImage)
+}
+
 func UpdateKBAgentContainer4HostNetwork(synthesizedComp *SynthesizedComponent) {
 	idx, c := intctrlutil.GetContainerByName(synthesizedComp.PodSpec.Containers, kbagent.ContainerName)
 	if c == nil {
@@ -128,7 +132,7 @@ func buildKBAgentContainer(synthesizedComp *SynthesizedComponent) error {
 
 	newContainer := func(name string, f func(*builder.ContainerBuilder) error) (*corev1.Container, error) {
 		b := builder.NewContainerBuilder(name).
-			SetImage(viper.GetString(constant.KBToolsImage)).
+			SetImage(kbToolsImage()).
 			SetImagePullPolicy(corev1.PullIfNotPresent).
 			AddCommands(kbagent.BinaryPath).
 			AddEnv(mergedActionEnv4KBAgent(synthesizedComp)...).
@@ -450,7 +454,7 @@ func handleCustomImageNContainerDefined(synthesizedComp *SynthesizedComponent, c
 	if len(image) > 0 {
 		// init-container to copy binaries to the shared mount point /kubeblocks
 		initContainer := builder.NewContainerBuilder(kbagent.InitContainerName).
-			SetImage(viper.GetString(constant.KBToolsImage)).
+			SetImage(kbToolsImage()).
 			SetImagePullPolicy(corev1.PullIfNotPresent).
 			AddCommands(kbagent.InitCommand()...).
 			AddVolumeMounts(kbagent.SharedVolumeMount()).

--- a/pkg/controller/component/kbagent.go
+++ b/pkg/controller/component/kbagent.go
@@ -55,10 +55,6 @@ var (
 	roleLabelVolumeMount = corev1.VolumeMount{Name: roleLabelVolumeName, MountPath: podMetadataMountPath, ReadOnly: true}
 )
 
-func kbToolsImage() string {
-	return viper.GetString(constant.KBToolsImage)
-}
-
 func UpdateKBAgentContainer4HostNetwork(synthesizedComp *SynthesizedComponent) {
 	idx, c := intctrlutil.GetContainerByName(synthesizedComp.PodSpec.Containers, kbagent.ContainerName)
 	if c == nil {
@@ -132,7 +128,7 @@ func buildKBAgentContainer(synthesizedComp *SynthesizedComponent) error {
 
 	newContainer := func(name string, f func(*builder.ContainerBuilder) error) (*corev1.Container, error) {
 		b := builder.NewContainerBuilder(name).
-			SetImage(kbToolsImage()).
+			SetImage(viper.GetString(constant.KBToolsImage)).
 			SetImagePullPolicy(corev1.PullIfNotPresent).
 			AddCommands(kbagent.BinaryPath).
 			AddEnv(mergedActionEnv4KBAgent(synthesizedComp)...).
@@ -454,7 +450,7 @@ func handleCustomImageNContainerDefined(synthesizedComp *SynthesizedComponent, c
 	if len(image) > 0 {
 		// init-container to copy binaries to the shared mount point /kubeblocks
 		initContainer := builder.NewContainerBuilder(kbagent.InitContainerName).
-			SetImage(kbToolsImage()).
+			SetImage(viper.GetString(constant.KBToolsImage)).
 			SetImagePullPolicy(corev1.PullIfNotPresent).
 			AddCommands(kbagent.InitCommand()...).
 			AddVolumeMounts(kbagent.SharedVolumeMount()).


### PR DESCRIPTION
## What this PR does

When lifecycle exec actions for a service-versioned instance template do not resolve to a custom action image, materialize the configured KubeBlocks tools image for the kbagent and kbagent-worker image overrides.

This prevents optional empty action images from becoming invalid empty Pod container images. Existing custom action image selection behavior is left unchanged.

## Scope

This PR is intentionally limited to issue #10793. It does not change InstanceTemplate image application, add a second synthesis pass, or address the broader structural requirements of per-template custom action images.

## Tests

- scripts/codex-go-test.sh ./pkg/controller/component -ginkgo.focus=Component-Version -count=1

Fixes #10793