### PR TITLE
fix(dataprotection): preserve OneToOne source Pod identity during scale-out restore

### DIFF
--- a/pkg/controller/instancetemplate/ordinal.go
+++ b/pkg/controller/instancetemplate/ordinal.go
@@ -66,6 +66,23 @@ func getOrdinal(podName string) (int32, error) {
 	return int32(ordinal), nil
 }
 
+// GetTemplateNameAndOrdinal parses the instance template name and ordinal from
+// a Pod name that belongs to the specified workload.
+func GetTemplateNameAndOrdinal(workloadName, podName string) (string, int32, error) {
+	parentName, ordinal := parseParentNameAndOrdinal(podName)
+	if ordinal < 0 {
+		return "", 0, fmt.Errorf("failed to obtain pod ordinal from %q", podName)
+	}
+	if parentName == workloadName {
+		return "", int32(ordinal), nil
+	}
+	prefix := workloadName + "-"
+	if !strings.HasPrefix(parentName, prefix) {
+		return "", 0, fmt.Errorf("pod %q does not belong to workload %q", podName, workloadName)
+	}
+	return strings.TrimPrefix(parentName, prefix), int32(ordinal), nil
+}
+
 // parseParentNameAndOrdinal parses parent (instance template) Name and ordinal from the give instance name.
 // -1 will be returned if no numeric suffix contained.
 func parseParentNameAndOrdinal(s string) (string, int) {

--- a/pkg/controller/instancetemplate/ordinal_test.go
+++ b/pkg/controller/instancetemplate/ordinal_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package instancetemplate
+
+import "testing"
+
+func TestGetTemplateNameAndOrdinal(t *testing.T) {
+	testCases := []struct {
+		name         string
+		workloadName string
+		podName      string
+		templateName string
+		ordinal      int32
+		wantErr      bool
+	}{
+		{name: "default template", workloadName: "cluster-comp", podName: "cluster-comp-3", ordinal: 3},
+		{name: "template with dashes", workloadName: "cluster-comp", podName: "cluster-comp-b-a-3", templateName: "b-a", ordinal: 3},
+		{name: "workload suffix is not a template", workloadName: "cluster-comp-a", podName: "cluster-comp-a-3", ordinal: 3},
+		{name: "different workload", workloadName: "cluster-comp", podName: "other-comp-3", wantErr: true},
+		{name: "missing ordinal", workloadName: "cluster-comp", podName: "cluster-comp-template-", wantErr: true},
+		{name: "invalid ordinal", workloadName: "cluster-comp", podName: "cluster-comp-template-x", wantErr: true},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			templateName, ordinal, err := GetTemplateNameAndOrdinal(testCase.workloadName, testCase.podName)
+			if testCase.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("GetTemplateNameAndOrdinal() error = %v", err)
+			}
+			if templateName != testCase.templateName || ordinal != testCase.ordinal {
+				t.Fatalf("GetTemplateNameAndOrdinal() = %q, %d; want %q, %d", templateName, ordinal, testCase.templateName, testCase.ordinal)
+			}
+		})
+	}
+}

