### PR TITLE
fix(helm): support an independent datasafed registry on release-1.1

### DIFF
--- a/deploy/helm/templates/dataprotection.yaml
+++ b/deploy/helm/templates/dataprotection.yaml
@@ -150,7 +150,7 @@ spec:
                 secretKeyRef:
                   {{- include "dataprotection.encryptionKeySecretKeyRef" . | nindent 18 }}
             - name: DATASAFED_IMAGE
-              value: "{{ .Values.dataProtection.image.registry | default $dataProtectionImageRegistry }}/{{ .Values.dataProtection.image.datasafed.repository }}:{{ .Values.dataProtection.image.datasafed.tag | default "latest" }}"
+              value: "{{ .Values.dataProtection.image.datasafed.registry | default .Values.dataProtection.image.registry | default $dataProtectionImageRegistry }}/{{ .Values.dataProtection.image.datasafed.repository }}:{{ .Values.dataProtection.image.datasafed.tag | default "latest" }}"
             - name: GC_FREQUENCY_SECONDS
               value: "{{ .Values.dataProtection.gcFrequencySeconds }}"
             - name: WORKER_SERVICE_ACCOUNT_NAME

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -400,6 +400,8 @@ dataProtection:
     tag: ""
     imagePullSecrets: []
     datasafed:
+      ## @param dataProtection.image.datasafed.registry Datasafed image registry; empty uses dataProtection.image.registry, then the global image registry default.
+      registry: ""
       repository: apecloud/datasafed
       tag: "0.2.3"
   ## @param toleration

--- a/test/README.md
+++ b/test/README.md
@@ -5,3 +5,12 @@ Additional external test apps and test data. Feel free to structure the `/test` 
 Examples:
 
 * https://github.com/openshift/origin/tree/master/test (test data is in the `/testdata` subdirectory)
+
+## Helm Chart Rendering
+
+Install Helm, then run `go test ./test/helm -count=1 -v` from the repository root.
+These tests render the real chart without contacting a Kubernetes cluster. They
+are skipped when Helm is not installed.
+
+The chart tests cover datasafed registry overrides, legacy registry fallbacks,
+and isolation from other rendered resources and image settings.

