### PR TITLE
chore(ops): separate horizontal scaling execution paths

### DIFF
--- a/pkg/operations/horizontal_scaling.go
+++ b/pkg/operations/horizontal_scaling.go
@@ -22,25 +22,16 @@ package operations
 import (
 	"fmt"
 	"slices"
-	"strconv"
-	"strings"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
-	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
 	opsv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
 	"github.com/apecloud/kubeblocks/pkg/constant"
-	intctrlcomp "github.com/apecloud/kubeblocks/pkg/controller/component"
-	"github.com/apecloud/kubeblocks/pkg/controller/model"
-	"github.com/apecloud/kubeblocks/pkg/controller/plan"
 	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
 )
 
@@ -119,31 +110,18 @@ func (hs horizontalScalingOpsHandler) Action(reqCtx intctrlutil.RequestCtx, cli 
 		if horizontalScaling.Shards != nil {
 			return nil
 		}
-		lastCompConfiguration := opsRes.OpsRequest.Status.LastConfiguration.Components[obj.GetComponentName()]
-		if err := hs.validateHorizontalScaling(opsRes, lastCompConfiguration, horizontalScaling); err != nil {
-			return err
-		}
-		replicas, instances, offlineInstances, err := hs.getExpectedCompValues(opsRes, compSpec.DeepCopy(),
-			lastCompConfiguration, horizontalScaling)
+		expected, err := hs.prepareReplicaScaling(opsRes, compSpec, horizontalScaling)
 		if err != nil {
 			return err
 		}
-		var insReplicas int32
-		for _, v := range instances {
-			insReplicas += v.GetReplicas()
-		}
-		if insReplicas > replicas {
-			errMsg := fmt.Sprintf(`the total number of replicas for the instance template cannot be greater than the number of replicas for component "%s" after horizontally scaling`,
-				horizontalScaling.ComponentName)
-			return intctrlutil.NewFatalError(errMsg)
-		}
 		if horizontalScaling.ScaleOut != nil && horizontalScaling.ScaleOut.FromBackup != nil {
-			// Wait for the persistent volume to be restored from backup before proceeding.
+			// The backup path submits this configuration from reconcileBackupScaling
+			// only after all persistent volumes have been restored.
 			return nil
 		}
-		compSpec.Replicas = replicas
-		compSpec.Instances = instances
-		compSpec.OfflineInstances = offlineInstances
+		compSpec.Replicas = expected.Replicas
+		compSpec.Instances = expected.Instances
+		compSpec.OfflineInstances = expected.OfflineInstances
 		return nil
 	}); err != nil {
 		return err
@@ -166,184 +144,62 @@ func (hs horizontalScalingOpsHandler) ReconcileAction(reqCtx intctrlutil.Request
 			// horizontal scaling for shard count.
 			return handleComponentProgressForScalingShards(reqCtx, cli, opsRes, pgRes, compStatus)
 		}
-		var err error
-		lastCompConfiguration := opsRes.OpsRequest.Status.LastConfiguration.Components[pgRes.compOps.GetComponentName()]
-		clusterComponentSpec := pgRes.clusterComponent.DeepCopy()
 		if horizontalScaling.ScaleOut != nil && horizontalScaling.ScaleOut.FromBackup != nil {
-			if err := hs.restoreDataFromBackup(reqCtx, cli, opsRes, pgRes, clusterComponentSpec, horizontalScaling, lastCompConfiguration, compStatus); err != nil {
-				return 0, 0, err
-			}
+			return hs.reconcileBackupScaling(reqCtx, cli, opsRes, pgRes, compStatus)
 		}
-		pgRes.createdPodSet, pgRes.deletedPodSet, err = hs.getCreateAndDeletePodSet(opsRes, lastCompConfiguration, *clusterComponentSpec, horizontalScaling, pgRes.fullComponentName)
-		if err != nil {
-			return 0, 0, err
-		}
-		return handleComponentProgressForScalingReplicas(reqCtx, cli, opsRes, pgRes, compStatus)
+		return hs.reconcileReplicaScaling(reqCtx, cli, opsRes, pgRes, pgRes.clusterComponent.DeepCopy(), compStatus)
 	}
 	compOpsHelper := newComponentOpsHelper(opsRes.OpsRequest.Spec.HorizontalScalingList)
 	return compOpsHelper.reconcileActionWithComponentOps(reqCtx, cli, opsRes, "", handleComponentProgress)
 }
 
