### PR TITLE
chore: complete shard add before shard removal

### DIFF
--- a/controllers/apps/cluster/transformer_cluster_component.go
+++ b/controllers/apps/cluster/transformer_cluster_component.go
@@ -908,7 +908,23 @@ func (h *clusterShardingHandler) update(transCtx *clusterTransformContext, dag *
 		return err
 	}
 
+	pendingAdds := make(map[string]*appsv1.Component)
+	for name := range toDelete {
+		if comp := runningCompsMap[name]; comp.Annotations[shardingAddShardKey] != "" {
+			pendingAdds[name] = comp.DeepCopy()
+		}
+	}
 	errorSkip, err3 := h.handleShardAddNRemove(transCtx, name, runningCompsMap, protoCompsMap, toCreate, toDelete, toUpdate)
+
+	// Preserve completed adds when a subsequent remove failure keeps the shard alive.
+	graphCli, _ := transCtx.Client.(model.GraphClient)
+	for name, original := range pendingAdds {
+		if errorSkip.Has(name) && runningCompsMap[name].Annotations[shardingAddShardKey] == "" {
+			updated := original.DeepCopy()
+			delete(updated.Annotations, shardingAddShardKey)
+			graphCli.Update(dag, original, updated)
+		}
+	}
 
 	// TODO: update strategy
 	h.deleteComps(transCtx, dag, runningCompsMap, toDelete.Difference(errorSkip))

