### PR TITLE
fix(kbagent): cancel exec process groups

### DIFF
--- a/pkg/kbagent/service/action_utils.go
+++ b/pkg/kbagent/service/action_utils.go
@@ -31,6 +31,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"text/template"
 	"time"
 
@@ -214,6 +215,17 @@ func execActionCallX(ctx context.Context, cancel context.CancelFunc,
 	}()
 
 	cmd := exec.CommandContext(ctx, action.Commands[0], mergedArgs...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return os.ErrProcessDone
+		}
+		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		if err == syscall.ESRCH {
+			return os.ErrProcessDone
+		}
+		return err
+	}
 	if len(mergedEnv) > 0 {
 		cmd.Env = mergedEnv
 	}

--- a/pkg/kbagent/service/action_utils_test.go
+++ b/pkg/kbagent/service/action_utils_test.go
@@ -30,8 +30,10 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -154,6 +156,47 @@ var _ = Describe("action utils", func() {
 			Expect(err).ShouldNot(BeNil())
 			Expect(errors.Is(err, proto.ErrTimedOut)).Should(BeTrue())
 		})
+
+		DescribeTable("kills the exec process group", func(explicitCancel bool) {
+			dir, err := os.MkdirTemp("", "kbagent-process-group-*")
+			Expect(err).ShouldNot(HaveOccurred())
+			DeferCleanup(os.RemoveAll, dir)
+			readyMarker := filepath.Join(dir, "ready")
+			childMarker := filepath.Join(dir, "child-finished")
+			action := &proto.Action{Exec: &proto.ExecAction{Commands: []string{
+				"/bin/bash", "-c", `(sleep 1; touch "$1") & touch "$0"; wait`, readyMarker, childMarker,
+			}}}
+			callCtx, cancel := context.WithCancel(ctx)
+			if !explicitCancel {
+				cancel()
+				callCtx, cancel = context.WithTimeout(ctx, 300*time.Millisecond)
+			}
+			defer cancel()
+			timeout := int32(-1)
+			stdout := &bytes.Buffer{}
+			errChan, err := nonBlockingCallActionX(callCtx, action, nil, &timeout, nil, stdout, nil)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(func() bool {
+				_, err := os.Stat(readyMarker)
+				return err == nil
+			}, time.Second, 10*time.Millisecond).Should(BeTrue())
+			if explicitCancel {
+				cancel()
+			}
+			var callErr error
+			Eventually(errChan, 2*time.Second).Should(Receive(&callErr))
+			Expect(callErr).Should(HaveOccurred())
+			if !explicitCancel {
+				Expect(errors.Is(callErr, proto.ErrTimedOut)).Should(BeTrue())
+			}
+			Consistently(func() bool {
+				_, err := os.Stat(childMarker)
+				return err == nil
+			}, 1200*time.Millisecond, 20*time.Millisecond).Should(BeFalse())
+		},
+			Entry("on deadline", false),
+			Entry("on explicit cancellation", true),
+		)
 
 		It("x - timeout and stdout", func() {
 			action := &proto.Action{


### PR DESCRIPTION
On release-1.0, cancelling a nested exec action kills only its direct shell. Its descendants can keep running and hold stdout/stderr pipes open, so an action configured with a one-second timeout can still be blocked after 12 seconds. The published tools `1.0.3-beta.12` reproduces this with tini active and four live `sleep` descendants.

Backport main's existing dedicated process group and group cancellation logic. Keep tini orphan reaping, direct-child `Wait`, exit/output handling and the current action API. Add regressions for deadline and explicit cancellation with inherited output pipes and a child side-effect marker.

Validation:
- Both new cases fail before the patch and pass after it.
- `go test ./cmd/kbagent ./pkg/kbagent/...` passes.
- Focused cancellation tests pass with the race detector.
- Real HTTP action tests against the same published image with the patched kbagent binary: 2,000 completed orphan actions leave zero zombies; 12 one-second timeouts return in three batches of about one second each, with zero live sleep descendants and zero zombies; SIGTERM exits with code 0. The shared-binary injection path passes the same checks.

Fixes #10862. Related to #10856. This addresses the release-1.0 cancellation gap found during that investigation. The original field zombie recurrence uses older tools without tini and still requires a deployment remedy; this PR does not close that rollout or claim field acceptance.
