### PR TITLE
chore: support explicit target pod selection

### DIFF
--- a/pkg/controller/lifecycle/kbagent.go
+++ b/pkg/controller/lifecycle/kbagent.go
@@ -261,7 +261,7 @@ func (a *kbagent) callAction(ctx context.Context, cli client.Reader, spec *appsv
 	if err1 != nil {
 		return nil, err1
 	}
-	return a.callActionWithSelector(ctx, spec, lfa, req)
+	return a.callActionWithSelector(ctx, spec, lfa, req, opts)
 }
 
 // BuildKBAgentRetryPolicy normalizes the API retry policy into the kbagent wire contract.
@@ -378,8 +378,9 @@ func (a *kbagent) templateVarsParameters() (map[string]string, error) {
 	return m, nil
 }
 
-func (a *kbagent) callActionWithSelector(ctx context.Context, spec *appsv1.Action, lfa lifecycleAction, req *proto.ActionRequest) ([]byte, error) {
-	pods, err := a.selectTargetPods(spec)
+func (a *kbagent) callActionWithSelector(ctx context.Context, spec *appsv1.Action, lfa lifecycleAction,
+	req *proto.ActionRequest, opts *Options) ([]byte, error) {
+	pods, err := a.selectTargetPods(spec, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -387,7 +388,7 @@ func (a *kbagent) callActionWithSelector(ctx context.Context, spec *appsv1.Actio
 		return nil, fmt.Errorf("no available pod to execute action %s", lfa.name())
 	}
 	selector, _ := resolveTargetPodSelector(spec)
-	aggregateErrors := selector == appsv1.AllReplicas
+	aggregateErrors := (opts == nil || opts.TargetPodName == "") && selector == appsv1.AllReplicas
 
 	// TODO: impl
 	//  - back-off to retry
@@ -452,7 +453,15 @@ func (a *kbagent) callActionWithSelector(ctx context.Context, spec *appsv1.Actio
 	return output, nil
 }
 
-func (a *kbagent) selectTargetPods(spec *appsv1.Action) ([]*corev1.Pod, error) {
+func (a *kbagent) selectTargetPods(spec *appsv1.Action, opts *Options) ([]*corev1.Pod, error) {
+	if opts != nil && opts.TargetPodName != "" {
+		for _, pod := range a.pods {
+			if pod.Name == opts.TargetPodName {
+				return []*corev1.Pod{pod}, nil
+			}
+		}
+		return nil, fmt.Errorf("target pod %s is not available to execute action", opts.TargetPodName)
+	}
 	return SelectTargetPods(a.pods, a.pod, spec)
 }
 

--- a/pkg/controller/lifecycle/lifecycle.go
+++ b/pkg/controller/lifecycle/lifecycle.go
@@ -30,7 +30,12 @@ import (
 )
 
 type Options struct {
-	Rerun                      bool
+	Rerun bool
+
+	// TargetPodName, when set, executes the Action only on the named Pod and
+	// overrides the Action's targetPodSelector. The Pod must be present in the
+	// lifecycle's Pod list; an unavailable target returns an error without fallback.
+	TargetPodName              string
 	TimeoutSeconds             *int32
 	RetryPolicy                *appsv1.RetryPolicy
 	Arguments                  [][]string

--- a/pkg/controller/lifecycle/lifecycle_test.go
+++ b/pkg/controller/lifecycle/lifecycle_test.go
@@ -289,6 +289,82 @@ var _ = Describe("lifecycle", func() {
 			Expect(err).Should(BeNil())
 		})
 
+		DescribeTable("executes on an exact target pod regardless of selector", func(selector appsv1.TargetPodSelector, matchingKey string) {
+			lifecycleActions.PostProvision.Exec.TargetPodSelector = selector
+			lifecycleActions.PostProvision.Exec.MatchingKey = matchingKey
+			pods = []*corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "pod-0"}},
+				{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "pod-1"}},
+			}
+			lifecycle, err := New(namespace, clusterName, compName, lifecycleActions, nil, nil, pods)
+			Expect(err).Should(BeNil())
+			selected, err := lifecycle.(*kbagent).selectTargetPods(
+				lifecycleActions.PostProvision, &Options{TargetPodName: "pod-1"})
+			Expect(err).Should(BeNil())
+			Expect(selected).Should(HaveLen(1))
+			Expect(selected[0].Name).Should(Equal("pod-1"))
+
+			mockKBAgentClient(func(recorder *kbacli.MockClientMockRecorder) {
+				recorder.Action(gomock.Any(), gomock.Any()).Return(proto.ActionResponse{}, nil).Times(1)
+			})
+
+			err = lifecycle.PostProvision(ctx, k8sClient, &Options{TargetPodName: "pod-1"})
+			Expect(err).Should(BeNil())
+		},
+			Entry("default", appsv1.TargetPodSelector(""), ""),
+			Entry("any replica", appsv1.AnyReplica, ""),
+			Entry("all replicas", appsv1.AllReplicas, ""),
+			Entry("role with no matching pod", appsv1.RoleSelector, "leader"),
+			Entry("ordinal selecting a different pod", appsv1.OrdinalSelector, "0"),
+		)
+
+		DescribeTable("preserves the selector without an exact target", func(opts *Options) {
+			lifecycleActions.PostProvision.Exec.TargetPodSelector = appsv1.AllReplicas
+			pods = []*corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "pod-0"}},
+				{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "pod-1"}},
+			}
+			lifecycle, err := New(namespace, clusterName, compName, lifecycleActions, nil, nil, pods)
+			Expect(err).Should(BeNil())
+			mockKBAgentClient(func(recorder *kbacli.MockClientMockRecorder) {
+				recorder.Action(gomock.Any(), gomock.Any()).Return(proto.ActionResponse{}, nil).Times(2)
+			})
+			Expect(lifecycle.PostProvision(ctx, k8sClient, opts)).Should(Succeed())
+		},
+			Entry("nil options", (*Options)(nil)),
+			Entry("empty target name", &Options{}),
+		)
+
+		It("returns a single target error when overriding all replicas", func() {
+			lifecycleActions.PostProvision.Exec.TargetPodSelector = appsv1.AllReplicas
+			pods = []*corev1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "pod-0"}},
+				{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "pod-1"}},
+			}
+			lifecycle, err := New(namespace, clusterName, compName, lifecycleActions, nil, nil, pods)
+			Expect(err).Should(BeNil())
+			mockKBAgentClient(func(recorder *kbacli.MockClientMockRecorder) {
+				recorder.Action(gomock.Any(), gomock.Any()).Return(
+					proto.ActionResponse{Error: proto.Error2Type(proto.ErrInProgress)}, nil).Times(1)
+			})
+			err = lifecycle.PostProvision(ctx, k8sClient, &Options{TargetPodName: "pod-1"})
+			Expect(errors.Is(err, ErrActionInProgress)).Should(BeTrue())
+			Expect(err.Error()).Should(ContainSubstring("pod-1"))
+			var aggregate *actionAggregateError
+			Expect(errors.As(err, &aggregate)).Should(BeFalse())
+		})
+
+		It("rejects an unavailable exact target pod", func() {
+			mockKBAgentClient(func(recorder *kbacli.MockClientMockRecorder) {
+				recorder.Action(gomock.Any(), gomock.Any()).Times(0)
+			})
+			lifecycle, err := New(namespace, clusterName, compName, lifecycleActions, nil, nil, pods)
+			Expect(err).Should(BeNil())
+
+			err = lifecycle.PostProvision(ctx, k8sClient, &Options{TargetPodName: "missing"})
+			Expect(err).Should(MatchError(ContainSubstring("target pod missing is not available")))
+		})
+
 		It("succeed", func() {
 			lifecycle, err := New(namespace, clusterName, compName, lifecycleActions, nil, nil, pods)
 			Expect(err).Should(BeNil())


### PR DESCRIPTION
## Summary

Allow lifecycle callers to execute an Action on an explicitly selected Pod. A caller that already knows its target can address that Pod without repeating the Action's selector or invoking other replicas.

## Changes

- Add the internal `Options.TargetPodName` option and pass it through the Action call path.
- When set, use only the named Pod from the lifecycle's Pod list, overriding `targetPodSelector`. Return an error without invoking another Pod if the target is absent.
- Preserve the existing selector behavior when options are nil or the target name is empty.
- Return the normal single-target Action error when overriding `AllReplicas`, rather than a multi-target aggregate.

This does not change the public Action API, kb-agent protocol, or existing callers. Target selection and retry scheduling remain the caller's responsibility.

## Testing

- Full lifecycle and cluster controller test suites.
- Exact-target selection with default, AnyReplica, AllReplicas, Role, and Ordinal selectors.
- Missing target returns an error without calling another Pod.
- Nil options and an empty target name preserve multi-Pod selection.
- An AllReplicas override returns a single-target error with its Pod identity and error code preserved.
- Formatting and whitespace checks.
