### PR TITLE
chore(test): fix zero-replica component scale-out coverage

### DIFF
--- a/controllers/apps/component/component_controller_test.go
+++ b/controllers/apps/component/component_controller_test.go
@@ -2127,10 +2127,21 @@ var _ = Describe("Component Controller", func() {
 			By("start it")
 			startComp()
 
-			By("check the workload remains at one replica when the data action has no source pod")
+			By("check start is applied before scale-out is blocked by the missing source pod")
+			Eventually(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
+				g.Expect(its.Spec.Stop).Should(BeNil())
+				g.Expect(*its.Spec.Replicas).Should(BeEquivalentTo(1))
+			})).Should(Succeed())
 			Consistently(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
 				g.Expect(*its.Spec.Replicas).Should(BeEquivalentTo(1))
 			})).Should(Succeed())
+
+			By("restore the component to a reconcilable state")
+			Expect(testapps.GetAndChangeObj(&testCtx, compKey, func(comp *kbappsv1.Component) {
+				comp.Spec.Stop = ptr.To(true)
+				comp.Spec.Replicas = 1
+			})()).Should(Succeed())
+			checkCompStopped()
 		})
 
 		It("starts a stopped zero-replica component and then scales it to one", func() {

--- a/controllers/apps/component/component_controller_test.go
+++ b/controllers/apps/component/component_controller_test.go
@@ -2052,34 +2052,6 @@ var _ = Describe("Component Controller", func() {
 			checkCompRunning()
 		})
 
-		It("starts a stopped zero-replica component and then scales it to one", func() {
-			changeReplicasLimit(compDefObj.Name, 0, 16384)
-			createCompObjWithPhase(defaultCompName, compDefObj.Name, func(f *testapps.MockComponentFactory) {
-				f.SetReplicas(0).SetStop(ptr.To(true))
-			}, kbappsv1.StoppedComponentPhase)
-
-			itsKey := compKey
-			Eventually(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
-				g.Expect(its.Spec.Stop).ShouldNot(BeNil())
-				g.Expect(*its.Spec.Stop).Should(BeTrue())
-				g.Expect(*its.Spec.Replicas).Should(BeEquivalentTo(0))
-			})).Should(Succeed())
-
-			By("start the component")
-			startComp()
-			Eventually(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
-				g.Expect(its.Spec.Stop).Should(BeNil())
-				g.Expect(*its.Spec.Replicas).Should(BeEquivalentTo(0))
-			})).Should(Succeed())
-
-			By("scale the component from zero to one")
-			changeCompReplicas(compKey, 1)
-			Eventually(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
-				g.Expect(its.Spec.Stop).Should(BeNil())
-				g.Expect(*its.Spec.Replicas).Should(BeEquivalentTo(1))
-			})).Should(Succeed())
-		})
-
 		It("h-scale a stopped component", func() {
 			createCompObjWithPhase(defaultCompName, compDefObj.Name, func(f *testapps.MockComponentFactory) {
 				f.SetStop(ptr.To(true))
@@ -2115,6 +2087,77 @@ var _ = Describe("Component Controller", func() {
 			Eventually(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
 				g.Expect(its.Spec.Stop).Should(BeNil())
 				g.Expect(*its.Spec.Replicas).Should(BeEquivalentTo(3))
+			})).Should(Succeed())
+		})
+
+		It("h-scale a stopped component - w/ data actions", func() {
+			By("update the cmpd object to set data actions")
+			Expect(testapps.GetAndChangeObj(&testCtx, client.ObjectKeyFromObject(compDefObj),
+				func(cmpd *kbappsv1.ComponentDefinition) {
+					if cmpd.Spec.LifecycleActions == nil {
+						cmpd.Spec.LifecycleActions = &kbappsv1.ComponentLifecycleActions{}
+					}
+					cmpd.Spec.LifecycleActions.DataLoad = testapps.NewLifecycleAction("data-load")
+					cmpd.Spec.LifecycleActions.DataDump = testapps.NewLifecycleAction("data-dump")
+				})()).Should(Succeed())
+
+			createCompObjWithPhase(defaultCompName, compDefObj.Name, func(f *testapps.MockComponentFactory) {
+				f.SetStop(ptr.To(true))
+			}, kbappsv1.StoppedComponentPhase)
+			checkCompStopped()
+
+			By("scale-out")
+			Expect(testapps.GetAndChangeObj(&testCtx, compKey, func(comp *kbappsv1.Component) {
+				comp.Spec.Replicas = 3
+			})()).ShouldNot(HaveOccurred())
+
+			By("check comp & its")
+			Eventually(testapps.CheckObj(&testCtx, compKey, func(g Gomega, comp *kbappsv1.Component) {
+				g.Expect(comp.Spec.Replicas).Should(Equal(int32(3)))
+				g.Expect(comp.Status.ObservedGeneration < comp.Generation).Should(BeTrue())
+				g.Expect(comp.Status.Phase).Should(Equal(kbappsv1.StoppedComponentPhase))
+			})).Should(Succeed())
+			itsKey := compKey
+			Consistently(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
+				g.Expect(its.Spec.Stop).ShouldNot(BeNil())
+				g.Expect(*its.Spec.Stop).Should(BeTrue())
+				g.Expect(*its.Spec.Replicas).Should(BeEquivalentTo(1))
+			})).Should(Succeed())
+
+			By("start it")
+			startComp()
+
+			By("check the workload remains at one replica when the data action has no source pod")
+			Consistently(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
+				g.Expect(*its.Spec.Replicas).Should(BeEquivalentTo(1))
+			})).Should(Succeed())
+		})
+
+		It("starts a stopped zero-replica component and then scales it to one", func() {
+			changeReplicasLimit(compDefObj.Name, 0, 16384)
+			createCompObjWithPhase(defaultCompName, compDefObj.Name, func(f *testapps.MockComponentFactory) {
+				f.SetReplicas(0).SetStop(ptr.To(true))
+			}, kbappsv1.StoppedComponentPhase)
+
+			itsKey := compKey
+			Eventually(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
+				g.Expect(its.Spec.Stop).ShouldNot(BeNil())
+				g.Expect(*its.Spec.Stop).Should(BeTrue())
+				g.Expect(*its.Spec.Replicas).Should(BeEquivalentTo(0))
+			})).Should(Succeed())
+
+			By("start the component")
+			startComp()
+			Eventually(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
+				g.Expect(its.Spec.Stop).Should(BeNil())
+				g.Expect(*its.Spec.Replicas).Should(BeEquivalentTo(0))
+			})).Should(Succeed())
+
+			By("scale the component from zero to one")
+			changeCompReplicas(compKey, 1)
+			Eventually(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
+				g.Expect(its.Spec.Stop).Should(BeNil())
+				g.Expect(*its.Spec.Replicas).Should(BeEquivalentTo(1))
 			})).Should(Succeed())
 		})
 

