### PR TITLE
fix(ops): propagate scale-out restore environment

### DIFF
--- a/pkg/controller/plan/restore.go
+++ b/pkg/controller/plan/restore.go
@@ -87,6 +87,11 @@ func NewRestoreManager(ctx context.Context,
 	}
 }
 
+// SetRestoreEnv sets the user-provided environment for generated Restore objects.
+func (r *RestoreManager) SetRestoreEnv(env []corev1.EnvVar) {
+	r.env = env
+}
+
 func (r *RestoreManager) DoRestore(comp *component.SynthesizedComponent, compObj *appsv1.Component, postProvisionDone bool) error {
 	if compObj.Annotations[constant.SkipRestoreAnnotationKey] == "true" {
 		return nil

--- a/pkg/controller/plan/restore_env_test.go
+++ b/pkg/controller/plan/restore_env_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package plan
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/controller/component"
+)
+
+func TestRestoreManagerBuildPrepareDataRestoreEnv(t *testing.T) {
+	manager := &RestoreManager{
+		Cluster: &appsv1.Cluster{ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster", Namespace: "default", UID: types.UID("12345678-rest-of-uid"),
+		}},
+		namespace: "default",
+		replicas:  1,
+	}
+	restoreEnv := []corev1.EnvVar{{Name: "RESTORE_ENV", Value: "from-plan-intent"}}
+	manager.SetRestoreEnv(restoreEnv)
+
+	restore, err := manager.BuildPrepareDataRestore(&component.SynthesizedComponent{
+		Name: "mysql",
+		VolumeClaimTemplates: []corev1.PersistentVolumeClaimTemplate{{
+			ObjectMeta: metav1.ObjectMeta{Name: "data"},
+		}},
+	}, &dpv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: "backup"},
+		Status: dpv1alpha1.BackupStatus{BackupMethod: &dpv1alpha1.BackupMethod{
+			Name:          "snapshot",
+			TargetVolumes: &dpv1alpha1.TargetVolumeInfo{Volumes: []string{"data"}},
+		}},
+	}, nil)
+	if err != nil {
+		t.Fatalf("BuildPrepareDataRestore() error = %v", err)
+	}
+	if restore == nil {
+		t.Fatal("restore is nil")
+	}
+	if !reflect.DeepEqual(restore.Spec.Env, restoreEnv) {
+		t.Fatalf("restore env = %#v, want %#v", restore.Spec.Env, restoreEnv)
+	}
+}

--- a/pkg/operations/horizontal_scaling.go
+++ b/pkg/operations/horizontal_scaling.go
@@ -290,6 +290,7 @@ func (hs horizontalScalingOpsHandler) restoreDataFromBackup(reqCtx intctrlutil.R
 			constant.KBAppComponentLabelKey: pgRes.compOps.GetComponentName(),
 		}, 1, int32(podIndexInt))
 		restoreMGR.RestoreTime = fromBackup.RestorePointInTime
+		restoreMGR.SetRestoreEnv(fromBackup.RestoreEnv)
 		restoreMGR.RestoreNamePrefix = string(opsRes.OpsRequest.UID[:8])
 		// check restore status
 		restoreMeta := restoreMGR.GetRestoreObjectMeta(synthesizedComponent, dpv1alpha1.PrepareData, templateName)

--- a/pkg/operations/horizontal_scaling_test.go
+++ b/pkg/operations/horizontal_scaling_test.go
@@ -281,9 +281,11 @@ var _ = Describe("HorizontalScaling OpsRequest", func() {
 			})).Should(Succeed())
 
 			By("scale out replicas from a full backup")
+			restoreEnv := []corev1.EnvVar{{Name: "RESTORE_ENV", Value: "true"}}
 			horizontalScaling := opsv1alpha1.HorizontalScaling{ScaleOut: &opsv1alpha1.ScaleOut{
 				FromBackup: &opsv1alpha1.FromBackup{
-					Name: backupName,
+					Name:       backupName,
+					RestoreEnv: restoreEnv,
 				},
 			}}
 
@@ -306,6 +308,7 @@ var _ = Describe("HorizontalScaling OpsRequest", func() {
 					Namespace: restoreMeta.Namespace,
 					Name:      restoreMeta.Name,
 				}, func(restore *dpv1alpha1.Restore) {
+					Expect(restore.Spec.Env).Should(Equal(restoreEnv))
 					restore.Status.Phase = dpv1alpha1.RestorePhaseCompleted
 				})
 			}


### PR DESCRIPTION
Fixes #10815.

Release 1.1 counterpart of #10817.

## Problem

During horizontal scale-out from a Backup, scaleOut.fromBackup.restoreEnv is dropped before the generated Restore is created.

## Changes

- add an explicit RestoreManager setter for user-provided Restore environment
- pass FromBackup.restoreEnv into the scale-out Restore plan
- verify Restore.spec.env in focused plan and Operations coverage

## Scope

This PR only propagates restore environment on release-1.1. It does not change Backup validation, namespaces, authorization, VolumeSnapshot behavior, or source-target selection.

## Validation

- scripts/codex-go-test.sh ./pkg/controller/plan -count=1
- scripts/codex-go-test.sh ./pkg/operations -count=1
- git diff --check
