### PR TITLE
fix(dataprotection): ignore target PVC deletion during restore

### DIFF
--- a/controllers/dataprotection/types.go
+++ b/controllers/dataprotection/types.go
@@ -97,3 +97,5 @@ const (
 )
 
 var reconcileInterval = time.Second
+
+const restoreTargetDeletingRequeueInterval = 30 * time.Second

--- a/controllers/dataprotection/types.go
+++ b/controllers/dataprotection/types.go
@@ -97,5 +97,3 @@ const (
 )
 
 var reconcileInterval = time.Second
-
-const restoreTargetDeletingRequeueInterval = 30 * time.Second

--- a/controllers/dataprotection/types.go
+++ b/controllers/dataprotection/types.go
@@ -93,7 +93,8 @@ const (
 	ReasonPopulatingSucceed     = "Succeed"
 	ReasonPopulatingProvisioned = "Provisioned"
 
-	PersistentVolumeClaimPopulating corev1.PersistentVolumeClaimConditionType = "Populating"
+	PersistentVolumeClaimPopulating            corev1.PersistentVolumeClaimConditionType = "Populating"
+	PersistentVolumeClaimRestoreTargetDeleting corev1.PersistentVolumeClaimConditionType = "RestoreTargetDeleting"
 )
 
 var reconcileInterval = time.Second

