### PR TITLE
fix(dataprotection): preserve OneToOne source Pod identity during scale-out restore

### DIFF
--- a/pkg/controller/instancetemplate/ordinal.go
+++ b/pkg/controller/instancetemplate/ordinal.go
@@ -66,6 +66,31 @@ func getOrdinal(podName string) (int32, error) {
 	return int32(ordinal), nil
 }
 
+// GetTemplateNameAndOrdinal parses the instance template name and ordinal from
+// a Pod name that belongs to the specified workload.
+func GetTemplateNameAndOrdinal(workloadName, podName string) (string, int32, error) {
+	prefix := workloadName + "-"
+	if !strings.HasPrefix(podName, prefix) {
+		return "", 0, fmt.Errorf("pod %q does not belong to workload %q", podName, workloadName)
+	}
+	podSuffix := strings.TrimPrefix(podName, prefix)
+	lastDashIndex := strings.LastIndex(podSuffix, "-")
+	if lastDashIndex == len(podSuffix)-1 {
+		return "", 0, fmt.Errorf("no pod ordinal found after the last dash")
+	}
+	templateName := ""
+	indexStr := podSuffix
+	if lastDashIndex >= 0 {
+		templateName = podSuffix[:lastDashIndex]
+		indexStr = podSuffix[lastDashIndex+1:]
+	}
+	index, err := strconv.ParseInt(indexStr, 10, 32)
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to obtain pod ordinal: %w", err)
+	}
+	return templateName, int32(index), nil
+}
+
 // parseParentNameAndOrdinal parses parent (instance template) Name and ordinal from the give instance name.
 // -1 will be returned if no numeric suffix contained.
 func parseParentNameAndOrdinal(s string) (string, int) {

--- a/pkg/controller/instancetemplate/ordinal.go
+++ b/pkg/controller/instancetemplate/ordinal.go
@@ -69,26 +69,18 @@ func getOrdinal(podName string) (int32, error) {
 // GetTemplateNameAndOrdinal parses the instance template name and ordinal from
 // a Pod name that belongs to the specified workload.
 func GetTemplateNameAndOrdinal(workloadName, podName string) (string, int32, error) {
+	parentName, ordinal := parseParentNameAndOrdinal(podName)
+	if ordinal < 0 {
+		return "", 0, fmt.Errorf("failed to obtain pod ordinal from %q", podName)
+	}
+	if parentName == workloadName {
+		return "", int32(ordinal), nil
+	}
 	prefix := workloadName + "-"
-	if !strings.HasPrefix(podName, prefix) {
+	if !strings.HasPrefix(parentName, prefix) {
 		return "", 0, fmt.Errorf("pod %q does not belong to workload %q", podName, workloadName)
 	}
-	podSuffix := strings.TrimPrefix(podName, prefix)
-	lastDashIndex := strings.LastIndex(podSuffix, "-")
-	if lastDashIndex == len(podSuffix)-1 {
-		return "", 0, fmt.Errorf("no pod ordinal found after the last dash")
-	}
-	templateName := ""
-	indexStr := podSuffix
-	if lastDashIndex >= 0 {
-		templateName = podSuffix[:lastDashIndex]
-		indexStr = podSuffix[lastDashIndex+1:]
-	}
-	index, err := strconv.ParseInt(indexStr, 10, 32)
-	if err != nil {
-		return "", 0, fmt.Errorf("failed to obtain pod ordinal: %w", err)
-	}
-	return templateName, int32(index), nil
+	return strings.TrimPrefix(parentName, prefix), int32(ordinal), nil
 }
 
 // parseParentNameAndOrdinal parses parent (instance template) Name and ordinal from the give instance name.

--- a/pkg/controller/instancetemplate/ordinal_test.go
+++ b/pkg/controller/instancetemplate/ordinal_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package instancetemplate
+
+import "testing"
+
+func TestGetTemplateNameAndOrdinal(t *testing.T) {
+	testCases := []struct {
+		name         string
+		workloadName string
+		podName      string
+		templateName string
+		ordinal      int32
+		wantErr      bool
+	}{
+		{name: "default template", workloadName: "cluster-comp", podName: "cluster-comp-3", ordinal: 3},
+		{name: "template with dashes", workloadName: "cluster-comp", podName: "cluster-comp-b-a-3", templateName: "b-a", ordinal: 3},
+		{name: "workload suffix is not a template", workloadName: "cluster-comp-a", podName: "cluster-comp-a-3", ordinal: 3},
+		{name: "different workload", workloadName: "cluster-comp", podName: "other-comp-3", wantErr: true},
+		{name: "missing ordinal", workloadName: "cluster-comp", podName: "cluster-comp-template-", wantErr: true},
+		{name: "invalid ordinal", workloadName: "cluster-comp", podName: "cluster-comp-template-x", wantErr: true},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			templateName, ordinal, err := GetTemplateNameAndOrdinal(testCase.workloadName, testCase.podName)
+			if testCase.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("GetTemplateNameAndOrdinal() error = %v", err)
+			}
+			if templateName != testCase.templateName || ordinal != testCase.ordinal {
+				t.Fatalf("GetTemplateNameAndOrdinal() = %q, %d; want %q, %d", templateName, ordinal, testCase.templateName, testCase.ordinal)
+			}
+		})
+	}
+}

