### PR TITLE
fix(kbagent): cancel exec process groups

### DIFF
--- a/pkg/kbagent/service/action_utils.go
+++ b/pkg/kbagent/service/action_utils.go
@@ -31,6 +31,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"text/template"
 	"time"
 
@@ -214,6 +215,17 @@ func execActionCallX(ctx context.Context, cancel context.CancelFunc,
 	}()
 
 	cmd := exec.CommandContext(ctx, action.Commands[0], mergedArgs...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return os.ErrProcessDone
+		}
+		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		if err == syscall.ESRCH {
+			return os.ErrProcessDone
+		}
+		return err
+	}
 	if len(mergedEnv) > 0 {
 		cmd.Env = mergedEnv
 	}

--- a/pkg/kbagent/service/action_utils_test.go
+++ b/pkg/kbagent/service/action_utils_test.go
@@ -30,8 +30,10 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -154,6 +156,47 @@ var _ = Describe("action utils", func() {
 			Expect(err).ShouldNot(BeNil())
 			Expect(errors.Is(err, proto.ErrTimedOut)).Should(BeTrue())
 		})
+
+		DescribeTable("kills the exec process group", func(explicitCancel bool) {
+			dir, err := os.MkdirTemp("", "kbagent-process-group-*")
+			Expect(err).ShouldNot(HaveOccurred())
+			DeferCleanup(os.RemoveAll, dir)
+			readyMarker := filepath.Join(dir, "ready")
+			childMarker := filepath.Join(dir, "child-finished")
+			action := &proto.Action{Exec: &proto.ExecAction{Commands: []string{
+				"/bin/bash", "-c", `(sleep 1; touch "$1") & touch "$0"; wait`, readyMarker, childMarker,
+			}}}
+			callCtx, cancel := context.WithCancel(ctx)
+			if !explicitCancel {
+				cancel()
+				callCtx, cancel = context.WithTimeout(ctx, 300*time.Millisecond)
+			}
+			defer cancel()
+			timeout := int32(-1)
+			stdout := &bytes.Buffer{}
+			errChan, err := nonBlockingCallActionX(callCtx, action, nil, &timeout, nil, stdout, nil)
+			Expect(err).ShouldNot(HaveOccurred())
+			Eventually(func() bool {
+				_, err := os.Stat(readyMarker)
+				return err == nil
+			}, time.Second, 10*time.Millisecond).Should(BeTrue())
+			if explicitCancel {
+				cancel()
+			}
+			var callErr error
+			Eventually(errChan, 2*time.Second).Should(Receive(&callErr))
+			Expect(callErr).Should(HaveOccurred())
+			if !explicitCancel {
+				Expect(errors.Is(callErr, proto.ErrTimedOut)).Should(BeTrue())
+			}
+			Consistently(func() bool {
+				_, err := os.Stat(childMarker)
+				return err == nil
+			}, 1200*time.Millisecond, 20*time.Millisecond).Should(BeFalse())
+		},
+			Entry("on deadline", false),
+			Entry("on explicit cancellation", true),
+		)
 
 		It("x - timeout and stdout", func() {
 			action := &proto.Action{


### PR DESCRIPTION
Cancelling an exec action on release-1.1 kills only its direct process. Descendants can continue running and hold inherited output pipes open, delaying the timeout response and allowing side effects after cancellation.

Backport main's dedicated process group and group SIGKILL cancellation from #10715 (4373264ccb7a441c920ae0486b86c7b5edde6abb). The cancellation implementation and regression tests match the release-1.0 fix in #10861. Existing timeout/error handling, direct-child Wait, and tini orphan reaping remain intact.

Validation on macOS arm64, using the repository Go test wrapper:
- Both new regression cases (deadline and explicit cancellation) fail against unpatched release-1.1 because the descendant still creates its side-effect marker.
- `scripts/codex-go-test.sh ./cmd/kbagent ./pkg/kbagent/... -count=1` passes with the patch.
- `scripts/codex-go-test.sh -race ./pkg/kbagent/service -run TestAPIs -ginkgo.focus='kills the exec process group' -count=1` passes.
- The same package suite and focused race tests pass independently at #10861 head 2e098a014c10de1b69aad9ba236bfe5cbfa8dd01.
- Verified the command setup/cancellation block is byte-identical to main at a9325df95b2ab8b01cd2c0f388e5a676e65ed097.

Related to #10862 and #10856. Linux container/image acceptance was not repeated for this backport.
