### PR TITLE
fix: retain per-pod services during scale-in

### DIFF
--- a/controllers/apps/component/transformer_component_service.go
+++ b/controllers/apps/component/transformer_component_service.go
@@ -42,7 +42,6 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
-	"github.com/apecloud/kubeblocks/pkg/controller/multicluster"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 )
 
@@ -193,20 +192,7 @@ func (t *componentServiceTransformer) podsNameNSuffix(transCtx *componentTransfo
 	}
 	// Updating the InstanceSet does not synchronously remove its Pods. Keep their
 	// addresses through termination, until the Pod objects have actually disappeared.
-	podCtx := transCtx.Context
-	placement := transCtx.Component.Annotations[constant.KBAppMultiClusterPlacementKey]
-	if placement == "" && runningITS != nil {
-		placement = runningITS.Annotations[constant.KBAppMultiClusterPlacementKey]
-	}
-	if placement == "" && protoITS != nil {
-		placement = protoITS.Annotations[constant.KBAppMultiClusterPlacementKey]
-	}
-	if placement != "" {
-		podCtx = multicluster.IntoContext(podCtx, placement)
-	}
-	synthesizeComp := transCtx.SynthesizeComponent
-	instances, err := component.ListOwnedPods(podCtx, transCtx.Client,
-		synthesizeComp.Namespace, synthesizeComp.ClusterName, synthesizeComp.Name)
+	instances, err := component.ListOwnedInstances(transCtx.Context, transCtx.Client, transCtx.Component, runningITS, protoITS)
 	if err != nil {
 		return nil, false, err
 	}

--- a/controllers/apps/component/transformer_component_service.go
+++ b/controllers/apps/component/transformer_component_service.go
@@ -149,7 +149,7 @@ func (t *componentServiceTransformer) buildPodService(transCtx *componentTransfo
 		return nil, err
 	}
 
-	services := make([]*appsv1.ComponentService, 0)
+	compServices := make([]*appsv1.ComponentService, 0)
 	for podName, suffix := range pods {
 		svc := service.DeepCopy()
 		svc.Name = fmt.Sprintf("%s-%s", service.Name, suffix)
@@ -162,18 +162,18 @@ func (t *componentServiceTransformer) buildPodService(transCtx *componentTransfo
 			svc.Spec.Selector = make(map[string]string)
 		}
 		svc.Spec.Selector[constant.KBAppPodNameLabelKey] = podName
-		services = append(services, svc)
+		compServices = append(compServices, svc)
 	}
-	builtServices, err := t.buildServices(transCtx.Component, transCtx.SynthesizeComponent, services)
+	services, err := t.buildServices(transCtx.Component, transCtx.SynthesizeComponent, compServices)
 	if err != nil {
 		return nil, err
 	}
 	if pendingScaleIn {
 		// Return the Services to retain along with a retry, so memberLeave and the
 		// workload update can proceed while their eventual cleanup is still pending.
-		return builtServices, intctrlutil.NewDelayedRequeueError(time.Second, "waiting for scaled-in instances to disappear before deleting pod services")
+		return services, intctrlutil.NewDelayedRequeueError(time.Second, "waiting for scaled-in instances to disappear before deleting pod services")
 	}