--- a/test/helm/dataprotection_test.go
+++ b/test/helm/dataprotection_test.go
@@ -1,7 +1,5 @@
 /*
-Copyright (C) 2026 ApeCloud Co., Ltd.
-
-This file is part of KubeBlocks project.
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/helm/dataprotection_test.go
+++ b/test/helm/dataprotection_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright (C) 2026 ApeCloud Co., Ltd.
+
+This file is part of KubeBlocks project.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helm
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/yaml"
+)
+
+const defaultRegistry = "apecloud-registry.cn-zhangjiakou.cr.aliyuncs.com"
+
+func renderChart(t *testing.T, settings ...string) []map[string]interface{} {
+	t.Helper()
+	helm, err := exec.LookPath("helm")
+	if err != nil {
+		t.Skip("Helm is required for chart rendering tests")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	args := []string{"template", "kb", "../../deploy/helm", "--namespace", "kb-system",
+		"--set-string", "dataProtection.encryptionKey=chart-render-test-key"}
+	for _, setting := range settings {
+		args = append(args, "--set", setting)
+	}
+	cmd := exec.CommandContext(ctx, helm, args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	output, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("helm template: %v\n%s", err, stderr.String())
+	}
+	decoder := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(output), 4096)
+	var objects []map[string]interface{}
+	for {
+		var object map[string]interface{}
+		err := decoder.Decode(&object)
+		if err == io.EOF {
+			return objects
+		}
+		if err != nil {
+			t.Fatalf("decode rendered manifest: %v", err)
+		}
+		if len(object) > 0 {
+			objects = append(objects, object)
+		}
+	}
+}
+
+func datasafedEnv(t *testing.T, objects []map[string]interface{}) (map[string]interface{}, []interface{}, map[string]interface{}) {
+	t.Helper()
+	for _, object := range objects {
+		name, _, _ := unstructured.NestedString(object, "metadata", "name")
+		if object["kind"] != "Deployment" || name != "kb-kubeblocks-dataprotection" {
+			continue
+		}
+		containers, _, err := unstructured.NestedSlice(object, "spec", "template", "spec", "containers")
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, item := range containers {
+			container := item.(map[string]interface{})
+			if container["name"] != "dataprotection" {
+				continue
+			}
+			for _, item := range container["env"].([]interface{}) {
+				env := item.(map[string]interface{})
+				if env["name"] == "DATASAFED_IMAGE" {
+					return object, containers, env
+				}
+			}
+		}
+	}
+	t.Fatal("DATASAFED_IMAGE not found in dataprotection Deployment")
+	return nil, nil, nil
+}
+
+func TestDataSafedRegistry(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings []string
+		image    string
+	}{
+		{"default", nil, defaultRegistry + "/apecloud/datasafed:0.2.3"},
+		{"global fallback", []string{"image.registry=global.example.com"}, "global.example.com/apecloud/datasafed:0.2.3"},
+		{"DP fallback", []string{"image.registry=global.example.com", "dataProtection.image.registry=dp.example.com"}, "dp.example.com/apecloud/datasafed:0.2.3"},
+		{"independent registry", []string{"dataProtection.image.datasafed.registry=public.example.com"}, "public.example.com/apecloud/datasafed:0.2.3"},
+		{"independent precedence", []string{"image.registry=global.example.com", "dataProtection.image.registry=dp.example.com", "dataProtection.image.datasafed.registry=public.example.com:5000"}, "public.example.com:5000/apecloud/datasafed:0.2.3"},
+		{"empty registry", []string{"dataProtection.image.registry=dp.example.com", "dataProtection.image.datasafed.registry="}, "dp.example.com/apecloud/datasafed:0.2.3"},
+		{"null registry", []string{"dataProtection.image.registry=dp.example.com", "dataProtection.image.datasafed.registry=null"}, "dp.example.com/apecloud/datasafed:0.2.3"},
+		{"empty registries", []string{"image.registry=", "dataProtection.image.registry=", "dataProtection.image.datasafed.registry="}, defaultRegistry + "/apecloud/datasafed:0.2.3"},
+		{"custom repository and tag", []string{"dataProtection.image.datasafed.registry=public.example.com", "dataProtection.image.datasafed.repository=custom/datasafed", "dataProtection.image.datasafed.tag=custom"}, "public.example.com/custom/datasafed:custom"},
+		{"empty tag fallback", []string{"dataProtection.image.datasafed.registry=public.example.com", "dataProtection.image.datasafed.tag="}, "public.example.com/apecloud/datasafed:latest"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, env := datasafedEnv(t, renderChart(t, tt.settings...))
+			if env["value"] != tt.image {
+				t.Fatalf("DATASAFED_IMAGE = %q, want %q", env["value"], tt.image)
+			}
+		})
+	}
+}
+
+func TestDataSafedRegistryOnlyChangesDataSafedImage(t *testing.T) {
+	settings := []string{"image.registry=controller.example.com", "dataProtection.image.registry=harbor.example.com:5000"}
+	want := renderChart(t, settings...)
+	got := renderChart(t, append(settings, "dataProtection.image.datasafed.registry=public.example.com")...)
+	object, containers, env := datasafedEnv(t, want)
+	if env["value"] != "harbor.example.com:5000/apecloud/datasafed:0.2.3" {
+		t.Fatalf("unexpected legacy image: %v", env["value"])
+	}
+	env["value"] = "public.example.com/apecloud/datasafed:0.2.3"
+	if err := unstructured.SetNestedSlice(object, containers, "spec", "template", "spec", "containers"); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatal("independent registry must change only DATASAFED_IMAGE across all rendered objects")
+	}
+}
+
+func TestDataSafedRegistryWithDataProtectionDisabled(t *testing.T) {
+	for _, object := range renderChart(t, "dataProtection.enabled=false", "dataProtection.image.datasafed.registry=public.example.com") {
+		name, _, _ := unstructured.NestedString(object, "metadata", "name")
+		if object["kind"] == "Deployment" && strings.HasSuffix(name, "-dataprotection") {
+			t.Fatal("dataprotection Deployment rendered while disabled")
+		}
+	}
+}


### PR DESCRIPTION
Fixes #10849. Main counterpart: #10847.

Allow the release-1.1 chart to keep datasafed in a separate registry when the DataProtection controller image is moved to Harbor. This candidate is based directly on the Oracle test's fixed source `805b8b3c05c1846bf9218cb83d96a5d627cbd2ae`.

Add optional `dataProtection.image.datasafed.registry`, defaulting to empty. A nonempty value overrides only `DATASAFED_IMAGE`; omitted, empty, and null values preserve the current DP/global/ACR fallback. The existing addon chart registry setting is unchanged. The new value is documented inline; this chart does not have a values schema.

Validation on this release-1.1 base:

- `go test ./test/helm -count=1 -v` passes with Helm 3.19.0 and 4.2.0.
- Complete rendered objects differ only in `DATASAFED_IMAGE` when the independent registry is set.
- Eight legacy configurations produce byte-identical full manifests before and after the change.
- `helm lint deploy/helm --strict` and `git diff --check` pass.
- The repository license-header check passes.

The rendering tests require Helm and skip when it is absent. Live image pulls and Oracle's platform/chart combination remain separate validation.

Chinese design: [DOC-94@v1](https://infracreate.com/project-manager/designs/c3678fe0-eb12-4c3c-a252-a8436705d24a).