--- a/pkg/controller/plan/restore.go
+++ b/pkg/controller/plan/restore.go
@@ -128,15 +128,28 @@ func (r *RestoreManager) DoPrepareData(comp *component.SynthesizedComponent,
 // is nothing to prepareData-restore for this component. Callers must handle
 // the nil Restore instead of using it.
 func (r *RestoreManager) BuildPrepareDataRestore(comp *component.SynthesizedComponent, backupObj *dpv1alpha1.Backup, template *appsv1.InstanceTemplate) (*dpv1alpha1.Restore, error) {
-	templateName := ""
 	startingIndex := r.startingIndex
 	if template != nil {
-		templateName = template.Name
 		if len(template.Ordinals.Ranges) > 0 {
 			// todo: currently restore api does not support multiple ranges, if implement in current way it
 			// need to use multiple restore objects
 			startingIndex = template.Ordinals.Ranges[0].Start
 		}
+	}
+	return r.buildPrepareDataRestore(comp, backupObj, template, startingIndex)
+}
+
+// BuildPrepareDataRestoreForPod builds the Restore for one known Pod during
+// scale-out. The manager's startingIndex is the Pod's actual ordinal and must
+// not be replaced by the start of its instance template's ordinal range.
+func (r *RestoreManager) BuildPrepareDataRestoreForPod(comp *component.SynthesizedComponent, backupObj *dpv1alpha1.Backup, template *appsv1.InstanceTemplate) (*dpv1alpha1.Restore, error) {
+	return r.buildPrepareDataRestore(comp, backupObj, template, r.startingIndex)
+}
+
+func (r *RestoreManager) buildPrepareDataRestore(comp *component.SynthesizedComponent, backupObj *dpv1alpha1.Backup, template *appsv1.InstanceTemplate, startingIndex int32) (*dpv1alpha1.Restore, error) {
+	templateName := ""
+	if template != nil {
+		templateName = template.Name
 	}
 	backupMethod := backupObj.Status.BackupMethod
 	if backupMethod == nil {

--- a/pkg/controller/plan/restore.go
+++ b/pkg/controller/plan/restore.go
@@ -60,7 +60,9 @@ type RestoreManager struct {
 	replicas            int32
 	restoreLabels       map[string]string
 	RestoreNamePrefix   string
-	SourceTargetName    string
+	// SourceTargetName overrides the source target for prepareData Restores.
+	// It is primarily used by scale-out restoration.
+	SourceTargetName string
 }
 
 func NewRestoreManager(ctx context.Context,

--- a/pkg/dataprotection/restore/manager.go
+++ b/pkg/dataprotection/restore/manager.go
@@ -385,13 +385,9 @@ func (r *RestoreManager) RestorePVCFromSnapshot(reqCtx intctrlutil.RequestCtx, c
 	if prepareDataConfig == nil {
 		return nil
 	}
-	createPVCWithSnapshot := func(claim dpv1alpha1.RestoreVolumeClaim, sourceIndex int) error {
+	createPVCWithSnapshot := func(claim dpv1alpha1.RestoreVolumeClaim, sourceTargetPodName string) error {
 		if claim.VolumeSource == "" {
 			return intctrlutil.NewFatalError(fmt.Sprintf(`claim "%s"" volumeSource can not be empty if the backup uses volume snapshot`, claim.Name))
-		}
-		sourceTargetPodName, err := GetSourcePodNameFromTarget(target, prepareDataConfig.RequiredPolicyForAllPodSelection, sourceIndex)
-		if err != nil {
-			return err
 		}
 		var volumeSnapshotName string
 		if target.PodSelector.Strategy == dpv1alpha1.PodSelectionStrategyAny || sourceTargetPodName != "" {
@@ -413,7 +409,11 @@ func (r *RestoreManager) RestorePVCFromSnapshot(reqCtx intctrlutil.RequestCtx, c
 		return r.createPVCIfNotExist(reqCtx, cli, claim.ObjectMeta, claim.VolumeClaimSpec)
 	}
 	for i := range prepareDataConfig.RestoreVolumeClaims {
-		if err := createPVCWithSnapshot(prepareDataConfig.RestoreVolumeClaims[i], 0); err != nil {
+		sourceTargetPodName, err := GetSourcePodNameFromTarget(target, prepareDataConfig.RequiredPolicyForAllPodSelection, 0)
+		if err != nil {
+			return err
+		}
+		if err := createPVCWithSnapshot(prepareDataConfig.RestoreVolumeClaims[i], sourceTargetPodName); err != nil {
 			return err
 		}
 	}
@@ -422,13 +422,22 @@ func (r *RestoreManager) RestorePVCFromSnapshot(reqCtx intctrlutil.RequestCtx, c
 		restoreJobReplicas := GetRestoreActionsCountForPrepareData(prepareDataConfig)
 		for i := 0; i < restoreJobReplicas; i++ {
 			//  create pvc from claims template, build volumes and volumeMounts
-			for _, claim := range prepareDataConfig.RestoreVolumeClaimsTemplate.Templates {
+			for _, c := range prepareDataConfig.RestoreVolumeClaimsTemplate.Templates {
+				// Deep-copy metadata maps so each replica gets its own pod identity.
+				claim := *c.DeepCopy()
 				index := i + int(claimTemplate.StartingIndex)
 				claim.Name = fmt.Sprintf("%s-%d", claim.Name, index)
 				// HACK: add InstanceSet related labels to the PVC,
 				// so that it can be managed by InstanceSet
 				addItsManagingLabels(&claim, index)
-				if err := createPVCWithSnapshot(claim, index); err != nil {
+				sourceTargetPodName, err := GetSourcePodNameForTargetPod(target,
+					prepareDataConfig.RequiredPolicyForAllPodSelection,
+					claim.Labels[constant.KBAppPodNameLabelKey],
+					claim.Labels[constant.KBAppInstanceTemplateLabelKey])
+				if err != nil {
+					return err
+				}
+				if err := createPVCWithSnapshot(claim, sourceTargetPodName); err != nil {
 					return err
 				}
 			}
@@ -541,11 +550,16 @@ func (r *RestoreManager) BuildPrepareDataJobs(reqCtx intctrlutil.RequestCtx, cli
 				jobBuilder.addToSpecificVolumesAndMounts(volume, volumeMount)
 			}
 		}
-		sourceIndex := i
-		if claimsTemplate != nil {
-			sourceIndex += int(claimsTemplate.StartingIndex)
+		var sourceTargetPodName string
+		var err error
+		if claimsTemplate == nil {
+			sourceTargetPodName, err = GetSourcePodNameFromTarget(target, prepareDataConfig.RequiredPolicyForAllPodSelection, i)
+		} else {
+			sourceTargetPodName, err = GetSourcePodNameForTargetPod(target,
+				prepareDataConfig.RequiredPolicyForAllPodSelection,
+				jobBuilder.labels[constant.KBAppPodNameLabelKey],
+				jobBuilder.labels[constant.KBAppInstanceTemplateLabelKey])
 		}
-		sourceTargetPodName, err := GetSourcePodNameFromTarget(target, prepareDataConfig.RequiredPolicyForAllPodSelection, sourceIndex)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/dataprotection/restore/manager.go
+++ b/pkg/dataprotection/restore/manager.go
@@ -430,10 +430,19 @@ func (r *RestoreManager) RestorePVCFromSnapshot(reqCtx intctrlutil.RequestCtx, c
 				// HACK: add InstanceSet related labels to the PVC,
 				// so that it can be managed by InstanceSet
 				addItsManagingLabels(&claim, index)
-				sourceTargetPodName, err := GetSourcePodNameForTargetPod(target,
-					prepareDataConfig.RequiredPolicyForAllPodSelection,
-					claim.Labels[constant.KBAppPodNameLabelKey],
-					claim.Labels[constant.KBAppInstanceTemplateLabelKey])
+				var sourceTargetPodName string
+				var err error
+				if targetPodName := claim.Labels[constant.KBAppPodNameLabelKey]; targetPodName != "" {
+					sourceTargetPodName, err = GetSourcePodNameForTargetPod(target,
+						prepareDataConfig.RequiredPolicyForAllPodSelection,
+						targetPodName,
+						claim.Labels[constant.KBAppInstanceTemplateLabelKey])
+				} else {
+					// Preserve positional selection for generic claims-template Restores
+					// that do not carry a KubeBlocks target Pod identity.
+					sourceTargetPodName, err = GetSourcePodNameFromTarget(target,
+						prepareDataConfig.RequiredPolicyForAllPodSelection, i)
+				}
 				if err != nil {
 					return err
 				}
@@ -552,12 +561,13 @@ func (r *RestoreManager) BuildPrepareDataJobs(reqCtx intctrlutil.RequestCtx, cli
 		}
 		var sourceTargetPodName string
 		var err error
-		if claimsTemplate == nil {
+		targetPodName := jobBuilder.labels[constant.KBAppPodNameLabelKey]
+		if claimsTemplate == nil || targetPodName == "" {
 			sourceTargetPodName, err = GetSourcePodNameFromTarget(target, prepareDataConfig.RequiredPolicyForAllPodSelection, i)
 		} else {
 			sourceTargetPodName, err = GetSourcePodNameForTargetPod(target,
 				prepareDataConfig.RequiredPolicyForAllPodSelection,
-				jobBuilder.labels[constant.KBAppPodNameLabelKey],
+				targetPodName,
 				jobBuilder.labels[constant.KBAppInstanceTemplateLabelKey])
 		}
 		if err != nil {

--- a/pkg/dataprotection/restore/manager.go
+++ b/pkg/dataprotection/restore/manager.go
@@ -385,11 +385,11 @@ func (r *RestoreManager) RestorePVCFromSnapshot(reqCtx intctrlutil.RequestCtx, c
 	if prepareDataConfig == nil {
 		return nil
 	}
-	createPVCWithSnapshot := func(claim dpv1alpha1.RestoreVolumeClaim) error {
+	createPVCWithSnapshot := func(claim dpv1alpha1.RestoreVolumeClaim, sourceIndex int) error {
 		if claim.VolumeSource == "" {
 			return intctrlutil.NewFatalError(fmt.Sprintf(`claim "%s"" volumeSource can not be empty if the backup uses volume snapshot`, claim.Name))
 		}
-		sourceTargetPodName, err := GetSourcePodNameFromTarget(target, prepareDataConfig.RequiredPolicyForAllPodSelection, 0)
+		sourceTargetPodName, err := GetSourcePodNameFromTarget(target, prepareDataConfig.RequiredPolicyForAllPodSelection, sourceIndex)
 		if err != nil {
 			return err
 		}
@@ -413,7 +413,7 @@ func (r *RestoreManager) RestorePVCFromSnapshot(reqCtx intctrlutil.RequestCtx, c
 		return r.createPVCIfNotExist(reqCtx, cli, claim.ObjectMeta, claim.VolumeClaimSpec)
 	}
 	for i := range prepareDataConfig.RestoreVolumeClaims {
-		if err := createPVCWithSnapshot(prepareDataConfig.RestoreVolumeClaims[i]); err != nil {
+		if err := createPVCWithSnapshot(prepareDataConfig.RestoreVolumeClaims[i], 0); err != nil {
 			return err
 		}
 	}
@@ -428,7 +428,7 @@ func (r *RestoreManager) RestorePVCFromSnapshot(reqCtx intctrlutil.RequestCtx, c
 				// HACK: add InstanceSet related labels to the PVC,
 				// so that it can be managed by InstanceSet
 				addItsManagingLabels(&claim, index)
-				if err := createPVCWithSnapshot(claim); err != nil {
+				if err := createPVCWithSnapshot(claim, index); err != nil {
 					return err
 				}
 			}
@@ -541,7 +541,11 @@ func (r *RestoreManager) BuildPrepareDataJobs(reqCtx intctrlutil.RequestCtx, cli
 				jobBuilder.addToSpecificVolumesAndMounts(volume, volumeMount)
 			}
 		}
-		sourceTargetPodName, err := GetSourcePodNameFromTarget(target, prepareDataConfig.RequiredPolicyForAllPodSelection, i)
+		sourceIndex := i
+		if claimsTemplate != nil {
+			sourceIndex += int(claimsTemplate.StartingIndex)
+		}
+		sourceTargetPodName, err := GetSourcePodNameFromTarget(target, prepareDataConfig.RequiredPolicyForAllPodSelection, sourceIndex)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/dataprotection/restore/manager_test.go
+++ b/pkg/dataprotection/restore/manager_test.go
@@ -257,18 +257,53 @@ var _ = Describe("RestoreManager Test", func() {
 
 		It("test with RestorePVCFromSnapshot function", func() {
 			reqCtx := getReqCtx()
-			startingIndex := 0
+			startingIndex := 1
 			useVolumeSnapshot := true
 			restoreMGR, backupSet := initResources(reqCtx, startingIndex, useVolumeSnapshot, func(f *testdp.MockRestoreFactory) {
 				f.SetVolumeClaimsTemplate(testdp.MysqlTemplateName, testdp.DataVolumeName,
-					testdp.DataVolumeMountPath, "", int32(replicas), int32(startingIndex), nil)
+					testdp.DataVolumeMountPath, "", int32(replicas), int32(startingIndex), nil).
+					SetPrepareDataRequiredPolicy(dpv1alpha1.OneToOneRestorePolicy, "")
 			})
+			backupSet.Backup.Status.Target.PodSelector.Strategy = dpv1alpha1.PodSelectionStrategyAll
+			backupSet.Backup.Status.Target.SelectedTargetPods = []string{"pod-0", "pod-1", "pod-2"}
+			backupSet.Backup.Status.Actions = []dpv1alpha1.ActionStatus{
+				{
+					TargetPodName: "pod-0",
+					VolumeSnapshots: []dpv1alpha1.VolumeSnapshotStatus{{
+						Name:       "snapshot-0",
+						VolumeName: testdp.DataVolumeName,
+					}},
+				},
+				{
+					TargetPodName: "pod-1",
+					VolumeSnapshots: []dpv1alpha1.VolumeSnapshotStatus{{
+						Name:       "snapshot-1",
+						VolumeName: testdp.DataVolumeName,
+					}},
+				},
+				{
+					TargetPodName: "pod-2",
+					VolumeSnapshots: []dpv1alpha1.VolumeSnapshotStatus{{
+						Name:       "snapshot-2",
+						VolumeName: testdp.DataVolumeName,
+					}},
+				},
+			}
 
 			By("test RestorePVCFromSnapshot function")
 			target := utils.GetBackupStatusTarget(backupSet.Backup, restoreMGR.Restore.Spec.Backup.SourceTargetName)
 			Expect(restoreMGR.RestorePVCFromSnapshot(reqCtx, k8sClient, *backupSet, target)).Should(Succeed())
 
 			checkPVC(startingIndex, useVolumeSnapshot, "restore")
+			for i := 0; i < replicas; i++ {
+				pvc := &corev1.PersistentVolumeClaim{}
+				Expect(k8sClient.Get(ctx, client.ObjectKey{
+					Namespace: testCtx.DefaultNamespace,
+					Name:      fmt.Sprintf("%s-%d", testdp.MysqlTemplateName, startingIndex+i),
+				}, pvc)).Should(Succeed())
+				Expect(pvc.Spec.DataSource).ShouldNot(BeNil())
+				Expect(pvc.Spec.DataSource.Name).Should(Equal(fmt.Sprintf("snapshot-%d", startingIndex+i)))
+			}
 		})
 
 		It("test with BuildPrepareDataJobs function and Parallel volumeRestorePolicy", func() {
@@ -278,8 +313,11 @@ var _ = Describe("RestoreManager Test", func() {
 				f.SetVolumeClaimsTemplate(testdp.MysqlTemplateName, testdp.DataVolumeName,
 					testdp.DataVolumeMountPath, "", int32(replicas), int32(startingIndex), map[string]string{
 						constant.AppInstanceLabelKey: instanceName,
-					})
+					}).SetPrepareDataRequiredPolicy(dpv1alpha1.OneToOneRestorePolicy, "")
 			})
+			backupSet.Backup.Status.Path = "/repo/test/backup"
+			backupSet.Backup.Status.Target.PodSelector.Strategy = dpv1alpha1.PodSelectionStrategyAll
+			backupSet.Backup.Status.Target.SelectedTargetPods = []string{"pod-0", "pod-1", "pod-2"}
 
 			By(fmt.Sprintf("test BuildPrepareDataJobs function, expect for %d jobs", replicas))
 			actionSetName := "preparedata-0"
@@ -291,6 +329,10 @@ var _ = Describe("RestoreManager Test", func() {
 			Expect(len(jobs)).Should(Equal(replicas))
 			// image should be expanded by env
 			Expect(jobs[0].Spec.Template.Spec.Containers[0].Image).Should(ContainSubstring(testdp.ImageTag))
+			for i := 0; i < replicas; i++ {
+				env := utils.CovertEnvToMap(jobs[i].Spec.Template.Spec.Containers[0].Env)
+				Expect(env[dptypes.DPTargetRelativePath]).Should(Equal(fmt.Sprintf("pod-%d", startingIndex+i)))
+			}
 
 			checkPVC(startingIndex, false, "restore")
 		})

--- a/pkg/dataprotection/restore/manager_test.go
+++ b/pkg/dataprotection/restore/manager_test.go
@@ -271,6 +271,8 @@ var _ = Describe("RestoreManager Test", func() {
 					SetPrepareDataRequiredPolicy(dpv1alpha1.OneToOneRestorePolicy, "")
 			})
 			backupSet.Backup.Status.Target.PodSelector.Strategy = dpv1alpha1.PodSelectionStrategyAll
+			backupSet.Backup.Status.Target.PodSelector.MatchLabels[constant.AppInstanceLabelKey] = "source"
+			backupSet.Backup.Status.Target.PodSelector.MatchLabels[constant.KBAppComponentLabelKey] = cmpName
 			backupSet.Backup.Status.Target.SelectedTargetPods = []string{"source-mysql-az-a-4", "source-mysql-az-a-3"}
 			backupSet.Backup.Status.Actions = []dpv1alpha1.ActionStatus{
 				{
@@ -318,6 +320,8 @@ var _ = Describe("RestoreManager Test", func() {
 			})
 			backupSet.Backup.Status.Path = "/repo/test/backup"
 			backupSet.Backup.Status.Target.PodSelector.Strategy = dpv1alpha1.PodSelectionStrategyAll
+			backupSet.Backup.Status.Target.PodSelector.MatchLabels[constant.AppInstanceLabelKey] = "source"
+			backupSet.Backup.Status.Target.PodSelector.MatchLabels[constant.KBAppComponentLabelKey] = cmpName
 			backupSet.Backup.Status.Target.SelectedTargetPods = []string{"source-mysql-4", "source-mysql-3"}
 
 			By(fmt.Sprintf("test BuildPrepareDataJobs function, expect for %d jobs", replicas))
@@ -353,6 +357,8 @@ var _ = Describe("RestoreManager Test", func() {
 			})
 			backupSet.Backup.Status.Path = "/repo/test/backup"
 			backupSet.Backup.Status.Target.PodSelector.Strategy = dpv1alpha1.PodSelectionStrategyAll
+			backupSet.Backup.Status.Target.PodSelector.MatchLabels[constant.AppInstanceLabelKey] = "source"
+			backupSet.Backup.Status.Target.PodSelector.MatchLabels[constant.KBAppComponentLabelKey] = cmpName
 			backupSet.Backup.Status.Target.SelectedTargetPods = []string{
 				"source-mysql-other-301",
 				"source-mysql-abc-301",

--- a/pkg/dataprotection/restore/manager_test.go
+++ b/pkg/dataprotection/restore/manager_test.go
@@ -257,34 +257,33 @@ var _ = Describe("RestoreManager Test", func() {
 
 		It("test with RestorePVCFromSnapshot function", func() {
 			reqCtx := getReqCtx()
-			startingIndex := 1
+			startingIndex := 3
+			templateName := "az-a"
+			cmpName := "mysql"
 			useVolumeSnapshot := true
 			restoreMGR, backupSet := initResources(reqCtx, startingIndex, useVolumeSnapshot, func(f *testdp.MockRestoreFactory) {
 				f.SetVolumeClaimsTemplate(testdp.MysqlTemplateName, testdp.DataVolumeName,
-					testdp.DataVolumeMountPath, "", int32(replicas), int32(startingIndex), nil).
+					testdp.DataVolumeMountPath, "", int32(replicas), int32(startingIndex), map[string]string{
+						constant.AppInstanceLabelKey:           instanceName,
+						constant.KBAppComponentLabelKey:        cmpName,
+						constant.KBAppInstanceTemplateLabelKey: templateName,
+					}).
 					SetPrepareDataRequiredPolicy(dpv1alpha1.OneToOneRestorePolicy, "")
 			})
 			backupSet.Backup.Status.Target.PodSelector.Strategy = dpv1alpha1.PodSelectionStrategyAll
-			backupSet.Backup.Status.Target.SelectedTargetPods = []string{"pod-0", "pod-1", "pod-2"}
+			backupSet.Backup.Status.Target.SelectedTargetPods = []string{"source-mysql-az-a-4", "source-mysql-az-a-3"}
 			backupSet.Backup.Status.Actions = []dpv1alpha1.ActionStatus{
 				{
-					TargetPodName: "pod-0",
+					TargetPodName: "source-mysql-az-a-4",
 					VolumeSnapshots: []dpv1alpha1.VolumeSnapshotStatus{{
-						Name:       "snapshot-0",
+						Name:       "snapshot-4",
 						VolumeName: testdp.DataVolumeName,
 					}},
 				},
 				{
-					TargetPodName: "pod-1",
+					TargetPodName: "source-mysql-az-a-3",
 					VolumeSnapshots: []dpv1alpha1.VolumeSnapshotStatus{{
-						Name:       "snapshot-1",
-						VolumeName: testdp.DataVolumeName,
-					}},
-				},
-				{
-					TargetPodName: "pod-2",
-					VolumeSnapshots: []dpv1alpha1.VolumeSnapshotStatus{{
-						Name:       "snapshot-2",
+						Name:       "snapshot-3",
 						VolumeName: testdp.DataVolumeName,
 					}},
 				},
@@ -294,7 +293,7 @@ var _ = Describe("RestoreManager Test", func() {
 			target := utils.GetBackupStatusTarget(backupSet.Backup, restoreMGR.Restore.Spec.Backup.SourceTargetName)
 			Expect(restoreMGR.RestorePVCFromSnapshot(reqCtx, k8sClient, *backupSet, target)).Should(Succeed())
 
-			checkPVC(startingIndex, useVolumeSnapshot, "restore")
+			checkPVC(startingIndex, useVolumeSnapshot, constant.AppName)
 			for i := 0; i < replicas; i++ {
 				pvc := &corev1.PersistentVolumeClaim{}
 				Expect(k8sClient.Get(ctx, client.ObjectKey{
@@ -308,16 +307,18 @@ var _ = Describe("RestoreManager Test", func() {
 
 		It("test with BuildPrepareDataJobs function and Parallel volumeRestorePolicy", func() {
 			reqCtx := getReqCtx()
-			startingIndex := 1
+			startingIndex := 3
+			cmpName := "mysql"
 			restoreMGR, backupSet := initResources(reqCtx, startingIndex, false, func(f *testdp.MockRestoreFactory) {
 				f.SetVolumeClaimsTemplate(testdp.MysqlTemplateName, testdp.DataVolumeName,
 					testdp.DataVolumeMountPath, "", int32(replicas), int32(startingIndex), map[string]string{
-						constant.AppInstanceLabelKey: instanceName,
+						constant.AppInstanceLabelKey:    instanceName,
+						constant.KBAppComponentLabelKey: cmpName,
 					}).SetPrepareDataRequiredPolicy(dpv1alpha1.OneToOneRestorePolicy, "")
 			})
 			backupSet.Backup.Status.Path = "/repo/test/backup"
 			backupSet.Backup.Status.Target.PodSelector.Strategy = dpv1alpha1.PodSelectionStrategyAll
-			backupSet.Backup.Status.Target.SelectedTargetPods = []string{"pod-0", "pod-1", "pod-2"}
+			backupSet.Backup.Status.Target.SelectedTargetPods = []string{"source-mysql-4", "source-mysql-3"}
 
 			By(fmt.Sprintf("test BuildPrepareDataJobs function, expect for %d jobs", replicas))
 			actionSetName := "preparedata-0"
@@ -331,10 +332,10 @@ var _ = Describe("RestoreManager Test", func() {
 			Expect(jobs[0].Spec.Template.Spec.Containers[0].Image).Should(ContainSubstring(testdp.ImageTag))
 			for i := 0; i < replicas; i++ {
 				env := utils.CovertEnvToMap(jobs[i].Spec.Template.Spec.Containers[0].Env)
-				Expect(env[dptypes.DPTargetRelativePath]).Should(Equal(fmt.Sprintf("pod-%d", startingIndex+i)))
+				Expect(env[dptypes.DPTargetRelativePath]).Should(Equal(fmt.Sprintf("source-mysql-%d", startingIndex+i)))
 			}
 
-			checkPVC(startingIndex, false, "restore")
+			checkPVC(startingIndex, false, constant.AppName)
 		})
 
 		It("test with BuildPrepareDataJobs function with InstanceTemplates claims", func() {
@@ -348,8 +349,16 @@ var _ = Describe("RestoreManager Test", func() {
 						constant.AppInstanceLabelKey:           instanceName,
 						constant.KBAppComponentLabelKey:        cmpName,
 						constant.KBAppInstanceTemplateLabelKey: templateName,
-					})
+					}).SetPrepareDataRequiredPolicy(dpv1alpha1.OneToOneRestorePolicy, "")
 			})
+			backupSet.Backup.Status.Path = "/repo/test/backup"
+			backupSet.Backup.Status.Target.PodSelector.Strategy = dpv1alpha1.PodSelectionStrategyAll
+			backupSet.Backup.Status.Target.SelectedTargetPods = []string{
+				"source-mysql-other-301",
+				"source-mysql-abc-301",
+				"source-mysql-other-300",
+				"source-mysql-abc-300",
+			}
 			By(fmt.Sprintf("test BuildPrepareDataJobs function, expect job label pod name contains template '%s' and ordinal correct", templateName))
 			actionSetName := "preparedata-0"
 			target := utils.GetBackupStatusTarget(backupSet.Backup, restoreMGR.Restore.Spec.Backup.SourceTargetName)
@@ -359,6 +368,8 @@ var _ = Describe("RestoreManager Test", func() {
 			// job label contains pod name and ordinal match
 			for i := 0; i < replicas; i++ {
 				Expect(jobs[i].Spec.Template.Labels[constant.KBAppPodNameLabelKey]).Should(Equal(fmt.Sprintf("%s-%s-%s-%d", instanceName, cmpName, templateName, startingIndex+i)))
+				env := utils.CovertEnvToMap(jobs[i].Spec.Template.Spec.Containers[0].Env)
+				Expect(env[dptypes.DPTargetRelativePath]).Should(Equal(fmt.Sprintf("source-mysql-%s-%d", templateName, startingIndex+i)))
 			}
 
 			checkPVC(startingIndex, false, constant.AppName)

--- a/pkg/dataprotection/restore/utils.go
+++ b/pkg/dataprotection/restore/utils.go
@@ -336,6 +336,67 @@ func GetSourcePodNameFromTarget(target *dpv1alpha1.BackupStatusTarget,
 	return target.SelectedTargetPods[index], nil
 }
 
+// GetSourcePodNameForTargetPod gets the source pod for a concrete target pod.
+// SelectedTargetPods is an unordered list, so OneToOne restore must match pod
+// identity instead of treating the target pod ordinal as a slice index.
+func GetSourcePodNameForTargetPod(target *dpv1alpha1.BackupStatusTarget,
+	requiredPolicy *dpv1alpha1.RequiredPolicyForAllPodSelection,
+	targetPodName, instanceTemplateName string) (string, error) {
+	if target.PodSelector.Strategy == dpv1alpha1.PodSelectionStrategyAny {
+		return "", nil
+	}
+	if requiredPolicy == nil {
+		return "", intctrlutil.NewFatalError("requiredPolicyForAllPodSelection can not be empty when the pod selection strategy of the source target is All")
+	}
+	if requiredPolicy.DataRestorePolicy == dpv1alpha1.OneToManyRestorePolicy {
+		if requiredPolicy.SourceOfOneToMany == nil || requiredPolicy.SourceOfOneToMany.TargetPodName == "" {
+			return "", intctrlutil.NewFatalError("the source target pod can not be empty when restore policy is OneToMany")
+		}
+		return requiredPolicy.SourceOfOneToMany.TargetPodName, nil
+	}
+	if targetPodName == "" {
+		return "", intctrlutil.NewFatalError("target pod name can not be empty when restore policy is OneToOne")
+	}
+	if slices.Contains(target.SelectedTargetPods, targetPodName) {
+		return targetPodName, nil
+	}
+
+	targetOrdinal, ok := podOrdinal(targetPodName)
+	if !ok {
+		return "", intctrlutil.NewFatalError(fmt.Sprintf("source target pod can not be inferred from target pod %q", targetPodName))
+	}
+	var candidates []string
+	for _, sourcePodName := range target.SelectedTargetPods {
+		sourceOrdinal, ok := podOrdinal(sourcePodName)
+		if !ok || sourceOrdinal != targetOrdinal {
+			continue
+		}
+		if instanceTemplateName != "" {
+			sourceParent := sourcePodName[:strings.LastIndex(sourcePodName, "-")]
+			if !strings.HasSuffix(sourceParent, "-"+instanceTemplateName) {
+				continue
+			}
+		}
+		candidates = append(candidates, sourcePodName)
+	}
+	if len(candidates) == 1 {
+		return candidates[0], nil
+	}
+	if len(candidates) > 1 {
+		return "", intctrlutil.NewFatalError(fmt.Sprintf("multiple selected source target pods match target pod %q and instance template %q: %v", targetPodName, instanceTemplateName, candidates))
+	}
+	return "", intctrlutil.NewFatalError(fmt.Sprintf("no selected source target pod matches target pod %q and instance template %q", targetPodName, instanceTemplateName))
+}
+
+func podOrdinal(podName string) (int, bool) {
+	index := strings.LastIndex(podName, "-")
+	if index < 0 || index == len(podName)-1 {
+		return 0, false
+	}
+	ordinal, err := strconv.Atoi(podName[index+1:])
+	return ordinal, err == nil
+}
+
 // GetVolumeSnapshotsBySourcePod gets the volume snapshots of the backup and group by source target pod.
 func GetVolumeSnapshotsBySourcePod(backup *dpv1alpha1.Backup, target *dpv1alpha1.BackupStatusTarget, sourcePodName string) map[string]string {
 	actions := backup.Status.Actions

--- a/pkg/dataprotection/restore/utils.go
+++ b/pkg/dataprotection/restore/utils.go
@@ -37,6 +37,7 @@ import (
 
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/instancetemplate"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 	"github.com/apecloud/kubeblocks/pkg/dataprotection/utils"
@@ -365,15 +366,20 @@ func GetSourcePodNameForTargetPod(target *dpv1alpha1.BackupStatusTarget,
 	if !ok {
 		return "", intctrlutil.NewFatalError(fmt.Sprintf("source target pod can not be inferred from target pod %q", targetPodName))
 	}
+	sourceWorkloadName := backupTargetWorkloadName(target)
+	if sourceWorkloadName == "" && instanceTemplateName != "" {
+		return "", intctrlutil.NewFatalError(fmt.Sprintf("source workload identity is required to match instance template %q", instanceTemplateName))
+	}
 	var candidates []string
 	for _, sourcePodName := range target.SelectedTargetPods {
-		sourceOrdinal, ok := podOrdinal(sourcePodName)
-		if !ok || sourceOrdinal != targetOrdinal {
-			continue
-		}
-		if instanceTemplateName != "" {
-			sourceParent := sourcePodName[:strings.LastIndex(sourcePodName, "-")]
-			if !strings.HasSuffix(sourceParent, "-"+instanceTemplateName) {
+		if sourceWorkloadName != "" {
+			sourceTemplateName, sourceOrdinal, err := instancetemplate.GetTemplateNameAndOrdinal(sourceWorkloadName, sourcePodName)
+			if err != nil || int(sourceOrdinal) != targetOrdinal || sourceTemplateName != instanceTemplateName {
+				continue
+			}
+		} else {
+			sourceOrdinal, ok := podOrdinal(sourcePodName)
+			if !ok || sourceOrdinal != targetOrdinal {
 				continue
 			}
 		}
@@ -386,6 +392,18 @@ func GetSourcePodNameForTargetPod(target *dpv1alpha1.BackupStatusTarget,
 		return "", intctrlutil.NewFatalError(fmt.Sprintf("multiple selected source target pods match target pod %q and instance template %q: %v", targetPodName, instanceTemplateName, candidates))
 	}
 	return "", intctrlutil.NewFatalError(fmt.Sprintf("no selected source target pod matches target pod %q and instance template %q", targetPodName, instanceTemplateName))
+}
+
+func backupTargetWorkloadName(target *dpv1alpha1.BackupStatusTarget) string {
+	if target == nil || target.PodSelector == nil || target.PodSelector.LabelSelector == nil {
+		return ""
+	}
+	clusterName := target.PodSelector.MatchLabels[constant.AppInstanceLabelKey]
+	componentName := target.PodSelector.MatchLabels[constant.KBAppComponentLabelKey]
+	if clusterName == "" || componentName == "" {
+		return ""
+	}
+	return constant.GenerateWorkloadNamePattern(clusterName, componentName)
 }
 
 func podOrdinal(podName string) (int, bool) {

--- a/pkg/dataprotection/restore/utils_test.go
+++ b/pkg/dataprotection/restore/utils_test.go
@@ -213,6 +213,48 @@ func TestRestoreSourcePodAndSnapshotHelpers(t *testing.T) {
 	assert.Nil(t, GetVolumeSnapshotsBySourcePod(backup, target, "missing"))
 }
 
+func TestGetSourcePodNameForTargetPod(t *testing.T) {
+	target := &dpv1alpha1.BackupStatusTarget{
+		BackupTarget: dpv1alpha1.BackupTarget{
+			PodSelector: &dpv1alpha1.PodSelector{Strategy: dpv1alpha1.PodSelectionStrategyAll},
+		},
+	}
+	policy := &dpv1alpha1.RequiredPolicyForAllPodSelection{DataRestorePolicy: dpv1alpha1.OneToOneRestorePolicy}
+
+	t.Run("matches an instance template pod without depending on list order", func(t *testing.T) {
+		target.SelectedTargetPods = []string{"source-redis-az-a-4", "source-redis-az-a-3"}
+		podName, err := GetSourcePodNameForTargetPod(target, policy, "target-redis-az-a-3", "az-a")
+		assert.NoError(t, err)
+		assert.Equal(t, "source-redis-az-a-3", podName)
+	})
+
+	t.Run("uses the instance template to disambiguate a shared ordinal", func(t *testing.T) {
+		target.SelectedTargetPods = []string{"source-redis-az-b-3", "source-redis-az-a-3"}
+		podName, err := GetSourcePodNameForTargetPod(target, policy, "target-redis-az-a-3", "az-a")
+		assert.NoError(t, err)
+		assert.Equal(t, "source-redis-az-a-3", podName)
+	})
+
+	t.Run("matches a flat ordinal with holes", func(t *testing.T) {
+		target.SelectedTargetPods = []string{"source-redis-7", "source-redis-2"}
+		podName, err := GetSourcePodNameForTargetPod(target, policy, "target-redis-7", "")
+		assert.NoError(t, err)
+		assert.Equal(t, "source-redis-7", podName)
+	})
+
+	t.Run("rejects an ambiguous flat ordinal", func(t *testing.T) {
+		target.SelectedTargetPods = []string{"source-redis-az-a-3", "source-redis-az-b-3"}
+		_, err := GetSourcePodNameForTargetPod(target, policy, "target-redis-3", "")
+		assert.ErrorContains(t, err, "multiple selected source target pods")
+	})
+
+	t.Run("rejects a missing identity", func(t *testing.T) {
+		target.SelectedTargetPods = []string{"source-redis-az-a-4"}
+		_, err := GetSourcePodNameForTargetPod(target, policy, "target-redis-az-a-3", "az-a")
+		assert.ErrorContains(t, err, "no selected source target pod matches")
+	})
+}
+
 func TestValidateParentBackupSet(t *testing.T) {
 	now := metav1.NewTime(time.Now())
 	later := metav1.NewTime(now.Add(time.Hour))

--- a/pkg/dataprotection/restore/utils_test.go
+++ b/pkg/dataprotection/restore/utils_test.go
@@ -216,7 +216,13 @@ func TestRestoreSourcePodAndSnapshotHelpers(t *testing.T) {
 func TestGetSourcePodNameForTargetPod(t *testing.T) {
 	target := &dpv1alpha1.BackupStatusTarget{
 		BackupTarget: dpv1alpha1.BackupTarget{
-			PodSelector: &dpv1alpha1.PodSelector{Strategy: dpv1alpha1.PodSelectionStrategyAll},
+			PodSelector: &dpv1alpha1.PodSelector{
+				LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+					constant.AppInstanceLabelKey:    "source",
+					constant.KBAppComponentLabelKey: "redis",
+				}},
+				Strategy: dpv1alpha1.PodSelectionStrategyAll,
+			},
 		},
 	}
 	policy := &dpv1alpha1.RequiredPolicyForAllPodSelection{DataRestorePolicy: dpv1alpha1.OneToOneRestorePolicy}
@@ -235,6 +241,21 @@ func TestGetSourcePodNameForTargetPod(t *testing.T) {
 		assert.Equal(t, "source-redis-az-a-3", podName)
 	})
 
+	t.Run("matches the exact template instead of a template-name suffix", func(t *testing.T) {
+		target.SelectedTargetPods = []string{"source-redis-b-a-3", "source-redis-a-3"}
+		podName, err := GetSourcePodNameForTargetPod(target, policy, "target-redis-a-3", "a")
+		assert.NoError(t, err)
+		assert.Equal(t, "source-redis-a-3", podName)
+	})
+
+	t.Run("does not treat a flat workload suffix as a template", func(t *testing.T) {
+		target.PodSelector.MatchLabels[constant.KBAppComponentLabelKey] = "redis-a"
+		target.SelectedTargetPods = []string{"source-redis-a-3"}
+		_, err := GetSourcePodNameForTargetPod(target, policy, "target-redis-a-3", "a")
+		assert.ErrorContains(t, err, "no selected source target pod matches")
+		target.PodSelector.MatchLabels[constant.KBAppComponentLabelKey] = "redis"
+	})
+
 	t.Run("matches a flat ordinal with holes", func(t *testing.T) {
 		target.SelectedTargetPods = []string{"source-redis-7", "source-redis-2"}
 		podName, err := GetSourcePodNameForTargetPod(target, policy, "target-redis-7", "")
@@ -243,6 +264,9 @@ func TestGetSourcePodNameForTargetPod(t *testing.T) {
 	})
 
 	t.Run("rejects an ambiguous flat ordinal", func(t *testing.T) {
+		labelSelector := target.PodSelector.LabelSelector
+		target.PodSelector.LabelSelector = nil
+		defer func() { target.PodSelector.LabelSelector = labelSelector }()
 		target.SelectedTargetPods = []string{"source-redis-az-a-3", "source-redis-az-b-3"}
 		_, err := GetSourcePodNameForTargetPod(target, policy, "target-redis-3", "")
 		assert.ErrorContains(t, err, "multiple selected source target pods")

--- a/pkg/operations/horizontal_scaling.go
+++ b/pkg/operations/horizontal_scaling.go
@@ -229,7 +229,7 @@ func (hs horizontalScalingOpsHandler) createRestore(reqCtx intctrlutil.RequestCt
 		return intctrlutil.NewFatalError(fmt.Sprintf("scale-out from backup %s/%s is not supported because it has multiple source targets", backupObj.Namespace, backupObj.Name))
 	}
 	// create restore
-	restore, err := restoreMGR.BuildPrepareDataRestore(synthesizedComponent, backupObj, getTemplate(templateName))
+	restore, err := restoreMGR.BuildPrepareDataRestoreForPod(synthesizedComponent, backupObj, getTemplate(templateName))
 	if err != nil {
 		if intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeRestoreFailed) {
 			return intctrlutil.NewFatalError(err.Error())

--- a/pkg/operations/horizontal_scaling_test.go
+++ b/pkg/operations/horizontal_scaling_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -46,6 +47,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
 	"github.com/apecloud/kubeblocks/pkg/controller/plan"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+	dprestore "github.com/apecloud/kubeblocks/pkg/dataprotection/restore"
 	"github.com/apecloud/kubeblocks/pkg/generics"
 	opsutil "github.com/apecloud/kubeblocks/pkg/operations/util"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
@@ -987,6 +989,102 @@ func createHorizontalScaling(clusterName string, horizontalScaling opsv1alpha1.H
 	opsRequest := testops.CreateOpsRequest(ctx, testCtx, ops)
 	opsRequest.Status.Phase = opsv1alpha1.OpsPendingPhase
 	return opsRequest
+}
+
+func TestHorizontalScalingCreateRestorePreservesPerPodStartingIndex(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	for _, addToScheme := range []func(*runtime.Scheme) error{
+		corev1.AddToScheme,
+		appsv1.AddToScheme,
+		dpv1alpha1.AddToScheme,
+		opsv1alpha1.AddToScheme,
+	} {
+		if err := addToScheme(scheme); err != nil {
+			t.Fatalf("add scheme: %v", err)
+		}
+	}
+
+	cluster := &appsv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "redis", Namespace: "default", UID: types.UID("cluster1")},
+	}
+	opsRequest := &opsv1alpha1.OpsRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "scale-out-from-backup", Namespace: "default", UID: types.UID("opsreq1")},
+	}
+	backup := &dpv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: "redis-backup", Namespace: "default"},
+		Status: dpv1alpha1.BackupStatus{
+			Phase: dpv1alpha1.BackupPhaseCompleted,
+			BackupMethod: &dpv1alpha1.BackupMethod{
+				Name:          "snapshot",
+				TargetVolumes: &dpv1alpha1.TargetVolumeInfo{Volumes: []string{"data"}},
+			},
+			Targets: []dpv1alpha1.BackupStatusTarget{{
+				BackupTarget: dpv1alpha1.BackupTarget{
+					Name:        "redis",
+					PodSelector: &dpv1alpha1.PodSelector{Strategy: dpv1alpha1.PodSelectionStrategyAll},
+				},
+				SelectedTargetPods: []string{"redis-0", "redis-1", "redis-2", "redis-3", "redis-4"},
+			}},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster, opsRequest, backup).Build()
+	opsRes := &OpsResource{Cluster: cluster, OpsRequest: opsRequest}
+	synthesizedComponent := &component.SynthesizedComponent{
+		Name: "redis",
+		VolumeClaimTemplates: []corev1.PersistentVolumeClaimTemplate{{
+			ObjectMeta: metav1.ObjectMeta{Name: "data"},
+		}},
+	}
+	componentSpec := &appsv1.ClusterComponentSpec{
+		Name: "redis",
+		Instances: []appsv1.InstanceTemplate{{
+			Name: "az-a",
+			Ordinals: appsv1.Ordinals{
+				Ranges: []appsv1.Range{{Start: 3, End: 4}},
+			},
+		}},
+	}
+	for _, ordinal := range []int32{3, 4} {
+		restoreMGR := plan.NewRestoreManager(ctx, cli, cluster, scheme, map[string]string{
+			constant.OpsRequestNameLabelKey: opsRequest.Name,
+		}, 1, ordinal)
+		err := horizontalScalingOpsHandler{}.createRestore(
+			intctrlutil.RequestCtx{Ctx: ctx, Recorder: record.NewFakeRecorder(1)},
+			cli, opsRes, synthesizedComponent, restoreMGR, componentSpec, backup, "az-a")
+		if err != nil {
+			t.Fatalf("create restore for ordinal %d: %v", ordinal, err)
+		}
+	}
+
+	restoreList := &dpv1alpha1.RestoreList{}
+	if err := cli.List(ctx, restoreList, client.InNamespace("default")); err != nil {
+		t.Fatalf("list restores: %v", err)
+	}
+	if len(restoreList.Items) != 2 {
+		t.Fatalf("expected two restores, got %d", len(restoreList.Items))
+	}
+	restoresByOrdinal := map[int32]dpv1alpha1.Restore{}
+	for i := range restoreList.Items {
+		restore := restoreList.Items[i]
+		startingIndex := restore.Spec.PrepareDataConfig.RestoreVolumeClaimsTemplate.StartingIndex
+		restoresByOrdinal[startingIndex] = restore
+	}
+	for _, ordinal := range []int32{3, 4} {
+		restore, ok := restoresByOrdinal[ordinal]
+		if !ok {
+			t.Fatalf("missing restore for actual scale-out pod ordinal %d", ordinal)
+		}
+		requiredPolicy := restore.Spec.PrepareDataConfig.RequiredPolicyForAllPodSelection
+		sourcePod, err := dprestore.GetSourcePodNameFromTarget(&backup.Status.Targets[0], requiredPolicy, int(ordinal))
+		if err != nil {
+			t.Fatalf("resolve source pod for ordinal %d: %v", ordinal, err)
+		}
+		expectedSourcePod := fmt.Sprintf("redis-%d", ordinal)
+		if sourcePod != expectedSourcePod {
+			t.Fatalf("source pod = %q, want %q for actual scale-out pod ordinal %d", sourcePod, expectedSourcePod, ordinal)
+		}
+	}
 }
 
 func cancelOpsRequest(reqCtx intctrlutil.RequestCtx, opsRes *OpsResource, cancelTime time.Time) {

--- a/pkg/operations/horizontal_scaling_test.go
+++ b/pkg/operations/horizontal_scaling_test.go
@@ -47,7 +47,6 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
 	"github.com/apecloud/kubeblocks/pkg/controller/plan"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
-	dprestore "github.com/apecloud/kubeblocks/pkg/dataprotection/restore"
 	"github.com/apecloud/kubeblocks/pkg/generics"
 	opsutil "github.com/apecloud/kubeblocks/pkg/operations/util"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
@@ -1024,7 +1023,7 @@ func TestHorizontalScalingCreateRestorePreservesPerPodStartingIndex(t *testing.T
 					Name:        "redis",
 					PodSelector: &dpv1alpha1.PodSelector{Strategy: dpv1alpha1.PodSelectionStrategyAll},
 				},
-				SelectedTargetPods: []string{"redis-0", "redis-1", "redis-2", "redis-3", "redis-4"},
+				SelectedTargetPods: []string{"redis-az-a-4", "redis-az-a-3"},
 			}},
 		},
 	}
@@ -1075,14 +1074,12 @@ func TestHorizontalScalingCreateRestorePreservesPerPodStartingIndex(t *testing.T
 		if !ok {
 			t.Fatalf("missing restore for actual scale-out pod ordinal %d", ordinal)
 		}
-		requiredPolicy := restore.Spec.PrepareDataConfig.RequiredPolicyForAllPodSelection
-		sourcePod, err := dprestore.GetSourcePodNameFromTarget(&backup.Status.Targets[0], requiredPolicy, int(ordinal))
-		if err != nil {
-			t.Fatalf("resolve source pod for ordinal %d: %v", ordinal, err)
+		claimTemplate := restore.Spec.PrepareDataConfig.RestoreVolumeClaimsTemplate
+		if claimTemplate.Replicas != 1 {
+			t.Fatalf("restore replicas = %d, want 1 for ordinal %d", claimTemplate.Replicas, ordinal)
 		}
-		expectedSourcePod := fmt.Sprintf("redis-%d", ordinal)
-		if sourcePod != expectedSourcePod {
-			t.Fatalf("source pod = %q, want %q for actual scale-out pod ordinal %d", sourcePod, expectedSourcePod, ordinal)
+		if got := claimTemplate.Templates[0].Labels[constant.KBAppInstanceTemplateLabelKey]; got != "az-a" {
+			t.Fatalf("instance template label = %q, want %q for ordinal %d", got, "az-a", ordinal)
 		}
 	}
 }

--- a/pkg/operations/rebuild_instance_inplace.go
+++ b/pkg/operations/rebuild_instance_inplace.go
@@ -21,7 +21,6 @@ package operations
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -40,6 +39,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/builder"
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/instanceset"
+	"github.com/apecloud/kubeblocks/pkg/controller/instancetemplate"
 	"github.com/apecloud/kubeblocks/pkg/controller/plan"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	dputils "github.com/apecloud/kubeblocks/pkg/dataprotection/utils"
@@ -741,7 +741,7 @@ func getPVCMapAndVolumes(opsRes *OpsResource,
 	}
 	// backup's ready, then start to check restore
 	workloadName := constant.GenerateWorkloadNamePattern(opsRes.Cluster.Name, synthesizedComp.Name)
-	templateName, _, err := getTemplateNameAndOrdinal(workloadName, targetPod.Name)
+	templateName, _, err := instancetemplate.GetTemplateNameAndOrdinal(workloadName, targetPod.Name)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -823,25 +823,4 @@ func instanceIsAvailable(
 		return true, nil
 	}
 	return false, nil
-}
-
-func getTemplateNameAndOrdinal(workloadName, podName string) (string, int32, error) {
-	podSuffix := strings.Replace(podName, workloadName+"-", "", 1)
-	lastDashIndex := strings.LastIndex(podSuffix, "-")
-	if lastDashIndex == len(podSuffix)-1 {
-		return "", 0, fmt.Errorf("no pod ordinal found after the last dash")
-	}
-	templateName := ""
-	indexStr := ""
-	if lastDashIndex == -1 {
-		indexStr = podSuffix
-	} else {
-		templateName = podSuffix[0:lastDashIndex]
-		indexStr = podSuffix[lastDashIndex+1:]
-	}
-	index, err := strconv.ParseInt(indexStr, 10, 32)
-	if err != nil {
-		return "", 0, fmt.Errorf("failed to obtain pod ordinal")
-	}
-	return templateName, int32(index), nil
 }

--- a/pkg/operations/rebuild_instance_test.go
+++ b/pkg/operations/rebuild_instance_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/instanceset"
+	"github.com/apecloud/kubeblocks/pkg/controller/instancetemplate"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 	"github.com/apecloud/kubeblocks/pkg/generics"
@@ -293,17 +294,17 @@ var _ = Describe("OpsUtil functions", func() {
 			Expect(volumes).Should(BeEmpty())
 			Expect(volumeMounts).Should(BeEmpty())
 
-			templateName, ordinal, err := getTemplateNameAndOrdinal(constant.GenerateWorkloadNamePattern(clusterName, defaultCompName), targetPod.Name)
+			templateName, ordinal, err := instancetemplate.GetTemplateNameAndOrdinal(constant.GenerateWorkloadNamePattern(clusterName, defaultCompName), targetPod.Name)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(templateName).Should(BeEmpty())
 			Expect(ordinal).Should(Equal(int32(0)))
-			templateName, ordinal, err = getTemplateNameAndOrdinal("cluster-comp", "cluster-comp-template-3")
+			templateName, ordinal, err = instancetemplate.GetTemplateNameAndOrdinal("cluster-comp", "cluster-comp-template-3")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(templateName).Should(Equal("template"))
 			Expect(ordinal).Should(Equal(int32(3)))
-			_, _, err = getTemplateNameAndOrdinal("cluster-comp", "cluster-comp-template-")
+			_, _, err = instancetemplate.GetTemplateNameAndOrdinal("cluster-comp", "cluster-comp-template-")
 			Expect(err).Should(HaveOccurred())
-			_, _, err = getTemplateNameAndOrdinal("cluster-comp", "cluster-comp-template-x")
+			_, _, err = instancetemplate.GetTemplateNameAndOrdinal("cluster-comp", "cluster-comp-template-x")
 			Expect(err).Should(HaveOccurred())
 
 			helper := &inplaceRebuildHelper{synthesizedComp: synthesizedComp, targetPod: targetPod}


### PR DESCRIPTION
Fixes #10828.

## Problem

Horizontal scale-out creates one Restore per new Pod. The Restore must preserve the actual target Pod ordinal so that it creates the PVC for the intended Pod.

For OneToOne restore, however, `BackupStatusTarget.SelectedTargetPods` is an unordered list, not an ordinal-indexed array. It may contain only pods selected from one instance template, contain ordinal holes, or contain multiple templates that reuse the same numeric ordinal. Using the target ordinal as `SelectedTargetPods[ordinal]` can therefore select the wrong source Pod or return no source Pod at all.

For example, a target that selected only template `az-a` may report:

```text
SelectedTargetPods = ["redis-az-a-3", "redis-az-a-4"]
```

Restoring ordinal 3 must select `redis-az-a-3`; indexing the list at position 3 is invalid. On the snapshot path this can create a PVC without a snapshot dataSource, while the prepare-data path can skip the restore Job.

## What changed

- Preserve the actual scale-out Pod ordinal when building each per-Pod Restore.
- For Ops-generated claims templates that carry a target Pod identity, resolve OneToOne prepare-data sources by identity:
  - use an exact Pod-name match when available;
  - otherwise match the instance-template name plus ordinal;
  - for flat ordinals, match the unique ordinal;
  - reject missing or ambiguous matches instead of silently creating an empty restore.
- Preserve positional source selection for generic user-defined claims-template Restores without KubeBlocks target Pod labels.
- Deep-copy claim-template metadata for each snapshot PVC so Pod identity labels do not leak between replicas.
- Keep direct non-template volume claims and postReady behavior unchanged because they are outside this PR boundary.
- Replace the synthetic continuous-list test with regressions covering reversed list order, non-zero ordinals, ordinal holes, and multiple templates sharing an ordinal.

## Validation

Run after merging the latest `origin/main` into the branch:

- `scripts/codex-go-test.sh ./pkg/dataprotection/restore -count=1`
- `scripts/codex-go-test.sh ./pkg/controller/plan -count=1`
- `scripts/codex-go-test.sh ./pkg/operations -count=1`
- `scripts/codex-go-test.sh ./controllers/dataprotection -count=1`
- `git diff --check`

All passed on branch head `8171645fc`.

## Backport analysis

Both `release-1.1` and `release-1.0` contain the same positional OneToOne source-selection behavior and are affected. The complete patch does not apply cleanly to either release branch because their restore, plan, and operations code differs from main. Automatic cherry-pick is not safe; each release requires an independently adapted PR.