### PR TITLE
fix(ops): support flat-ordinal vertical scaling and volume expansion

### DIFF
--- a/controllers/operations/opsrequest_controller_test.go
+++ b/controllers/operations/opsrequest_controller_test.go
@@ -440,8 +440,19 @@ var _ = Describe("OpsRequest Controller", func() {
 
 		itsList := testk8s.ListAndCheckInstanceSetWithComponent(&testCtx, clusterKey, mysqlCompName)
 		mysqlIts := &itsList.Items[0]
+		mockDefaultTemplateReady := func(its *workloads.InstanceSet) {
+			testk8s.MockInstanceSetReady(its, pod)
+			// This fixture has one default-template instance. Publish its API
+			// assignment separately from the actual Pod resource update below.
+			for i := range its.Status.InstanceStatus {
+				status := &its.Status.InstanceStatus[i]
+				status.TemplateName = pointer.String("")
+				status.DesiredState = workloads.InstanceDesiredStateActive
+				status.CurrentState = workloads.InstanceCurrentStatePresent
+			}
+		}
 		Expect(testapps.ChangeObjStatus(&testCtx, mysqlIts, func() {
-			testk8s.MockInstanceSetReady(mysqlIts, pod)
+			mockDefaultTemplateReady(mysqlIts)
 		})).ShouldNot(HaveOccurred())
 		Eventually(testapps.GetClusterPhase(&testCtx, clusterKey)).Should(Equal(appsv1.RunningClusterPhase))
 
@@ -466,7 +477,7 @@ var _ = Describe("OpsRequest Controller", func() {
 
 		By("mock bring Cluster and changed component back to running status")
 		Expect(testapps.GetAndChangeObjStatus(&testCtx, client.ObjectKeyFromObject(mysqlIts), func(tmpIts *workloads.InstanceSet) {
-			testk8s.MockInstanceSetReady(tmpIts, pod)
+			mockDefaultTemplateReady(tmpIts)
 		})()).ShouldNot(HaveOccurred())
 		Eventually(testapps.GetClusterComponentPhase(&testCtx, clusterKey, mysqlCompName)).Should(Equal(appsv1.RunningComponentPhase))
 		Eventually(testapps.GetClusterPhase(&testCtx, clusterKey)).Should(Equal(appsv1.RunningClusterPhase))

--- a/pkg/operations/instance_status.go
+++ b/pkg/operations/instance_status.go
@@ -1,0 +1,106 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+package operations
+
+import (
+	"fmt"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	workloadsv1 "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+)
+
+func instanceStatusByName(statuses []workloadsv1.InstanceStatus) (map[string]workloadsv1.InstanceStatus, error) {
+	result := make(map[string]workloadsv1.InstanceStatus, len(statuses))
+	for _, status := range statuses {
+		if status.PodName == "" {
+			return nil, fmt.Errorf("InstanceSet published an empty instance identity")
+		}
+		if _, ok := result[status.PodName]; ok {
+			return nil, fmt.Errorf("InstanceSet published duplicate instance identity %q", status.PodName)
+		}
+		result[status.PodName] = status
+	}
+	return result, nil
+}
+
+func activeInstanceTemplates(statuses []workloadsv1.InstanceStatus,
+	include func(workloadsv1.InstanceStatus) bool) (map[string]string, error) {
+	if _, err := instanceStatusByName(statuses); err != nil {
+		return nil, err
+	}
+	result := map[string]string{}
+	for _, status := range statuses {
+		if status.EffectiveDesiredState() != workloadsv1.InstanceDesiredStateActive || include != nil && !include(status) {
+			continue
+		}
+		if status.TemplateName == nil {
+			return nil, intctrlutil.NewErrorf(intctrlutil.ErrorTypeNeedWaiting,
+				"waiting for InstanceSet to publish the template assignment of instance %q", status.PodName)
+		}
+		result[status.PodName] = *status.TemplateName
+	}
+	return result, nil
+}
+
+func expectedTemplateReplicas(component *appsv1.ClusterComponentSpec) (map[string]int32, bool) {
+	if component == nil {
+		return nil, false
+	}
+	expected := map[string]int32{}
+	defaultReplicas := component.Replicas
+	for _, template := range component.Instances {
+		replicas := template.GetReplicas()
+		if replicas > 0 {
+			expected[template.Name] += replicas
+		}
+		defaultReplicas -= replicas
+	}
+	if defaultReplicas < 0 {
+		return nil, false
+	}
+	if defaultReplicas > 0 {
+		expected[""] = defaultReplicas
+	}
+	return expected, true
+}
+
+func assignmentsMatchComponent(assignments map[string]string, component *appsv1.ClusterComponentSpec) bool {
+	if component == nil || int32(len(assignments)) != component.Replicas {
+		return false
+	}
+	expected, ok := expectedTemplateReplicas(component)
+	if !ok {
+		return false
+	}
+	actual := map[string]int32{}
+	for _, templateName := range assignments {
+		actual[templateName]++
+	}
+	if len(actual) != len(expected) {
+		return false
+	}
+	for templateName, count := range expected {
+		if actual[templateName] != count {
+			return false
+		}
+	}
+	return true
+}
+
+func activeAssignmentsForTarget(workload Workload, component *appsv1.ClusterComponentSpec) (map[string]string, bool, error) {
+	assignments, err := activeInstanceTemplates(workload.GetInstanceStatuses(), nil)
+	if err != nil {
+		return nil, false, err
+	}
+	return assignments, assignmentsMatchComponent(assignments, component), nil
+}

--- a/pkg/operations/instance_status.go
+++ b/pkg/operations/instance_status.go
@@ -19,28 +19,27 @@ import (
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 )
 
-func instanceStatusByName(statuses []workloadsv1.InstanceStatus) (map[string]workloadsv1.InstanceStatus, error) {
-	result := make(map[string]workloadsv1.InstanceStatus, len(statuses))
+func validateInstanceIdentities(statuses []workloadsv1.InstanceStatus) error {
+	names := make(map[string]struct{}, len(statuses))
 	for _, status := range statuses {
 		if status.PodName == "" {
-			return nil, fmt.Errorf("InstanceSet published an empty instance identity")
+			return fmt.Errorf("InstanceSet published an empty instance identity")
 		}
-		if _, ok := result[status.PodName]; ok {
-			return nil, fmt.Errorf("InstanceSet published duplicate instance identity %q", status.PodName)
+		if _, ok := names[status.PodName]; ok {
+			return fmt.Errorf("InstanceSet published duplicate instance identity %q", status.PodName)
 		}
-		result[status.PodName] = status
+		names[status.PodName] = struct{}{}
 	}
-	return result, nil
+	return nil
 }
 
-func activeInstanceTemplates(statuses []workloadsv1.InstanceStatus,
-	include func(workloadsv1.InstanceStatus) bool) (map[string]string, error) {
-	return instanceTemplatesByState(statuses, workloadsv1.InstanceDesiredStateActive, include)
+func activeInstanceTemplates(statuses []workloadsv1.InstanceStatus) (map[string]string, error) {
+	return instanceTemplatesByState(statuses, workloadsv1.InstanceDesiredStateActive, nil)
 }
 
 func instanceTemplatesByState(statuses []workloadsv1.InstanceStatus, desired workloadsv1.InstanceDesiredState,
 	include func(workloadsv1.InstanceStatus) bool) (map[string]string, error) {
-	if _, err := instanceStatusByName(statuses); err != nil {
+	if err := validateInstanceIdentities(statuses); err != nil {
 		return nil, err
 	}
 	result := map[string]string{}
@@ -103,7 +102,7 @@ func assignmentsMatchComponent(assignments map[string]string, component *appsv1.
 }
 
 func activeAssignmentsForTarget(workload Workload, component *appsv1.ClusterComponentSpec) (map[string]string, bool, error) {
-	assignments, err := activeInstanceTemplates(workload.GetInstanceStatuses(), nil)
+	assignments, err := activeInstanceTemplates(workload.GetInstanceStatuses())
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/operations/instance_status.go
+++ b/pkg/operations/instance_status.go
@@ -35,12 +35,17 @@ func instanceStatusByName(statuses []workloadsv1.InstanceStatus) (map[string]wor
 
 func activeInstanceTemplates(statuses []workloadsv1.InstanceStatus,
 	include func(workloadsv1.InstanceStatus) bool) (map[string]string, error) {
+	return instanceTemplatesByState(statuses, workloadsv1.InstanceDesiredStateActive, include)
+}
+
+func instanceTemplatesByState(statuses []workloadsv1.InstanceStatus, desired workloadsv1.InstanceDesiredState,
+	include func(workloadsv1.InstanceStatus) bool) (map[string]string, error) {
 	if _, err := instanceStatusByName(statuses); err != nil {
 		return nil, err
 	}
 	result := map[string]string{}
 	for _, status := range statuses {
-		if status.EffectiveDesiredState() != workloadsv1.InstanceDesiredStateActive || include != nil && !include(status) {
+		if status.EffectiveDesiredState() != desired || include != nil && !include(status) {
 			continue
 		}
 		if status.TemplateName == nil {

--- a/pkg/operations/instance_status_test.go
+++ b/pkg/operations/instance_status_test.go
@@ -14,6 +14,7 @@ package operations
 import (
 	"context"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -33,15 +34,128 @@ import (
 
 func templateName(name string) *string { return &name }
 
+func TestVerticalScalingDefaultAndEmptySelection(t *testing.T) {
+	for _, tc := range []struct {
+		name                                string
+		zeroTemplate, zeroComponent, cancel bool
+	}{
+		{name: "default"},
+		{name: "zero-template", zeroTemplate: true},
+		{name: "zero-component", zeroComponent: true},
+		{name: "cancel-default", cancel: true},
+		{name: "cancel-zero-template", zeroTemplate: true, cancel: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			scheme := runtime.NewScheme()
+			for _, add := range []func(*runtime.Scheme) error{corev1.AddToScheme, appsv1.AddToScheme, workloads.AddToScheme, opsv1alpha1.AddToScheme} {
+				if err := add(scheme); err != nil {
+					t.Fatal(err)
+				}
+			}
+			target := corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")}}
+			original := corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")}}
+			comp := appsv1.ClusterComponentSpec{Name: "db", ComponentDef: "database", Replicas: 1, FlatInstanceOrdinal: true, Resources: target}
+			vs := opsv1alpha1.VerticalScaling{ComponentOps: opsv1alpha1.ComponentOps{ComponentName: "db"}, ResourceRequirements: target}
+			last := opsv1alpha1.LastComponentConfiguration{ResourceRequirements: original}
+			if tc.zeroTemplate {
+				comp.Instances = []appsv1.InstanceTemplate{{Name: "unused", Replicas: pointer.Int32(0), Resources: &target}}
+				vs.ResourceRequirements = corev1.ResourceRequirements{}
+				vs.Instances = []opsv1alpha1.InstanceResourceTemplate{{Name: "unused", ResourceRequirements: target}}
+				last.Instances = []appsv1.InstanceTemplate{{Name: "unused", Resources: &original}}
+			}
+			if tc.zeroComponent {
+				comp.Replicas = 0
+			}
+			cluster := &appsv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
+				Spec:   appsv1.ClusterSpec{ComponentSpecs: []appsv1.ClusterComponentSpec{comp}},
+				Status: appsv1.ClusterStatus{Components: map[string]appsv1.ClusterComponentStatus{"db": {Phase: appsv1.RunningComponentPhase}}}}
+			its := &workloads.InstanceSet{ObjectMeta: metav1.ObjectMeta{Name: "demo-db", Namespace: "default"}}
+			ops := &opsv1alpha1.OpsRequest{ObjectMeta: metav1.ObjectMeta{Name: "scale", Namespace: "default"},
+				Spec: opsv1alpha1.OpsRequestSpec{Cancel: tc.cancel, SpecificOpsRequest: opsv1alpha1.SpecificOpsRequest{VerticalScalingList: []opsv1alpha1.VerticalScaling{vs}}},
+				Status: opsv1alpha1.OpsRequestStatus{Phase: opsv1alpha1.OpsRunningPhase, StartTimestamp: metav1.NewTime(time.Now().Add(-time.Minute)),
+					LastConfiguration: opsv1alpha1.LastConfiguration{Components: map[string]opsv1alpha1.LastComponentConfiguration{"db": last}}}}
+			if tc.cancel {
+				ops.Status.Phase = opsv1alpha1.OpsCancellingPhase
+				ops.Status.CancelTimestamp = ops.Status.StartTimestamp
+			}
+			objects := []client.Object{cluster, its, ops, &appsv1.ComponentDefinition{ObjectMeta: metav1.ObjectMeta{Name: "database"}}}
+			// These unrelated Pods must never be selected, including when the
+			// authoritative selection is empty. Their resources already match.
+			for _, name := range []string{"demo-db-42", "demo-db-7", "demo-db-8"} {
+				objects = append(objects, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", CreationTimestamp: metav1.Now(), Labels: constant.GetCompLabels("demo", "db")},
+					Spec:   corev1.PodSpec{Containers: []corev1.Container{{Name: "db", Resources: target}}},
+					Status: corev1.PodStatus{Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}}})
+			}
+			cli := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(ops, its).WithObjects(objects...).Build()
+			opsRes := &OpsResource{Cluster: cluster, OpsRequest: ops, Recorder: record.NewFakeRecorder(30), Runtimes: map[string]OpsRuntime{"db": newOpsRuntime(ctx, cli, "")}}
+			handler := verticalScalingHandler{}
+			if tc.cancel {
+				if err := handler.Cancel(intctrlutil.RequestCtx{Ctx: ctx}, cli, opsRes); err != nil {
+					t.Fatal(err)
+				}
+			}
+			check := func(want opsv1alpha1.OpsPhase, progress string, participants int) {
+				t.Helper()
+				phase, _, err := handler.ReconcileAction(intctrlutil.RequestCtx{Ctx: ctx}, cli, opsRes)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if phase != want || ops.Status.Progress != progress {
+					t.Fatalf("got %s %s, want %s %s", phase, ops.Status.Progress, want, progress)
+				}
+				details := ops.Status.Components["db"].ProgressDetails
+				if len(details) != participants {
+					t.Fatalf("unexpected participants: %#v", details)
+				}
+				if participants == 1 && details[0].ObjectKey != "Pod/demo-db-42" {
+					t.Fatalf("unexpected participant: %s", details[0].ObjectKey)
+				}
+			}
+			if !tc.zeroComponent {
+				check(opsv1alpha1.OpsRunningPhase, "0/1", 0)
+			}
+			its.Status.InstanceStatus = []workloads.InstanceStatus{
+				{PodName: "demo-db-7", DesiredState: workloads.InstanceDesiredStateReleased},
+				{PodName: "demo-db-8", DesiredState: workloads.InstanceDesiredStateOffline},
+			}
+			if !tc.zeroComponent {
+				its.Status.InstanceStatus = append(its.Status.InstanceStatus, workloads.InstanceStatus{PodName: "demo-db-42", TemplateName: templateName(""), DesiredState: workloads.InstanceDesiredStateActive})
+			}
+			if err := cli.Status().Update(ctx, its); err != nil {
+				t.Fatal(err)
+			}
+			if tc.zeroTemplate || tc.zeroComponent {
+				check(opsv1alpha1.OpsSucceedPhase, "0/0", 0)
+				return
+			}
+			if tc.cancel {
+				check(opsv1alpha1.OpsRunningPhase, "0/1", 1)
+				pod := &corev1.Pod{}
+				if err := cli.Get(ctx, client.ObjectKey{Name: "demo-db-42", Namespace: "default"}, pod); err != nil {
+					t.Fatal(err)
+				}
+				pod.Spec.Containers[0].Resources = original
+				if err := cli.Update(ctx, pod); err != nil {
+					t.Fatal(err)
+				}
+			}
+			check(opsv1alpha1.OpsSucceedPhase, "1/1", 1)
+		})
+	}
+}
+
 func TestStoppedVolumeExpansionUsesRetainedPVCs(t *testing.T) {
 	for _, tc := range []struct {
 		name, podName, template string
 		flat                    bool
+		defaultReplicas         bool
 	}{
 		{name: "flat-default", podName: "demo-db-42", flat: true},
 		{name: "flat-template", podName: "demo-db-42", template: "large", flat: true},
 		{name: "nonflat-default", podName: "demo-db-0"},
 		{name: "nonflat-template", podName: "demo-db-large-0", template: "large"},
+		{name: "template-default-replicas", podName: "demo-db-42", template: "large", flat: true, defaultReplicas: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
@@ -55,6 +169,9 @@ func TestStoppedVolumeExpansionUsesRetainedPVCs(t *testing.T) {
 				Stop: pointer.Bool(true), OfflineInstances: []string{"demo-db-8"}}
 			if tc.template != "" {
 				component.Instances = []appsv1.InstanceTemplate{{Name: tc.template, Replicas: pointer.Int32(1)}}
+				if tc.defaultReplicas {
+					component.Instances[0].Replicas = nil
+				}
 			}
 			cluster := &appsv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
 				Spec:   appsv1.ClusterSpec{ComponentSpecs: []appsv1.ClusterComponentSpec{component}},

--- a/pkg/operations/instance_status_test.go
+++ b/pkg/operations/instance_status_test.go
@@ -1,0 +1,237 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+package operations
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	opsv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+)
+
+func templateName(name string) *string { return &name }
+
+// Exercise the real Operations runtime and handlers against explicit API objects.
+// The instance names intentionally carry no template name or contiguous ordinal.
+func TestScalingUsesAssignedInstancesAndActualObjects(t *testing.T) {
+	ctx := context.Background()
+	for _, operation := range []string{"vertical", "volume"} {
+		t.Run(operation, func(t *testing.T) {
+			scheme := runtime.NewScheme()
+			for _, add := range []func(*runtime.Scheme) error{corev1.AddToScheme, appsv1.AddToScheme, workloads.AddToScheme, opsv1alpha1.AddToScheme} {
+				if err := add(scheme); err != nil {
+					t.Fatal(err)
+				}
+			}
+			resources := corev1.ResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")}}
+			cluster := &appsv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
+				Spec: appsv1.ClusterSpec{ComponentSpecs: []appsv1.ClusterComponentSpec{{Name: "db", ComponentDef: "database", Replicas: 3, FlatInstanceOrdinal: true,
+					Instances: []appsv1.InstanceTemplate{{Name: "large", Replicas: pointer.Int32(2), Resources: &resources}}}}},
+				Status: appsv1.ClusterStatus{Components: map[string]appsv1.ClusterComponentStatus{"db": {Phase: appsv1.RunningComponentPhase}}}}
+			its := &workloads.InstanceSet{ObjectMeta: metav1.ObjectMeta{Name: "demo-db", Namespace: "default"},
+				Status: workloads.InstanceSetStatus{InstanceStatus: []workloads.InstanceStatus{
+					{PodName: "demo-db-7", TemplateName: templateName("large"), DesiredState: workloads.InstanceDesiredStateActive, CurrentState: workloads.InstanceCurrentStatePresent, UpToDate: true},
+					{PodName: "demo-db-42", TemplateName: templateName("large"), DesiredState: workloads.InstanceDesiredStateActive, CurrentState: workloads.InstanceCurrentStatePresent, UpToDate: true},
+					{PodName: "demo-db-3", TemplateName: templateName(""), DesiredState: workloads.InstanceDesiredStateActive},
+					{PodName: "demo-db-8", DesiredState: workloads.InstanceDesiredStateOffline},
+					{PodName: "demo-db-9", TemplateName: templateName("large"), DesiredState: workloads.InstanceDesiredStateReleased},
+				}}}
+			ops := &opsv1alpha1.OpsRequest{ObjectMeta: metav1.ObjectMeta{Name: "scaling", Namespace: "default"},
+				Spec: opsv1alpha1.OpsRequestSpec{SpecificOpsRequest: opsv1alpha1.SpecificOpsRequest{VerticalScalingList: []opsv1alpha1.VerticalScaling{{
+					ComponentOps: opsv1alpha1.ComponentOps{ComponentName: "db"}, Instances: []opsv1alpha1.InstanceResourceTemplate{{Name: "large", ResourceRequirements: resources}},
+				}}}}, Status: opsv1alpha1.OpsRequestStatus{Phase: opsv1alpha1.OpsRunningPhase}}
+			objects := []client.Object{cluster, its, ops, &appsv1.ComponentDefinition{ObjectMeta: metav1.ObjectMeta{Name: "database"}}}
+			for _, name := range []string{"demo-db-7", "demo-db-42", "demo-db-3", "demo-db-9"} {
+				objects = append(objects, &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", Labels: constant.GetCompLabels("demo", "db")},
+					Spec:   corev1.PodSpec{Containers: []corev1.Container{{Name: "db"}}, Volumes: []corev1.Volume{{Name: "data", VolumeSource: corev1.VolumeSource{PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "data-" + name}}}}},
+					Status: corev1.PodStatus{Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}}},
+					&corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "data-" + name, Namespace: "default", Labels: constant.GetCompLabels("demo", "db")},
+						Spec:   corev1.PersistentVolumeClaimSpec{Resources: corev1.VolumeResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("2Gi")}}},
+						Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound, Capacity: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")}}})
+			}
+			cli := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(ops, its, &corev1.PersistentVolumeClaim{}).WithObjects(objects...).Build()
+			opsRes := &OpsResource{Cluster: cluster, OpsRequest: ops, Recorder: record.NewFakeRecorder(50), Runtimes: map[string]OpsRuntime{"db": newOpsRuntime(ctx, cli, "")}}
+			compStatus := &opsv1alpha1.OpsRequestComponentStatus{}
+			check := func(wantCompleted int) {
+				t.Helper()
+				if operation == "vertical" {
+					phase, _, err := (verticalScalingHandler{}).ReconcileAction(intctrlutil.RequestCtx{Ctx: ctx}, cli, opsRes)
+					if err != nil {
+						t.Fatal(err)
+					}
+					wantPhase := opsv1alpha1.OpsRunningPhase
+					if wantCompleted == 2 {
+						wantPhase = opsv1alpha1.OpsSucceedPhase
+					}
+					if phase != wantPhase {
+						t.Fatalf("phase=%s, want %s", phase, wantPhase)
+					}
+					status := ops.Status.Components["db"]
+					compStatus = &status
+				} else {
+					succeeded, completed, err := (volumeExpansionOpsHandler{}).handleVCTExpansionProgress(intctrlutil.RequestCtx{Ctx: ctx}, cli, opsRes, compStatus, resource.MustParse("2Gi"), volumeExpansionHelper{
+						compOps: opsv1alpha1.VolumeExpansion{ComponentOps: opsv1alpha1.ComponentOps{ComponentName: "db"}}, fullComponentName: "db", expectCount: 2, templateName: "large", vctName: "data"})
+					if err != nil {
+						t.Fatal(err)
+					}
+					if succeeded != wantCompleted || completed != wantCompleted {
+						t.Fatalf("progress=%d/%d, want %d", succeeded, completed, wantCompleted)
+					}
+				}
+				for _, detail := range compStatus.ProgressDetails {
+					if detail.ObjectKey != "Pod/demo-db-7" && detail.ObjectKey != "Pod/demo-db-42" && detail.ObjectKey != "PVC/data-demo-db-7" && detail.ObjectKey != "PVC/data-demo-db-42" {
+						t.Fatalf("unexpected participant: %s", detail.ObjectKey)
+					}
+				}
+			}
+			published := its.Status.InstanceStatus
+			its.Status.InstanceStatus = nil
+			if err := cli.Status().Update(ctx, its); err != nil {
+				t.Fatal(err)
+			}
+			check(0) // Existing Pods do not replace an unpublished allocation.
+			its.Status.InstanceStatus = published
+			if err := cli.Status().Update(ctx, its); err != nil {
+				t.Fatal(err)
+			}
+			check(0) // UpToDate alone must not bypass actual Pod/PVC checks.
+			for i, name := range []string{"demo-db-7", "demo-db-42"} {
+				key := client.ObjectKey{Namespace: "default", Name: name}
+				if operation == "vertical" {
+					pod := &corev1.Pod{}
+					if err := cli.Get(ctx, key, pod); err != nil {
+						t.Fatal(err)
+					}
+					pod.Spec.Containers[0].Resources = resources
+					if err := cli.Update(ctx, pod); err != nil {
+						t.Fatal(err)
+					}
+				} else {
+					key.Name = "data-" + name
+					pvc := &corev1.PersistentVolumeClaim{}
+					if err := cli.Get(ctx, key, pvc); err != nil {
+						t.Fatal(err)
+					}
+					pvc.Status.Capacity[corev1.ResourceStorage] = resource.MustParse("2Gi")
+					if err := cli.Status().Update(ctx, pvc); err != nil {
+						t.Fatal(err)
+					}
+				}
+				check(i + 1)
+			}
+		})
+	}
+}
+
+func TestInstanceStatusSelection(t *testing.T) {
+	statuses := []workloads.InstanceStatus{
+		{PodName: "demo-0", TemplateName: templateName(""), DesiredState: workloads.InstanceDesiredStateActive},
+		{PodName: "demo-1", TemplateName: templateName("big"), DesiredState: workloads.InstanceDesiredStateActive},
+		{PodName: "demo-2", DesiredState: workloads.InstanceDesiredStateOffline},
+	}
+	active, err := activeInstanceTemplates(statuses, nil)
+	if err != nil {
+		t.Fatalf("select active assignments: %v", err)
+	}
+	if len(active) != 2 || active["demo-0"] != "" || active["demo-1"] != "big" {
+		t.Fatalf("unexpected active assignments: %#v", active)
+	}
+	statuses[0].TemplateName = nil
+	if _, err := activeInstanceTemplates(statuses, nil); !intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeNeedWaiting) {
+		t.Fatalf("expected an active instance with unknown template to wait, got %v", err)
+	}
+	for _, invalid := range [][]workloads.InstanceStatus{
+		{{PodName: ""}},
+		{{PodName: "duplicate"}, {PodName: "duplicate"}},
+	} {
+		if _, err := activeInstanceTemplates(invalid, nil); err == nil {
+			t.Fatalf("invalid identities must not be silently accepted: %#v", invalid)
+		}
+	}
+}
+
+func TestActiveAssignmentsMatchComponent(t *testing.T) {
+	component := &appsv1.ClusterComponentSpec{
+		Replicas:  3,
+		Instances: []appsv1.InstanceTemplate{{Name: "big", Replicas: pointer.Int32(1)}},
+	}
+	matching := map[string]string{"demo-0": "", "demo-1": "", "demo-2": "big"}
+	if !assignmentsMatchComponent(matching, component) {
+		t.Fatal("expected allocation to match component")
+	}
+	if assignmentsMatchComponent(map[string]string{"demo-0": "", "demo-1": "big", "demo-2": "big"}, component) {
+		t.Fatal("template distribution mismatch must not be accepted")
+	}
+	component = &appsv1.ClusterComponentSpec{
+		Replicas:  2,
+		Instances: []appsv1.InstanceTemplate{{Name: "big", Replicas: pointer.Int32(0)}},
+	}
+	if !assignmentsMatchComponent(map[string]string{"demo-0": "", "demo-1": ""}, component) {
+		t.Fatal("zero-replica templates must not require an allocation")
+	}
+}
+
+func TestVolumeExpansionWaitsWithoutReportingSuccessForIncompleteAllocation(t *testing.T) {
+	const (
+		namespace     = "default"
+		clusterName   = "demo"
+		componentName = "database"
+	)
+	scheme := runtime.NewScheme()
+	if err := workloads.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	its := &workloads.InstanceSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      constant.GenerateClusterComponentName(clusterName, componentName),
+		},
+		Status: workloads.InstanceSetStatus{InstanceStatus: []workloads.InstanceStatus{{
+			PodName: "allocated-identity", TemplateName: templateName(""),
+			DesiredState: workloads.InstanceDesiredStateActive,
+		}}},
+	}
+	cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(its).Build()
+	opsRes := &OpsResource{
+		Cluster:    &appsv1.Cluster{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: clusterName}},
+		OpsRequest: &opsv1alpha1.OpsRequest{},
+		Runtimes:   map[string]OpsRuntime{componentName: newOpsRuntime(context.Background(), cli, "")},
+	}
+	compStatus := &opsv1alpha1.OpsRequestComponentStatus{}
+	succeeded, completed, err := (volumeExpansionOpsHandler{}).handleVCTExpansionProgress(
+		intctrlutil.RequestCtx{Ctx: context.Background()}, cli, opsRes, compStatus,
+		resource.MustParse("2Gi"), volumeExpansionHelper{
+			compOps:           opsv1alpha1.VolumeExpansion{ComponentOps: opsv1alpha1.ComponentOps{ComponentName: componentName}},
+			fullComponentName: componentName,
+			expectCount:       2,
+			vctName:           "data",
+		})
+	if err != nil {
+		t.Fatalf("wait for allocation: %v", err)
+	}
+	if succeeded != 0 || completed != 0 {
+		t.Fatalf("incomplete allocation must not report progress, got succeeded=%d completed=%d", succeeded, completed)
+	}
+}

--- a/pkg/operations/instance_status_test.go
+++ b/pkg/operations/instance_status_test.go
@@ -345,7 +345,7 @@ func TestInstanceStatusSelection(t *testing.T) {
 		{PodName: "demo-1", TemplateName: templateName("big"), DesiredState: workloads.InstanceDesiredStateActive},
 		{PodName: "demo-2", DesiredState: workloads.InstanceDesiredStateOffline},
 	}
-	active, err := activeInstanceTemplates(statuses, nil)
+	active, err := activeInstanceTemplates(statuses)
 	if err != nil {
 		t.Fatalf("select active assignments: %v", err)
 	}
@@ -353,14 +353,14 @@ func TestInstanceStatusSelection(t *testing.T) {
 		t.Fatalf("unexpected active assignments: %#v", active)
 	}
 	statuses[0].TemplateName = nil
-	if _, err := activeInstanceTemplates(statuses, nil); !intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeNeedWaiting) {
+	if _, err := activeInstanceTemplates(statuses); !intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeNeedWaiting) {
 		t.Fatalf("expected an active instance with unknown template to wait, got %v", err)
 	}
 	for _, invalid := range [][]workloads.InstanceStatus{
 		{{PodName: ""}},
 		{{PodName: "duplicate"}, {PodName: "duplicate"}},
 	} {
-		if _, err := activeInstanceTemplates(invalid, nil); err == nil {
+		if _, err := activeInstanceTemplates(invalid); err == nil {
 			t.Fatalf("invalid identities must not be silently accepted: %#v", invalid)
 		}
 	}

--- a/pkg/operations/instance_status_test.go
+++ b/pkg/operations/instance_status_test.go
@@ -33,6 +33,83 @@ import (
 
 func templateName(name string) *string { return &name }
 
+func TestStoppedVolumeExpansionUsesRetainedPVCs(t *testing.T) {
+	for _, tc := range []struct {
+		name, podName, template string
+		flat                    bool
+	}{
+		{name: "flat-default", podName: "demo-db-42", flat: true},
+		{name: "flat-template", podName: "demo-db-42", template: "large", flat: true},
+		{name: "nonflat-default", podName: "demo-db-0"},
+		{name: "nonflat-template", podName: "demo-db-large-0", template: "large"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			scheme := runtime.NewScheme()
+			for _, add := range []func(*runtime.Scheme) error{corev1.AddToScheme, appsv1.AddToScheme, workloads.AddToScheme, opsv1alpha1.AddToScheme} {
+				if err := add(scheme); err != nil {
+					t.Fatal(err)
+				}
+			}
+			component := appsv1.ClusterComponentSpec{Name: "db", Replicas: 1, FlatInstanceOrdinal: tc.flat,
+				Stop: pointer.Bool(true), OfflineInstances: []string{"demo-db-8"}}
+			if tc.template != "" {
+				component.Instances = []appsv1.InstanceTemplate{{Name: tc.template, Replicas: pointer.Int32(1)}}
+			}
+			cluster := &appsv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default"},
+				Spec:   appsv1.ClusterSpec{ComponentSpecs: []appsv1.ClusterComponentSpec{component}},
+				Status: appsv1.ClusterStatus{Components: map[string]appsv1.ClusterComponentStatus{"db": {Phase: appsv1.StoppedComponentPhase}}}}
+			its := &workloads.InstanceSet{ObjectMeta: metav1.ObjectMeta{Name: "demo-db", Namespace: "default"},
+				Spec: workloads.InstanceSetSpec{Stop: pointer.Bool(true), Replicas: pointer.Int32(1), OfflineInstances: component.OfflineInstances},
+				Status: workloads.InstanceSetStatus{InstanceStatus: []workloads.InstanceStatus{
+					{PodName: tc.podName, TemplateName: templateName(tc.template), DesiredState: workloads.InstanceDesiredStateOffline, CurrentState: workloads.InstanceCurrentStateAbsent},
+					{PodName: "demo-db-8", DesiredState: workloads.InstanceDesiredStateOffline, CurrentState: workloads.InstanceCurrentStateAbsent},
+					{PodName: "demo-db-9", TemplateName: templateName(tc.template), DesiredState: workloads.InstanceDesiredStateReleased, CurrentState: workloads.InstanceCurrentStateTerminating},
+				}}}
+			ops := &opsv1alpha1.OpsRequest{ObjectMeta: metav1.ObjectMeta{Name: "expand", Namespace: "default"},
+				Spec: opsv1alpha1.OpsRequestSpec{SpecificOpsRequest: opsv1alpha1.SpecificOpsRequest{VolumeExpansionList: []opsv1alpha1.VolumeExpansion{{
+					ComponentOps: opsv1alpha1.ComponentOps{ComponentName: "db"}, VolumeClaimTemplates: []opsv1alpha1.OpsRequestVolumeClaimTemplate{{Name: "data", Storage: resource.MustParse("2Gi")}},
+				}}}}, Status: opsv1alpha1.OpsRequestStatus{Phase: opsv1alpha1.OpsRunningPhase, StartTimestamp: metav1.Now()}}
+			objects := []client.Object{cluster, its, ops}
+			for _, name := range []string{tc.podName, "demo-db-8", "demo-db-9"} {
+				labels := constant.GetCompLabels("demo", "db")
+				labels[constant.VolumeClaimTemplateNameLabelKey] = "data"
+				objects = append(objects, &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "data-" + name, Namespace: "default", Labels: labels},
+					Spec: corev1.PersistentVolumeClaimSpec{Resources: corev1.VolumeResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("2Gi")}}},
+					Status: corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimBound, Capacity: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")},
+						Conditions: []corev1.PersistentVolumeClaimCondition{{Type: corev1.PersistentVolumeClaimResizing, Status: corev1.ConditionTrue}}}})
+			}
+			cli := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(ops, &corev1.PersistentVolumeClaim{}).WithObjects(objects...).Build()
+			opsRes := &OpsResource{Cluster: cluster, OpsRequest: ops, Recorder: record.NewFakeRecorder(20), Runtimes: map[string]OpsRuntime{"db": newOpsRuntime(ctx, cli, "")}}
+			check := func(want opsv1alpha1.OpsPhase, progress string) {
+				t.Helper()
+				phase, _, err := (volumeExpansionOpsHandler{}).ReconcileAction(intctrlutil.RequestCtx{Ctx: ctx}, cli, opsRes)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if phase != want || ops.Status.Progress != progress {
+					t.Fatalf("got %s %s, want %s %s", phase, ops.Status.Progress, want, progress)
+				}
+				details := ops.Status.Components["db"].ProgressDetails
+				if len(details) != 1 || details[0].ObjectKey != "PVC/data-"+tc.podName {
+					t.Fatalf("unexpected participants: %#v", details)
+				}
+			}
+			check(opsv1alpha1.OpsRunningPhase, "0/1")
+			pvc := &corev1.PersistentVolumeClaim{}
+			if err := cli.Get(ctx, client.ObjectKey{Namespace: "default", Name: "data-" + tc.podName}, pvc); err != nil {
+				t.Fatal(err)
+			}
+			pvc.Status.Capacity[corev1.ResourceStorage] = resource.MustParse("2Gi")
+			pvc.Status.Conditions = nil
+			if err := cli.Status().Update(ctx, pvc); err != nil {
+				t.Fatal(err)
+			}
+			check(opsv1alpha1.OpsSucceedPhase, "1/1")
+		})
+	}
+}
+
 // Exercise the real Operations runtime and handlers against explicit API objects.
 // The instance names intentionally carry no template name or contiguous ordinal.
 func TestScalingUsesAssignedInstancesAndActualObjects(t *testing.T) {

--- a/pkg/operations/ops_runtime.go
+++ b/pkg/operations/ops_runtime.go
@@ -117,6 +117,10 @@ func (r *opsRuntime) GetWorkload(namespace, clusterName, compName string) (Workl
 		workload.notReadySet = instanceset.GetPodNameSetFromInstanceSetCondition(its, workloads.InstanceReady)
 		workload.notAvailableSet = instanceset.GetPodNameSetFromInstanceSetCondition(its, workloads.InstanceAvailable)
 		workload.failedSet = instanceset.GetPodNameSetFromInstanceSetCondition(its, workloads.InstanceFailure)
+		workload.instanceStatuses = make([]workloads.InstanceStatus, len(its.Status.InstanceStatus))
+		for i := range its.Status.InstanceStatus {
+			its.Status.InstanceStatus[i].DeepCopyInto(&workload.instanceStatuses[i])
+		}
 		return workload, nil
 	}
 	pods, err := component.ListOwnedPods(r.dataContext(), r.cli, namespace, clusterName, compName, r.dataListOpts...)
@@ -343,6 +347,7 @@ func (r *opsRuntime) dataContext() context.Context {
 
 type defaultWorkload struct {
 	minReadySeconds    int32
+	instanceStatuses   []workloads.InstanceStatus
 	currentRevisionMap map[string]string
 	notReadySet        sets.Set[string]
 	notAvailableSet    sets.Set[string]
@@ -351,6 +356,14 @@ type defaultWorkload struct {
 }
 
 func (w *defaultWorkload) GetMinReadySeconds() int32 { return w.minReadySeconds }
+
+func (w *defaultWorkload) GetInstanceStatuses() []workloads.InstanceStatus {
+	result := make([]workloads.InstanceStatus, len(w.instanceStatuses))
+	for i := range w.instanceStatuses {
+		w.instanceStatuses[i].DeepCopyInto(&result[i])
+	}
+	return result
+}
 
 func (w *defaultWorkload) GetCurrentRevisionMap() map[string]string { return w.currentRevisionMap }
 

--- a/pkg/operations/ops_runtime_test.go
+++ b/pkg/operations/ops_runtime_test.go
@@ -66,6 +66,12 @@ func TestOpsRuntimeBuildsInstanceAPIView(t *testing.T) {
 			CurrentRevisions: map[string]string{
 				instanceName: "rev-a",
 			},
+			InstanceStatus: []workloads.InstanceStatus{{
+				PodName:      instanceName,
+				TemplateName: templateName("big"),
+				DesiredState: workloads.InstanceDesiredStateActive,
+				CurrentState: workloads.InstanceCurrentStatePresent,
+			}},
 		},
 	}
 	pod := &corev1.Pod{
@@ -193,6 +199,15 @@ func TestOpsRuntimeBuildsInstanceAPIView(t *testing.T) {
 	}
 	if got := workload.GetCurrentRevisionMap()[instanceName]; got != "rev-a" {
 		t.Fatalf("unexpected current revision: %s", got)
+	}
+	instanceStatuses := workload.GetInstanceStatuses()
+	if len(instanceStatuses) != 1 || instanceStatuses[0].PodName != instanceName ||
+		instanceStatuses[0].TemplateName == nil || *instanceStatuses[0].TemplateName != "big" {
+		t.Fatalf("unexpected instance statuses: %#v", instanceStatuses)
+	}
+	instanceStatuses[0].PodName = "mutated"
+	if workload.GetInstanceStatuses()[0].PodName != instanceName {
+		t.Fatal("GetInstanceStatuses must return a deep copy")
 	}
 
 	instance, err := rt.GetInstance(namespace, clusterName, component, instanceName)

--- a/pkg/operations/type.go
+++ b/pkg/operations/type.go
@@ -134,6 +134,7 @@ type OpsRuntime interface {
 
 type Workload interface {
 	GetMinReadySeconds() int32
+	GetInstanceStatuses() []workloads.InstanceStatus
 	GetInstanceNameSet() sets.Set[string]
 	GetCurrentRevisionMap() map[string]string
 	GetNotReadyInstanceNameSet() sets.Set[string]

--- a/pkg/operations/vertical_scaling.go
+++ b/pkg/operations/vertical_scaling.go
@@ -108,9 +108,14 @@ func (vs verticalScalingHandler) ReconcileAction(reqCtx intctrlutil.RequestCtx, 
 		if len(pgRes.clusterComponent.Instances) != 0 {
 			// obtain the pods which should be updated.
 			updatedPodSet := map[string]string{}
+			updatedTemplates := map[string]struct{}{}
 			vsInsMap := vs.covertInsResourcesToMap(verticalScaling)
 			templateReplicasCnt := int32(0)
 			runtime, err := opsRes.GetRuntime(pgRes.compOps.GetComponentName())
+			if err != nil {
+				return 0, 0, err
+			}
+			workload, err := runtime.GetWorkload(opsRes.Cluster.Namespace, opsRes.Cluster.Name, pgRes.fullComponentName)
 			if err != nil {
 				return 0, 0, err
 			}
@@ -118,28 +123,26 @@ func (vs verticalScalingHandler) ReconcileAction(reqCtx intctrlutil.RequestCtx, 
 				replicas := template.GetReplicas()
 				insVS := vsInsMap[template.Name]
 				if vs.verticalScalingInsTemplate(verticalScaling, template, insVS) {
-					templatePodNames, err := runtime.GenerateTemplateInstanceNames(
-						opsRes.Cluster.Name, pgRes.fullComponentName, template.Name, replicas, pgRes.clusterComponent.OfflineInstances, template.Ordinals)
-					if err != nil {
-						return 0, 0, err
-					}
-					for _, podName := range templatePodNames {
-						updatedPodSet[podName] = template.Name
-					}
+					updatedTemplates[template.Name] = struct{}{}
 				}
 				templateReplicasCnt += replicas
 			}
 			if vs.verticalScalingComp(verticalScaling) && templateReplicasCnt < pgRes.clusterComponent.Replicas {
-				podNames, err := runtime.GenerateTemplateInstanceNames(
-					opsRes.Cluster.Name, pgRes.fullComponentName, "", pgRes.clusterComponent.Replicas-templateReplicasCnt, pgRes.clusterComponent.OfflineInstances, appsv1.Ordinals{})
-				if err != nil {
-					return 0, 0, err
-				}
-				for _, podName := range podNames {
-					updatedPodSet[podName] = ""
-				}
+				updatedTemplates[""] = struct{}{}
 			} else {
 				pgRes.noWaitComponentCompleted = true
+			}
+			allActive, complete, err := activeAssignmentsForTarget(workload, pgRes.clusterComponent)
+			if err != nil {
+				return 0, 0, err
+			}
+			if !complete {
+				return 1, 0, nil
+			}
+			for podName, templateName := range allActive {
+				if _, ok := updatedTemplates[templateName]; ok {
+					updatedPodSet[podName] = templateName
+				}
 			}
 			pgRes.updatedPodSet = updatedPodSet
 		}

--- a/pkg/operations/vertical_scaling.go
+++ b/pkg/operations/vertical_scaling.go
@@ -56,8 +56,7 @@ func (vs verticalScalingHandler) ActionStartedCondition(reqCtx intctrlutil.Reque
 	return opsv1alpha1.NewVerticalScalingCondition(opsRes.OpsRequest), nil
 }
 
-// Action modifies cluster component resources according to
-// the definition of opsRequest with spec.componentNames and spec.componentOps.verticalScaling
+// Action applies spec.verticalScaling to the requested component and instance-template resources.
 func (vs verticalScalingHandler) Action(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes *OpsResource) error {
 	applyVerticalScaling := func(compSpec *appsv1.ClusterComponentSpec, obj ComponentOpsInterface) error {
 		verticalScaling := obj.(opsv1alpha1.VerticalScaling)
@@ -105,46 +104,50 @@ func (vs verticalScalingHandler) ReconcileAction(reqCtx intctrlutil.RequestCtx, 
 		pgRes *progressResource,
 		compStatus *opsv1alpha1.OpsRequestComponentStatus) (expectProgressCount int32, completedCount int32, err error) {
 		verticalScaling := pgRes.compOps.(opsv1alpha1.VerticalScaling)
-		if len(pgRes.clusterComponent.Instances) != 0 {
-			// obtain the pods which should be updated.
-			updatedPodSet := map[string]string{}
-			updatedTemplates := map[string]struct{}{}
-			vsInsMap := vs.covertInsResourcesToMap(verticalScaling)
-			templateReplicasCnt := int32(0)
-			runtime, err := opsRes.GetRuntime(pgRes.compOps.GetComponentName())
-			if err != nil {
-				return 0, 0, err
+		// obtain the pods which should be updated.
+		updatedPodSet := map[string]string{}
+		updatedTemplates := map[string]struct{}{}
+		vsInsMap := vs.covertInsResourcesToMap(verticalScaling)
+		templateReplicasCnt := int32(0)
+		runtime, err := opsRes.GetRuntime(pgRes.compOps.GetComponentName())
+		if err != nil {
+			return 0, 0, err
+		}
+		workload, err := runtime.GetWorkload(opsRes.Cluster.Namespace, opsRes.Cluster.Name, pgRes.fullComponentName)
+		if err != nil {
+			return 0, 0, err
+		}
+		for _, template := range pgRes.clusterComponent.Instances {
+			replicas := template.GetReplicas()
+			insVS := vsInsMap[template.Name]
+			if vs.verticalScalingInsTemplate(verticalScaling, template, insVS) {
+				updatedTemplates[template.Name] = struct{}{}
 			}
-			workload, err := runtime.GetWorkload(opsRes.Cluster.Namespace, opsRes.Cluster.Name, pgRes.fullComponentName)
-			if err != nil {
-				return 0, 0, err
+			templateReplicasCnt += replicas
+		}
+		if vs.verticalScalingComp(verticalScaling) && templateReplicasCnt < pgRes.clusterComponent.Replicas {
+			updatedTemplates[""] = struct{}{}
+		} else if len(pgRes.clusterComponent.Instances) > 0 {
+			pgRes.noWaitComponentCompleted = true
+		}
+		allActive, complete, err := activeAssignmentsForTarget(workload, pgRes.clusterComponent)
+		if err != nil {
+			return 0, 0, err
+		}
+		if !complete {
+			return 1, 0, nil
+		}
+		for podName, templateName := range allActive {
+			if _, ok := updatedTemplates[templateName]; ok {
+				updatedPodSet[podName] = templateName
 			}
-			for _, template := range pgRes.clusterComponent.Instances {
-				replicas := template.GetReplicas()
-				insVS := vsInsMap[template.Name]
-				if vs.verticalScalingInsTemplate(verticalScaling, template, insVS) {
-					updatedTemplates[template.Name] = struct{}{}
-				}
-				templateReplicasCnt += replicas
-			}
-			if vs.verticalScalingComp(verticalScaling) && templateReplicasCnt < pgRes.clusterComponent.Replicas {
-				updatedTemplates[""] = struct{}{}
-			} else {
-				pgRes.noWaitComponentCompleted = true
-			}
-			allActive, complete, err := activeAssignmentsForTarget(workload, pgRes.clusterComponent)
-			if err != nil {
-				return 0, 0, err
-			}
-			if !complete {
-				return 1, 0, nil
-			}
-			for podName, templateName := range allActive {
-				if _, ok := updatedTemplates[templateName]; ok {
-					updatedPodSet[podName] = templateName
-				}
-			}
-			pgRes.updatedPodSet = updatedPodSet
+		}
+		pgRes.updatedPodSet = updatedPodSet
+		if len(updatedPodSet) == 0 {
+			// A complete allocation with no affected instances is a no-op, not
+			// a request to use the shared progress helper's all-Pod fallback.
+			pgRes.noWaitComponentCompleted = true
+			return 0, 0, nil
 		}
 		return handleComponentStatusProgress(reqCtx, cli, opsRes, pgRes, compStatus, vs.podApplyCompOps)
 	}

--- a/pkg/operations/vertical_scaling_test.go
+++ b/pkg/operations/vertical_scaling_test.go
@@ -68,6 +68,7 @@ var _ = Describe("VerticalScaling OpsRequest", func() {
 		// namespaced
 		testapps.ClearResources(&testCtx, generics.OpsRequestSignature, inNS, ml)
 		testapps.ClearResources(&testCtx, generics.PodSignature, inNS, ml, client.GracePeriodSeconds(0))
+		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.InstanceSetSignature, true, inNS, ml)
 	}
 
 	BeforeEach(cleanEnv)
@@ -109,6 +110,8 @@ var _ = Describe("VerticalScaling OpsRequest", func() {
 					cluster.Spec.ComponentSpecs[0].Instances = instances
 				})).Should(Succeed())
 			}
+			testapps.MockInstanceSetComponent(&testCtx, clusterName, defaultCompName)
+			testapps.MockInstanceSetStatus(testCtx, opsRes.Cluster, defaultCompName)
 			By("create VerticalScaling ops")
 			ops := testops.NewOpsRequestObj("vertical-scaling-ops-"+testCtx.GetRandomStr(), testCtx.DefaultNamespace,
 				clusterName, opsv1alpha1.VerticalScalingType)

--- a/pkg/operations/vertical_scaling_test.go
+++ b/pkg/operations/vertical_scaling_test.go
@@ -252,6 +252,8 @@ var _ = Describe("VerticalScaling OpsRequest", func() {
 			reqCtx := intctrlutil.RequestCtx{Ctx: ctx}
 			opsRes, _, _ := initOperationsResources(compDefName, clusterName)
 			podList := initInstanceSetPods(ctx, k8sClient, opsRes)
+			testapps.MockInstanceSetComponent(&testCtx, clusterName, defaultCompName)
+			testapps.MockInstanceSetStatus(testCtx, opsRes.Cluster, defaultCompName)
 
 			By("create VerticalScaling ops")
 			ops := testops.NewOpsRequestObj("vertical-scaling-ops-"+randomStr, testCtx.DefaultNamespace,

--- a/pkg/operations/volume_expansion.go
+++ b/pkg/operations/volume_expansion.go
@@ -61,7 +61,7 @@ const (
 )
 
 func init() {
-	// the volume expansion operation only supports online expansion now
+	// Expansion progress is checked on PVCs, including those retained after Stop.
 	volumeExpansionBehaviour := OpsBehaviour{
 		OpsHandler:  volumeExpansionOpsHandler{},
 		QueueBySelf: true,
@@ -147,7 +147,7 @@ func (ve volumeExpansionOpsHandler) ReconcileAction(reqCtx intctrlutil.RequestCt
 					veHelpers = append(veHelpers, volumeExpansionHelper{
 						compOps:           compOps,
 						fullComponentName: fullComponentName,
-						expectCount:       int(*template.Replicas),
+						expectCount:       int(template.GetReplicas()),
 						vctName:           vct.Name,
 						templateName:      template.Name,
 						stopped:           stopped,

--- a/pkg/operations/volume_expansion.go
+++ b/pkg/operations/volume_expansion.go
@@ -29,6 +29,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
@@ -48,6 +49,8 @@ type volumeExpansionHelper struct {
 	vctName           string
 	expectCount       int
 	templateName      string
+	stopped           bool
+	explicitOffline   sets.Set[string]
 }
 
 var _ OpsHandler = volumeExpansionOpsHandler{}
@@ -126,6 +129,8 @@ func (ve volumeExpansionOpsHandler) ReconcileAction(reqCtx intctrlutil.RequestCt
 	var veHelpers []volumeExpansionHelper
 	setVeHelpers := func(compSpec appsv1.ClusterComponentSpec, compOps ComponentOpsInterface, fullComponentName string) {
 		volumeExpansion := compOps.(opsv1alpha1.VolumeExpansion)
+		stopped := compSpec.Stop != nil && *compSpec.Stop
+		explicitOffline := sets.New(compSpec.OfflineInstances...)
 		if len(volumeExpansion.VolumeClaimTemplates) > 0 {
 			expectReplicas := compSpec.Replicas - getTemplateReplicas(compSpec.Instances)
 			for _, vct := range volumeExpansion.VolumeClaimTemplates {
@@ -134,6 +139,8 @@ func (ve volumeExpansionOpsHandler) ReconcileAction(reqCtx intctrlutil.RequestCt
 					fullComponentName: fullComponentName,
 					expectCount:       int(expectReplicas),
 					vctName:           vct.Name,
+					stopped:           stopped,
+					explicitOffline:   explicitOffline,
 				})
 				for _, template := range compSpec.Instances {
 					// todo: consider instance template with volumeClaimTemplates
@@ -143,6 +150,8 @@ func (ve volumeExpansionOpsHandler) ReconcileAction(reqCtx intctrlutil.RequestCt
 						expectCount:       int(*template.Replicas),
 						vctName:           vct.Name,
 						templateName:      template.Name,
+						stopped:           stopped,
+						explicitOffline:   explicitOffline,
 					})
 				}
 			}
@@ -293,9 +302,16 @@ func (ve volumeExpansionOpsHandler) handleVCTExpansionProgress(reqCtx intctrluti
 	if err != nil {
 		return 0, 0, err
 	}
-	instances, err := activeInstanceTemplates(workload.GetInstanceStatuses(),
+	desiredState := workloads.InstanceDesiredStateActive
+	if veHelper.stopped {
+		// Stop retains the normal allocation as Offline, while explicitly
+		// offlined instances remain outside this operation's replica count.
+		desiredState = workloads.InstanceDesiredStateOffline
+	}
+	instances, err := instanceTemplatesByState(workload.GetInstanceStatuses(), desiredState,
 		func(status workloads.InstanceStatus) bool {
-			return status.TemplateName == nil || *status.TemplateName == veHelper.templateName
+			return !veHelper.explicitOffline.Has(status.PodName) &&
+				(status.TemplateName == nil || *status.TemplateName == veHelper.templateName)
 		})
 	if err != nil {
 		return 0, 0, err

--- a/pkg/operations/volume_expansion.go
+++ b/pkg/operations/volume_expansion.go
@@ -29,11 +29,11 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	opsv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/sharding"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
@@ -43,13 +43,11 @@ type volumeExpansionOpsHandler struct {
 }
 
 type volumeExpansionHelper struct {
-	compOps              ComponentOpsInterface
-	fullComponentName    string
-	vctName              string
-	expectCount          int
-	offlineInstanceNames []string
-	templateName         string
-	ordinals             appsv1.Ordinals
+	compOps           ComponentOpsInterface
+	fullComponentName string
+	vctName           string
+	expectCount       int
+	templateName      string
 }
 
 var _ OpsHandler = volumeExpansionOpsHandler{}
@@ -132,22 +130,19 @@ func (ve volumeExpansionOpsHandler) ReconcileAction(reqCtx intctrlutil.RequestCt
 			expectReplicas := compSpec.Replicas - getTemplateReplicas(compSpec.Instances)
 			for _, vct := range volumeExpansion.VolumeClaimTemplates {
 				veHelpers = append(veHelpers, volumeExpansionHelper{
-					compOps:              compOps,
-					fullComponentName:    fullComponentName,
-					expectCount:          int(expectReplicas),
-					vctName:              vct.Name,
-					offlineInstanceNames: compSpec.OfflineInstances,
+					compOps:           compOps,
+					fullComponentName: fullComponentName,
+					expectCount:       int(expectReplicas),
+					vctName:           vct.Name,
 				})
 				for _, template := range compSpec.Instances {
 					// todo: consider instance template with volumeClaimTemplates
 					veHelpers = append(veHelpers, volumeExpansionHelper{
-						compOps:              compOps,
-						fullComponentName:    fullComponentName,
-						expectCount:          int(*template.Replicas),
-						vctName:              vct.Name,
-						offlineInstanceNames: compSpec.OfflineInstances,
-						templateName:         template.Name,
-						ordinals:             template.Ordinals,
+						compOps:           compOps,
+						fullComponentName: fullComponentName,
+						expectCount:       int(*template.Replicas),
+						vctName:           vct.Name,
+						templateName:      template.Name,
 					})
 				}
 			}
@@ -294,13 +289,21 @@ func (ve volumeExpansionOpsHandler) handleVCTExpansionProgress(reqCtx intctrluti
 	if err != nil {
 		return 0, 0, err
 	}
-	instanceNames, err := runtime.GenerateTemplateInstanceNames(
-		opsRes.Cluster.Name, veHelper.fullComponentName, veHelper.templateName, int32(veHelper.expectCount), veHelper.offlineInstanceNames, veHelper.ordinals)
+	workload, err := runtime.GetWorkload(opsRes.Cluster.Namespace, opsRes.Cluster.Name, veHelper.fullComponentName)
 	if err != nil {
 		return 0, 0, err
 	}
-	instanceNameSet := sets.New(instanceNames...)
-	for instanceName := range instanceNameSet {
+	instances, err := activeInstanceTemplates(workload.GetInstanceStatuses(),
+		func(status workloads.InstanceStatus) bool {
+			return status.TemplateName == nil || *status.TemplateName == veHelper.templateName
+		})
+	if err != nil {
+		return 0, 0, err
+	}
+	if len(instances) != veHelper.expectCount {
+		return 0, 0, nil
+	}
+	for instanceName := range instances {
 		instance, getErr := runtime.GetInstance(opsRes.Cluster.Namespace, opsRes.Cluster.Name, veHelper.fullComponentName, instanceName)
 		if getErr != nil {
 			if apierrors.IsNotFound(getErr) {

--- a/pkg/operations/volume_expansion_test.go
+++ b/pkg/operations/volume_expansion_test.go
@@ -77,6 +77,7 @@ var _ = Describe("OpsRequest Controller Volume Expansion Handler", func() {
 		ml := client.HasLabels{testCtx.TestObjLabelKey}
 		// delete pvc resources
 		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.PersistentVolumeClaimSignature, true, inNS, ml)
+		testapps.ClearResourcesWithRemoveFinalizerOption(&testCtx, generics.InstanceSetSignature, true, inNS, ml)
 		// namespaced
 		testapps.ClearResources(&testCtx, generics.OpsRequestSignature, inNS, ml)
 		// non-namespaced
@@ -399,6 +400,8 @@ var _ = Describe("OpsRequest Controller Volume Expansion Handler", func() {
 		It("VolumeExpansion should work", func() {
 			reqCtx := intctrlutil.RequestCtx{Ctx: ctx}
 			_, clusterObject := testapps.InitConsensusMysql(&testCtx, clusterName, compDefName, consensusCompName)
+			testapps.MockInstanceSetComponent(&testCtx, clusterName, consensusCompName)
+			testapps.MockInstanceSetStatus(testCtx, clusterObject, consensusCompName)
 			// init storageClass
 			sc := testapps.CreateStorageClass(&testCtx, storageClassName, true)
 			Expect(testapps.ChangeObj(&testCtx, sc, func(lsc *storagev1.StorageClass) {
@@ -446,6 +449,8 @@ var _ = Describe("OpsRequest Controller Volume Expansion Handler", func() {
 					},
 				}
 			})).ShouldNot(HaveOccurred())
+			testapps.MockInstanceSetComponent(&testCtx, clusterName, consensusCompName)
+			testapps.MockInstanceSetStatus(testCtx, clusterObject, consensusCompName)
 			// init storageClass
 			sc := testapps.CreateStorageClass(&testCtx, storageClassName, true)
 			Expect(testapps.ChangeObj(&testCtx, sc, func(lsc *storagev1.StorageClass) {

--- a/pkg/testutil/apps/cluster_instance_set_test_util.go
+++ b/pkg/testutil/apps/cluster_instance_set_test_util.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"sort"
 
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -295,9 +296,35 @@ func MockInstanceSetPod(
 }
 
 func generateInstanceNames(parentName, templateName string,
-	replicas int32, offlineInstances []string) []string {
+	replicas int32, offlineInstances []string, ordinals ...appsv1.Ordinals) []string {
+	if replicas <= 0 {
+		return nil
+	}
 	usedNames := sets.New(offlineInstances...)
 	var instanceNameList []string
+	if len(ordinals) > 0 && (len(ordinals[0].Ranges) > 0 || len(ordinals[0].Discrete) > 0) {
+		ordinalSet := sets.New(ordinals[0].Discrete...)
+		for _, ordinalRange := range ordinals[0].Ranges {
+			for ordinal := ordinalRange.Start; ordinal <= ordinalRange.End; ordinal++ {
+				ordinalSet.Insert(ordinal)
+			}
+		}
+		ordinalList := sets.List(ordinalSet)
+		sort.Slice(ordinalList, func(i, j int) bool { return ordinalList[i] < ordinalList[j] })
+		for _, ordinal := range ordinalList {
+			name := fmt.Sprintf("%s-%d", parentName, ordinal)
+			if templateName != "" {
+				name = fmt.Sprintf("%s-%s-%d", parentName, templateName, ordinal)
+			}
+			if !usedNames.Has(name) {
+				instanceNameList = append(instanceNameList, name)
+			}
+			if len(instanceNameList) == int(replicas) {
+				break
+			}
+		}
+		return instanceNameList
+	}
 	ordinal := 0
 	for count := int32(0); count < replicas; count++ {
 		var name string
@@ -325,11 +352,11 @@ func generatePodNames(cluster *appsv1.Cluster, compName string) []string {
 	for _, insTpl := range compSpec.Instances {
 		insReplicas := *insTpl.Replicas
 		insTPLReplicasCnt += insReplicas
-		podNames = append(podNames, generateInstanceNames(workloadName, insTpl.Name, insReplicas, compSpec.OfflineInstances)...)
+		podNames = append(podNames, generateInstanceNames(workloadName, insTpl.Name, insReplicas, compSpec.OfflineInstances, insTpl.Ordinals)...)
 	}
 	if insTPLReplicasCnt < compSpec.Replicas {
 		podNames = append(podNames, generateInstanceNames(workloadName, "",
-			compSpec.Replicas-insTPLReplicasCnt, compSpec.OfflineInstances)...)
+			compSpec.Replicas-insTPLReplicasCnt, compSpec.OfflineInstances, compSpec.Ordinals)...)
 	}
 	return podNames
 }
@@ -341,11 +368,11 @@ func generatePodNames2(clusterName, compName string, comp *appsv1.Component) []s
 	for _, insTpl := range comp.Spec.Instances {
 		insReplicas := *insTpl.Replicas
 		insTPLReplicasCnt += insReplicas
-		podNames = append(podNames, generateInstanceNames(workloadName, insTpl.Name, insReplicas, comp.Spec.OfflineInstances)...)
+		podNames = append(podNames, generateInstanceNames(workloadName, insTpl.Name, insReplicas, comp.Spec.OfflineInstances, insTpl.Ordinals)...)
 	}
 	if insTPLReplicasCnt < comp.Spec.Replicas {
 		podNames = append(podNames, generateInstanceNames(workloadName, "",
-			comp.Spec.Replicas-insTPLReplicasCnt, comp.Spec.OfflineInstances)...)
+			comp.Spec.Replicas-insTPLReplicasCnt, comp.Spec.OfflineInstances, comp.Spec.Ordinals)...)
 	}
 	return podNames
 }
@@ -404,6 +431,35 @@ func MockInstanceSetStatus(testCtx testutil.TestContext, cluster *appsv1.Cluster
 		instanceStatus = append(instanceStatus, status)
 	}
 	compSpec := cluster.Spec.GetComponentByName(compName)
+	// Publish desired identities even before their Pods exist. Keep the existing
+	// observed role information; selecting an identity does not imply readiness.
+	byName := make(map[string]workloads.InstanceStatus, len(instanceStatus))
+	for _, status := range instanceStatus {
+		byName[status.PodName] = status
+	}
+	instanceStatus = nil
+	for _, podName := range currentPodNames {
+		status := byName[podName]
+		templateName := appsv1.GetInstanceTemplateName(cluster.Name, compName, podName)
+		status.PodName = podName
+		status.TemplateName = &templateName
+		status.DesiredState = workloads.InstanceDesiredStateActive
+		if compSpec.Stop != nil && *compSpec.Stop {
+			status.DesiredState = workloads.InstanceDesiredStateOffline
+		}
+		status.CurrentState = workloads.InstanceCurrentStateAbsent
+		for _, pod := range podList.Items {
+			if pod.Name == podName {
+				status.CurrentState = workloads.InstanceCurrentStatePresent
+				if !pod.DeletionTimestamp.IsZero() {
+					status.CurrentState = workloads.InstanceCurrentStateTerminating
+					status.Role = ""
+				}
+				break
+			}
+		}
+		instanceStatus = append(instanceStatus, status)
+	}
 	gomega.Eventually(GetAndChangeObjStatus(&testCtx, client.ObjectKey{Name: itsName, Namespace: cluster.Namespace}, func(its *workloads.InstanceSet) {
 		its.Status.CurrentRevisions = currRevisions
 		its.Status.UpdateRevisions = updateRevisions


### PR DESCRIPTION
## Summary

Support VerticalScaling and VolumeExpansion for components with flat instance ordinals. Select instances and their templates from the public InstanceSet `status.instanceStatus` API instead of deriving names from template names and ordinals.

Both ordinal modes use the same selection path. This fixes these two operations' instance-selection failures described in #10704; other operation types are outside this PR.

## Behavior

- VerticalScaling selects Active instances in affected templates, including the default template and templates inheriting component resources. Completion still checks actual Pod resources and availability. Cancellation uses the same selection rules. A complete allocation with no affected instances is a no-op, not a fallback to all Pods.
- VolumeExpansion selects Active instances for running components. For stopped components, it selects Stop-retained Offline instances, excluding explicitly configured `offlineInstances`. Completion still checks actual PVC requested storage, capacity and binding state, including when the Pod no longer exists.
- Missing required template information or incomplete allocation keeps the operation waiting. There is no fallback to instance-name planning or inference from Pods/PVC labels.
- Add an independent read-only InstanceStatus view to Operations runtime and small identity/selection helpers. Existing revision, health, Pod and PVC data sources are unchanged; `Ready` and `UpToDate` do not replace operation-specific completion checks.

## Scope

No HorizontalScaling, FromBackup, RebuildInstance, Start or Stop handler changes. No Operations API/CRD changes, source/target snapshots, generation protocol or new package.

Broader consolidation of Operations Pod/PVC reads and public API contracts is tracked separately in #10851.

## Validation

- `scripts/codex-go-test.sh ./pkg/operations -count=1`
- `scripts/codex-go-test.sh ./controllers/operations -count=1`
- `make lint`

Regression coverage includes non-contiguous flat names, default/named templates, unpublished/incomplete allocation, unknown templates, duplicate names, template distribution, zero affected instances, cancellation and Stop-retained PVC-only expansion in both ordinal modes. Tests verify that matching InstanceStatus flags do not bypass actual Pod/PVC checks, and Offline/Released distractors do not contribute progress.

Existing success assertions are preserved. Test fixtures publish the required API identity/template fields independently of actual Pod resource or PVC capacity changes. These tests exercise the Operations runtime and handlers; they are not end-to-end tests with real ITS/ITS2 controllers.
