### PR TITLE
chore: validate sharding definitions when loading referenced resources

### DIFF
--- a/controllers/apps/cluster/transformer_cluster_normalization.go
+++ b/controllers/apps/cluster/transformer_cluster_normalization.go
@@ -35,6 +35,7 @@ import (
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
+	appsutil "github.com/apecloud/kubeblocks/controllers/apps/util"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
@@ -70,6 +71,11 @@ func (t *clusterNormalizationTransformer) Transform(ctx graph.TransformContext, 
 		return err
 	}
 
+	// Check each resolved sharding definition once before building shard components.
+	if err = t.checkShardingDefinitions(transCtx); err != nil {
+		return err
+	}
+
 	// resolve component definitions referenced for components
 	if err = t.resolveDefinitions4Components(transCtx); err != nil {
 		return err
@@ -92,6 +98,19 @@ func (t *clusterNormalizationTransformer) Transform(ctx graph.TransformContext, 
 	// write-back the resolved definitions and service versions to cluster spec.
 	t.writeBackCompNShardingSpecs(transCtx)
 
+	return nil
+}
+
+func (t *clusterNormalizationTransformer) checkShardingDefinitions(transCtx *clusterTransformContext) error {
+	for _, def := range transCtx.shardingDefs {
+		if def.Generation != def.Status.ObservedGeneration || def.Status.Phase == "" {
+			return controllerutil.NewRequeueError(appsutil.RequeueDuration,
+				fmt.Sprintf("the referenced ShardingDefinition is awaiting validation: %s", def.Name))
+		}
+		if def.Status.Phase != appsv1.AvailablePhase {
+			return fmt.Errorf("the referenced ShardingDefinition is unavailable: %s: %s", def.Name, def.Status.Message)
+		}
+	}
 	return nil
 }
 

--- a/controllers/apps/cluster/transformer_cluster_normalization.go
+++ b/controllers/apps/cluster/transformer_cluster_normalization.go
@@ -71,11 +71,6 @@ func (t *clusterNormalizationTransformer) Transform(ctx graph.TransformContext, 
 		return err
 	}
 
-	// Check each resolved sharding definition once before building shard components.
-	if err = t.checkShardingDefinitions(transCtx); err != nil {
-		return err
-	}
-
 	// resolve component definitions referenced for components
 	if err = t.resolveDefinitions4Components(transCtx); err != nil {
 		return err
@@ -98,19 +93,6 @@ func (t *clusterNormalizationTransformer) Transform(ctx graph.TransformContext, 
 	// write-back the resolved definitions and service versions to cluster spec.
 	t.writeBackCompNShardingSpecs(transCtx)
 
-	return nil
-}
-
-func (t *clusterNormalizationTransformer) checkShardingDefinitions(transCtx *clusterTransformContext) error {
-	for _, def := range transCtx.shardingDefs {
-		if def.Generation != def.Status.ObservedGeneration || def.Status.Phase == "" {
-			return controllerutil.NewRequeueError(appsutil.RequeueDuration,
-				fmt.Sprintf("the referenced ShardingDefinition is awaiting validation: %s", def.Name))
-		}
-		if def.Status.Phase != appsv1.AvailablePhase {
-			return fmt.Errorf("the referenced ShardingDefinition is unavailable: %s: %s", def.Name, def.Status.Message)
-		}
-	}
 	return nil
 }
 
@@ -348,9 +330,9 @@ func (t *clusterNormalizationTransformer) resolveDefinitions4ShardTemplate(trans
 	var shardingDef *appsv1.ShardingDefinition
 	shardingDefName = t.shardingDefinitionName(shardingDefName, comp)
 	if len(shardingDefName) > 0 {
-		shardingDef, err = resolveShardingDefinition(transCtx.Context, transCtx.Client, shardingDefName)
+		shardingDef, err = getNCheckShardingDefinition(transCtx.Context, transCtx.Client, shardingDefName)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, controllerutil.NewRequeueError(appsutil.RequeueDuration, err.Error())
 		}
 		if len(spec.ComponentDef) == 0 {
 			spec.ComponentDef = shardingDef.Spec.Template.CompDef
@@ -678,6 +660,20 @@ func clusterTopologyCompMatched(comp appsv1.ClusterTopologyComponent, compName s
 		return strings.HasPrefix(compName, comp.Name)
 	}
 	return false
+}
+
+func getNCheckShardingDefinition(ctx context.Context, cli client.Reader, name string) (*appsv1.ShardingDefinition, error) {
+	shardingDef, err := resolveShardingDefinition(ctx, cli, name)
+	if err != nil {
+		return nil, err
+	}
+	if shardingDef.Generation != shardingDef.Status.ObservedGeneration {
+		return nil, fmt.Errorf("the referenced ShardingDefinition is not up to date: %s", shardingDef.Name)
+	}
+	if shardingDef.Status.Phase != appsv1.AvailablePhase {
+		return nil, fmt.Errorf("the referenced ShardingDefinition is unavailable: %s", shardingDef.Name)
+	}
+	return shardingDef, nil
 }
 
 // resolveShardingDefinition resolves and returns the specific sharding definition object supported.

--- a/controllers/apps/cluster/transformer_cluster_normalization_test.go
+++ b/controllers/apps/cluster/transformer_cluster_normalization_test.go
@@ -40,7 +40,7 @@ import (
 
 var _ = Describe("sharding definition availability during normalization", func() {
 	DescribeTable("checks resolved definitions before building shard components",
-		func(phase appsv1.Phase, observed int64, waiting bool, detail string) {
+		func(phase appsv1.Phase, observed int64, detail string) {
 			scheme := runtime.NewScheme()
 			Expect(appsv1.AddToScheme(scheme)).Should(Succeed())
 			compDef := testapps.NewComponentDefinitionFactory("comp-v1").SetServiceVersion("1.0.0").GetObject()
@@ -49,7 +49,7 @@ var _ = Describe("sharding definition availability during normalization", func()
 			def := testapps.NewShardingDefinitionFactory("shard-v2", compDef.Name).GetObject()
 			def.Generation = 2
 			def.Status = appsv1.ShardingDefinitionStatus{
-				Phase: phase, ObservedGeneration: observed, Message: "invalid lifecycle action",
+				Phase: phase, ObservedGeneration: observed,
 			}
 			oldDef := def.DeepCopy()
 			oldDef.Name = "shard-v1"
@@ -72,25 +72,24 @@ var _ = Describe("sharding definition availability during normalization", func()
 					if detail == "" {
 						Expect(err).ShouldNot(HaveOccurred())
 						Expect(transCtx.shardingComps["shard"]).Should(HaveLen(1))
+						Expect(transCtx.shardingDefs).Should(HaveKey(def.Name))
 					} else {
-						Expect(err).Should(MatchError(ContainSubstring(detail)))
-						Expect(err.Error()).Should(ContainSubstring(def.Name))
-						Expect(intctrlutil.IsRequeueError(err)).Should(Equal(waiting))
+						// Selection must not fall back to an older available definition.
+						Expect(err).Should(MatchError(ContainSubstring("the referenced ShardingDefinition is " + detail + ": " + def.Name)))
+						Expect(intctrlutil.IsRequeueError(err)).Should(BeTrue())
 						Expect(transCtx.shardingComps).Should(BeEmpty())
 						Expect(transCtx.Cluster.Status.Conditions).Should(ContainElement(And(
 							HaveField("Status", metav1.ConditionFalse), HaveField("Message", ContainSubstring(detail)))))
 					}
-					// Selection remains unchanged: never fall back to an older available definition.
-					Expect(transCtx.shardingDefs).Should(HaveKey(def.Name))
 				}
 			}
 		},
-		Entry("not yet observed", appsv1.Phase(""), int64(0), true, "awaiting validation"),
-		Entry("empty phase", appsv1.Phase(""), int64(2), true, "awaiting validation"),
-		Entry("stale available", appsv1.AvailablePhase, int64(1), true, "awaiting validation"),
-		Entry("stale unavailable", appsv1.UnavailablePhase, int64(1), true, "awaiting validation"),
-		Entry("current unavailable", appsv1.UnavailablePhase, int64(2), false, "invalid lifecycle action"),
-		Entry("current available", appsv1.AvailablePhase, int64(2), false, ""),
+		Entry("not yet observed", appsv1.Phase(""), int64(0), "not up to date"),
+		Entry("empty phase", appsv1.Phase(""), int64(2), "unavailable"),
+		Entry("stale available", appsv1.AvailablePhase, int64(1), "not up to date"),
+		Entry("stale unavailable", appsv1.UnavailablePhase, int64(1), "not up to date"),
+		Entry("current unavailable", appsv1.UnavailablePhase, int64(2), "unavailable"),
+		Entry("current available", appsv1.AvailablePhase, int64(2), ""),
 	)
 })
 

--- a/controllers/apps/cluster/transformer_cluster_normalization_test.go
+++ b/controllers/apps/cluster/transformer_cluster_normalization_test.go
@@ -24,13 +24,75 @@ import (
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
+	"github.com/apecloud/kubeblocks/pkg/controller/graph"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 	"github.com/apecloud/kubeblocks/pkg/generics"
 	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
 )
+
+var _ = Describe("sharding definition availability during normalization", func() {
+	DescribeTable("checks resolved definitions before building shard components",
+		func(phase appsv1.Phase, observed int64, waiting bool, detail string) {
+			scheme := runtime.NewScheme()
+			Expect(appsv1.AddToScheme(scheme)).Should(Succeed())
+			compDef := testapps.NewComponentDefinitionFactory("comp-v1").SetServiceVersion("1.0.0").GetObject()
+			// ComponentDefinition availability is outside this check's scope.
+			compDef.Status.Phase = appsv1.UnavailablePhase
+			def := testapps.NewShardingDefinitionFactory("shard-v2", compDef.Name).GetObject()
+			def.Generation = 2
+			def.Status = appsv1.ShardingDefinitionStatus{
+				Phase: phase, ObservedGeneration: observed, Message: "invalid lifecycle action",
+			}
+			oldDef := def.DeepCopy()
+			oldDef.Name = "shard-v1"
+			oldDef.Status.Phase, oldDef.Status.ObservedGeneration = appsv1.AvailablePhase, 2
+			cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(compDef, def, oldDef).Build()
+			for _, ref := range []string{def.Name, "shard-"} {
+				for _, template := range []bool{false, true} {
+					cluster := testapps.NewClusterFactory(testCtx.DefaultNamespace, "availability-cluster", "").
+						AddSharding("shard", ref, compDef.Name).SetShards(1).GetObject()
+					if template {
+						cluster.Spec.Shardings[0].ShardingDef = oldDef.Name
+						cluster.Spec.Shardings[0].ShardTemplates = []appsv1.ShardTemplate{{
+							Name: "custom", ShardingDef: ptr.To(ref), Shards: ptr.To(int32(1)),
+						}}
+					}
+					transCtx := &clusterTransformContext{
+						Context: ctx, Client: cli, Cluster: cluster.DeepCopy(), OrigCluster: cluster.DeepCopy(),
+					}
+					err := (&clusterNormalizationTransformer{}).Transform(transCtx, graph.NewDAG())
+					if detail == "" {
+						Expect(err).ShouldNot(HaveOccurred())
+						Expect(transCtx.shardingComps["shard"]).Should(HaveLen(1))
+					} else {
+						Expect(err).Should(MatchError(ContainSubstring(detail)))
+						Expect(err.Error()).Should(ContainSubstring(def.Name))
+						Expect(intctrlutil.IsRequeueError(err)).Should(Equal(waiting))
+						Expect(transCtx.shardingComps).Should(BeEmpty())
+						Expect(transCtx.Cluster.Status.Conditions).Should(ContainElement(And(
+							HaveField("Status", metav1.ConditionFalse), HaveField("Message", ContainSubstring(detail)))))
+					}
+					// Selection remains unchanged: never fall back to an older available definition.
+					Expect(transCtx.shardingDefs).Should(HaveKey(def.Name))
+				}
+			}
+		},
+		Entry("not yet observed", appsv1.Phase(""), int64(0), true, "awaiting validation"),
+		Entry("empty phase", appsv1.Phase(""), int64(2), true, "awaiting validation"),
+		Entry("stale available", appsv1.AvailablePhase, int64(1), true, "awaiting validation"),
+		Entry("stale unavailable", appsv1.UnavailablePhase, int64(1), true, "awaiting validation"),
+		Entry("current unavailable", appsv1.UnavailablePhase, int64(2), false, "invalid lifecycle action"),
+		Entry("current available", appsv1.AvailablePhase, int64(2), false, ""),
+	)
+})
 
 var _ = Describe("resolve CompDefinition and ServiceVersion", func() {
 	var (

--- a/controllers/apps/cluster/transformer_cluster_normalization_test.go
+++ b/controllers/apps/cluster/transformer_cluster_normalization_test.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
@@ -46,7 +47,8 @@ var _ = Describe("sharding definition availability during normalization", func()
 			compDef := testapps.NewComponentDefinitionFactory("comp-v1").SetServiceVersion("1.0.0").GetObject()
 			// ComponentDefinition availability is outside this check's scope.
 			compDef.Status.Phase = appsv1.UnavailablePhase
-			def := testapps.NewShardingDefinitionFactory("shard-v2", compDef.Name).GetObject()
+			def := testapps.NewShardingDefinitionFactory("shard-v2", compDef.Name).
+				AddAnnotations(constant.CRDAPIVersionAnnotationKey, appsv1.GroupVersion.String()).GetObject()
 			def.Generation = 2
 			def.Status = appsv1.ShardingDefinitionStatus{
 				Phase: phase, ObservedGeneration: observed,


### PR DESCRIPTION
Backport of #10859 to `release-1.1`.

Load and validate ShardingDefinitions in the existing `resolveDefinitions4ShardTemplate` resource-loading path before reading their specs. Match ComponentDefinition's `getNCheckCompDefinition`: check the observed generation first, then the Available phase, and wrap errors as requeues at the call site. The top-level `Transform` flow is unchanged.

The automatic cherry-pick conflicts with release imports. This backport retains those release APIs and the CRD API version handling. Tests cover exact names, patterns, and shard-template overrides. Regression fixtures include the CRD API version annotation required by this release.

Validation:

- All 164 Cluster specs passed: `go test -mod=readonly ./controllers/apps/cluster -count=1 -v -ginkgo.no-color`, with local envtest assets and repository-generated mocks.
- `golangci-lint` v2.8.0: `run ./...` reported zero issues.
- `git diff --check` passed.
