### PR TITLE
fix(apps): allow unpinned referenced account secrets

### DIFF
--- a/controllers/apps/component/transformer_component_account.go
+++ b/controllers/apps/component/transformer_component_account.go
@@ -200,7 +200,8 @@ func (t *componentAccountTransformer) getPasswordFromSecret(transCtx *componentT
 	if err := transCtx.GetClient().Get(transCtx.GetContext(), secretKey, secret); err != nil {
 		return nil, err
 	}
-	if revision, ok := secret.Annotations[constant.SecretRevisionAnnotationKey]; ok && revision != account.SecretRefRevision {
+	if revision, ok := secret.Annotations[constant.SecretRevisionAnnotationKey]; ok &&
+		account.SecretRefRevision != "" && revision != account.SecretRefRevision {
 		return nil, ctrlutil.NewRequeueError(time.Second,
 			fmt.Sprintf("wait for referenced account secret %s/%s revision %s",
 				secret.Namespace, secret.Name, account.SecretRefRevision))

--- a/controllers/apps/component/transformer_component_account_test.go
+++ b/controllers/apps/component/transformer_component_account_test.go
@@ -186,6 +186,12 @@ func TestBuildAccountSecretRevisionContract(t *testing.T) {
 	if err = fakeClient.Update(context.Background(), referenced); err != nil {
 		t.Fatalf("update referenced Secret revision: %v", err)
 	}
+	unversionedAccount := account
+	unversionedAccount.SecretRefRevision = ""
+	if _, err = (&componentAccountTransformer{}).buildAccountSecret(transCtx, unversionedAccount); err != nil {
+		t.Fatalf("a managed Secret should be read when no revision is requested: %v", err)
+	}
+
 	if _, err = (&componentAccountTransformer{}).buildAccountSecret(transCtx, account); !intctrlutil.IsRequeueError(err) || intctrlutil.IsDelayedRequeueError(err) {
 		t.Fatalf("a managed Secret with a mismatched revision should stop and requeue, got %v", err)
 	}


### PR DESCRIPTION
## What changed

- enforce the referenced account Secret revision only when `secretRefRevision` is explicitly set
- preserve the existing mismatch/requeue behavior for an explicit revision pin
- cover omitted, mismatched, and matching revisions in the account Secret regression test

## Why

A referenced account Secret managed by KubeBlocks carries the `apps.kubeblocks.io/secret-revision` annotation. When the consuming account omitted the optional `secretRefRevision`, the component controller compared that annotation with an empty value and requeued indefinitely.

Omitting `secretRefRevision` should consume the current Secret without a revision pin. An explicit value continues to require a matching Secret revision.

## Validation

- `scripts/codex-go-test.sh ./controllers/apps/component -run TestBuildAccountSecretRevisionContract -count=1`
- `scripts/codex-go-test.sh ./controllers/apps/component -count=1`

Fixes #10809