--- a/controllers/dataprotection/types.go
+++ b/controllers/dataprotection/types.go
@@ -82,10 +82,9 @@ const (
 	AnnPopulateFrom = "dataprotection.kubeblocks.io/populate-from"
 
 	// event reason
-	ReasonStartToVolumePopulate    = "StartToVolumePopulate"
-	ReasonVolumePopulateSucceed    = "VolumePopulateSucceed"
-	ReasonVolumePopulateFailed     = "VolumePopulateFailed"
-	ReasonRestoreTargetPVCDeleting = "RestoreTargetPVCDeleting"
+	ReasonStartToVolumePopulate = "StartToVolumePopulate"
+	ReasonVolumePopulateSucceed = "VolumePopulateSucceed"
+	ReasonVolumePopulateFailed  = "VolumePopulateFailed"
 
 	// pvc condition type and reason
 	ReasonPopulatingFailed      = "Failed"
@@ -93,8 +92,7 @@ const (
 	ReasonPopulatingSucceed     = "Succeed"
 	ReasonPopulatingProvisioned = "Provisioned"
 
-	PersistentVolumeClaimPopulating            corev1.PersistentVolumeClaimConditionType = "Populating"
-	PersistentVolumeClaimRestoreTargetDeleting corev1.PersistentVolumeClaimConditionType = "RestoreTargetDeleting"
+	PersistentVolumeClaimPopulating corev1.PersistentVolumeClaimConditionType = "Populating"
 )
 
 var reconcileInterval = time.Second

--- a/controllers/dataprotection/types.go
+++ b/controllers/dataprotection/types.go
@@ -82,9 +82,10 @@ const (
 	AnnPopulateFrom = "dataprotection.kubeblocks.io/populate-from"
 
 	// event reason
-	ReasonStartToVolumePopulate = "StartToVolumePopulate"
-	ReasonVolumePopulateSucceed = "VolumePopulateSucceed"
-	ReasonVolumePopulateFailed  = "VolumePopulateFailed"
+	ReasonStartToVolumePopulate  = "StartToVolumePopulate"
+	ReasonVolumePopulateSucceed  = "VolumePopulateSucceed"
+	ReasonVolumePopulateFailed   = "VolumePopulateFailed"
+	ReasonTargetPVCDeleteBlocked = "TargetPVCDeleteBlocked"
 
 	// pvc condition type and reason
 	ReasonPopulatingFailed      = "Failed"

--- a/controllers/dataprotection/types.go
+++ b/controllers/dataprotection/types.go
@@ -82,10 +82,10 @@ const (
 	AnnPopulateFrom = "dataprotection.kubeblocks.io/populate-from"
 
 	// event reason
-	ReasonStartToVolumePopulate  = "StartToVolumePopulate"
-	ReasonVolumePopulateSucceed  = "VolumePopulateSucceed"
-	ReasonVolumePopulateFailed   = "VolumePopulateFailed"
-	ReasonTargetPVCDeleteBlocked = "TargetPVCDeleteBlocked"
+	ReasonStartToVolumePopulate    = "StartToVolumePopulate"
+	ReasonVolumePopulateSucceed    = "VolumePopulateSucceed"
+	ReasonVolumePopulateFailed     = "VolumePopulateFailed"
+	ReasonRestoreTargetPVCDeleting = "RestoreTargetPVCDeleting"
 
 	// pvc condition type and reason
 	ReasonPopulatingFailed      = "Failed"

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -175,7 +175,7 @@ func (r *VolumePopulatorReconciler) syncPVC(reqCtx intctrlutil.RequestCtx, pvc *
 	if !pvc.DeletionTimestamp.IsZero() {
 		// Target PVC deletion is not part of the restore lifecycle. Keep the
 		// restore waiting without mutating its resources or protection finalizer.
-		message := fmt.Sprintf("restore is waiting because target PVC %s/%s is deleting; target PVC deletion is not handled by the data protection controller",
+		message := fmt.Sprintf("restore is waiting because target PVC %s/%s is deleting",
 			pvc.Namespace, pvc.Name)
 		r.Recorder.Event(pvc, corev1.EventTypeWarning, ReasonRestoreTargetPVCDeleting, message)
 		return intctrlutil.NewRequeueError(reconcileInterval, message)

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -173,6 +173,9 @@ func (r *VolumePopulatorReconciler) syncPVC(reqCtx intctrlutil.RequestCtx, pvc *
 		return nil
 	}
 	if !pvc.DeletionTimestamp.IsZero() {
+		if pvcRestoreFailed(pvc) {
+			return r.waitForDeletingRestoreTargetPVC(reqCtx, pvc)
+		}
 		if pvcReadyForRestoreProgression(pvc) {
 			return r.releasePopulateResources(reqCtx, pvc)
 		}
@@ -201,13 +204,13 @@ func (r *VolumePopulatorReconciler) waitForDeletingRestoreTargetPVC(reqCtx intct
 	pvc *corev1.PersistentVolumeClaim) error {
 	message := fmt.Sprintf("restore is waiting because target PVC %s/%s is deleting", pvc.Namespace, pvc.Name)
 	condition := corev1.PersistentVolumeClaimCondition{
-		Type:               corev1.PersistentVolumeClaimConditionType(appsv1.ConditionTypeRestore),
-		Status:             corev1.ConditionUnknown,
+		Type:               PersistentVolumeClaimRestoreTargetDeleting,
+		Status:             corev1.ConditionTrue,
 		LastTransitionTime: metav1.Now(),
 		Reason:             ReasonRestoreTargetPVCDeleting,
 		Message:            message,
 	}
-	existing := findPVCConditionByType(pvc, appsv1.ConditionTypeRestore)
+	existing := findPVCConditionByType(pvc, string(PersistentVolumeClaimRestoreTargetDeleting))
 	if existing == nil || existing.Status != condition.Status || existing.Reason != condition.Reason ||
 		existing.Message != condition.Message {
 		patch := client.MergeFrom(pvc.DeepCopy())
@@ -1026,15 +1029,8 @@ func (r *VolumePopulatorReconciler) completeBoundPVCIfNeeded(reqCtx intctrlutil.
 	pvc *corev1.PersistentVolumeClaim,
 	restoreCtx *pvcRestoreContext) error {
 	populateReleased := pvcPopulateReleased(pvc)
-	for i := range pvc.Status.Conditions {
-		condition := pvc.Status.Conditions[i]
-		if string(condition.Type) != appsv1.ConditionTypeRestore {
-			continue
-		}
-		if condition.Status == corev1.ConditionFalse {
-			return nil
-		}
-		break
+	if pvcRestoreFailed(pvc) {
+		return nil
 	}
 	if !populateReleased {
 		if !pvcBindingCompleted(pvc) {
@@ -1487,6 +1483,11 @@ func pvcPopulateReleased(pvc *corev1.PersistentVolumeClaim) bool {
 	cond := findPVCConditionByType(pvc, string(PersistentVolumeClaimPopulating))
 	return cond != nil && cond.Status == corev1.ConditionTrue &&
 		(cond.Reason == ReasonPopulatingSucceed || cond.Reason == ReasonPopulatingProvisioned)
+}
+
+func pvcRestoreFailed(pvc *corev1.PersistentVolumeClaim) bool {
+	cond := findPVCConditionByType(pvc, appsv1.ConditionTypeRestore)
+	return cond != nil && cond.Status == corev1.ConditionFalse
 }
 
 func pvcReadyForRestoreProgression(pvc *corev1.PersistentVolumeClaim) bool {

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -173,12 +173,10 @@ func (r *VolumePopulatorReconciler) syncPVC(reqCtx intctrlutil.RequestCtx, pvc *
 		return nil
 	}
 	if !pvc.DeletionTimestamp.IsZero() {
-		// Target PVC deletion is not part of the restore lifecycle. Keep the
-		// restore waiting without mutating its resources or protection finalizer.
-		message := fmt.Sprintf("restore is waiting because target PVC %s/%s is deleting",
-			pvc.Namespace, pvc.Name)
-		r.Recorder.Event(pvc, corev1.EventTypeWarning, ReasonRestoreTargetPVCDeleting, message)
-		return intctrlutil.NewRequeueError(reconcileInterval, message)
+		if pvcReadyForRestoreProgression(pvc) {
+			return r.releasePopulateResources(reqCtx, pvc)
+		}
+		return r.waitForDeletingRestoreTargetPVC(reqCtx, pvc)
 	}
 	var restoreCtx *pvcRestoreContext
 	if pvc.Spec.DataSourceRef.Kind == dptypes.RestoreKind {
@@ -197,6 +195,30 @@ func (r *VolumePopulatorReconciler) syncPVC(reqCtx intctrlutil.RequestCtx, pvc *
 		return err
 	}
 	return nil
+}
+
+func (r *VolumePopulatorReconciler) waitForDeletingRestoreTargetPVC(reqCtx intctrlutil.RequestCtx,
+	pvc *corev1.PersistentVolumeClaim) error {
+	message := fmt.Sprintf("restore is waiting because target PVC %s/%s is deleting", pvc.Namespace, pvc.Name)
+	condition := corev1.PersistentVolumeClaimCondition{
+		Type:               corev1.PersistentVolumeClaimConditionType(appsv1.ConditionTypeRestore),
+		Status:             corev1.ConditionUnknown,
+		LastTransitionTime: metav1.Now(),
+		Reason:             ReasonRestoreTargetPVCDeleting,
+		Message:            message,
+	}
+	existing := findPVCConditionByType(pvc, appsv1.ConditionTypeRestore)
+	if existing == nil || existing.Status != condition.Status || existing.Reason != condition.Reason ||
+		existing.Message != condition.Message {
+		patch := client.MergeFrom(pvc.DeepCopy())
+		upsertPVCCondition(&pvc.Status.Conditions, condition)
+		if err := r.Client.Status().Patch(reqCtx.Ctx, pvc, patch); err != nil {
+			return intctrlutil.NewRequeueError(reconcileInterval,
+				fmt.Sprintf("failed to record deleting restore target PVC: %v", err))
+		}
+		r.Recorder.Event(pvc, corev1.EventTypeWarning, ReasonRestoreTargetPVCDeleting, message)
+	}
+	return intctrlutil.NewRequeueError(restoreTargetDeletingRequeueInterval, message)
 }
 
 // dispatchUnboundPVC routes an unbound PVC to either Populate or ProvisionOnly.

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -172,15 +172,6 @@ func (r *VolumePopulatorReconciler) syncPVC(reqCtx intctrlutil.RequestCtx, pvc *
 	if !matched {
 		return nil
 	}
-	if !pvc.DeletionTimestamp.IsZero() {
-		if pvcRestoreFailed(pvc) {
-			return r.waitForDeletingRestoreTargetPVC(reqCtx, pvc)
-		}
-		if pvcReadyForRestoreProgression(pvc) {
-			return r.releasePopulateResources(reqCtx, pvc)
-		}
-		return r.waitForDeletingRestoreTargetPVC(reqCtx, pvc)
-	}
 	var restoreCtx *pvcRestoreContext
 	if pvc.Spec.DataSourceRef.Kind == dptypes.RestoreKind {
 		restoreCtx, err = r.validateRestoreRefAndBuildMGR(reqCtx, pvc)
@@ -198,30 +189,6 @@ func (r *VolumePopulatorReconciler) syncPVC(reqCtx intctrlutil.RequestCtx, pvc *
 		return err
 	}
 	return nil
-}
-
-func (r *VolumePopulatorReconciler) waitForDeletingRestoreTargetPVC(reqCtx intctrlutil.RequestCtx,
-	pvc *corev1.PersistentVolumeClaim) error {
-	message := fmt.Sprintf("restore is waiting because target PVC %s/%s is deleting", pvc.Namespace, pvc.Name)
-	condition := corev1.PersistentVolumeClaimCondition{
-		Type:               PersistentVolumeClaimRestoreTargetDeleting,
-		Status:             corev1.ConditionTrue,
-		LastTransitionTime: metav1.Now(),
-		Reason:             ReasonRestoreTargetPVCDeleting,
-		Message:            message,
-	}
-	existing := findPVCConditionByType(pvc, string(PersistentVolumeClaimRestoreTargetDeleting))
-	if existing == nil || existing.Status != condition.Status || existing.Reason != condition.Reason ||
-		existing.Message != condition.Message {
-		patch := client.MergeFrom(pvc.DeepCopy())
-		upsertPVCCondition(&pvc.Status.Conditions, condition)
-		if err := r.Client.Status().Patch(reqCtx.Ctx, pvc, patch); err != nil {
-			return intctrlutil.NewRequeueError(reconcileInterval,
-				fmt.Sprintf("failed to record deleting restore target PVC: %v", err))
-		}
-		r.Recorder.Event(pvc, corev1.EventTypeWarning, ReasonRestoreTargetPVCDeleting, message)
-	}
-	return intctrlutil.NewRequeueError(reconcileInterval, message)
 }
 
 // dispatchUnboundPVC routes an unbound PVC to either Populate or ProvisionOnly.
@@ -1029,8 +996,15 @@ func (r *VolumePopulatorReconciler) completeBoundPVCIfNeeded(reqCtx intctrlutil.
 	pvc *corev1.PersistentVolumeClaim,
 	restoreCtx *pvcRestoreContext) error {
 	populateReleased := pvcPopulateReleased(pvc)
-	if pvcRestoreFailed(pvc) {
-		return nil
+	for i := range pvc.Status.Conditions {
+		condition := pvc.Status.Conditions[i]
+		if string(condition.Type) != appsv1.ConditionTypeRestore {
+			continue
+		}
+		if condition.Status == corev1.ConditionFalse {
+			return nil
+		}
+		break
 	}
 	if !populateReleased {
 		if !pvcBindingCompleted(pvc) {
@@ -1483,11 +1457,6 @@ func pvcPopulateReleased(pvc *corev1.PersistentVolumeClaim) bool {
 	cond := findPVCConditionByType(pvc, string(PersistentVolumeClaimPopulating))
 	return cond != nil && cond.Status == corev1.ConditionTrue &&
 		(cond.Reason == ReasonPopulatingSucceed || cond.Reason == ReasonPopulatingProvisioned)
-}
-
-func pvcRestoreFailed(pvc *corev1.PersistentVolumeClaim) bool {
-	cond := findPVCConditionByType(pvc, appsv1.ConditionTypeRestore)
-	return cond != nil && cond.Status == corev1.ConditionFalse
 }
 
 func pvcReadyForRestoreProgression(pvc *corev1.PersistentVolumeClaim) bool {

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -173,7 +173,13 @@ func (r *VolumePopulatorReconciler) syncPVC(reqCtx intctrlutil.RequestCtx, pvc *
 		return nil
 	}
 	if !pvc.DeletionTimestamp.IsZero() {
-		return r.cleanupDeletingPVC(reqCtx, pvc)
+		// Deleting the target PVC does not authorize the volume populator to tear
+		// down restore resources or release its protection finalizer. Destructive
+		// cleanup must be coordinated by the owning resource lifecycle.
+		message := fmt.Sprintf("target PVC %s/%s deletion is blocked while volume population resources may still be active",
+			pvc.Namespace, pvc.Name)
+		r.Recorder.Event(pvc, corev1.EventTypeWarning, ReasonTargetPVCDeleteBlocked, message)
+		return intctrlutil.NewRequeueError(reconcileInterval, message)
 	}
 	var restoreCtx *pvcRestoreContext
 	if pvc.Spec.DataSourceRef.Kind == dptypes.RestoreKind {
@@ -1615,16 +1621,6 @@ func postReadyRestoreLabels(pvc *corev1.PersistentVolumeClaim, comp *appsv1.Comp
 func postReadyRestoreName(componentUID types.UID) string {
 	// Backup dataSource restore is an initial, single-attempt restore for a Component UID.
 	return constant.ShortenKubeName(fmt.Sprintf("restore-%s-post-ready", componentUID), constant.KubeNameMaxLength)
-}
-
-// cleanupDeletingPVC releases population resources when the target PVC is
-// being deleted. Keep this entry point separate from successful completion so
-// deletion-specific teardown can evolve without broadening the success path.
-func (r *VolumePopulatorReconciler) cleanupDeletingPVC(reqCtx intctrlutil.RequestCtx, pvc *corev1.PersistentVolumeClaim) error {
-	if err := r.deletePopulatePVC(reqCtx, pvc); err != nil {
-		return err
-	}
-	return r.releaseTargetPVC(reqCtx, pvc)
 }
 
 // releasePopulateResources releases only the temporary PVC and the target PVC

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -218,7 +218,7 @@ func (r *VolumePopulatorReconciler) waitForDeletingRestoreTargetPVC(reqCtx intct
 		}
 		r.Recorder.Event(pvc, corev1.EventTypeWarning, ReasonRestoreTargetPVCDeleting, message)
 	}
-	return intctrlutil.NewRequeueError(restoreTargetDeletingRequeueInterval, message)
+	return intctrlutil.NewRequeueError(reconcileInterval, message)
 }
 
 // dispatchUnboundPVC routes an unbound PVC to either Populate or ProvisionOnly.

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -173,12 +173,11 @@ func (r *VolumePopulatorReconciler) syncPVC(reqCtx intctrlutil.RequestCtx, pvc *
 		return nil
 	}
 	if !pvc.DeletionTimestamp.IsZero() {
-		// Deleting the target PVC does not authorize the volume populator to tear
-		// down restore resources or release its protection finalizer. Destructive
-		// cleanup must be coordinated by the owning resource lifecycle.
-		message := fmt.Sprintf("target PVC %s/%s deletion is blocked while volume population resources may still be active",
+		// Target PVC deletion is not part of the restore lifecycle. Keep the
+		// restore waiting without mutating its resources or protection finalizer.
+		message := fmt.Sprintf("restore is waiting because target PVC %s/%s is deleting; target PVC deletion is not handled by the data protection controller",
 			pvc.Namespace, pvc.Name)
-		r.Recorder.Event(pvc, corev1.EventTypeWarning, ReasonTargetPVCDeleteBlocked, message)
+		r.Recorder.Event(pvc, corev1.EventTypeWarning, ReasonRestoreTargetPVCDeleting, message)
 		return intctrlutil.NewRequeueError(reconcileInterval, message)
 	}
 	var restoreCtx *pvcRestoreContext

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -1556,10 +1556,11 @@ func TestDeletingUnfinishedTargetPVCWaitsWithoutCleaningPopulation(t *testing.T)
 	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), current))
 	require.Contains(t, current.Finalizers, dptypes.DataProtectionFinalizerName,
 		"target PVC must remain protected")
-	restoreCondition := findPVCConditionByType(current, kbappsv1.ConditionTypeRestore)
-	require.NotNil(t, restoreCondition)
-	require.Equal(t, corev1.ConditionUnknown, restoreCondition.Status)
-	require.Equal(t, ReasonRestoreTargetPVCDeleting, restoreCondition.Reason)
+	require.Nil(t, findPVCConditionByType(current, kbappsv1.ConditionTypeRestore))
+	deletingCondition := findPVCConditionByType(current, string(PersistentVolumeClaimRestoreTargetDeleting))
+	require.NotNil(t, deletingCondition)
+	require.Equal(t, corev1.ConditionTrue, deletingCondition.Status)
+	require.Equal(t, ReasonRestoreTargetPVCDeleting, deletingCondition.Reason)
 	event := <-recorder.Events
 	require.Contains(t, event, ReasonRestoreTargetPVCDeleting)
 	require.Contains(t, event, "restore is waiting")
@@ -1574,7 +1575,7 @@ func TestDeletingUnfinishedTargetPVCWaitsWithoutCleaningPopulation(t *testing.T)
 	}
 }
 
-func TestDeletingCompletedTargetPVCFinishesSuccessfulCleanup(t *testing.T) {
+func TestDeletingFailedTargetPVCKeepsFailureAndPopulationResources(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 	apiGroup := dptypes.DataprotectionAPIGroup
@@ -1585,7 +1586,7 @@ func TestDeletingCompletedTargetPVCFinishesSuccessfulCleanup(t *testing.T) {
 			Name:              "data-0",
 			UID:               "data-0-uid",
 			DeletionTimestamp: &now,
-			Finalizers:        []string{dptypes.DataProtectionFinalizerName, "example.io/keep"},
+			Finalizers:        []string{dptypes.DataProtectionFinalizerName},
 			Annotations:       map[string]string{volume.AnnBindCompleted: "yes"},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
@@ -1596,6 +1597,14 @@ func TestDeletingCompletedTargetPVCFinishesSuccessfulCleanup(t *testing.T) {
 				Name:     "backup",
 			},
 		},
+		Status: corev1.PersistentVolumeClaimStatus{Conditions: []corev1.PersistentVolumeClaimCondition{
+			{
+				Type:    corev1.PersistentVolumeClaimConditionType(kbappsv1.ConditionTypeRestore),
+				Status:  corev1.ConditionFalse,
+				Reason:  ReasonPopulatingFailed,
+				Message: "execution restore failed",
+			},
+		}},
 	}
 	populatePVC := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
 		Namespace: pvc.Namespace,
@@ -1603,7 +1612,8 @@ func TestDeletingCompletedTargetPVCFinishesSuccessfulCleanup(t *testing.T) {
 	}}
 	recorder := record.NewFakeRecorder(1)
 	reconciler := &VolumePopulatorReconciler{
-		Client:   fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc, populatePVC).Build(),
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(pvc).
+			WithObjects(pvc, populatePVC).Build(),
 		Scheme:   scheme,
 		Recorder: recorder,
 	}
@@ -1612,17 +1622,104 @@ func TestDeletingCompletedTargetPVCFinishesSuccessfulCleanup(t *testing.T) {
 		NamespacedName: client.ObjectKeyFromObject(pvc),
 	})
 	require.NoError(t, err)
-	require.Zero(t, result.RequeueAfter)
-	require.True(t, apierrors.IsNotFound(reconciler.Client.Get(context.Background(),
-		client.ObjectKeyFromObject(populatePVC), &corev1.PersistentVolumeClaim{})))
+	require.Equal(t, reconcileInterval, result.RequeueAfter)
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(populatePVC),
+		&corev1.PersistentVolumeClaim{}))
 	current := &corev1.PersistentVolumeClaim{}
 	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), current))
-	require.NotContains(t, current.Finalizers, dptypes.DataProtectionFinalizerName)
-	require.Contains(t, current.Finalizers, "example.io/keep")
-	select {
-	case event := <-recorder.Events:
-		require.Failf(t, "unexpected wait event", "got %q", event)
-	default:
+	require.Contains(t, current.Finalizers, dptypes.DataProtectionFinalizerName)
+	restoreCondition := findPVCConditionByType(current, kbappsv1.ConditionTypeRestore)
+	require.NotNil(t, restoreCondition)
+	require.Equal(t, corev1.ConditionFalse, restoreCondition.Status)
+	require.Equal(t, ReasonPopulatingFailed, restoreCondition.Reason)
+	require.Equal(t, "execution restore failed", restoreCondition.Message)
+	deletingCondition := findPVCConditionByType(current, string(PersistentVolumeClaimRestoreTargetDeleting))
+	require.NotNil(t, deletingCondition)
+	require.Equal(t, corev1.ConditionTrue, deletingCondition.Status)
+	require.Equal(t, ReasonRestoreTargetPVCDeleting, deletingCondition.Reason)
+}
+
+func TestDeletingCompletedTargetPVCFinishesSuccessfulCleanup(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		conditions  []corev1.PersistentVolumeClaimCondition
+	}{
+		{
+			name:        "binding completed",
+			annotations: map[string]string{volume.AnnBindCompleted: "yes"},
+		},
+		{
+			name: "population succeeded",
+			conditions: []corev1.PersistentVolumeClaimCondition{{
+				Type:   PersistentVolumeClaimPopulating,
+				Status: corev1.ConditionTrue,
+				Reason: ReasonPopulatingSucceed,
+			}},
+		},
+		{
+			name: "provisioning completed",
+			conditions: []corev1.PersistentVolumeClaimCondition{{
+				Type:   PersistentVolumeClaimPopulating,
+				Status: corev1.ConditionTrue,
+				Reason: ReasonPopulatingProvisioned,
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			require.NoError(t, corev1.AddToScheme(scheme))
+			apiGroup := dptypes.DataprotectionAPIGroup
+			now := metav1.Now()
+			pvc := &corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:         "default",
+					Name:              "data-0",
+					UID:               "data-0-uid",
+					DeletionTimestamp: &now,
+					Finalizers:        []string{dptypes.DataProtectionFinalizerName, "example.io/keep"},
+					Annotations:       tt.annotations,
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					VolumeName: "restored-pv",
+					DataSourceRef: &corev1.TypedObjectReference{
+						APIGroup: &apiGroup,
+						Kind:     dptypes.BackupKind,
+						Name:     "backup",
+					},
+				},
+				Status: corev1.PersistentVolumeClaimStatus{Conditions: tt.conditions},
+			}
+			populatePVC := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+				Namespace: pvc.Namespace,
+				Name:      getPopulatePVCName(pvc.UID),
+			}}
+			recorder := record.NewFakeRecorder(1)
+			reconciler := &VolumePopulatorReconciler{
+				Client:   fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc, populatePVC).Build(),
+				Scheme:   scheme,
+				Recorder: recorder,
+			}
+
+			result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+				NamespacedName: client.ObjectKeyFromObject(pvc),
+			})
+			require.NoError(t, err)
+			require.Zero(t, result.RequeueAfter)
+			require.True(t, apierrors.IsNotFound(reconciler.Client.Get(context.Background(),
+				client.ObjectKeyFromObject(populatePVC), &corev1.PersistentVolumeClaim{})))
+			current := &corev1.PersistentVolumeClaim{}
+			require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), current))
+			require.NotContains(t, current.Finalizers, dptypes.DataProtectionFinalizerName)
+			require.Contains(t, current.Finalizers, "example.io/keep")
+			select {
+			case event := <-recorder.Events:
+				require.Failf(t, "unexpected wait event", "got %q", event)
+			default:
+			}
+		})
 	}
 }
 

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -1559,7 +1559,6 @@ func TestDeletingTargetPVCWaitsWithoutCleaningPopulation(t *testing.T) {
 	event := <-recorder.Events
 	require.Contains(t, event, ReasonRestoreTargetPVCDeleting)
 	require.Contains(t, event, "restore is waiting")
-	require.Contains(t, event, "target PVC deletion is not handled")
 }
 
 func TestSuccessfulPopulateReleaseRemovesOnlyHelperAndTargetFinalizer(t *testing.T) {

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -1510,7 +1510,7 @@ func TestDispatchUnboundPVCFailsWhenNoRestoreActionsExist(t *testing.T) {
 		"expected fatal error when neither prepareData nor postReady exists, got: %v", err)
 }
 
