### PR TITLE
feat(ops): select backup source target for scale-out restore

### DIFF
--- a/apis/operations/v1alpha1/opsrequest_types.go
+++ b/apis/operations/v1alpha1/opsrequest_types.go
@@ -518,6 +518,13 @@ type FromBackup struct {
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
 
+	// Specifies the backup source target name to restore from.
+	// This field is required when the referenced Backup has multiple source targets.
+	// It is propagated to Restore.spec.backup.sourceTargetName.
+	//
+	// +optional
+	SourceTargetName string `json:"sourceTargetName,omitempty"`
+
 	// Defines container environment variables for the restore process.
 	// merged with the ones specified in the Backup and ActionSet resources.
 	//

--- a/config/crd/bases/operations.kubeblocks.io_opsrequests.yaml
+++ b/config/crd/bases/operations.kubeblocks.io_opsrequests.yaml
@@ -757,6 +757,12 @@ spec:
                                 - RFC3339 format, e.g. "2023-11-25T18:52:53Z"
                                 - A human-readable date-time format, e.g. "Jul 25,2023 18:52:53 UTC+0800"
                               type: string
+                            sourceTargetName:
+                              description: |-
+                                Specifies the backup source target name to restore from.
+                                This field is required when the referenced Backup has multiple source targets.
+                                It is propagated to Restore.spec.backup.sourceTargetName.
+                              type: string
                           required:
                           - name
                           type: object

--- a/deploy/helm/crds/operations.kubeblocks.io_opsrequests.yaml
+++ b/deploy/helm/crds/operations.kubeblocks.io_opsrequests.yaml
@@ -757,6 +757,12 @@ spec:
                                 - RFC3339 format, e.g. "2023-11-25T18:52:53Z"
                                 - A human-readable date-time format, e.g. "Jul 25,2023 18:52:53 UTC+0800"
                               type: string
+                            sourceTargetName:
+                              description: |-
+                                Specifies the backup source target name to restore from.
+                                This field is required when the referenced Backup has multiple source targets.
+                                It is propagated to Restore.spec.backup.sourceTargetName.
+                              type: string
                           required:
                           - name
                           type: object

--- a/docs/developer_docs/api-reference/operations.md
+++ b/docs/developer_docs/api-reference/operations.md
@@ -1095,6 +1095,20 @@ If not specified, the namespace of the OpsRequest will be used.</p>
 </tr>
 <tr>
 <td>
+<code>sourceTargetName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Specifies the backup source target name to restore from.
+This field is required when the referenced Backup has multiple source targets.
+It is propagated to Restore.spec.backup.sourceTargetName.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>restoreEnv</code><br/>
 <em>
 <a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#envvar-v1-core">

--- a/pkg/controller/plan/restore.go
+++ b/pkg/controller/plan/restore.go
@@ -65,6 +65,7 @@ type RestoreManager struct {
 	replicas                          int32
 	restoreLabels                     map[string]string
 	RestoreNamePrefix                 string
+	SourceTargetName                  string
 }
 
 func NewRestoreManager(ctx context.Context,
@@ -266,6 +267,9 @@ func (r *RestoreManager) BuildPrepareDataRestore(comp *component.SynthesizedComp
 		return nil, nil
 	}
 	sourceTargetName := comp.Annotations[constant.BackupSourceTargetAnnotationKey]
+	if r.SourceTargetName != "" {
+		sourceTargetName = r.SourceTargetName
+	}
 	sourceTarget := dputils.GetBackupStatusTarget(backupObj, sourceTargetName)
 	restore := &dpv1alpha1.Restore{
 		ObjectMeta: r.GetRestoreObjectMeta(comp, dpv1alpha1.PrepareData, templateName),

--- a/pkg/controller/plan/restore_env_test.go
+++ b/pkg/controller/plan/restore_env_test.go
@@ -29,6 +29,7 @@ import (
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 )
 
@@ -63,5 +64,57 @@ func TestRestoreManagerBuildPrepareDataRestoreEnv(t *testing.T) {
 	}
 	if !reflect.DeepEqual(restore.Spec.Env, restoreEnv) {
 		t.Fatalf("restore env = %#v, want %#v", restore.Spec.Env, restoreEnv)
+	}
+}
+
+func TestRestoreManagerBuildPrepareDataRestoreSourceTargetOverride(t *testing.T) {
+	manager := &RestoreManager{
+		Cluster: &appsv1.Cluster{ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster", Namespace: "default", UID: types.UID("12345678-rest-of-uid"),
+		}},
+		namespace:        "default",
+		replicas:         1,
+		SourceTargetName: "target-b",
+	}
+	comp := &component.SynthesizedComponent{
+		Name:        "mysql",
+		Annotations: map[string]string{constant.BackupSourceTargetAnnotationKey: "target-a"},
+		VolumeClaimTemplates: []corev1.PersistentVolumeClaimTemplate{{
+			ObjectMeta: metav1.ObjectMeta{Name: "data"},
+		}},
+	}
+	backup := &dpv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: "backup"},
+		Status: dpv1alpha1.BackupStatus{
+			Targets: []dpv1alpha1.BackupStatusTarget{
+				{BackupTarget: dpv1alpha1.BackupTarget{Name: "target-a", PodSelector: &dpv1alpha1.PodSelector{}}},
+				{BackupTarget: dpv1alpha1.BackupTarget{Name: "target-b", PodSelector: &dpv1alpha1.PodSelector{Strategy: dpv1alpha1.PodSelectionStrategyAll}}},
+			},
+			BackupMethod: &dpv1alpha1.BackupMethod{
+				Name:          "snapshot",
+				TargetVolumes: &dpv1alpha1.TargetVolumeInfo{Volumes: []string{"data"}},
+			},
+		},
+	}
+
+	restore, err := manager.BuildPrepareDataRestore(comp, backup, nil)
+	if err != nil {
+		t.Fatalf("BuildPrepareDataRestore() error = %v", err)
+	}
+	if restore.Spec.Backup.SourceTargetName != "target-b" {
+		t.Fatalf("source target name = %q, want target-b", restore.Spec.Backup.SourceTargetName)
+	}
+	policy := restore.Spec.PrepareDataConfig.RequiredPolicyForAllPodSelection
+	if policy == nil || policy.DataRestorePolicy != dpv1alpha1.OneToOneRestorePolicy {
+		t.Fatalf("required policy = %#v, want one-to-one", policy)
+	}
+
+	manager.SourceTargetName = ""
+	restore, err = manager.BuildPrepareDataRestore(comp, backup, nil)
+	if err != nil {
+		t.Fatalf("BuildPrepareDataRestore() with annotation fallback error = %v", err)
+	}
+	if restore.Spec.Backup.SourceTargetName != "target-a" {
+		t.Fatalf("annotation fallback source target name = %q, want target-a", restore.Spec.Backup.SourceTargetName)
 	}
 }