--- a/pkg/controller/plan/restore.go
+++ b/pkg/controller/plan/restore.go
@@ -65,7 +65,9 @@ type RestoreManager struct {
 	replicas                          int32
 	restoreLabels                     map[string]string
 	RestoreNamePrefix                 string
-	SourceTargetName                  string
+	// SourceTargetName overrides the source target for prepareData Restores.
+	// It is primarily used by scale-out restoration.
+	SourceTargetName string
 }
 
 func NewRestoreManager(ctx context.Context,
@@ -211,15 +213,28 @@ func (r *RestoreManager) DoPrepareData(comp *component.SynthesizedComponent,
 }
 
 func (r *RestoreManager) BuildPrepareDataRestore(comp *component.SynthesizedComponent, backupObj *dpv1alpha1.Backup, template *appsv1.InstanceTemplate) (*dpv1alpha1.Restore, error) {
-	templateName := ""
 	startingIndex := r.startingIndex
 	if template != nil {
-		templateName = template.Name
 		if len(template.Ordinals.Ranges) > 0 {
 			// todo: currently restore api does not support multiple ranges, if implement in current way it
 			// need to use multiple restore objects
 			startingIndex = template.Ordinals.Ranges[0].Start
 		}
+	}
+	return r.buildPrepareDataRestore(comp, backupObj, template, startingIndex)
+}
+
+// BuildPrepareDataRestoreForPod builds the Restore for one known Pod during
+// scale-out. The manager's startingIndex is the Pod's actual ordinal and must
+// not be replaced by the start of its instance template's ordinal range.
+func (r *RestoreManager) BuildPrepareDataRestoreForPod(comp *component.SynthesizedComponent, backupObj *dpv1alpha1.Backup, template *appsv1.InstanceTemplate) (*dpv1alpha1.Restore, error) {
+	return r.buildPrepareDataRestore(comp, backupObj, template, r.startingIndex)
+}
+
+func (r *RestoreManager) buildPrepareDataRestore(comp *component.SynthesizedComponent, backupObj *dpv1alpha1.Backup, template *appsv1.InstanceTemplate, startingIndex int32) (*dpv1alpha1.Restore, error) {
+	templateName := ""
+	if template != nil {
+		templateName = template.Name
 	}
 	backupMethod := backupObj.Status.BackupMethod
 	if backupMethod == nil {

--- a/pkg/dataprotection/restore/manager.go
+++ b/pkg/dataprotection/restore/manager.go
@@ -385,7 +385,7 @@ func (r *RestoreManager) RestorePVCFromSnapshot(reqCtx intctrlutil.RequestCtx, c
 	if prepareDataConfig == nil {
 		return nil
 	}
-	createPVCWithSnapshot := func(claim dpv1alpha1.RestoreVolumeClaim) error {
+	createPVCWithSnapshot := func(claim dpv1alpha1.RestoreVolumeClaim, sourceTargetPodName string) error {
 		if claim.VolumeSource == "" {
 			return intctrlutil.NewFatalError(fmt.Sprintf(`claim "%s"" volumeSource can not be empty if the backup uses volume snapshot`, claim.Name))
 		}
@@ -397,10 +397,6 @@ func (r *RestoreManager) RestorePVCFromSnapshot(reqCtx intctrlutil.RequestCtx, c
 			&vsv1.VolumeSnapshot{}); err != nil {
 			return err
 		} else if !exist {
-			sourceTargetPodName, err := GetSourcePodNameFromTarget(target, prepareDataConfig.RequiredPolicyForAllPodSelection, 0)
-			if err != nil {
-				return err
-			}
 			if target.PodSelector.Strategy == dpv1alpha1.PodSelectionStrategyAny || sourceTargetPodName != "" {
 				snapshotGroup := GetVolumeSnapshotsBySourcePod(backupSet.Backup, target, sourceTargetPodName)
 				if snapshotGroup == nil {
@@ -421,7 +417,11 @@ func (r *RestoreManager) RestorePVCFromSnapshot(reqCtx intctrlutil.RequestCtx, c
 		return r.createPVCIfNotExist(reqCtx, cli, claim.ObjectMeta, claim.VolumeClaimSpec)
 	}
 	for i := range prepareDataConfig.RestoreVolumeClaims {
-		if err := createPVCWithSnapshot(prepareDataConfig.RestoreVolumeClaims[i]); err != nil {
+		sourceTargetPodName, err := GetSourcePodNameFromTarget(target, prepareDataConfig.RequiredPolicyForAllPodSelection, 0)
+		if err != nil {
+			return err
+		}
+		if err := createPVCWithSnapshot(prepareDataConfig.RestoreVolumeClaims[i], sourceTargetPodName); err != nil {
 			return err
 		}
 	}
@@ -430,13 +430,31 @@ func (r *RestoreManager) RestorePVCFromSnapshot(reqCtx intctrlutil.RequestCtx, c
 		restoreJobReplicas := GetRestoreActionsCountForPrepareData(prepareDataConfig)
 		for i := 0; i < restoreJobReplicas; i++ {
 			//  create pvc from claims template, build volumes and volumeMounts
-			for _, claim := range prepareDataConfig.RestoreVolumeClaimsTemplate.Templates {
+			for _, c := range prepareDataConfig.RestoreVolumeClaimsTemplate.Templates {
+				// Deep-copy metadata maps so each replica gets its own pod identity.
+				claim := *c.DeepCopy()
 				index := i + int(claimTemplate.StartingIndex)
 				claim.Name = fmt.Sprintf("%s-%d", claim.Name, index)
 				// HACK: add InstanceSet related labels to the PVC,
 				// so that it can be managed by InstanceSet
 				addItsManagingLabels(&claim, index)
-				if err := createPVCWithSnapshot(claim); err != nil {
+				var sourceTargetPodName string
+				var err error
+				if targetPodName := claim.Labels[constant.KBAppPodNameLabelKey]; targetPodName != "" {
+					sourceTargetPodName, err = GetSourcePodNameForTargetPod(target,
+						prepareDataConfig.RequiredPolicyForAllPodSelection,
+						targetPodName,
+						claim.Labels[constant.KBAppInstanceTemplateLabelKey])
+				} else {
+					// Preserve positional selection for generic claims-template Restores
+					// that do not carry a KubeBlocks target Pod identity.
+					sourceTargetPodName, err = GetSourcePodNameFromTarget(target,
+						prepareDataConfig.RequiredPolicyForAllPodSelection, i)
+				}
+				if err != nil {
+					return err
+				}
+				if err := createPVCWithSnapshot(claim, sourceTargetPodName); err != nil {
 					return err
 				}
 			}
@@ -549,7 +567,17 @@ func (r *RestoreManager) BuildPrepareDataJobs(reqCtx intctrlutil.RequestCtx, cli
 				jobBuilder.addToSpecificVolumesAndMounts(volume, volumeMount)
 			}
 		}
-		sourceTargetPodName, err := GetSourcePodNameFromTarget(target, prepareDataConfig.RequiredPolicyForAllPodSelection, i)
+		var sourceTargetPodName string
+		var err error
+		targetPodName := jobBuilder.labels[constant.KBAppPodNameLabelKey]
+		if claimsTemplate == nil || targetPodName == "" {
+			sourceTargetPodName, err = GetSourcePodNameFromTarget(target, prepareDataConfig.RequiredPolicyForAllPodSelection, i)
+		} else {
+			sourceTargetPodName, err = GetSourcePodNameForTargetPod(target,
+				prepareDataConfig.RequiredPolicyForAllPodSelection,
+				targetPodName,
+				jobBuilder.labels[constant.KBAppInstanceTemplateLabelKey])
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/dataprotection/restore/manager_test.go
+++ b/pkg/dataprotection/restore/manager_test.go
@@ -218,29 +218,72 @@ var _ = Describe("RestoreManager Test", func() {
 
 		It("test with RestorePVCFromSnapshot function", func() {
 			reqCtx := getReqCtx()
-			startingIndex := 0
+			startingIndex := 3
+			templateName := "az-a"
+			cmpName := "mysql"
 			useVolumeSnapshot := true
 			restoreMGR, backupSet := initResources(reqCtx, startingIndex, useVolumeSnapshot, func(f *testdp.MockRestoreFactory) {
 				f.SetVolumeClaimsTemplate(testdp.MysqlTemplateName, testdp.DataVolumeName,
-					testdp.DataVolumeMountPath, "", int32(replicas), int32(startingIndex), nil)
+					testdp.DataVolumeMountPath, "", int32(replicas), int32(startingIndex), map[string]string{
+						constant.AppInstanceLabelKey:           instanceName,
+						constant.KBAppComponentLabelKey:        cmpName,
+						constant.KBAppInstanceTemplateLabelKey: templateName,
+					}).
+					SetPrepareDataRequiredPolicy(dpv1alpha1.OneToOneRestorePolicy, "")
 			})
+			backupSet.Backup.Status.Target.PodSelector.Strategy = dpv1alpha1.PodSelectionStrategyAll
+			backupSet.Backup.Status.Target.PodSelector.MatchLabels[constant.AppInstanceLabelKey] = "source"
+			backupSet.Backup.Status.Target.PodSelector.MatchLabels[constant.KBAppComponentLabelKey] = cmpName
+			backupSet.Backup.Status.Target.SelectedTargetPods = []string{"source-mysql-az-a-4", "source-mysql-az-a-3"}
+			backupSet.Backup.Status.Actions = []dpv1alpha1.ActionStatus{
+				{
+					TargetPodName: "source-mysql-az-a-4",
+					VolumeSnapshots: []dpv1alpha1.VolumeSnapshotStatus{{
+						Name:       "snapshot-4",
+						VolumeName: testdp.DataVolumeName,
+					}},
+				},
+				{
+					TargetPodName: "source-mysql-az-a-3",
+					VolumeSnapshots: []dpv1alpha1.VolumeSnapshotStatus{{
+						Name:       "snapshot-3",
+						VolumeName: testdp.DataVolumeName,
+					}},
+				},
+			}
 
 			By("test RestorePVCFromSnapshot function")
 			target := utils.GetBackupStatusTarget(backupSet.Backup, restoreMGR.Restore.Spec.Backup.SourceTargetName)
 			Expect(restoreMGR.RestorePVCFromSnapshot(reqCtx, k8sClient, *backupSet, target)).Should(Succeed())
 
-			checkPVC(startingIndex, useVolumeSnapshot, "restore")
+			checkPVC(startingIndex, useVolumeSnapshot, constant.AppName)
+			for i := 0; i < replicas; i++ {
+				pvc := &corev1.PersistentVolumeClaim{}
+				Expect(k8sClient.Get(ctx, client.ObjectKey{
+					Namespace: testCtx.DefaultNamespace,
+					Name:      fmt.Sprintf("%s-%d", testdp.MysqlTemplateName, startingIndex+i),
+				}, pvc)).Should(Succeed())
+				Expect(pvc.Spec.DataSource).ShouldNot(BeNil())
+				Expect(pvc.Spec.DataSource.Name).Should(Equal(fmt.Sprintf("snapshot-%d", startingIndex+i)))
+			}
 		})
 
 		It("test with BuildPrepareDataJobs function and Parallel volumeRestorePolicy", func() {
 			reqCtx := getReqCtx()
-			startingIndex := 1
+			startingIndex := 3
+			cmpName := "mysql"
 			restoreMGR, backupSet := initResources(reqCtx, startingIndex, false, func(f *testdp.MockRestoreFactory) {
 				f.SetVolumeClaimsTemplate(testdp.MysqlTemplateName, testdp.DataVolumeName,
 					testdp.DataVolumeMountPath, "", int32(replicas), int32(startingIndex), map[string]string{
-						constant.AppInstanceLabelKey: instanceName,
-					})
+						constant.AppInstanceLabelKey:    instanceName,
+						constant.KBAppComponentLabelKey: cmpName,
+					}).SetPrepareDataRequiredPolicy(dpv1alpha1.OneToOneRestorePolicy, "")
 			})
+			backupSet.Backup.Status.Path = "/repo/test/backup"
+			backupSet.Backup.Status.Target.PodSelector.Strategy = dpv1alpha1.PodSelectionStrategyAll
+			backupSet.Backup.Status.Target.PodSelector.MatchLabels[constant.AppInstanceLabelKey] = "source"
+			backupSet.Backup.Status.Target.PodSelector.MatchLabels[constant.KBAppComponentLabelKey] = cmpName
+			backupSet.Backup.Status.Target.SelectedTargetPods = []string{"source-mysql-4", "source-mysql-3"}
 
 			By(fmt.Sprintf("test BuildPrepareDataJobs function, expect for %d jobs", replicas))
 			actionSetName := "preparedata-0"
@@ -252,8 +295,12 @@ var _ = Describe("RestoreManager Test", func() {
 			Expect(len(jobs)).Should(Equal(replicas))
 			// image should be expanded by env
 			Expect(jobs[0].Spec.Template.Spec.Containers[0].Image).Should(ContainSubstring(testdp.ImageTag))
+			for i := 0; i < replicas; i++ {
+				env := utils.CovertEnvToMap(jobs[i].Spec.Template.Spec.Containers[0].Env)
+				Expect(env[dptypes.DPTargetRelativePath]).Should(Equal(fmt.Sprintf("source-mysql-%d", startingIndex+i)))
+			}
 
-			checkPVC(startingIndex, false, "restore")
+			checkPVC(startingIndex, false, constant.AppName)
 		})
 
 		It("test with BuildPrepareDataJobs function with InstanceTemplates claims", func() {
@@ -267,8 +314,18 @@ var _ = Describe("RestoreManager Test", func() {
 						constant.AppInstanceLabelKey:           instanceName,
 						constant.KBAppComponentLabelKey:        cmpName,
 						constant.KBAppInstanceTemplateLabelKey: templateName,
-					})
+					}).SetPrepareDataRequiredPolicy(dpv1alpha1.OneToOneRestorePolicy, "")
 			})
+			backupSet.Backup.Status.Path = "/repo/test/backup"
+			backupSet.Backup.Status.Target.PodSelector.Strategy = dpv1alpha1.PodSelectionStrategyAll
+			backupSet.Backup.Status.Target.PodSelector.MatchLabels[constant.AppInstanceLabelKey] = "source"
+			backupSet.Backup.Status.Target.PodSelector.MatchLabels[constant.KBAppComponentLabelKey] = cmpName
+			backupSet.Backup.Status.Target.SelectedTargetPods = []string{
+				"source-mysql-other-301",
+				"source-mysql-abc-301",
+				"source-mysql-other-300",
+				"source-mysql-abc-300",
+			}
 			By(fmt.Sprintf("test BuildPrepareDataJobs function, expect job label pod name contains template '%s' and ordinal correct", templateName))
 			actionSetName := "preparedata-0"
 			target := utils.GetBackupStatusTarget(backupSet.Backup, restoreMGR.Restore.Spec.Backup.SourceTargetName)
@@ -278,6 +335,8 @@ var _ = Describe("RestoreManager Test", func() {
 			// job label contains pod name and ordinal match
 			for i := 0; i < replicas; i++ {
 				Expect(jobs[i].Spec.Template.Labels[constant.KBAppPodNameLabelKey]).Should(Equal(fmt.Sprintf("%s-%s-%s-%d", instanceName, cmpName, templateName, startingIndex+i)))
+				env := utils.CovertEnvToMap(jobs[i].Spec.Template.Spec.Containers[0].Env)
+				Expect(env[dptypes.DPTargetRelativePath]).Should(Equal(fmt.Sprintf("source-mysql-%s-%d", templateName, startingIndex+i)))
 			}
 
 			checkPVC(startingIndex, false, constant.AppName)

--- a/pkg/dataprotection/restore/utils.go
+++ b/pkg/dataprotection/restore/utils.go
@@ -38,6 +38,7 @@ import (
 
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/instancetemplate"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 	"github.com/apecloud/kubeblocks/pkg/dataprotection/utils"
@@ -382,6 +383,84 @@ func GetSourcePodNameFromTarget(target *dpv1alpha1.BackupStatusTarget,
 	}
 	// get the source target pod according to index for 'OneToOne' policy
 	return target.SelectedTargetPods[index], nil
+}
+
+// GetSourcePodNameForTargetPod gets the source pod for a concrete target pod.
+// SelectedTargetPods is an unordered list, so OneToOne restore must match pod
+// identity instead of treating the target pod ordinal as a slice index.
+func GetSourcePodNameForTargetPod(target *dpv1alpha1.BackupStatusTarget,
+	requiredPolicy *dpv1alpha1.RequiredPolicyForAllPodSelection,
+	targetPodName, instanceTemplateName string) (string, error) {
+	if target.PodSelector.Strategy == dpv1alpha1.PodSelectionStrategyAny {
+		return "", nil
+	}
+	if requiredPolicy == nil {
+		return "", intctrlutil.NewFatalError("requiredPolicyForAllPodSelection can not be empty when the pod selection strategy of the source target is All")
+	}
+	if requiredPolicy.DataRestorePolicy == dpv1alpha1.OneToManyRestorePolicy {
+		if requiredPolicy.SourceOfOneToMany == nil || requiredPolicy.SourceOfOneToMany.TargetPodName == "" {
+			return "", intctrlutil.NewFatalError("the source target pod can not be empty when restore policy is OneToMany")
+		}
+		return requiredPolicy.SourceOfOneToMany.TargetPodName, nil
+	}
+	if targetPodName == "" {
+		return "", intctrlutil.NewFatalError("target pod name can not be empty when restore policy is OneToOne")
+	}
+	if slices.Contains(target.SelectedTargetPods, targetPodName) {
+		return targetPodName, nil
+	}
+
+	targetOrdinal, ok := podOrdinal(targetPodName)
+	if !ok {
+		return "", intctrlutil.NewFatalError(fmt.Sprintf("source target pod can not be inferred from target pod %q", targetPodName))
+	}
+	sourceWorkloadName := backupTargetWorkloadName(target)
+	if sourceWorkloadName == "" && instanceTemplateName != "" {
+		return "", intctrlutil.NewFatalError(fmt.Sprintf("source workload identity is required to match instance template %q", instanceTemplateName))
+	}
+	var candidates []string
+	for _, sourcePodName := range target.SelectedTargetPods {
+		if sourceWorkloadName != "" {
+			sourceTemplateName, sourceOrdinal, err := instancetemplate.GetTemplateNameAndOrdinal(sourceWorkloadName, sourcePodName)
+			if err != nil || int(sourceOrdinal) != targetOrdinal || sourceTemplateName != instanceTemplateName {
+				continue
+			}
+		} else {
+			sourceOrdinal, ok := podOrdinal(sourcePodName)
+			if !ok || sourceOrdinal != targetOrdinal {
+				continue
+			}
+		}
+		candidates = append(candidates, sourcePodName)
+	}
+	if len(candidates) == 1 {
+		return candidates[0], nil
+	}
+	if len(candidates) > 1 {
+		return "", intctrlutil.NewFatalError(fmt.Sprintf("multiple selected source target pods match target pod %q and instance template %q: %v", targetPodName, instanceTemplateName, candidates))
+	}
+	return "", intctrlutil.NewFatalError(fmt.Sprintf("no selected source target pod matches target pod %q and instance template %q", targetPodName, instanceTemplateName))
+}
+
+func backupTargetWorkloadName(target *dpv1alpha1.BackupStatusTarget) string {
+	if target == nil || target.PodSelector == nil || target.PodSelector.LabelSelector == nil {
+		return ""
+	}
+	clusterName := target.PodSelector.MatchLabels[constant.AppInstanceLabelKey]
+	componentName := target.PodSelector.MatchLabels[constant.KBAppComponentLabelKey]
+	if clusterName == "" || componentName == "" {
+		return ""
+	}
+	return constant.GenerateWorkloadNamePattern(clusterName, componentName)
+}
+
+func podOrdinal(podName string) (int, bool) {
+	index := strings.LastIndex(podName, "-")
+	if index < 0 || index == len(podName)-1 {
+		return 0, false
+	}
+	ordinal, err := strconv.Atoi(podName[index+1:])
+	return ordinal, err == nil
 }
 
 // GetVolumeSnapshotsBySourcePod gets the volume snapshots of the backup and group by source target pod.

--- a/pkg/dataprotection/restore/utils_test.go
+++ b/pkg/dataprotection/restore/utils_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package restore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+)
+
+func TestGetSourcePodNameForTargetPod(t *testing.T) {
+	target := &dpv1alpha1.BackupStatusTarget{
+		BackupTarget: dpv1alpha1.BackupTarget{
+			PodSelector: &dpv1alpha1.PodSelector{
+				LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+					constant.AppInstanceLabelKey:    "source",
+					constant.KBAppComponentLabelKey: "redis",
+				}},
+				Strategy: dpv1alpha1.PodSelectionStrategyAll,
+			},
+		},
+	}
+	policy := &dpv1alpha1.RequiredPolicyForAllPodSelection{DataRestorePolicy: dpv1alpha1.OneToOneRestorePolicy}
+
+	t.Run("matches instance template identity without list order", func(t *testing.T) {
+		target.SelectedTargetPods = []string{"source-redis-az-a-4", "source-redis-az-a-3"}
+		podName, err := GetSourcePodNameForTargetPod(target, policy, "target-redis-az-a-3", "az-a")
+		assert.NoError(t, err)
+		assert.Equal(t, "source-redis-az-a-3", podName)
+	})
+
+	t.Run("disambiguates templates sharing an ordinal", func(t *testing.T) {
+		target.SelectedTargetPods = []string{"source-redis-az-b-3", "source-redis-az-a-3"}
+		podName, err := GetSourcePodNameForTargetPod(target, policy, "target-redis-az-a-3", "az-a")
+		assert.NoError(t, err)
+		assert.Equal(t, "source-redis-az-a-3", podName)
+	})
+
+	t.Run("matches the exact template rather than a suffix", func(t *testing.T) {
+		target.SelectedTargetPods = []string{"source-redis-b-a-3", "source-redis-a-3"}
+		podName, err := GetSourcePodNameForTargetPod(target, policy, "target-redis-a-3", "a")
+		assert.NoError(t, err)
+		assert.Equal(t, "source-redis-a-3", podName)
+	})
+
+	t.Run("does not treat a flat workload suffix as a template", func(t *testing.T) {
+		target.PodSelector.MatchLabels[constant.KBAppComponentLabelKey] = "redis-a"
+		target.SelectedTargetPods = []string{"source-redis-a-3"}
+		_, err := GetSourcePodNameForTargetPod(target, policy, "target-redis-a-3", "a")
+		assert.ErrorContains(t, err, "no selected source target pod matches")
+		target.PodSelector.MatchLabels[constant.KBAppComponentLabelKey] = "redis"
+	})
+
+	t.Run("matches a flat ordinal with holes", func(t *testing.T) {
+		target.SelectedTargetPods = []string{"source-redis-7", "source-redis-2"}
+		podName, err := GetSourcePodNameForTargetPod(target, policy, "target-redis-7", "")
+		assert.NoError(t, err)
+		assert.Equal(t, "source-redis-7", podName)
+	})
+
+	t.Run("rejects an ambiguous generic ordinal", func(t *testing.T) {
+		labelSelector := target.PodSelector.LabelSelector
+		target.PodSelector.LabelSelector = nil
+		defer func() { target.PodSelector.LabelSelector = labelSelector }()
+		target.SelectedTargetPods = []string{"source-redis-az-a-3", "source-redis-az-b-3"}
+		_, err := GetSourcePodNameForTargetPod(target, policy, "target-redis-3", "")
+		assert.ErrorContains(t, err, "multiple selected source target pods")
+	})
+
+	t.Run("rejects a missing identity", func(t *testing.T) {
+		target.SelectedTargetPods = []string{"source-redis-az-a-4"}
+		_, err := GetSourcePodNameForTargetPod(target, policy, "target-redis-az-a-3", "az-a")
+		assert.ErrorContains(t, err, "no selected source target pod matches")
+	})
+}

--- a/pkg/operations/horizontal_scaling.go
+++ b/pkg/operations/horizontal_scaling.go
@@ -225,7 +225,7 @@ func (hs horizontalScalingOpsHandler) createRestore(reqCtx intctrlutil.RequestCt
 		return nil
 	}
 	// create restore
-	restore, err := restoreMGR.BuildPrepareDataRestore(synthesizedComponent, backupObj, getTemplate(templateName))
+	restore, err := restoreMGR.BuildPrepareDataRestoreForPod(synthesizedComponent, backupObj, getTemplate(templateName))
 	if err != nil {
 		if intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeRestoreFailed) {
 			return intctrlutil.NewFatalError(err.Error())

--- a/pkg/operations/horizontal_scaling_test.go
+++ b/pkg/operations/horizontal_scaling_test.go
@@ -20,7 +20,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package operations
 
 import (
+	"context"
 	"fmt"
+	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -28,10 +30,13 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
@@ -998,6 +1003,100 @@ func createHorizontalScaling(clusterName string, horizontalScaling opsv1alpha1.H
 	opsRequest := testops.CreateOpsRequest(ctx, testCtx, ops)
 	opsRequest.Status.Phase = opsv1alpha1.OpsPendingPhase
 	return opsRequest
+}
+
+func TestHorizontalScalingCreateRestorePreservesPerPodStartingIndex(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	for _, addToScheme := range []func(*runtime.Scheme) error{
+		corev1.AddToScheme,
+		appsv1.AddToScheme,
+		dpv1alpha1.AddToScheme,
+		opsv1alpha1.AddToScheme,
+	} {
+		if err := addToScheme(scheme); err != nil {
+			t.Fatalf("add scheme: %v", err)
+		}
+	}
+
+	cluster := &appsv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "redis", Namespace: "default", UID: types.UID("cluster1")},
+	}
+	opsRequest := &opsv1alpha1.OpsRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: "scale-out-from-backup", Namespace: "default", UID: types.UID("opsreq1")},
+	}
+	backup := &dpv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: "redis-backup", Namespace: "default"},
+		Status: dpv1alpha1.BackupStatus{
+			Phase: dpv1alpha1.BackupPhaseCompleted,
+			BackupMethod: &dpv1alpha1.BackupMethod{
+				Name:          "snapshot",
+				TargetVolumes: &dpv1alpha1.TargetVolumeInfo{Volumes: []string{"data"}},
+			},
+			Targets: []dpv1alpha1.BackupStatusTarget{{
+				BackupTarget: dpv1alpha1.BackupTarget{
+					Name:        "redis",
+					PodSelector: &dpv1alpha1.PodSelector{Strategy: dpv1alpha1.PodSelectionStrategyAll},
+				},
+				SelectedTargetPods: []string{"redis-az-a-4", "redis-az-a-3"},
+			}},
+		},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cluster, opsRequest, backup).Build()
+	opsRes := &OpsResource{Cluster: cluster, OpsRequest: opsRequest}
+	synthesizedComponent := &component.SynthesizedComponent{
+		Name: "redis",
+		VolumeClaimTemplates: []corev1.PersistentVolumeClaimTemplate{{
+			ObjectMeta: metav1.ObjectMeta{Name: "data"},
+		}},
+	}
+	componentSpec := &appsv1.ClusterComponentSpec{
+		Name: "redis",
+		Instances: []appsv1.InstanceTemplate{{
+			Name: "az-a",
+			Ordinals: appsv1.Ordinals{
+				Ranges: []appsv1.Range{{Start: 3, End: 4}},
+			},
+		}},
+	}
+	for _, ordinal := range []int32{3, 4} {
+		restoreMGR := plan.NewRestoreManager(ctx, cli, cluster, scheme, map[string]string{
+			constant.OpsRequestNameLabelKey: opsRequest.Name,
+		}, 1, ordinal)
+		err := horizontalScalingOpsHandler{}.createRestore(
+			intctrlutil.RequestCtx{Ctx: ctx, Recorder: record.NewFakeRecorder(1)},
+			cli, opsRes, synthesizedComponent, restoreMGR, componentSpec, backup, "az-a")
+		if err != nil {
+			t.Fatalf("create restore for ordinal %d: %v", ordinal, err)
+		}
+	}
+
+	restoreList := &dpv1alpha1.RestoreList{}
+	if err := cli.List(ctx, restoreList, client.InNamespace("default")); err != nil {
+		t.Fatalf("list restores: %v", err)
+	}
+	if len(restoreList.Items) != 2 {
+		t.Fatalf("expected two restores, got %d", len(restoreList.Items))
+	}
+	restoresByOrdinal := map[int32]dpv1alpha1.Restore{}
+	for i := range restoreList.Items {
+		restore := restoreList.Items[i]
+		startingIndex := restore.Spec.PrepareDataConfig.RestoreVolumeClaimsTemplate.StartingIndex
+		restoresByOrdinal[startingIndex] = restore
+	}
+	for _, ordinal := range []int32{3, 4} {
+		restore, ok := restoresByOrdinal[ordinal]
+		if !ok {
+			t.Fatalf("missing restore for actual scale-out pod ordinal %d", ordinal)
+		}
+		claimTemplate := restore.Spec.PrepareDataConfig.RestoreVolumeClaimsTemplate
+		if claimTemplate.Replicas != 1 {
+			t.Fatalf("restore replicas = %d, want 1 for ordinal %d", claimTemplate.Replicas, ordinal)
+		}
+		if got := claimTemplate.Templates[0].Labels[constant.KBAppInstanceTemplateLabelKey]; got != "az-a" {
+			t.Fatalf("instance template label = %q, want %q for ordinal %d", got, "az-a", ordinal)
+		}
+	}
 }
 
 func cancelOpsRequest(reqCtx intctrlutil.RequestCtx, opsRes *OpsResource, cancelTime time.Time) {

--- a/pkg/operations/rebuild_instance_inplace.go
+++ b/pkg/operations/rebuild_instance_inplace.go
@@ -21,7 +21,6 @@ package operations
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -42,6 +41,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/factory"
 	"github.com/apecloud/kubeblocks/pkg/controller/instanceset"
+	"github.com/apecloud/kubeblocks/pkg/controller/instancetemplate"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	dputils "github.com/apecloud/kubeblocks/pkg/dataprotection/utils"
 	viper "github.com/apecloud/kubeblocks/pkg/viperx"
@@ -741,7 +741,7 @@ func getPVCMapAndVolumes(opsRes *OpsResource,
 	}
 	// backup's ready, then start to check restore
 	workloadName := constant.GenerateWorkloadNamePattern(opsRes.Cluster.Name, synthesizedComp.Name)
-	templateName, _, err := getTemplateNameAndOrdinal(workloadName, targetPod.Name)
+	templateName, _, err := instancetemplate.GetTemplateNameAndOrdinal(workloadName, targetPod.Name)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -861,25 +861,4 @@ func generateAllPodNames(
 		})
 	}
 	return instanceset.GenerateAllInstanceNames(fullCompName, compReplicas, templates, offlineInstances, appsv1.Ordinals{})
-}
-
-func getTemplateNameAndOrdinal(workloadName, podName string) (string, int32, error) {
-	podSuffix := strings.Replace(podName, workloadName+"-", "", 1)
-	lastDashIndex := strings.LastIndex(podSuffix, "-")
-	if lastDashIndex == len(podSuffix)-1 {
-		return "", 0, fmt.Errorf("no pod ordinal found after the last dash")
-	}
-	templateName := ""
-	indexStr := ""
-	if lastDashIndex == -1 {
-		indexStr = podSuffix
-	} else {
-		templateName = podSuffix[0:lastDashIndex]
-		indexStr = podSuffix[lastDashIndex+1:]
-	}
-	index, err := strconv.ParseInt(indexStr, 10, 32)
-	if err != nil {
-		return "", 0, fmt.Errorf("failed to obtain pod ordinal")
-	}
-	return templateName, int32(index), nil
 }


### PR DESCRIPTION
Backport of #10826 for `release-1.1`. Related to #10828.

## Problem

Scale-out creates one Restore per new Pod. The Restore currently replaces the actual Pod ordinal with the start of its instance-template range, and DP later treats `BackupStatusTarget.SelectedTargetPods` as an ordinal-indexed array. Kubernetes list order does not provide that contract, so reversed lists, ordinal holes, and multiple templates sharing the same ordinal can select the wrong source Pod or produce an empty restore.

## What changed

- Preserve the actual scale-out Pod ordinal when building each per-Pod Restore.
- Resolve OneToOne source Pods by exact workload/template/ordinal identity rather than list position.
- Preserve positional behavior for generic claims-template Restores without KubeBlocks Pod identity labels.
- Apply the same identity mapping to snapshot PVCs and prepare-data Jobs.
- Reuse the workload Pod-name parser for exact template extraction.
- Clarify that `RestoreManager.SourceTargetName` is a prepareData/scale-out override.

## Release adaptation

This is an independent `release-1.1` port rather than an automatic cherry-pick because the restore manager, tests, and Ops source-target support differ from main.

## Validation

Passed with the repository test wrapper (using the current generated mock overlay because the release branch's generated mock file is incomplete):

- `./pkg/controller/instancetemplate`
- `./pkg/dataprotection/restore`
- `./pkg/controller/plan`
- `./pkg/operations`
- `git diff --check`