-func TestDeletingTargetPVCWaitsWithoutCleaningPopulation(t *testing.T) {
+func TestDeletingUnfinishedTargetPVCWaitsWithoutCleaningPopulation(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
@@ -1538,6 +1538,69 @@ func TestDeletingTargetPVCWaitsWithoutCleaningPopulation(t *testing.T) {
 			Name:      getPopulatePVCName(pvc.UID),
 		},
 	}
+	recorder := record.NewFakeRecorder(2)
+	reconciler := &VolumePopulatorReconciler{
+		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(pvc).
+			WithObjects(pvc, populatePVC).Build(),
+		Scheme:   scheme,
+		Recorder: recorder,
+	}
+	req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(pvc)}
+
+	result, err := reconciler.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, restoreTargetDeletingRequeueInterval, result.RequeueAfter)
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(populatePVC), &corev1.PersistentVolumeClaim{}),
+		"populate PVC must remain untouched")
+	current := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), current))
+	require.Contains(t, current.Finalizers, dptypes.DataProtectionFinalizerName,
+		"target PVC must remain protected")
+	restoreCondition := findPVCConditionByType(current, kbappsv1.ConditionTypeRestore)
+	require.NotNil(t, restoreCondition)
+	require.Equal(t, corev1.ConditionUnknown, restoreCondition.Status)
+	require.Equal(t, ReasonRestoreTargetPVCDeleting, restoreCondition.Reason)
+	event := <-recorder.Events
+	require.Contains(t, event, ReasonRestoreTargetPVCDeleting)
+	require.Contains(t, event, "restore is waiting")
+
+	result, err = reconciler.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, restoreTargetDeletingRequeueInterval, result.RequeueAfter)
+	select {
+	case duplicate := <-recorder.Events:
+		require.Failf(t, "unexpected duplicate event", "got %q", duplicate)
+	default:
+	}
+}
+
+func TestDeletingCompletedTargetPVCFinishesSuccessfulCleanup(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	apiGroup := dptypes.DataprotectionAPIGroup
+	now := metav1.Now()
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         "default",
+			Name:              "data-0",
+			UID:               "data-0-uid",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{dptypes.DataProtectionFinalizerName, "example.io/keep"},
+			Annotations:       map[string]string{volume.AnnBindCompleted: "yes"},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			VolumeName: "restored-pv",
+			DataSourceRef: &corev1.TypedObjectReference{
+				APIGroup: &apiGroup,
+				Kind:     dptypes.BackupKind,
+				Name:     "backup",
+			},
+		},
+	}
+	populatePVC := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
+		Namespace: pvc.Namespace,
+		Name:      getPopulatePVCName(pvc.UID),
+	}}
 	recorder := record.NewFakeRecorder(1)
 	reconciler := &VolumePopulatorReconciler{
 		Client:   fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc, populatePVC).Build(),
