### PR TITLE
feat(helm): configure aliyun ESSD performance level

### DIFF
--- a/deploy/helm/templates/storageclass.yaml
+++ b/deploy/helm/templates/storageclass.yaml
@@ -45,6 +45,9 @@ parameters:
   ## parameters references: https://github.com/kubernetes-sigs/alibaba-cloud-csi-driver/blob/master/docs/disk.md
   fstype: {{ .Values.storageClass.provider.aliyun.fsType | default "xfs" }}
   type: {{ .Values.storageClass.provider.aliyun.volumeType }}
+  {{- with .Values.storageClass.provider.aliyun.performanceLevel }}
+  performanceLevel: {{ . | quote }}
+  {{- end }}
 provisioner: diskplugin.csi.alibabacloud.com
 reclaimPolicy: {{ .Values.storageClass.reclaimPolicy | default "Delete" }}
 volumeBindingMode: WaitForFirstConsumer

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -521,6 +521,9 @@ storageClass:
     aliyun:
       volumeType: cloud_essd
       fsType: xfs
+      ## @param storageClass.provider.aliyun.performanceLevel -- Specifies the performance level for Alibaba Cloud ESSD volumes.
+      ## Valid options: PL0, PL1, PL2, PL3. Leave empty to use the CSI driver's default.
+      performanceLevel: ""
     azure:
       volumeType: managed
       fsType: xfs

--- a/test/helm/storageclass_test.go
+++ b/test/helm/storageclass_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helm
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func storageClassParameters(t *testing.T, objects []map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	for _, object := range objects {
+		name, _, _ := unstructured.NestedString(object, "metadata", "name")
+		if object["kind"] != "StorageClass" || name != "kb-default-sc" {
+			continue
+		}
+		parameters, found, err := unstructured.NestedMap(object, "parameters")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !found {
+			t.Fatal("parameters not found in default StorageClass")
+		}
+		return parameters
+	}
+	t.Fatal("default StorageClass not found")
+	return nil
+}
+
+func TestAliyunStorageClassPerformanceLevel(t *testing.T) {
+	parameters := storageClassParameters(t, renderChart(t, "provider=aliyun"))
+	if _, found := parameters["performanceLevel"]; found {
+		t.Fatal("performanceLevel must be omitted by default")
+	}
+
+	parameters = storageClassParameters(t, renderChart(t,
+		"provider=aliyun",
+		"storageClass.provider.aliyun.performanceLevel=PL0",
+	))
+	if parameters["performanceLevel"] != "PL0" {
+		t.Fatalf("performanceLevel = %q, want PL0", parameters["performanceLevel"])
+	}
+}


### PR DESCRIPTION
## What this PR does

Adds an optional `storageClass.provider.aliyun.performanceLevel` Helm value and renders it into the Alibaba Cloud StorageClass parameters when configured.

The value is empty by default, so existing installations keep the Alibaba Cloud CSI driver's current default behavior. Operators can opt into PL0 with:

```yaml
storageClass:
  provider:
    aliyun:
      performanceLevel: PL0
```

This also adds a chart-rendering test that verifies:

- `performanceLevel` is omitted by default.
- setting the value to `PL0` renders `parameters.performanceLevel: PL0`.

Closes #10874.

## Validation

- `helm lint deploy/helm --set-string dataProtection.encryptionKey=chart-render-test-key --set provider=aliyun --set storageClass.provider.aliyun.performanceLevel=PL0`
- `GOPROXY=https://goproxy.cn,direct go test ./test/helm`
- `git diff --check`
