### PR TITLE
fix(dataprotection): register workload types in manager scheme

### DIFF
--- a/cmd/dataprotection/main.go
+++ b/cmd/dataprotection/main.go
@@ -52,6 +52,7 @@ import (
 	appsv1alpha1 "github.com/apecloud/kubeblocks/apis/apps/v1alpha1"
 	dpv1alpha1 "github.com/apecloud/kubeblocks/apis/dataprotection/v1alpha1"
 	opsv1alpha1 "github.com/apecloud/kubeblocks/apis/operations/v1alpha1"
+	workloadsv1 "github.com/apecloud/kubeblocks/apis/workloads/v1"
 	dpcontrollers "github.com/apecloud/kubeblocks/controllers/dataprotection"
 	"github.com/apecloud/kubeblocks/pkg/constant"
 	"github.com/apecloud/kubeblocks/pkg/controller/multicluster"
@@ -95,6 +96,7 @@ func init() {
 	utilruntime.Must(appsv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(opsv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(dpv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(workloadsv1.AddToScheme(scheme))
 	utilruntime.Must(snapshotv1.AddToScheme(scheme))
 	utilruntime.Must(snapshotv1beta1.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme


### PR DESCRIPTION
Register `workloads/v1` in the DataProtection manager scheme so restore PVC owner lookups can resolve `Instance` and `InstanceSet`.

Fixes #10881.

Validation: local startup-scheme unit test passed for both workload types. The temporary test file is not included.
