### PR TITLE
chore: document and validate non-blocking action usage

### DIFF
--- a/apis/apps/v1/componentdefinition_types.go
+++ b/apis/apps/v1/componentdefinition_types.go
@@ -1911,6 +1911,9 @@ type Action struct {
 	// suitable for long-running Actions, such as data migration, rebalancing, or
 	// draining, whose duration depends on data volume or runtime conditions.
 	//
+	// Non-blocking mode can be enabled only for Action fields that explicitly
+	// document support for it.
+	//
 	// This field cannot be updated.
 	//
 	// +kubebuilder:default=false

--- a/config/crd/bases/apps.kubeblocks.io_clusters.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_clusters.yaml
@@ -653,6 +653,9 @@ spec:
                                   suitable for long-running Actions, such as data migration, rebalancing, or
                                   draining, whose duration depends on data volume or runtime conditions.
 
+                                  Non-blocking mode can be enabled only for Action fields that explicitly
+                                  document support for it.
+
                                   This field cannot be updated.
                                 type: boolean
                               preCondition:
@@ -11919,6 +11922,9 @@ spec:
                                       When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                                       suitable for long-running Actions, such as data migration, rebalancing, or
                                       draining, whose duration depends on data volume or runtime conditions.
+
+                                      Non-blocking mode can be enabled only for Action fields that explicitly
+                                      document support for it.
 
                                       This field cannot be updated.
                                     type: boolean

--- a/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_componentdefinitions.yaml
@@ -4093,6 +4093,9 @@ spec:
                             suitable for long-running Actions, such as data migration, rebalancing, or
                             draining, whose duration depends on data volume or runtime conditions.
 
+                            Non-blocking mode can be enabled only for Action fields that explicitly
+                            document support for it.
+
                             This field cannot be updated.
                           type: boolean
                         preCondition:
@@ -4705,6 +4708,9 @@ spec:
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
 
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
+
                           This field cannot be updated.
                         type: boolean
                       preCondition:
@@ -5154,6 +5160,9 @@ spec:
                           When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
+
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
 
                           This field cannot be updated.
                         type: boolean
@@ -5621,6 +5630,9 @@ spec:
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
 
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
+
                           This field cannot be updated.
                         type: boolean
                       preCondition:
@@ -6069,6 +6081,9 @@ spec:
                           When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
+
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
 
                           This field cannot be updated.
                         type: boolean
@@ -6521,6 +6536,9 @@ spec:
                           When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
+
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
 
                           This field cannot be updated.
                         type: boolean
@@ -6976,6 +6994,9 @@ spec:
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
 
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
+
                           This field cannot be updated.
                         type: boolean
                       preCondition:
@@ -7419,6 +7440,9 @@ spec:
                           When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
+
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
 
                           This field cannot be updated.
                         type: boolean
@@ -7864,6 +7888,9 @@ spec:
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
 
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
+
                           This field cannot be updated.
                         type: boolean
                       preCondition:
@@ -8307,6 +8334,9 @@ spec:
                           When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
+
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
 
                           This field cannot be updated.
                         type: boolean
@@ -8754,6 +8784,9 @@ spec:
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
 
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
+
                           This field cannot be updated.
                         type: boolean
                       preCondition:
@@ -9191,6 +9224,9 @@ spec:
                           When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
+
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
 
                           This field cannot be updated.
                         type: boolean
@@ -9679,6 +9715,9 @@ spec:
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
 
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
+
                           This field cannot be updated.
                         type: boolean
                       periodSeconds:
@@ -10144,6 +10183,9 @@ spec:
                           When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
+
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
 
                           This field cannot be updated.
                         type: boolean
@@ -18312,6 +18354,9 @@ spec:
                             When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                             suitable for long-running Actions, such as data migration, rebalancing, or
                             draining, whose duration depends on data volume or runtime conditions.
+
+                            Non-blocking mode can be enabled only for Action fields that explicitly
+                            document support for it.
 
                             This field cannot be updated.
                           type: boolean

--- a/config/crd/bases/apps.kubeblocks.io_components.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_components.yaml
@@ -535,6 +535,9 @@ spec:
                             suitable for long-running Actions, such as data migration, rebalancing, or
                             draining, whose duration depends on data volume or runtime conditions.
 
+                            Non-blocking mode can be enabled only for Action fields that explicitly
+                            document support for it.
+
                             This field cannot be updated.
                           type: boolean
                         preCondition:
@@ -996,6 +999,9 @@ spec:
                             When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                             suitable for long-running Actions, such as data migration, rebalancing, or
                             draining, whose duration depends on data volume or runtime conditions.
+
+                            Non-blocking mode can be enabled only for Action fields that explicitly
+                            document support for it.
 
                             This field cannot be updated.
                           type: boolean

--- a/config/crd/bases/apps.kubeblocks.io_rollouts.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_rollouts.yaml
@@ -509,6 +509,9 @@ spec:
                                             suitable for long-running Actions, such as data migration, rebalancing, or
                                             draining, whose duration depends on data volume or runtime conditions.
 
+                                            Non-blocking mode can be enabled only for Action fields that explicitly
+                                            document support for it.
+
                                             This field cannot be updated.
                                           type: boolean
                                         preCondition:
@@ -965,6 +968,9 @@ spec:
                                             When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                                             suitable for long-running Actions, such as data migration, rebalancing, or
                                             draining, whose duration depends on data volume or runtime conditions.
+
+                                            Non-blocking mode can be enabled only for Action fields that explicitly
+                                            document support for it.
 
                                             This field cannot be updated.
                                           type: boolean
@@ -3900,6 +3906,9 @@ spec:
                                             suitable for long-running Actions, such as data migration, rebalancing, or
                                             draining, whose duration depends on data volume or runtime conditions.
 
+                                            Non-blocking mode can be enabled only for Action fields that explicitly
+                                            document support for it.
+
                                             This field cannot be updated.
                                           type: boolean
                                         preCondition:
@@ -4356,6 +4365,9 @@ spec:
                                             When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                                             suitable for long-running Actions, such as data migration, rebalancing, or
                                             draining, whose duration depends on data volume or runtime conditions.
+
+                                            Non-blocking mode can be enabled only for Action fields that explicitly
+                                            document support for it.
 
                                             This field cannot be updated.
                                           type: boolean

--- a/config/crd/bases/apps.kubeblocks.io_shardingdefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_shardingdefinitions.yaml
@@ -422,6 +422,9 @@ spec:
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
 
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
+
                           This field cannot be updated.
                         type: boolean
                       preCondition:
@@ -885,6 +888,9 @@ spec:
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
 
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
+
                           This field cannot be updated.
                         type: boolean
                       preCondition:
@@ -1343,6 +1349,9 @@ spec:
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
 
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
+
                           This field cannot be updated.
                         type: boolean
                       preCondition:
@@ -1800,6 +1809,9 @@ spec:
                           When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
+
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
 
                           This field cannot be updated.
                         type: boolean

--- a/config/crd/bases/apps.kubeblocks.io_sidecardefinitions.yaml
+++ b/config/crd/bases/apps.kubeblocks.io_sidecardefinitions.yaml
@@ -469,6 +469,9 @@ spec:
                             suitable for long-running Actions, such as data migration, rebalancing, or
                             draining, whose duration depends on data volume or runtime conditions.
 
+                            Non-blocking mode can be enabled only for Action fields that explicitly
+                            document support for it.
+
                             This field cannot be updated.
                           type: boolean
                         preCondition:
@@ -2358,6 +2361,9 @@ spec:
                             When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                             suitable for long-running Actions, such as data migration, rebalancing, or
                             draining, whose duration depends on data volume or runtime conditions.
+
+                            Non-blocking mode can be enabled only for Action fields that explicitly
+                            document support for it.
 
                             This field cannot be updated.
                           type: boolean

--- a/config/crd/bases/parameters.kubeblocks.io_componentparameters.yaml
+++ b/config/crd/bases/parameters.kubeblocks.io_componentparameters.yaml
@@ -561,6 +561,9 @@ spec:
                                 suitable for long-running Actions, such as data migration, rebalancing, or
                                 draining, whose duration depends on data volume or runtime conditions.
 
+                                Non-blocking mode can be enabled only for Action fields that explicitly
+                                document support for it.
+
                                 This field cannot be updated.
                               type: boolean
                             preCondition:

--- a/config/crd/bases/workloads.kubeblocks.io_instances.yaml
+++ b/config/crd/bases/workloads.kubeblocks.io_instances.yaml
@@ -431,6 +431,9 @@ spec:
                             suitable for long-running Actions, such as data migration, rebalancing, or
                             draining, whose duration depends on data volume or runtime conditions.
 
+                            Non-blocking mode can be enabled only for Action fields that explicitly
+                            document support for it.
+
                             This field cannot be updated.
                           type: boolean
                         preCondition:
@@ -1880,6 +1883,9 @@ spec:
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
 
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
+
                           This field cannot be updated.
                         type: boolean
                       preCondition:
@@ -2315,6 +2321,9 @@ spec:
                           When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
+
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
 
                           This field cannot be updated.
                         type: boolean

--- a/config/crd/bases/workloads.kubeblocks.io_instancesets.yaml
+++ b/config/crd/bases/workloads.kubeblocks.io_instancesets.yaml
@@ -431,6 +431,9 @@ spec:
                             suitable for long-running Actions, such as data migration, rebalancing, or
                             draining, whose duration depends on data volume or runtime conditions.
 
+                            Non-blocking mode can be enabled only for Action fields that explicitly
+                            document support for it.
+
                             This field cannot be updated.
                           type: boolean
                         preCondition:
@@ -2860,6 +2863,9 @@ spec:
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
 
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
+
                           This field cannot be updated.
                         type: boolean
                       preCondition:
@@ -3295,6 +3301,9 @@ spec:
                           When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
+
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
 
                           This field cannot be updated.
                         type: boolean

--- a/controllers/apps/component/transformer_component_validation.go
+++ b/controllers/apps/component/transformer_component_validation.go
@@ -62,9 +62,21 @@ func (t *componentValidationTransformer) Transform(ctx graph.TransformContext, d
 	if err = validateExternalManagedConfigSources(transCtx); err != nil {
 		return intctrlutil.NewRequeueError(appsutil.RequeueDuration, err.Error())
 	}
+	if err = validateNonBlockingReconfigureActions(comp); err != nil {
+		return intctrlutil.NewRequeueError(appsutil.RequeueDuration, err.Error())
+	}
 	// if err = validateSidecarContainers(comp, transCtx.CompDef); err != nil {
 	// 	return newRequeueError(requeueDuration, err.Error())
 	// }
+	return nil
+}
+
+func validateNonBlockingReconfigureActions(comp *appsv1.Component) error {
+	for i, config := range comp.Spec.Configs {
+		if config.ReconfigureAction != nil && config.ReconfigureAction.NonBlocking {
+			return fmt.Errorf("spec.configs[%d].reconfigureAction does not support non-blocking mode", i)
+		}
+	}
 	return nil
 }
 

--- a/controllers/apps/component/transformer_component_validation_test.go
+++ b/controllers/apps/component/transformer_component_validation_test.go
@@ -181,6 +181,41 @@ func TestValidateExternalManagedConfigSources(t *testing.T) {
 	}
 }
 