--- a/pkg/operations/horizontal_scaling.go
+++ b/pkg/operations/horizontal_scaling.go
@@ -295,6 +295,7 @@ func (hs horizontalScalingOpsHandler) restoreDataFromBackup(reqCtx intctrlutil.R
 		restoreMGR.RestoreTime = fromBackup.RestorePointInTime
 		restoreMGR.SetRestoreEnv(fromBackup.RestoreEnv)
 		restoreMGR.RestoreNamePrefix = string(opsRes.OpsRequest.UID[:8])
+		restoreMGR.SourceTargetName = fromBackup.SourceTargetName
 		// check restore status
 		restoreMeta := restoreMGR.GetRestoreObjectMeta(synthesizedComponent, dpv1alpha1.PrepareData, templateName)
 		restore := &dpv1alpha1.Restore{}

--- a/pkg/operations/horizontal_scaling_test.go
+++ b/pkg/operations/horizontal_scaling_test.go
@@ -278,20 +278,36 @@ var _ = Describe("HorizontalScaling OpsRequest", func() {
 						Volumes: []string{"data"},
 					},
 				}
+				backup.Status.Targets = []dpv1alpha1.BackupStatusTarget{
+					{BackupTarget: dpv1alpha1.BackupTarget{Name: "target-a", PodSelector: &dpv1alpha1.PodSelector{}}},
+					{BackupTarget: dpv1alpha1.BackupTarget{Name: "target-b", PodSelector: &dpv1alpha1.PodSelector{Strategy: dpv1alpha1.PodSelectionStrategyAll}}},
+				}
 			})).Should(Succeed())
 
 			By("scale out replicas from a full backup")
 			restoreEnv := []corev1.EnvVar{{Name: "RESTORE_ENV", Value: "true"}}
 			horizontalScaling := opsv1alpha1.HorizontalScaling{ScaleOut: &opsv1alpha1.ScaleOut{
 				FromBackup: &opsv1alpha1.FromBackup{
-					Name:       backupName,
-					RestoreEnv: restoreEnv,
+					Name:             backupName,
+					SourceTargetName: "target-b",
+					RestoreEnv:       restoreEnv,
 				},
 			}}
 
 			horizontalScaling.ScaleOut.ReplicaChanges = pointer.Int32(2)
 			reqCtx := intctrlutil.RequestCtx{Ctx: testCtx.Ctx, Recorder: eventRecorder}
 			opsRes, _ := commonHScaleConsensusCompTest(reqCtx, nil, horizontalScaling, false, true)
