### PR TITLE
fix(helm): exclude extra labels from deployment selectors

### DIFF
--- a/deploy/helm/templates/dataprotection.yaml
+++ b/deploy/helm/templates/dataprotection.yaml
@@ -20,9 +20,6 @@ spec:
     matchLabels:
       app.kubernetes.io/component: "dataprotection"
       {{- include "kubeblocks.selectorLabels" . | nindent 6 }}
-      {{- with .Values.dataProtection.extraLabels }}
-        {{- toYaml . | nindent 6 }}
-      {{- end }}
   {{- if .Values.updateStrategy }}
   strategy:
     {{ toYaml .Values.updateStrategy | nindent 4 | trim }}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -18,9 +18,6 @@ spec:
     matchLabels:
       app.kubernetes.io/component: "apps"
       {{- include "kubeblocks.selectorLabels" . | nindent 6 }}
-      {{- with .Values.extraLabels }}
-        {{- toYaml . | nindent 6 }}
-      {{- end }}
   {{- if .Values.updateStrategy }}
   strategy:
     {{ toYaml .Values.updateStrategy | nindent 4 | trim }}


### PR DESCRIPTION
Fixes #10888.

Remove `extraLabels` and `dataProtection.extraLabels` from Deployment selectors while retaining them on Pod templates. This prevents immutable-selector errors when adding extra Pod labels during an upgrade.