+func TestValidateNonBlockingReconfigureActions(t *testing.T) {
+	tests := []struct {
+		name    string
+		comp    *appsv1.Component
+		wantErr bool
+	}{
+		{
+			name: "rejects config reconfigure action",
+			comp: &appsv1.Component{Spec: appsv1.ComponentSpec{
+				Configs: []appsv1.ClusterComponentConfig{{
+					ReconfigureAction: &appsv1.Action{NonBlocking: true},
+				}},
+			}},
+			wantErr: true,
+		},
+		{
+			name: "does not validate custom actions owned by higher-level APIs",
+			comp: &appsv1.Component{Spec: appsv1.ComponentSpec{
+				CustomActions: []appsv1.CustomAction{{
+					Name:   "custom",
+					Action: &appsv1.Action{NonBlocking: true},
+				}},
+			}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateNonBlockingReconfigureActions(tt.comp)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateNonBlockingReconfigureActions() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func externalManagedConfig(name, cmName string) appsv1.ClusterComponentConfig {
 	return appsv1.ClusterComponentConfig{
 		Name: ptr.To(name),

--- a/controllers/apps/componentdefinition_controller.go
+++ b/controllers/apps/componentdefinition_controller.go
@@ -516,6 +516,55 @@ func (r *ComponentDefinitionReconciler) validatePolicyRules(cli client.Client, r
 
 func (r *ComponentDefinitionReconciler) validateLifecycleActions(cli client.Client, reqCtx intctrlutil.RequestCtx,
 	cmpd *appsv1.ComponentDefinition) error {
+	validate := func(path string, action *appsv1.Action) error {
+		if action != nil && action.NonBlocking {
+			return fmt.Errorf("%s does not support non-blocking mode", path)
+		}
+		return nil
+	}
+
+	if actions := cmpd.Spec.LifecycleActions; actions != nil {
+		type actionField struct {
+			path   string
+			action *appsv1.Action
+		}
+		actionFields := []actionField{
+			{"spec.lifecycleActions.postProvision", actions.PostProvision},
+			{"spec.lifecycleActions.preTerminate", actions.PreTerminate},
+			{"spec.lifecycleActions.switchover", actions.Switchover},
+			{"spec.lifecycleActions.memberJoin", actions.MemberJoin},
+			{"spec.lifecycleActions.memberLeave", actions.MemberLeave},
+			{"spec.lifecycleActions.readonly", actions.Readonly},
+			{"spec.lifecycleActions.readwrite", actions.Readwrite},
+			{"spec.lifecycleActions.dataDump", actions.DataDump},
+			{"spec.lifecycleActions.dataLoad", actions.DataLoad},
+			{"spec.lifecycleActions.reconfigure", actions.Reconfigure},
+			{"spec.lifecycleActions.accountProvision", actions.AccountProvision},
+		}
+		if actions.RoleProbe != nil {
+			actionFields = append(actionFields,
+				actionField{"spec.lifecycleActions.roleProbe", &actions.RoleProbe.Action})
+		}
+		if actions.AvailableProbe != nil {
+			actionFields = append(actionFields,
+				actionField{"spec.lifecycleActions.availableProbe", &actions.AvailableProbe.Action})
+		}
+		for _, field := range actionFields {
+			if err := validate(field.path, field.action); err != nil {
+				return err
+			}
+		}
+	}
+	for i := range cmpd.Spec.Configs {
+		if err := validate(fmt.Sprintf("spec.configs[%d].reconfigure", i), cmpd.Spec.Configs[i].Reconfigure); err != nil {
+			return err
+		}
+	}
+	for i := range cmpd.Spec.Scripts {
+		if err := validate(fmt.Sprintf("spec.scripts[%d].reconfigure", i), cmpd.Spec.Scripts[i].Reconfigure); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/controllers/apps/componentdefinition_controller_test.go
+++ b/controllers/apps/componentdefinition_controller_test.go
@@ -34,6 +34,7 @@ import (
 
 	kbappsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
+	ctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/generics"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
 )
@@ -99,6 +100,69 @@ var _ = Describe("ComponentDefinition Controller", func() {
 					g.Expect(cmpd.Status.ObservedGeneration).Should(Equal(cmpd.GetGeneration()))
 					g.Expect(cmpd.Status.Phase).Should(Equal(kbappsv1.AvailablePhase))
 				})).Should(Succeed())
+		})
+	})
+
+	Context("non-blocking actions", func() {
+		It("rejects non-blocking mode from every ComponentDefinition action entry", func() {
+			testCases := []struct {
+				path string
+				set  func(*kbappsv1.ComponentDefinitionSpec)
+			}{
+				{"spec.lifecycleActions.postProvision", func(spec *kbappsv1.ComponentDefinitionSpec) {
+					spec.LifecycleActions = &kbappsv1.ComponentLifecycleActions{PostProvision: &kbappsv1.Action{NonBlocking: true}}
+				}},
+				{"spec.lifecycleActions.preTerminate", func(spec *kbappsv1.ComponentDefinitionSpec) {
+					spec.LifecycleActions = &kbappsv1.ComponentLifecycleActions{PreTerminate: &kbappsv1.Action{NonBlocking: true}}
+				}},
+				{"spec.lifecycleActions.roleProbe", func(spec *kbappsv1.ComponentDefinitionSpec) {
+					spec.LifecycleActions = &kbappsv1.ComponentLifecycleActions{RoleProbe: &kbappsv1.Probe{Action: kbappsv1.Action{NonBlocking: true}}}
+				}},
+				{"spec.lifecycleActions.availableProbe", func(spec *kbappsv1.ComponentDefinitionSpec) {
+					spec.LifecycleActions = &kbappsv1.ComponentLifecycleActions{AvailableProbe: &kbappsv1.Probe{Action: kbappsv1.Action{NonBlocking: true}}}
+				}},
+				{"spec.lifecycleActions.switchover", func(spec *kbappsv1.ComponentDefinitionSpec) {
+					spec.LifecycleActions = &kbappsv1.ComponentLifecycleActions{Switchover: &kbappsv1.Action{NonBlocking: true}}
+				}},
+				{"spec.lifecycleActions.memberJoin", func(spec *kbappsv1.ComponentDefinitionSpec) {
+					spec.LifecycleActions = &kbappsv1.ComponentLifecycleActions{MemberJoin: &kbappsv1.Action{NonBlocking: true}}
+				}},
+				{"spec.lifecycleActions.memberLeave", func(spec *kbappsv1.ComponentDefinitionSpec) {
+					spec.LifecycleActions = &kbappsv1.ComponentLifecycleActions{MemberLeave: &kbappsv1.Action{NonBlocking: true}}
+				}},
+				{"spec.lifecycleActions.readonly", func(spec *kbappsv1.ComponentDefinitionSpec) {
+					spec.LifecycleActions = &kbappsv1.ComponentLifecycleActions{Readonly: &kbappsv1.Action{NonBlocking: true}}
+				}},
+				{"spec.lifecycleActions.readwrite", func(spec *kbappsv1.ComponentDefinitionSpec) {
+					spec.LifecycleActions = &kbappsv1.ComponentLifecycleActions{Readwrite: &kbappsv1.Action{NonBlocking: true}}
+				}},
+				{"spec.lifecycleActions.dataDump", func(spec *kbappsv1.ComponentDefinitionSpec) {
+					spec.LifecycleActions = &kbappsv1.ComponentLifecycleActions{DataDump: &kbappsv1.Action{NonBlocking: true}}
+				}},
+				{"spec.lifecycleActions.dataLoad", func(spec *kbappsv1.ComponentDefinitionSpec) {
+					spec.LifecycleActions = &kbappsv1.ComponentLifecycleActions{DataLoad: &kbappsv1.Action{NonBlocking: true}}
+				}},
+				{"spec.lifecycleActions.reconfigure", func(spec *kbappsv1.ComponentDefinitionSpec) {
+					spec.LifecycleActions = &kbappsv1.ComponentLifecycleActions{Reconfigure: &kbappsv1.Action{NonBlocking: true}}
+				}},
+				{"spec.lifecycleActions.accountProvision", func(spec *kbappsv1.ComponentDefinitionSpec) {
+					spec.LifecycleActions = &kbappsv1.ComponentLifecycleActions{AccountProvision: &kbappsv1.Action{NonBlocking: true}}
+				}},
+				{"spec.configs[0].reconfigure", func(spec *kbappsv1.ComponentDefinitionSpec) {
+					spec.Configs = []kbappsv1.ComponentFileTemplate{{Reconfigure: &kbappsv1.Action{NonBlocking: true}}}
+				}},
+				{"spec.scripts[0].reconfigure", func(spec *kbappsv1.ComponentDefinitionSpec) {
+					spec.Scripts = []kbappsv1.ComponentFileTemplate{{Reconfigure: &kbappsv1.Action{NonBlocking: true}}}
+				}},
+			}
+
+			reconciler := &ComponentDefinitionReconciler{}
+			for _, testCase := range testCases {
+				cmpd := &kbappsv1.ComponentDefinition{}
+				testCase.set(&cmpd.Spec)
+				err := reconciler.validateLifecycleActions(nil, ctrlutil.RequestCtx{}, cmpd)
+				Expect(err).Should(MatchError(ContainSubstring(testCase.path)), testCase.path)
+			}
 		})
 	})
 

--- a/controllers/apps/shardingdefinition_controller.go
+++ b/controllers/apps/shardingdefinition_controller.go
@@ -261,6 +261,22 @@ func (r *ShardingDefinitionReconciler) requireParallelProvision() bool {
 
 func (r *ShardingDefinitionReconciler) validateLifecycleActions(ctx context.Context, cli client.Client,
 	shardingDef *appsv1.ShardingDefinition) error {
+	actions := shardingDef.Spec.LifecycleActions
+	if actions == nil {
+		return nil
+	}
+	unsupported := []struct {
+		path   string
+		action *appsv1.ShardingAction
+	}{
+		{"spec.lifecycleActions.postProvision", actions.PostProvision},
+		{"spec.lifecycleActions.preTerminate", actions.PreTerminate},
+	}
+	for _, field := range unsupported {
+		if field.action != nil && field.action.NonBlocking {
+			return fmt.Errorf("%s does not support non-blocking mode", field.path)
+		}
+	}
 	return nil
 }
 

--- a/controllers/apps/shardingdefinition_controller_test.go
+++ b/controllers/apps/shardingdefinition_controller_test.go
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package apps
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -98,6 +99,43 @@ var _ = Describe("ShardingDefinition Controller", func() {
 					g.Expect(sdd.Status.ObservedGeneration).Should(Equal(sdd.GetGeneration()))
 					g.Expect(sdd.Status.Phase).Should(Equal(appsv1.AvailablePhase))
 				})).Should(Succeed())
+		})
+	})
+
+	Context("non-blocking actions", func() {
+		It("allows shardAdd and shardRemove", func() {
+			shardingDef := &appsv1.ShardingDefinition{
+				Spec: appsv1.ShardingDefinitionSpec{
+					LifecycleActions: &appsv1.ShardingLifecycleActions{
+						ShardAdd:    &appsv1.ShardingAction{Action: appsv1.Action{NonBlocking: true}},
+						ShardRemove: &appsv1.ShardingAction{Action: appsv1.Action{NonBlocking: true}},
+					},
+				},
+			}
+			err := (&ShardingDefinitionReconciler{}).validateLifecycleActions(context.Background(), nil, shardingDef)
+			Expect(err).Should(BeNil())
+		})
+
+		It("rejects postProvision and preTerminate", func() {
+			reconciler := &ShardingDefinitionReconciler{}
+			for _, testCase := range []struct {
+				path   string
+				action func(*appsv1.ShardingLifecycleActions)
+			}{
+				{"spec.lifecycleActions.postProvision", func(actions *appsv1.ShardingLifecycleActions) {
+					actions.PostProvision = &appsv1.ShardingAction{Action: appsv1.Action{NonBlocking: true}}
+				}},
+				{"spec.lifecycleActions.preTerminate", func(actions *appsv1.ShardingLifecycleActions) {
+					actions.PreTerminate = &appsv1.ShardingAction{Action: appsv1.Action{NonBlocking: true}}
+				}},
+			} {
+				shardingDef := &appsv1.ShardingDefinition{
+					Spec: appsv1.ShardingDefinitionSpec{LifecycleActions: &appsv1.ShardingLifecycleActions{}},
+				}
+				testCase.action(shardingDef.Spec.LifecycleActions)
+				err := reconciler.validateLifecycleActions(context.Background(), nil, shardingDef)
+				Expect(err).Should(MatchError(ContainSubstring(testCase.path)), testCase.path)
+			}
 		})
 	})
 