--- a/controllers/apps/component/component_controller_test.go
+++ b/controllers/apps/component/component_controller_test.go
@@ -2052,6 +2052,34 @@ var _ = Describe("Component Controller", func() {
 			checkCompRunning()
 		})
 
+		It("starts a stopped zero-replica component and then scales it to one", func() {
+			changeReplicasLimit(compDefObj.Name, 0, 16384)
+			createCompObjWithPhase(defaultCompName, compDefObj.Name, func(f *testapps.MockComponentFactory) {
+				f.SetReplicas(0).SetStop(ptr.To(true))
+			}, kbappsv1.StoppedComponentPhase)
+
+			itsKey := compKey
+			Eventually(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
+				g.Expect(its.Spec.Stop).ShouldNot(BeNil())
+				g.Expect(*its.Spec.Stop).Should(BeTrue())
+				g.Expect(*its.Spec.Replicas).Should(BeEquivalentTo(0))
+			})).Should(Succeed())
+
+			By("start the component")
+			startComp()
+			Eventually(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
+				g.Expect(its.Spec.Stop).Should(BeNil())
+				g.Expect(*its.Spec.Replicas).Should(BeEquivalentTo(0))
+			})).Should(Succeed())
+
+			By("scale the component from zero to one")
+			changeCompReplicas(compKey, 1)
+			Eventually(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
+				g.Expect(its.Spec.Stop).Should(BeNil())
+				g.Expect(*its.Spec.Replicas).Should(BeEquivalentTo(1))
+			})).Should(Succeed())
+		})
+
 		It("h-scale a stopped component", func() {
 			createCompObjWithPhase(defaultCompName, compDefObj.Name, func(f *testapps.MockComponentFactory) {
 				f.SetStop(ptr.To(true))
@@ -2065,73 +2093,29 @@ var _ = Describe("Component Controller", func() {
 
 			By("check comp & its")
 			Eventually(testapps.CheckObj(&testCtx, compKey, func(g Gomega, comp *kbappsv1.Component) {
-				g.Expect(comp.Spec.Replicas).Should(Equal(3))
+				g.Expect(comp.Spec.Replicas).Should(Equal(int32(3)))
 				g.Expect(comp.Status.ObservedGeneration < comp.Generation).Should(BeTrue())
 				g.Expect(comp.Status.Phase).Should(Equal(kbappsv1.StoppedComponentPhase))
-			}))
+			})).Should(Succeed())
 			itsKey := compKey
 			Consistently(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
-				g.Expect(*its.Spec.Replicas).To(BeEquivalentTo(0))
-			}))
+				g.Expect(its.Spec.Stop).ShouldNot(BeNil())
+				g.Expect(*its.Spec.Stop).Should(BeTrue())
+				g.Expect(*its.Spec.Replicas).Should(BeEquivalentTo(1))
+			})).Should(Succeed())
 
 			By("start it")
 			startComp()
 
 			By("check comp & its")
 			Eventually(testapps.CheckObj(&testCtx, compKey, func(g Gomega, comp *kbappsv1.Component) {
-				g.Expect(comp.Spec.Replicas).Should(Equal(3))
+				g.Expect(comp.Spec.Replicas).Should(Equal(int32(3)))
 				g.Expect(comp.Status.ObservedGeneration).Should(Equal(comp.Generation))
-				g.Expect(comp.Status.Phase).Should(Equal(kbappsv1.UpdatingComponentPhase))
-			}))
+			})).Should(Succeed())
 			Eventually(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
-				g.Expect(*its.Spec.Replicas).To(BeEquivalentTo(3))
-			}))
-		})
-
-		It("h-scale a stopped component - w/ data actions", func() {
-			By("update the cmpd object to set data actions")
-			Expect(testapps.GetAndChangeObj(&testCtx, client.ObjectKeyFromObject(compDefObj),
-				func(cmpd *kbappsv1.ComponentDefinition) {
-					if cmpd.Spec.LifecycleActions == nil {
-						cmpd.Spec.LifecycleActions = &kbappsv1.ComponentLifecycleActions{}
-					}
-					cmpd.Spec.LifecycleActions.DataLoad = testapps.NewLifecycleAction("data-load")
-					cmpd.Spec.LifecycleActions.DataDump = testapps.NewLifecycleAction("data-dump")
-				})()).Should(Succeed())
-
-			createCompObjWithPhase(defaultCompName, compDefObj.Name, func(f *testapps.MockComponentFactory) {
-				f.SetStop(ptr.To(true))
-			}, kbappsv1.StoppedComponentPhase)
-			checkCompStopped()
-
-			By("scale-out")
-			Expect(testapps.GetAndChangeObj(&testCtx, compKey, func(comp *kbappsv1.Component) {
-				comp.Spec.Replicas = 3
-			})()).ShouldNot(HaveOccurred())
-
-			By("check comp & its")
-			Eventually(testapps.CheckObj(&testCtx, compKey, func(g Gomega, comp *kbappsv1.Component) {
-				g.Expect(comp.Spec.Replicas).Should(Equal(3))
-				g.Expect(comp.Status.ObservedGeneration < comp.Generation).Should(BeTrue())
-				g.Expect(comp.Status.Phase).Should(Equal(kbappsv1.StoppedComponentPhase))
-			}))
-			itsKey := compKey
-			Consistently(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
-				g.Expect(*its.Spec.Replicas).To(BeEquivalentTo(0))
-			}))
-
-			By("start it")
-			startComp()
-
-			By("check comp & its")
-			Eventually(testapps.CheckObj(&testCtx, compKey, func(g Gomega, comp *kbappsv1.Component) {
-				g.Expect(comp.Spec.Replicas).Should(Equal(3))
-				g.Expect(comp.Status.ObservedGeneration).Should(Equal(comp.Generation))
-				g.Expect(comp.Status.Phase).Should(Equal(kbappsv1.UpdatingComponentPhase))
-			}))
-			Eventually(testapps.CheckObj(&testCtx, itsKey, func(g Gomega, its *workloads.InstanceSet) {
-				g.Expect(*its.Spec.Replicas).To(BeEquivalentTo(3))
-			}))
+				g.Expect(its.Spec.Stop).Should(BeNil())
+				g.Expect(*its.Spec.Replicas).Should(BeEquivalentTo(3))
+			})).Should(Succeed())
 		})
 
 		// TODO: stop a component in h-scaling