-	return builtServices, nil
+	return services, nil
 }
 
 func (t *componentServiceTransformer) podsNameNSuffix(transCtx *componentTransformContext, runningITS, protoITS *workloadsv1.InstanceSet) (map[string]string, bool, error) {

--- a/controllers/apps/component/transformer_component_service.go
+++ b/controllers/apps/component/transformer_component_service.go
@@ -80,22 +80,18 @@ func (t *componentServiceTransformer) Transform(ctx graph.TransformContext, dag 
 	}
 
 	graphCli, _ := transCtx.Client.(model.GraphClient)
-	var podNamesNSuffix map[string]string
-	var pendingScaleIn bool
+	var delayedErr error
 	for _, service := range synthesizeComp.ComponentServices {
 		// component controller does not handle the default headless service; the default headless service is managed by the InstanceSet.
 		if t.skipDefaultHeadlessSvc(synthesizeComp, &service) {
 			continue
 		}
-		if t.isPodService(&service) && (service.DisableAutoProvision == nil || !*service.DisableAutoProvision) && podNamesNSuffix == nil {
-			podNamesNSuffix, pendingScaleIn, err = t.podsNameNSuffix(transCtx, runningITS, protoITS)
-			if err != nil {
+		services, err := t.buildCompService(transCtx, &service, runningITS, protoITS)
+		if err != nil {
+			if !intctrlutil.IsDelayedRequeueError(err) {
 				return err
 			}
-		}
-		services, err := t.buildCompService(transCtx.Component, synthesizeComp, &service, podNamesNSuffix)
-		if err != nil {
-			return err
+			delayedErr = err
 		}
 		for _, svc := range services {
 			if err = t.createOrUpdateService(ctx, dag, graphCli, &service, svc, transCtx.ComponentOrig); err != nil {
@@ -112,12 +108,7 @@ func (t *componentServiceTransformer) Transform(ctx graph.TransformContext, dag 
 		graphCli.Delete(dag, runningServices[svc])
 	}
 
-	if pendingScaleIn {
-		// Continue the transformer chain so memberLeave and the workload update can
-		// make progress, but revisit cleanup even if no further workload event arrives.
-		return intctrlutil.NewDelayedRequeueError(time.Second, "waiting for scaled-in instances to disappear before deleting pod services")
-	}
-	return nil
+	return delayedErr
 }
 
 func (t *componentServiceTransformer) listOwnedServices(ctx context.Context, cli client.Reader,
@@ -135,24 +126,29 @@ func (t *componentServiceTransformer) listOwnedServices(ctx context.Context, cli
 	return owned, nil
 }
 
-func (t *componentServiceTransformer) buildCompService(comp *appsv1.Component,
-	synthesizeComp *component.SynthesizedComponent, service *appsv1.ComponentService, pods map[string]string) ([]*corev1.Service, error) {
+func (t *componentServiceTransformer) buildCompService(transCtx *componentTransformContext,
+	service *appsv1.ComponentService, runningITS, protoITS *workloadsv1.InstanceSet) ([]*corev1.Service, error) {
 	if service.DisableAutoProvision != nil && *service.DisableAutoProvision {
 		return nil, nil
 	}
 
 	if t.isPodService(service) {
-		return t.buildPodService(comp, synthesizeComp, service, pods)
+		return t.buildPodService(transCtx, service, runningITS, protoITS)
 	}
-	return t.buildServices(comp, synthesizeComp, []*appsv1.ComponentService{service})
+	return t.buildServices(transCtx.Component, transCtx.SynthesizeComponent, []*appsv1.ComponentService{service})
 }
 
 func (t *componentServiceTransformer) isPodService(service *appsv1.ComponentService) bool {
 	return service.PodService != nil && *service.PodService
 }
 
-func (t *componentServiceTransformer) buildPodService(comp *appsv1.Component,
-	synthesizeComp *component.SynthesizedComponent, service *appsv1.ComponentService, pods map[string]string) ([]*corev1.Service, error) {
+func (t *componentServiceTransformer) buildPodService(transCtx *componentTransformContext,
+	service *appsv1.ComponentService, runningITS, protoITS *workloadsv1.InstanceSet) ([]*corev1.Service, error) {
+	pods, pendingScaleIn, err := t.podsNameNSuffix(transCtx, runningITS, protoITS)
+	if err != nil {
+		return nil, err
+	}
+
 	services := make([]*appsv1.ComponentService, 0)
 	for podName, suffix := range pods {
 		svc := service.DeepCopy()
@@ -168,7 +164,16 @@ func (t *componentServiceTransformer) buildPodService(comp *appsv1.Component,
 		svc.Spec.Selector[constant.KBAppPodNameLabelKey] = podName
 		services = append(services, svc)
 	}
-	return t.buildServices(comp, synthesizeComp, services)
+	builtServices, err := t.buildServices(transCtx.Component, transCtx.SynthesizeComponent, services)
+	if err != nil {
+		return nil, err
+	}
+	if pendingScaleIn {
+		// Return the Services to retain along with a retry, so memberLeave and the
+		// workload update can proceed while their eventual cleanup is still pending.
+		return builtServices, intctrlutil.NewDelayedRequeueError(time.Second, "waiting for scaled-in instances to disappear before deleting pod services")
+	}
+	return builtServices, nil
 }
 
 func (t *componentServiceTransformer) podsNameNSuffix(transCtx *componentTransformContext, runningITS, protoITS *workloadsv1.InstanceSet) (map[string]string, bool, error) {

--- a/controllers/apps/component/transformer_component_service.go
+++ b/controllers/apps/component/transformer_component_service.go
@@ -149,7 +149,7 @@ func (t *componentServiceTransformer) buildPodService(transCtx *componentTransfo
 		return nil, err
 	}
 
-	compServices := make([]*appsv1.ComponentService, 0)
+	services := make([]*appsv1.ComponentService, 0)
 	for podName, suffix := range pods {
 		svc := service.DeepCopy()
 		svc.Name = fmt.Sprintf("%s-%s", service.Name, suffix)
@@ -162,18 +162,18 @@ func (t *componentServiceTransformer) buildPodService(transCtx *componentTransfo
 			svc.Spec.Selector = make(map[string]string)
 		}
 		svc.Spec.Selector[constant.KBAppPodNameLabelKey] = podName
-		compServices = append(compServices, svc)
+		services = append(services, svc)
 	}
-	services, err := t.buildServices(transCtx.Component, transCtx.SynthesizeComponent, compServices)
+	serviceObjects, err := t.buildServices(transCtx.Component, transCtx.SynthesizeComponent, services)
 	if err != nil {
 		return nil, err
 	}
 	if pendingScaleIn {
 		// Return the Services to retain along with a retry, so memberLeave and the
 		// workload update can proceed while their eventual cleanup is still pending.
-		return services, intctrlutil.NewDelayedRequeueError(time.Second, "waiting for scaled-in instances to disappear before deleting pod services")
+		return serviceObjects, intctrlutil.NewDelayedRequeueError(time.Second, "waiting for scaled-in instances to disappear before deleting pod services")
 	}
-	return services, nil
+	return serviceObjects, nil
 }
 
 func (t *componentServiceTransformer) podsNameNSuffix(transCtx *componentTransformContext, runningITS, protoITS *workloadsv1.InstanceSet) (map[string]string, bool, error) {

--- a/controllers/apps/component/transformer_component_service.go
+++ b/controllers/apps/component/transformer_component_service.go
@@ -24,11 +24,13 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
@@ -40,6 +42,7 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
+	"github.com/apecloud/kubeblocks/pkg/controller/multicluster"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 )
 
@@ -77,12 +80,20 @@ func (t *componentServiceTransformer) Transform(ctx graph.TransformContext, dag 
 	}
 
 	graphCli, _ := transCtx.Client.(model.GraphClient)
+	var podNamesNSuffix map[string]string
+	var pendingScaleIn bool
 	for _, service := range synthesizeComp.ComponentServices {
 		// component controller does not handle the default headless service; the default headless service is managed by the InstanceSet.
 		if t.skipDefaultHeadlessSvc(synthesizeComp, &service) {
 			continue
 		}
-		services, err := t.buildCompService(transCtx.Component, synthesizeComp, &service, runningITS, protoITS)
+		if t.isPodService(&service) && (service.DisableAutoProvision == nil || !*service.DisableAutoProvision) && podNamesNSuffix == nil {
+			podNamesNSuffix, pendingScaleIn, err = t.podsNameNSuffix(transCtx, runningITS, protoITS)
+			if err != nil {
+				return err
+			}
+		}
+		services, err := t.buildCompService(transCtx.Component, synthesizeComp, &service, podNamesNSuffix)
 		if err != nil {
 			return err
 		}
@@ -101,6 +112,11 @@ func (t *componentServiceTransformer) Transform(ctx graph.TransformContext, dag 
 		graphCli.Delete(dag, runningServices[svc])
 	}
 
+	if pendingScaleIn {
+		// Continue the transformer chain so memberLeave and the workload update can
+		// make progress, but revisit cleanup even if no further workload event arrives.
+		return intctrlutil.NewDelayedRequeueError(time.Second, "waiting for scaled-in instances to disappear before deleting pod services")
+	}
 	return nil
 }
 
@@ -120,13 +136,13 @@ func (t *componentServiceTransformer) listOwnedServices(ctx context.Context, cli
 }
 
 func (t *componentServiceTransformer) buildCompService(comp *appsv1.Component,
-	synthesizeComp *component.SynthesizedComponent, service *appsv1.ComponentService, runningITS, protoITS *workloadsv1.InstanceSet) ([]*corev1.Service, error) {
+	synthesizeComp *component.SynthesizedComponent, service *appsv1.ComponentService, pods map[string]string) ([]*corev1.Service, error) {
 	if service.DisableAutoProvision != nil && *service.DisableAutoProvision {
 		return nil, nil
 	}
 
 	if t.isPodService(service) {
-		return t.buildPodService(comp, synthesizeComp, service, runningITS, protoITS)
+		return t.buildPodService(comp, synthesizeComp, service, pods)
 	}
 	return t.buildServices(comp, synthesizeComp, []*appsv1.ComponentService{service})
 }
@@ -136,12 +152,7 @@ func (t *componentServiceTransformer) isPodService(service *appsv1.ComponentServ
 }
 
 func (t *componentServiceTransformer) buildPodService(comp *appsv1.Component,
-	synthesizeComp *component.SynthesizedComponent, service *appsv1.ComponentService, runningITS, protoITS *workloadsv1.InstanceSet) ([]*corev1.Service, error) {
-	pods, err := t.podsNameNSuffix(synthesizeComp, runningITS, protoITS)
-	if err != nil {
-		return nil, err
-	}
-
+	synthesizeComp *component.SynthesizedComponent, service *appsv1.ComponentService, pods map[string]string) ([]*corev1.Service, error) {
 	services := make([]*appsv1.ComponentService, 0)
 	for podName, suffix := range pods {
 		svc := service.DeepCopy()
@@ -160,21 +171,53 @@ func (t *componentServiceTransformer) buildPodService(comp *appsv1.Component,
 	return t.buildServices(comp, synthesizeComp, services)
 }
 
-func (t *componentServiceTransformer) podsNameNSuffix(synthesizeComp *component.SynthesizedComponent, runningITS, protoITS *workloadsv1.InstanceSet) (map[string]string, error) {
-	podNames, err := component.GetDesiredPodNamesByITS(runningITS, protoITS)
+func (t *componentServiceTransformer) podsNameNSuffix(transCtx *componentTransformContext, runningITS, protoITS *workloadsv1.InstanceSet) (map[string]string, bool, error) {
+	desiredPodNames, err := component.GetDesiredPodNamesByITS(runningITS, protoITS)
 	if err != nil {
-		return nil, err
+		return nil, false, err
+	}
+	podNames := sets.New(desiredPodNames...)
+	// The running workload still owns replicas whose memberLeave has not completed,
+	// including replicas whose Pods are temporarily absent.
+	if runningITS != nil {
+		currentPodNames, err := component.GetCurrentPodNamesByITS(runningITS)
+		if err != nil {
+			return nil, false, err
+		}
+		podNames.Insert(currentPodNames...)
+	}
+	// Updating the InstanceSet does not synchronously remove its Pods. Keep their
+	// addresses through termination, until the Pod objects have actually disappeared.
+	podCtx := transCtx.Context
+	placement := transCtx.Component.Annotations[constant.KBAppMultiClusterPlacementKey]
+	if placement == "" && runningITS != nil {
+		placement = runningITS.Annotations[constant.KBAppMultiClusterPlacementKey]
+	}
+	if placement == "" && protoITS != nil {
+		placement = protoITS.Annotations[constant.KBAppMultiClusterPlacementKey]
+	}
+	if placement != "" {
+		podCtx = multicluster.IntoContext(podCtx, placement)
+	}
+	synthesizeComp := transCtx.SynthesizeComponent
+	instances, err := component.ListOwnedPods(podCtx, transCtx.Client,
+		synthesizeComp.Namespace, synthesizeComp.ClusterName, synthesizeComp.Name)
+	if err != nil {
+		return nil, false, err
+	}
+	for _, pod := range instances {
+		podNames.Insert(pod.Name)
 	}
 	pods := make(map[string]string)
-	prefix := fmt.Sprintf("%s-", synthesizeComp.FullCompName)
-	for _, podName := range podNames {
+	prefix := fmt.Sprintf("%s-", transCtx.SynthesizeComponent.FullCompName)
+	for podName := range podNames {
 		suffix, found := strings.CutPrefix(podName, prefix)
 		if !found || len(suffix) == 0 {
-			return nil, fmt.Errorf("invalid pod name when building pod services: %s", podName)
+			return nil, false, fmt.Errorf("invalid pod name when building pod services: %s", podName)
 		}
 		pods[podName] = suffix
 	}
-	return pods, nil
+	return pods, podNames.Len() > len(desiredPodNames), nil
 }
 
 func (t *componentServiceTransformer) buildServices(comp *appsv1.Component,

--- a/controllers/apps/component/transformer_component_service_test.go
+++ b/controllers/apps/component/transformer_component_service_test.go
@@ -273,21 +273,13 @@ var _ = Describe("component service transformer test", func() {
 			Entry("returns a subsequent build failure instead of the retry", true),
 		)
 
-		DescribeTable("precreates services before Pods exist",
-			func(currentReplicas *int32) {
-				if currentReplicas == nil {
-					transCtx.RunningWorkload = nil
-				} else {
-					transCtx.RunningWorkload.Spec.Replicas = currentReplicas
-				}
-				Expect((&componentServiceTransformer{}).Transform(transCtx, dag)).To(Succeed())
-				graphCli := transCtx.Client.(model.GraphClient)
-				Expect(graphCli.FindAll(dag, &corev1.Service{})).To(HaveLen(3))
-				Expect(graphCli.IsAction(dag, podService(2), model.ActionCreatePtr())).To(BeTrue())
-			},
-			Entry("on creation", nil),
-			Entry("on scale-out", ptr.To[int32](1)),
-		)
+		It("precreates services during scale-out before Pods exist", func() {
+			transCtx.RunningWorkload.Spec.Replicas = ptr.To[int32](1)
+			Expect((&componentServiceTransformer{}).Transform(transCtx, dag)).To(Succeed())
+			graphCli := transCtx.Client.(model.GraphClient)
+			Expect(graphCli.FindAll(dag, &corev1.Service{})).To(HaveLen(3))
+			Expect(graphCli.IsAction(dag, podService(2), model.ActionCreatePtr())).To(BeTrue())
+		})
 
 		It("retains named and offline instances by name instead of replica count", func() {
 			transCtx.SynthesizeComponent.Replicas = 1
@@ -324,47 +316,45 @@ var _ = Describe("component service transformer test", func() {
 			Expect(names).To(ConsistOf(podServiceName(2), podServiceName(5), podServiceName(8), podServiceName(11)))
 		})
 
-		DescribeTable("queries Pods in the data placement and retains their Service assistant objects", func(source string) {
+		DescribeTable("retains remote Pod services until their Pods disappear", func(componentPlacement bool) {
 			transCtx.SynthesizeComponent.Replicas = 1
 			transCtx.RunningWorkload.Spec.Replicas = ptr.To[int32](1)
-			transCtx.SynthesizeComponent.EnableInstanceAPI = ptr.To(true)
-			transCtx.SynthesizeComponent.Annotations = map[string]string{constant.KBAppMultiClusterPlacementKey: "test-context"}
-			switch source {
-			case "component":
-				transCtx.Component.Annotations = transCtx.SynthesizeComponent.Annotations
-				transCtx.RunningWorkload.Annotations = map[string]string{constant.KBAppMultiClusterPlacementKey: "old-context"}
-			case "running":
-				transCtx.RunningWorkload.Annotations = transCtx.SynthesizeComponent.Annotations
-				transCtx.SynthesizeComponent.AnnotationsInjectedToWorkload = map[string]string{constant.KBAppMultiClusterPlacementKey: "other-context"}
-			case "desired":
-				transCtx.RunningWorkload = nil
-				transCtx.SynthesizeComponent.AnnotationsInjectedToWorkload = transCtx.SynthesizeComponent.Annotations
-			case "context":
-				transCtx.Context = multicluster.IntoContext(ctx, "test-context")
+			annotations := map[string]string{constant.KBAppMultiClusterPlacementKey: "member-a"}
+			if componentPlacement {
+				transCtx.Component.Annotations = annotations
+			} else {
+				transCtx.RunningWorkload.Annotations = annotations
 			}
-			listedPods := false
-			cli := fake.NewClientBuilder().WithScheme(k8sClient.Scheme()).WithObjects(newPod("1")).
-				WithInterceptorFuncs(interceptor.Funcs{List: func(ctx context.Context, cli client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
-					if _, ok := list.(*corev1.PodList); ok {
-						placement, err := multicluster.FromContext(ctx)
-						Expect(err).NotTo(HaveOccurred())
-						Expect(placement).To(Equal("test-context"))
-						Expect(opts).To(ContainElement(multicluster.InDataContext()))
-						listedPods = true
-					}
-					return cli.List(ctx, list, opts...)
-				}}).Build()
-			transCtx.Client = model.NewGraphClient(cli)
-			Expect(controllerutil.IsDelayedRequeueError((&componentServiceTransformer{}).Transform(transCtx, dag))).To(BeTrue())
-			Expect(listedPods).To(BeTrue())
-			Expect(transCtx.SynthesizeComponent.InstanceAssistantObjects).To(ContainElement(corev1.ObjectReference{
-				Kind: "Service", Namespace: transCtx.Component.Namespace, Name: podServiceName(1),
-			}))
+			transCtx.SynthesizeComponent.EnableInstanceAPI = ptr.To(true)
+			transCtx.SynthesizeComponent.Annotations = annotations
+			remotePod := newPod("1")
+			svc1, svc2 := podService(1), podService(2)
+			control := fake.NewClientBuilder().WithScheme(k8sClient.Scheme()).WithObjects(svc1, svc2).Build()
+			memberA := fake.NewClientBuilder().WithScheme(k8sClient.Scheme()).WithObjects(remotePod).Build()
+			memberB := fake.NewClientBuilder().WithScheme(k8sClient.Scheme()).WithObjects(newPod("2")).Build()
+			cli := multicluster.NewClient(control, map[string]client.Client{"member-a": memberA, "member-b": memberB})
+			graphCli := model.NewGraphClient(cli)
+			transCtx.Client = graphCli
+			reconcile := func() error {
+				dag = newDAG(graphCli, transCtx.Component)
+				transCtx.SynthesizeComponent.InstanceAssistantObjects = nil
+				return (&componentServiceTransformer{}).Transform(transCtx, dag)
+			}
+
+			Expect(controllerutil.IsDelayedRequeueError(reconcile())).To(BeTrue())
+			Expect(graphCli.IsAction(dag, svc1, model.ActionUpdatePtr())).To(BeTrue())
+			// A Pod with matching labels in an unrelated cluster must not retain its Service.
+			Expect(graphCli.IsAction(dag, svc2, model.ActionDeletePtr())).To(BeTrue())
+			ref := corev1.ObjectReference{Kind: "Service", Namespace: svc1.Namespace, Name: svc1.Name}
+			Expect(transCtx.SynthesizeComponent.InstanceAssistantObjects).To(ContainElement(ref))
+
+			Expect(memberA.Delete(ctx, remotePod)).To(Succeed())
+			Expect(reconcile()).To(Succeed())
+			Expect(graphCli.IsAction(dag, svc1, model.ActionDeletePtr())).To(BeTrue())
+			Expect(transCtx.SynthesizeComponent.InstanceAssistantObjects).NotTo(ContainElement(ref))
 		},
-			Entry("Component placement takes precedence", "component"),
-			Entry("falls back to the running InstanceSet", "running"),
-			Entry("uses desired placement before the InstanceSet exists", "desired"),
-			Entry("preserves an existing context without placement annotations", "context"),
+			Entry("using Component placement", true),
+			Entry("using existing workload placement when the Component has none", false),
 		)
 
 		It("does not delete Services when listing Pods fails", func() {
@@ -382,24 +372,17 @@ var _ = Describe("component service transformer test", func() {
 			Expect(transCtx.Client.(model.GraphClient).FindAll(dag, &corev1.Service{})).To(BeEmpty())
 		})
 
-		DescribeTable("cleans up explicitly removed pod services even while Pods exist",
-			func(disable bool) {
-				svc := podService(1)
-				reader.Objects = append(reader.Objects, newPod("1"), svc)
-				transCtx.SynthesizeComponent.Replicas = 1
-				if disable {
-					transCtx.SynthesizeComponent.ComponentServices[0].DisableAutoProvision = truep()
-				} else {
-					transCtx.SynthesizeComponent.ComponentServices = nil
-				}
-				Expect((&componentServiceTransformer{}).Transform(transCtx, dag)).To(Succeed())
-				Expect(transCtx.Client.(model.GraphClient).IsAction(dag, svc, model.ActionDeletePtr())).To(BeTrue())
-			},
-			Entry("removed from the configuration", false),
-			Entry("auto provision disabled", true),
-		)
+		It("cleans up disabled pod services even while Pods exist", func() {
+			svc := podService(1)
+			reader.Objects = append(reader.Objects, newPod("1"), svc)
+			transCtx.SynthesizeComponent.Replicas = 1
+			transCtx.SynthesizeComponent.ComponentServices[0].DisableAutoProvision = truep()
+			Expect((&componentServiceTransformer{}).Transform(transCtx, dag)).To(Succeed())
+			Expect(transCtx.Client.(model.GraphClient).IsAction(dag, svc, model.ActionDeletePtr())).To(BeTrue())
+		})
 
 		It("provision", func() {
+			transCtx.RunningWorkload = nil
 			transformer := &componentServiceTransformer{}
 			err := transformer.Transform(transCtx, dag)
 			Expect(err).Should(BeNil())
@@ -419,6 +402,7 @@ var _ = Describe("component service transformer test", func() {
 		})
 
 		It("deletion", func() {
+			reader.Objects = append(reader.Objects, newPod("1"))
 			services := make([]client.Object, 0)
 			for i := int32(0); i < transCtx.SynthesizeComponent.Replicas; i++ {
 				services = append(services, podService(i))

--- a/controllers/apps/component/transformer_component_service_test.go
+++ b/controllers/apps/component/transformer_component_service_test.go
@@ -239,6 +239,40 @@ var _ = Describe("component service transformer test", func() {
 			Expect(graphCli.IsAction(dag, podService(2), model.ActionCreatePtr())).To(BeTrue())
 		})
 
+		DescribeTable("handles delayed requeues while building multiple services", func(invalidRole bool) {
+			transCtx.SynthesizeComponent.Replicas = 1
+			obsolete := podService(9)
+			reader.Objects = append(reader.Objects, podService(0), podService(1), podService(2), obsolete)
+			otherPodService := transCtx.SynthesizeComponent.ComponentServices[0].DeepCopy()
+			otherPodService.Name, otherPodService.ServiceName = "other", "other"
+			ordinaryService := appsv1.ComponentService{Service: appsv1.Service{Name: "client", ServiceName: "client"}}
+			if invalidRole {
+				ordinaryService.RoleSelector = "missing"
+			}
+			transCtx.SynthesizeComponent.ComponentServices = append(transCtx.SynthesizeComponent.ComponentServices,
+				*otherPodService, ordinaryService)
+
+			err := (&componentServiceTransformer{}).Transform(transCtx, dag)
+			graphCli := transCtx.Client.(model.GraphClient)
+			Expect(graphCli.IsAction(dag, podService(1), model.ActionDeletePtr())).To(BeFalse())
+			other := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+				Namespace: transCtx.Component.Namespace,
+				Name:      constant.GenerateComponentServiceName(clusterName, compName, "other-2"),
+			}}
+			Expect(graphCli.IsAction(dag, other, model.ActionCreatePtr())).To(BeTrue())
+			if invalidRole {
+				Expect(err).To(MatchError("role selector for service is not defined, service: client, role: missing"))
+				Expect(graphCli.IsAction(dag, obsolete, model.ActionDeletePtr())).To(BeFalse())
+			} else {
+				Expect(controllerutil.IsDelayedRequeueError(err)).To(BeTrue())
+				Expect(graphCli.FindAll(dag, &corev1.Service{})).To(HaveLen(8))
+				Expect(graphCli.IsAction(dag, obsolete, model.ActionDeletePtr())).To(BeTrue())
+			}
+		},
+			Entry("continues provisioning and cleanup without losing the retry", false),
+			Entry("returns a subsequent build failure instead of the retry", true),
+		)
+
 		DescribeTable("precreates services before Pods exist",
 			func(currentReplicas *int32) {
 				if currentReplicas == nil {

--- a/controllers/apps/component/transformer_component_service_test.go
+++ b/controllers/apps/component/transformer_component_service_test.go
@@ -20,10 +20,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 package component
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strings"
 
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -31,6 +33,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
 	workloadsv1 "github.com/apecloud/kubeblocks/apis/workloads/v1"
@@ -39,7 +43,11 @@ import (
 	"github.com/apecloud/kubeblocks/pkg/controller/component"
 	"github.com/apecloud/kubeblocks/pkg/controller/graph"
 	"github.com/apecloud/kubeblocks/pkg/controller/model"
+	"github.com/apecloud/kubeblocks/pkg/controller/multicluster"
 	"github.com/apecloud/kubeblocks/pkg/controllerutil"
+	kbacli "github.com/apecloud/kubeblocks/pkg/kbagent/client"
+	kbagentproto "github.com/apecloud/kubeblocks/pkg/kbagent/proto"
+	testapps "github.com/apecloud/kubeblocks/pkg/testutil/apps"
 )
 
 var _ = Describe("component service transformer test", func() {
@@ -138,6 +146,224 @@ var _ = Describe("component service transformer test", func() {
 			// set as pod service
 			transCtx.SynthesizeComponent.ComponentServices[0].PodService = truep()
 		})
+
+		newPod := func(suffix string) *corev1.Pod {
+			return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Namespace: transCtx.Component.Namespace,
+				Name:      transCtx.Component.Name + "-" + suffix,
+				Labels:    transCtx.Component.Labels,
+			}}
+		}
+
+		It("retains pod services until memberLeave succeeds and the Pod disappears", func() {
+			pod0, pod1 := newPod("0"), newPod("1")
+			svc0, svc1 := podService(0), podService(1)
+			cli := fake.NewClientBuilder().WithScheme(k8sClient.Scheme()).WithObjects(pod0, pod1, svc0, svc1).Build()
+			graphCli := model.NewGraphClient(cli)
+			transCtx.Client = graphCli
+			transCtx.EventRecorder = &capturingEventRecorder{}
+			transCtx.SynthesizeComponent.Replicas = 2
+			transCtx.SynthesizeComponent.LifecycleActions.ComponentLifecycleActions = &appsv1.ComponentLifecycleActions{
+				MemberLeave: &appsv1.Action{Exec: &appsv1.ExecAction{Image: "test-image"}},
+			}
+			var err error
+			transCtx.RunningWorkload, err = component.BuildInstanceSet(transCtx.SynthesizeComponent, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(component.StatusReplicasStatus(transCtx.RunningWorkload, []string{pod0.Name, pod1.Name}, true, false)).To(Succeed())
+			transCtx.SynthesizeComponent.Replicas = 1
+
+			allowLeave := false
+			testapps.MockKBAgentClient(func(recorder *kbacli.MockClientMockRecorder) {
+				recorder.Action(gomock.Any(), gomock.Any()).Times(2).DoAndReturn(func(_ context.Context, req kbagentproto.ActionRequest) (kbagentproto.ActionResponse, error) {
+					Expect(req.Action).To(Equal("memberLeave"))
+					Expect(req.Parameters["KB_LEAVE_MEMBER_POD_NAME"]).To(Equal(pod1.Name))
+					if !allowLeave {
+						return kbagentproto.ActionResponse{Error: kbagentproto.Error2Type(kbagentproto.ErrFailed), Message: "leave blocked"}, nil
+					}
+					return kbagentproto.ActionResponse{}, nil
+				})
+			})
+			DeferCleanup(func() { kbacli.SetMockClient(nil, nil) })
+			chain := graph.TransformerChain{&componentServiceTransformer{}, &componentWorkloadTransformer{Client: cli}}
+			reconcile := func() error {
+				dag = newDAG(graphCli, transCtx.Component)
+				return chain.ApplyTo(transCtx, dag)
+			}
+
+			By("executing memberLeave despite deferred Service cleanup, and retaining the workload on failure")
+			err = reconcile()
+			Expect(controllerutil.IsRequeueError(err)).To(BeTrue())
+			Expect(err.Error()).To(ContainSubstring("leave blocked"))
+			Expect(graphCli.IsAction(dag, svc1, model.ActionDeletePtr())).To(BeFalse())
+			Expect(graphCli.FindAll(dag, &corev1.Service{})).To(HaveLen(2))
+			Expect(graphCli.FindAll(dag, &workloadsv1.InstanceSet{})).To(BeEmpty())
+
+			By("allowing the workload update after memberLeave succeeds")
+			allowLeave = true
+			Expect(controllerutil.IsDelayedRequeueError(reconcile())).To(BeTrue())
+			Expect(graphCli.IsAction(dag, svc1, model.ActionDeletePtr())).To(BeFalse())
+			workloads := graphCli.FindAll(dag, &workloadsv1.InstanceSet{})
+			Expect(workloads).To(HaveLen(1))
+			updated := workloads[0].(*workloadsv1.InstanceSet)
+			Expect(*updated.Spec.Replicas).To(Equal(int32(1)))
+			Expect(graphCli.IsAction(dag, updated, model.ActionUpdatePtr())).To(BeTrue())
+			transCtx.RunningWorkload = updated
+
+			By("retaining the address after the ITS update while the Pod still exists")
+			Expect(controllerutil.IsDelayedRequeueError(reconcile())).To(BeTrue())
+			Expect(graphCli.IsAction(dag, svc1, model.ActionDeletePtr())).To(BeFalse())
+
+			By("retaining the address while the Pod is terminating")
+			Expect(cli.Get(ctx, client.ObjectKeyFromObject(pod1), pod1)).To(Succeed())
+			pod1.Finalizers = []string{"test.kubeblocks.io/hold"}
+			Expect(cli.Update(ctx, pod1)).To(Succeed())
+			Expect(cli.Delete(ctx, pod1)).To(Succeed())
+			Expect(controllerutil.IsDelayedRequeueError(reconcile())).To(BeTrue())
+			Expect(graphCli.IsAction(dag, svc1, model.ActionDeletePtr())).To(BeFalse())
+
+			By("cleaning up only after the Pod object disappears")
+			Expect(cli.Get(ctx, client.ObjectKeyFromObject(pod1), pod1)).To(Succeed())
+			pod1.Finalizers = nil
+			Expect(cli.Update(ctx, pod1)).To(Succeed())
+			Expect(reconcile()).To(Succeed())
+			Expect(graphCli.IsAction(dag, svc1, model.ActionDeletePtr())).To(BeTrue())
+			Expect(graphCli.IsAction(dag, svc0, model.ActionDeletePtr())).To(BeFalse())
+		})
+
+		It("recreates services for current replicas even when their Pods are temporarily absent", func() {
+			transCtx.SynthesizeComponent.Replicas = 1
+			err := (&componentServiceTransformer{}).Transform(transCtx, dag)
+			Expect(controllerutil.IsDelayedRequeueError(err)).To(BeTrue())
+			graphCli := transCtx.Client.(model.GraphClient)
+			Expect(graphCli.FindAll(dag, &corev1.Service{})).To(HaveLen(3))
+			Expect(graphCli.IsAction(dag, podService(2), model.ActionCreatePtr())).To(BeTrue())
+		})
+
+		DescribeTable("precreates services before Pods exist",
+			func(currentReplicas *int32) {
+				if currentReplicas == nil {
+					transCtx.RunningWorkload = nil
+				} else {
+					transCtx.RunningWorkload.Spec.Replicas = currentReplicas
+				}
+				Expect((&componentServiceTransformer{}).Transform(transCtx, dag)).To(Succeed())
+				graphCli := transCtx.Client.(model.GraphClient)
+				Expect(graphCli.FindAll(dag, &corev1.Service{})).To(HaveLen(3))
+				Expect(graphCli.IsAction(dag, podService(2), model.ActionCreatePtr())).To(BeTrue())
+			},
+			Entry("on creation", nil),
+			Entry("on scale-out", ptr.To[int32](1)),
+		)
+
+		It("retains named and offline instances by name instead of replica count", func() {
+			transCtx.SynthesizeComponent.Replicas = 1
+			transCtx.SynthesizeComponent.Instances = []appsv1.InstanceTemplate{{Name: "reader", Replicas: ptr.To[int32](1)}}
+			transCtx.RunningWorkload.Spec.Instances = []workloadsv1.InstanceTemplate{{Name: "reader", Replicas: ptr.To[int32](2)}}
+			transCtx.RunningWorkload.Spec.Replicas = ptr.To[int32](2)
+			transCtx.SynthesizeComponent.OfflineInstances = []string{newPod("reader-0").Name}
+			reader.Objects = append(reader.Objects, newPod("reader-7"))
+			err := (&componentServiceTransformer{}).Transform(transCtx, dag)
+			Expect(controllerutil.IsDelayedRequeueError(err)).To(BeTrue())
+			graphCli := transCtx.Client.(model.GraphClient)
+			services := graphCli.FindAll(dag, &corev1.Service{})
+			selectors := make([]string, 0, len(services))
+			for _, obj := range services {
+				svc := obj.(*corev1.Service)
+				selectors = append(selectors, svc.Spec.Selector[constant.KBAppPodNameLabelKey])
+			}
+			Expect(selectors).To(ConsistOf(newPod("reader-0").Name, newPod("reader-1").Name, newPod("reader-7").Name))
+		})
+
+		It("retains services across changes to non-contiguous ordinals", func() {
+			transCtx.SynthesizeComponent.Replicas = 2
+			transCtx.SynthesizeComponent.Ordinals = appsv1.Ordinals{Discrete: []int32{2, 8}}
+			transCtx.RunningWorkload.Spec.Replicas = ptr.To[int32](2)
+			transCtx.RunningWorkload.Spec.Ordinals = appsv1.Ordinals{Discrete: []int32{2, 5}}
+			reader.Objects = append(reader.Objects, newPod("11"))
+			Expect(controllerutil.IsDelayedRequeueError((&componentServiceTransformer{}).Transform(transCtx, dag))).To(BeTrue())
+			graphCli := transCtx.Client.(model.GraphClient)
+			services := graphCli.FindAll(dag, &corev1.Service{})
+			names := make([]string, 0, len(services))
+			for _, svc := range services {
+				names = append(names, svc.GetName())
+			}
+			Expect(names).To(ConsistOf(podServiceName(2), podServiceName(5), podServiceName(8), podServiceName(11)))
+		})
+
+		DescribeTable("queries Pods in the data placement and retains their Service assistant objects", func(source string) {
+			transCtx.SynthesizeComponent.Replicas = 1
+			transCtx.RunningWorkload.Spec.Replicas = ptr.To[int32](1)
+			transCtx.SynthesizeComponent.EnableInstanceAPI = ptr.To(true)
+			transCtx.SynthesizeComponent.Annotations = map[string]string{constant.KBAppMultiClusterPlacementKey: "test-context"}
+			switch source {
+			case "component":
+				transCtx.Component.Annotations = transCtx.SynthesizeComponent.Annotations
+				transCtx.RunningWorkload.Annotations = map[string]string{constant.KBAppMultiClusterPlacementKey: "old-context"}
+			case "running":
+				transCtx.RunningWorkload.Annotations = transCtx.SynthesizeComponent.Annotations
+				transCtx.SynthesizeComponent.AnnotationsInjectedToWorkload = map[string]string{constant.KBAppMultiClusterPlacementKey: "other-context"}
+			case "desired":
+				transCtx.RunningWorkload = nil
+				transCtx.SynthesizeComponent.AnnotationsInjectedToWorkload = transCtx.SynthesizeComponent.Annotations
+			case "context":
+				transCtx.Context = multicluster.IntoContext(ctx, "test-context")
+			}
+			listedPods := false
+			cli := fake.NewClientBuilder().WithScheme(k8sClient.Scheme()).WithObjects(newPod("1")).
+				WithInterceptorFuncs(interceptor.Funcs{List: func(ctx context.Context, cli client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+					if _, ok := list.(*corev1.PodList); ok {
+						placement, err := multicluster.FromContext(ctx)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(placement).To(Equal("test-context"))
+						Expect(opts).To(ContainElement(multicluster.InDataContext()))
+						listedPods = true
+					}
+					return cli.List(ctx, list, opts...)
+				}}).Build()
+			transCtx.Client = model.NewGraphClient(cli)
+			Expect(controllerutil.IsDelayedRequeueError((&componentServiceTransformer{}).Transform(transCtx, dag))).To(BeTrue())
+			Expect(listedPods).To(BeTrue())
+			Expect(transCtx.SynthesizeComponent.InstanceAssistantObjects).To(ContainElement(corev1.ObjectReference{
+				Kind: "Service", Namespace: transCtx.Component.Namespace, Name: podServiceName(1),
+			}))
+		},
+			Entry("Component placement takes precedence", "component"),
+			Entry("falls back to the running InstanceSet", "running"),
+			Entry("uses desired placement before the InstanceSet exists", "desired"),
+			Entry("preserves an existing context without placement annotations", "context"),
+		)
+
+		It("does not delete Services when listing Pods fails", func() {
+			cli := fake.NewClientBuilder().WithScheme(k8sClient.Scheme()).WithObjects(podService(1)).
+				WithInterceptorFuncs(interceptor.Funcs{List: func(ctx context.Context, cli client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+					if _, ok := list.(*corev1.PodList); ok {
+						return fmt.Errorf("pod list unavailable")
+					}
+					return cli.List(ctx, list, opts...)
+				}}).Build()
+			transCtx.Client = model.NewGraphClient(cli)
+			transCtx.SynthesizeComponent.Replicas = 1
+			transCtx.RunningWorkload.Spec.Replicas = ptr.To[int32](1)
+			Expect((&componentServiceTransformer{}).Transform(transCtx, dag)).To(MatchError("pod list unavailable"))
+			Expect(transCtx.Client.(model.GraphClient).FindAll(dag, &corev1.Service{})).To(BeEmpty())
+		})
+
+		DescribeTable("cleans up explicitly removed pod services even while Pods exist",
+			func(disable bool) {
+				svc := podService(1)
+				reader.Objects = append(reader.Objects, newPod("1"), svc)
+				transCtx.SynthesizeComponent.Replicas = 1
+				if disable {
+					transCtx.SynthesizeComponent.ComponentServices[0].DisableAutoProvision = truep()
+				} else {
+					transCtx.SynthesizeComponent.ComponentServices = nil
+				}
+				Expect((&componentServiceTransformer{}).Transform(transCtx, dag)).To(Succeed())
+				Expect(transCtx.Client.(model.GraphClient).IsAction(dag, svc, model.ActionDeletePtr())).To(BeTrue())
+			},
+			Entry("removed from the configuration", false),
+			Entry("auto provision disabled", true),
+		)
 
 		It("provision", func() {
 			transformer := &componentServiceTransformer{}

--- a/pkg/controller/component/utils.go
+++ b/pkg/controller/component/utils.go
@@ -45,6 +45,31 @@ func inDataContext() *multicluster.ClientOption {
 	return multicluster.InDataContext()
 }
 
+func dataContextOf(ctx context.Context, objects ...client.Object) context.Context {
+	for _, obj := range objects {
+		if isNilObject(obj) || obj.GetAnnotations() == nil {
+			continue
+		}
+		if placement := obj.GetAnnotations()[constant.KBAppMultiClusterPlacementKey]; placement != "" {
+			return multicluster.IntoContext(ctx, placement)
+		}
+	}
+	return ctx
+}
+
+func isNilObject(obj client.Object) bool {
+	if obj == nil {
+		return true
+	}
+	v := reflect.ValueOf(obj)
+	switch v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return v.IsNil()
+	default:
+		return false
+	}
+}
+
 func ValidateDefNameRegexp(defNamePattern string) error {
 	_, err := regexp.Compile(defNamePattern)
 	return err

--- a/pkg/controller/component/workload_utils.go
+++ b/pkg/controller/component/workload_utils.go
@@ -44,6 +44,21 @@ func ListOwnedPods(ctx context.Context, cli client.Reader, namespace, clusterNam
 	return listPods(ctx, cli, namespace, clusterName, compName, nil, opts...)
 }
 
+// ListOwnedInstances returns the pods that currently represent a Component's instances.
+func ListOwnedInstances(ctx context.Context, cli client.Reader, comp *appsv1.Component,
+	objects ...client.Object) ([]*corev1.Pod, error) {
+	clusterName, err := GetClusterName(comp)
+	if err != nil {
+		return nil, err
+	}
+	compName, err := getCompLabelValue(comp, constant.KBAppComponentLabelKey)
+	if err != nil {
+		return nil, err
+	}
+	objects = append([]client.Object{comp}, objects...)
+	return ListOwnedPods(dataContextOf(ctx, objects...), cli, comp.Namespace, clusterName, compName)
+}
+
 func ListOwnedPodsWithRole(ctx context.Context, cli client.Reader, namespace, clusterName, compName, role string,
 	opts ...client.ListOption) ([]*corev1.Pod, error) {
 	roleLabel := map[string]string{constant.RoleLabelKey: role}


### PR DESCRIPTION
Backport of #10869 to `release-1.1`.

Scale-in could delete a member's per-Pod Service while `memberLeave` was still failing and the InstanceSet retained the Pod. Keep Services for desired instances, instances in the running InstanceSet spec, and Pods that still exist, including terminating Pods. Delete a scaled-in instance's Service only after it leaves all three sets.

`buildPodService` returns the Service objects together with a delayed requeue while cleanup is pending. `buildCompService` forwards the result and `Transform` handles the error generically, allowing the workload transformer to complete the leave action and scale in.

Backport main's `ListOwnedInstances` and its placement-context helper into the shared Component package, using the existing 1.1 label accessor and `ListOwnedPods` implementation. This keeps the Service transformer identical to main and confines placement selection to the Pod query. Initializing placement globally in the Component controller would also affect existing queries for cross-Component Service references.

Validation:
- Same behavior tests as #10869: failed/successful `memberLeave`, InstanceSet updates, Pod termination/deletion, provisioning/scale-out, instance naming, query failures, explicit Service removal/disablement, and multiple-Service delayed/fatal error handling.
- Real multicluster routing with fake cluster clients verifies Component placement and existing-workload fallback, unrelated-cluster isolation, eventual Service cleanup, and assistant-object registration/removal.
- Passed `scripts/codex-go-test.sh ./controllers/apps/component ./pkg/controller/component -count=1`, changed-code lint against `origin/release-1.1` for both packages, and `git diff --check`.

Fixes #10865