--- a/controllers/apps/cluster/transformer_cluster_component.go
+++ b/controllers/apps/cluster/transformer_cluster_component.go
@@ -1368,7 +1368,7 @@ func (h *clusterShardingHandler) handleShardAddNRemove(transCtx *clusterTransfor
 			for name := range toUpdate {
 				err1 := h.handleShardAdd(transCtx, shardingName, maps.Values(runningCompsMap), runningCompsMap[name])
 				if err1 != nil {
-					transCtx.Logger.Error(err, "failed to call the shard add action", "shard", name)
+					transCtx.Logger.Error(err1, "failed to call the shard add action", "shard", name)
 					if err == nil {
 						err = err1
 					}
@@ -1383,7 +1383,7 @@ func (h *clusterShardingHandler) handleShardAddNRemove(transCtx *clusterTransfor
 			for name := range toDelete {
 				err1 := h.handleShardRemove(transCtx, shardingName, maps.Values(runningCompsMap), runningCompsMap[name])
 				if err1 != nil {
-					transCtx.Logger.Error(err, "failed to call the shard remove action", "shard", name)
+					transCtx.Logger.Error(err1, "failed to call the shard remove action", "shard", name)
 					if err == nil {
 						err = err1
 					}
@@ -1441,17 +1441,15 @@ func (h *clusterShardingHandler) handleShardRemove(transCtx *clusterTransformCon
 		pending = func() bool {
 			return runningComp.DeletionTimestamp.IsZero()
 		}
-
-		skipIfShardAddNotDone = func() bool {
-			return runningComp.Annotations[shardingAddShardKey] != ""
-		}
 	)
 
-	if shardingDef == nil || shardingDef.Spec.LifecycleActions == nil || shardingDef.Spec.LifecycleActions.ShardRemove == nil {
-		return nil
+	if runningComp.Annotations[shardingAddShardKey] != "" {
+		if err := h.handleShardAdd(transCtx, shardingName, runningComps, runningComp); err != nil {
+			return err
+		}
 	}
 
-	if skipIfShardAddNotDone() {
+	if shardingDef == nil || shardingDef.Spec.LifecycleActions == nil || shardingDef.Spec.LifecycleActions.ShardRemove == nil {
 		return nil
 	}
 

--- a/controllers/apps/cluster/transformer_cluster_component_test.go
+++ b/controllers/apps/cluster/transformer_cluster_component_test.go
@@ -2485,6 +2485,81 @@ var _ = Describe("cluster component transformer test", func() {
 				Expect(actionDone).Should(BeTrue())
 			})
 
+			DescribeTable("persists completed shard-add when shard-remove fails", func(transportError bool) {
+				transCtx.shardingDefs[shardingDefName].Spec.LifecycleActions = &appsv1.ShardingLifecycleActions{
+					ShardAdd:    mockShardingAction("shard-add"),
+					ShardRemove: mockShardingAction("shard-remove"),
+				}
+				transCtx.shardingCompsWithTpl[sharding1aName][""] = nil
+				shardComp, pod := mockShardCompWithPod(appsv1.RunningComponentPhase, map[string]string{
+					constant.KBAppClusterUIDKey: "test-uid",
+					shardingAddShardKey:         "test",
+				})
+				original := shardComp.DeepCopy()
+				transCtx.Client = model.NewGraphClient(&appsutil.MockReader{Objects: []client.Object{shardComp, pod}})
+				var calls []string
+				removeFails := true
+				testapps.MockKBAgentClient(func(recorder *kbacli.MockClientMockRecorder) {
+					recorder.Action(gomock.Any(), gomock.Any()).DoAndReturn(
+						func(_ context.Context, req kbagentproto.ActionRequest) (kbagentproto.ActionResponse, error) {
+							calls = append(calls, req.Action)
+							if req.Action == "udf-"+shardingRemoveShardAction && removeFails {
+								if transportError {
+									return kbagentproto.ActionResponse{}, fmt.Errorf("remove transport error")
+								}
+								return kbagentproto.ActionResponse{Error: kbagentproto.Error2Type(kbagentproto.ErrFailed)}, nil
+							}
+							return kbagentproto.ActionResponse{}, nil
+						}).AnyTimes()
+				})
+
+				err := transformer.Transform(transCtx, dag)
+				Expect(err).ShouldNot(BeNil())
+				Expect(ictrlutil.IsDelayedRequeueError(err)).Should(BeFalse())
+				Expect(calls).Should(Equal([]string{"udf-" + shardingAddShardAction, "udf-" + shardingRemoveShardAction}))
+
+				By("persisting only the completed add marker without scheduling deletion")
+				expected := original.DeepCopy()
+				delete(expected.Annotations, shardingAddShardKey)
+				var persisted *appsv1.Component
+				updates := 0
+				Expect(dag.WalkReverseTopoOrder(func(vertex graph.Vertex) error {
+					node := vertex.(*model.ObjectVertex)
+					if comp, ok := node.Obj.(*appsv1.Component); ok {
+						Expect(*node.Action).Should(Equal(model.UPDATE))
+						Expect(node.OriObj).Should(Equal(original))
+						Expect(comp).Should(Equal(expected))
+						persisted = comp.DeepCopy()
+						updates++
+					}
+					return nil
+				}, nil)).Should(Succeed())
+				Expect(updates).Should(Equal(1))
+
+				By("retrying only remove from the persisted Component in a fresh DAG")
+				removeFails = false
+				graphCli := model.NewGraphClient(&appsutil.MockReader{Objects: []client.Object{persisted, pod}})
+				transCtx.Client = graphCli
+				dag = newDAG(graphCli, transCtx.Cluster)
+				Expect(transformer.Transform(transCtx, dag)).Should(Succeed())
+				Expect(calls).Should(Equal([]string{
+					"udf-" + shardingAddShardAction, "udf-" + shardingRemoveShardAction, "udf-" + shardingRemoveShardAction,
+				}))
+				deletes := 0
+				Expect(dag.WalkReverseTopoOrder(func(vertex graph.Vertex) error {
+					node := vertex.(*model.ObjectVertex)
+					if comp, ok := node.Obj.(*appsv1.Component); ok && *node.Action == model.DELETE {
+						Expect(comp.Name).Should(Equal(persisted.Name))
+						deletes++
+					}
+					return nil
+				}, nil)).Should(Succeed())
+				Expect(deletes).Should(Equal(1))
+			},
+				Entry("terminal failure", false),
+				Entry("transport error", true),
+			)
+
 			DescribeTable("finishes marked shard-add before deletion", func(removeDefined, addFails bool) {
 				transCtx.shardingDefs[shardingDefName].Spec.LifecycleActions = &appsv1.ShardingLifecycleActions{
 					ShardAdd: mockShardingAction("shard-add"),

--- a/controllers/apps/cluster/transformer_cluster_component_test.go
+++ b/controllers/apps/cluster/transformer_cluster_component_test.go
@@ -2485,10 +2485,12 @@ var _ = Describe("cluster component transformer test", func() {
 				Expect(actionDone).Should(BeTrue())
 			})
 
-			It("shard-add - pending or failed", func() {
+			DescribeTable("finishes marked shard-add before deletion", func(removeDefined, addFails bool) {
 				transCtx.shardingDefs[shardingDefName].Spec.LifecycleActions = &appsv1.ShardingLifecycleActions{
-					ShardAdd:    mockShardingAction("shard-add"),
-					ShardRemove: mockShardingAction("shard-remove"),
+					ShardAdd: mockShardingAction("shard-add"),
+				}
+				if removeDefined {
+					transCtx.shardingDefs[shardingDefName].Spec.LifecycleActions.ShardRemove = mockShardingAction("shard-remove")
 				}
 
 				transCtx.shardingCompsWithTpl[sharding1aName][""] = nil
@@ -2501,25 +2503,53 @@ var _ = Describe("cluster component transformer test", func() {
 				}(transCtx)}
 				transCtx.Client = model.NewGraphClient(reader)
 
-				mockKBAgent(shardingRemoveShardAction)
+				var calls []string
+				testapps.MockKBAgentClient(func(recorder *kbacli.MockClientMockRecorder) {
+					recorder.Action(gomock.Any(), gomock.Any()).DoAndReturn(
+						func(_ context.Context, req kbagentproto.ActionRequest) (kbagentproto.ActionResponse, error) {
+							calls = append(calls, req.Action)
+							if req.Action == "udf-"+shardingAddShardAction && addFails {
+								return kbagentproto.ActionResponse{Error: kbagentproto.Error2Type(kbagentproto.ErrFailed)}, nil
+							}
+							return kbagentproto.ActionResponse{}, nil
+						}).AnyTimes()
+				})
 
 				err := transformer.Transform(transCtx, dag)
-				Expect(err).Should(BeNil())
-
-				By("check the shard being deleted")
-				walk := func(vertex graph.Vertex) error {
-					node, ok := vertex.(*model.ObjectVertex)
-					Expect(ok).Should(BeTrue())
-					if reflect.TypeOf(node.Obj).AssignableTo(reflect.TypeOf(&appsv1.Component{})) {
-						Expect(*node.Action).Should(BeElementOf(model.DELETE, model.UPDATE))
+				expectedCalls := []string{"udf-" + shardingAddShardAction}
+				if addFails {
+					Expect(err).ShouldNot(BeNil())
+					By("check failed shard-add blocks deletion even without shard-remove")
+					graphCli := transCtx.Client.(model.GraphClient)
+					Expect(graphCli.FindAll(dag, &appsv1.Component{})).Should(BeEmpty())
+				} else {
+					Expect(err).Should(BeNil())
+					if removeDefined {
+						expectedCalls = append(expectedCalls, "udf-"+shardingRemoveShardAction)
 					}
-					return nil
-				}
-				Expect(dag.WalkReverseTopoOrder(walk, nil)).Should(BeNil())
 
-				By("check the shard-remove action is NOT done")
-				Expect(actionDone).Should(BeFalse())
-			})
+					By("check deletion is scheduled after the action prerequisites succeed")
+					deletes := 0
+					walk := func(vertex graph.Vertex) error {
+						node, ok := vertex.(*model.ObjectVertex)
+						Expect(ok).Should(BeTrue())
+						if comp, ok := node.Obj.(*appsv1.Component); ok && *node.Action == model.DELETE {
+							Expect(comp.Name).Should(Equal(shardComp.Name))
+							Expect(comp.Annotations).ShouldNot(HaveKey(shardingAddShardKey))
+							deletes++
+						}
+						return nil
+					}
+					Expect(dag.WalkReverseTopoOrder(walk, nil)).Should(Succeed())
+					Expect(deletes).Should(Equal(1))
+				}
+				Expect(calls).Should(Equal(expectedCalls))
+			},
+				Entry("add failure with remove defined", true, true),
+				Entry("add failure without remove defined", false, true),
+				Entry("add succeeds before remove", true, false),
+				Entry("add succeeds without remove defined", false, false),
+			)
 		})
 	})
 })


### PR DESCRIPTION
## Summary

Complete a shard's outstanding `shardAdd` action before allowing scale-in to remove it.

Previously, a shard with the add marker could be deleted without completing its add action: `handleShardRemove` returned success when that marker was present, so the caller did not exclude the shard from deletion. An absent `shardRemove` hook also bypassed the outstanding add action.

## Changes

- Process a marked `shardAdd` before checking or invoking `shardRemove`.
- Return add errors through the existing deletion-skip path, preserving the shard when add fails, even if no remove hook is configured.
- After add succeeds, proceed with the configured remove hook and the existing deletion flow.
- If remove fails after add succeeds, persist the cleared add marker while keeping deletion blocked, so the next reconciliation retries only remove.
- Log the current shard's action error rather than the outer accumulated error in the add/remove loops.

This fixes the existing blocking lifecycle flow. It introduces no API changes, non-blocking execution support, new annotations, or controller scheduling mechanisms. ShardAdd and shardRemove do not have to be configured as a pair.

## Testing

- Regression coverage in the existing cluster transformer suite for add success/failure, with and without a remove hook; verifies call ordering and deletion scheduling.
- Two-round regression coverage for remove terminal failures and transport errors: save only the cleared add marker, retain the original error, and retry remove without repeating add.
- New regression cases reproduce the bug against the unmodified implementation.
- Full cluster controller suite and formatting/whitespace checks.
