### PR TITLE
fix(ops): fail fast on missing backup method

### DIFF
--- a/pkg/operations/horizontal_scaling.go
+++ b/pkg/operations/horizontal_scaling.go
@@ -231,6 +231,9 @@ func (hs horizontalScalingOpsHandler) createRestore(reqCtx intctrlutil.RequestCt
 	// create restore
 	restore, err := restoreMGR.BuildPrepareDataRestore(synthesizedComponent, backupObj, getTemplate(templateName))
 	if err != nil {
+		if intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeRestoreFailed) {
+			return intctrlutil.NewFatalError(err.Error())
+		}
 		return err
 	}
 	if restore == nil {

--- a/pkg/operations/horizontal_scaling_test.go
+++ b/pkg/operations/horizontal_scaling_test.go
@@ -1008,20 +1008,28 @@ func TestHorizontalScalingCreateRestoreReturnsFatalWhenNoRestoreBuilt(t *testing
 	testCases := []struct {
 		name         string
 		backupMethod *dpv1alpha1.BackupMethod
-	}{{
-		// logical backups (e.g. TiDB BR) have no targetVolumes at all
-		name:         "backup method without target volumes",
-		backupMethod: &dpv1alpha1.BackupMethod{Name: "br"},
-	}, {
-		// targetVolumes exist but none match the component's volume claim templates
-		name: "backup method target volumes match no component volume",
-		backupMethod: &dpv1alpha1.BackupMethod{
-			Name: "br",
-			TargetVolumes: &dpv1alpha1.TargetVolumeInfo{
-				Volumes: []string{"other-data"},
+		expectError  string
+	}{
+		{
+			name:         "completed backup without backup method",
+			backupMethod: nil,
+			expectError:  "status.backupMethod",
+		}, {
+			// logical backups (e.g. TiDB BR) have no targetVolumes at all
+			name:         "backup method without target volumes",
+			backupMethod: &dpv1alpha1.BackupMethod{Name: "br"},
+			expectError:  "has no target volumes matching component",
+		}, {
+			// targetVolumes exist but none match the component's volume claim templates
+			name: "backup method target volumes match no component volume",
+			backupMethod: &dpv1alpha1.BackupMethod{
+				Name: "br",
+				TargetVolumes: &dpv1alpha1.TargetVolumeInfo{
+					Volumes: []string{"other-data"},
+				},
 			},
-		},
-	}}
+			expectError: "has no target volumes matching component",
+		}}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
@@ -1087,7 +1095,7 @@ func TestHorizontalScalingCreateRestoreReturnsFatalWhenNoRestoreBuilt(t *testing
 			if !intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal) {
 				t.Fatalf("expected fatal error, got %T: %v", err, err)
 			}
-			if !strings.Contains(err.Error(), "has no target volumes matching component") {
+			if !strings.Contains(err.Error(), tc.expectError) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 


### PR DESCRIPTION
Fixes #10816.

## Problem

A Backup may report `status.phase: Completed` while `status.backupMethod` is empty. The restore plan detects that invalid state before any Restore exists, but its non-terminal error currently leaves the horizontal-scaling OpsRequest retrying instead of failing.

## Changes

- keep detection of the incomplete Backup status in the shared restore plan
- classify the plan's `RestoreFailed` result as fatal at the scale-out Operations boundary
- verify the completed-without-backupMethod case is terminal and creates no Restore

## Scope

This PR only changes missing-backupMethod error classification for scale-out restore. It does not change restore environment propagation, namespaces, authorization, VolumeSnapshot behavior, or source-target selection.

This is the narrow fail-fast replacement for the corresponding part of #10597.

## Validation

- `scripts/codex-go-test.sh ./pkg/operations -count=1`
- `git diff --check`