@@ -1549,16 +1612,18 @@ func TestDeletingTargetPVCWaitsWithoutCleaningPopulation(t *testing.T) {
 		NamespacedName: client.ObjectKeyFromObject(pvc),
 	})
 	require.NoError(t, err)
-	require.Positive(t, result.RequeueAfter)
-	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(populatePVC), &corev1.PersistentVolumeClaim{}),
-		"populate PVC must remain untouched")
+	require.Zero(t, result.RequeueAfter)
+	require.True(t, apierrors.IsNotFound(reconciler.Client.Get(context.Background(),
+		client.ObjectKeyFromObject(populatePVC), &corev1.PersistentVolumeClaim{})))
 	current := &corev1.PersistentVolumeClaim{}
 	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), current))
-	require.Contains(t, current.Finalizers, dptypes.DataProtectionFinalizerName,
-		"target PVC must remain protected")
-	event := <-recorder.Events
-	require.Contains(t, event, ReasonRestoreTargetPVCDeleting)
-	require.Contains(t, event, "restore is waiting")
+	require.NotContains(t, current.Finalizers, dptypes.DataProtectionFinalizerName)
+	require.Contains(t, current.Finalizers, "example.io/keep")
+	select {
+	case event := <-recorder.Events:
+		require.Failf(t, "unexpected wait event", "got %q", event)
+	default:
+	}
 }
 
 func TestSuccessfulPopulateReleaseRemovesOnlyHelperAndTargetFinalizer(t *testing.T) {

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -39,7 +39,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/component-helpers/storage/volume"
 	"k8s.io/utils/ptr"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -1510,215 +1509,42 @@ func TestDispatchUnboundPVCFailsWhenNoRestoreActionsExist(t *testing.T) {
 		"expected fatal error when neither prepareData nor postReady exists, got: %v", err)
 }
 