--- a/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_clusters.yaml
@@ -653,6 +653,9 @@ spec:
                                   suitable for long-running Actions, such as data migration, rebalancing, or
                                   draining, whose duration depends on data volume or runtime conditions.
 
+                                  Non-blocking mode can be enabled only for Action fields that explicitly
+                                  document support for it.
+
                                   This field cannot be updated.
                                 type: boolean
                               preCondition:
@@ -11919,6 +11922,9 @@ spec:
                                       When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                                       suitable for long-running Actions, such as data migration, rebalancing, or
                                       draining, whose duration depends on data volume or runtime conditions.
+
+                                      Non-blocking mode can be enabled only for Action fields that explicitly
+                                      document support for it.
 
                                       This field cannot be updated.
                                     type: boolean

--- a/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_componentdefinitions.yaml
@@ -4093,6 +4093,9 @@ spec:
                             suitable for long-running Actions, such as data migration, rebalancing, or
                             draining, whose duration depends on data volume or runtime conditions.
 
+                            Non-blocking mode can be enabled only for Action fields that explicitly
+                            document support for it.
+
                             This field cannot be updated.
                           type: boolean
                         preCondition:
@@ -4705,6 +4708,9 @@ spec:
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
 
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
+
                           This field cannot be updated.
                         type: boolean
                       preCondition:
@@ -5154,6 +5160,9 @@ spec:
                           When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
+
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
 
                           This field cannot be updated.
                         type: boolean
@@ -5621,6 +5630,9 @@ spec:
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
 
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
+
                           This field cannot be updated.
                         type: boolean
                       preCondition:
@@ -6069,6 +6081,9 @@ spec:
                           When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
+
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
 
                           This field cannot be updated.
                         type: boolean
@@ -6521,6 +6536,9 @@ spec:
                           When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
+
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
 
                           This field cannot be updated.
                         type: boolean
@@ -6976,6 +6994,9 @@ spec:
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
 
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
+
                           This field cannot be updated.
                         type: boolean
                       preCondition:
@@ -7419,6 +7440,9 @@ spec:
                           When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
+
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
 
                           This field cannot be updated.
                         type: boolean
@@ -7864,6 +7888,9 @@ spec:
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
 
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
+
                           This field cannot be updated.
                         type: boolean
                       preCondition:
@@ -8307,6 +8334,9 @@ spec:
                           When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
+
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
 
                           This field cannot be updated.
                         type: boolean
@@ -8754,6 +8784,9 @@ spec:
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
 
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
+
                           This field cannot be updated.
                         type: boolean
                       preCondition:
@@ -9191,6 +9224,9 @@ spec:
                           When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