+			restoreList := &dpv1alpha1.RestoreList{}
+			Expect(k8sClient.List(ctx, restoreList, client.MatchingLabels{
+				constant.OpsRequestNameLabelKey: opsRes.OpsRequest.Name,
+			}, client.InNamespace(opsRes.OpsRequest.Namespace))).Should(Succeed())
+			Expect(restoreList.Items).Should(HaveLen(2))
+			for i := range restoreList.Items {
+				Expect(restoreList.Items[i].Spec.Backup.SourceTargetName).Should(Equal("target-b"))
+				Expect(restoreList.Items[i].Spec.PrepareDataConfig.RequiredPolicyForAllPodSelection).NotTo(BeNil())
+				Expect(restoreList.Items[i].Spec.PrepareDataConfig.RequiredPolicyForAllPodSelection.DataRestorePolicy).
+					Should(Equal(dpv1alpha1.OneToOneRestorePolicy))
+			}
 
 			By("mock restore phase to completed")
 			comp, compDef, err := component.GetCompNCompDefByName(reqCtx.Ctx, k8sClient, opsRes.Cluster.Namespace, constant.GenerateClusterComponentName(opsRes.Cluster.Name, defaultCompName))


### PR DESCRIPTION
Related to #10594 and #10595.

## Problem

DataProtection in release-1.1 already supports `Restore.spec.backup.sourceTargetName`, and the annotation-based restore flow can populate it. However, `OpsRequest.scaleOut.fromBackup` cannot explicitly select a source target from a multi-target Backup.

## What changed

- Add optional `scaleOut.fromBackup.sourceTargetName` to the release-1.1 Ops API, generated CRDs, and API documentation.
- Propagate the OpsRequest value to `Restore.spec.backup.sourceTargetName` for the PrepareData/PVC scale-out restore path.
- Let the explicit OpsRequest value override `kubeblocks.io/backup-source-target` for that PrepareData Restore.
- Preserve the existing annotation fallback when the OpsRequest field is empty.

## Scope

This is the release-1.1 counterpart of #10594, adapted to the release-specific annotation-based plan implementation.

It does not change DataProtection target lookup semantics and does not extend the postReady path. The new manager field is consumed only while building the PrepareData Restore used by scale-out.

## Validation

- `scripts/codex-go-test.sh ./pkg/controller/plan -count=1`
- `scripts/codex-go-test.sh ./pkg/operations -count=1`
- `make manifests`
- `make doc`
- `git diff --check`

Both affected Go packages pass on the exact branch tree. Tests cover explicit Ops target propagation, Ops-over-annotation precedence, annotation fallback, and the required OneToOne policy for an `All` source target.