-func TestDeletingUnfinishedTargetPVCWaitsWithoutCleaningPopulation(t *testing.T) {
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
-	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
-	apiGroup := dptypes.DataprotectionAPIGroup
-	now := metav1.Now()
-	pvc := &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:         "default",
-			Name:              "data-0",
-			UID:               "data-0-uid",
-			DeletionTimestamp: &now,
-			Finalizers:        []string{dptypes.DataProtectionFinalizerName},
-		},
-		Spec: corev1.PersistentVolumeClaimSpec{
-			DataSourceRef: &corev1.TypedObjectReference{
-				APIGroup: &apiGroup,
-				Kind:     dptypes.BackupKind,
-				Name:     "already-deleted-backup",
-			},
-		},
-	}
-	populatePVC := &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: pvc.Namespace,
-			Name:      getPopulatePVCName(pvc.UID),
-		},
-	}
-	recorder := record.NewFakeRecorder(2)
-	reconciler := &VolumePopulatorReconciler{
-		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(pvc).
-			WithObjects(pvc, populatePVC).Build(),
-		Scheme:   scheme,
-		Recorder: recorder,
-	}
-	req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(pvc)}
-
-	result, err := reconciler.Reconcile(context.Background(), req)
-	require.NoError(t, err)
-	require.Equal(t, reconcileInterval, result.RequeueAfter)
-	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(populatePVC), &corev1.PersistentVolumeClaim{}),
-		"populate PVC must remain untouched")
-	current := &corev1.PersistentVolumeClaim{}
-	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), current))
-	require.Contains(t, current.Finalizers, dptypes.DataProtectionFinalizerName,
-		"target PVC must remain protected")
-	require.Nil(t, findPVCConditionByType(current, kbappsv1.ConditionTypeRestore))
-	deletingCondition := findPVCConditionByType(current, string(PersistentVolumeClaimRestoreTargetDeleting))
-	require.NotNil(t, deletingCondition)
-	require.Equal(t, corev1.ConditionTrue, deletingCondition.Status)
-	require.Equal(t, ReasonRestoreTargetPVCDeleting, deletingCondition.Reason)
-	event := <-recorder.Events
-	require.Contains(t, event, ReasonRestoreTargetPVCDeleting)
-	require.Contains(t, event, "restore is waiting")
-
-	result, err = reconciler.Reconcile(context.Background(), req)
-	require.NoError(t, err)
-	require.Equal(t, reconcileInterval, result.RequeueAfter)
-	select {
-	case duplicate := <-recorder.Events:
-		require.Failf(t, "unexpected duplicate event", "got %q", duplicate)
-	default:
-	}
-}
-
-func TestDeletingFailedTargetPVCKeepsFailureAndPopulationResources(t *testing.T) {
-	scheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(scheme))
-	apiGroup := dptypes.DataprotectionAPIGroup
-	now := metav1.Now()
-	pvc := &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:         "default",
-			Name:              "data-0",
-			UID:               "data-0-uid",
-			DeletionTimestamp: &now,
-			Finalizers:        []string{dptypes.DataProtectionFinalizerName},
-			Annotations:       map[string]string{volume.AnnBindCompleted: "yes"},
-		},
-		Spec: corev1.PersistentVolumeClaimSpec{
-			VolumeName: "restored-pv",
-			DataSourceRef: &corev1.TypedObjectReference{
-				APIGroup: &apiGroup,
-				Kind:     dptypes.BackupKind,
-				Name:     "backup",
-			},
-		},
-		Status: corev1.PersistentVolumeClaimStatus{Conditions: []corev1.PersistentVolumeClaimCondition{
-			{
-				Type:    corev1.PersistentVolumeClaimConditionType(kbappsv1.ConditionTypeRestore),
-				Status:  corev1.ConditionFalse,
-				Reason:  ReasonPopulatingFailed,
-				Message: "execution restore failed",
-			},
-		}},
-	}
-	populatePVC := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
-		Namespace: pvc.Namespace,
-		Name:      getPopulatePVCName(pvc.UID),
-	}}
-	recorder := record.NewFakeRecorder(1)
-	reconciler := &VolumePopulatorReconciler{
-		Client: fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(pvc).
-			WithObjects(pvc, populatePVC).Build(),
-		Scheme:   scheme,
-		Recorder: recorder,
-	}
-
-	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: client.ObjectKeyFromObject(pvc),
-	})
-	require.NoError(t, err)
-	require.Equal(t, reconcileInterval, result.RequeueAfter)
-	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(populatePVC),
-		&corev1.PersistentVolumeClaim{}))
-	current := &corev1.PersistentVolumeClaim{}
-	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), current))
-	require.Contains(t, current.Finalizers, dptypes.DataProtectionFinalizerName)
-	restoreCondition := findPVCConditionByType(current, kbappsv1.ConditionTypeRestore)
-	require.NotNil(t, restoreCondition)
-	require.Equal(t, corev1.ConditionFalse, restoreCondition.Status)
-	require.Equal(t, ReasonPopulatingFailed, restoreCondition.Reason)
-	require.Equal(t, "execution restore failed", restoreCondition.Message)
-	deletingCondition := findPVCConditionByType(current, string(PersistentVolumeClaimRestoreTargetDeleting))
-	require.NotNil(t, deletingCondition)
-	require.Equal(t, corev1.ConditionTrue, deletingCondition.Status)
-	require.Equal(t, ReasonRestoreTargetPVCDeleting, deletingCondition.Reason)
-}
-
-func TestDeletingCompletedTargetPVCFinishesSuccessfulCleanup(t *testing.T) {
-	tests := []struct {
-		name        string
-		annotations map[string]string
-		conditions  []corev1.PersistentVolumeClaimCondition
-	}{
-		{
-			name:        "binding completed",
-			annotations: map[string]string{volume.AnnBindCompleted: "yes"},
-		},
-		{
-			name: "population succeeded",
-			conditions: []corev1.PersistentVolumeClaimCondition{{
-				Type:   PersistentVolumeClaimPopulating,
-				Status: corev1.ConditionTrue,
-				Reason: ReasonPopulatingSucceed,
-			}},
-		},
-		{
-			name: "provisioning completed",
-			conditions: []corev1.PersistentVolumeClaimCondition{{
-				Type:   PersistentVolumeClaimPopulating,
-				Status: corev1.ConditionTrue,
-				Reason: ReasonPopulatingProvisioned,
-			}},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+func TestDeletingTargetPVCWithDPFinalizerUsesNormalRestorePath(t *testing.T) {
+	for _, deleting := range []bool{false, true} {
+		t.Run(fmt.Sprintf("deleting=%t", deleting), func(t *testing.T) {
 			scheme := runtime.NewScheme()
 			require.NoError(t, corev1.AddToScheme(scheme))
+			require.NoError(t, dpv1alpha1.AddToScheme(scheme))
 			apiGroup := dptypes.DataprotectionAPIGroup
-			now := metav1.Now()
 			pvc := &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace:         "default",
-					Name:              "data-0",
-					UID:               "data-0-uid",
-					DeletionTimestamp: &now,
-					Finalizers:        []string{dptypes.DataProtectionFinalizerName, "example.io/keep"},
-					Annotations:       tt.annotations,
+					Namespace:  "default",
+					Name:       "data-0",
+					UID:        "data-0-uid",
+					Finalizers: []string{dptypes.DataProtectionFinalizerName},
 				},
-				Spec: corev1.PersistentVolumeClaimSpec{
-					VolumeName: "restored-pv",
-					DataSourceRef: &corev1.TypedObjectReference{
-						APIGroup: &apiGroup,
-						Kind:     dptypes.BackupKind,
-						Name:     "backup",
-					},
-				},
-				Status: corev1.PersistentVolumeClaimStatus{Conditions: tt.conditions},
+				Spec: corev1.PersistentVolumeClaimSpec{DataSourceRef: &corev1.TypedObjectReference{
+					APIGroup: &apiGroup,
+					Kind:     dptypes.BackupKind,
+					Name:     "missing-backup",
+				}},
 			}
-			populatePVC := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
-				Namespace: pvc.Namespace,
-				Name:      getPopulatePVCName(pvc.UID),
-			}}
-			recorder := record.NewFakeRecorder(1)
+			if deleting {
+				now := metav1.Now()
+				pvc.DeletionTimestamp = &now
+			}
 			reconciler := &VolumePopulatorReconciler{
-				Client:   fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc, populatePVC).Build(),
-				Scheme:   scheme,
-				Recorder: recorder,
+				Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc).Build(),
+				Scheme: scheme,
 			}
 
-			result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
-				NamespacedName: client.ObjectKeyFromObject(pvc),
-			})
-			require.NoError(t, err)
-			require.Zero(t, result.RequeueAfter)
-			require.True(t, apierrors.IsNotFound(reconciler.Client.Get(context.Background(),
-				client.ObjectKeyFromObject(populatePVC), &corev1.PersistentVolumeClaim{})))
+			err := reconciler.syncPVC(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc)
+
+			require.Error(t, err)
+			require.True(t, apierrors.IsNotFound(err), "deletion must not replace the ordinary restore error: %v", err)
 			current := &corev1.PersistentVolumeClaim{}
 			require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), current))