-func (hs horizontalScalingOpsHandler) getBackupObj(reqCtx intctrlutil.RequestCtx,
-	cli client.Client,
-	opsRes *OpsResource,
-	fromBackup opsv1alpha1.FromBackup) (*dpv1alpha1.Backup, error) {
-	backupNamespace := opsRes.Cluster.Namespace
-	if fromBackup.Namespace != "" {
-		backupNamespace = fromBackup.Namespace
-	}
-	backupObj := &dpv1alpha1.Backup{}
-	if err := cli.Get(reqCtx.Ctx, client.ObjectKey{Namespace: backupNamespace, Name: fromBackup.Name}, backupObj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, intctrlutil.NewFatalError(fmt.Sprintf("backup %s not found", fromBackup.Name))
-		}
+// prepareReplicaScaling validates and computes the target configuration for both
+// ordinary and backup requests. Each path decides when to submit it.
+func (hs horizontalScalingOpsHandler) prepareReplicaScaling(opsRes *OpsResource,
+	compSpec *appsv1.ClusterComponentSpec,
+	horizontalScaling opsv1alpha1.HorizontalScaling) (*appsv1.ClusterComponentSpec, error) {
+	lastCompConfiguration := opsRes.OpsRequest.Status.LastConfiguration.Components[horizontalScaling.ComponentName]
+	if err := hs.validateHorizontalScaling(opsRes, lastCompConfiguration, horizontalScaling); err != nil {
 		return nil, err
 	}
-	if backupObj.Status.Phase != dpv1alpha1.BackupPhaseCompleted {
-		return nil, intctrlutil.NewFatalError(fmt.Sprintf("backup %s phase is not completed", fromBackup.Name))
-	}
-	return backupObj, nil
-}
-
-func (hs horizontalScalingOpsHandler) createRestore(reqCtx intctrlutil.RequestCtx,
-	cli client.Client,
-	opsRes *OpsResource,
-	synthesizedComponent *intctrlcomp.SynthesizedComponent,
-	restoreMGR *plan.RestoreManager,
-	compSpecDeepyCopy *appsv1.ClusterComponentSpec,
-	backupObj *dpv1alpha1.Backup,
-	templateName string) error {
-	getTemplate := func(templateName string) *appsv1.InstanceTemplate {
-		if templateName == "" {
-			return nil
-		}
-		for _, template := range compSpecDeepyCopy.Instances {
-			if template.Name == templateName {
-				return &template
-			}
-		}
-		return nil
-	}
-	// create restore
-	restore, err := restoreMGR.BuildPrepareDataRestoreForPod(synthesizedComponent, backupObj, getTemplate(templateName))
+	expected := compSpec.DeepCopy()
+	replicas, instances, offlineInstances, err := hs.getExpectedCompValues(opsRes, expected,
+		lastCompConfiguration, horizontalScaling)
 	if err != nil {
-		if intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeRestoreFailed) {
-			return intctrlutil.NewFatalError(err.Error())
-		}
-		return err
+		return nil, err
 	}
-	if restore == nil {
-		return intctrlutil.NewFatalError(fmt.Sprintf("scale-out from backup %s/%s is not supported because backup method %q has no target volumes matching component %q",
-			backupObj.Namespace, backupObj.Name, backupObj.Status.BackupMethod.Name, synthesizedComponent.Name))
+	var insReplicas int32
+	for _, v := range instances {
+		insReplicas += v.GetReplicas()
 	}
-	scheme, _ := opsv1alpha1.SchemeBuilder.Build()
-	if err := intctrlutil.SetOwnership(opsRes.OpsRequest, restore, scheme, ""); err != nil {
-		return err
+	if insReplicas > replicas {
+		errMsg := fmt.Sprintf(`the total number of replicas for the instance template cannot be greater than the number of replicas for component "%s" after horizontally scaling`,
+			horizontalScaling.ComponentName)
+		return nil, intctrlutil.NewFatalError(errMsg)
 	}
-	if err := cli.Create(reqCtx.Ctx, restore); err != nil {
-		return err
-	}
-	reqCtx.Recorder.Eventf(opsRes.OpsRequest, corev1.EventTypeNormal, "RestoreCreated", "Restore %s created", restore.Name)
-	return nil
+	expected.Replicas = replicas
+	expected.Instances = instances
+	expected.OfflineInstances = offlineInstances
+	return expected, nil
 }
 
-func (hs horizontalScalingOpsHandler) restoreDataFromBackup(reqCtx intctrlutil.RequestCtx,
+// reconcileReplicaScaling determines the affected instances and checks their
+// actual progress. Backup scaling shares this step after preparing its local spec.
+func (hs horizontalScalingOpsHandler) reconcileReplicaScaling(reqCtx intctrlutil.RequestCtx,
 	cli client.Client,
 	opsRes *OpsResource,
 	pgRes *progressResource,
-	compSpecDeepyCopy *appsv1.ClusterComponentSpec,
-	horizontalScaling opsv1alpha1.HorizontalScaling,
-	lastCompConfiguration opsv1alpha1.LastComponentConfiguration,
-	compStatus *opsv1alpha1.OpsRequestComponentStatus) error {
-	restoreCompletedMsg := "Restore Data Completed"
-	// check if restore completed
-	if compStatus.Message == restoreCompletedMsg {
-		return nil
-	}
-	// get and check backup
-	fromBackup := horizontalScaling.ScaleOut.FromBackup
-	backupObj, err := hs.getBackupObj(reqCtx, cli, opsRes, *fromBackup)
+	clusterComponentSpec *appsv1.ClusterComponentSpec,
+	compStatus *opsv1alpha1.OpsRequestComponentStatus) (int32, int32, error) {
+	horizontalScaling := pgRes.compOps.(opsv1alpha1.HorizontalScaling)
+	lastCompConfiguration := opsRes.OpsRequest.Status.LastConfiguration.Components[horizontalScaling.ComponentName]
+	var err error
+	pgRes.createdPodSet, pgRes.deletedPodSet, err = hs.getCreateAndDeletePodSet(opsRes, lastCompConfiguration,
+		*clusterComponentSpec, horizontalScaling, pgRes.fullComponentName)
 	if err != nil {
-		return err
+		return 0, 0, err
 	}
-	replicas, instances, offlineInstances, err := hs.getExpectedCompValues(opsRes, compSpecDeepyCopy,
-		lastCompConfiguration, horizontalScaling)
-	if err != nil {
-		return err
-	}
-	compSpecDeepyCopy.Replicas = replicas
-	compSpecDeepyCopy.Instances = instances
-	compSpecDeepyCopy.OfflineInstances = offlineInstances
-	createdPodSet, _, err := hs.getCreateAndDeletePodSet(opsRes, lastCompConfiguration, *compSpecDeepyCopy, horizontalScaling, pgRes.fullComponentName)
-	if err != nil {
-		return err
-	}
-	comp, compDef, err := intctrlcomp.GetCompNCompDefByName(reqCtx.Ctx, cli, opsRes.Cluster.Namespace, constant.GenerateClusterComponentName(opsRes.Cluster.Name, pgRes.fullComponentName))
-	if err != nil {
-		return err
-	}
-	synthesizedComponent, err := intctrlcomp.BuildSynthesizedComponent(reqCtx.Ctx, cli, compDef, comp)
-	if err != nil {
-		return err
-	}
-	allRestoreCompleted := true
-	for podName, templateName := range createdPodSet {
-		idx := strings.LastIndex(podName, "-")
-		podIndex := podName[idx+1:]
-		podIndexInt, _ := strconv.ParseInt(podIndex, 10, 32)
-		restoreMGR := plan.NewRestoreManager(reqCtx.Ctx, cli, opsRes.Cluster, model.GetScheme(), map[string]string{
-			constant.OpsRequestNameLabelKey: opsRes.OpsRequest.Name,
-			constant.AppInstanceLabelKey:    opsRes.Cluster.Name,
-			constant.KBAppComponentLabelKey: pgRes.compOps.GetComponentName(),
-		}, 1, int32(podIndexInt))
-		restoreMGR.RestoreTime = fromBackup.RestorePointInTime
-		restoreMGR.SetRestoreEnv(fromBackup.RestoreEnv)
-		restoreMGR.RestoreNamePrefix = string(opsRes.OpsRequest.UID[:8])
-		restoreMGR.SourceTargetName = fromBackup.SourceTargetName
-		// check restore status
-		restoreMeta := restoreMGR.GetRestoreObjectMeta(synthesizedComponent, dpv1alpha1.PrepareData, templateName)
-		restore := &dpv1alpha1.Restore{}
-		if err := cli.Get(reqCtx.Ctx, types.NamespacedName{Namespace: opsRes.Cluster.Namespace, Name: restoreMeta.Name}, restore); err != nil {
-			if apierrors.IsNotFound(err) {
-				allRestoreCompleted = false
-				if err = hs.createRestore(reqCtx, cli, opsRes, synthesizedComponent, restoreMGR, compSpecDeepyCopy, backupObj, templateName); err != nil {
-					return err
-				}
-				continue
-			}
-			return err
-		}
-		if restore.Status.Phase == dpv1alpha1.RestorePhaseFailed {
-			return intctrlutil.NewFatalError(fmt.Sprintf("restore for horizontalScaling failed: you can describe the restore resource \"%s\"", restore.Name))
-		}
-		if restore.Status.Phase != dpv1alpha1.RestorePhaseCompleted {
-			allRestoreCompleted = false
-		}
-	}
-	compStatus.Message = "Restore Data In Progress"
-	if allRestoreCompleted {
-		if err := hs.scaleOutComponentAfterRestoreData(reqCtx, cli, opsRes, compSpecDeepyCopy); err != nil {
-			return err
-		}
-		// set restore completed message
-		compStatus.Message = restoreCompletedMsg
-	}
-	return nil
-}
-
-func (hs horizontalScalingOpsHandler) scaleOutComponentAfterRestoreData(reqCtx intctrlutil.RequestCtx,
-	cli client.Client,
-	opsRes *OpsResource,
-	compSpecDeepyCopy *appsv1.ClusterComponentSpec) error {
-	for i := range opsRes.Cluster.Spec.ComponentSpecs {
-		compSpec := &opsRes.Cluster.Spec.ComponentSpecs[i]
-		if compSpec.Name == compSpecDeepyCopy.Name {
-			compSpec.Replicas = compSpecDeepyCopy.Replicas
-			compSpec.OfflineInstances = compSpecDeepyCopy.OfflineInstances
-			compSpec.Instances = compSpecDeepyCopy.Instances
-		}
-	}
-	return cli.Update(reqCtx.Ctx, opsRes.Cluster)
+	return handleComponentProgressForScalingReplicas(reqCtx, cli, opsRes, pgRes, compStatus)
 }
 
 // SaveLastConfiguration records last configuration to the OpsRequest.status.lastConfiguration

--- a/pkg/operations/horizontal_scaling.go
+++ b/pkg/operations/horizontal_scaling.go
@@ -110,7 +110,7 @@ func (hs horizontalScalingOpsHandler) Action(reqCtx intctrlutil.RequestCtx, cli 
 		if horizontalScaling.Shards != nil {
 			return nil
 		}
-		expected, err := hs.prepareReplicaScaling(opsRes, compSpec, horizontalScaling)
+		replicas, instances, offlineInstances, err := hs.prepareReplicaScaling(opsRes, horizontalScaling)
 		if err != nil {
 			return err
 		}
@@ -119,9 +119,9 @@ func (hs horizontalScalingOpsHandler) Action(reqCtx intctrlutil.RequestCtx, cli 
 			// only after all persistent volumes have been restored.
 			return nil
 		}
-		compSpec.Replicas = expected.Replicas
-		compSpec.Instances = expected.Instances
-		compSpec.OfflineInstances = expected.OfflineInstances
+		compSpec.Replicas = replicas
+		compSpec.Instances = instances
+		compSpec.OfflineInstances = offlineInstances
 		return nil
 	}); err != nil {
 		return err
@@ -147,7 +147,10 @@ func (hs horizontalScalingOpsHandler) ReconcileAction(reqCtx intctrlutil.Request
 		if horizontalScaling.ScaleOut != nil && horizontalScaling.ScaleOut.FromBackup != nil {
 			return hs.reconcileBackupScaling(reqCtx, cli, opsRes, pgRes, compStatus)
 		}
-		return hs.reconcileReplicaScaling(reqCtx, cli, opsRes, pgRes, pgRes.clusterComponent.DeepCopy(), compStatus)
+		if err := hs.setReplicaScalingParticipants(opsRes, pgRes); err != nil {
+			return 0, 0, err
+		}
+		return handleComponentProgressForScalingReplicas(reqCtx, cli, opsRes, pgRes, compStatus)
 	}
 	compOpsHelper := newComponentOpsHelper(opsRes.OpsRequest.Spec.HorizontalScalingList)
 	return compOpsHelper.reconcileActionWithComponentOps(reqCtx, cli, opsRes, "", handleComponentProgress)
@@ -156,17 +159,15 @@ func (hs horizontalScalingOpsHandler) ReconcileAction(reqCtx intctrlutil.Request
 // prepareReplicaScaling validates and computes the target configuration for both
 // ordinary and backup requests. Each path decides when to submit it.
 func (hs horizontalScalingOpsHandler) prepareReplicaScaling(opsRes *OpsResource,
-	compSpec *appsv1.ClusterComponentSpec,
-	horizontalScaling opsv1alpha1.HorizontalScaling) (*appsv1.ClusterComponentSpec, error) {
+	horizontalScaling opsv1alpha1.HorizontalScaling) (int32, []appsv1.InstanceTemplate, []string, error) {
 	lastCompConfiguration := opsRes.OpsRequest.Status.LastConfiguration.Components[horizontalScaling.ComponentName]
 	if err := hs.validateHorizontalScaling(opsRes, lastCompConfiguration, horizontalScaling); err != nil {
-		return nil, err
+		return 0, nil, nil, err
 	}
-	expected := compSpec.DeepCopy()
-	replicas, instances, offlineInstances, err := hs.getExpectedCompValues(opsRes, expected,
+	replicas, instances, offlineInstances, err := hs.getExpectedCompValues(opsRes,
 		lastCompConfiguration, horizontalScaling)
 	if err != nil {
-		return nil, err
+		return 0, nil, nil, err
 	}
 	var insReplicas int32
 	for _, v := range instances {
@@ -175,31 +176,27 @@ func (hs horizontalScalingOpsHandler) prepareReplicaScaling(opsRes *OpsResource,
 	if insReplicas > replicas {
 		errMsg := fmt.Sprintf(`the total number of replicas for the instance template cannot be greater than the number of replicas for component "%s" after horizontally scaling`,
 			horizontalScaling.ComponentName)
-		return nil, intctrlutil.NewFatalError(errMsg)
+		return 0, nil, nil, intctrlutil.NewFatalError(errMsg)
 	}
-	expected.Replicas = replicas
-	expected.Instances = instances
-	expected.OfflineInstances = offlineInstances
-	return expected, nil
+	return replicas, instances, offlineInstances, nil
 }
 
-// reconcileReplicaScaling determines the affected instances and checks their
-// actual progress. Backup scaling shares this step after preparing its local spec.
-func (hs horizontalScalingOpsHandler) reconcileReplicaScaling(reqCtx intctrlutil.RequestCtx,
-	cli client.Client,
-	opsRes *OpsResource,
-	pgRes *progressResource,
-	clusterComponentSpec *appsv1.ClusterComponentSpec,
-	compStatus *opsv1alpha1.OpsRequestComponentStatus) (int32, int32, error) {
+// setReplicaScalingParticipants selects the instances whose progress both paths
+// track, independently of when the target configuration is submitted.
+func (hs horizontalScalingOpsHandler) setReplicaScalingParticipants(opsRes *OpsResource,
+	pgRes *progressResource) error {
 	horizontalScaling := pgRes.compOps.(opsv1alpha1.HorizontalScaling)
 	lastCompConfiguration := opsRes.OpsRequest.Status.LastConfiguration.Components[horizontalScaling.ComponentName]
 	var err error
-	pgRes.createdPodSet, pgRes.deletedPodSet, err = hs.getCreateAndDeletePodSet(opsRes, lastCompConfiguration,
-		*clusterComponentSpec, horizontalScaling, pgRes.fullComponentName)
+	pgRes.createdPodSet, pgRes.deletedPodSet, err = hs.getReplicaScalingChanges(opsRes, lastCompConfiguration,
+		horizontalScaling, pgRes.fullComponentName)
 	if err != nil {
-		return 0, 0, err
+		return err
 	}
-	return handleComponentProgressForScalingReplicas(reqCtx, cli, opsRes, pgRes, compStatus)
+	if opsRes.OpsRequest.Status.Phase == opsv1alpha1.OpsCancellingPhase {
+		pgRes.createdPodSet, pgRes.deletedPodSet = pgRes.deletedPodSet, pgRes.createdPodSet
+	}
+	return nil
 }
 
 // SaveLastConfiguration records last configuration to the OpsRequest.status.lastConfiguration
@@ -228,10 +225,10 @@ func (hs horizontalScalingOpsHandler) SaveLastConfiguration(reqCtx intctrlutil.R
 	return nil
 }
 
-// getCreateAndDeletePodSet gets the pod set that are created and deleted in this opsRequest.
-func (hs horizontalScalingOpsHandler) getCreateAndDeletePodSet(opsRes *OpsResource,
+// getReplicaScalingChanges compares the saved and requested instance names in
+// the forward direction. Callers choose how to use the changes when cancelling.
+func (hs horizontalScalingOpsHandler) getReplicaScalingChanges(opsRes *OpsResource,
 	lastCompConfiguration opsv1alpha1.LastComponentConfiguration,
-	currCompSpec appsv1.ClusterComponentSpec,
 	horizontalScaling opsv1alpha1.HorizontalScaling,
 	fullCompName string) (map[string]string, map[string]string, error) {
 	clusterName := opsRes.Cluster.Name
@@ -244,7 +241,7 @@ func (hs horizontalScalingOpsHandler) getCreateAndDeletePodSet(opsRes *OpsResour
 	if err != nil {
 		return nil, nil, err
 	}
-	expectReplicas, expectInstanceTpls, expectOfflineInstances, err := hs.getExpectedCompValues(opsRes, &currCompSpec, lastCompConfiguration, horizontalScaling)
+	expectReplicas, expectInstanceTpls, expectOfflineInstances, err := hs.getExpectedCompValues(opsRes, lastCompConfiguration, horizontalScaling)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -264,10 +261,6 @@ func (hs horizontalScalingOpsHandler) getCreateAndDeletePodSet(opsRes *OpsResour
 		if _, ok := currPodSet[k]; !ok {
 			deletePodSet[k] = appsv1.GetInstanceTemplateName(clusterName, fullCompName, k)
 		}
-	}
-	if opsRes.OpsRequest.Status.Phase == opsv1alpha1.OpsCancellingPhase {
-		// when cancelling this opsRequest, revert the changes.
-		return deletePodSet, createPodSet, nil
 	}
 	return createPodSet, deletePodSet, nil
 }
@@ -293,13 +286,21 @@ func (hs horizontalScalingOpsHandler) checkIntersectionWithEarlierOps(opsRes *Op
 	currOpsHScaling, earlierOpsHScaling opsv1alpha1.HorizontalScaling) error {
 	getCreatedOrDeletedPodSet := func(ops *opsv1alpha1.OpsRequest, hScaling opsv1alpha1.HorizontalScaling) (map[string]string, map[string]string, error) {
 		lastCompSnapshot := ops.Status.LastConfiguration.Components[earlierOpsHScaling.ComponentName]
-		compSpec := getComponentSpecOrShardingTemplate(opsRes.Cluster, earlierOpsHScaling.ComponentName).DeepCopy()
-		var err error
-		compSpec.Replicas, compSpec.Instances, compSpec.OfflineInstances, err = hs.getExpectedCompValues(opsRes, compSpec, lastCompSnapshot, hScaling)
+		// Preserve target validation before instance-set generation, including its
+		// error order relative to the earlier and current requests.
+		if _, _, _, err := hs.getExpectedCompValues(opsRes, lastCompSnapshot, hScaling); err != nil {
+			return nil, nil, err
+		}
+		created, deleted, err := hs.getReplicaScalingChanges(opsRes, lastCompSnapshot, hScaling, hScaling.ComponentName)
 		if err != nil {
 			return nil, nil, err
 		}
-		return hs.getCreateAndDeletePodSet(opsRes, lastCompSnapshot, *compSpec, hScaling, hScaling.ComponentName)
+		// Both comparisons use the current request's phase, as in the original
+		// intersection check, even when calculating changes for an earlier Ops.
+		if opsRes.OpsRequest.Status.Phase == opsv1alpha1.OpsCancellingPhase {
+			created, deleted = deleted, created
+		}
+		return created, deleted, nil
 	}
 	createdPodSetForEarlier, _, err := getCreatedOrDeletedPodSet(earlierOps, earlierOpsHScaling)
 	if err != nil {
@@ -322,16 +323,24 @@ func (hs horizontalScalingOpsHandler) checkIntersectionWithEarlierOps(opsRes *Op
 // getExpectedCompValues gets the expected replicas, instances, offlineInstances.
 func (hs horizontalScalingOpsHandler) getExpectedCompValues(
 	opsRes *OpsResource,
-	compSpec *appsv1.ClusterComponentSpec,
 	lastCompConfiguration opsv1alpha1.LastComponentConfiguration,
 	horizontalScaling opsv1alpha1.HorizontalScaling) (int32, []appsv1.InstanceTemplate, []string, error) {
 	compReplicas := *lastCompConfiguration.Replicas
 	compInstanceTpls := slices.Clone(lastCompConfiguration.Instances)
 	compOfflineInstances := lastCompConfiguration.OfflineInstances
-	filteredHorizontal, err := filterHorizontalScalingSpec(opsRes, compReplicas, compInstanceTpls, compOfflineInstances, horizontalScaling.DeepCopy())
+	filteredHorizontal := horizontalScaling.DeepCopy()
+	// Obtain the existing names before filtering, even for requests without
+	// explicit online/offline lists, preserving the original lookup/error order.
+	runtime, err := opsRes.GetRuntime(horizontalScaling.ComponentName)
 	if err != nil {
 		return 0, nil, nil, err
 	}
+	podSet, err := runtime.GenerateInstanceNameSet(opsRes.Cluster.Name, horizontalScaling.ComponentName,
+		compReplicas, compInstanceTpls, compOfflineInstances)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	filterHorizontalScalingSpec(podSet, compOfflineInstances, filteredHorizontal)
 	expectOfflineInstances := hs.getCompExpectedOfflineInstances(compOfflineInstances, *filteredHorizontal)
 	err = hs.autoSyncReplicaChanges(opsRes, *filteredHorizontal, compReplicas, compInstanceTpls, expectOfflineInstances)
 	if err != nil {
@@ -345,21 +354,10 @@ func (hs horizontalScalingOpsHandler) getExpectedCompValues(
 // only offlined instances could be taken online.
 // and only onlined instances could be taken offline.
 func filterHorizontalScalingSpec(
-	opsRes *OpsResource,
-	compReplicas int32,
-	compInstanceTpls []appsv1.InstanceTemplate,
+	podSet map[string]string,
 	compOfflineInstances []string,
-	horizontalScaling *opsv1alpha1.HorizontalScaling) (*opsv1alpha1.HorizontalScaling, error) {
+	horizontalScaling *opsv1alpha1.HorizontalScaling) {
 	offlineInstances := sets.New(compOfflineInstances...)
-	runtime, err := opsRes.GetRuntime(horizontalScaling.ComponentName)
-	if err != nil {
-		return nil, err
-	}
-	podSet, err := runtime.GenerateInstanceNameSet(opsRes.Cluster.Name, horizontalScaling.ComponentName,
-		compReplicas, compInstanceTpls, compOfflineInstances)
-	if err != nil {
-		return nil, err
-	}
 	if horizontalScaling.ScaleIn != nil && len(horizontalScaling.ScaleIn.OnlineInstancesToOffline) > 0 {
 		onlinedInstanceFromOps := sets.Set[string]{}
 		for _, insName := range horizontalScaling.ScaleIn.OnlineInstancesToOffline {
@@ -378,8 +376,6 @@ func filterHorizontalScalingSpec(
 		}
 		horizontalScaling.ScaleOut.OfflineInstancesToOnline = sets.List(offlinedInstanceFromOps)
 	}
-	return horizontalScaling, nil
-
 }
 
 // autoSyncReplicaChanges auto-sync the replicaChanges of the component and instance templates.
@@ -389,53 +385,55 @@ func (hs horizontalScalingOpsHandler) autoSyncReplicaChanges(
 	compReplicas int32,
 	compInstanceTpls []appsv1.InstanceTemplate,
 	compExpectOfflineInstances []string) error {
-	// sync the replicaChanges for component and instance template.
-	getSyncedInstancesAndReplicaChanges := func(offlineOrOnlineInsCountMap map[string]int32,
-		replicaChanger opsv1alpha1.ReplicaChanger,
-		newInstances []appsv1.InstanceTemplate) ([]opsv1alpha1.InstanceReplicasTemplate, *int32) {
-		allReplicaChanges := int32(0)
-		insTplMap := map[string]sets.Empty{}
-		for _, v := range replicaChanger.Instances {
-			insTplMap[v.Name] = sets.Empty{}
-			allReplicaChanges += v.ReplicaChanges
-		}
-		for k, v := range offlineOrOnlineInsCountMap {
-			if k == "" {
-				allReplicaChanges += v
-				continue
-			}
-			if _, ok := insTplMap[k]; !ok {
-				// auto sync the replicaChanges for the instance template if the replicaChanges is not specified.
-				replicaChanger.Instances = append(replicaChanger.Instances, opsv1alpha1.InstanceReplicasTemplate{Name: k, ReplicaChanges: v})
-				allReplicaChanges += v
-			}
-		}
-		for _, v := range newInstances {
-			allReplicaChanges += v.GetReplicas()
-		}
-		if replicaChanger.ReplicaChanges != nil {
-			allReplicaChanges = *replicaChanger.ReplicaChanges
-		}
-		return replicaChanger.Instances, &allReplicaChanges
-	}
 	// auto sync the replicaChanges.
 	scaleIn := horizontalScaling.ScaleIn
 	if scaleIn != nil {
 		offlineInsCountMap := opsRes.OpsRequest.CountOfflineOrOnlineInstances(opsRes.Cluster.Name, horizontalScaling.ComponentName, scaleIn.OnlineInstancesToOffline)
-		scaleIn.Instances, scaleIn.ReplicaChanges = getSyncedInstancesAndReplicaChanges(offlineInsCountMap, scaleIn.ReplicaChanger, nil)
+		scaleIn.Instances, scaleIn.ReplicaChanges = syncReplicaChangesFromCounts(offlineInsCountMap, scaleIn.ReplicaChanger, nil)
 	}
 	scaleOut := horizontalScaling.ScaleOut
 	if scaleOut != nil {
-		onlineInsCountMap, err := hs.getToOnlineInsCountMap(opsRes, horizontalScaling, compReplicas, compInstanceTpls, compExpectOfflineInstances)
+		onlineInsCountMap, err := hs.getPlannedOnlineInstanceCounts(opsRes, horizontalScaling, compReplicas, compInstanceTpls, compExpectOfflineInstances)
 		if err != nil {
 			return err
 		}
-		scaleOut.Instances, scaleOut.ReplicaChanges = getSyncedInstancesAndReplicaChanges(onlineInsCountMap, scaleOut.ReplicaChanger, scaleOut.NewInstances)
+		scaleOut.Instances, scaleOut.ReplicaChanges = syncReplicaChangesFromCounts(onlineInsCountMap, scaleOut.ReplicaChanger, scaleOut.NewInstances)
 	}
 	return nil
 }
 
-func (hs horizontalScalingOpsHandler) getToOnlineInsCountMap(
+// syncReplicaChangesFromCounts applies per-template instance counts and explicit
+// replica changes without consulting runtime objects or instance naming rules.
+func syncReplicaChangesFromCounts(offlineOrOnlineInsCountMap map[string]int32,
+	replicaChanger opsv1alpha1.ReplicaChanger,
+	newInstances []appsv1.InstanceTemplate) ([]opsv1alpha1.InstanceReplicasTemplate, *int32) {
+	allReplicaChanges := int32(0)
+	insTplMap := map[string]sets.Empty{}
+	for _, v := range replicaChanger.Instances {
+		insTplMap[v.Name] = sets.Empty{}
+		allReplicaChanges += v.ReplicaChanges
+	}
+	for k, v := range offlineOrOnlineInsCountMap {
+		if k == "" {
+			allReplicaChanges += v
+			continue
+		}
+		if _, ok := insTplMap[k]; !ok {
+			// auto sync the replicaChanges for the instance template if the replicaChanges is not specified.
+			replicaChanger.Instances = append(replicaChanger.Instances, opsv1alpha1.InstanceReplicasTemplate{Name: k, ReplicaChanges: v})
+			allReplicaChanges += v
+		}
+	}
+	for _, v := range newInstances {
+		allReplicaChanges += v.GetReplicas()
+	}
+	if replicaChanger.ReplicaChanges != nil {
+		allReplicaChanges = *replicaChanger.ReplicaChanges
+	}
+	return replicaChanger.Instances, &allReplicaChanges
+}
+
+func (hs horizontalScalingOpsHandler) getPlannedOnlineInstanceCounts(
 	opsRes *OpsResource,
 	horizontalScaling opsv1alpha1.HorizontalScaling,
 	compReplicas int32,
@@ -445,21 +443,10 @@ func (hs horizontalScalingOpsHandler) getToOnlineInsCountMap(
 		return nil, nil
 	}
 	compInstanceTplsClone := slices.Clone(compInstanceTpls)
-	slices.Sort(horizontalScaling.ScaleOut.OfflineInstancesToOnline)
 	// 1. Automatically synchronize replicaChanges based on the specified OfflineInstancesToOnline
-	offlineInsMap := map[string][]string{}
-	instanceTplChangesMap := map[string]int32{}
-	for _, tplChange := range horizontalScaling.ScaleOut.ReplicaChanger.Instances {
-		instanceTplChangesMap[tplChange.Name] = tplChange.ReplicaChanges
-	}
-	for _, insName := range horizontalScaling.ScaleOut.OfflineInstancesToOnline {
-		insTplName := appsv1.GetInstanceTemplateName(opsRes.Cluster.Name, horizontalScaling.ComponentName, insName)
-		if _, ok := instanceTplChangesMap[insTplName]; ok {
-			// Ignore the template instance that has already been specified in the replica changes.
-			continue
-		}
-		offlineInsMap[insTplName] = append(offlineInsMap[insTplName], insName)
-		compReplicas += 1
+	offlineInsMap := groupInstancesToOnline(opsRes.Cluster.Name, horizontalScaling.ComponentName, horizontalScaling.ScaleOut)
+	for _, insNames := range offlineInsMap {
+		compReplicas += int32(len(insNames))
 	}
 	for i := range compInstanceTplsClone {
 		tplName := compInstanceTplsClone[i].Name
@@ -478,18 +465,42 @@ func (hs horizontalScalingOpsHandler) getToOnlineInsCountMap(
 		return nil, err
 	}
 	// 3. count the number of online instances for each instance template.
+	return countPlannedOnlineInstances(offlineInsMap, podSet), nil
+}
+
+// groupInstancesToOnline resolves template membership using the current naming
+// rules. Preserve sorted order within each template for prefix counting below.
+func groupInstancesToOnline(clusterName, componentName string, scaleOut *opsv1alpha1.ScaleOut) map[string][]string {
+	slices.Sort(scaleOut.OfflineInstancesToOnline)
+	offlineInsMap := map[string][]string{}
+	instanceTplChangesMap := map[string]int32{}
+	for _, tplChange := range scaleOut.ReplicaChanger.Instances {
+		instanceTplChangesMap[tplChange.Name] = tplChange.ReplicaChanges
+	}
+	for _, insName := range scaleOut.OfflineInstancesToOnline {
+		insTplName := appsv1.GetInstanceTemplateName(clusterName, componentName, insName)
+		if _, ok := instanceTplChangesMap[insTplName]; ok {
+			// Explicit template replica changes take precedence over inferred counts.
+			continue
+		}
+		offlineInsMap[insTplName] = append(offlineInsMap[insTplName], insName)
+	}
+	return offlineInsMap
+}
+
+func countPlannedOnlineInstances(offlineInsMap map[string][]string, podSet map[string]string) map[string]int32 {
 	onlineInsCountMap := map[string]int32{}
 	for insTplName, insNames := range offlineInsMap {
 		for _, insName := range insNames {
-			// Once replica synchronization is complete, sequentially process each instance in the toOnline list to confirm its successful creation.
-			// If any instance fails to come online, break it.
+			// Count the leading requested names present in the plan, stopping at
+			// the first missing name in each template. This does not check readiness.
 			if _, ok := podSet[insName]; !ok {
 				break
 			}
 			onlineInsCountMap[insTplName]++
 		}
 	}
-	return onlineInsCountMap, nil
+	return onlineInsCountMap
 }
 
 // getCompExpectReplicas gets the expected replicas for the component.
@@ -504,7 +515,7 @@ func (hs horizontalScalingOpsHandler) getCompExpectReplicas(horizontalScaling op
 	return compReplicas
 }
 
-// getCompExpectedOfflineInstances gets the expected instance templates of the component.
+// getCompExpectedInstances gets the expected instance templates of the component.
 func (hs horizontalScalingOpsHandler) getCompExpectedInstances(
 	compInstanceTpls []appsv1.InstanceTemplate,
 	horizontalScaling opsv1alpha1.HorizontalScaling,

--- a/pkg/operations/horizontal_scaling_backup.go
+++ b/pkg/operations/horizontal_scaling_backup.go
@@ -48,15 +48,17 @@ func (hs horizontalScalingOpsHandler) reconcileBackupScaling(reqCtx intctrlutil.
 	compStatus *opsv1alpha1.OpsRequestComponentStatus) (int32, int32, error) {
 	horizontalScaling := pgRes.compOps.(opsv1alpha1.HorizontalScaling)
 	lastCompConfiguration := opsRes.OpsRequest.Status.LastConfiguration.Components[horizontalScaling.ComponentName]
-	clusterComponentSpec := pgRes.clusterComponent.DeepCopy()
 	// Preserve the restore step during cancellation as well as normal reconciliation.
-	if err := hs.restoreDataFromBackup(reqCtx, cli, opsRes, pgRes, clusterComponentSpec,
+	if err := hs.restoreDataFromBackup(reqCtx, cli, opsRes, pgRes, pgRes.clusterComponent.DeepCopy(),
 		horizontalScaling, lastCompConfiguration, compStatus); err != nil {
 		return 0, 0, err
 	}
-	// restoreDataFromBackup may have prepared a target spec even while Restore is
-	// pending. Keep using that local spec for the existing progress calculation.
-	return hs.reconcileReplicaScaling(reqCtx, cli, opsRes, pgRes, clusterComponentSpec, compStatus)
+	// Continue checking instance progress even while Restore is pending, as in
+	// the existing lifecycle. Only the target configuration write waits for Restore.
+	if err := hs.setReplicaScalingParticipants(opsRes, pgRes); err != nil {
+		return 0, 0, err
+	}
+	return handleComponentProgressForScalingReplicas(reqCtx, cli, opsRes, pgRes, compStatus)
 }
 
 func (hs horizontalScalingOpsHandler) getBackupObj(reqCtx intctrlutil.RequestCtx,
@@ -85,14 +87,14 @@ func (hs horizontalScalingOpsHandler) createRestore(reqCtx intctrlutil.RequestCt
 	opsRes *OpsResource,
 	synthesizedComponent *intctrlcomp.SynthesizedComponent,
 	restoreMGR *plan.RestoreManager,
-	compSpecDeepyCopy *appsv1.ClusterComponentSpec,
+	targetCompSpec *appsv1.ClusterComponentSpec,
 	backupObj *dpv1alpha1.Backup,
 	templateName string) error {
 	getTemplate := func(templateName string) *appsv1.InstanceTemplate {
 		if templateName == "" {
 			return nil
 		}
-		for _, template := range compSpecDeepyCopy.Instances {
+		for _, template := range targetCompSpec.Instances {
 			if template.Name == templateName {
 				return &template
 			}
@@ -126,7 +128,7 @@ func (hs horizontalScalingOpsHandler) restoreDataFromBackup(reqCtx intctrlutil.R
 	cli client.Client,
 	opsRes *OpsResource,
 	pgRes *progressResource,
-	compSpecDeepyCopy *appsv1.ClusterComponentSpec,
+	targetCompSpec *appsv1.ClusterComponentSpec,
 	horizontalScaling opsv1alpha1.HorizontalScaling,
 	lastCompConfiguration opsv1alpha1.LastComponentConfiguration,
 	compStatus *opsv1alpha1.OpsRequestComponentStatus) error {
@@ -141,17 +143,21 @@ func (hs horizontalScalingOpsHandler) restoreDataFromBackup(reqCtx intctrlutil.R
 	if err != nil {
 		return err
 	}
-	replicas, instances, offlineInstances, err := hs.getExpectedCompValues(opsRes, compSpecDeepyCopy,
+	replicas, instances, offlineInstances, err := hs.getExpectedCompValues(opsRes,
 		lastCompConfiguration, horizontalScaling)
 	if err != nil {
 		return err
 	}
-	compSpecDeepyCopy.Replicas = replicas
-	compSpecDeepyCopy.Instances = instances
-	compSpecDeepyCopy.OfflineInstances = offlineInstances
-	createdPodSet, _, err := hs.getCreateAndDeletePodSet(opsRes, lastCompConfiguration, *compSpecDeepyCopy, horizontalScaling, pgRes.fullComponentName)
+	targetCompSpec.Replicas = replicas
+	targetCompSpec.Instances = instances
+	targetCompSpec.OfflineInstances = offlineInstances
+	createdPodSet, deletedPodSet, err := hs.getReplicaScalingChanges(opsRes, lastCompConfiguration, horizontalScaling, pgRes.fullComponentName)
 	if err != nil {
 		return err
+	}
+	if opsRes.OpsRequest.Status.Phase == opsv1alpha1.OpsCancellingPhase {
+		// Preserve which instances the existing cancellation path restores.
+		createdPodSet = deletedPodSet
 	}
 	comp, compDef, err := intctrlcomp.GetCompNCompDefByName(reqCtx.Ctx, cli, opsRes.Cluster.Namespace, constant.GenerateClusterComponentName(opsRes.Cluster.Name, pgRes.fullComponentName))
 	if err != nil {
@@ -181,7 +187,7 @@ func (hs horizontalScalingOpsHandler) restoreDataFromBackup(reqCtx intctrlutil.R
 		if err := cli.Get(reqCtx.Ctx, types.NamespacedName{Namespace: opsRes.Cluster.Namespace, Name: restoreMeta.Name}, restore); err != nil {
 			if apierrors.IsNotFound(err) {
 				allRestoreCompleted = false
-				if err = hs.createRestore(reqCtx, cli, opsRes, synthesizedComponent, restoreMGR, compSpecDeepyCopy, backupObj, templateName); err != nil {
+				if err = hs.createRestore(reqCtx, cli, opsRes, synthesizedComponent, restoreMGR, targetCompSpec, backupObj, templateName); err != nil {
 					return err
 				}
 				continue
@@ -197,7 +203,7 @@ func (hs horizontalScalingOpsHandler) restoreDataFromBackup(reqCtx intctrlutil.R
 	}
 	compStatus.Message = "Restore Data In Progress"
 	if allRestoreCompleted {
-		if err := hs.scaleOutComponentAfterRestoreData(reqCtx, cli, opsRes, compSpecDeepyCopy); err != nil {
+		if err := hs.scaleOutComponentAfterRestoreData(reqCtx, cli, opsRes, targetCompSpec); err != nil {
 			return err
 		}
 		// set restore completed message
@@ -209,13 +215,13 @@ func (hs horizontalScalingOpsHandler) restoreDataFromBackup(reqCtx intctrlutil.R
 func (hs horizontalScalingOpsHandler) scaleOutComponentAfterRestoreData(reqCtx intctrlutil.RequestCtx,
 	cli client.Client,
 	opsRes *OpsResource,
-	compSpecDeepyCopy *appsv1.ClusterComponentSpec) error {
+	targetCompSpec *appsv1.ClusterComponentSpec) error {
 	for i := range opsRes.Cluster.Spec.ComponentSpecs {
 		compSpec := &opsRes.Cluster.Spec.ComponentSpecs[i]
-		if compSpec.Name == compSpecDeepyCopy.Name {
-			compSpec.Replicas = compSpecDeepyCopy.Replicas
-			compSpec.OfflineInstances = compSpecDeepyCopy.OfflineInstances
-			compSpec.Instances = compSpecDeepyCopy.Instances
+		if compSpec.Name == targetCompSpec.Name {
+			compSpec.Replicas = targetCompSpec.Replicas
+			compSpec.OfflineInstances = targetCompSpec.OfflineInstances
+			compSpec.Instances = targetCompSpec.Instances
 		}
 	}
 	return cli.Update(reqCtx.Ctx, opsRes.Cluster)

--- a/pkg/operations/horizontal_scaling_backup.go
+++ b/pkg/operations/horizontal_scaling_backup.go
@@ -1,0 +1,222 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package operations
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	opsv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	intctrlcomp "github.com/apecloud/kubeblocks/pkg/controller/component"
+	"github.com/apecloud/kubeblocks/pkg/controller/model"
+	"github.com/apecloud/kubeblocks/pkg/controller/plan"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+)
+
+// reconcileBackupScaling prepares volumes before submitting the target configuration,
+// then tracks the same instance changes as ordinary replica scaling.
+func (hs horizontalScalingOpsHandler) reconcileBackupScaling(reqCtx intctrlutil.RequestCtx,
+	cli client.Client,
+	opsRes *OpsResource,
+	pgRes *progressResource,
+	compStatus *opsv1alpha1.OpsRequestComponentStatus) (int32, int32, error) {
+	horizontalScaling := pgRes.compOps.(opsv1alpha1.HorizontalScaling)
+	lastCompConfiguration := opsRes.OpsRequest.Status.LastConfiguration.Components[horizontalScaling.ComponentName]
+	clusterComponentSpec := pgRes.clusterComponent.DeepCopy()
+	// Preserve the restore step during cancellation as well as normal reconciliation.
+	if err := hs.restoreDataFromBackup(reqCtx, cli, opsRes, pgRes, clusterComponentSpec,
+		horizontalScaling, lastCompConfiguration, compStatus); err != nil {
+		return 0, 0, err
+	}
+	// restoreDataFromBackup may have prepared a target spec even while Restore is
+	// pending. Keep using that local spec for the existing progress calculation.
+	return hs.reconcileReplicaScaling(reqCtx, cli, opsRes, pgRes, clusterComponentSpec, compStatus)
+}
+
+func (hs horizontalScalingOpsHandler) getBackupObj(reqCtx intctrlutil.RequestCtx,
+	cli client.Client,
+	opsRes *OpsResource,
+	fromBackup opsv1alpha1.FromBackup) (*dpv1alpha1.Backup, error) {
+	backupNamespace := opsRes.Cluster.Namespace
+	if fromBackup.Namespace != "" {
+		backupNamespace = fromBackup.Namespace
+	}
+	backupObj := &dpv1alpha1.Backup{}
+	if err := cli.Get(reqCtx.Ctx, client.ObjectKey{Namespace: backupNamespace, Name: fromBackup.Name}, backupObj); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, intctrlutil.NewFatalError(fmt.Sprintf("backup %s not found", fromBackup.Name))
+		}
+		return nil, err
+	}
+	if backupObj.Status.Phase != dpv1alpha1.BackupPhaseCompleted {
+		return nil, intctrlutil.NewFatalError(fmt.Sprintf("backup %s phase is not completed", fromBackup.Name))
+	}
+	return backupObj, nil
+}
+
+func (hs horizontalScalingOpsHandler) createRestore(reqCtx intctrlutil.RequestCtx,
+	cli client.Client,
+	opsRes *OpsResource,
+	synthesizedComponent *intctrlcomp.SynthesizedComponent,
+	restoreMGR *plan.RestoreManager,
+	compSpecDeepyCopy *appsv1.ClusterComponentSpec,
+	backupObj *dpv1alpha1.Backup,
+	templateName string) error {
+	getTemplate := func(templateName string) *appsv1.InstanceTemplate {
+		if templateName == "" {
+			return nil
+		}
+		for _, template := range compSpecDeepyCopy.Instances {
+			if template.Name == templateName {
+				return &template
+			}
+		}
+		return nil
+	}
+	// create restore
+	restore, err := restoreMGR.BuildPrepareDataRestoreForPod(synthesizedComponent, backupObj, getTemplate(templateName))
+	if err != nil {
+		if intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeRestoreFailed) {
+			return intctrlutil.NewFatalError(err.Error())
+		}
+		return err
+	}
+	if restore == nil {
+		return intctrlutil.NewFatalError(fmt.Sprintf("scale-out from backup %s/%s is not supported because backup method %q has no target volumes matching component %q",
+			backupObj.Namespace, backupObj.Name, backupObj.Status.BackupMethod.Name, synthesizedComponent.Name))
+	}
+	scheme, _ := opsv1alpha1.SchemeBuilder.Build()
+	if err := intctrlutil.SetOwnership(opsRes.OpsRequest, restore, scheme, ""); err != nil {
+		return err
+	}
+	if err := cli.Create(reqCtx.Ctx, restore); err != nil {
+		return err
+	}
+	reqCtx.Recorder.Eventf(opsRes.OpsRequest, corev1.EventTypeNormal, "RestoreCreated", "Restore %s created", restore.Name)
+	return nil
+}
+
+func (hs horizontalScalingOpsHandler) restoreDataFromBackup(reqCtx intctrlutil.RequestCtx,
+	cli client.Client,
+	opsRes *OpsResource,
+	pgRes *progressResource,
+	compSpecDeepyCopy *appsv1.ClusterComponentSpec,
+	horizontalScaling opsv1alpha1.HorizontalScaling,
+	lastCompConfiguration opsv1alpha1.LastComponentConfiguration,
+	compStatus *opsv1alpha1.OpsRequestComponentStatus) error {
+	restoreCompletedMsg := "Restore Data Completed"
+	// check if restore completed
+	if compStatus.Message == restoreCompletedMsg {
+		return nil
+	}
+	// get and check backup
+	fromBackup := horizontalScaling.ScaleOut.FromBackup
+	backupObj, err := hs.getBackupObj(reqCtx, cli, opsRes, *fromBackup)
+	if err != nil {
+		return err
+	}
+	replicas, instances, offlineInstances, err := hs.getExpectedCompValues(opsRes, compSpecDeepyCopy,
+		lastCompConfiguration, horizontalScaling)
+	if err != nil {
+		return err
+	}
+	compSpecDeepyCopy.Replicas = replicas
+	compSpecDeepyCopy.Instances = instances
+	compSpecDeepyCopy.OfflineInstances = offlineInstances
+	createdPodSet, _, err := hs.getCreateAndDeletePodSet(opsRes, lastCompConfiguration, *compSpecDeepyCopy, horizontalScaling, pgRes.fullComponentName)
+	if err != nil {
+		return err
+	}
+	comp, compDef, err := intctrlcomp.GetCompNCompDefByName(reqCtx.Ctx, cli, opsRes.Cluster.Namespace, constant.GenerateClusterComponentName(opsRes.Cluster.Name, pgRes.fullComponentName))
+	if err != nil {
+		return err
+	}
+	synthesizedComponent, err := intctrlcomp.BuildSynthesizedComponent(reqCtx.Ctx, cli, compDef, comp)
+	if err != nil {
+		return err
+	}
+	allRestoreCompleted := true
+	for podName, templateName := range createdPodSet {
+		idx := strings.LastIndex(podName, "-")
+		podIndex := podName[idx+1:]
+		podIndexInt, _ := strconv.ParseInt(podIndex, 10, 32)
+		restoreMGR := plan.NewRestoreManager(reqCtx.Ctx, cli, opsRes.Cluster, model.GetScheme(), map[string]string{
+			constant.OpsRequestNameLabelKey: opsRes.OpsRequest.Name,
+			constant.AppInstanceLabelKey:    opsRes.Cluster.Name,
+			constant.KBAppComponentLabelKey: pgRes.compOps.GetComponentName(),
+		}, 1, int32(podIndexInt))
+		restoreMGR.RestoreTime = fromBackup.RestorePointInTime
+		restoreMGR.SetRestoreEnv(fromBackup.RestoreEnv)
+		restoreMGR.RestoreNamePrefix = string(opsRes.OpsRequest.UID[:8])
+		restoreMGR.SourceTargetName = fromBackup.SourceTargetName
+		// check restore status
+		restoreMeta := restoreMGR.GetRestoreObjectMeta(synthesizedComponent, dpv1alpha1.PrepareData, templateName)
+		restore := &dpv1alpha1.Restore{}
+		if err := cli.Get(reqCtx.Ctx, types.NamespacedName{Namespace: opsRes.Cluster.Namespace, Name: restoreMeta.Name}, restore); err != nil {
+			if apierrors.IsNotFound(err) {
+				allRestoreCompleted = false
+				if err = hs.createRestore(reqCtx, cli, opsRes, synthesizedComponent, restoreMGR, compSpecDeepyCopy, backupObj, templateName); err != nil {
+					return err
+				}
+				continue
+			}
+			return err
+		}
+		if restore.Status.Phase == dpv1alpha1.RestorePhaseFailed {
+			return intctrlutil.NewFatalError(fmt.Sprintf("restore for horizontalScaling failed: you can describe the restore resource \"%s\"", restore.Name))
+		}
+		if restore.Status.Phase != dpv1alpha1.RestorePhaseCompleted {
+			allRestoreCompleted = false
+		}
+	}
+	compStatus.Message = "Restore Data In Progress"
+	if allRestoreCompleted {
+		if err := hs.scaleOutComponentAfterRestoreData(reqCtx, cli, opsRes, compSpecDeepyCopy); err != nil {
+			return err
+		}
+		// set restore completed message
+		compStatus.Message = restoreCompletedMsg
+	}
+	return nil
+}
+
+func (hs horizontalScalingOpsHandler) scaleOutComponentAfterRestoreData(reqCtx intctrlutil.RequestCtx,
+	cli client.Client,
+	opsRes *OpsResource,
+	compSpecDeepyCopy *appsv1.ClusterComponentSpec) error {
+	for i := range opsRes.Cluster.Spec.ComponentSpecs {
+		compSpec := &opsRes.Cluster.Spec.ComponentSpecs[i]
+		if compSpec.Name == compSpecDeepyCopy.Name {
+			compSpec.Replicas = compSpecDeepyCopy.Replicas
+			compSpec.OfflineInstances = compSpecDeepyCopy.OfflineInstances
+			compSpec.Instances = compSpecDeepyCopy.Instances
+		}
+	}
+	return cli.Update(reqCtx.Ctx, opsRes.Cluster)
+}

--- a/pkg/operations/horizontal_scaling_paths_test.go
+++ b/pkg/operations/horizontal_scaling_paths_test.go
@@ -1,0 +1,394 @@
+/*
+Copyright (C) 2022-2026 ApeCloud Co., Ltd
+
+This file is part of KubeBlocks project
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+*/
+
+package operations
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	appsv1 "github.com/apecloud/kubeblocks/apis/apps/v1"
+	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
+	opsv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
+	workloads "github.com/apecloud/kubeblocks/apis/workloads/v1"
+	"github.com/apecloud/kubeblocks/pkg/constant"
+	"github.com/apecloud/kubeblocks/pkg/controller/component"
+	intctrlutil "github.com/apecloud/kubeblocks/pkg/controllerutil"
+)
+
+// Use the real naming and workload runtime; only API storage is in memory.
+type horizontalScalingFixture struct {
+	cli                                      client.Client
+	res                                      *OpsResource
+	req                                      intctrlutil.RequestCtx
+	clusterWrites, backupReads, restoreReads int
+}
+
+func newHorizontalScalingFixture(t *testing.T, requests ...opsv1alpha1.HorizontalScaling) *horizontalScalingFixture {
+	t.Helper()
+	f := &horizontalScalingFixture{}
+	f.req = intctrlutil.RequestCtx{Ctx: context.Background(), Recorder: record.NewFakeRecorder(100)}
+	scheme := runtime.NewScheme()
+	for _, add := range []func(*runtime.Scheme) error{corev1.AddToScheme, appsv1.AddToScheme,
+		dpv1alpha1.AddToScheme, opsv1alpha1.AddToScheme, workloads.AddToScheme} {
+		if err := add(scheme); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cluster := &appsv1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default", UID: "cluster1"},
+		Status: appsv1.ClusterStatus{Phase: appsv1.RunningClusterPhase}}
+	ops := &opsv1alpha1.OpsRequest{ObjectMeta: metav1.ObjectMeta{Name: "scale", Namespace: "default", UID: "opsreq123"},
+		Spec: opsv1alpha1.OpsRequestSpec{Type: opsv1alpha1.HorizontalScalingType,
+			SpecificOpsRequest: opsv1alpha1.SpecificOpsRequest{HorizontalScalingList: requests}},
+		Status: opsv1alpha1.OpsRequestStatus{Phase: opsv1alpha1.OpsRunningPhase}}
+	objects := []client.Object{cluster, ops, &appsv1.ComponentDefinition{ObjectMeta: metav1.ObjectMeta{Name: "database"}}}
+	for _, request := range requests {
+		spec := appsv1.ClusterComponentSpec{Name: request.ComponentName, ComponentDef: "database", Replicas: 1,
+			VolumeClaimTemplates: []appsv1.PersistentVolumeClaimTemplate{{Name: "data"}}}
+		cluster.Spec.ComponentSpecs = append(cluster.Spec.ComponentSpecs, spec)
+		comp, err := component.BuildComponent(cluster, &spec, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		objects = append(objects, comp)
+	}
+	f.cli = fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).
+		WithStatusSubresource(ops, &dpv1alpha1.Restore{}).WithInterceptorFuncs(interceptor.Funcs{
+		Get: func(ctx context.Context, cli client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			switch obj.(type) {
+			case *dpv1alpha1.Backup:
+				f.backupReads++
+			case *dpv1alpha1.Restore:
+				f.restoreReads++
+			}
+			return cli.Get(ctx, key, obj, opts...)
+		},
+		Update: func(ctx context.Context, cli client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			if _, ok := obj.(*appsv1.Cluster); ok {
+				f.clusterWrites++
+			}
+			return cli.Update(ctx, obj, opts...)
+		},
+	}).Build()
+	f.res = &OpsResource{Cluster: cluster, OpsRequest: ops, Recorder: f.req.Recorder}
+	var err error
+	f.res.Runtimes, err = buildOpsRuntimes(f.req.Ctx, f.cli, f.res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := (horizontalScalingOpsHandler{}).SaveLastConfiguration(f.req, f.cli, f.res); err != nil {
+		t.Fatal(err)
+	}
+	// OpsManager persists this snapshot before invoking Action/ReconcileAction.
+	if err := f.cli.Status().Update(f.req.Ctx, ops); err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+func scaleOutRequest(name string, backup bool) opsv1alpha1.HorizontalScaling {
+	r := opsv1alpha1.HorizontalScaling{ComponentOps: opsv1alpha1.ComponentOps{ComponentName: name},
+		ScaleOut: &opsv1alpha1.ScaleOut{ReplicaChanger: opsv1alpha1.ReplicaChanger{ReplicaChanges: pointer.Int32(1)}}}
+	if backup {
+		r.ScaleOut.FromBackup = &opsv1alpha1.FromBackup{Name: "snapshot"}
+	}
+	return r
+}
+
+func (f *horizontalScalingFixture) addBackup(t *testing.T) {
+	t.Helper()
+	backup := &dpv1alpha1.Backup{ObjectMeta: metav1.ObjectMeta{Name: "snapshot", Namespace: "default"},
+		Status: dpv1alpha1.BackupStatus{Phase: dpv1alpha1.BackupPhaseCompleted,
+			BackupMethod: &dpv1alpha1.BackupMethod{Name: "snapshot", SnapshotVolumes: pointer.Bool(true),
+				TargetVolumes: &dpv1alpha1.TargetVolumeInfo{Volumes: []string{"data"}}},
+			Targets: []dpv1alpha1.BackupStatusTarget{{BackupTarget: dpv1alpha1.BackupTarget{
+				Name: "db", PodSelector: &dpv1alpha1.PodSelector{}}}}}}
+	if err := f.cli.Create(f.req.Ctx, backup); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (f *horizontalScalingFixture) replicas(t *testing.T, name string, want int32) {
+	t.Helper()
+	cluster := &appsv1.Cluster{}
+	if err := f.cli.Get(f.req.Ctx, client.ObjectKeyFromObject(f.res.Cluster), cluster); err != nil {
+		t.Fatal(err)
+	}
+	if got := cluster.Spec.GetComponentByName(name).Replicas; got != want {
+		t.Fatalf("%s replicas = %d, want %d", name, got, want)
+	}
+}
+
+func (f *horizontalScalingFixture) reconcile(t *testing.T) {
+	t.Helper()
+	if _, _, err := (horizontalScalingOpsHandler{}).ReconcileAction(f.req, f.cli, f.res); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHorizontalScalingOrdinaryPathDoesNotRestore(t *testing.T) {
+	f := newHorizontalScalingFixture(t, scaleOutRequest("db", false))
+	if err := (horizontalScalingOpsHandler{}).Action(f.req, f.cli, f.res); err != nil {
+		t.Fatal(err)
+	}
+	f.replicas(t, "db", 2)
+	f.reconcile(t)
+	if f.backupReads != 0 || f.restoreReads != 0 || f.clusterWrites != 1 {
+		t.Fatalf("ordinary path API calls: backup=%d restore=%d cluster writes=%d", f.backupReads, f.restoreReads, f.clusterWrites)
+	}
+	details := f.res.OpsRequest.Status.Components["db"].ProgressDetails
+	if f.res.OpsRequest.Status.Progress != "0/1" || len(details) != 1 || details[0].ObjectKey != "Pod/demo-db-1" || details[0].Status != opsv1alpha1.PendingProgressStatus {
+		t.Fatalf("unexpected create progress: %+v", f.res.OpsRequest.Status)
+	}
+}
+
+func TestHorizontalScalingMixedComponentsRestoreTiming(t *testing.T) {
+	for _, backupFirst := range []bool{false, true} {
+		name := "ordinary-first"
+		if backupFirst {
+			name = "backup-first"
+		}
+		t.Run(name, func(t *testing.T) {
+			requests := []opsv1alpha1.HorizontalScaling{scaleOutRequest("ordinary", false), scaleOutRequest("restored", true)}
+			if backupFirst {
+				requests[0], requests[1] = requests[1], requests[0]
+			}
+			f := newHorizontalScalingFixture(t, requests...)
+			f.addBackup(t)
+			if err := (horizontalScalingOpsHandler{}).Action(f.req, f.cli, f.res); err != nil {
+				t.Fatal(err)
+			}
+			f.replicas(t, "ordinary", 2)
+			f.replicas(t, "restored", 1)
+			if f.backupReads != 0 || f.restoreReads != 0 {
+				t.Fatal("Action must defer Restore work")
+			}
+			for i := 0; i < 2; i++ {
+				f.reconcile(t)
+				f.replicas(t, "restored", 1)
+				if f.clusterWrites != 1 {
+					t.Fatal("pending Restore wrote target configuration")
+				}
+				if got := f.res.OpsRequest.Status.Components["restored"].Message; got != "Restore Data In Progress" {
+					t.Fatalf("message = %q", got)
+				}
+				if got := f.res.OpsRequest.Status.Progress; got != "0/2" {
+					t.Fatalf("progress = %q", got)
+				}
+			}
+			restores := &dpv1alpha1.RestoreList{}
+			if err := f.cli.List(f.req.Ctx, restores); err != nil {
+				t.Fatal(err)
+			}
+			if len(restores.Items) != 1 {
+				t.Fatalf("repeated reconcile created %d restores", len(restores.Items))
+			}
+			restore := &restores.Items[0]
+			if restore.Spec.PrepareDataConfig.RestoreVolumeClaimsTemplate.StartingIndex != 1 {
+				t.Fatal("unexpected restore ordinal")
+			}
+			restore.Status.Phase = dpv1alpha1.RestorePhaseCompleted
+			if err := f.cli.Status().Update(f.req.Ctx, restore); err != nil {
+				t.Fatal(err)
+			}
+			f.reconcile(t)
+			f.replicas(t, "restored", 2)
+			if f.clusterWrites != 2 || f.res.OpsRequest.Status.Components["restored"].Message != "Restore Data Completed" {
+				t.Fatal("missing restore completion write/message")
+			}
+			reads := f.backupReads + f.restoreReads
+			f.reconcile(t)
+			if f.clusterWrites != 2 || reads != f.backupReads+f.restoreReads {
+				t.Fatal("completed marker did not skip repeated restore work")
+			}
+		})
+	}
+}
+
+func TestHorizontalScalingRestoreFailureAndCancellation(t *testing.T) {
+	t.Run("failed-restore", func(t *testing.T) {
+		f := newHorizontalScalingFixture(t, scaleOutRequest("db", true))
+		f.addBackup(t)
+		if err := (horizontalScalingOpsHandler{}).Action(f.req, f.cli, f.res); err != nil {
+			t.Fatal(err)
+		}
+		f.reconcile(t)
+		restores := &dpv1alpha1.RestoreList{}
+		if err := f.cli.List(f.req.Ctx, restores); err != nil {
+			t.Fatal(err)
+		}
+		if len(restores.Items) != 1 {
+			t.Fatalf("restores = %d", len(restores.Items))
+		}
+		restore := &restores.Items[0]
+		restore.Status.Phase = dpv1alpha1.RestorePhaseFailed
+		if err := f.cli.Status().Update(f.req.Ctx, restore); err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < 2; i++ {
+			_, _, err := (horizontalScalingOpsHandler{}).ReconcileAction(f.req, f.cli, f.res)
+			if !intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal) || !strings.Contains(err.Error(), "restore for horizontalScaling failed") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			f.replicas(t, "db", 1)
+			if f.clusterWrites != 1 {
+				t.Fatal("failed Restore wrote target configuration")
+			}
+		}
+	})
+	t.Run("cancelling-still-validates-backup", func(t *testing.T) {
+		f := newHorizontalScalingFixture(t, scaleOutRequest("db", true))
+		f.res.OpsRequest.Status.Phase = opsv1alpha1.OpsCancellingPhase
+		if err := (horizontalScalingOpsHandler{}).Cancel(f.req, f.cli, f.res); err != nil {
+			t.Fatal(err)
+		}
+		_, _, err := (horizontalScalingOpsHandler{}).ReconcileAction(f.req, f.cli, f.res)
+		if !intctrlutil.IsTargetError(err, intctrlutil.ErrorTypeFatal) || !strings.Contains(err.Error(), "backup snapshot not found") {
+			t.Fatalf("unexpected cancellation error: %v", err)
+		}
+		if f.backupReads != 1 {
+			t.Fatal("Cancelling bypassed the existing backup path")
+		}
+	})
+}
+
+func TestHorizontalScalingCancelRestoresConfigurationAndDirection(t *testing.T) {
+	f := newHorizontalScalingFixture(t, scaleOutRequest("db", false))
+	spec := &f.res.Cluster.Spec.ComponentSpecs[0]
+	spec.Instances = []appsv1.InstanceTemplate{{Name: "foo", Replicas: pointer.Int32(1)}}
+	spec.OfflineInstances = []string{"demo-db-foo-0"}
+	hs := horizontalScalingOpsHandler{}
+	if err := hs.SaveLastConfiguration(f.req, f.cli, f.res); err != nil {
+		t.Fatal(err)
+	}
+	last := f.res.OpsRequest.Status.LastConfiguration.Components["db"]
+	if err := hs.Action(f.req, f.cli, f.res); err != nil {
+		t.Fatal(err)
+	}
+	created, deleted, err := hs.getCreateAndDeletePodSet(f.res, last, *spec, f.res.OpsRequest.Spec.HorizontalScalingList[0], "db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(created, map[string]string{"demo-db-0": ""}) || len(deleted) != 0 {
+		t.Fatalf("unexpected sets: %v %v", created, deleted)
+	}
+	f.res.OpsRequest.Status.Phase = opsv1alpha1.OpsCancellingPhase
+	if err := hs.Cancel(f.req, f.cli, f.res); err != nil {
+		t.Fatal(err)
+	}
+	if spec.Replicas != *last.Replicas || !reflect.DeepEqual(spec.Instances, last.Instances) || !reflect.DeepEqual(spec.OfflineInstances, last.OfflineInstances) {
+		t.Fatal("Cancel did not restore the original configuration")
+	}
+	f.reconcile(t)
+	details := f.res.OpsRequest.Status.Components["db"].ProgressDetails
+	if f.res.OpsRequest.Status.Progress != "1/1" || len(details) != 1 || details[0].ObjectKey != "Pod/demo-db-0" || !strings.Contains(details[0].Message, "delete") {
+		t.Fatalf("unexpected cancel progress: %+v", f.res.OpsRequest.Status)
+	}
+}
+
+func TestHorizontalScalingShardCountAndShardReplicas(t *testing.T) {
+	for _, changeCount := range []bool{false, true} {
+		name := "replicas-per-shard"
+		request := scaleOutRequest("sharded", false)
+		if changeCount {
+			name = "shard-count"
+			request.ScaleOut = nil
+			request.Shards = pointer.Int32(3)
+		}
+		t.Run(name, func(t *testing.T) {
+			f := newHorizontalScalingFixture(t, request)
+			cluster := f.res.Cluster
+			cluster.Spec.Shardings = []appsv1.ClusterSharding{{Name: "sharded", Shards: 2, Template: cluster.Spec.ComponentSpecs[0]}}
+			cluster.Spec.ComponentSpecs = nil
+			for _, shard := range []string{"sharded-a", "sharded-b"} {
+				comp := &appsv1.Component{ObjectMeta: metav1.ObjectMeta{Name: "demo-" + shard, Namespace: "default",
+					Labels: constant.GetCompLabels("demo", shard, map[string]string{constant.KBAppShardingNameLabelKey: "sharded"})}}
+				if err := f.cli.Create(f.req.Ctx, comp); err != nil {
+					t.Fatal(err)
+				}
+			}
+			hs := horizontalScalingOpsHandler{}
+			if err := hs.SaveLastConfiguration(f.req, f.cli, f.res); err != nil {
+				t.Fatal(err)
+			}
+			if err := f.cli.Status().Update(f.req.Ctx, f.res.OpsRequest); err != nil {
+				t.Fatal(err)
+			}
+			if err := hs.Action(f.req, f.cli, f.res); err != nil {
+				t.Fatal(err)
+			}
+			wantShards, wantReplicas, wantProgress := int32(2), int32(2), "0/2"
+			if changeCount {
+				wantShards, wantReplicas, wantProgress = 3, 1, "0/1"
+			}
+			if got := cluster.Spec.Shardings[0]; got.Shards != wantShards || got.Template.Replicas != wantReplicas {
+				t.Fatalf("unexpected sharding: %+v", got)
+			}
+			f.reconcile(t)
+			if got := f.res.OpsRequest.Status.Progress; got != wantProgress {
+				t.Fatalf("progress = %s, want %s", got, wantProgress)
+			}
+			details := f.res.OpsRequest.Status.Components["sharded"].ProgressDetails
+			if len(details) != 2 {
+				t.Fatalf("progress details = %+v", details)
+			}
+			for _, detail := range details {
+				prefix := "Pod/demo-sharded-"
+				if changeCount {
+					prefix = "Component/demo-sharded-"
+				}
+				if !strings.HasPrefix(detail.ObjectKey, prefix) {
+					t.Fatalf("wrong progress path: %+v", detail)
+				}
+			}
+			if f.backupReads != 0 || f.restoreReads != 0 {
+				t.Fatal("sharding request entered Restore path")
+			}
+		})
+	}
+}
+
+// Characterize main's cancellation behavior; fixing it belongs in a separate change.
+func TestHorizontalScalingCancellingBackupStillSubmitsTarget(t *testing.T) {
+	f := newHorizontalScalingFixture(t, scaleOutRequest("db", true))
+	f.addBackup(t)
+	hs := horizontalScalingOpsHandler{}
+	if err := hs.Action(f.req, f.cli, f.res); err != nil {
+		t.Fatal(err)
+	}
+	f.reconcile(t)
+	f.res.OpsRequest.Status.Phase = opsv1alpha1.OpsCancellingPhase
+	if err := f.cli.Status().Update(f.req.Ctx, f.res.OpsRequest); err != nil {
+		t.Fatal(err)
+	}
+	if err := hs.Cancel(f.req, f.cli, f.res); err != nil {
+		t.Fatal(err)
+	}
+	f.replicas(t, "db", 1)
+	f.reconcile(t)
+	// Cancelling swaps the create/delete sets, so this pure scale-out request
+	// has no restores to wait for and submits its original scale-out target.
+	f.replicas(t, "db", 2)
+	if f.res.OpsRequest.Status.Components["db"].Message != "Restore Data Completed" {
+		t.Fatal("unexpected cancellation restore message")
+	}
+}

--- a/pkg/operations/horizontal_scaling_paths_test.go
+++ b/pkg/operations/horizontal_scaling_paths_test.go
@@ -13,6 +13,8 @@ package operations
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -41,6 +43,167 @@ type horizontalScalingFixture struct {
 	res                                      *OpsResource
 	req                                      intctrlutil.RequestCtx
 	clusterWrites, backupReads, restoreReads int
+}
+
+// Observe the real runtime and inject failures only to check short-circuit order.
+type horizontalScalingRuntimeTrace struct {
+	OpsRuntime
+	calls  []string
+	specs  []appsv1.ClusterComponentSpec
+	failAt int
+	err    error
+}
+
+func (r *horizontalScalingRuntimeTrace) GenerateInstanceNameSet(clusterName, compName string, replicas int32,
+	instances []appsv1.InstanceTemplate, offline []string) (map[string]string, error) {
+	r.calls = append(r.calls, fmt.Sprintf("names(%s,%d)", compName, replicas))
+	spec := appsv1.ClusterComponentSpec{Name: compName, Replicas: replicas, Instances: instances, OfflineInstances: offline}
+	r.specs = append(r.specs, *spec.DeepCopy())
+	if r.failAt > 0 && len(r.calls) == r.failAt {
+		return nil, r.err
+	}
+	return r.OpsRuntime.GenerateInstanceNameSet(clusterName, compName, replicas, instances, offline)
+}
+
+func (r *horizontalScalingRuntimeTrace) GetWorkload(namespace, clusterName, compName string) (Workload, error) {
+	r.calls = append(r.calls, "workload("+compName+")")
+	return r.OpsRuntime.GetWorkload(namespace, clusterName, compName)
+}
+
+func TestHorizontalScalingParticipantAndProgressOrder(t *testing.T) {
+	for _, fromBackup := range []bool{false, true} {
+		want := []string{"names(db,1)", "names(db,1)", "names(db,2)", "workload(db)"}
+		if fromBackup {
+			want = append([]string{"names(db,1)", "names(db,1)", "names(db,1)", "names(db,2)"}, want...)
+		}
+		// Fail each name-planning step in turn to ensure no later planning,
+		// workload checks, or target writes occur after the first error.
+		for failAt := 0; failAt < len(want); failAt++ {
+			t.Run(fmt.Sprintf("backup=%t/failAt=%d", fromBackup, failAt), func(t *testing.T) {
+				f := newHorizontalScalingFixture(t, scaleOutRequest("db", fromBackup))
+				if fromBackup {
+					f.addBackup(t)
+				}
+				trace := &horizontalScalingRuntimeTrace{OpsRuntime: f.res.Runtimes["db"], err: errors.New("name planning failed")}
+				f.res.Runtimes["db"] = trace
+				hs := horizontalScalingOpsHandler{}
+				if err := hs.Action(f.req, f.cli, f.res); err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(trace.calls, []string{"names(db,1)"}) {
+					t.Fatalf("Action calls = %v", trace.calls)
+				}
+				trace.calls, trace.specs, trace.failAt = nil, nil, failAt
+				phase, _, err := hs.ReconcileAction(f.req, f.cli, f.res)
+				if phase != opsv1alpha1.OpsRunningPhase {
+					t.Fatalf("phase = %s", phase)
+				}
+				wantCalls := want
+				if failAt > 0 {
+					wantCalls = want[:failAt]
+					if !errors.Is(err, trace.err) {
+						t.Fatalf("error = %v, want injected error", err)
+					}
+				} else if err != nil {
+					t.Fatal(err)
+				}
+				if !reflect.DeepEqual(trace.calls, wantCalls) {
+					t.Fatalf("calls = %v, want %v", trace.calls, wantCalls)
+				}
+				if f.clusterWrites != 1 {
+					t.Fatalf("cluster writes = %d", f.clusterWrites)
+				}
+				restores := &dpv1alpha1.RestoreList{}
+				if err := f.cli.List(f.req.Ctx, restores); err != nil {
+					t.Fatal(err)
+				}
+				wantRestores := 0
+				if fromBackup && (failAt == 0 || failAt > 4) {
+					wantRestores = 1
+				}
+				if len(restores.Items) != wantRestores {
+					t.Fatalf("restores = %d, want %d", len(restores.Items), wantRestores)
+				}
+			})
+		}
+	}
+}
+
+func TestHorizontalScalingOnlineInferenceInputs(t *testing.T) {
+	for _, tc := range []struct {
+		name                                             string
+		template, explicitTotal, explicitTemplate, empty bool
+		wantCalls                                        []string
+		wantReplicas                                     int32
+	}{
+		{name: "infer-default", wantCalls: []string{"names(db,1)", "names(db,2)"}, wantReplicas: 2},
+		{name: "infer-template", template: true, wantCalls: []string{"names(db,1)", "names(db,2)"}, wantReplicas: 2},
+		{name: "explicit-total-skips-inference", explicitTotal: true, wantCalls: []string{"names(db,1)"}, wantReplicas: 2},
+		{name: "explicit-template-keeps-lookup", template: true, explicitTemplate: true, wantCalls: []string{"names(db,1)", "names(db,1)"}, wantReplicas: 2},
+		{name: "empty-list-skips-inference", empty: true, wantCalls: []string{"names(db,1)"}, wantReplicas: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			request := scaleOutRequest("db", false)
+			request.ScaleOut.ReplicaChanges = nil
+			instance := "demo-db-0"
+			if tc.template {
+				instance = "demo-db-foo-0"
+			}
+			if !tc.empty {
+				request.ScaleOut.OfflineInstancesToOnline = []string{instance}
+			}
+			if tc.explicitTotal {
+				request.ScaleOut.ReplicaChanges = pointer.Int32(1)
+			}
+			if tc.explicitTemplate {
+				request.ScaleOut.Instances = []opsv1alpha1.InstanceReplicasTemplate{{Name: "foo", ReplicaChanges: 1}}
+			}
+			f := newHorizontalScalingFixture(t, request)
+			spec := &f.res.Cluster.Spec.ComponentSpecs[0]
+			spec.OfflineInstances = []string{instance}
+			if tc.template {
+				spec.Instances = []appsv1.InstanceTemplate{{Name: "foo", Replicas: pointer.Int32(1)}}
+			}
+			hs := horizontalScalingOpsHandler{}
+			if err := hs.SaveLastConfiguration(f.req, f.cli, f.res); err != nil {
+				t.Fatal(err)
+			}
+			original := spec.DeepCopy()
+			trace := &horizontalScalingRuntimeTrace{OpsRuntime: f.res.Runtimes["db"]}
+			f.res.Runtimes["db"] = trace
+			if err := hs.Action(f.req, f.cli, f.res); err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(trace.calls, tc.wantCalls) {
+				t.Fatalf("calls = %v, want %v", trace.calls, tc.wantCalls)
+			}
+			if !reflect.DeepEqual(trace.specs[0].Instances, original.Instances) || !reflect.DeepEqual(trace.specs[0].OfflineInstances, original.OfflineInstances) {
+				t.Fatalf("initial planning inputs = %+v", trace.specs[0])
+			}
+			if len(trace.specs) == 2 {
+				candidate := trace.specs[1]
+				if len(candidate.OfflineInstances) != 0 {
+					t.Fatalf("candidate offline = %v", candidate.OfflineInstances)
+				}
+				if tc.template {
+					want := int32(2)
+					if tc.explicitTemplate {
+						want = 1
+					}
+					if len(candidate.Instances) != 1 || candidate.Instances[0].GetReplicas() != want {
+						t.Fatalf("candidate instances = %+v", candidate.Instances)
+					}
+				}
+			}
+			f.replicas(t, "db", tc.wantReplicas)
+			if tc.template && (len(spec.Instances) != 1 || spec.Instances[0].GetReplicas() != 2) {
+				t.Fatalf("target instances = %+v", spec.Instances)
+			}
+			if !tc.empty && len(spec.OfflineInstances) != 0 {
+				t.Fatalf("target offline = %v", spec.OfflineInstances)
+			}
+		})
+	}
 }
 
 func newHorizontalScalingFixture(t *testing.T, requests ...opsv1alpha1.HorizontalScaling) *horizontalScalingFixture {
@@ -138,10 +301,14 @@ func (f *horizontalScalingFixture) replicas(t *testing.T, name string, want int3
 	}
 }
 
-func (f *horizontalScalingFixture) reconcile(t *testing.T) {
+func (f *horizontalScalingFixture) reconcile(t *testing.T, want opsv1alpha1.OpsPhase) {
 	t.Helper()
-	if _, _, err := (horizontalScalingOpsHandler{}).ReconcileAction(f.req, f.cli, f.res); err != nil {
+	phase, _, err := (horizontalScalingOpsHandler{}).ReconcileAction(f.req, f.cli, f.res)
+	if err != nil {
 		t.Fatal(err)
+	}
+	if phase != want {
+		t.Fatalf("reconcile phase = %s, want %s", phase, want)
 	}
 }
 
@@ -151,7 +318,7 @@ func TestHorizontalScalingOrdinaryPathDoesNotRestore(t *testing.T) {
 		t.Fatal(err)
 	}
 	f.replicas(t, "db", 2)
-	f.reconcile(t)
+	f.reconcile(t, opsv1alpha1.OpsRunningPhase)
 	if f.backupReads != 0 || f.restoreReads != 0 || f.clusterWrites != 1 {
 		t.Fatalf("ordinary path API calls: backup=%d restore=%d cluster writes=%d", f.backupReads, f.restoreReads, f.clusterWrites)
 	}
@@ -183,7 +350,7 @@ func TestHorizontalScalingMixedComponentsRestoreTiming(t *testing.T) {
 				t.Fatal("Action must defer Restore work")
 			}
 			for i := 0; i < 2; i++ {
-				f.reconcile(t)
+				f.reconcile(t, opsv1alpha1.OpsRunningPhase)
 				f.replicas(t, "restored", 1)
 				if f.clusterWrites != 1 {
 					t.Fatal("pending Restore wrote target configuration")
@@ -210,15 +377,40 @@ func TestHorizontalScalingMixedComponentsRestoreTiming(t *testing.T) {
 			if err := f.cli.Status().Update(f.req.Ctx, restore); err != nil {
 				t.Fatal(err)
 			}
-			f.reconcile(t)
+			f.reconcile(t, opsv1alpha1.OpsRunningPhase)
 			f.replicas(t, "restored", 2)
 			if f.clusterWrites != 2 || f.res.OpsRequest.Status.Components["restored"].Message != "Restore Data Completed" {
 				t.Fatal("missing restore completion write/message")
 			}
 			reads := f.backupReads + f.restoreReads
-			f.reconcile(t)
+			f.reconcile(t, opsv1alpha1.OpsRunningPhase)
 			if f.clusterWrites != 2 || reads != f.backupReads+f.restoreReads {
 				t.Fatal("completed marker did not skip repeated restore work")
+			}
+			// Restore completion alone does not complete the Ops: the newly
+			// requested instances must become available on both paths.
+			for _, name := range []string{"ordinary", "restored"} {
+				pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "demo-" + name + "-1", Namespace: "default",
+					Labels: constant.GetCompLabels("demo", name)},
+					Status: corev1.PodStatus{Phase: corev1.PodRunning,
+						Conditions: []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}}}
+				if err := f.cli.Create(f.req.Ctx, pod); err != nil {
+					t.Fatal(err)
+				}
+			}
+			f.reconcile(t, opsv1alpha1.OpsSucceedPhase)
+			if got := f.res.OpsRequest.Status.Progress; got != "2/2" {
+				t.Fatalf("completed progress = %q", got)
+			}
+			for _, name := range []string{"ordinary", "restored"} {
+				details := f.res.OpsRequest.Status.Components[name].ProgressDetails
+				if len(details) != 1 || details[0].ObjectKey != "Pod/demo-"+name+"-1" || details[0].Status != opsv1alpha1.SucceedProgressStatus {
+					t.Fatalf("unexpected completed participants for %s: %+v", name, details)
+				}
+			}
+			f.reconcile(t, opsv1alpha1.OpsSucceedPhase)
+			if f.clusterWrites != 2 || reads != f.backupReads+f.restoreReads {
+				t.Fatal("completed Ops repeated restore work")
 			}
 		})
 	}
@@ -231,7 +423,7 @@ func TestHorizontalScalingRestoreFailureAndCancellation(t *testing.T) {
 		if err := (horizontalScalingOpsHandler{}).Action(f.req, f.cli, f.res); err != nil {
 			t.Fatal(err)
 		}
-		f.reconcile(t)
+		f.reconcile(t, opsv1alpha1.OpsRunningPhase)
 		restores := &dpv1alpha1.RestoreList{}
 		if err := f.cli.List(f.req.Ctx, restores); err != nil {
 			t.Fatal(err)
@@ -281,15 +473,17 @@ func TestHorizontalScalingCancelRestoresConfigurationAndDirection(t *testing.T) 
 		t.Fatal(err)
 	}
 	last := f.res.OpsRequest.Status.LastConfiguration.Components["db"]
+	if err := f.cli.Status().Update(f.req.Ctx, f.res.OpsRequest); err != nil {
+		t.Fatal(err)
+	}
 	if err := hs.Action(f.req, f.cli, f.res); err != nil {
 		t.Fatal(err)
 	}
-	created, deleted, err := hs.getCreateAndDeletePodSet(f.res, last, *spec, f.res.OpsRequest.Spec.HorizontalScalingList[0], "db")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(created, map[string]string{"demo-db-0": ""}) || len(deleted) != 0 {
-		t.Fatalf("unexpected sets: %v %v", created, deleted)
+	f.reconcile(t, opsv1alpha1.OpsRunningPhase)
+	details := f.res.OpsRequest.Status.Components["db"].ProgressDetails
+	if f.res.OpsRequest.Status.Progress != "0/1" || len(details) != 1 || details[0].ObjectKey != "Pod/demo-db-0" ||
+		details[0].Status != opsv1alpha1.PendingProgressStatus || !strings.Contains(details[0].Message, "create") {
+		t.Fatalf("unexpected create participants: %+v", f.res.OpsRequest.Status)
 	}
 	f.res.OpsRequest.Status.Phase = opsv1alpha1.OpsCancellingPhase
 	if err := hs.Cancel(f.req, f.cli, f.res); err != nil {
@@ -298,8 +492,9 @@ func TestHorizontalScalingCancelRestoresConfigurationAndDirection(t *testing.T) 
 	if spec.Replicas != *last.Replicas || !reflect.DeepEqual(spec.Instances, last.Instances) || !reflect.DeepEqual(spec.OfflineInstances, last.OfflineInstances) {
 		t.Fatal("Cancel did not restore the original configuration")
 	}
-	f.reconcile(t)
-	details := f.res.OpsRequest.Status.Components["db"].ProgressDetails
+	// ReconcileAction reports successful rollback; OpsManager maps it to Cancelled.
+	f.reconcile(t, opsv1alpha1.OpsSucceedPhase)
+	details = f.res.OpsRequest.Status.Components["db"].ProgressDetails
 	if f.res.OpsRequest.Status.Progress != "1/1" || len(details) != 1 || details[0].ObjectKey != "Pod/demo-db-0" || !strings.Contains(details[0].Message, "delete") {
 		t.Fatalf("unexpected cancel progress: %+v", f.res.OpsRequest.Status)
 	}
@@ -343,7 +538,7 @@ func TestHorizontalScalingShardCountAndShardReplicas(t *testing.T) {
 			if got := cluster.Spec.Shardings[0]; got.Shards != wantShards || got.Template.Replicas != wantReplicas {
 				t.Fatalf("unexpected sharding: %+v", got)
 			}
-			f.reconcile(t)
+			f.reconcile(t, opsv1alpha1.OpsRunningPhase)
 			if got := f.res.OpsRequest.Status.Progress; got != wantProgress {
 				t.Fatalf("progress = %s, want %s", got, wantProgress)
 			}
@@ -375,7 +570,7 @@ func TestHorizontalScalingCancellingBackupStillSubmitsTarget(t *testing.T) {
 	if err := hs.Action(f.req, f.cli, f.res); err != nil {
 		t.Fatal(err)
 	}
-	f.reconcile(t)
+	f.reconcile(t, opsv1alpha1.OpsRunningPhase)
 	f.res.OpsRequest.Status.Phase = opsv1alpha1.OpsCancellingPhase
 	if err := f.cli.Status().Update(f.req.Ctx, f.res.OpsRequest); err != nil {
 		t.Fatal(err)
@@ -384,7 +579,7 @@ func TestHorizontalScalingCancellingBackupStillSubmitsTarget(t *testing.T) {
 		t.Fatal(err)
 	}
 	f.replicas(t, "db", 1)
-	f.reconcile(t)
+	f.reconcile(t, opsv1alpha1.OpsSucceedPhase)
 	// Cancelling swaps the create/delete sets, so this pure scale-out request
 	// has no restores to wait for and submits its original scale-out target.
 	f.replicas(t, "db", 2)


### PR DESCRIPTION
Horizontal scaling currently interleaves replica progress with backup restoration in the same handler. Separating those steps makes it easier to follow when a component's target configuration is submitted, especially when one OpsRequest mixes ordinary and FromBackup components.

Keep `horizontalScalingOpsHandler` as the lifecycle entry point and dispatch each component independently. `horizontal_scaling.go` retains ordinary replica scaling and shared calculations. `horizontal_scaling_backup.go` owns backup validation, Restore creation/waiting, and post-restore Cluster updates. Shard-count requests continue to use the existing dedicated shard progress helpers.

The shared responsibilities are explicit:

- Both replica paths select participants with `setReplicaScalingParticipants`, then call the existing `handleComponentProgressForScalingReplicas` directly to inspect actual workload progress. Backup reconciliation still selects participants and checks progress while Restore is pending.
- Runtime name generation supplies the request filter with an explicit name set. Template grouping uses the existing naming rules; replica arithmetic consumes per-template counts, and planned online counting consumes grouped names plus the generated plan. These steps preserve lookup order and short-circuit conditions without introducing a provider or workflow framework.
- `getReplicaScalingChanges` computes forward changes shared by progress, restoration, and earlier-Ops intersection checks. Each caller explicitly applies the original cancellation direction. The earlier-Ops check retains its pre-calculation and current-request phase semantics.
- Remove the unused current-component-spec parameter chain and redundant copies: target calculation already consumes the saved configuration and request. The backup-local target spec remains for Restore preparation and the eventual Cluster write.

This is a behavior-preserving refactor based on main at `117bd375f32012110de428e1f0f425265486244a`. It preserves earlier-Ops intersection checks, configuration calculation inputs and order, the Action-time Cluster update, deferred FromBackup target writes, Restore messages/re-entry, cancellation direction, and existing error/completion handling. Naming and actual workload checks remain unchanged. There are no API/CRD, InstanceStatus, flat ordinal, queueing, or other operation changes.

Validation:

- Before refactoring: full `./pkg/operations` and `./controllers/operations` suites passed using `scripts/codex-go-test.sh`.
- Added regression coverage for ordinary requests without Restore access, both mixed-component orders, pending/completed/failed Restore timing and repeated reconcile, original configuration restoration and delete progress on cancellation, and shard-count versus per-shard replica progress. The original test file is unchanged; participant assertions in the added tests now exercise lifecycle progress directly.
- Assert Running/Succeed phases, including waiting for actual instances after Restore completion. Trace the real runtime to verify planning-before-progress order and stop at each injected planning error. Check name-generation inputs and skipped lookups for inferred versus explicit replica changes.
- All added HScale tests also pass against the exact main implementation using a Go overlay; the overlay replaces only the refactored production file and excludes the newly extracted backup file.
- After refactoring: full `./pkg/operations` and `./controllers/operations` suites passed using the same wrapper.
- `make lint`: passed, 0 issues. `git diff --check`: passed. No generated files are included.

Existing issue intentionally preserved: cancelling a pure FromBackup scale-out can submit its scale-out target again. `Cancel` restores the original spec, but the subsequent reconcile still runs restoration; cancellation swaps the create/delete sets, leaving an empty restore wait set and allowing the target write plus `Restore Data Completed`. `TestHorizontalScalingCancellingBackupStillSubmitsTarget` reproduces this on main and on this branch. Fixing that behavior requires a separate change.