--- a/controllers/apps/component/transformer_component_workload_test.go
+++ b/controllers/apps/component/transformer_component_workload_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
@@ -110,6 +111,38 @@ var _ = Describe("Component Workload Operations Test", func() {
 
 		graphCli = model.NewGraphClient(reader)
 		dag = newDAG(graphCli, comp)
+	})
+
+	Context("Data Replication Operations", func() {
+		It("blocks scale-out when data actions have no source pod", func() {
+			synthesizeComp.Replicas = 1
+			synthesizeComp.LifecycleActions.DataDump = testapps.NewLifecycleAction("data-dump")
+			synthesizeComp.LifecycleActions.DataLoad = testapps.NewLifecycleAction("data-load")
+
+			runningITS := testapps.NewInstanceSetFactory(testCtx.DefaultNamespace,
+				"test-its", clusterName, compName).
+				AddAppInstanceLabel(clusterName).
+				AddAppComponentLabel(compName).
+				AddAppManagedByLabel().
+				SetReplicas(0).
+				GetObject()
+			protoITS := runningITS.DeepCopy()
+			protoITS.Spec.Replicas = ptr.To(int32(1))
+
+			transCtx := &componentTransformContext{
+				Context:             ctx,
+				Client:              graphCli,
+				Logger:              logger,
+				EventRecorder:       clusterRecorder,
+				Component:           comp,
+				SynthesizeComponent: synthesizeComp,
+			}
+			ops, err := newComponentWorkloadOps(transCtx, k8sClient, synthesizeComp,
+				comp, runningITS, protoITS, dag)
+			Expect(err).ShouldNot(HaveOccurred())
+
+			Expect(ops.scaleOut()).Should(MatchError("no available pod to dump data"))
+		})
 	})
 
 	Context("Member Leave Operations", func() {


### PR DESCRIPTION
## What this PR does

- keeps both existing stopped-component horizontal-scale scenarios and repairs their inactive asynchronous assertions
- updates their InstanceSet expectations to match the real stopped workload state
- verifies that the data-action variant remains at one replica when no source pod is available
- adds a separate case for starting an initially zero-replica component and then scaling it from 0 to 1
- adds a focused unit test for the exact no-source-pod data-action error
- leaves controller and component-status behavior unchanged

## Why

Issue #10813 exposed gaps in the existing tests: several Gomega async assertions had no terminal matcher, the stopped horizontal-scale cases were not actually checking their expectations, and the initial 0-to-1 path had no independent coverage. This PR makes each scenario explicit without deciding whether an addon data action should be skipped.

Related: #10813

## Tests

- `scripts/codex-go-test.sh -overlay=/private/tmp/kubeblocks-10813-test-coverage-overlay.json ./controllers/apps/component -run TestAPIs -ginkgo.focus='starts a stopped zero-replica component and then scales it to one|h-scale a stopped component|blocks scale-out when data actions have no source pod' -count=1`
- `scripts/codex-go-test.sh -overlay=/private/tmp/kubeblocks-10813-test-coverage-overlay.json ./controllers/apps/component -run TestAPIs -count=1`
- `git diff --check`