### PR TITLE
fix(ops): propagate scale-out restore environment

### DIFF
--- a/pkg/controller/plan/restore.go
+++ b/pkg/controller/plan/restore.go
@@ -82,6 +82,11 @@ func NewRestoreManager(ctx context.Context,
 	}
 }
 
+// SetRestoreEnv sets the user-provided environment for generated Restore objects.
+func (r *RestoreManager) SetRestoreEnv(env []corev1.EnvVar) {
+	r.env = env
+}
+
 func (r *RestoreManager) DoPrepareData(comp *component.SynthesizedComponent,
 	compObj *appsv1.Component,
 	backupObj *dpv1alpha1.Backup) error {

--- a/pkg/controller/plan/restore_test.go
+++ b/pkg/controller/plan/restore_test.go
@@ -209,6 +209,8 @@ func TestBuildPersistentVolumeClaimLabels(t *testing.T) {
 
 func TestRestoreManagerBuildPrepareDataRestore(t *testing.T) {
 	manager := newRestoreManagerForTest()
+	restoreEnv := []corev1.EnvVar{{Name: "RESTORE_ENV", Value: "from-plan-intent"}}
+	manager.SetRestoreEnv(restoreEnv)
 	comp := &component.SynthesizedComponent{
 		Name:     "mysql",
 		Replicas: 2,
@@ -265,6 +267,9 @@ func TestRestoreManagerBuildPrepareDataRestore(t *testing.T) {
 		restore.Spec.Backup.Namespace != "default" ||
 		restore.Spec.Backup.SourceTargetName != "target-a" {
 		t.Fatalf("unexpected backup ref: %#v", restore.Spec.Backup)
+	}
+	if !reflect.DeepEqual(restore.Spec.Env, restoreEnv) {
+		t.Fatalf("restore env = %#v, want %#v", restore.Spec.Env, restoreEnv)
 	}
 	cfg := restore.Spec.PrepareDataConfig
 	if cfg == nil {

--- a/pkg/operations/horizontal_scaling.go
+++ b/pkg/operations/horizontal_scaling.go
@@ -298,6 +298,7 @@ func (hs horizontalScalingOpsHandler) restoreDataFromBackup(reqCtx intctrlutil.R
 			constant.KBAppComponentLabelKey: pgRes.compOps.GetComponentName(),
 		}, 1, int32(podIndexInt))
 		restoreMGR.RestoreTime = fromBackup.RestorePointInTime
+		restoreMGR.SetRestoreEnv(fromBackup.RestoreEnv)
 		restoreMGR.RestoreNamePrefix = string(opsRes.OpsRequest.UID[:8])
 		// check restore status
 		restoreMeta := restoreMGR.GetRestoreObjectMeta(synthesizedComponent, dpv1alpha1.PrepareData, templateName)

--- a/pkg/operations/horizontal_scaling_test.go
+++ b/pkg/operations/horizontal_scaling_test.go
@@ -286,9 +286,11 @@ var _ = Describe("HorizontalScaling OpsRequest", func() {
 			})).Should(Succeed())
 
 			By("scale out replicas from a full backup")
+			restoreEnv := []corev1.EnvVar{{Name: "RESTORE_ENV", Value: "true"}}
 			horizontalScaling := opsv1alpha1.HorizontalScaling{ScaleOut: &opsv1alpha1.ScaleOut{
 				FromBackup: &opsv1alpha1.FromBackup{
-					Name: backupName,
+					Name:       backupName,
+					RestoreEnv: restoreEnv,
 				},
 			}}
 
@@ -311,6 +313,7 @@ var _ = Describe("HorizontalScaling OpsRequest", func() {
 					Namespace: restoreMeta.Namespace,
 					Name:      restoreMeta.Name,
 				}, func(restore *dpv1alpha1.Restore) {
+					Expect(restore.Spec.Env).Should(Equal(restoreEnv))
 					restore.Status.Phase = dpv1alpha1.RestorePhaseCompleted
 				})
 			}


### PR DESCRIPTION
Fixes #10815.

## Problem

`scaleOut.fromBackup.restoreEnv` is currently dropped before the horizontal-scaling path creates its Restore objects.

## Changes

- add an explicit restore-plan setter for user-provided Restore environment
- pass `FromBackup.restoreEnv` into each scale-out Restore plan
- verify the generated `Restore.spec.env` in both plan and Operations tests

The Restore carries this public intent unchanged. DataProtection remains the sole owner of the final merge with Backup and ActionSet environment variables.

## Scope

This PR only propagates restore environment. It does not change Backup validation, namespaces, authorization, VolumeSnapshot behavior, or source-target selection.

This is the narrow restore-environment replacement for the corresponding part of #10597.

## Validation

- `scripts/codex-go-test.sh ./pkg/controller/plan -count=1`
- `scripts/codex-go-test.sh ./pkg/operations -count=1`
- `git diff --check`
