### PR TITLE
fix(ops): support flat-ordinal instance rebuilds

### DIFF
--- a/pkg/operations/horizontal_scaling.go
+++ b/pkg/operations/horizontal_scaling.go
@@ -974,16 +974,6 @@ func (hs horizontalScalingOpsHandler) validateOfflineInstancesToOnline(
 	return nil
 }
 
-func sourceAssignmentsForWorkload(last opsv1alpha1.LastComponentConfiguration, workloadName string) map[string]string {
-	result := map[string]string{}
-	for _, assignment := range last.SourceInstanceAssignments {
-		if assignment.WorkloadName == workloadName && assignment.DesiredState == workloads.InstanceDesiredStateActive {
-			result[assignment.PodName] = assignment.TemplateName
-		}
-	}
-	return result
-}
-
 func horizontalDiffMatchesOperation(horizontalScaling opsv1alpha1.HorizontalScaling,
 	created, deleted map[string]string) bool {
 	if horizontalScaling.ScaleOut == nil && len(created) > 0 {

--- a/pkg/operations/instance_status.go
+++ b/pkg/operations/instance_status.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	opsv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
 	workloadsv1 "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 )
@@ -123,4 +124,27 @@ func diffAssignments(source, target map[string]string) (created, deleted map[str
 		}
 	}
 	return created, deleted
+}
+
+func sourceAssignmentsForWorkload(last opsv1alpha1.LastComponentConfiguration, workloadName string) map[string]string {
+	result := map[string]string{}
+	for _, assignment := range last.SourceInstanceAssignments {
+		if assignment.WorkloadName == workloadName && assignment.DesiredState == workloadsv1.InstanceDesiredStateActive {
+			result[assignment.PodName] = assignment.TemplateName
+		}
+	}
+	return result
+}
+
+func instanceTemplateByName(statuses []workloadsv1.InstanceStatus, name string) (string, error) {
+	if err := validateInstanceIdentities(statuses); err != nil {
+		return "", err
+	}
+	for _, status := range statuses {
+		if status.PodName == name && status.TemplateName != nil {
+			return *status.TemplateName, nil
+		}
+	}
+	return "", intctrlutil.NewErrorf(intctrlutil.ErrorTypeNeedWaiting,
+		"waiting for InstanceSet to publish the template assignment of instance %q", name)
 }

--- a/pkg/operations/rebuild_instance.go
+++ b/pkg/operations/rebuild_instance.go
@@ -22,6 +22,7 @@ package operations
 import (
 	"context"
 	"fmt"
+	"maps"
 	"reflect"
 	"slices"
 	"strings"
@@ -48,8 +49,7 @@ import (
 )
 
 const (
-	scalingOutPodPrefixMsg    = "Scaling out a new pod"
-	reasonCompReplicasChanged = "ComponentReplicasChanged"
+	scalingOutPodPrefixMsg = "Scaling out a new pod"
 )
 
 type rebuildInstanceWrapper struct {
@@ -80,6 +80,9 @@ func (r rebuildInstanceOpsHandler) ActionStartedCondition(reqCtx intctrlutil.Req
 }
 
 func (r rebuildInstanceOpsHandler) Action(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes *OpsResource) error {
+	if err := r.validatePlacement(opsRes); err != nil {
+		return err
+	}
 	for _, v := range opsRes.OpsRequest.Spec.RebuildFrom {
 		compPhase := r.getCompStatusFromCluster(opsRes, v.ComponentName)
 		if compPhase == nil {
@@ -170,6 +173,9 @@ func (r rebuildInstanceOpsHandler) validateRebuildInstanceWithHScale(reqCtx intc
 }
 
 func (r rebuildInstanceOpsHandler) SaveLastConfiguration(reqCtx intctrlutil.RequestCtx, cli client.Client, opsRes *OpsResource) error {
+	if err := r.validatePlacement(opsRes); err != nil {
+		return err
+	}
 	compOpsHelper := newComponentOpsHelper(opsRes.OpsRequest.Spec.RebuildFrom)
 	getLastComponentInfo := func(compSpec appsv1.ClusterComponentSpec, comOps ComponentOpsInterface) opsv1alpha1.LastComponentConfiguration {
 		lastCompConfiguration := opsv1alpha1.LastComponentConfiguration{
@@ -180,7 +186,60 @@ func (r rebuildInstanceOpsHandler) SaveLastConfiguration(reqCtx intctrlutil.Requ
 		return lastCompConfiguration
 	}
 	compOpsHelper.saveLastConfigurations(opsRes, getLastComponentInfo)
+	for _, rebuild := range opsRes.OpsRequest.Spec.RebuildFrom {
+		if rebuild.InPlace {
+			continue
+		}
+		comp := opsRes.Cluster.Spec.GetComponentByName(rebuild.ComponentName)
+		if comp == nil {
+			return intctrlutil.NewFatalError("sharding cluster only supports to rebuild instance in place")
+		}
+		runtime, err := opsRes.GetRuntime(comp.Name)
+		if err != nil {
+			return err
+		}
+		workload, err := runtime.GetWorkload(opsRes.Cluster.Namespace, opsRes.Cluster.Name, comp.Name)
+		if err != nil {
+			return err
+		}
+		active, complete, err := activeAssignmentsForTarget(workload, comp)
+		if err != nil {
+			return err
+		}
+		if !complete {
+			return intctrlutil.NewErrorf(intctrlutil.ErrorTypeNeedWaiting, "waiting for the source instance allocation of component %q", comp.Name)
+		}
+		for _, instance := range rebuild.Instances {
+			if _, ok := active[instance.Name]; !ok {
+				return intctrlutil.NewFatalError(fmt.Sprintf("rebuild instance %q is not in the Active allocation", instance.Name))
+			}
+		}
+		last := opsRes.OpsRequest.Status.LastConfiguration.Components[comp.Name]
+		for _, name := range slices.Sorted(maps.Keys(active)) {
+			last.SourceInstanceAssignments = append(last.SourceInstanceAssignments, opsv1alpha1.InstanceTemplateAssignment{
+				WorkloadName: constant.GenerateClusterComponentName(opsRes.Cluster.Name, comp.Name),
+				PodName:      name, TemplateName: active[name], DesiredState: workloads.InstanceDesiredStateActive,
+			})
+		}
+		opsRes.OpsRequest.Status.LastConfiguration.Components[comp.Name] = last
+	}
 	return nil
+}
+
+// Placement must be written before the replacement is created. Only the non-flat
+// naming scheme can supply that name before InstanceSet allocates it.
+func (r rebuildInstanceOpsHandler) validatePlacement(opsRes *OpsResource) error {
+	for _, rebuild := range opsRes.OpsRequest.Spec.RebuildFrom {
+		comp := opsRes.Cluster.Spec.GetComponentByName(rebuild.ComponentName)
+		if !rebuild.InPlace && comp != nil && comp.FlatInstanceOrdinal && rebuildNeedsPlacement(rebuild) {
+			return intctrlutil.NewFatalError("non-in-place rebuild with targetNodeName is not supported for flat instance ordinals")
+		}
+	}
+	return nil
+}
+
+func rebuildNeedsPlacement(rebuild opsv1alpha1.RebuildInstance) bool {
+	return slices.ContainsFunc(rebuild.Instances, func(instance opsv1alpha1.Instance) bool { return instance.TargetNodeName != "" })
 }
 
 func (r rebuildInstanceOpsHandler) getInstanceProgressDetail(compStatus opsv1alpha1.OpsRequestComponentStatus, instance string) opsv1alpha1.ProgressStatusDetail {
@@ -342,7 +401,9 @@ func (r rebuildInstanceOpsHandler) rebuildInstancesWithHScaling(reqCtx intctrlut
 
 		if len(instancesNeedToOffline) > 0 {
 			// 3. offline the instances that require rebuilding when the new pod successfully scales out.
-			r.offlineSpecifiedInstances(compSpec, opsRes.Cluster.Name, instancesNeedToOffline)
+			if err := r.offlineSpecifiedInstances(opsRes, compSpec, instancesNeedToOffline); err != nil {
+				return 0, 0, err
+			}
 		}
 		break
 	}
@@ -354,37 +415,37 @@ func (r rebuildInstanceOpsHandler) scaleOutRequiredInstances(reqCtx intctrlutil.
 	opsRes *OpsResource,
 	rebuildInstance opsv1alpha1.RebuildInstance,
 	compStatus *opsv1alpha1.OpsRequestComponentStatus) error {
-	// 1. sort the instances
-	slices.SortFunc(rebuildInstance.Instances, func(a, b opsv1alpha1.Instance) int {
-		return strings.Compare(a.Name, b.Name)
-	})
-
-	// 2. assemble the corresponding replicas and instances based on the template
-	rebuildInsWrapper := r.getRebuildInstanceWrapper(opsRes, rebuildInstance)
+	// Assemble the corresponding replicas and instances based on the saved templates.
+	rebuildInsWrapper, err := r.getRebuildInstanceWrapper(opsRes, rebuildInstance)
+	if err != nil {
+		return err
+	}
 
 	compName := rebuildInstance.ComponentName
-	lastCompConfiguration := opsRes.OpsRequest.Status.LastConfiguration.Components[compName]
 
 	for i := range opsRes.Cluster.Spec.ComponentSpecs {
 		compSpec := &opsRes.Cluster.Spec.ComponentSpecs[i]
 		if compSpec.Name != compName {
 			continue
 		}
-		if *lastCompConfiguration.Replicas != compSpec.Replicas {
-			// means the componentSpec has been updated, ignore it.
-			opsRes.Recorder.Eventf(opsRes.OpsRequest, corev1.EventTypeWarning, reasonCompReplicasChanged, "then replicas of the component %s has been changed", compName)
-			continue
+		if !rebuildNeedsPlacement(rebuildInstance) {
+			return r.scaleOutAllocatedInstances(opsRes, compSpec, rebuildInstance, compStatus, rebuildInsWrapper)
 		}
-		return r.scaleOutCompReplicasAndSyncProgress(reqCtx, cli, opsRes, compSpec, rebuildInstance, compStatus, rebuildInsWrapper)
+		return r.scaleOutWithPlacement(reqCtx, cli, opsRes, compSpec, rebuildInstance, compStatus, rebuildInsWrapper)
 	}
 	return nil
 }
 
 // getRebuildInstanceWrapper assembles the corresponding replicas and instances based on the template
-func (r rebuildInstanceOpsHandler) getRebuildInstanceWrapper(opsRes *OpsResource, rebuildInstance opsv1alpha1.RebuildInstance) map[string]*rebuildInstanceWrapper {
+func (r rebuildInstanceOpsHandler) getRebuildInstanceWrapper(opsRes *OpsResource, rebuildInstance opsv1alpha1.RebuildInstance) (map[string]*rebuildInstanceWrapper, error) {
 	rebuildInsWrapper := map[string]*rebuildInstanceWrapper{}
+	last := opsRes.OpsRequest.Status.LastConfiguration.Components[rebuildInstance.ComponentName]
+	source := sourceAssignmentsForWorkload(last, constant.GenerateClusterComponentName(opsRes.Cluster.Name, rebuildInstance.ComponentName))
 	for _, ins := range rebuildInstance.Instances {
-		insTplName := appsv1.GetInstanceTemplateName(opsRes.Cluster.Name, rebuildInstance.ComponentName, ins.Name)
+		insTplName, ok := source[ins.Name]
+		if !ok {
+			return nil, fmt.Errorf("missing source assignment for rebuild instance %q", ins.Name)
+		}
 		if _, ok := rebuildInsWrapper[insTplName]; !ok {
 			rebuildInsWrapper[insTplName] = &rebuildInstanceWrapper{replicas: 1, insNames: []string{ins.Name}}
 		} else {
@@ -392,62 +453,152 @@ func (r rebuildInstanceOpsHandler) getRebuildInstanceWrapper(opsRes *OpsResource
 			rebuildInsWrapper[insTplName].insNames = append(rebuildInsWrapper[insTplName].insNames, ins.Name)
 		}
 	}
-	return rebuildInsWrapper
+	return rebuildInsWrapper, nil
 }
 
-func (r rebuildInstanceOpsHandler) scaleOutCompReplicasAndSyncProgress(reqCtx intctrlutil.RequestCtx,
+// rebuildExpansion derives the target from saved configuration, never from a
+// possibly already-expanded live spec. This also recovers a lost progress patch.
+func rebuildExpansion(opsRes *OpsResource, comp *appsv1.ClusterComponentSpec,
+	wrappers map[string]*rebuildInstanceWrapper) (*appsv1.ClusterComponentSpec, error) {
+	last := opsRes.OpsRequest.Status.LastConfiguration.Components[comp.Name]
+	if last.Replicas == nil {
+		return nil, fmt.Errorf("missing source configuration for component %q", comp.Name)
+	}
+	source := comp.DeepCopy()
+	source.Replicas, source.Instances, source.OfflineInstances = *last.Replicas, last.Instances, last.OfflineInstances
+	target := source.DeepCopy()
+	for _, wrapper := range wrappers {
+		target.Replicas += wrapper.replicas
+	}
+	for i := range target.Instances {
+		if wrapper := wrappers[target.Instances[i].Name]; wrapper != nil {
+			target.Instances[i].Replicas = pointer.Int32(target.Instances[i].GetReplicas() + wrapper.replicas)
+		}
+	}
+	sameAllocationSpec := func(a, b *appsv1.ClusterComponentSpec) bool {
+		return a.Replicas == b.Replicas && reflect.DeepEqual(a.Instances, b.Instances) && slices.Equal(a.OfflineInstances, b.OfflineInstances)
+	}
+	if !sameAllocationSpec(comp, source) && !sameAllocationSpec(comp, target) {
+		return nil, intctrlutil.NewFatalError(fmt.Sprintf("the replica configuration of component %q has been modified by another operation", comp.Name))
+	}
+	return target, nil
+}
+
+func (r rebuildInstanceOpsHandler) scaleOutAllocatedInstances(opsRes *OpsResource,
+	comp *appsv1.ClusterComponentSpec, rebuild opsv1alpha1.RebuildInstance,
+	status *opsv1alpha1.OpsRequestComponentStatus, wrappers map[string]*rebuildInstanceWrapper) error {
+	targetSpec, err := rebuildExpansion(opsRes, comp, wrappers)
+	if err != nil {
+		return err
+	}
+	if comp.Replicas != targetSpec.Replicas {
+		comp.Replicas, comp.Instances = targetSpec.Replicas, targetSpec.Instances
+		return nil
+	}
+	runtime, err := opsRes.GetRuntime(comp.Name)
+	if err != nil {
+		return err
+	}
+	workload, err := runtime.GetWorkload(opsRes.Cluster.Namespace, opsRes.Cluster.Name, comp.Name)
+	if err != nil {
+		return err
+	}
+	target, complete, err := activeAssignmentsForTarget(workload, targetSpec)
+	if err != nil || !complete {
+		return err // no mapping yet: ReconcileAction continues reporting Running.
+	}
+	mapping, err := replacementInstanceMapping(opsRes, comp.Name, target, wrappers)
+	if err != nil {
+		return err
+	}
+	r.recordReplacementInstances(opsRes, rebuild, status, mapping)
+	return nil
+}
+
+func replacementInstanceMapping(opsRes *OpsResource, componentName string, target map[string]string,
+	wrappers map[string]*rebuildInstanceWrapper) (map[string]string, error) {
+	last := opsRes.OpsRequest.Status.LastConfiguration.Components[componentName]
+	source := sourceAssignmentsForWorkload(last, constant.GenerateClusterComponentName(opsRes.Cluster.Name, componentName))
+	if last.Replicas == nil || !assignmentsMatchComponent(source, &appsv1.ClusterComponentSpec{Replicas: *last.Replicas, Instances: last.Instances}) {
+		return nil, fmt.Errorf("source allocation of component %q is incomplete", componentName)
+	}
+	for name, template := range source {
+		if actual, ok := target[name]; !ok || actual != template {
+			return nil, intctrlutil.NewErrorf(intctrlutil.ErrorTypeNeedWaiting, "waiting for the replacement allocation of component %q", componentName)
+		}
+	}
+	created, _ := diffAssignments(source, target)
+	byTemplate := map[string][]string{}
+	for name, template := range created {
+		byTemplate[template] = append(byTemplate[template], name)
+	}
+	if len(byTemplate) != len(wrappers) {
+		return nil, intctrlutil.NewErrorf(intctrlutil.ErrorTypeNeedWaiting, "waiting for replacement instances in the requested templates")
+	}
+	mapping := map[string]string{}
+	for template, wrapper := range wrappers {
+		names := byTemplate[template]
+		if len(names) != len(wrapper.insNames) {
+			return nil, intctrlutil.NewErrorf(intctrlutil.ErrorTypeNeedWaiting, "waiting for replacement instances in template %q", template)
+		}
+		slices.Sort(names)
+		originals := slices.Clone(wrapper.insNames)
+		slices.Sort(originals)
+		for i, name := range originals {
+			mapping[name] = names[i]
+		}
+	}
+	return mapping, nil
+}
+
+func (r rebuildInstanceOpsHandler) recordReplacementInstances(opsRes *OpsResource, rebuild opsv1alpha1.RebuildInstance,
+	status *opsv1alpha1.OpsRequestComponentStatus, mapping map[string]string) {
+	for _, instance := range rebuild.Instances {
+		setComponentStatusProgressDetail(opsRes.Recorder, opsRes.OpsRequest, &status.ProgressDetails,
+			opsv1alpha1.ProgressStatusDetail{
+				ObjectKey: getProgressObjectKey(constant.PodKind, instance.Name),
+				Status:    opsv1alpha1.ProcessingProgressStatus,
+				Message:   r.buildScalingOutPodMessage(mapping[instance.Name], "Processing"),
+			})
+	}
+}
+
+// Only non-flat TargetNodeName requests may use predicted replacement names.
+// Persist placement before the Cluster spec update can trigger Pod creation.
+func (r rebuildInstanceOpsHandler) scaleOutWithPlacement(reqCtx intctrlutil.RequestCtx,
 	cli client.Client,
 	opsRes *OpsResource,
 	compSpec *appsv1.ClusterComponentSpec,
 	rebuildInstance opsv1alpha1.RebuildInstance,
 	compStatus *opsv1alpha1.OpsRequestComponentStatus,
 	rebuildInsWrapper map[string]*rebuildInstanceWrapper) error {
-	scaleOutInsMap := map[string]string{}
+	if compSpec.FlatInstanceOrdinal {
+		return intctrlutil.NewFatalError("non-in-place rebuild with targetNodeName is not supported for flat instance ordinals")
+	}
+	targetSpec, err := rebuildExpansion(opsRes, compSpec, rebuildInsWrapper)
+	if err != nil {
+		return err
+	}
 	runtime, err := opsRes.GetRuntime(compSpec.Name)
 	if err != nil {
 		return err
 	}
-	setScaleOutInsMap := func(templateName string, replicas int32, offlineInstances []string, wrapper *rebuildInstanceWrapper) error {
-		insNames, _ := runtime.GenerateTemplateInstanceNames(opsRes.Cluster.Name, compSpec.Name, templateName, replicas, offlineInstances, appsv1.Ordinals{})
-		for i, insName := range wrapper.insNames {
-			scaleOutInsMap[insName] = insNames[int(replicas-wrapper.replicas)+i]
-		}
-		return nil
+	target, err := runtime.GenerateInstanceNameSet(opsRes.Cluster.Name, compSpec.Name, targetSpec.Replicas, targetSpec.Instances, targetSpec.OfflineInstances)
+	if err != nil {
+		return err
 	}
-	// update component spec to scale out required instances.
-	workloadName := constant.GenerateWorkloadNamePattern(opsRes.Cluster.Name, compSpec.Name)
-	var allTemplateReplicas int32
-	for j := range compSpec.Instances {
-		insTpl := &compSpec.Instances[j]
-		if wrapper, ok := rebuildInsWrapper[insTpl.Name]; ok {
-			insTpl.Replicas = pointer.Int32(insTpl.GetReplicas() + wrapper.replicas)
-			if err := setScaleOutInsMap(insTpl.Name, *insTpl.Replicas, compSpec.OfflineInstances, wrapper); err != nil {
-				return err
-			}
-		}
-		allTemplateReplicas += insTpl.GetReplicas()
-	}
-	compSpec.Replicas += int32(len(rebuildInstance.Instances))
-	if wrapper, ok := rebuildInsWrapper[""]; ok {
-		if err := setScaleOutInsMap("", compSpec.Replicas-allTemplateReplicas, compSpec.OfflineInstances, wrapper); err != nil {
-			return err
-		}
+	scaleOutInsMap, err := replacementInstanceMapping(opsRes, compSpec.Name, target, rebuildInsWrapper)
+	if err != nil {
+		return err
 	}
 
 	its := &workloads.InstanceSet{}
-	if err := cli.Get(reqCtx.Ctx, types.NamespacedName{Name: workloadName, Namespace: opsRes.OpsRequest.Namespace}, its); err != nil {
+	if err := cli.Get(reqCtx.Ctx, types.NamespacedName{Name: constant.GenerateClusterComponentName(opsRes.Cluster.Name, compSpec.Name), Namespace: opsRes.OpsRequest.Namespace}, its); err != nil {
 		return err
 	}
 	itsUpdated := false
 	for _, ins := range rebuildInstance.Instances {
-		// set progress details
 		scaleOutInsName := scaleOutInsMap[ins.Name]
-		setComponentStatusProgressDetail(opsRes.Recorder, opsRes.OpsRequest, &compStatus.ProgressDetails,
-			opsv1alpha1.ProgressStatusDetail{
-				ObjectKey: getProgressObjectKey(constant.PodKind, ins.Name),
-				Status:    opsv1alpha1.ProcessingProgressStatus,
-				Message:   r.buildScalingOutPodMessage(scaleOutInsName, "Processing"),
-			})
 
 		// specify node to scale out
 		if ins.TargetNodeName != "" {
@@ -463,6 +614,8 @@ func (r rebuildInstanceOpsHandler) scaleOutCompReplicasAndSyncProgress(reqCtx in
 			return err
 		}
 	}
+	compSpec.Replicas, compSpec.Instances = targetSpec.Replicas, targetSpec.Instances
+	r.recordReplacementInstances(opsRes, rebuildInstance, compStatus, scaleOutInsMap)
 	return nil
 }
 
@@ -482,17 +635,25 @@ func (r rebuildInstanceOpsHandler) checkProgressForScalingOutPods(reqCtx intctrl
 	if err != nil {
 		return 0, 0, nil, err
 	}
-	currPodSet, _ := runtime.GenerateInstanceNameSet(opsRes.Cluster.Name, compSpec.Name,
-		compSpec.Replicas, compSpec.Instances, compSpec.OfflineInstances)
+	workload, err := runtime.GetWorkload(opsRes.Cluster.Namespace, opsRes.Cluster.Name, compSpec.Name)
+	if err != nil {
+		return 0, 0, nil, err
+	}
+	currPodSet, complete, err := activeAssignmentsForTarget(workload, compSpec)
+	if err != nil || !complete {
+		return 0, 0, nil, err
+	}
 	synthesizedComp, err := r.buildSynthesizedComponent(reqCtx.Ctx, cli, opsRes.Cluster, compSpec.Name)
 	if err != nil {
 		return 0, 0, nil, err
 	}
 	roleAware := len(synthesizedComp.Roles) > 0
+	last := opsRes.OpsRequest.Status.LastConfiguration.Components[compSpec.Name]
+	source := sourceAssignmentsForWorkload(last, constant.GenerateClusterComponentName(opsRes.Cluster.Name, compSpec.Name))
 	for _, instance := range rebuildInstance.Instances {
 		progressDetail := r.getInstanceProgressDetail(*compStatus, instance.Name)
 		scalingOutPodName := r.getScalingOutPodNameFromMessage(progressDetail.Message)
-		if _, ok := currPodSet[scalingOutPodName]; !ok {
+		if template, ok := currPodSet[scalingOutPodName]; !ok || template != source[instance.Name] {
 			return 0, 0, nil, intctrlutil.NewFatalError(fmt.Sprintf(`the replicas of the component "%s" has been modified by another operation`, compSpec.Name))
 		}
 		scaledOutInstance, err := runtime.GetInstance(opsRes.Cluster.Namespace, opsRes.Cluster.Name, compSpec.Name, scalingOutPodName)
@@ -520,8 +681,8 @@ func (r rebuildInstanceOpsHandler) checkProgressForScalingOutPods(reqCtx intctrl
 			if err != nil && !apierrors.IsNotFound(err) {
 				return 0, 0, nil, err
 			}
-			if apierrors.IsNotFound(err) {
-				// f the pod that needs to be rebuilt is not found, and the new pod is available,
+			if apierrors.IsNotFound(err) || !oldInstance.HasPod() {
+				// Retained PVCs do not prevent completion once the old Pod is gone.
 				// it indicates that the rebuild process has been completed.
 				completedCount += 1
 				progressDetail.SetStatusAndMessage(opsv1alpha1.SucceedProgressStatus,
@@ -545,10 +706,17 @@ func (r rebuildInstanceOpsHandler) checkProgressForScalingOutPods(reqCtx intctrl
 }
 
 // offlineSpecifiedInstances to take the specific instances offline.
-func (r rebuildInstanceOpsHandler) offlineSpecifiedInstances(compSpec *appsv1.ClusterComponentSpec, clusterName string, instancesNeedToOffline []string) {
+func (r rebuildInstanceOpsHandler) offlineSpecifiedInstances(opsRes *OpsResource, compSpec *appsv1.ClusterComponentSpec, instancesNeedToOffline []string) error {
+	last := opsRes.OpsRequest.Status.LastConfiguration.Components[compSpec.Name]
+	source := sourceAssignmentsForWorkload(last, constant.GenerateClusterComponentName(opsRes.Cluster.Name, compSpec.Name))
+	for _, name := range instancesNeedToOffline {
+		if _, ok := source[name]; !ok {
+			return fmt.Errorf("missing source template for rebuild instance %q", name)
+		}
+	}
 	for _, insName := range instancesNeedToOffline {
 		compSpec.OfflineInstances = append(compSpec.OfflineInstances, insName)
-		templateName := appsv1.GetInstanceTemplateName(clusterName, compSpec.Name, insName)
+		templateName := source[insName]
 		if templateName == constant.EmptyInsTemplateName {
 			continue
 		}
@@ -560,6 +728,7 @@ func (r rebuildInstanceOpsHandler) offlineSpecifiedInstances(compSpec *appsv1.Cl
 		}
 	}
 	compSpec.Replicas -= int32(len(instancesNeedToOffline))
+	return nil
 }
 
 func (r rebuildInstanceOpsHandler) buildScalingOutPodMessage(scaleOutPodName string, status string) string {
@@ -626,7 +795,19 @@ func (r rebuildInstanceOpsHandler) prepareInplaceRebuildHelper(reqCtx intctrluti
 		return nil, err
 	}
 	rebuildPrefix := fmt.Sprintf("rebuild-%s", opsRes.OpsRequest.UID[:8])
-	pvcMap, volumes, volumeMounts, err := getPVCMapAndVolumes(opsRes, synthesizedComp, targetPod, rebuildPrefix, index, rebuildInstance.BackupName == "")
+	runtime, err := opsRes.GetRuntime(rebuildInstance.ComponentName)
+	if err != nil {
+		return nil, err
+	}
+	workload, err := runtime.GetWorkload(opsRes.Cluster.Namespace, opsRes.Cluster.Name, synthesizedComp.Name)
+	if err != nil {
+		return nil, err
+	}
+	templateName, err := instanceTemplateByName(workload.GetInstanceStatuses(), instance.Name)
+	if err != nil {
+		return nil, err
+	}
+	pvcMap, volumes, volumeMounts, err := getPVCMapAndVolumes(opsRes, synthesizedComp, targetPod, templateName, rebuildPrefix, index, rebuildInstance.BackupName == "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operations/rebuild_instance_inplace.go
+++ b/pkg/operations/rebuild_instance_inplace.go
@@ -39,7 +39,6 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/builder"
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/instanceset"
-	"github.com/apecloud/kubeblocks/pkg/controller/instancetemplate"
 	"github.com/apecloud/kubeblocks/pkg/controller/plan"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	dputils "github.com/apecloud/kubeblocks/pkg/dataprotection/utils"
@@ -724,6 +723,7 @@ func (inPlaceHelper *inplaceRebuildHelper) removePVCFinalizer(reqCtx intctrlutil
 func getPVCMapAndVolumes(opsRes *OpsResource,
 	synthesizedComp *component.SynthesizedComponent,
 	targetPod *corev1.Pod,
+	templateName string,
 	rebuildPrefix string,
 	index int,
 	noBackup bool) (map[string]*corev1.PersistentVolumeClaim, []corev1.Volume, []corev1.VolumeMount, error) {
@@ -741,10 +741,6 @@ func getPVCMapAndVolumes(opsRes *OpsResource,
 	}
 	// backup's ready, then start to check restore
 	workloadName := constant.GenerateWorkloadNamePattern(opsRes.Cluster.Name, synthesizedComp.Name)
-	templateName, _, err := instancetemplate.GetTemplateNameAndOrdinal(workloadName, targetPod.Name)
-	if err != nil {
-		return nil, nil, nil, err
-	}
 	// TODO: create pvc by the volumeClaimTemplates of instance template if it is necessary.
 	for i, vct := range synthesizedComp.VolumeClaimTemplates {
 		sourcePVCName := volumePVCMap[vct.Name]

--- a/pkg/operations/rebuild_instance_test.go
+++ b/pkg/operations/rebuild_instance_test.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -43,6 +44,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/instanceset"
 	"github.com/apecloud/kubeblocks/pkg/controller/instancetemplate"
+	"github.com/apecloud/kubeblocks/pkg/controller/kubebuilderx"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	dptypes "github.com/apecloud/kubeblocks/pkg/dataprotection/types"
 	"github.com/apecloud/kubeblocks/pkg/generics"
@@ -93,6 +95,42 @@ var _ = Describe("OpsUtil functions", func() {
 	AfterEach(cleanEnv)
 
 	Context("Test Rebuild-Instance opsRequest", func() {
+		// Run the real workload revision/status producers against the current Pods.
+		// Tests explicitly choose when workload reconciliation catches up with Ops;
+		// no hand-written InstanceStatus can make an unallocated name appear ready.
+		publishInstanceStatus := func(opsRes *OpsResource) *workloads.InstanceSet {
+			comp := opsRes.Cluster.Spec.GetComponentByName(defaultCompName)
+			its := &workloads.InstanceSet{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: opsRes.Cluster.Namespace,
+				Name: constant.GenerateClusterComponentName(opsRes.Cluster.Name, defaultCompName)}, its)).To(Succeed())
+			its.Spec.Replicas = ptr.To(comp.Replicas)
+			its.Spec.FlatInstanceOrdinal = comp.FlatInstanceOrdinal
+			its.Spec.OfflineInstances = slices.Clone(comp.OfflineInstances)
+			its.Spec.Instances = nil
+			for _, template := range comp.Instances {
+				its.Spec.Instances = append(its.Spec.Instances, workloads.InstanceTemplate{
+					Name: template.Name, Replicas: template.Replicas,
+					Ordinals: workloads.Ordinals{Discrete: template.Ordinals.Discrete},
+				})
+			}
+			Expect(k8sClient.Update(ctx, its)).To(Succeed())
+			tree := kubebuilderx.NewObjectTree()
+			tree.SetRoot(its)
+			pods := &corev1.PodList{}
+			Expect(k8sClient.List(ctx, pods, client.InNamespace(its.Namespace), client.MatchingLabels{
+				constant.AppInstanceLabelKey: opsRes.Cluster.Name, constant.KBAppComponentLabelKey: defaultCompName,
+			})).To(Succeed())
+			for i := range pods.Items {
+				Expect(tree.Add(&pods.Items[i])).To(Succeed())
+			}
+			_, err := instanceset.NewRevisionUpdateReconciler().Reconcile(tree)
+			Expect(err).NotTo(HaveOccurred())
+			_, err = instanceset.NewStatusReconciler().Reconcile(tree)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Status().Update(ctx, its)).To(Succeed())
+			return its
+		}
+
 		createRebuildInstanceOps := func(backupName string, inPlace bool, instanceNames ...string) *opsv1alpha1.OpsRequest {
 			opsName := "rebuild-instance-" + testCtx.GetRandomStr()
 			ops := testops.NewOpsRequestObj(opsName, testCtx.DefaultNamespace,
@@ -281,14 +319,14 @@ var _ = Describe("OpsUtil functions", func() {
 				OpsRequest: opsRequest,
 			}
 
-			pvcMap, volumes, volumeMounts, err := getPVCMapAndVolumes(opsRes, synthesizedComp, targetPod, "rebuild", 0, false)
+			pvcMap, volumes, volumeMounts, err := getPVCMapAndVolumes(opsRes, synthesizedComp, targetPod, "", "rebuild", 0, false)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(pvcMap).Should(HaveKey("source-pvc"))
 			Expect(volumes).Should(HaveLen(1))
 			Expect(volumeMounts).Should(ContainElement(corev1.VolumeMount{Name: "data", MountPath: "/kb-tmp/0"}))
 			Expect(pvcMap["source-pvc"].Annotations).Should(HaveKeyWithValue(rebuildFromAnnotation, opsRequest.Name))
 
-			pvcMap, volumes, volumeMounts, err = getPVCMapAndVolumes(opsRes, synthesizedComp, targetPod, "rebuild", 0, true)
+			pvcMap, volumes, volumeMounts, err = getPVCMapAndVolumes(opsRes, synthesizedComp, targetPod, "", "rebuild", 0, true)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(pvcMap["source-pvc"].Name).Should(Equal("source-pvc"))
 			Expect(volumes).Should(BeEmpty())
@@ -667,6 +705,7 @@ var _ = Describe("OpsUtil functions", func() {
 			By("init operations resources ")
 			opsRes := prepareOpsRes("", true)
 			its := testapps.MockInstanceSetComponent(&testCtx, clusterName, defaultCompName)
+			publishInstanceStatus(opsRes)
 			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsRunningPhase
 			reqCtx := intctrlutil.RequestCtx{Ctx: testCtx.Ctx}
 			matchingLabels := client.MatchingLabels{
@@ -832,6 +871,7 @@ var _ = Describe("OpsUtil functions", func() {
 			})).Should(Succeed())
 			opsRes := prepareOpsRes(backup.Name, true)
 			_ = testapps.MockInstanceSetComponent(&testCtx, clusterName, defaultCompName)
+			publishInstanceStatus(opsRes)
 			if ignoreRoleCheck {
 				Expect(testapps.ChangeObj(&testCtx, opsRes.OpsRequest, func(request *opsv1alpha1.OpsRequest) {
 					if request.Annotations == nil {
@@ -893,12 +933,183 @@ var _ = Describe("OpsUtil functions", func() {
 			testRebuildInstanceWithBackup(true)
 		})
 
+		DescribeTable("rebuilds from the published allocation without predicting replacement names", func(flat bool) {
+			opsRes, _, _ := initOperationsResources(compDefName, clusterName)
+			comp := &opsRes.Cluster.Spec.ComponentSpecs[0]
+			comp.FlatInstanceOrdinal = flat
+			comp.Instances = []appsv1.InstanceTemplate{{Name: "large", Replicas: ptr.To(int32(1))}}
+			Expect(k8sClient.Update(ctx, opsRes.Cluster)).To(Succeed())
+			createComponentObject(opsRes)
+			its := testapps.MockInstanceSetComponent(&testCtx, clusterName, defaultCompName)
+			prefix := its.Name
+			original, healthy, named := prefix+"-0", prefix+"-1", prefix+"-large-0"
+			if flat {
+				original, healthy, named = prefix+"-7", prefix+"-9", prefix+"-42"
+				// Existing owner allocation: the names deliberately do not encode templates.
+				its.Status.AssignedOrdinals = map[string]workloads.Ordinals{
+					"": {Discrete: []int32{7, 9}}, "large": {Discrete: []int32{42}},
+				}
+				Expect(k8sClient.Status().Update(ctx, its)).To(Succeed())
+			}
+			testapps.MockInstanceSetPod(&testCtx, its, clusterName, defaultCompName, healthy, "leader")
+			oldPod := testapps.MockInstanceSetPod(&testCtx, its, clusterName, defaultCompName, named, "follower")
+			Expect(testapps.ChangeObjStatus(&testCtx, oldPod, func() { oldPod.Status.Conditions = nil })).To(Succeed())
+			// The first requested instance has no Pod, but its retained volume still exists.
+			pvc := testapps.NewPersistentVolumeClaimFactory(testCtx.DefaultNamespace, "data-"+original,
+				clusterName, defaultCompName, "data").SetStorage("1Gi").Create(&testCtx).GetObject()
+			ops := testops.NewOpsRequestObj("rebuild-allocated-"+testCtx.GetRandomStr(), testCtx.DefaultNamespace,
+				clusterName, opsv1alpha1.RebuildInstanceType)
+			ops.Spec.Force = true
+			ops.Spec.RebuildFrom = []opsv1alpha1.RebuildInstance{{
+				ComponentOps: opsv1alpha1.ComponentOps{ComponentName: defaultCompName},
+				Instances:    []opsv1alpha1.Instance{{Name: named}, {Name: original}},
+			}}
+			opsRes.OpsRequest = testops.CreateOpsRequest(ctx, testCtx, ops)
+			opsRes.OpsRequest.Status.Phase = opsv1alpha1.OpsRunningPhase
+			opsRes.OpsRequest.Status.Progress = "0/2"
+			opsRes.Runtimes = map[string]OpsRuntime{defaultCompName: newOpsRuntime(ctx, k8sClient, "")}
+			reqCtx := intctrlutil.RequestCtx{Ctx: ctx}
+			handler := rebuildInstanceOpsHandler{}
+
+			By("waiting for source publication instead of falling back to names or PVC labels")
+			err := handler.SaveLastConfiguration(reqCtx, k8sClient, opsRes)
+			Expect(intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeNeedWaiting)).To(BeTrue())
+			its = publishInstanceStatus(opsRes)
+			Expect(its.FindInstanceStatus(original).CurrentState).To(Equal(workloads.InstanceCurrentStateAbsent))
+			// An unrelated offline identity with unknown template must not block rebuild.
+			its.Status.InstanceStatus = append(its.Status.InstanceStatus, workloads.InstanceStatus{
+				PodName: prefix + "-99", DesiredState: workloads.InstanceDesiredStateOffline,
+				CurrentState: workloads.InstanceCurrentStateAbsent,
+			})
+			Expect(k8sClient.Status().Update(ctx, its)).To(Succeed())
+			Expect(handler.SaveLastConfiguration(reqCtx, k8sClient, opsRes)).To(Succeed())
+			Expect(handler.Action(reqCtx, k8sClient, opsRes)).To(Succeed())
+			Expect(opsRes.OpsRequest.Status.LastConfiguration.Components[defaultCompName].SourceInstanceAssignments).To(HaveLen(3))
+			Expect(k8sClient.Status().Update(ctx, opsRes.OpsRequest)).To(Succeed())
+
+			reconcile := func() opsv1alpha1.OpsPhase {
+				phase, _, err := handler.ReconcileAction(reqCtx, k8sClient, opsRes)
+				Expect(err).NotTo(HaveOccurred())
+				// Each iteration resumes from persisted state, as after a controller restart.
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(opsRes.Cluster), opsRes.Cluster)).To(Succeed())
+				Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(opsRes.OpsRequest), opsRes.OpsRequest)).To(Succeed())
+				comp = &opsRes.Cluster.Spec.ComponentSpecs[0]
+				return phase
+			}
+			By("writing expansion once and waiting across repeated reconciles with old status")
+			Expect(reconcile()).To(Equal(opsv1alpha1.OpsRunningPhase))
+			Expect(comp.Replicas).To(Equal(int32(5)))
+			for i := 0; i < 2; i++ {
+				Expect(reconcile()).To(Equal(opsv1alpha1.OpsRunningPhase))
+				Expect(comp.Replicas).To(Equal(int32(5)))
+				Expect(opsRes.OpsRequest.Status.Components[defaultCompName].ProgressDetails).To(BeEmpty())
+			}
+			By("letting the actual allocator publish replacements before any new Pod exists")
+			its = publishInstanceStatus(opsRes)
+			Expect(reconcile()).To(Equal(opsv1alpha1.OpsRunningPhase))
+			progress := opsRes.OpsRequest.Status.Components[defaultCompName]
+			Expect(progress.ProgressDetails).To(HaveLen(2))
+			replacements := map[string]string{}
+			for _, name := range []string{original, named} {
+				detail := handler.getInstanceProgressDetail(progress, name)
+				replacement := handler.getScalingOutPodNameFromMessage(detail.Message)
+				Expect(replacement).NotTo(BeEmpty())
+				Expect(replacement).NotTo(BeElementOf(original, named, healthy))
+				Expect(its.FindInstanceStatus(replacement).CurrentState).To(Equal(workloads.InstanceCurrentStateAbsent))
+				expectedTemplate := ""
+				if name == named {
+					expectedTemplate = "large"
+				}
+				Expect(*its.FindInstanceStatus(replacement).TemplateName).To(Equal(expectedTemplate))
+				replacements[name] = replacement
+			}
+			Expect(reconcile()).To(Equal(opsv1alpha1.OpsRunningPhase))
+			Expect(comp.OfflineInstances).To(BeEmpty())
+			Expect(opsRes.OpsRequest.Status.Components[defaultCompName].ProgressDetails).To(Equal(progress.ProgressDetails))
+
+			By("checking actual Pod availability, not the identity or UpToDate fields")
+			var newPods []*corev1.Pod
+			for _, replacement := range replacements {
+				pod := testapps.MockInstanceSetPod(&testCtx, its, clusterName, defaultCompName, replacement, "follower")
+				Expect(testapps.ChangeObjStatus(&testCtx, pod, func() { pod.Status.Conditions = nil })).To(Succeed())
+				newPods = append(newPods, pod)
+			}
+			Expect(reconcile()).To(Equal(opsv1alpha1.OpsRunningPhase))
+			Expect(comp.OfflineInstances).To(BeEmpty())
+			for _, pod := range newPods {
+				Expect(testapps.ChangeObjStatus(&testCtx, pod, func() { testk8s.MockPodAvailable(pod, metav1.Now()) })).To(Succeed())
+			}
+			Expect(reconcile()).To(Equal(opsv1alpha1.OpsRunningPhase))
+			Expect(comp.Replicas).To(Equal(int32(3)))
+			Expect(comp.Instances[0].GetReplicas()).To(Equal(int32(1)))
+			Expect(comp.OfflineInstances).To(ConsistOf(original, named))
+			publishInstanceStatus(opsRes)
+			Expect(reconcile()).To(Equal(opsv1alpha1.OpsRunningPhase)) // old named Pod still exists
+			testk8s.MockPodIsTerminating(ctx, testCtx, oldPod)
+			testk8s.RemovePodFinalizer(ctx, testCtx, oldPod)
+			publishInstanceStatus(opsRes)
+			Expect(reconcile()).To(Equal(opsv1alpha1.OpsSucceedPhase))
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(pvc), &corev1.PersistentVolumeClaim{})).To(Succeed())
+		}, Entry("flat ordinals", true), Entry("non-flat ordinals", false))
+
+		It("uses the published template for an in-place flat instance and its restored PVC labels", func() {
+			opsRes, _, _ := initOperationsResources(compDefName, clusterName)
+			comp := &opsRes.Cluster.Spec.ComponentSpecs[0]
+			comp.FlatInstanceOrdinal = true
+			comp.Instances = []appsv1.InstanceTemplate{{Name: "large", Replicas: ptr.To(int32(1))}}
+			Expect(k8sClient.Update(ctx, opsRes.Cluster)).To(Succeed())
+			createComponentObject(opsRes)
+			its := testapps.MockInstanceSetComponent(&testCtx, clusterName, defaultCompName)
+			its.Status.AssignedOrdinals = map[string]workloads.Ordinals{
+				"": {Discrete: []int32{8, 9}}, "large": {Discrete: []int32{7}},
+			}
+			Expect(k8sClient.Status().Update(ctx, its)).To(Succeed())
+			pod := testapps.MockInstanceSetPod(&testCtx, its, clusterName, defaultCompName, its.Name+"-7", "follower")
+			opsRes.OpsRequest = createRebuildInstanceOps("", true, pod.Name)
+			opsRes.Runtimes = map[string]OpsRuntime{defaultCompName: newOpsRuntime(ctx, k8sClient, "")}
+			handler := rebuildInstanceOpsHandler{}
+			rebuild := opsRes.OpsRequest.Spec.RebuildFrom[0]
+			_, err := handler.prepareInplaceRebuildHelper(intctrlutil.RequestCtx{Ctx: ctx}, k8sClient, opsRes, rebuild, rebuild.Instances[0], 0)
+			Expect(intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeNeedWaiting)).To(BeTrue())
+			its = publishInstanceStatus(opsRes)
+			Expect(*its.FindInstanceStatus(pod.Name).TemplateName).To(Equal("large"))
+			helper, err := handler.prepareInplaceRebuildHelper(intctrlutil.RequestCtx{Ctx: ctx}, k8sClient, opsRes, rebuild, rebuild.Instances[0], 0)
+			Expect(err).NotTo(HaveOccurred())
+			template, err := instanceTemplateByName(its.Status.InstanceStatus, pod.Name)
+			Expect(err).NotTo(HaveOccurred())
+			pvcs, _, _, err := getPVCMapAndVolumes(opsRes, helper.synthesizedComp, pod, template, "rebuild", 0, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pvcs).NotTo(BeEmpty())
+			for _, pvc := range pvcs {
+				Expect(pvc.Labels[constant.KBAppInstanceTemplateLabelKey]).To(Equal("large"))
+			}
+		})
+
+		It("rejects flat replacement placement before waiting for status or mutating resources", func() {
+			opsRes, _, _ := initOperationsResources(compDefName, clusterName)
+			opsRes.Cluster.Spec.ComponentSpecs[0].FlatInstanceOrdinal = true
+			opsRes.OpsRequest = createRebuildInstanceOps("", false, clusterName+"-mysql-7")
+			beforeCluster, beforeOps := opsRes.Cluster.DeepCopy(), opsRes.OpsRequest.DeepCopy()
+			handler := rebuildInstanceOpsHandler{}
+			for _, action := range []func(intctrlutil.RequestCtx, client.Client, *OpsResource) error{handler.SaveLastConfiguration, handler.Action} {
+				err := action(intctrlutil.RequestCtx{Ctx: ctx}, k8sClient, opsRes)
+				Expect(intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal)).To(BeTrue())
+				Expect(err.Error()).To(ContainSubstring("targetNodeName"))
+				Expect(opsRes.Cluster).To(Equal(beforeCluster))
+				Expect(opsRes.OpsRequest).To(Equal(beforeOps))
+			}
+			opsRes.OpsRequest.Spec.RebuildFrom[0].InPlace = true
+			Expect(handler.SaveLastConfiguration(intctrlutil.RequestCtx{Ctx: ctx}, k8sClient, opsRes)).To(Succeed())
+			Expect(opsRes.OpsRequest.Status.LastConfiguration.Components[defaultCompName].SourceInstanceAssignments).To(BeEmpty())
+		})
+
 		It("rebuild instance with horizontal scaling", func() {
 			By("init operations resources ")
 			opsRes, _, _ := initOperationsResources(compDefName, clusterName)
 			createComponentObject(opsRes)
 			its := testapps.MockInstanceSetComponent(&testCtx, clusterName, defaultCompName)
 			podList := testapps.MockInstanceSetPods(&testCtx, its, opsRes.Cluster, defaultCompName)
+			publishInstanceStatus(opsRes)
 			opsRes.OpsRequest = createRebuildInstanceOps("", false, podList[1].Name, podList[2].Name)
 
 			By("mock cluster/component phase to Failed")
@@ -955,6 +1166,7 @@ var _ = Describe("OpsUtil functions", func() {
 			testapps.MockInstanceSetPod(&testCtx, nil, clusterName, defaultCompName, podPrefix+"-4", "follower")
 
 			By("expect specified instances to take offline")
+			publishInstanceStatus(opsRes)
 			_, _ = GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
 			compSpec := opsRes.Cluster.Spec.GetComponentByName(defaultCompName)
 			Expect(compSpec.Replicas).Should(BeEquivalentTo(3))
@@ -966,6 +1178,7 @@ var _ = Describe("OpsUtil functions", func() {
 			testk8s.RemovePodFinalizer(ctx, testCtx, podList[1])
 			testk8s.MockPodIsTerminating(ctx, testCtx, podList[2])
 			testk8s.RemovePodFinalizer(ctx, testCtx, podList[2])
+			publishInstanceStatus(opsRes)
 			_, _ = GetOpsManager().Reconcile(reqCtx, k8sClient, opsRes)
 			Expect(opsRes.OpsRequest.Status.Phase).Should(Equal(opsv1alpha1.OpsSucceedPhase))
 		})


### PR DESCRIPTION
### What type of PR is this?

Bug fix.

### What this PR does / why we need it

Support rebuilding flat-ordinal instances using the public InstanceSet `status.instanceStatus` API. A flat-ordinal instance name does not encode its template, and Operations must not predict names that InstanceSet has not allocated yet.

This PR migrates ordinary RebuildInstance paths for both ordinal modes:

- In-place rebuild reads the requested instance's template from InstanceStatus, including when labeling PVCs for backup restore. Missing template information causes a wait, not a name-based fallback.
- Non-in-place rebuild saves the existing Active instance assignments before increasing replicas. Once InstanceSet publishes the expanded allocation, it identifies the new instances, pairs them with the requested instances by template and stable name order, and persists those pairs in the existing ProgressDetails.
- Repeated reconciliation resumes from the saved configuration and persisted mapping without incrementing replicas again or selecting different replacement instances.
- Completion still requires actual replacement Pod availability and old Pod removal. Retained PVCs alone do not prevent completion after the old Pod disappears.

The only remaining preallocation-name path is isolated to **non-flat, non-in-place rebuild with TargetNodeName**, where node placement must be written before Pod creation. The flat-ordinal version of that combination is rejected before resource changes. In-place TargetNodeName remains supported. Sharding remains limited to in-place rebuild.

### Dependencies and scope

Part of #10704. This PR is stacked on #10852 (`bugfix/ops-hscale-instance-status`) to reuse its minimal `SourceInstanceAssignments` API and instance-assignment helpers. Review the diff against that branch; retarget to main after the dependency is merged and synchronized.

No new API fields, CRD changes, workload status producer changes, generation-based snapshot protocol, or HScale cancellation changes are introduced here. The small change in `horizontal_scaling.go` only moves an unchanged shared reader to `instance_status.go`. Existing direct Pod/PVC/InstanceSet actions used to execute rebuild remain outside this identity/template migration.

### Which issue(s) this PR fixes

Addresses the RebuildInstance portion of #10704.

### How this PR has been tested

- Operations and Operations controller test suites: `scripts/codex-go-test.sh ./pkg/operations ./controllers/operations -count=1`.
- `make lint`.
- New envtest cases run the real InstanceSet revision/status producers and Rebuild ReconcileAction for flat and non-flat default/named templates. They cover delayed allocation publication, allocated-but-absent replacement Pods, recovery from persisted state, actual Pod availability, old Pod removal with retained PVCs, and unrelated Offline instances with unknown templates.
- In-place flat template/PVC labeling and rejection of unsupported placement are covered. Existing backup, no-backup, and non-flat placement success assertions are retained; their API input is now published by the real workload reconcilers rather than synthesized success status.

### Special notes for reviewers

This is a Rebuild-only change. It does not depend on, or define, the pending flat-ordinal HorizontalScaling cancellation semantics.
