### PR TITLE
fix(dataprotection): identify and route restore dependencies

### DIFF
--- a/controllers/apps/cluster/restore_intent.go
+++ b/controllers/apps/cluster/restore_intent.go
@@ -84,6 +84,7 @@ func injectRestoreIntentToVCT(cluster *appsv1.Cluster, componentName string, vct
 	vct.Annotations[constant.RestoreSourceKindAnnotationKey] = restore.Source.Kind
 	vct.Annotations[constant.RestoreSourceNameAnnotationKey] = restore.Source.Name
 	vct.Annotations[constant.RestoreSourceNamespaceAnnotationKey] = sourceNamespace
+	vct.Annotations[constant.KBAppClusterUIDKey] = string(cluster.UID)
 	vct.Annotations[constant.RestoreComponentAnnotationKey] = componentName
 	vct.Annotations[constant.RestoreVolumeTemplateAnnotationKey] = vct.Name
 	delete(vct.Annotations, constant.RestorePITRAnnotationKey)
@@ -118,6 +119,7 @@ func cleanupRestoreIntentFromVCT(vct *appsv1.PersistentVolumeClaimTemplate) {
 		delete(vct.Annotations, constant.RestoreSourceKindAnnotationKey)
 		delete(vct.Annotations, constant.RestoreSourceNameAnnotationKey)
 		delete(vct.Annotations, constant.RestoreSourceNamespaceAnnotationKey)
+		delete(vct.Annotations, constant.KBAppClusterUIDKey)
 		delete(vct.Annotations, constant.RestorePITRAnnotationKey)
 		delete(vct.Annotations, constant.RestoreParametersAnnotationKey)
 		delete(vct.Annotations, constant.RestoreComponentAnnotationKey)
@@ -138,6 +140,7 @@ func hasRestoreIntent(vct *appsv1.PersistentVolumeClaimTemplate) bool {
 		constant.RestoreSourceKindAnnotationKey,
 		constant.RestoreSourceNameAnnotationKey,
 		constant.RestoreSourceNamespaceAnnotationKey,
+		constant.KBAppClusterUIDKey,
 		constant.RestoreComponentAnnotationKey,
 		constant.RestoreVolumeTemplateAnnotationKey,
 	} {

--- a/controllers/apps/cluster/restore_intent_test.go
+++ b/controllers/apps/cluster/restore_intent_test.go
@@ -47,6 +47,7 @@ func TestInjectRestoreIntentRemovesStaleOptionalAnnotations(t *testing.T) {
 	cluster := &appsv1.Cluster{}
 	cluster.Name = "test-cluster"
 	cluster.Namespace = "test-ns"
+	cluster.UID = "cluster-uid"
 	cluster.Spec.Restore = &appsv1.ClusterRestore{
 		Source: appsv1.ClusterRestoreSource{
 			APIGroup:  testRestoreSourceAPIGroup,
@@ -72,6 +73,7 @@ func TestInjectRestoreIntentRemovesStaleOptionalAnnotations(t *testing.T) {
 	require.Equal(t, "backup", vct.Spec.DataSourceRef.Name)
 	require.NotNil(t, vct.Spec.DataSourceRef.Namespace)
 	require.Equal(t, "backup-ns", *vct.Spec.DataSourceRef.Namespace)
+	require.Equal(t, string(cluster.UID), vct.Annotations[constant.KBAppClusterUIDKey])
 }
 
 func TestInjectRestoreIntentOmitsDataSourceRefNamespaceForSameNamespaceSource(t *testing.T) {
@@ -154,6 +156,7 @@ func TestApplyClusterRestoreIntentCleansTemplatesAfterRestoreCompleted(t *testin
 			Annotations: map[string]string{
 				constant.RestoreSourceKindAnnotationKey: testRestoreSourceKind,
 				constant.RestorePITRAnnotationKey:       "stale-pitr",
+				constant.KBAppClusterUIDKey:             "cluster-uid",
 			},
 			Spec: corev1.PersistentVolumeClaimSpec{
 				DataSourceRef: &corev1.TypedObjectReference{
@@ -172,6 +175,7 @@ func TestApplyClusterRestoreIntentCleansTemplatesAfterRestoreCompleted(t *testin
 	require.Nil(t, vct.Annotations)
 	require.NotContains(t, vct.Annotations, constant.RestoreSourceKindAnnotationKey)
 	require.NotContains(t, vct.Annotations, constant.RestorePITRAnnotationKey)
+	require.NotContains(t, vct.Annotations, constant.KBAppClusterUIDKey)
 }
 
 func TestApplyClusterRestoreIntentKeepsNonRestoreDataSourceAfterRestoreCompleted(t *testing.T) {

--- a/controllers/dataprotection/volumepopulator_controller.go
+++ b/controllers/dataprotection/volumepopulator_controller.go
@@ -156,35 +156,32 @@ func (r *VolumePopulatorReconciler) mapRestoreToPVCs(ctx context.Context, obj cl
 		pvc := &corev1.PersistentVolumeClaim{}
 		key := types.NamespacedName{Namespace: restore.Namespace, Name: owner.Name}
 		if err := r.Client.Get(ctx, key, pvc); err != nil || pvc.UID != owner.UID ||
-			!isClusterRestorePVC(pvc) || restore.Name != getPopulatePVCName(pvc.UID) {
+			!isClusterRestorePVC(pvc) || restore.Name != getPopulatePVCName(pvc.UID) ||
+			restore.Labels[dptypes.ClusterUIDLabelKey] != clusterRestorePVCUID(pvc) {
 			return nil
 		}
 		return []reconcile.Request{{NamespacedName: key}}
 	}
 
-	owner := exactOwnerReference(restore.OwnerReferences, appsv1.GroupVersion.String(), "Component")
-	if owner == nil {
+	// A Component can disappear before a postReady Restore deletion event is
+	// observed. The Restore carries enough correlation identity to notify its
+	// PVC dependents without resolving the live Component.
+	if internalPostReadyRestoreOwner(restore) == nil {
 		return nil
 	}
-	comp := &appsv1.Component{}
-	key := types.NamespacedName{Namespace: restore.Namespace, Name: owner.Name}
-	if err := r.Client.Get(ctx, key, comp); err != nil || comp.UID != owner.UID ||
-		restore.Name != postReadyRestoreName(comp.UID) {
+	clusterName := restore.Labels[constant.AppInstanceLabelKey]
+	if clusterName == "" || restore.Labels[constant.KBAppComponentLabelKey] == "" {
 		return nil
 	}
-	clusterName := comp.Labels[constant.AppInstanceLabelKey]
-	componentName := restore.Labels[constant.KBAppComponentLabelKey]
-	ownerComponentName := comp.Labels[constant.KBAppComponentLabelKey]
-	if clusterName == "" || componentName == "" || ownerComponentName == "" ||
-		restore.Labels[constant.AppInstanceLabelKey] != clusterName {
-		return nil
-	}
-	// A postReady Restore is owned by its target Component, while its labels
-	// identify only the first source PVC that created it. Other Components in
-	// the Cluster can wait on the same Restore through postReady redirection.
+	includeTerminal := !restore.DeletionTimestamp.IsZero() ||
+		restore.Status.Phase == dpv1alpha1.RestorePhaseCompleted ||
+		restore.Status.Phase == dpv1alpha1.RestorePhaseFailed
+	// The component label identifies the first source PVC, while the owner
+	// reference identifies the target Component. Redirected postReady restores
+	// can therefore have dependents in other Components of the same Cluster.
 	return r.mapRestorePVCs(ctx, restore.Namespace, client.MatchingLabels{
 		constant.AppInstanceLabelKey: clusterName,
-	})
+	}, restore.Labels[dptypes.ClusterUIDLabelKey], includeTerminal)
 }
 
 func (r *VolumePopulatorReconciler) mapComponentToPVCs(ctx context.Context, obj client.Object) []reconcile.Request {
@@ -197,13 +194,16 @@ func (r *VolumePopulatorReconciler) mapComponentToPVCs(ctx context.Context, obj 
 	if clusterName == "" || componentName == "" {
 		return nil
 	}
-	// A PVC can depend on another Component through a redirected postReady
-	// Restore. That relationship is derived from Backup status and is not
-	// represented on the Component, so a Component event must fan out to all
-	// active restore PVCs in its Cluster.
+	clusterOwner := exactOwnerReference(comp.OwnerReferences, appsv1.GroupVersion.String(), appsv1.ClusterKind)
+	if clusterOwner == nil || clusterOwner.Name != clusterName {
+		return nil
+	}
+	// A PVC can depend on another Component through redirected postReady. The
+	// dependency is not represented on the Component, so normal Component
+	// changes fan out to unfinished restore PVCs in the exact Cluster instance.
 	return r.mapRestorePVCs(ctx, comp.Namespace, client.MatchingLabels{
 		constant.AppInstanceLabelKey: clusterName,
-	})
+	}, string(clusterOwner.UID), false)
 }
 
 func (r *VolumePopulatorReconciler) mapClusterToPVCs(ctx context.Context, obj client.Object) []reconcile.Request {
@@ -213,11 +213,14 @@ func (r *VolumePopulatorReconciler) mapClusterToPVCs(ctx context.Context, obj cl
 	}
 	return r.mapRestorePVCs(ctx, cluster.Namespace, client.MatchingLabels{
 		constant.AppInstanceLabelKey: cluster.Name,
-	})
+	}, string(cluster.UID), false)
 }
 
 func (r *VolumePopulatorReconciler) mapRestorePVCs(ctx context.Context, namespace string,
-	labels client.MatchingLabels) []reconcile.Request {
+	labels client.MatchingLabels, clusterUID string, includeTerminal bool) []reconcile.Request {
+	if clusterUID == "" {
+		return nil
+	}
 	list := &corev1.PersistentVolumeClaimList{}
 	if err := r.Client.List(ctx, list, client.InNamespace(namespace), labels); err != nil {
 		return nil
@@ -225,7 +228,8 @@ func (r *VolumePopulatorReconciler) mapRestorePVCs(ctx context.Context, namespac
 	requests := make([]reconcile.Request, 0, len(list.Items))
 	for i := range list.Items {
 		pvc := &list.Items[i]
-		if !isClusterRestorePVC(pvc) || pvcRestoreTerminal(pvc) {
+		if !isClusterRestorePVC(pvc) || clusterRestorePVCUID(pvc) != clusterUID ||
+			(!includeTerminal && pvcRestoreTerminal(pvc)) {
 			continue
 		}
 		requests = append(requests, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(pvc)})
@@ -240,6 +244,9 @@ func isClusterRestorePVC(pvc *corev1.PersistentVolumeClaim) bool {
 		return false
 	}
 	if pvc.Labels[constant.AppInstanceLabelKey] == "" || pvc.Labels[constant.KBAppComponentLabelKey] == "" {
+		return false
+	}
+	if clusterRestorePVCUID(pvc) == "" {
 		return false
 	}
 	for _, key := range []string{
@@ -259,6 +266,21 @@ func isClusterRestorePVC(pvc *corev1.PersistentVolumeClaim) bool {
 		restoreComponent == pvc.Labels[constant.KBAppShardTemplateLabelKey]
 }
 
+// clusterRestorePVCUID returns the Cluster correlation identity inherited
+// from restore intent. A later verified label may repeat it, but conflicting
+// identities are never accepted.
+func clusterRestorePVCUID(pvc *corev1.PersistentVolumeClaim) string {
+	annotationUID := pvc.Annotations[constant.KBAppClusterUIDKey]
+	labelUID := pvc.Labels[dptypes.ClusterUIDLabelKey]
+	if annotationUID != "" && labelUID != "" && annotationUID != labelUID {
+		return ""
+	}
+	if labelUID != "" {
+		return labelUID
+	}
+	return annotationUID
+}
+
 func pvcRestoreTerminal(pvc *corev1.PersistentVolumeClaim) bool {
 	condition := findPVCConditionByType(pvc, appsv1.ConditionTypeRestore)
 	return condition != nil && (condition.Status == corev1.ConditionTrue || condition.Status == corev1.ConditionFalse)
@@ -271,6 +293,16 @@ func exactOwnerReference(refs []metav1.OwnerReference, apiVersion, kind string) 
 		}
 	}
 	return nil
+}
+
+func internalPostReadyRestoreOwner(restore *dpv1alpha1.Restore) *metav1.OwnerReference {
+	owner := exactOwnerReference(restore.OwnerReferences, appsv1.GroupVersion.String(), appsv1.ComponentKind)
+	if owner == nil || restore.Name != postReadyRestoreName(owner.UID) ||
+		restore.Labels[dprestore.DataProtectionRestoreLabelKey] != restore.Name ||
+		restore.Labels[dptypes.ComponentUIDLabelKey] != string(owner.UID) {
+		return nil
+	}
+	return owner
 }
 
 func restoreDependencyPredicate() predicate.Predicate {
@@ -898,6 +930,9 @@ func internalRestoreLabels(pvc *corev1.PersistentVolumeClaim) map[string]string 
 		dprestore.DataProtectionRestoreLabelKey:          getPopulatePVCName(pvc.UID),
 		dprestore.DataProtectionRestoreNamespaceLabelKey: pvc.Namespace,
 		dprestore.DataProtectionPopulatePVCLabelKey:      getPopulatePVCName(pvc.UID),
+	}
+	if clusterUID := clusterRestorePVCUID(pvc); clusterUID != "" {
+		labels[dptypes.ClusterUIDLabelKey] = clusterUID
 	}
 	for _, key := range []string{
 		constant.AppInstanceLabelKey,
@@ -1836,6 +1871,10 @@ func postReadyRestoreLabels(pvc *corev1.PersistentVolumeClaim, comp *appsv1.Comp
 	labels := map[string]string{
 		dprestore.DataProtectionRestoreLabelKey:          restoreName,
 		dprestore.DataProtectionRestoreNamespaceLabelKey: pvc.Namespace,
+		dptypes.ComponentUIDLabelKey:                     string(comp.UID),
+	}
+	if clusterUID := clusterRestorePVCUID(pvc); clusterUID != "" {
+		labels[dptypes.ClusterUIDLabelKey] = clusterUID
 	}
 	for _, key := range []string{
 		constant.AppInstanceLabelKey,
@@ -1947,6 +1986,7 @@ func (r *VolumePopulatorReconciler) getPopulatePVC(reqCtx intctrlutil.RequestCtx
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      populatePVCName,
 				Namespace: pvc.Namespace,
+				Labels:    internalRestoreLabels(pvc),
 			},
 			Spec: corev1.PersistentVolumeClaimSpec{
 				AccessModes:      pvc.Spec.AccessModes,
@@ -2004,6 +2044,7 @@ func (r *VolumePopulatorReconciler) getProvisionOnlyPVC(reqCtx intctrlutil.Reque
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      populatePVCName,
 				Namespace: pvc.Namespace,
+				Labels:    internalRestoreLabels(pvc),
 			},
 			Spec: corev1.PersistentVolumeClaimSpec{
 				AccessModes:      pvc.Spec.AccessModes,

--- a/controllers/dataprotection/volumepopulator_controller_test.go
+++ b/controllers/dataprotection/volumepopulator_controller_test.go
@@ -3970,7 +3970,10 @@ func TestMapExecutionRestoreToTargetPVC(t *testing.T) {
 	pvc := dependencyRestorePVC("data-mysql-0", "mysql", "pvc-uid")
 	restore := &dpv1alpha1.Restore{ObjectMeta: metav1.ObjectMeta{
 		Namespace: pvc.Namespace, Name: getPopulatePVCName(pvc.UID),
-		Labels: map[string]string{dprestore.DataProtectionRestoreLabelKey: getPopulatePVCName(pvc.UID)},
+		Labels: map[string]string{
+			dprestore.DataProtectionRestoreLabelKey: getPopulatePVCName(pvc.UID),
+			dptypes.ClusterUIDLabelKey:              "cluster-uid",
+		},
 		OwnerReferences: []metav1.OwnerReference{{
 			APIVersion: corev1.SchemeGroupVersion.String(), Kind: "PersistentVolumeClaim",
 			Name: pvc.Name, UID: pvc.UID,
@@ -3983,12 +3986,15 @@ func TestMapExecutionRestoreToTargetPVC(t *testing.T) {
 	badOwner := restore.DeepCopy()
 	badOwner.OwnerReferences[0].UID = "another-pvc"
 	require.Empty(t, reconciler.mapRestoreToPVCs(context.Background(), badOwner))
+	wrongCluster := restore.DeepCopy()
+	wrongCluster.Labels[dptypes.ClusterUIDLabelKey] = "unmatched-cluster-uid"
+	require.Empty(t, reconciler.mapRestoreToPVCs(context.Background(), wrongCluster))
 	sourceRestore := restore.DeepCopy()
 	sourceRestore.Labels = nil
 	require.Empty(t, reconciler.mapRestoreToPVCs(context.Background(), sourceRestore))
 }
 
-func TestMapPostReadyRestoreToNonTerminalComponentPVCs(t *testing.T) {
+func TestMapPostReadyRestoreWithoutComponent(t *testing.T) {
 	comp := &kbappsv1.Component{ObjectMeta: metav1.ObjectMeta{
 		Namespace: "default", Name: "cluster-mysql", UID: "component-uid",
 		Labels: map[string]string{
@@ -4000,32 +4006,59 @@ func TestMapPostReadyRestoreToNonTerminalComponentPVCs(t *testing.T) {
 	terminal.Status.Conditions = []corev1.PersistentVolumeClaimCondition{{
 		Type: corev1.PersistentVolumeClaimConditionType(kbappsv1.ConditionTypeRestore), Status: corev1.ConditionTrue,
 	}}
+	failed := dependencyRestorePVC("failed", "mysql", "failed-pvc")
+	failed.Status.Conditions = []corev1.PersistentVolumeClaimCondition{{
+		Type: corev1.PersistentVolumeClaimConditionType(kbappsv1.ConditionTypeRestore), Status: corev1.ConditionFalse,
+	}}
 	redirectTarget := dependencyRestorePVC("data-postgresql-0", "postgresql", "redirect-pvc")
 	otherRedirectSource := dependencyRestorePVC("data-tikv-0", "tikv", "other-redirect-pvc")
+	foreign := dependencyRestorePVC("foreign", "mysql", "foreign-pvc")
+	foreign.Annotations[constant.KBAppClusterUIDKey] = "another-cluster-uid"
+	conflicting := dependencyRestorePVC("conflicting", "mysql", "conflicting-pvc")
+	conflicting.Labels[dptypes.ClusterUIDLabelKey] = "another-cluster-uid"
 	restore := &dpv1alpha1.Restore{ObjectMeta: metav1.ObjectMeta{
 		Namespace: comp.Namespace, Name: postReadyRestoreName(comp.UID),
-		Labels: map[string]string{
-			dprestore.DataProtectionRestoreLabelKey: postReadyRestoreName(comp.UID),
-			constant.AppInstanceLabelKey:            "cluster", constant.KBAppComponentLabelKey: "mysql",
-		},
+		Labels: postReadyRestoreLabels(running, comp),
 		OwnerReferences: []metav1.OwnerReference{{
 			APIVersion: kbappsv1.GroupVersion.String(), Kind: "Component", Name: comp.Name, UID: comp.UID,
 		}},
 	}}
-	reconciler := dependencyTestReconciler(t, comp, running, terminal, redirectTarget, otherRedirectSource)
-	require.ElementsMatch(t, []reconcile.Request{
+	// The event must be sufficient after the Component itself has disappeared.
+	reconciler := dependencyTestReconciler(t, running, terminal, failed, redirectTarget,
+		otherRedirectSource, foreign, conflicting)
+	pending := []reconcile.Request{
 		{NamespacedName: client.ObjectKeyFromObject(running)},
 		{NamespacedName: client.ObjectKeyFromObject(redirectTarget)},
 		{NamespacedName: client.ObjectKeyFromObject(otherRedirectSource)},
-	}, reconciler.mapRestoreToPVCs(context.Background(), restore))
+	}
+	require.ElementsMatch(t, pending, reconciler.mapRestoreToPVCs(context.Background(), restore))
 
 	redirected := restore.DeepCopy()
 	redirected.Labels[constant.KBAppComponentLabelKey] = "postgresql"
-	require.ElementsMatch(t, []reconcile.Request{
-		{NamespacedName: client.ObjectKeyFromObject(running)},
-		{NamespacedName: client.ObjectKeyFromObject(redirectTarget)},
-		{NamespacedName: client.ObjectKeyFromObject(otherRedirectSource)},
-	}, reconciler.mapRestoreToPVCs(context.Background(), redirected))
+	require.ElementsMatch(t, pending, reconciler.mapRestoreToPVCs(context.Background(), redirected))
+
+	all := append(append([]reconcile.Request(nil), pending...),
+		reconcile.Request{NamespacedName: client.ObjectKeyFromObject(terminal)},
+		reconcile.Request{NamespacedName: client.ObjectKeyFromObject(failed)})
+	for _, phase := range []dpv1alpha1.RestorePhase{dpv1alpha1.RestorePhaseCompleted, dpv1alpha1.RestorePhaseFailed} {
+		obj := restore.DeepCopy()
+		obj.Status.Phase = phase
+		require.ElementsMatch(t, all, reconciler.mapRestoreToPVCs(context.Background(), obj))
+	}
+	deleting := restore.DeepCopy()
+	now := metav1.Now()
+	deleting.DeletionTimestamp = &now
+	require.ElementsMatch(t, all, reconciler.mapRestoreToPVCs(context.Background(), deleting))
+
+	wrongOwner := restore.DeepCopy()
+	wrongOwner.OwnerReferences[0].UID = "another-component"
+	require.Empty(t, reconciler.mapRestoreToPVCs(context.Background(), wrongOwner))
+	wrongIdentity := restore.DeepCopy()
+	wrongIdentity.Labels[dptypes.ComponentUIDLabelKey] = "another-component"
+	require.Empty(t, reconciler.mapRestoreToPVCs(context.Background(), wrongIdentity))
+	wrongCluster := restore.DeepCopy()
+	wrongCluster.Labels[dptypes.ClusterUIDLabelKey] = "unmatched-cluster-uid"
+	require.Empty(t, reconciler.mapRestoreToPVCs(context.Background(), wrongCluster))
 }
 
 func TestMapComponentAndClusterDependencies(t *testing.T) {
@@ -4037,14 +4070,22 @@ func TestMapComponentAndClusterDependencies(t *testing.T) {
 	terminal.Status.Conditions = []corev1.PersistentVolumeClaimCondition{{
 		Type: corev1.PersistentVolumeClaimConditionType(kbappsv1.ConditionTypeRestore), Status: corev1.ConditionFalse,
 	}}
+	foreign := dependencyRestorePVC("foreign", "mysql", "foreign-pvc")
+	foreign.Annotations[constant.KBAppClusterUIDKey] = "another-cluster-uid"
 	comp := &kbappsv1.Component{ObjectMeta: metav1.ObjectMeta{
-		Namespace: "default", Name: "cluster-mysql",
+		Namespace: "default", Name: "cluster-mysql", UID: "component-uid",
 		Labels: map[string]string{
 			constant.AppInstanceLabelKey: "cluster", constant.KBAppComponentLabelKey: "mysql",
 		},
+		OwnerReferences: []metav1.OwnerReference{{
+			APIVersion: kbappsv1.GroupVersion.String(), Kind: kbappsv1.ClusterKind,
+			Name: "cluster", UID: "cluster-uid",
+		}},
 	}}
-	cluster := &kbappsv1.Cluster{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "cluster"}}
-	reconciler := dependencyTestReconciler(t, mysql, postgresql, invalid, terminal)
+	cluster := &kbappsv1.Cluster{ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default", Name: "cluster", UID: "cluster-uid",
+	}}
+	reconciler := dependencyTestReconciler(t, mysql, postgresql, invalid, terminal, foreign)
 
 	require.ElementsMatch(t, []reconcile.Request{
 		{NamespacedName: client.ObjectKeyFromObject(mysql)},
@@ -4083,6 +4124,29 @@ func TestClusterRestorePVCIdentitySupportsSharding(t *testing.T) {
 			require.Equal(t, tt.want, isClusterRestorePVC(pvc))
 		})
 	}
+}
+
+func TestInternalRestoreCorrelationIdentity(t *testing.T) {
+	pvc := dependencyRestorePVC("data-mysql-0", "mysql", "pvc-uid")
+	comp := &kbappsv1.Component{ObjectMeta: metav1.ObjectMeta{
+		Namespace: pvc.Namespace, Name: "cluster-mysql", UID: "component-uid",
+	}}
+
+	require.Equal(t, "cluster-uid", internalRestoreLabels(pvc)[dptypes.ClusterUIDLabelKey])
+	postReadyLabels := postReadyRestoreLabels(pvc, comp)
+	require.Equal(t, "cluster-uid", postReadyLabels[dptypes.ClusterUIDLabelKey])
+	require.Equal(t, string(comp.UID), postReadyLabels[dptypes.ComponentUIDLabelKey])
+
+	reconciler := dependencyTestReconciler(t)
+	helper, err := reconciler.getProvisionOnlyPVC(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, pvc, "")
+	require.NoError(t, err)
+	require.Equal(t, "cluster-uid", helper.Labels[dptypes.ClusterUIDLabelKey])
+
+	conflicting := pvc.DeepCopy()
+	conflicting.Labels[dptypes.ClusterUIDLabelKey] = "another-cluster-uid"
+	require.Empty(t, clusterRestorePVCUID(conflicting))
+	require.False(t, isClusterRestorePVC(conflicting))
 }
 
 func TestDependencyPredicates(t *testing.T) {
@@ -4143,6 +4207,7 @@ func dependencyRestorePVC(name, componentName string, uid types.UID) *corev1.Per
 				constant.AppInstanceLabelKey: "cluster", constant.KBAppComponentLabelKey: componentName,
 			},
 			Annotations: map[string]string{
+				constant.KBAppClusterUIDKey:                 "cluster-uid",
 				constant.RestoreSourceAPIGroupAnnotationKey: dptypes.DataprotectionAPIGroup,
 				constant.RestoreSourceKindAnnotationKey:     dptypes.BackupKind,
 				constant.RestoreSourceNameAnnotationKey:     "backup",

--- a/pkg/dataprotection/types/constant.go
+++ b/pkg/dataprotection/types/constant.go
@@ -86,6 +86,8 @@ const (
 const (
 	// ClusterUIDLabelKey specifies the cluster UID label key.
 	ClusterUIDLabelKey = "dataprotection.kubeblocks.io/cluster-uid"
+	// ComponentUIDLabelKey specifies the component UID label key.
+	ComponentUIDLabelKey = "dataprotection.kubeblocks.io/component-uid"
 	// BackupNameLabelKey specifies the backup name label key.
 	BackupNameLabelKey = "dataprotection.kubeblocks.io/backup-name"
 	// BackupNamespaceLabelKey specifies the backup namespace label key.


### PR DESCRIPTION
## Problem

VolumePopulator dependency events need stable Cluster and Component correlation without making those labels a deletion authorization mechanism.

## Changes

- carry the Cluster UID through VCT restore intent into target and internal restore resources
- identify postReady Restore objects by their actual Component owner UID
- map execution Restore events to the exact target PVC
- map postReady events after the owner Component disappears
- isolate dependency fan-out by Cluster UID and include terminal PVCs for terminal/deleting Restore events
- keep all mappers enqueue-only; this PR adds no finalizer or deletion behavior

## Compatibility

UID metadata is correlation only. Existing UID-less resources continue through the existing requeue path and are not migrated.

## Tests

- restore intent UID injection and cleanup
- execution/postReady/Component/Cluster dependency mapping
- terminal/deleting Restore fan-out
- sharding and mismatched identity filtering
- full controllers/dataprotection suite

Refs #10755

Split from #10777.