-			require.NotContains(t, current.Finalizers, dptypes.DataProtectionFinalizerName)
-			require.Contains(t, current.Finalizers, "example.io/keep")
-			select {
-			case event := <-recorder.Events:
-				require.Failf(t, "unexpected wait event", "got %q", event)
-			default:
-			}
+			require.Contains(t, current.Finalizers, dptypes.DataProtectionFinalizerName)
 		})
 	}
 }

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/component-helpers/storage/volume"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -1509,7 +1510,7 @@ func TestDispatchUnboundPVCFailsWhenNoRestoreActionsExist(t *testing.T) {
 		"expected fatal error when neither prepareData nor postReady exists, got: %v", err)
 }
 
-func TestDeletingTargetPVCCleansPopulationWithoutValidatingSource(t *testing.T) {
+func TestDeletingTargetPVCWaitsWithoutCleaningPopulation(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 	require.NoError(t, dpv1alpha1.AddToScheme(scheme))
@@ -1537,15 +1538,25 @@ func TestDeletingTargetPVCCleansPopulationWithoutValidatingSource(t *testing.T) 
 			Name:      getPopulatePVCName(pvc.UID),
 		},
 	}
+	recorder := record.NewFakeRecorder(1)
 	reconciler := &VolumePopulatorReconciler{
-		Client: fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc, populatePVC).Build(),
-		Scheme: scheme,
+		Client:   fake.NewClientBuilder().WithScheme(scheme).WithObjects(pvc, populatePVC).Build(),
+		Scheme:   scheme,
+		Recorder: recorder,
 	}
 
