### PR TITLE
chore: isolate probe tests and stop background runners

### DIFF
--- a/pkg/kbagent/service/probe.go
+++ b/pkg/kbagent/service/probe.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -45,16 +46,16 @@ const (
 
 var (
 	defaultRetrySendEventInterval = 1 * time.Minute
-	retrySendEventInterval        = defaultRetrySendEventInterval
 	fileChangeWatchDebounce       = 200 * time.Millisecond
 )
 
 func newProbeService(logger logr.Logger, actionService *actionService, probes []proto.Probe) (*probeService, error) {
 	sp := &probeService{
-		logger:        logger,
-		actionService: actionService,
-		probes:        make(map[string]*proto.Probe),
-		runners:       make(map[string]*probeRunner),
+		logger:                 logger,
+		actionService:          actionService,
+		probes:                 make(map[string]*proto.Probe),
+		runners:                make(map[string]*probeRunner),
+		retrySendEventInterval: defaultRetrySendEventInterval,
 	}
 	for i, p := range probes {
 		if _, ok := actionService.actions[p.Action]; !ok {
@@ -67,11 +68,13 @@ func newProbeService(logger logr.Logger, actionService *actionService, probes []
 }
 
 type probeService struct {
-	logger               logr.Logger
-	actionService        *actionService
-	probes               map[string]*proto.Probe
-	runners              map[string]*probeRunner
-	sendEventWithMessage func(logger *logr.Logger, reason string, message string, sync bool) error
+	logger                 logr.Logger
+	actionService          *actionService
+	probes                 map[string]*proto.Probe
+	runners                map[string]*probeRunner
+	sendEventWithMessage   func(logger *logr.Logger, reason string, message string, sync bool) error
+	retrySendEventInterval time.Duration
+	wg                     sync.WaitGroup
 }
 
 var _ Service = &probeService{}
@@ -85,14 +88,23 @@ func (s *probeService) URI() string {
 }
 
 func (s *probeService) Start() error {
+	return s.start(context.Background())
+}
+
+func (s *probeService) start(ctx context.Context) error {
 	for name := range s.probes {
 		runner := &probeRunner{
-			logger:               s.logger.WithValues("probe", name),
-			actionService:        s.actionService,
-			latestEvent:          make(chan proto.ProbeEvent, 1),
-			sendEventWithMessage: s.sendEventWithMessage,
+			logger:                 s.logger.WithValues("probe", name),
+			actionService:          s.actionService,
+			latestEvent:            make(chan proto.ProbeEvent, 1),
+			sendEventWithMessage:   s.sendEventWithMessage,
+			retrySendEventInterval: s.retrySendEventInterval,
 		}
-		go runner.run(s.probes[name])
+		s.wg.Add(1)
+		go func(probe *proto.Probe) {
+			defer s.wg.Done()
+			runner.run(ctx, probe)
+		}(s.probes[name])
 		s.runners[name] = runner
 	}
 	return nil
@@ -107,14 +119,16 @@ func (s *probeService) HandleRequest(context.Context, []byte) ([]byte, error) {
 }
 
 type probeRunner struct {
-	logger               logr.Logger
-	actionService        *actionService
-	ticker               *time.Ticker
-	succeedCount         int64
-	failedCount          int64
-	latestOutput         []byte
-	latestEvent          chan proto.ProbeEvent
-	sendEventWithMessage func(logger *logr.Logger, reason string, message string, sync bool) error
+	logger                 logr.Logger
+	actionService          *actionService
+	ticker                 *time.Ticker
+	succeedCount           int64
+	failedCount            int64
+	latestOutput           []byte
+	latestEvent            chan proto.ProbeEvent
+	sendEventWithMessage   func(logger *logr.Logger, reason string, message string, sync bool) error
+	retrySendEventInterval time.Duration
+	wg                     sync.WaitGroup
 }
 
 type fileChangeWatch struct {
@@ -122,32 +136,44 @@ type fileChangeWatch struct {
 	dir  bool
 }
 
-func (r *probeRunner) run(probe *proto.Probe) {
-	r.logger.Info("probe started", "config", probe)
-
-	if probe.InitialDelaySeconds > 0 {
-		time.Sleep(time.Duration(probe.InitialDelaySeconds) * time.Second)
-	}
-
-	// launch the report loop first
-	r.launchReportLoop(probe)
-
-	r.launchProbeLoop(probe, r.launchFileChangeWatchLoop(probe))
-}
-
-func (r *probeRunner) launchProbeLoop(probe *proto.Probe, forceProbe <-chan struct{}) {
+func (r *probeRunner) run(ctx context.Context, config *proto.Probe) {
+	defer r.wg.Wait()
+	// Normalize a private copy before the probe and report loops read it.
+	probe := *config
 	if probe.PeriodSeconds <= 0 {
 		probe.PeriodSeconds = defaultProbePeriodSeconds
 	}
+	if probe.ReportPeriodSeconds > 0 && probe.ReportPeriodSeconds < probe.PeriodSeconds {
+		probe.ReportPeriodSeconds = probe.PeriodSeconds
+	}
+	r.logger.Info("probe started", "config", probe)
+
+	if probe.InitialDelaySeconds > 0 {
+		timer := time.NewTimer(time.Duration(probe.InitialDelaySeconds) * time.Second)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		}
+	}
+
+	// launch the report loop first
+	r.launchReportLoop(ctx, &probe)
+
+	r.launchProbeLoop(ctx, &probe, r.launchFileChangeWatchLoop(ctx, &probe))
+}
+
+func (r *probeRunner) launchProbeLoop(ctx context.Context, probe *proto.Probe, forceProbe <-chan struct{}) {
 	r.ticker = time.NewTicker(time.Duration(probe.PeriodSeconds) * time.Second)
 	defer r.ticker.Stop()
 
-	r.probeLoop(probe, forceProbe)
+	r.probeLoop(ctx, probe, forceProbe)
 }
 
-func (r *probeRunner) probeLoop(probe *proto.Probe, forceProbe <-chan struct{}) {
+func (r *probeRunner) probeLoop(ctx context.Context, probe *proto.Probe, forceProbe <-chan struct{}) {
 	once := func(forceReport bool) {
-		output, err := r.actionService.handleRequest(context.Background(), &proto.ActionRequest{Action: probe.Action})
+		output, err := r.actionService.handleRequest(ctx, &proto.ActionRequest{Action: probe.Action})
 		if err == nil {
 			r.succeedCount++
 			r.failedCount = 0
@@ -168,6 +194,8 @@ func (r *probeRunner) probeLoop(probe *proto.Probe, forceProbe <-chan struct{}) 
 
 	for {
 		select {
+		case <-ctx.Done():
+			return
 		case <-r.ticker.C:
 			once(false)
 		case <-forceProbe:
@@ -225,7 +253,7 @@ func (r *probeRunner) fail(probe *proto.Probe) bool {
 	return false
 }
 
-func (r *probeRunner) launchFileChangeWatchLoop(probe *proto.Probe) <-chan struct{} {
+func (r *probeRunner) launchFileChangeWatchLoop(ctx context.Context, probe *proto.Probe) <-chan struct{} {
 	if len(probe.ReportOnFileChange) == 0 {
 		return nil
 	}
@@ -261,13 +289,20 @@ func (r *probeRunner) launchFileChangeWatchLoop(probe *proto.Probe) <-chan struc
 		return forceProbe
 	}
 
+	r.wg.Add(1)
 	go func() {
+		defer r.wg.Done()
 		defer watcher.Close()
 
 		var (
 			timer  *time.Timer
 			timerC <-chan time.Time
 		)
+		defer func() {
+			if timer != nil {
+				timer.Stop()
+			}
+		}()
 		resetTimer := func() {
 			if timer == nil {
 				timer = time.NewTimer(fileChangeWatchDebounce)
@@ -291,6 +326,8 @@ func (r *probeRunner) launchFileChangeWatchLoop(probe *proto.Probe) <-chan struc
 
 		for {
 			select {
+			case <-ctx.Done():
+				return
 			case event, ok := <-watcher.Events:
 				if !ok {
 					return
@@ -367,19 +404,18 @@ func (r *probeRunner) buildEvent(instance, probe string, code int32, output []by
 	}
 }
 
-func (r *probeRunner) launchReportLoop(probe *proto.Probe) {
+func (r *probeRunner) launchReportLoop(ctx context.Context, probe *proto.Probe) {
+	r.wg.Add(1)
 	go func() {
+		defer r.wg.Done()
 		var reportChan <-chan time.Time
 		if probe.ReportPeriodSeconds > 0 {
-			if probe.ReportPeriodSeconds < probe.PeriodSeconds {
-				probe.ReportPeriodSeconds = probe.PeriodSeconds
-			}
 			ticker := time.NewTicker(time.Duration(probe.ReportPeriodSeconds) * time.Second)
 			defer ticker.Stop()
 			reportChan = ticker.C
 		}
 
-		retryTicker := time.NewTicker(retrySendEventInterval)
+		retryTicker := time.NewTicker(r.retrySendEventInterval)
 		defer retryTicker.Stop()
 
 		var event proto.ProbeEvent
@@ -426,6 +462,8 @@ func (r *probeRunner) launchReportLoop(probe *proto.Probe) {
 		needsRetry := false
 		for {
 			select {
+			case <-ctx.Done():
+				return
 			case latest := <-r.latestEvent:
 				event = latest
 				hasEvent = true

--- a/pkg/kbagent/service/probe_test.go
+++ b/pkg/kbagent/service/probe_test.go
@@ -20,10 +20,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package service
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -48,25 +50,36 @@ var _ = Describe("probe", func() {
 					},
 				},
 			}
-			probes = []proto.Probe{
-				{
-					Action:              probeName,
-					InitialDelaySeconds: 0,
-					PeriodSeconds:       1,
-					SuccessThreshold:    1,
-					FailureThreshold:    1,
-					ReportPeriodSeconds: 0,
-				},
-			}
+			probes []proto.Probe
 
 			actionSvc *actionService
 		)
 
 		BeforeEach(func() {
+			probes = []proto.Probe{{
+				Action:           probeName,
+				PeriodSeconds:    1,
+				SuccessThreshold: 1,
+				FailureThreshold: 1,
+			}}
 			var err error
 			actionSvc, err = newActionService(logr.New(nil), actions)
 			Expect(err).Should(BeNil())
 		})
+
+		startService := func(service *probeService) {
+			probeCtx, cancel := context.WithCancel(ctx)
+			DeferCleanup(func() {
+				cancel()
+				done := make(chan struct{})
+				go func() {
+					service.wg.Wait()
+					close(done)
+				}()
+				Eventually(done).Should(BeClosed())
+			})
+			Expect(service.start(probeCtx)).Should(Succeed())
+		}
 
 		It("new", func() {
 			service, err := newProbeService(logr.New(nil), actionSvc, probes)
@@ -80,7 +93,7 @@ var _ = Describe("probe", func() {
 			Expect(err).Should(BeNil())
 			Expect(service).ShouldNot(BeNil())
 
-			Expect(service.Start()).Should(Succeed())
+			startService(service)
 			Expect(len(service.probes)).Should(Equal(len(service.runners)))
 		})
 
@@ -96,18 +109,18 @@ var _ = Describe("probe", func() {
 
 		It("initial delay seconds", func() {
 			probes[0].InitialDelaySeconds = 60
-			defer func() { probes[0].InitialDelaySeconds = 0 }()
 
 			service, err := newProbeService(logr.New(nil), actionSvc, probes)
 			Expect(err).Should(BeNil())
 			Expect(service).ShouldNot(BeNil())
 
-			Expect(service.Start()).Should(Succeed())
-
-			time.Sleep(1 * time.Second)
-			r := service.runners[probeName]
-			Expect(r).ShouldNot(BeNil())
-			Expect(r.ticker).Should(BeNil())
+			events := make(chan struct{}, 1)
+			service.sendEventWithMessage = func(_ *logr.Logger, _, _ string, _ bool) error {
+				events <- struct{}{}
+				return nil
+			}
+			startService(service)
+			Consistently(events, time.Second).ShouldNot(Receive())
 		})
 
 		It("send event", func() {
@@ -127,7 +140,7 @@ var _ = Describe("probe", func() {
 			}
 
 			By("start probe service")
-			Expect(service.Start()).Should(Succeed())
+			startService(service)
 
 			By("check received event")
 			var receivedData struct{ reason, message string }
@@ -140,10 +153,26 @@ var _ = Describe("probe", func() {
 			Eventually(event.Output).Should(Equal([]byte("leader")))
 		})
 
+		It("normalizes probe periods without modifying the shared configuration", func() {
+			probes[0].PeriodSeconds = 0
+			probes[0].ReportPeriodSeconds = 1
+			service, err := newProbeService(logr.New(nil), actionSvc, probes)
+			Expect(err).Should(BeNil())
+			events := make(chan struct{}, 1)
+			service.sendEventWithMessage = func(_ *logr.Logger, _, _ string, _ bool) error {
+				events <- struct{}{}
+				return nil
+			}
+			startService(service)
+			Eventually(events).Should(Receive())
+			Expect(probes[0].PeriodSeconds).Should(BeZero())
+			Expect(probes[0].ReportPeriodSeconds).Should(Equal(int32(1)))
+		})
+
 		It("send event when report-on-file-change trigger fires with unchanged output", func() {
 			tmpDir, err := os.MkdirTemp("", "kbagent-file-change-*")
 			Expect(err).Should(BeNil())
-			defer os.RemoveAll(tmpDir)
+			DeferCleanup(os.RemoveAll, tmpDir)
 
 			triggerPath := filepath.Join(tmpDir, "trigger")
 			Expect(os.WriteFile(triggerPath, []byte("current"), 0644)).Should(Succeed())
@@ -166,7 +195,7 @@ var _ = Describe("probe", func() {
 			}
 
 			By("start probe service")
-			Expect(service.Start()).Should(Succeed())
+			startService(service)
 
 			By("drain initial event")
 			var receivedData struct{ reason, message string }
@@ -223,20 +252,19 @@ var _ = Describe("probe", func() {
 
 			By("mock send event function with error")
 			var (
-				count = 0
+				count atomic.Int64
 			)
 			service.sendEventWithMessage = func(_ *logr.Logger, reason string, message string, _ bool) error {
-				count += 1
+				count.Add(1)
 				return fmt.Errorf("API server error")
 			}
-			retrySendEventInterval = 1 * time.Second
-			defer func() { retrySendEventInterval = defaultRetrySendEventInterval }()
+			service.retrySendEventInterval = time.Second
 
 			By("start probe service")
-			Expect(service.Start()).Should(Succeed())
+			startService(service)
 
 			By("wait for probe to send event error")
-			Eventually(func() int { return count }, 2*retrySendEventInterval).Should(BeNumerically(">", 1))
+			Eventually(count.Load, 2*service.retrySendEventInterval).Should(BeNumerically(">", 1))
 		})
 
 		It("send event - after API server recover", func() {
@@ -247,32 +275,30 @@ var _ = Describe("probe", func() {
 
 			By("mock send event function with temporary error")
 			var (
-				count     = 0
+				count     atomic.Int64
 				eventChan = make(chan struct {
 					reason  string
 					message string
 				}, 128)
 			)
 			service.sendEventWithMessage = func(_ *logr.Logger, reason string, message string, _ bool) error {
-				count += 1
-				if count <= 2 {
+				if count.Add(1) <= 2 {
 					return fmt.Errorf("API server error")
 				}
 				eventChan <- struct{ reason, message string }{reason, message}
 				return nil
 			}
-			retrySendEventInterval = 1 * time.Second
-			defer func() { retrySendEventInterval = defaultRetrySendEventInterval }()
+			service.retrySendEventInterval = time.Second
 
 			By("start probe service")
-			Expect(service.Start()).Should(Succeed())
+			startService(service)
 
 			By("wait for probe to send event error")
-			Eventually(func() int { return count }, 2*retrySendEventInterval).Should(BeNumerically(">", 1))
+			Eventually(count.Load, 2*service.retrySendEventInterval).Should(BeNumerically(">", 1))
 
 			By("check received event after recover")
 			var receivedData struct{ reason, message string }
-			Eventually(eventChan, 2*retrySendEventInterval).Should(Receive(&receivedData))
+			Eventually(eventChan, 2*service.retrySendEventInterval).Should(Receive(&receivedData))
 			Expect(receivedData.reason).Should(Equal(probeName))
 			var event proto.ProbeEvent
 			Expect(json.Unmarshal([]byte(receivedData.message), &event)).Should(Succeed())


### PR DESCRIPTION
Backport of #10858 to `release-1.0`.

Probe tests share mutable configuration with runners that outlive their specs, race on callback counters, and modify a global retry interval. Use fresh test fixtures, atomic counters, service-local retry timing, and cancellable internal startup with cleanup that waits for probe, report, and file-watch loops. Normalize a private configuration copy before concurrent loops start; the public Service interface is unchanged.

Automatic cherry-pick conflicts in the test import block. This backport resolves that conflict by retaining the release imports and adding `sync/atomic`. It preserves the release branch's existing `json.Marshal` event serialization. Only the two probe files change.

Validation:

- The unmodified release branch reproduced the race: all 11 selected assertions passed, but the suite failed under the race detector.
- Probe race tests passed in three separate runs, 12 specs per run:
  `go test -mod=readonly -race ./pkg/kbagent/service -count=1 -v -ginkgo.focus=probe -ginkgo.no-color`
- The complete service package passed under the race detector, 59 specs:
  `go test -mod=readonly -race ./pkg/kbagent/service -count=1 -v -ginkgo.no-color`
- `golangci-lint` v2.8.0 reported zero issues for `./pkg/kbagent/service`.
- `goimports` and `git diff --check` passed.