+
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
 
                           This field cannot be updated.
                         type: boolean
@@ -9679,6 +9715,9 @@ spec:
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
 
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
+
                           This field cannot be updated.
                         type: boolean
                       periodSeconds:
@@ -10144,6 +10183,9 @@ spec:
                           When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
+
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
 
                           This field cannot be updated.
                         type: boolean
@@ -18312,6 +18354,9 @@ spec:
                             When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                             suitable for long-running Actions, such as data migration, rebalancing, or
                             draining, whose duration depends on data volume or runtime conditions.
+
+                            Non-blocking mode can be enabled only for Action fields that explicitly
+                            document support for it.
 
                             This field cannot be updated.
                           type: boolean

--- a/deploy/helm/crds/apps.kubeblocks.io_components.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_components.yaml
@@ -535,6 +535,9 @@ spec:
                             suitable for long-running Actions, such as data migration, rebalancing, or
                             draining, whose duration depends on data volume or runtime conditions.
 
+                            Non-blocking mode can be enabled only for Action fields that explicitly
+                            document support for it.
+
                             This field cannot be updated.
                           type: boolean
                         preCondition:
@@ -996,6 +999,9 @@ spec:
                             When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                             suitable for long-running Actions, such as data migration, rebalancing, or
                             draining, whose duration depends on data volume or runtime conditions.