-	err := reconciler.syncPVC(intctrlutil.RequestCtx{Ctx: context.Background()}, pvc)
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: client.ObjectKeyFromObject(pvc),
+	})
 	require.NoError(t, err)
-	err = reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(populatePVC), &corev1.PersistentVolumeClaim{})
-	require.True(t, apierrors.IsNotFound(err), "populate PVC should be deleted, got: %v", err)
+	require.Positive(t, result.RequeueAfter)
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(populatePVC), &corev1.PersistentVolumeClaim{}),
+		"populate PVC must remain untouched")
+	current := &corev1.PersistentVolumeClaim{}
+	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), current))
+	require.Contains(t, current.Finalizers, dptypes.DataProtectionFinalizerName,
+		"target PVC must remain protected")
+	require.Contains(t, <-recorder.Events, ReasonTargetPVCDeleteBlocked)
 }
 
 func TestSuccessfulPopulateReleaseRemovesOnlyHelperAndTargetFinalizer(t *testing.T) {

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -1556,7 +1556,10 @@ func TestDeletingTargetPVCWaitsWithoutCleaningPopulation(t *testing.T) {
 	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(pvc), current))
 	require.Contains(t, current.Finalizers, dptypes.DataProtectionFinalizerName,
 		"target PVC must remain protected")
-	require.Contains(t, <-recorder.Events, ReasonTargetPVCDeleteBlocked)
+	event := <-recorder.Events
+	require.Contains(t, event, ReasonRestoreTargetPVCDeleting)
+	require.Contains(t, event, "restore is waiting")
+	require.Contains(t, event, "target PVC deletion is not handled")
 }
 
 func TestSuccessfulPopulateReleaseRemovesOnlyHelperAndTargetFinalizer(t *testing.T) {

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -1549,7 +1549,7 @@ func TestDeletingUnfinishedTargetPVCWaitsWithoutCleaningPopulation(t *testing.T)
 
 	result, err := reconciler.Reconcile(context.Background(), req)
 	require.NoError(t, err)
-	require.Equal(t, restoreTargetDeletingRequeueInterval, result.RequeueAfter)
+	require.Equal(t, reconcileInterval, result.RequeueAfter)
 	require.NoError(t, reconciler.Client.Get(context.Background(), client.ObjectKeyFromObject(populatePVC), &corev1.PersistentVolumeClaim{}),
 		"populate PVC must remain untouched")
 	current := &corev1.PersistentVolumeClaim{}
@@ -1566,7 +1566,7 @@ func TestDeletingUnfinishedTargetPVCWaitsWithoutCleaningPopulation(t *testing.T)
 
 	result, err = reconciler.Reconcile(context.Background(), req)
 	require.NoError(t, err)
-	require.Equal(t, restoreTargetDeletingRequeueInterval, result.RequeueAfter)
+	require.Equal(t, reconcileInterval, result.RequeueAfter)
 	select {
 	case duplicate := <-recorder.Events:
 		require.Failf(t, "unexpected duplicate event", "got %q", duplicate)


### PR DESCRIPTION
## Problem

A target PVC deletion is not a restore cancellation signal. VolumePopulator must not introduce a separate cleanup, wait, condition, event, or requeue path based on `DeletionTimestamp`.

## Changes

- remove the target-PVC-deleting cleanup path introduced in #10630
- remove deletion-specific PVC condition, reason, warning event, and requeue behavior
- process a target PVC retained by the DP finalizer through the ordinary restore state machine, regardless of `DeletionTimestamp`
- preserve the existing failure-first and successful resource-release behavior

This PR intentionally does not add Cluster/Component lifecycle handling. Parent deletion cancellation is handled separately.

## Ownership

VolumePopulator never deletes the target PVC. It only owns its DP finalizer and restore side effects.

## Tests

- deleting and non-deleting target PVCs with the DP finalizer produce the same ordinary restore result
- full `controllers/dataprotection` package passes