+
+                            Non-blocking mode can be enabled only for Action fields that explicitly
+                            document support for it.
 
                             This field cannot be updated.
                           type: boolean

--- a/deploy/helm/crds/apps.kubeblocks.io_rollouts.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_rollouts.yaml
@@ -509,6 +509,9 @@ spec:
                                             suitable for long-running Actions, such as data migration, rebalancing, or
                                             draining, whose duration depends on data volume or runtime conditions.
 
+                                            Non-blocking mode can be enabled only for Action fields that explicitly
+                                            document support for it.
+
                                             This field cannot be updated.
                                           type: boolean
                                         preCondition:
@@ -965,6 +968,9 @@ spec:
                                             When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                                             suitable for long-running Actions, such as data migration, rebalancing, or
                                             draining, whose duration depends on data volume or runtime conditions.
+
+                                            Non-blocking mode can be enabled only for Action fields that explicitly
+                                            document support for it.
 
                                             This field cannot be updated.
                                           type: boolean
@@ -3900,6 +3906,9 @@ spec:
                                             suitable for long-running Actions, such as data migration, rebalancing, or
                                             draining, whose duration depends on data volume or runtime conditions.
 
+                                            Non-blocking mode can be enabled only for Action fields that explicitly
+                                            document support for it.
+
                                             This field cannot be updated.
                                           type: boolean
                                         preCondition:
@@ -4356,6 +4365,9 @@ spec:
                                             When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                                             suitable for long-running Actions, such as data migration, rebalancing, or
                                             draining, whose duration depends on data volume or runtime conditions.
+
+                                            Non-blocking mode can be enabled only for Action fields that explicitly
+                                            document support for it.
 
                                             This field cannot be updated.
                                           type: boolean

--- a/deploy/helm/crds/apps.kubeblocks.io_shardingdefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_shardingdefinitions.yaml
@@ -422,6 +422,9 @@ spec:
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
 
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
+
                           This field cannot be updated.
                         type: boolean
                       preCondition:
@@ -885,6 +888,9 @@ spec:
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
 
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
+
                           This field cannot be updated.
                         type: boolean
                       preCondition:
@@ -1343,6 +1349,9 @@ spec:
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
 
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
+
                           This field cannot be updated.
                         type: boolean
                       preCondition:
@@ -1800,6 +1809,9 @@ spec:
                           When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
+
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
 
                           This field cannot be updated.
                         type: boolean

--- a/deploy/helm/crds/apps.kubeblocks.io_sidecardefinitions.yaml
+++ b/deploy/helm/crds/apps.kubeblocks.io_sidecardefinitions.yaml
@@ -469,6 +469,9 @@ spec:
                             suitable for long-running Actions, such as data migration, rebalancing, or
                             draining, whose duration depends on data volume or runtime conditions.
 
+                            Non-blocking mode can be enabled only for Action fields that explicitly
+                            document support for it.
+
                             This field cannot be updated.
                           type: boolean
                         preCondition:
@@ -2358,6 +2361,9 @@ spec:
                             When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                             suitable for long-running Actions, such as data migration, rebalancing, or
                             draining, whose duration depends on data volume or runtime conditions.
+
+                            Non-blocking mode can be enabled only for Action fields that explicitly
+                            document support for it.
 
                             This field cannot be updated.
                           type: boolean

--- a/deploy/helm/crds/parameters.kubeblocks.io_componentparameters.yaml
+++ b/deploy/helm/crds/parameters.kubeblocks.io_componentparameters.yaml
@@ -561,6 +561,9 @@ spec:
                                 suitable for long-running Actions, such as data migration, rebalancing, or
                                 draining, whose duration depends on data volume or runtime conditions.
 
+                                Non-blocking mode can be enabled only for Action fields that explicitly
+                                document support for it.
+
                                 This field cannot be updated.
                               type: boolean
                             preCondition:

--- a/deploy/helm/crds/workloads.kubeblocks.io_instances.yaml
+++ b/deploy/helm/crds/workloads.kubeblocks.io_instances.yaml
@@ -431,6 +431,9 @@ spec:
                             suitable for long-running Actions, such as data migration, rebalancing, or
                             draining, whose duration depends on data volume or runtime conditions.
 
+                            Non-blocking mode can be enabled only for Action fields that explicitly
+                            document support for it.
+
                             This field cannot be updated.
                           type: boolean
                         preCondition:
@@ -1880,6 +1883,9 @@ spec:
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
 
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
+
                           This field cannot be updated.
                         type: boolean
                       preCondition:
@@ -2315,6 +2321,9 @@ spec:
                           When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
+
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
 
                           This field cannot be updated.
                         type: boolean

--- a/deploy/helm/crds/workloads.kubeblocks.io_instancesets.yaml
+++ b/deploy/helm/crds/workloads.kubeblocks.io_instancesets.yaml
@@ -431,6 +431,9 @@ spec:
                             suitable for long-running Actions, such as data migration, rebalancing, or
                             draining, whose duration depends on data volume or runtime conditions.
 
+                            Non-blocking mode can be enabled only for Action fields that explicitly
+                            document support for it.
+
                             This field cannot be updated.
                           type: boolean
                         preCondition:
@@ -2860,6 +2863,9 @@ spec:
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
 
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
+
                           This field cannot be updated.
                         type: boolean
                       preCondition:
@@ -3295,6 +3301,9 @@ spec:
                           When true, KubeBlocks runs the Action in non-blocking mode. This mode is
                           suitable for long-running Actions, such as data migration, rebalancing, or
                           draining, whose duration depends on data volume or runtime conditions.
+
+                          Non-blocking mode can be enabled only for Action fields that explicitly
+                          document support for it.
 
                           This field cannot be updated.
                         type: boolean

--- a/docs/developer_docs/api-reference/cluster.md
+++ b/docs/developer_docs/api-reference/cluster.md
@@ -2504,6 +2504,8 @@ for Actions that are expected to complete quickly.</p>
 <p>When true, KubeBlocks runs the Action in non-blocking mode. This mode is
 suitable for long-running Actions, such as data migration, rebalancing, or
 draining, whose duration depends on data volume or runtime conditions.</p>
+<p>Non-blocking mode can be enabled only for Action fields that explicitly
+document support for it.</p>
 <p>This field cannot be updated.</p>
 </td>
 </tr>


### PR DESCRIPTION
## Summary

The shared `Action` type exposes `nonBlocking`, but not every Action field supports non-blocking execution. Clarify this restriction in the API documentation and validate unsupported configurations through the existing controller validation paths.

## Changes

- Document that `nonBlocking: true` is allowed only on Action fields that explicitly document support.
- Reject non-blocking ComponentDefinition lifecycle actions, including probes, and config/script reconfigure actions.
- Reject non-blocking ShardingDefinition `postProvision` and `preTerminate` actions.
- Reject non-blocking Component config reconfigure actions.
- Update the generated CRD descriptions and API reference, and cover the validation rules in the existing test suites.

These checks use the existing Go validation mechanisms; no admission rules or Action execution behavior are changed. Blocking configurations remain unchanged. This PR does not enable non-blocking execution for any additional Action field.

## Testing

- Passed the full `controllers/apps` test suite.
- Passed `TestValidateNonBlockingReconfigureActions` in `controllers/apps/component`.
- Regenerated the API reference and verified all affected CRD specs against fresh controller-gen output; checked that the CRD and Helm copies match.
- Passed formatting and whitespace checks.
